### PR TITLE
load and show discord events on Dashboard

### DIFF
--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -82,6 +82,8 @@ export type Env = SharedHonoEnv & {
 	DISCORD_AUDIT_EXCLUDED_USER_IDS?: string
 	/** Shared key for trusted internal legacy-worker operations */
 	LEGACY_INTERNAL_KEY?: string
+	/** Guild ID of the community's main Discord server, used to read scheduled events */
+	MAIN_DISCORD_GUILD_ID?: string
 }
 
 /** Session user data attached to request context */

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -27,6 +27,7 @@ import dkpRoutes from './routes/dkp'
 import doctrinesRoutes from './routes/doctrines'
 import entitiesRoutes from './routes/entities'
 import esiRoutes from './routes/esi'
+import eventsRoutes from './routes/events'
 import fleetsRoutes from './routes/fleets'
 import freightRoutes from './routes/freight'
 import fulcrumRoutes from './routes/fulcrum'
@@ -121,6 +122,7 @@ const app = new Hono<App>()
 	.route('/api/discord', discordRoutes)
 	.route('/api/groups', groupsRoutes)
 	.route('/api/broadcasts', broadcastsRoutes)
+	.route('/api/events', eventsRoutes)
 	.route('/api/fleets', fleetsRoutes)
 	.route('/api/freight', freightRoutes)
 	.route('/api/fulcrum', fulcrumRoutes)

--- a/apps/core/src/routes/events.ts
+++ b/apps/core/src/routes/events.ts
@@ -1,0 +1,163 @@
+/**
+ * Events routes - read-only view of upcoming Discord scheduled events.
+ *
+ * Discord is the source of truth for events: they are created, edited, and
+ * cancelled in the Discord client. Auth reads the main guild's upcoming
+ * events for the dashboard and resolves each creator's Discord ID to their
+ * EVE main character name (the name the community actually recognizes).
+ */
+
+import { Hono } from 'hono'
+
+import { inArray } from '@repo/db-utils'
+import { getDiscordStub } from '@repo/discord'
+import { TimeCache, logger } from '@repo/hono-helpers'
+
+import { userCharacters, users } from '../db/schema'
+import { requireAuth } from '../middleware/session'
+
+import type { DiscordGuildScheduledEvent } from '@repo/discord'
+import type { Context } from 'hono'
+import type { App } from '../context'
+
+/** Discord scheduled-event status: 1 SCHEDULED, 2 ACTIVE, 3 COMPLETED, 4 CANCELED. */
+const STATUS_ACTIVE = 2
+
+/** An upcoming event with its creator resolved to an EVE main character name. */
+type EnrichedEvent = DiscordGuildScheduledEvent & {
+	/** Creator's EVE main character name, or null when it cannot be resolved. */
+	creatorMainCharacter: string | null
+}
+
+/**
+ * Shared cache of the guild's scheduled events (keyed by guild ID), 60s TTL.
+ *
+ * The event list is identical for every user, so caching here collapses
+ * many concurrent browser polls into one Discord API call per minute —
+ * keeping us well clear of Discord's per-route rate limits as usage grows.
+ */
+const eventsCache = new TimeCache<DiscordGuildScheduledEvent[]>(60_000)
+
+const app = new Hono<App>()
+
+/**
+ * Fetch and sort the main guild's scheduled events (soonest first).
+ * Cached for 60s and shared across all callers. Returns an empty list
+ * when no guild is configured.
+ */
+async function fetchGuildEvents(c: Context<App>) {
+	const guildId = c.env.MAIN_DISCORD_GUILD_ID
+	if (!guildId) {
+		logger.warn('MAIN_DISCORD_GUILD_ID is not configured; returning no events')
+		return []
+	}
+
+	return eventsCache.getOrSet(guildId, async () => {
+		const discord = getDiscordStub(c.env)
+		const events = await discord.listGuildScheduledEvents(guildId)
+		return [...events].sort(
+			(a, b) =>
+				new Date(a.scheduledStartTime).getTime() - new Date(b.scheduledStartTime).getTime()
+		)
+	})
+}
+
+/**
+ * Resolve event creators' Discord user IDs to EVE main character names.
+ *
+ * Builds a map from Discord user ID -> main character name by joining the
+ * users table (linked via discord_user_id) to user_characters. Creators who
+ * have not linked their Discord account simply resolve to null.
+ */
+async function resolveCreatorCharacters(
+	c: Context<App>,
+	events: DiscordGuildScheduledEvent[]
+): Promise<Map<string, string>> {
+	const discordUserIds = [
+		...new Set(
+			events
+				.map((event) => event.creator?.id)
+				.filter((id): id is string => typeof id === 'string' && id.length > 0)
+		),
+	]
+	if (discordUserIds.length === 0) {
+		return new Map()
+	}
+
+	const db = c.get('db')
+	if (!db) {
+		return new Map()
+	}
+
+	try {
+		// users -> the linked auth account; user_characters -> the main char name.
+		const matchedUsers = await db.query.users.findMany({
+			where: inArray(users.discordUserId, discordUserIds),
+			columns: { discordUserId: true, mainCharacterId: true },
+		})
+
+		const mainCharacterIds = matchedUsers
+			.map((user) => user.mainCharacterId)
+			.filter((id): id is string => !!id)
+		if (mainCharacterIds.length === 0) {
+			return new Map()
+		}
+
+		const characters = await db.query.userCharacters.findMany({
+			where: inArray(userCharacters.characterId, mainCharacterIds),
+			columns: { characterId: true, characterName: true },
+		})
+		const nameByCharacterId = new Map(
+			characters.map((char) => [char.characterId, char.characterName])
+		)
+
+		const result = new Map<string, string>()
+		for (const user of matchedUsers) {
+			if (!user.discordUserId || !user.mainCharacterId) continue
+			const name = nameByCharacterId.get(user.mainCharacterId)
+			if (name) result.set(user.discordUserId, name)
+		}
+		return result
+	} catch (error) {
+		// Resolution is best-effort — never fail the request over it.
+		logger.warn('Failed to resolve event creator characters:', {
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return new Map()
+	}
+}
+
+/**
+ * GET /events/upcoming
+ * Upcoming (not-yet-finished, non-cancelled) scheduled events, with each
+ * creator resolved to their EVE main character name. Powers the dashboard.
+ */
+app.get('/upcoming', requireAuth(), async (c) => {
+	try {
+		const events = await fetchGuildEvents(c)
+		const now = Date.now()
+		const upcoming = events.filter((event: DiscordGuildScheduledEvent) => {
+			if (event.status > STATUS_ACTIVE) return false // completed or canceled
+			// Keep events whose end (or start, if no end) is still in the future.
+			const end = event.scheduledEndTime ?? event.scheduledStartTime
+			return new Date(end).getTime() >= now
+		})
+
+		const creatorNames = await resolveCreatorCharacters(c, upcoming)
+		const enriched: EnrichedEvent[] = upcoming.map((event) => ({
+			...event,
+			creatorMainCharacter: event.creator
+				? (creatorNames.get(event.creator.id) ?? null)
+				: null,
+		}))
+
+		return c.json(enriched)
+	} catch (error) {
+		logger.error('Error listing upcoming Discord scheduled events:', {
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return c.json({ error: 'Failed to load upcoming events' }, 500)
+	}
+})
+
+export default app

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -28,7 +28,9 @@
 		"ENVIRONMENT": "production",
 		"SENTRY_RELEASE": "unknown",
 		"SENTRY_DSN": "https://8a3d31a3a18e448f97e19e3d9930547d@app.glitchtip.com/13711",
-		"LEGACY_AUTH_CALLBACK_URL": "https://pleaseignore.app/api/auth/legacy-auth/callback"
+		"LEGACY_AUTH_CALLBACK_URL": "https://pleaseignore.app/api/auth/legacy-auth/callback",
+		// Guild ID of the main Discord server; events are read from here.
+		"MAIN_DISCORD_GUILD_ID": "356398105404375041"
 	},
 	"durable_objects": {
 		"bindings": [

--- a/apps/discord/src/durable-object.ts
+++ b/apps/discord/src/durable-object.ts
@@ -14,6 +14,7 @@ import type {
 	Discord,
 	DiscordGuildMemberSnapshot,
 	DiscordGuildMembershipDetail,
+	DiscordGuildScheduledEvent,
 	DiscordRegisteredSlashCommand,
 	DiscordSlashCommandDefinition,
 	DiscordTokenResponse,
@@ -21,6 +22,28 @@ import type {
 	SendMessageResult,
 } from '@repo/discord'
 import type { Env } from './context'
+
+/**
+ * Raw shape of a Discord guild scheduled event as returned by the API.
+ * Only the fields we consume are typed.
+ */
+interface DiscordScheduledEventApiResponse {
+	id: string
+	name: string
+	description?: string | null
+	scheduled_start_time: string
+	scheduled_end_time?: string | null
+	entity_metadata?: { location?: string | null } | null
+	status: number
+	user_count?: number | null
+	/** Cover image hash; combine with the event ID to build the CDN URL. */
+	image?: string | null
+	creator?: {
+		id: string
+		username?: string | null
+		global_name?: string | null
+	} | null
+}
 
 /**
  * Discord Durable Object
@@ -1669,6 +1692,55 @@ export class DiscordDO extends DurableObject<Env> implements Discord {
 				success: false,
 				error: error instanceof Error ? error.message : 'Failed to delete slash command',
 			}
+		}
+	}
+
+	/**
+	 * List a guild's scheduled events using the bot token.
+	 *
+	 * Discord is the source of truth for events; this is a read-only call
+	 * used to display events created in the Discord client.
+	 */
+	async listGuildScheduledEvents(guildId: string): Promise<DiscordGuildScheduledEvent[]> {
+		const client = this.createDiscordClient()
+		const raw = await client.get<DiscordScheduledEventApiResponse[]>(
+			DiscordRoutes.guildScheduledEvents(guildId)
+		)
+		return raw.map((event) => this.toDiscordGuildScheduledEvent(guildId, event))
+	}
+
+	/**
+	 * Normalize a raw Discord scheduled-event API response into our shape.
+	 */
+	private toDiscordGuildScheduledEvent(
+		guildId: string,
+		raw: DiscordScheduledEventApiResponse
+	): DiscordGuildScheduledEvent {
+		// Cover image: built from the event ID + image hash, per Discord's CDN scheme.
+		const imageUrl = raw.image
+			? `https://cdn.discordapp.com/guild-events/${raw.id}/${raw.image}.png?size=512`
+			: null
+
+		const creator = raw.creator
+			? {
+					id: raw.creator.id,
+					username: raw.creator.username ?? '',
+					displayName: raw.creator.global_name ?? null,
+				}
+			: null
+
+		return {
+			id: raw.id,
+			guildId,
+			name: raw.name,
+			description: raw.description ?? null,
+			scheduledStartTime: raw.scheduled_start_time,
+			scheduledEndTime: raw.scheduled_end_time ?? null,
+			location: raw.entity_metadata?.location ?? null,
+			status: raw.status,
+			userCount: raw.user_count ?? null,
+			imageUrl,
+			creator,
 		}
 	}
 

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -2,7 +2,6 @@ import {
 	BookMarked,
 	BookOpen,
 	Briefcase,
-	Building2,
 	ChevronLeft,
 	ChevronDown,
 	ChevronRight,

--- a/apps/ui/src/client/features/events/api.ts
+++ b/apps/ui/src/client/features/events/api.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/lib/api'
+
+import type { DiscordScheduledEvent } from './types'
+
+/**
+ * List upcoming (not-yet-finished, non-cancelled) scheduled events from the
+ * main Discord server, with each creator resolved to an EVE main character.
+ */
+export async function listUpcomingEvents(): Promise<DiscordScheduledEvent[]> {
+	return apiClient.get('/events/upcoming')
+}

--- a/apps/ui/src/client/features/events/components/EventDetailDialog.tsx
+++ b/apps/ui/src/client/features/events/components/EventDetailDialog.tsx
@@ -1,0 +1,116 @@
+import { CalendarClock, ExternalLink, MapPin, User, Users } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+
+import { EventStatusBadge } from './EventStatusBadge'
+import { formatDuration, formatEveTime, formatLocal, formatRelative } from '../format'
+import { discordEventUrl } from '../types'
+
+import type { DiscordScheduledEvent } from '../types'
+
+interface EventDetailDialogProps {
+	event: DiscordScheduledEvent | null
+	open: boolean
+	onOpenChange: (open: boolean) => void
+}
+
+/** A small labelled detail row. */
+function DetailRow({ icon: Icon, children }: { icon: typeof MapPin; children: React.ReactNode }) {
+	return (
+		<div className="flex items-start gap-2 text-sm">
+			<Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+			<span className="text-foreground">{children}</span>
+		</div>
+	)
+}
+
+/**
+ * Detailed read-only popup for a single Discord scheduled event.
+ * The primary action links out to Discord, where users can RSVP.
+ */
+export function EventDetailDialog({ event, open, onOpenChange }: EventDetailDialogProps) {
+	if (!event) return null
+
+	const duration = event.scheduledEndTime
+		? formatDuration(event.scheduledStartTime, event.scheduledEndTime)
+		: null
+	// Prefer the resolved EVE main character; never show the raw Discord name.
+	const creatorName = event.creatorMainCharacter
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-lg overflow-hidden p-0">
+				{event.imageUrl && (
+					<img
+						src={event.imageUrl}
+						alt=""
+						className="h-40 w-full object-cover"
+					/>
+				)}
+
+				<div className="space-y-4 p-6">
+					<DialogHeader>
+						<div className="flex flex-wrap items-center gap-2">
+							<DialogTitle>{event.name}</DialogTitle>
+							<EventStatusBadge status={event.status} />
+						</div>
+					</DialogHeader>
+
+					{event.description && (
+						<p className="whitespace-pre-line text-sm text-muted-foreground">
+							{event.description}
+						</p>
+					)}
+
+					<div className="space-y-2 border-t pt-4">
+						<DetailRow icon={CalendarClock}>
+							<span>
+								{formatLocal(event.scheduledStartTime, {
+									dateStyle: 'full',
+									timeStyle: 'short',
+								})}
+								{event.scheduledEndTime && (
+									<span className="text-muted-foreground">
+										{' – '}
+										{formatLocal(event.scheduledEndTime, { timeStyle: 'short' })}
+										{duration ? ` (${duration})` : ''}
+									</span>
+								)}
+							</span>
+							{/* EVE (UTC) time + countdown — EVE runs on UTC. */}
+							<span className="mt-0.5 block text-xs text-muted-foreground">
+								{formatEveTime(event.scheduledStartTime)}
+								{event.scheduledEndTime
+									? ` – ${formatEveTime(event.scheduledEndTime)}`
+									: ''}{' '}
+								· {formatRelative(event.scheduledStartTime)}
+							</span>
+						</DetailRow>
+
+						{event.location && <DetailRow icon={MapPin}>{event.location}</DetailRow>}
+
+						{event.userCount !== null && event.userCount > 0 && (
+							<DetailRow icon={Users}>
+								{event.userCount} interested
+							</DetailRow>
+						)}
+
+						{creatorName && (
+							<DetailRow icon={User}>
+								Created by <span className="font-medium">{creatorName}</span>
+							</DetailRow>
+						)}
+					</div>
+
+					<Button asChild className="w-full">
+						<a href={discordEventUrl(event)} target="_blank" rel="noopener noreferrer">
+							<ExternalLink className="h-4 w-4" />
+							Open in Discord
+						</a>
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/ui/src/client/features/events/components/EventStatusBadge.tsx
+++ b/apps/ui/src/client/features/events/components/EventStatusBadge.tsx
@@ -1,0 +1,22 @@
+import { Badge } from '@/components/ui/badge'
+
+import { EVENT_STATUS } from '../types'
+
+const STATUS_META: Record<number, { label: string; variant: 'success' | 'secondary' | 'destructive' | 'default' }> = {
+	[EVENT_STATUS.SCHEDULED]: { label: 'Scheduled', variant: 'success' },
+	[EVENT_STATUS.ACTIVE]: { label: 'Live', variant: 'default' },
+	[EVENT_STATUS.COMPLETED]: { label: 'Completed', variant: 'secondary' },
+	[EVENT_STATUS.CANCELED]: { label: 'Cancelled', variant: 'destructive' },
+}
+
+/**
+ * Badge reflecting a Discord scheduled event's status.
+ */
+export function EventStatusBadge({ status }: { status: number }) {
+	const meta = STATUS_META[status] ?? { label: 'Unknown', variant: 'secondary' as const }
+	return (
+		<Badge variant={meta.variant} className="text-xs">
+			{meta.label}
+		</Badge>
+	)
+}

--- a/apps/ui/src/client/features/events/components/UpcomingEventsCard.tsx
+++ b/apps/ui/src/client/features/events/components/UpcomingEventsCard.tsx
@@ -1,0 +1,94 @@
+import { CalendarDays } from 'lucide-react'
+import { useState } from 'react'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+import { EventDetailDialog } from './EventDetailDialog'
+import { EventStatusBadge } from './EventStatusBadge'
+import { formatEveTime, formatLocal } from '../format'
+import { useUpcomingEvents } from '../hooks'
+
+import type { DiscordScheduledEvent } from '../types'
+
+/**
+ * Dashboard card listing all upcoming Discord events. Each row opens a
+ * detail popup; events are created and managed in the Discord server.
+ */
+export function UpcomingEventsCard() {
+	const { data: events, isLoading } = useUpcomingEvents()
+	const [selected, setSelected] = useState<DiscordScheduledEvent | null>(null)
+	const [dialogOpen, setDialogOpen] = useState(false)
+
+	const openEvent = (event: DiscordScheduledEvent) => {
+		setSelected(event)
+		setDialogOpen(true)
+	}
+
+	const list = events ?? []
+
+	return (
+		<>
+			<Card variant="default">
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2 text-xl md:text-2xl">
+						<CalendarDays className="h-5 w-5 text-primary" />
+						Upcoming Events
+					</CardTitle>
+					<CardDescription>Fleets, ops, and community events</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{isLoading ? (
+						<div className="space-y-2">
+							{Array.from({ length: 3 }).map((_, i) => (
+								<Skeleton key={i} className="h-12 w-full" />
+							))}
+						</div>
+					) : list.length === 0 ? (
+						<p className="text-sm text-muted-foreground">
+							No upcoming events. Events are scheduled in the Discord server.
+						</p>
+					) : (
+						<ul className="space-y-2">
+							{list.map((event) => (
+								<li key={event.id}>
+									<button
+										type="button"
+										onClick={() => openEvent(event)}
+										className="flex w-full flex-wrap items-center justify-between gap-2 rounded-md border bg-card/50 px-3 py-2 text-left transition-colors hover:bg-muted/50"
+									>
+										<span className="flex min-w-0 items-center gap-2">
+											<EventStatusBadge status={event.status} />
+											<span className="truncate font-medium text-foreground">
+												{event.name}
+											</span>
+										</span>
+										<span className="whitespace-nowrap text-right">
+											<span className="block text-sm text-muted-foreground">
+												{formatLocal(event.scheduledStartTime, {
+													weekday: 'short',
+													month: 'short',
+													day: 'numeric',
+													hour: '2-digit',
+													minute: '2-digit',
+												})}
+												{event.userCount !== null && event.userCount > 0 && (
+													<span className="ml-2">· {event.userCount} going</span>
+												)}
+											</span>
+											<span className="block text-xs text-muted-foreground/70">
+												{formatEveTime(event.scheduledStartTime)}
+											</span>
+										</span>
+									</button>
+								</li>
+							))}
+						</ul>
+					)}
+				</CardContent>
+			</Card>
+
+			<EventDetailDialog event={selected} open={dialogOpen} onOpenChange={setDialogOpen} />
+		</>
+	)
+}

--- a/apps/ui/src/client/features/events/format.ts
+++ b/apps/ui/src/client/features/events/format.ts
@@ -1,0 +1,61 @@
+/**
+ * Time formatting for events.
+ *
+ * Discord returns event times as absolute ISO-8601 instants. We show the
+ * viewer's local time alongside an EVE-time (UTC) hint, since EVE runs on
+ * UTC and fleet pings are typically written in EVE time.
+ */
+
+/** Format an ISO timestamp in the viewer's local timezone. */
+export function formatLocal(
+	iso: string,
+	options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' }
+): string {
+	return new Intl.DateTimeFormat(undefined, options).format(new Date(iso))
+}
+
+/** Format the EVE (UTC) time of an ISO timestamp, e.g. "20:00 EVE". */
+export function formatEveTime(iso: string): string {
+	const time = new Intl.DateTimeFormat('en-GB', {
+		hour: '2-digit',
+		minute: '2-digit',
+		timeZone: 'UTC',
+		hour12: false,
+	}).format(new Date(iso))
+	return `${time} EVE`
+}
+
+/**
+ * Full local date/time plus the EVE-time hint, e.g.
+ * "Sat, 8 Mar 2026, 20:00 (19:00 EVE)".
+ */
+export function formatLocalWithEve(
+	iso: string,
+	options?: Intl.DateTimeFormatOptions
+): string {
+	return `${formatLocal(iso, options)} (${formatEveTime(iso)})`
+}
+
+/** Human-readable relative time, e.g. "in 3 hours", "in 2 days". */
+export function formatRelative(iso: string): string {
+	const diffMs = new Date(iso).getTime() - Date.now()
+	if (diffMs <= 0) return 'in progress or started'
+
+	const minutes = Math.round(diffMs / 60000)
+	if (minutes < 60) return `in ${minutes} minute${minutes === 1 ? '' : 's'}`
+	const hours = Math.round(minutes / 60)
+	if (hours < 24) return `in ${hours} hour${hours === 1 ? '' : 's'}`
+	const days = Math.round(hours / 24)
+	return `in ${days} day${days === 1 ? '' : 's'}`
+}
+
+/** Human-readable duration between two ISO timestamps, e.g. "2h 30m". */
+export function formatDuration(startIso: string, endIso: string): string | null {
+	const ms = new Date(endIso).getTime() - new Date(startIso).getTime()
+	if (ms <= 0) return null
+	const minutes = Math.round(ms / 60000)
+	if (minutes < 60) return `${minutes} min`
+	const hours = Math.floor(minutes / 60)
+	const rem = minutes % 60
+	return rem === 0 ? `${hours}h` : `${hours}h ${rem}m`
+}

--- a/apps/ui/src/client/features/events/hooks.ts
+++ b/apps/ui/src/client/features/events/hooks.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { listUpcomingEvents } from './api'
+import { eventsKeys } from './query-keys'
+
+/** Discord events change infrequently; poll modestly. */
+const STALE_2M = 1000 * 60 * 2
+
+/**
+ * Upcoming (not-yet-finished) scheduled events from the main Discord server.
+ */
+export function useUpcomingEvents() {
+	return useQuery({
+		queryKey: eventsKeys.upcoming(),
+		queryFn: () => listUpcomingEvents(),
+		staleTime: STALE_2M,
+	})
+}

--- a/apps/ui/src/client/features/events/query-keys.ts
+++ b/apps/ui/src/client/features/events/query-keys.ts
@@ -1,0 +1,7 @@
+/**
+ * React Query keys for the Events feature.
+ */
+export const eventsKeys = {
+	all: ['events'] as const,
+	upcoming: () => [...eventsKeys.all, 'upcoming'] as const,
+}

--- a/apps/ui/src/client/features/events/types.ts
+++ b/apps/ui/src/client/features/events/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Client-side types for the Events feature.
+ *
+ * Events are owned by Discord — created and managed in the Discord client.
+ * Auth reads the main guild's scheduled events for display only. These
+ * shapes mirror what core's read-only /api/events endpoints return.
+ */
+
+/** Discord scheduled-event status codes. */
+export const EVENT_STATUS = {
+	SCHEDULED: 1,
+	ACTIVE: 2,
+	COMPLETED: 3,
+	CANCELED: 4,
+} as const
+
+export interface DiscordEventCreator {
+	id: string
+	username: string
+	displayName: string | null
+}
+
+export interface DiscordScheduledEvent {
+	id: string
+	guildId: string
+	name: string
+	description: string | null
+	/** ISO-8601 start time. */
+	scheduledStartTime: string
+	/** ISO-8601 end time. Null for channel-based (VOICE/STAGE) events. */
+	scheduledEndTime: string | null
+	/** Free-text location for EXTERNAL events; null otherwise. */
+	location: string | null
+	/** 1 SCHEDULED, 2 ACTIVE, 3 COMPLETED, 4 CANCELED. */
+	status: number
+	/** Subscribed/interested user count, when available. */
+	userCount: number | null
+	/** Cover image URL, or null when the event has no image. */
+	imageUrl: string | null
+	/** Who created the event, when available (raw Discord identity). */
+	creator: DiscordEventCreator | null
+	/**
+	 * The creator's EVE main character name, resolved by core from their
+	 * linked auth account. Null when the creator has not linked Discord.
+	 */
+	creatorMainCharacter: string | null
+}
+
+/** Build the public Discord URL for an event (opens in the Discord client/web). */
+export function discordEventUrl(event: Pick<DiscordScheduledEvent, 'guildId' | 'id'>): string {
+	return `https://discord.com/events/${event.guildId}/${event.id}`
+}

--- a/apps/ui/src/client/routes/dashboard.tsx
+++ b/apps/ui/src/client/routes/dashboard.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { DiscordCard } from '@/components/discord-card'
 import { LegacyCharacterCard } from '@/components/legacy-character-card'
 import { ServicesCard } from '@/components/services-card'
+import { UpcomingEventsCard } from '@/features/events/components/UpcomingEventsCard'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -467,6 +468,13 @@ export default function DashboardPage() {
 						</Card>
 					</div>
 				)}
+			</Section>
+
+			<div className="my-8" />
+
+			<Section>
+				{/* Upcoming Events */}
+				<UpcomingEventsCard />
 			</Section>
 
 			<div className="my-8" />

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -257,6 +257,44 @@ export interface DiscordRegisteredSlashCommand {
 	description: string
 }
 
+/**
+ * The creator of a Discord guild scheduled event.
+ */
+export interface DiscordEventCreator {
+	id: string
+	/** Discord username (e.g. "someuser"). */
+	username: string
+	/** Server/display name when set, otherwise null. */
+	displayName: string | null
+}
+
+/**
+ * A Discord guild scheduled event, as read from the Discord API.
+ *
+ * Discord is the source of truth for events: they are created and edited
+ * in the Discord client. Auth only reads them for display.
+ */
+export interface DiscordGuildScheduledEvent {
+	id: string
+	guildId: string
+	name: string
+	description: string | null
+	/** ISO-8601 start time. */
+	scheduledStartTime: string
+	/** ISO-8601 end time. Null for VOICE/STAGE events. */
+	scheduledEndTime: string | null
+	/** Free-text location for EXTERNAL events; null for channel-based events. */
+	location: string | null
+	/** Discord status: 1 SCHEDULED, 2 ACTIVE, 3 COMPLETED, 4 CANCELED. */
+	status: number
+	/** Number of users subscribed/interested, when available. */
+	userCount: number | null
+	/** Fully-qualified cover image URL, or null when the event has no image. */
+	imageUrl: string | null
+	/** The user who created the event, when available. */
+	creator: DiscordEventCreator | null
+}
+
 export interface Discord {
 	/**
 	 * Search linked core users by Discord username (case-insensitive, partial match)
@@ -426,6 +464,18 @@ export interface Discord {
 	 * Delete a channel message by ID
 	 */
 	deleteMessage(channelId: string, messageId: string): Promise<{ success: boolean; error?: string }>
+
+	/**
+	 * List a guild's scheduled events using the bot token.
+	 *
+	 * Discord is the source of truth for events; auth reads them for display
+	 * only. Events are created and managed in the Discord client.
+	 *
+	 * @param guildId - Discord guild ID
+	 * @returns The guild's scheduled events
+	 */
+	listGuildScheduledEvents(guildId: string): Promise<DiscordGuildScheduledEvent[]>
+
 
 	/**
 	 * Check which guilds a user is a member of using bot token

--- a/packages/discord/src/routes.ts
+++ b/packages/discord/src/routes.ts
@@ -32,6 +32,15 @@ export const DiscordRoutes = {
 	 * GET /guilds/{guildId}/members
 	 */
 	guildMembers: (guildId: string) => `/guilds/${guildId}/members`,
+
+	/**
+	 * Route for guild scheduled events.
+	 * GET /guilds/{guildId}/scheduled-events?with_user_count=true
+	 *
+	 * `with_user_count` makes Discord include the interested-user count.
+	 */
+	guildScheduledEvents: (guildId: string) =>
+		`/guilds/${guildId}/scheduled-events?with_user_count=true`,
 } as const
 
 export type DiscordRoutesType = typeof DiscordRoutes


### PR DESCRIPTION
showing Discord Events on Auth dashboard:
<img width="1630" height="1027" alt="image" src="https://github.com/user-attachments/assets/ed2c7c6e-bd5a-46b8-a6c0-5514a2666c07" />
<img width="796" height="629" alt="image" src="https://github.com/user-attachments/assets/2f8978c8-0ac9-4179-9f53-ffc1f24e2f63" />
