### PR TITLE
added permission urn:fleet-tracking:view-fleets

### DIFF
--- a/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
+++ b/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
@@ -154,7 +154,7 @@ describe('fleets tracking routes', () => {
 		})
 	})
 
-	it('scopes tracking list to self when user lacks view-all permission', async () => {
+	it('scopes tracking list to self when user lacks view-fleets permission', async () => {
 		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:create' }] as any)
 		fleetsStub.listTrackingSessions.mockResolvedValue({ items: [], total: 0 })
 		const app = createApp(makeUser({ id: 'self-user' }))
@@ -171,7 +171,26 @@ describe('fleets tracking routes', () => {
 		)
 	})
 
-	it('denies historical live detail to owner without view-all', async () => {
+	it('allows :view-fleets users to filter the tracking list by any userId', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([
+			{ urn: 'urn:fleet-tracking:view-fleets' },
+		] as any)
+		fleetsStub.listTrackingSessions.mockResolvedValue({ items: [], total: 0 })
+		const app = createApp(makeUser({ id: 'self-user' }))
+
+		const res = await app.request('/api/fleets/tracking?userId=other-user&limit=25&offset=0', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(fleetsStub.listTrackingSessions).toHaveBeenCalledWith(
+			expect.objectContaining({
+				startedByUserId: 'other-user',
+				limit: 25,
+				offset: 0,
+			})
+		)
+	})
+
+	it('denies historical live detail to owner without view-fleets', async () => {
 		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:create' }] as any)
 		fleetsStub.getTrackingSession.mockResolvedValue({
 			id: 's1',
@@ -185,6 +204,25 @@ describe('fleets tracking routes', () => {
 
 		expect(res.status).toBe(403)
 		expect(fleetsStub.getSessionLiveSnapshot).not.toHaveBeenCalled()
+	})
+
+	it('allows :view-fleets users to view ended sessions belonging to other users', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([
+			{ urn: 'urn:fleet-tracking:view-fleets' },
+		] as any)
+		fleetsStub.getTrackingSession.mockResolvedValue({
+			id: 's1',
+			status: 'ended',
+			startedByUserId: 'other-user',
+			characterId: '1001',
+		})
+		fleetsStub.getSessionLiveSnapshot.mockResolvedValue({ memberCount: 5 })
+
+		const app = createApp(makeUser({ id: 'user-1' }))
+		const res = await app.request('/api/fleets/tracking/s1/live', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(fleetsStub.getSessionLiveSnapshot).toHaveBeenCalledWith('s1')
 	})
 
 	it('allows active owner live detail access', async () => {

--- a/apps/core/src/routes/fleets.ts
+++ b/apps/core/src/routes/fleets.ts
@@ -353,25 +353,34 @@ app.delete('/quick-join/:token', async (c) => {
 // ============================================================================
 
 const FLEET_TRACKING_CREATE = 'urn:fleet-tracking:create'
+const FLEET_TRACKING_VIEW_FLEETS = 'urn:fleet-tracking:view-fleets'
 const FLEET_TRACKING_VIEW_ALL = 'urn:fleet-tracking:view-all'
 
 /**
  * Resolve the viewer's tracking permissions in one go.
- * Admin implies both perms.
+ * Admin implies every perm. :view-all implies :view-fleets (stats viewers
+ * always get session-detail visibility too).
  */
 async function resolveTrackingPerms(
 	c: Context<App>
-): Promise<{ canCreate: boolean; canViewAll: boolean; isAdmin: boolean }> {
+): Promise<{
+	canCreate: boolean
+	canViewFleets: boolean
+	canViewAll: boolean
+	isAdmin: boolean
+}> {
 	const user = c.get('user')!
 	const isAdmin = !!user.is_admin
 	if (isAdmin) {
-		return { canCreate: true, canViewAll: true, isAdmin: true }
+		return { canCreate: true, canViewFleets: true, canViewAll: true, isAdmin: true }
 	}
 	const userPerms = await getCachedUserPermissions(c.env, user.id)
 	const urns = new Set(userPerms.map((p) => p.urn))
+	const canViewAll = urns.has(FLEET_TRACKING_VIEW_ALL)
 	return {
 		canCreate: urns.has(FLEET_TRACKING_CREATE),
-		canViewAll: urns.has(FLEET_TRACKING_VIEW_ALL),
+		canViewFleets: canViewAll || urns.has(FLEET_TRACKING_VIEW_FLEETS),
+		canViewAll,
 		isAdmin: false,
 	}
 }
@@ -555,8 +564,8 @@ app.post('/tracking/:sessionId/kick-members', async (c) => {
  */
 app.get('/tracking', async (c) => {
 	const user = c.get('user')!
-	const { canCreate, canViewAll } = await resolveTrackingPerms(c)
-	if (!canCreate && !canViewAll) {
+	const { canCreate, canViewFleets } = await resolveTrackingPerms(c)
+	if (!canCreate && !canViewFleets) {
 		return c.json({ error: 'Fleet tracking is not available to you' }, 403)
 	}
 
@@ -582,7 +591,7 @@ app.get('/tracking', async (c) => {
 		offset: pagination.data.offset,
 	}
 
-	if (canViewAll) {
+	if (canViewFleets) {
 		if (userIdParam) filter.startedByUserId = userIdParam
 	} else {
 		// :create-only viewers see only their own sessions, regardless of query
@@ -622,14 +631,14 @@ async function resolveSessionAccess(
 	const session = await fleetsStub.getTrackingSession(sessionId)
 	if (!session) return c.json({ error: 'Session not found' }, 404)
 
-	const { canViewAll, isAdmin } = await resolveTrackingPerms(c)
+	const { canViewFleets, isAdmin } = await resolveTrackingPerms(c)
 	const isOwner = session.startedByUserId === user.id
 
-	if (!isOwner && !canViewAll && !isAdmin) {
+	if (!isOwner && !canViewFleets && !isAdmin) {
 		return c.json({ error: 'Session not found' }, 404)
 	}
 
-	const canViewDetail = canViewAll || isAdmin || (isOwner && session.status === 'active')
+	const canViewDetail = canViewFleets || isAdmin || (isOwner && session.status === 'active')
 	return { mode: 'allow', session, canViewDetail }
 }
 

--- a/apps/fleets/README.md
+++ b/apps/fleets/README.md
@@ -89,43 +89,44 @@ Note: fleet tracking authorization is enforced by the Core API routes in `apps/c
 
 ### Permission URNs
 
-- `urn:fleet-tracking:create`
-- `urn:fleet-tracking:view-all`
-- Site admins bypass both checks
+- `urn:fleet-tracking:create` — start tracking sessions for own characters; see own sessions.
+- `urn:fleet-tracking:view-fleets` — view all sessions (active + ended) and their detail tabs (live, current members, timeline, roster, ship-history, summary). Does NOT grant stats access.
+- `urn:fleet-tracking:view-all` — full access including stats / per-entity analytics. Implies `view-fleets`.
+- Site admins bypass all checks.
 
 ### Pages
 
-| Page | Site Admin | `view-all` | `create` | Notes |
-|---|---:|---:|---:|---|
-| `/fleet-tracking` | Yes | Yes | Yes | create-only users are scoped to their own sessions |
-| `/fleet-tracking/new` | Yes | Yes | Yes | Start submit requires character ownership |
-| `/fleet-tracking/stats` and stats details | Yes | Yes | No | Overview/search/corp stats are view-all only |
+| Page | Site Admin | `view-all` | `view-fleets` | `create` | Notes |
+|---|---:|---:|---:|---:|---|
+| `/fleet-tracking` | Yes | Yes | Yes | Yes | create-only users are scoped to their own sessions |
+| `/fleet-tracking/new` | Yes | Yes | No | Yes | Start submit requires character ownership |
+| `/fleet-tracking/stats` and stats details | Yes | Yes | No | No | Overview/search/corp stats are view-all only |
 
 ### API Endpoints (`/api/fleets/tracking*`)
 
-| Endpoint | Site Admin | `view-all` | `create` | Access rule |
-|---|---:|---:|---:|---|
-| `POST /tracking` | Yes | Yes | Yes | Must own selected character |
-| `GET /tracking` | Yes | Yes | Yes | create-only forced to own `startedByUserId` |
-| `GET /tracking/:sessionId` | Yes | Yes | Yes | create-only limited to own sessions |
-| `GET /tracking/:sessionId/live` | Yes | Yes | Conditional | create-only: own session + active |
-| `GET /tracking/:sessionId/current-members` | Yes | Yes | Conditional | create-only: own session + active |
-| `GET /tracking/:sessionId/timeline` | Yes | Yes | Conditional | create-only: own session + active |
-| `GET /tracking/:sessionId/members/:characterId/ship-history` | Yes | Yes | Conditional | create-only: own session + active |
-| `GET /tracking/:sessionId/roster` | Yes | Yes | Conditional | create-only: own session + active |
-| `GET /tracking/:sessionId/summary` | Yes | Yes | Yes | Owner/admin/view-all |
-| `DELETE /tracking/:sessionId` | Yes | No (unless owner) | No (unless owner) | Owner of active session or admin |
-| `POST /tracking/:sessionId/kick-members` | Yes | No (unless owner) | No (unless owner) | Owner of active session or admin |
+| Endpoint | Site Admin | `view-all` | `view-fleets` | `create` | Access rule |
+|---|---:|---:|---:|---:|---|
+| `POST /tracking` | Yes | No | No | Yes | Must own selected character |
+| `GET /tracking` | Yes | Yes | Yes | Yes | create-only forced to own `startedByUserId` |
+| `GET /tracking/:sessionId` | Yes | Yes | Yes | Yes | create-only limited to own sessions |
+| `GET /tracking/:sessionId/live` | Yes | Yes | Yes | Conditional | create-only: own session + active |
+| `GET /tracking/:sessionId/current-members` | Yes | Yes | Yes | Conditional | create-only: own session + active |
+| `GET /tracking/:sessionId/timeline` | Yes | Yes | Yes | Conditional | create-only: own session + active |
+| `GET /tracking/:sessionId/members/:characterId/ship-history` | Yes | Yes | Yes | Conditional | create-only: own session + active |
+| `GET /tracking/:sessionId/roster` | Yes | Yes | Yes | Conditional | create-only: own session + active |
+| `GET /tracking/:sessionId/summary` | Yes | Yes | Yes | Yes | Owner/admin/view-fleets |
+| `DELETE /tracking/:sessionId` | Yes | No (unless owner) | No (unless owner) | No (unless owner) | Owner of active session or admin |
+| `POST /tracking/:sessionId/kick-members` | Yes | No (unless owner) | No (unless owner) | No (unless owner) | Owner of active session or admin |
 
 ### Stats Endpoints (`/api/fleets/tracking/stats*`)
 
-| Endpoint | Site Admin | `view-all` | `create` | Access rule |
-|---|---:|---:|---:|---|
-| `GET /stats/overview` | Yes | Yes | No | view-all only |
-| `GET /stats/search` | Yes | Yes | No | view-all only |
-| `GET /stats/corporations/:corpId` | Yes | Yes | No | view-all only |
-| `GET /stats/characters/:characterId` | Yes | Yes | Yes (if own) | Own character unless view-all/admin |
-| `GET /stats/users/:userId` | Yes | Yes | Yes (if self) | Self unless view-all/admin |
+| Endpoint | Site Admin | `view-all` | `view-fleets` | `create` | Access rule |
+|---|---:|---:|---:|---:|---|
+| `GET /stats/overview` | Yes | Yes | No | No | view-all only |
+| `GET /stats/search` | Yes | Yes | No | No | view-all only |
+| `GET /stats/corporations/:corpId` | Yes | Yes | No | No | view-all only |
+| `GET /stats/characters/:characterId` | Yes | Yes | No | Yes (if own) | Own character unless view-all/admin |
+| `GET /stats/users/:userId` | Yes | Yes | No | Yes (if self) | Self unless view-all/admin |
 
 ### Related endpoint used by session details
 

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -285,6 +285,7 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 	const canSeeFleetTracking =
 		isSiteAdmin ||
 		hasAnyPermission('urn:fleet-tracking:create') ||
+		hasAnyPermission('urn:fleet-tracking:view-fleets') ||
 		hasAnyPermission('urn:fleet-tracking:view-all')
 	const canSeeFleetStats = isSiteAdmin || hasAnyPermission('urn:fleet-tracking:view-all')
 	if (canSeeFleetTracking) {

--- a/apps/ui/src/client/features/fleet-tracking/routes/character-stats.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/character-stats.tsx
@@ -15,7 +15,9 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { corporationLogoUrl } from '@/lib/eve-images'
 import { SessionStatsGrid } from '../components/session-stats-grid'
 import { ShipDistributionChart } from '../components/ship-distribution-chart'
@@ -27,10 +29,36 @@ export default function CharacterStats() {
 	const { characterId } = useParams<{ characterId: string }>()
 	usePageTitle('Character Stats')
 	const { range } = useRangeFromSearchParams()
+	const { user } = useAuth()
+	const { isAdmin, hasPermission } = useUserPermissions()
+	const canViewAll = isAdmin || hasPermission('urn:fleet-tracking:view-all')
+	const ownsCharacter = !!user?.characters.some((ch) => ch.characterId === characterId)
+	const canView = canViewAll || ownsCharacter
 
-	const { data, isLoading } = useCharacterStats(characterId, range)
+	const { data, isLoading } = useCharacterStats(canView ? characterId : undefined, range)
 
 	if (!characterId) return <Navigate to="/fleet-tracking/stats" replace />
+
+	if (!canView) {
+		return (
+			<Container>
+				<PageHeader
+					title="Character Stats"
+					action={
+						<Button asChild variant="ghost" size="sm">
+							<Link to="/fleet-tracking">
+								<ArrowLeft className="h-4 w-4" />
+								Fleet Tracking
+							</Link>
+						</Button>
+					}
+				/>
+				<div className="py-12 text-center text-muted-foreground">
+					You do not have permission to view this character's fleet tracking stats.
+				</div>
+			</Container>
+		)
+	}
 
 	return (
 		<Container>

--- a/apps/ui/src/client/features/fleet-tracking/routes/corporation-stats.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/corporation-stats.tsx
@@ -6,6 +6,7 @@ import { Container } from '@/components/ui/container'
 import { LoadingPage } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { RankingList } from '../components/ranking-list'
 import { SessionStatsGrid } from '../components/session-stats-grid'
 import { ShipDistributionChart } from '../components/ship-distribution-chart'
@@ -16,10 +17,34 @@ import { formatDuration } from '../utils/format'
 export default function CorporationStats() {
 	const { corpId } = useParams<{ corpId: string }>()
 	const { range } = useRangeFromSearchParams()
-	const { data, isLoading } = useCorporationStats(corpId, range)
+	const { isAdmin, hasPermission } = useUserPermissions()
+	const canView = isAdmin || hasPermission('urn:fleet-tracking:view-all')
+
+	const { data, isLoading } = useCorporationStats(canView ? corpId : undefined, range)
 	usePageTitle(data?.corporationName ? `${data.corporationName} — Corporation Stats` : 'Corporation Stats')
 
 	if (!corpId) return <Navigate to="/fleet-tracking/stats" replace />
+
+	if (!canView) {
+		return (
+			<Container>
+				<PageHeader
+					title="Corporation Stats"
+					action={
+						<Button asChild variant="ghost" size="sm">
+							<Link to="/fleet-tracking">
+								<ArrowLeft className="h-4 w-4" />
+								Fleet Tracking
+							</Link>
+						</Button>
+					}
+				/>
+				<div className="py-12 text-center text-muted-foreground">
+					You do not have permission to view corporation fleet tracking stats.
+				</div>
+			</Container>
+		)
+	}
 
 	return (
 		<Container>

--- a/apps/ui/src/client/features/fleet-tracking/routes/tracking-session-detail.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/tracking-session-detail.tsx
@@ -62,7 +62,8 @@ export default function TrackingSessionDetail() {
 
 	const isOwner = !!user && session.startedByUserId === user.id
 	const canViewAll = isAdmin || hasPermission('urn:fleet-tracking:view-all')
-	const canViewDetail = canViewAll || (isOwner && session.status === 'active')
+	const canViewFleets = canViewAll || hasPermission('urn:fleet-tracking:view-fleets')
+	const canViewDetail = canViewFleets || (isOwner && session.status === 'active')
 	const canStop = session.status === 'active' && (isOwner || isAdmin)
 
 	return (
@@ -541,8 +542,8 @@ function SummaryOnlyView({ sessionId }: { sessionId: string }) {
 						<p className="font-medium">Detailed history is restricted</p>
 						<p className="text-muted-foreground mt-1">
 							Viewing the member roster, full timeline, and ship-change events for ended sessions
-							requires the <code>urn:fleet-tracking:view-all</code> permission. Contact your alliance
-							leadership if you need access.
+							requires the <code>urn:fleet-tracking:view-fleets</code> permission. Contact your
+							alliance leadership if you need access.
 						</p>
 					</div>
 				</CardContent>

--- a/apps/ui/src/client/features/fleet-tracking/routes/tracking-sessions-list.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/tracking-sessions-list.tsx
@@ -51,6 +51,7 @@ export default function TrackingSessionsList() {
 	const { hasPermission, isAdmin } = useUserPermissions()
 	const canCreate = isAdmin || hasPermission('urn:fleet-tracking:create')
 	const canViewAll = isAdmin || hasPermission('urn:fleet-tracking:view-all')
+	const canViewFleets = canViewAll || hasPermission('urn:fleet-tracking:view-fleets')
 
 	const [tab, setTab] = useState<Tab>('all')
 	const [fromDate, setFromDate] = useState('')
@@ -99,7 +100,7 @@ export default function TrackingSessionsList() {
 						<CardTitle>Sessions</CardTitle>
 					</CardHeader>
 					<CardContent className="space-y-4">
-						{canViewAll && (
+						{canViewFleets && (
 							<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
 								<div className="xl:col-span-2">
 									<Select

--- a/apps/ui/src/client/features/fleet-tracking/routes/user-stats.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/user-stats.tsx
@@ -15,7 +15,9 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { SessionStatsGrid } from '../components/session-stats-grid'
 import { ShipDistributionChart } from '../components/ship-distribution-chart'
 import { StatsRangePicker, useRangeFromSearchParams } from '../components/stats-range-picker'
@@ -26,9 +28,36 @@ export default function UserStats() {
 	const { userId } = useParams<{ userId: string }>()
 	usePageTitle('User Stats')
 	const { range } = useRangeFromSearchParams()
-	const { data, isLoading } = useUserStats(userId, range)
+	const { user } = useAuth()
+	const { isAdmin, hasPermission } = useUserPermissions()
+	const canViewAll = isAdmin || hasPermission('urn:fleet-tracking:view-all')
+	const isSelf = !!user && user.id === userId
+	const canView = canViewAll || isSelf
+
+	const { data, isLoading } = useUserStats(canView ? userId : undefined, range)
 
 	if (!userId) return <Navigate to="/fleet-tracking/stats" replace />
+
+	if (!canView) {
+		return (
+			<Container>
+				<PageHeader
+					title="User Stats"
+					action={
+						<Button asChild variant="ghost" size="sm">
+							<Link to="/fleet-tracking">
+								<ArrowLeft className="h-4 w-4" />
+								Fleet Tracking
+							</Link>
+						</Button>
+					}
+				/>
+				<div className="py-12 text-center text-muted-foreground">
+					You do not have permission to view this user's fleet tracking stats.
+				</div>
+			</Container>
+		)
+	}
 
 	const mainName =
 		data?.perCharacter.find((p) => p.is_primary)?.characterName ??


### PR DESCRIPTION
at the request of Panda / Rad added urn:fleet-tracking:view-fleets to allow Strat FCs to be given access to fleets/sessions and their details after they ended but not the stats pages