### PR TITLE
Allow CEOs/directors to view fleet stats

### DIFF
--- a/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
+++ b/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getStub } from '@repo/do-utils'
 
 import fleetsRoutes from '../fleets'
+import { createDb } from '../../db'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 
 import type { SessionUser } from '../../context'
+import type * as DbModule from '../../db'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
@@ -25,8 +27,29 @@ vi.mock('../../lib/groups-cache', () => ({
 	getCachedCharacterPermissions: vi.fn(),
 }))
 
+// Preserve the real Drizzle `schema` (table definitions, no DB connection) but
+// stub `createDb` so the corp-stats handler doesn't hit a real database.
+vi.mock('../../db', async (importOriginal) => {
+	const actual = await importOriginal<typeof DbModule>()
+	return { ...actual, createDb: vi.fn() }
+})
+
 const getStubMock = vi.mocked(getStub)
 const getCachedUserPermissionsMock = vi.mocked(getCachedUserPermissions)
+const createDbMock = vi.mocked(createDb)
+
+/**
+ * Chainable Drizzle `select().from().where().limit()` stub that resolves to the
+ * provided rows. Used for the corp-name lookup in the corp-stats handler.
+ */
+function makeDbStub(rows: unknown[]): any {
+	const chain = {
+		from: () => chain,
+		where: () => chain,
+		limit: () => Promise.resolve(rows),
+	}
+	return { select: () => chain }
+}
 
 function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 	return {
@@ -69,9 +92,12 @@ function createApp(user: SessionUser) {
 
 describe('fleets tracking routes', () => {
 	const env = {
+		DATABASE_URL: 'postgres://test',
 		FLEETS: { name: 'FLEETS' },
 		BROADCASTS: { name: 'BROADCASTS' },
 		ESI_TYPE_RESOLVER: { name: 'ESI_TYPE_RESOLVER' },
+		EVE_CORPORATION_DATA: { name: 'EVE_CORPORATION_DATA' },
+		EVE_CHARACTER_DATA: { name: 'EVE_CHARACTER_DATA' },
 	} as any
 
 	let fleetsStub: {
@@ -83,11 +109,18 @@ describe('fleets tracking routes', () => {
 		getSessionRoster: ReturnType<typeof vi.fn>
 		getSessionSummary: ReturnType<typeof vi.fn>
 		getStatsOverview: ReturnType<typeof vi.fn>
+		getCharactersByCorpInWindow: ReturnType<typeof vi.fn>
+		getStatsForCharacters: ReturnType<typeof vi.fn>
 	}
 	let broadcastsStub: {
 		getBroadcastByFleetSessionId: ReturnType<typeof vi.fn>
 	}
 	let resolverStub: { resolveIds: ReturnType<typeof vi.fn> }
+	let corpDataStub: {
+		getCorporationInfo: ReturnType<typeof vi.fn>
+		getDirectors: ReturnType<typeof vi.fn>
+	}
+	let charDataStub: { getCharacterInfo: ReturnType<typeof vi.fn> }
 
 	beforeEach(() => {
 		vi.clearAllMocks()
@@ -101,6 +134,8 @@ describe('fleets tracking routes', () => {
 			getSessionRoster: vi.fn(),
 			getSessionSummary: vi.fn(),
 			getStatsOverview: vi.fn(),
+			getCharactersByCorpInWindow: vi.fn().mockResolvedValue([]),
+			getStatsForCharacters: vi.fn().mockResolvedValue({}),
 		}
 		broadcastsStub = {
 			getBroadcastByFleetSessionId: vi.fn().mockResolvedValue(null),
@@ -108,11 +143,23 @@ describe('fleets tracking routes', () => {
 		resolverStub = {
 			resolveIds: vi.fn().mockResolvedValue({ '1001': 'Pilot One' }),
 		}
+		corpDataStub = {
+			getCorporationInfo: vi.fn().mockResolvedValue(null),
+			getDirectors: vi.fn().mockResolvedValue([]),
+		}
+		charDataStub = {
+			getCharacterInfo: vi.fn().mockResolvedValue(null),
+		}
+
+		// Default: corp-name lookup returns one row.
+		createDbMock.mockReturnValue(makeDbStub([{ name: 'Test Corp' }]))
 
 		getStubMock.mockImplementation((binding: unknown) => {
 			if (binding === env.FLEETS) return fleetsStub as any
 			if (binding === env.BROADCASTS) return broadcastsStub as any
 			if (binding === env.ESI_TYPE_RESOLVER) return resolverStub as any
+			if (binding === env.EVE_CORPORATION_DATA) return corpDataStub as any
+			if (binding === env.EVE_CHARACTER_DATA) return charDataStub as any
 			throw new Error('Unexpected binding')
 		})
 	})
@@ -379,5 +426,101 @@ describe('fleets tracking routes', () => {
 				srpToken: 'token-123',
 			},
 		})
+	})
+
+	// ------------------------------------------------------------------
+	// Corp stats access: view-all/admin OR corp self-service (CEO/Director).
+	// Each case uses distinct user + corp ids to avoid the module-level
+	// 60s self-service cache (keyed by `${user.id}:${corporationId}`) and the
+	// 5min response cache (keyed by corpId) bleeding across tests.
+	// ------------------------------------------------------------------
+
+	function makeLeaderUser(id: string, characterId: string): SessionUser {
+		return makeUser({
+			id,
+			characters: [
+				{
+					id: 'uc-lead',
+					characterOwnerHash: `hash-${characterId}`,
+					characterId,
+					characterName: 'Leader',
+					is_primary: true,
+					hasValidToken: true,
+				},
+			],
+		})
+	}
+
+	it('allows a corp CEO to view their own corp stats without view-all', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '2001' })
+		charDataStub.getCharacterInfo.mockResolvedValue({ corporationId: '500' })
+
+		const app = createApp(makeLeaderUser('ceo-user', '2001'))
+		const res = await app.request('/api/fleets/tracking/stats/corporations/500', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(fleetsStub.getCharactersByCorpInWindow).toHaveBeenCalledWith('500', expect.anything())
+	})
+
+	it('allows a corp Director to view their own corp stats without view-all', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' })
+		corpDataStub.getDirectors.mockResolvedValue([{ characterId: '2002' }])
+		charDataStub.getCharacterInfo.mockResolvedValue({ corporationId: '501' })
+
+		const app = createApp(makeLeaderUser('director-user', '2002'))
+		const res = await app.request('/api/fleets/tracking/stats/corporations/501', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(fleetsStub.getCharactersByCorpInWindow).toHaveBeenCalledWith('501', expect.anything())
+	})
+
+	it('denies a plain corp member (not CEO/Director) from corp stats', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' })
+		corpDataStub.getDirectors.mockResolvedValue([])
+		charDataStub.getCharacterInfo.mockResolvedValue({ corporationId: '502' })
+
+		const app = createApp(makeLeaderUser('member-user', '2003'))
+		const res = await app.request('/api/fleets/tracking/stats/corporations/502', {}, env)
+
+		expect(res.status).toBe(403)
+		expect(fleetsStub.getCharactersByCorpInWindow).not.toHaveBeenCalled()
+	})
+
+	it('denies a CEO of a different corp from viewing another corp stats', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		// CEO of their own corp (600), but they request corp 503.
+		corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '2004' })
+		charDataStub.getCharacterInfo.mockResolvedValue({ corporationId: '600' })
+
+		const app = createApp(makeLeaderUser('other-corp-ceo', '2004'))
+		const res = await app.request('/api/fleets/tracking/stats/corporations/503', {}, env)
+
+		expect(res.status).toBe(403)
+		expect(fleetsStub.getCharactersByCorpInWindow).not.toHaveBeenCalled()
+	})
+
+	it('still allows view-all viewers to see any corp stats (no corp-leadership lookup)', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:view-all' }] as any)
+
+		const app = createApp(makeUser({ id: 'viewall-user' }))
+		const res = await app.request('/api/fleets/tracking/stats/corporations/504', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(fleetsStub.getCharactersByCorpInWindow).toHaveBeenCalledWith('504', expect.anything())
+		// Org-wide viewers short-circuit before any corp Durable Object lookup.
+		expect(corpDataStub.getCorporationInfo).not.toHaveBeenCalled()
+	})
+
+	it('still allows site admins to see any corp stats (no corp-leadership lookup)', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+
+		const app = createApp(makeUser({ id: 'admin-user', is_admin: true }))
+		const res = await app.request('/api/fleets/tracking/stats/corporations/505', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(corpDataStub.getCorporationInfo).not.toHaveBeenCalled()
 	})
 })

--- a/apps/core/src/routes/fleets.ts
+++ b/apps/core/src/routes/fleets.ts
@@ -11,6 +11,7 @@ import { createDb, schema } from '../db'
 import { getCachedCharacterPermissions, getCachedUserPermissions } from '../lib/groups-cache'
 import { validatePagination } from '../lib/validation'
 import { requireAuth } from '../middleware/session'
+import { hasCorporationSelfServiceAccess } from '../middleware/tax-permissions'
 
 import type { EsiTypeResolver } from '@repo/esi'
 import type { Broadcasts } from '@repo/broadcasts'
@@ -1438,13 +1439,21 @@ app.get('/tracking/stats/users/:userId', async (c) => {
  * Per-corporation stats (current members). Requires :view-all.
  */
 app.get('/tracking/stats/corporations/:corpId', async (c) => {
+	const corpId = c.req.param('corpId')
 	const { canViewAll } = await resolveTrackingPerms(c)
-	if (!canViewAll) return c.json({ error: 'view-all required' }, 403)
+	// Org-wide viewers/admins see any corp; otherwise fall back to corp
+	// self-service (CEO/Director of this specific corp). The short-circuit
+	// keeps view-all viewers from paying the extra Durable Object lookups.
+	const user = c.get('user')!
+	const isCorpLeader =
+		canViewAll || (await hasCorporationSelfServiceAccess(c.env, user, corpId))
+	if (!isCorpLeader) {
+		return c.json({ error: 'Not authorized to view this corporation' }, 403)
+	}
 
 	const rangeResult = parseStatsRange(c)
 	if (!rangeResult.success) return c.json({ error: rangeResult.error }, 400)
 	const range = rangeResult.data
-	const corpId = c.req.param('corpId')
 	const fleetsStub = getStub<Fleets>(c.env.FLEETS, 'default')
 
 	const data = await withStatsCache(c, 'view-all', async () => {

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -138,6 +138,14 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 	const pendingCount = invitations?.length || 0
 	const mainCharacter = user?.characters.find((c) => c.characterId === user.mainCharacterId)
 	const canSeeMumble = isMumbleFeatureEnabled && canAccessMumble(user)
+	const hasMemberCorporationAccess = hrCorporations?.some((corp) => corp.isMemberCorporation) ?? false
+	const canSeeFleetTrackingList =
+		isSiteAdmin ||
+		hasAnyPermission('urn:fleet-tracking:create') ||
+		hasAnyPermission('urn:fleet-tracking:view-fleets') ||
+		hasAnyPermission('urn:fleet-tracking:view-all')
+	const canSeeFleetTrackingStats =
+		isSiteAdmin || hasAnyPermission('urn:fleet-tracking:view-all') || hasMemberCorporationAccess
 	const isTaxRoute = location.pathname === '/tax' || location.pathname.startsWith('/tax/')
 	const isFreightRoute =
 		location.pathname === '/freight' || location.pathname.startsWith('/freight/')
@@ -191,6 +199,12 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 			setOpenMenus((prev) => ({ ...prev, '#hr': true }))
 		}
 	}, [isHrRoute, canSeeAllianceMemberNav])
+
+	useEffect(() => {
+		if (location.pathname.startsWith('/fleet-tracking')) {
+			setOpenMenus((prev) => ({ ...prev, '/fleet-tracking': true }))
+		}
+	}, [location.pathname])
 
 	const navItems: SidebarNavItem[] = [
 		{
@@ -262,6 +276,23 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 		})
 	}
 
+	if (canSeeFleetTrackingList || canSeeFleetTrackingStats) {
+		const fleetTrackingItems: SidebarNavItem[] = []
+		if (canSeeFleetTrackingList) {
+			fleetTrackingItems.push({ label: 'Fleets', href: '/fleet-tracking' })
+		}
+		if (canSeeFleetTrackingStats) {
+			fleetTrackingItems.push({ label: 'Statistics', href: '/fleet-tracking/stats' })
+		}
+
+		navItems.push({
+			label: 'Fleet Tracking',
+			href: canSeeFleetTrackingList ? '/fleet-tracking' : '/fleet-tracking/stats',
+			icon: Radar,
+			children: fleetTrackingItems.length > 0 ? fleetTrackingItems : undefined,
+		})
+	}
+
 	if (canSeeAllianceMemberNav) {
 		navItems.push(
 			{
@@ -301,26 +332,6 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 				icon: Swords,
 			},
 		)
-
-		const canSeeFleetTracking =
-			isSiteAdmin ||
-			hasAnyPermission('urn:fleet-tracking:create') ||
-			hasAnyPermission('urn:fleet-tracking:view-fleets') ||
-			hasAnyPermission('urn:fleet-tracking:view-all')
-		const canSeeFleetStats = isSiteAdmin || hasAnyPermission('urn:fleet-tracking:view-all')
-		if (canSeeFleetTracking) {
-			navItems.push({
-				label: 'Fleet Tracking',
-				href: '/fleet-tracking',
-				icon: Radar,
-				children: canSeeFleetStats
-					? [
-							{ label: 'Fleets', href: '/fleet-tracking' },
-							{ label: 'Statistics', href: '/fleet-tracking/stats' },
-						]
-					: undefined,
-			})
-		}
 
 		navItems.push(
 			{

--- a/apps/ui/src/client/features/fleet-tracking/hooks.ts
+++ b/apps/ui/src/client/features/fleet-tracking/hooks.ts
@@ -177,11 +177,15 @@ export const fleetStatsKeys = {
 
 const STATS_STALE_TIME = 60_000
 
-export function useStatsOverview(range?: Partial<StatsRange>) {
+export function useStatsOverview(
+	range?: Partial<StatsRange>,
+	options?: { enabled?: boolean }
+) {
 	return useQuery({
 		queryKey: fleetStatsKeys.overview(range),
 		queryFn: () => fleetTrackingApi.getStatsOverview(range),
 		staleTime: STATS_STALE_TIME,
+		enabled: options?.enabled ?? true,
 	})
 }
 
@@ -205,12 +209,13 @@ export function useUserStats(userId: string | undefined, range?: Partial<StatsRa
 
 export function useCorporationStats(
 	corporationId: string | undefined,
-	range?: Partial<StatsRange>
+	range?: Partial<StatsRange>,
+	options?: { enabled?: boolean }
 ) {
 	return useQuery({
 		queryKey: fleetStatsKeys.corporation(corporationId ?? '', range),
 		queryFn: () => fleetTrackingApi.getCorporationStats(corporationId!, range),
-		enabled: !!corporationId,
+		enabled: options?.enabled ?? !!corporationId,
 		staleTime: STATS_STALE_TIME,
 	})
 }

--- a/apps/ui/src/client/features/fleet-tracking/routes/corporation-stats.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/corporation-stats.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Container } from '@/components/ui/container'
 import { LoadingPage } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
+import { useCorporationAccess } from '@/features/corporations'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { RankingList } from '../components/ranking-list'
@@ -18,12 +19,23 @@ export default function CorporationStats() {
 	const { corpId } = useParams<{ corpId: string }>()
 	const { range } = useRangeFromSearchParams()
 	const { isAdmin, hasPermission } = useUserPermissions()
-	const canView = isAdmin || hasPermission('urn:fleet-tracking:view-all')
+	const canViewAll = isAdmin || hasPermission('urn:fleet-tracking:view-all')
+	const { data: corporationAccess, isLoading: corporationAccessLoading } = useCorporationAccess()
+	const memberCorporation = corporationAccess?.corporations.find(
+		(corp) => corp.corporationId === corpId && corp.isMemberCorporation
+	)
+	const canView = canViewAll || !!memberCorporation
 
-	const { data, isLoading } = useCorporationStats(canView ? corpId : undefined, range)
+	const { data, isLoading } = useCorporationStats(canView ? corpId : undefined, range, {
+		enabled: canView,
+	})
 	usePageTitle(data?.corporationName ? `${data.corporationName} — Corporation Stats` : 'Corporation Stats')
 
 	if (!corpId) return <Navigate to="/fleet-tracking/stats" replace />
+
+	if (!canView && corporationAccessLoading) {
+		return <LoadingPage />
+	}
 
 	if (!canView) {
 		return (

--- a/apps/ui/src/client/features/fleet-tracking/routes/stats-overview.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/stats-overview.tsx
@@ -5,6 +5,7 @@ import { Container } from '@/components/ui/container'
 import { LoadingPage } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
 import { Section } from '@/components/ui/section'
+import { useCorporationAccess } from '@/features/corporations'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { corporationLogoUrl } from '@/lib/eve-images'
@@ -20,16 +21,65 @@ export default function StatsOverview() {
 	usePageTitle('Fleet Tracking — Stats')
 	const { isAdmin, hasPermission } = useUserPermissions()
 	const canView = isAdmin || hasPermission('urn:fleet-tracking:view-all')
+	const { data: corporationAccess, isLoading: corporationAccessLoading } = useCorporationAccess()
 	const { range } = useRangeFromSearchParams()
+	const memberCorporations =
+		corporationAccess?.corporations.filter((corp) => corp.isMemberCorporation) ?? []
+	const canViewMemberCorporationStats = !canView && memberCorporations.length > 0
 
-	const { data, isLoading, isError } = useStatsOverview(range)
+	const { data, isLoading, isError } = useStatsOverview(range, { enabled: canView })
 
-	if (!canView) {
+	if (!canView && corporationAccessLoading) {
+		return <LoadingPage />
+	}
+
+	if (!canView && !canViewMemberCorporationStats) {
 		return (
 			<Container>
 				<div className="py-12 text-center text-muted-foreground">
 					You do not have permission to view fleet tracking statistics.
 				</div>
+			</Container>
+		)
+	}
+
+	if (canViewMemberCorporationStats) {
+		return (
+			<Container>
+				<PageHeader
+					title="Fleet Tracking — Statistics"
+					description="Choose one of your corporations to view fleet stats."
+				/>
+
+				<Section>
+					<Card>
+						<CardHeader className="pb-3">
+							<CardTitle>Your Corporations</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+								{memberCorporations.map((corp) => (
+									<Link
+										key={corp.corporationId}
+										to={`/fleet-tracking/stats/corporations/${corp.corporationId}`}
+										className="flex items-center gap-3 rounded-lg border border-border/70 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40"
+									>
+										<img
+											src={corporationLogoUrl(corp.corporationId, 32)}
+											alt={corp.name}
+											className="h-8 w-8 rounded-sm border border-border/60 shrink-0"
+											loading="lazy"
+										/>
+										<div className="min-w-0">
+											<div className="truncate font-medium">{corp.name}</div>
+											<div className="text-xs text-muted-foreground">{corp.ticker}</div>
+										</div>
+									</Link>
+								))}
+							</div>
+						</CardContent>
+					</Card>
+				</Section>
 			</Container>
 		)
 	}


### PR DESCRIPTION
The per-corporation fleet tracking stats endpoint
(GET /fleets/tracking/stats/corporations/:corpId) was gated solely on the org-wide urn:fleet-tracking:view-all permission, so corp leadership had no way to see their own corp's stats without also gaining access to every other corp's.

Add a corp-scoped self-service fallback: if the viewer is the CEO or a Director of the requested corp (and currently a member of it), they may view that corp's stats and only that corp's. view-all viewers and site admins still short-circuit without the extra leadership lookup.