### PR TITLE
fix director health verificatin

### DIFF
--- a/apps/core/src/routes/corporations/directors-routes.ts
+++ b/apps/core/src/routes/corporations/directors-routes.ts
@@ -311,7 +311,9 @@ app.post('/:corporationId/directors/verify-all', requireAuth(), requireAdmin(), 
 
 	try {
 		const stub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
-		const result = await stub.verifyAllDirectorsHealth(corporationId)
+		const result = await stub.verifyAllDirectorsHealth(corporationId, {
+			includePermanent: true,
+		})
 		const healthyCount = await syncManagedCorporationDirectorHealth(db, c.env, corporationId)
 
 		return c.json({

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -944,7 +944,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 * Verify health of all directors
 	 */
 	async verifyAllDirectorsHealth(
-		corporationId: string
+		corporationId: string,
+		options?: { includePermanent?: boolean; bypassPermanentFailures?: boolean }
 	): Promise<{ verified: number; failed: number }> {
 		const tokenStoreStub = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const directorManager = new DirectorManager(
@@ -953,7 +954,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			tokenStoreStub,
 			this.onDirectorAffiliationMismatch.bind(this)
 		)
-		const result = await directorManager.verifyAllDirectorsHealth()
+		const result = await directorManager.verifyAllDirectorsHealth(options)
 
 		// Invalidate cache so next fetch returns fresh data
 		await this.invalidateDirectorsCache(corporationId)

--- a/apps/eve-corporation-data/src/services/director-manager.ts
+++ b/apps/eve-corporation-data/src/services/director-manager.ts
@@ -357,8 +357,7 @@ export class DirectorManager {
 	private async checkAffiliation(
 		characterId: string
 	): Promise<{ matches: boolean; corporationId: string | null }> {
-		const numericCharacterId = Number.parseInt(characterId, 10)
-		if (!Number.isFinite(numericCharacterId)) {
+		if (!characterId) {
 			return { matches: false, corporationId: null }
 		}
 
@@ -387,12 +386,24 @@ export class DirectorManager {
 			throw new Error(`Director affiliation lookup failed for character ${characterId}: ${message}`)
 		}
 
+		logger.debug('[DirectorManager] Affiliation lookup response received', {
+			corporationId: this.corporationId,
+			characterId,
+			responseCount: affiliations.length,
+			responseSample: affiliations.slice(0, 3).map((entry) => ({
+				characterId: entry.character_id,
+				corporationId: entry.corporation_id,
+				allianceId: entry.alliance_id ?? null,
+				factionId: entry.faction_id ?? null,
+			})),
+		})
+
 		if (!Array.isArray(affiliations) || affiliations.length === 0) {
 			throw new Error(
 				`Director affiliation lookup returned no affiliations for character ${characterId}`
 			)
 		}
-		const affiliation = affiliations.find((entry) => entry.character_id === numericCharacterId)
+		const affiliation = affiliations.find((entry) => entry.character_id === Number.parseInt(characterId, 10))
 		if (!affiliation) {
 			throw new Error(
 				`Director affiliation lookup did not include character ${characterId}`
@@ -400,6 +411,11 @@ export class DirectorManager {
 		}
 
 		const corporationId = String(affiliation.corporation_id)
+		logger.debug('[DirectorManager] Affiliation lookup matched character', {
+			corporationId: this.corporationId,
+			characterId,
+			matchedCorporationId: corporationId,
+		})
 		return {
 			matches: corporationId === this.corporationId,
 			corporationId,
@@ -410,7 +426,7 @@ export class DirectorManager {
 		directorId: string
 		characterId: string
 		actualCorporationId: string | null
-		context: 'select-director' | 'verify-director-health'
+		context: 'select-director' | 'verify-director-health' | 'verify-all-permanent-affiliation'
 	}): Promise<void> {
 		const reason = `Director affiliation mismatch: expected corporation ${this.corporationId}, got ${params.actualCorporationId ?? 'unknown'}`
 
@@ -507,6 +523,31 @@ export class DirectorManager {
 				reason,
 				error: error instanceof Error ? error.message : String(error),
 			})
+		}
+	}
+
+	private async verifyPermanentDirectorAffiliation(directorId: string): Promise<void> {
+		const director = await this.db.query.corporationDirectors.findFirst({
+			where: eq(corporationDirectors.id, directorId),
+		})
+
+		if (!director) {
+			return
+		}
+
+		try {
+			const affiliationCheck = await this.checkAffiliation(String(director.characterId))
+			if (!affiliationCheck.matches) {
+				await this.handleAffiliationMismatch({
+					directorId,
+					characterId: String(director.characterId),
+					actualCorporationId: affiliationCheck.corporationId,
+					context: 'verify-all-permanent-affiliation',
+				})
+				return
+			}
+		} catch (error) {
+			return
 		}
 	}
 
@@ -913,8 +954,20 @@ export class DirectorManager {
 	/**
 	 * Verify health of all directors
 	 */
-	async verifyAllDirectorsHealth(): Promise<{ verified: number; failed: number }> {
+	async verifyAllDirectorsHealth(options?: {
+		includePermanent?: boolean
+		bypassPermanentFailures?: boolean
+	}): Promise<{ verified: number; failed: number }> {
 		const directors = await this.getAllDirectors()
+		const now = Date.now()
+		const includePermanent = options?.includePermanent ?? false
+		const bypassPermanentFailures = options?.bypassPermanentFailures ?? false
+
+		const activeDirectors = directors.filter((director) => {
+			if (!includePermanent && this.isPermanentlyFailed(director)) return false
+			if (director.nextRetryAt && director.nextRetryAt.getTime() > now) return false
+			return true
+		})
 
 		for (const director of directors) {
 			if (this.shouldForcePermanentDueToStaleness(director)) {
@@ -932,22 +985,34 @@ export class DirectorManager {
 			}
 		}
 
-		const now = Date.now()
-		const nonPermanentDirectors = directors.filter((director) => {
-			if (this.isPermanentlyFailed(director)) return false
-			if (director.nextRetryAt && director.nextRetryAt.getTime() > now) return false
-			return true
-		})
+		const nonPermanentDirectors = activeDirectors
+		const permanentDirectorsToAffiliationCheck =
+			!includePermanent && bypassPermanentFailures
+				? directors.filter(
+						(director) =>
+							this.isPermanentlyFailed(director) &&
+							!(director.nextRetryAt && director.nextRetryAt.getTime() > now)
+					)
+				: []
 
-		// Run all verifications in parallel
 		const results = await Promise.allSettled(
-			nonPermanentDirectors.map((director) => this.verifyDirectorHealth(director.directorId))
+			nonPermanentDirectors.map(async (director) => {
+				return await this.verifyDirectorHealth(director.directorId)
+			})
 		)
+
+		if (permanentDirectorsToAffiliationCheck.length > 0) {
+			await Promise.allSettled(
+				permanentDirectorsToAffiliationCheck.map(async (director) => {
+					await this.verifyPermanentDirectorAffiliation(director.directorId)
+					return true
+				})
+			)
+		}
 
 		// Count verified vs failed
 		let verified = 0
 		let failed = 0
-
 		for (const result of results) {
 			if (result.status === 'fulfilled' && result.value === true) {
 				verified++

--- a/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
@@ -685,4 +685,89 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 			})
 		)
 	})
+
+	it('re-tests permanent directors when includePermanent is enabled', async () => {
+		const where = vi.fn().mockResolvedValue(undefined)
+		const set = vi.fn().mockReturnValue({ where })
+		const update = vi.fn().mockReturnValue({ set })
+		const manager = new DirectorManager(
+			{ update } as never,
+			'98000001',
+			{} as never
+		)
+
+		const verifyDirectorHealth = vi.spyOn(manager, 'verifyDirectorHealth').mockResolvedValue(true)
+
+		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue([
+			{
+				directorId: 'dir-1',
+				characterId: '111',
+				characterName: 'Permanent',
+				isHealthy: false,
+				lastHealthCheck: null,
+				lastUsed: null,
+				failureCount: 3,
+				lastFailureReason: '[PERMANENT] Director affiliation mismatch: expected corporation 98000001, got 98000002',
+				nextRetryAt: null,
+				permanentFailureAt: new Date(),
+				priority: 1,
+			},
+		])
+
+		const result = await manager.verifyAllDirectorsHealth({ includePermanent: true })
+
+		expect(verifyDirectorHealth).toHaveBeenCalledWith('dir-1')
+		expect(result).toEqual({ verified: 1, failed: 0 })
+		expect(set).toHaveBeenCalledWith(
+			expect.objectContaining({
+				isVerified: true,
+			})
+		)
+	})
+
+	it('checks affiliation for permanent directors when permanent affiliation checks are enabled', async () => {
+		const where = vi.fn().mockResolvedValue(undefined)
+		const set = vi.fn().mockReturnValue({ where })
+		const update = vi.fn().mockReturnValue({ set })
+		const manager = new DirectorManager(
+			{ update } as never,
+			'98000001',
+			{} as never
+		)
+
+		const verifyDirectorHealth = vi.spyOn(manager, 'verifyDirectorHealth').mockResolvedValue(true)
+		const checkAffiliation = vi.spyOn(manager as any, 'checkAffiliation').mockResolvedValue({
+			matches: true,
+			corporationId: '98000001',
+		})
+
+		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue([
+			{
+				directorId: 'dir-1',
+				characterId: '111',
+				characterName: 'Permanent',
+				isHealthy: false,
+				lastHealthCheck: null,
+				lastUsed: null,
+				failureCount: 3,
+				lastFailureReason: '[PERMANENT] Director token expired and could not be refreshed. Re-authenticate this character.',
+				nextRetryAt: null,
+				permanentFailureAt: new Date(),
+				priority: 1,
+			},
+		])
+
+		const result = await manager.verifyAllDirectorsHealth({
+			bypassPermanentFailures: true,
+		})
+
+		expect(verifyDirectorHealth).not.toHaveBeenCalled()
+		expect(checkAffiliation).toHaveBeenCalledWith('111')
+		expect(result).toEqual({ verified: 0, failed: 1 })
+		expect(set).toHaveBeenCalledWith(
+			expect.objectContaining({
+				isVerified: false,
+			})
+		)
+	})
 })

--- a/apps/eve-corporation-data/src/workflows/steps/directors/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/directors/index.ts
@@ -70,7 +70,9 @@ export async function verifyAllDirectorsHealth(
 	corporationId: string
 ): Promise<{ verified: number; failed: number }> {
 	const directorManager = createDirectorManager(env, corporationId)
-	return await directorManager.verifyAllDirectorsHealth()
+	return await directorManager.verifyAllDirectorsHealth({
+		bypassPermanentFailures: true,
+	})
 }
 
 type EsiCorporationMemberRole = {

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -1697,6 +1697,17 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			String(normalizedIds[0]),
 			normalizedIds.map(String),
 			{ cacheMode: 'no-store' }
+		).then((affiliations) =>
+			affiliations.map((affiliation) => ({
+				character_id: Number.parseInt(String(affiliation.character_id), 10),
+				corporation_id: Number.parseInt(String(affiliation.corporation_id), 10),
+				alliance_id: affiliation.alliance_id
+					? Number.parseInt(String(affiliation.alliance_id), 10)
+					: undefined,
+				faction_id: affiliation.faction_id
+					? Number.parseInt(String(affiliation.faction_id), 10)
+					: undefined,
+			}))
 		)
 	}
 

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -958,9 +958,13 @@ export interface EveCorporationData {
 	/**
 	 * Verify health of all directors
 	 * @param corporationId - The corporation ID
+	 * @param options - Verification behavior flags
 	 * @returns Count of verified and failed directors
 	 */
-	verifyAllDirectorsHealth(corporationId: string): Promise<{ verified: number; failed: number }>
+	verifyAllDirectorsHealth(
+		corporationId: string,
+		options?: { includePermanent?: boolean; bypassPermanentFailures?: boolean }
+	): Promise<{ verified: number; failed: number }>
 
 	// ========================================================================
 	// STORAGE-ONLY METHODS (for workflow use)

--- a/packages/eve-token-store/src/index.ts
+++ b/packages/eve-token-store/src/index.ts
@@ -263,8 +263,10 @@ export interface EsiAlliance {
 }
 
 /**
- * ESI Character Affiliation response entry
- * https://esi.evetech.net/ui/#/Character/post_characters_affiliation
+ * Character Affiliation response entry.
+ *
+ * This matches the normalized contract we expose to callers and keeps the
+ * affiliation shape consistent with the rest of the codebase that consumes it.
  */
 export interface EsiCharacterAffiliation {
 	/** Character ID */


### PR DESCRIPTION
admins include the permanently failed directors when running manual verification