### PR TITLE
fix: allow HR roles to access corporation settings and reviewers to a…

### DIFF
--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -367,6 +367,7 @@ app.get('/browse/search', requireAuth(), async (c) => {
  */
 app.get('/browse/:corporationId', requireAuth(), async (c) => {
 	const corporationId = c.req.param('corporationId')
+	const user = c.get('user')!
 	const db = c.get('db')
 
 	if (!db) {
@@ -380,7 +381,12 @@ app.get('/browse/:corporationId', requireAuth(), async (c) => {
 			await checkCorporationAccess(c, corporationId)
 			hasManagementAccess = true
 		} catch {
-			// User doesn't have management access, continue with public check
+			// CEO/Director/Admin check failed — fall back to HR role check
+			const hr = getStub<Hr>(c.env.HR, 'default')
+			const hasHrRole = await hr.checkPermission(user.id, corporationId, 'hr_viewer')
+			if (hasHrRole) {
+				hasManagementAccess = true
+			}
 		}
 
 		// Get corporation - include non-recruiting if user has management access

--- a/apps/hr/src/durable-object.ts
+++ b/apps/hr/src/durable-object.ts
@@ -190,8 +190,7 @@ export class HrDO extends DurableObject<Env> implements Hr {
 		)
 		const hasAdminAccess = activeRoles.some((role) => role.role === 'hr_admin')
 
-		const requiresAdminAccess = status === 'accepted' || status === 'rejected'
-		const hasPermission = requiresAdminAccess ? hasAdminAccess : hasReviewerAccess
+		const hasPermission = hasReviewerAccess
 
 		if (!hasPermission) {
 			throw new Error('You do not have permission to update this application')

--- a/apps/ui/src/client/features/applications/components/application-action-panel.tsx
+++ b/apps/ui/src/client/features/applications/components/application-action-panel.tsx
@@ -78,8 +78,8 @@ export function ApplicationActionPanel({
 
 	// Determine available actions based on role
 	const canMarkUnderReview = userRole && ['hr_admin', 'hr_reviewer'].includes(userRole)
-	const canAccept = userRole === 'hr_admin'
-	const canReject = userRole === 'hr_admin'
+	const canAccept = userRole && ['hr_admin', 'hr_reviewer'].includes(userRole)
+	const canReject = userRole && ['hr_admin', 'hr_reviewer'].includes(userRole)
 
 	// Validate review notes (required for accept/reject)
 	const validateReviewNotes = (): boolean => {


### PR DESCRIPTION
- Add HR role fallback to GET /browse/:corporationId so HR admins/reviewers/viewers can load corporation data
- Allow hr_reviewer role to accept/reject applications (previously hr_admin only)
- Show accept/reject buttons in UI for hr_reviewer role