### PR TITLE
add l2 for prediction-markets

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -56,6 +56,7 @@
 		"@repo/markets": "workspace:*",
 		"@repo/moon-scan": "workspace:*",
 		"@repo/paste": "workspace:*",
+		"@repo/prediction-markets": "workspace:*",
 		"@repo/structures": "workspace:*",
 		"@repo/skills": "workspace:*",
 		"@repo/srp": "workspace:*",

--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -31,6 +31,8 @@ export type Env = SharedHonoEnv & {
 	DISCORD: DurableObjectNamespace
 	/** Bills Durable Object binding */
 	BILLS: DurableObjectNamespace
+	/** Prediction Markets Durable Object binding */
+	PREDICTION_MARKETS: DurableObjectNamespace
 	/** Corporation Tax Durable Object binding */
 	CORPORATION_TAX: DurableObjectNamespace
 	/** Broadcasts Durable Object binding */

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -19,6 +19,7 @@ import adminRoutes from './routes/admin'
 import adminStructuresRoutes from './routes/admin/structures'
 import authRoutes from './routes/auth'
 import billsAdminRoutes from './routes/bills-admin'
+import predictionMarketsAdminRoutes from './routes/prediction-markets-admin'
 import billsUserRoutes from './routes/bills-user'
 import broadcastsRoutes from './routes/broadcasts'
 import charactersRoutes from './routes/characters'
@@ -133,6 +134,7 @@ const app = new Hono<App>()
 	.route('/api/admin/structures', adminStructuresRoutes)
 	.route('/api/admin/navigation', adminNavigationLinksRoutes)
 	.route('/api/admin/bills', billsAdminRoutes) // Admin bills API
+	.route('/api/admin/prediction-markets', predictionMarketsAdminRoutes) // Admin prediction-markets API
 	.route('/api/admin', industryAdminRoutes) // Admin industry API
 	.route('/api/auth', authRoutes)
 	.route('/api/users', usersRoutes)

--- a/apps/core/src/routes/prediction-markets-admin.ts
+++ b/apps/core/src/routes/prediction-markets-admin.ts
@@ -1,0 +1,287 @@
+/**
+ * Prediction Markets — admin API
+ *
+ * Admin-only wallet management, deposits, and audit-log reads. Proxies to the
+ * PredictionMarketsDO via RPC; enriches user ids with character names server-side.
+ *
+ * Scope (v1): deposits only (no debit/adjust), self-target deposits blocked.
+ */
+
+import { Hono } from 'hono'
+import { z } from 'zod'
+
+import { and, eq, ilike, inArray } from '@repo/db-utils'
+import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
+
+import { requireAdmin, requireAuth } from '../middleware/session'
+import { userCharacters, users } from '../db/schema'
+
+import type { createDb } from '../db'
+import type { App } from '../context'
+import type { Context } from 'hono'
+import type { LedgerType, PredictionMarkets } from '@repo/prediction-markets'
+
+type CoreDb = ReturnType<typeof createDb>
+
+const NULL_NAME = { userName: null as string | null, mainCharacterId: null as string | null }
+
+const app = new Hono<App>()
+
+// [M1] Defense-in-depth: one guard for the whole router so a forgotten per-route
+// gate can never expose wallets/ledger. `is_admin` is loaded every request
+// (independent of the empty role cache under /api/admin/*).
+app.use('*', requireAuth(), requireAdmin())
+
+const stubOf = (c: Context<App>): PredictionMarkets =>
+	getStub<PredictionMarkets>(c.env.PREDICTION_MARKETS, 'default')
+
+function parsePage(
+	limitRaw: string | undefined,
+	offsetRaw: string | undefined,
+	def: number,
+	max: number
+): { limit: number; offset: number } {
+	const limit = Math.min(Math.max(parseInt(limitRaw || String(def), 10) || def, 1), max)
+	const offset = Math.max(parseInt(offsetRaw || '0', 10) || 0, 0)
+	return { limit, offset }
+}
+
+/** Resolve core user ids (uuid) → { userName, mainCharacterId } for display. */
+async function enrichUserNames(
+	db: CoreDb,
+	ids: Array<string | null>
+): Promise<Map<string, { userName: string | null; mainCharacterId: string | null }>> {
+	const uniq = [...new Set(ids.filter((x): x is string => Boolean(x)))]
+	if (uniq.length === 0) return new Map()
+	const rows = await db
+		.select({
+			id: users.id,
+			mainCharacterId: users.mainCharacterId,
+			characterName: userCharacters.characterName,
+		})
+		.from(users)
+		.leftJoin(userCharacters, eq(userCharacters.characterId, users.mainCharacterId))
+		.where(inArray(users.id, uniq))
+	return new Map(
+		rows.map((r) => [
+			r.id,
+			{ userName: r.characterName ?? null, mainCharacterId: r.mainCharacterId ?? null },
+		])
+	)
+}
+
+function nameOf(
+	names: Map<string, { userName: string | null; mainCharacterId: string | null }>,
+	userId: string | null
+): { userName: string | null; mainCharacterId: string | null } {
+	return userId ? (names.get(userId) ?? NULL_NAME) : NULL_NAME
+}
+
+function fail(c: Context<App>, error: unknown, what: string) {
+	if (error instanceof z.ZodError) {
+		return c.json({ error: 'Validation failed', issues: error.issues }, 400)
+	}
+	const msg = error instanceof Error ? error.message : String(error)
+	if (msg === 'SELF_TARGET_FORBIDDEN') {
+		return c.json({ error: 'Cannot deposit to your own wallet' }, 400)
+	}
+	if (msg === 'IDEMPOTENCY_KEY_CONFLICT') {
+		return c.json({ error: 'Idempotency key already used with different parameters' }, 409)
+	}
+	if (msg === 'INVALID_AMOUNT' || msg === 'REASON_REQUIRED') {
+		return c.json({ error: msg }, 400)
+	}
+	logger.error(`[PMAdmin] ${what} failed`, { error: msg })
+	return c.json({ error: msg }, 500)
+}
+
+// -------------------------------------------------------------------------
+// Wallets
+// -------------------------------------------------------------------------
+
+// GET /wallets?search=&sort=&order=&limit=&offset=
+app.get('/wallets', async (c) => {
+	try {
+		const db = c.get('db')
+		if (!db) return c.json({ error: 'Database not initialized' }, 500)
+
+		const { limit, offset } = parsePage(c.req.query('limit'), c.req.query('offset'), 25, 100)
+		const sortRaw = c.req.query('sort')
+		const sort = sortRaw === 'updatedAt' || sortRaw === 'userId' ? sortRaw : 'balance'
+		const order = c.req.query('order') === 'asc' ? 'asc' : 'desc'
+		const search = c.req.query('search')?.trim()
+
+		let userIds: string[] | undefined
+		if (search) {
+			const matches = await db
+				.selectDistinct({ userId: userCharacters.userId })
+				.from(userCharacters)
+				.where(ilike(userCharacters.characterName, `%${search}%`))
+				.limit(500)
+			userIds = matches.map((m) => m.userId)
+			if (userIds.length === 0) return c.json({ rows: [], total: 0 })
+		}
+
+		const { rows, total } = await stubOf(c).listWallets({ userIds, sort, order, limit, offset })
+		const names = await enrichUserNames(
+			db,
+			rows.map((r) => r.userId)
+		)
+		return c.json({
+			rows: rows.map((r) => ({ ...r, ...nameOf(names, r.userId) })),
+			total,
+		})
+	} catch (error) {
+		return fail(c, error, 'list wallets')
+	}
+})
+
+// GET /wallets/:userId
+app.get('/wallets/:userId', async (c) => {
+	try {
+		const db = c.get('db')
+		if (!db) return c.json({ error: 'Database not initialized' }, 500)
+		const userId = c.req.param('userId')
+		const { balance } = await stubOf(c).getWalletBalance(userId)
+		const names = await enrichUserNames(db, [userId])
+		return c.json({ userId, balance, ...nameOf(names, userId) })
+	} catch (error) {
+		return fail(c, error, 'get wallet')
+	}
+})
+
+// GET /wallets/:userId/ledger?limit=&offset=
+app.get('/wallets/:userId/ledger', async (c) => {
+	try {
+		const db = c.get('db')
+		if (!db) return c.json({ error: 'Database not initialized' }, 500)
+		const userId = c.req.param('userId')
+		const { limit, offset } = parsePage(c.req.query('limit'), c.req.query('offset'), 50, 200)
+		const { rows, total } = await stubOf(c).getGlobalLedger({ userId, limit, offset })
+		const names = await enrichUserNames(
+			db,
+			rows.map((r) => r.userId)
+		)
+		return c.json({
+			rows: rows.map((r) => ({ ...r, ...nameOf(names, r.userId) })),
+			total,
+		})
+	} catch (error) {
+		return fail(c, error, 'get user ledger')
+	}
+})
+
+// -------------------------------------------------------------------------
+// Deposits (credit only; self-target blocked)
+// -------------------------------------------------------------------------
+
+const depositSchema = z.object({
+	targetUserId: z.string().uuid(),
+	amount: z
+		.string()
+		.regex(/^\d+$/, 'amount must be a positive integer')
+		.refine((v) => BigInt(v) > 0n, 'amount must be greater than 0'),
+	reason: z.string().trim().min(3).max(500),
+	idempotencyKey: z.string().min(8).max(200).optional(),
+})
+
+// POST /deposits
+app.post('/deposits', async (c) => {
+	try {
+		const user = c.get('user')!
+		const body = depositSchema.parse(await c.req.json())
+		if (body.targetUserId === user.id) {
+			return c.json({ error: 'Cannot deposit to your own wallet' }, 400)
+		}
+		const result = await stubOf(c).grantPoints({
+			actorUserId: user.id,
+			targetUserId: body.targetUserId,
+			amount: body.amount,
+			reason: body.reason,
+			idempotencyKey: body.idempotencyKey,
+		})
+		logger.info('[PMAdmin] deposit', {
+			actorId: user.id,
+			targetUserId: body.targetUserId,
+			amount: body.amount,
+			deduped: result.deduped,
+		})
+		return c.json(result)
+	} catch (error) {
+		return fail(c, error, 'deposit')
+	}
+})
+
+// -------------------------------------------------------------------------
+// Audit logs
+// -------------------------------------------------------------------------
+
+const LEDGER_TYPES: readonly LedgerType[] = [
+	'grant',
+	'wager',
+	'refund',
+	'payout',
+	'rake',
+	'burn',
+	'adjustment',
+]
+
+// GET /audit/ledger?userId=&type=&marketId=&since=&until=&limit=&offset=
+app.get('/audit/ledger', async (c) => {
+	try {
+		const db = c.get('db')
+		if (!db) return c.json({ error: 'Database not initialized' }, 500)
+		const { limit, offset } = parsePage(c.req.query('limit'), c.req.query('offset'), 50, 200)
+		const typeRaw = c.req.query('type')
+		const type = LEDGER_TYPES.includes(typeRaw as LedgerType) ? (typeRaw as LedgerType) : undefined
+		const { rows, total } = await stubOf(c).getGlobalLedger({
+			userId: c.req.query('userId') || undefined,
+			type,
+			marketId: c.req.query('marketId') || undefined,
+			since: c.req.query('since') || undefined,
+			until: c.req.query('until') || undefined,
+			limit,
+			offset,
+		})
+		const names = await enrichUserNames(
+			db,
+			rows.map((r) => r.userId)
+		)
+		return c.json({
+			rows: rows.map((r) => ({ ...r, ...nameOf(names, r.userId) })),
+			total,
+		})
+	} catch (error) {
+		return fail(c, error, 'audit ledger')
+	}
+})
+
+// GET /audit/market-history?marketId=&includeInternal=&since=&until=&limit=&offset=
+app.get('/audit/market-history', async (c) => {
+	try {
+		const db = c.get('db')
+		if (!db) return c.json({ error: 'Database not initialized' }, 500)
+		const { limit, offset } = parsePage(c.req.query('limit'), c.req.query('offset'), 50, 200)
+		const { rows, total } = await stubOf(c).getGlobalMarketHistory({
+			marketId: c.req.query('marketId') || undefined,
+			includeInternal: c.req.query('includeInternal') === 'true',
+			since: c.req.query('since') || undefined,
+			until: c.req.query('until') || undefined,
+			limit,
+			offset,
+		})
+		const names = await enrichUserNames(
+			db,
+			rows.map((r) => r.actorUserId)
+		)
+		return c.json({
+			rows: rows.map((r) => ({ ...r, actor: r.actorUserId ? nameOf(names, r.actorUserId) : null })),
+			total,
+		})
+	} catch (error) {
+		return fail(c, error, 'audit market-history')
+	}
+})
+
+export default app

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -67,6 +67,11 @@
 				"script_name": "bills"
 			},
 			{
+				"name": "PREDICTION_MARKETS",
+				"class_name": "PredictionMarkets",
+				"script_name": "prediction-markets"
+			},
+			{
 				"name": "CORPORATION_TAX",
 				"class_name": "CorporationTax",
 				"script_name": "corporation-tax"

--- a/apps/prediction-markets/.migrations/0001_hard_reavers.sql
+++ b/apps/prediction-markets/.migrations/0001_hard_reavers.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "pm_ledger_created_id_idx" ON "pm_ledger" USING btree ("created_at","id");--> statement-breakpoint
+CREATE INDEX "pm_market_history_created_id_idx" ON "pm_market_history" USING btree ("created_at","id");

--- a/apps/prediction-markets/.migrations/meta/0001_snapshot.json
+++ b/apps/prediction-markets/.migrations/meta/0001_snapshot.json
@@ -1,0 +1,925 @@
+{
+  "id": "6c0a0b81-7d12-4cba-b611-200e9dfd7a4c",
+  "prevId": "837a3ed2-7443-44e5-89c2-a2296751945a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pm_bets": {
+      "name": "pm_bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_bet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_bets_idempotency_key_uq": {
+          "name": "pm_bets_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_user_idx": {
+          "name": "pm_bets_market_user_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_user_created_idx": {
+          "name": "pm_bets_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_outcome_idx": {
+          "name": "pm_bets_market_outcome_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_config": {
+      "name": "pm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_rake_bps": {
+          "name": "default_rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "default_min_stake": {
+          "name": "default_min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "two_of_n_threshold": {
+          "name": "two_of_n_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_ledger": {
+      "name": "pm_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pm_ledger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_ledger_bet_type_uq": {
+          "name": "pm_ledger_bet_type_uq",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_idempotency_key_uq": {
+          "name": "pm_ledger_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pm_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_user_created_idx": {
+          "name": "pm_ledger_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_market_idx": {
+          "name": "pm_ledger_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_created_id_idx": {
+          "name": "pm_ledger_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_history": {
+      "name": "pm_market_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "pm_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_market_history_market_created_idx": {
+          "name": "pm_market_history_market_created_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_history_created_id_idx": {
+          "name": "pm_market_history_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_outcomes": {
+      "name": "pm_market_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "pm_market_outcomes_market_label_uq": {
+          "name": "pm_market_outcomes_market_label_uq",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_outcomes_market_idx": {
+          "name": "pm_market_outcomes_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_markets": {
+      "name": "pm_markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_outcome_id": {
+          "name": "resolved_outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pool": {
+          "name": "total_pool",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "rake_bps": {
+          "name": "rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stake": {
+          "name": "min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "max_stake": {
+          "name": "max_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_user_cap": {
+          "name": "per_user_cap",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_of_n": {
+          "name": "two_of_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_markets_status_closes_idx": {
+          "name": "pm_markets_status_closes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_resolution_proposals": {
+      "name": "pm_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pm_resolution_proposals_market_status_idx": {
+          "name": "pm_resolution_proposals_market_status_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_wallets": {
+      "name": "pm_wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pm_bet_status": {
+      "name": "pm_bet_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "won",
+        "lost",
+        "refunded"
+      ]
+    },
+    "public.pm_ledger_type": {
+      "name": "pm_ledger_type",
+      "schema": "public",
+      "values": [
+        "grant",
+        "wager",
+        "refund",
+        "payout",
+        "rake",
+        "burn",
+        "adjustment"
+      ]
+    },
+    "public.pm_market_status": {
+      "name": "pm_market_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "resolving",
+        "resolved",
+        "voided"
+      ]
+    },
+    "public.pm_proposal_status": {
+      "name": "pm_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.pm_visibility": {
+      "name": "pm_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "internal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/prediction-markets/.migrations/meta/_journal.json
+++ b/apps/prediction-markets/.migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783387930608,
       "tag": "0000_mixed_black_widow",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783397156429,
+      "tag": "0001_hard_reavers",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/prediction-markets/src/db/schema.ts
+++ b/apps/prediction-markets/src/db/schema.ts
@@ -87,6 +87,8 @@ export const pmLedger = pgTable(
 			.where(sql`${t.idempotencyKey} is not null`),
 		index('pm_ledger_user_created_idx').on(t.userId, t.createdAt),
 		index('pm_ledger_market_idx').on(t.marketId),
+		// Global admin ledger/audit feed: ORDER BY created_at DESC, id DESC (scanned backward).
+		index('pm_ledger_created_id_idx').on(t.createdAt, t.id),
 	]
 )
 
@@ -182,7 +184,11 @@ export const pmMarketHistory = pgTable(
 		metadata: jsonb('metadata'),
 		createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 	},
-	(t) => [index('pm_market_history_market_created_idx').on(t.marketId, t.createdAt)]
+	(t) => [
+		index('pm_market_history_market_created_idx').on(t.marketId, t.createdAt),
+		// Global admin market-lifecycle audit feed: ORDER BY created_at DESC, id DESC.
+		index('pm_market_history_created_id_idx').on(t.createdAt, t.id),
+	]
 )
 
 /** Single-active-config for defaults. */

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from 'cloudflare:workers'
 
-import { and, desc, eq, ne, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, gte, inArray, lte, ne, sql } from '@repo/db-utils'
 import { captureException } from '@repo/hono-helpers'
 import { parseDateOrNull } from '@repo/worker-utils'
 
@@ -23,20 +23,27 @@ import type {
 	BetResult,
 	BetView,
 	CreateMarketInput,
+	GlobalLedgerOpts,
+	GlobalLedgerRow,
 	GrantPointsInput,
 	LeaderboardRow,
 	LedgerRow,
 	ListMarketsFilter,
+	ListWalletsOpts,
 	MarketDetail,
+	MarketHistoryOpts,
+	MarketHistoryRow,
 	MarketStatus,
 	MarketSummary,
+	Paged,
 	PlaceBetInput,
 	PredictionMarkets,
 	ResolveResult,
 	Visibility,
+	WalletRow,
 } from '@repo/prediction-markets'
 import type { Env } from './context'
-import type { PmBet, PmMarket } from './db/schema'
+import type { PmBet, PmLedgerRow, PmMarket, PmMarketHistoryRow } from './db/schema'
 
 type PmDatabase = ReturnType<typeof createDb>
 type PmTransaction = Parameters<Parameters<PmDatabase['transaction']>[0]>[0]
@@ -180,30 +187,149 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		}))
 	}
 
+	// ---- admin reads (offset + total) ----
+
+	async listWallets(opts?: ListWalletsOpts): Promise<Paged<WalletRow>> {
+		const limit = Math.min(Math.max(opts?.limit ?? 25, 1), 100)
+		const offset = Math.max(opts?.offset ?? 0, 0)
+		const column =
+			opts?.sort === 'updatedAt'
+				? pmWallets.updatedAt
+				: opts?.sort === 'userId'
+					? pmWallets.userId
+					: pmWallets.balance
+		const direction = opts?.order === 'asc' ? asc : desc
+		const where = opts?.userIds?.length ? inArray(pmWallets.userId, opts.userIds) : undefined
+
+		const rows = await this.db
+			.select()
+			.from(pmWallets)
+			.where(where)
+			.orderBy(direction(column), desc(pmWallets.userId))
+			.limit(limit)
+			.offset(offset)
+		const [{ total }] = await this.db
+			.select({ total: sql<number>`count(*)::int` })
+			.from(pmWallets)
+			.where(where)
+
+		return {
+			rows: rows.map((w) => ({
+				userId: w.userId,
+				balance: w.balance,
+				updatedAt: w.updatedAt.toISOString(),
+			})),
+			total,
+		}
+	}
+
+	async getGlobalLedger(opts?: GlobalLedgerOpts): Promise<Paged<GlobalLedgerRow>> {
+		const limit = Math.min(Math.max(opts?.limit ?? 50, 1), 200)
+		const offset = Math.max(opts?.offset ?? 0, 0)
+		const since = parseDateOrNull(opts?.since)
+		const until = parseDateOrNull(opts?.until)
+		const where = and(
+			opts?.userId ? eq(pmLedger.userId, opts.userId) : undefined,
+			opts?.type ? eq(pmLedger.type, opts.type) : undefined,
+			opts?.marketId ? eq(pmLedger.marketId, opts.marketId) : undefined,
+			since ? gte(pmLedger.createdAt, since) : undefined,
+			until ? lte(pmLedger.createdAt, until) : undefined
+		)
+
+		const rows = await this.db
+			.select()
+			.from(pmLedger)
+			.where(where)
+			.orderBy(desc(pmLedger.createdAt), desc(pmLedger.id))
+			.limit(limit)
+			.offset(offset)
+		const [{ total }] = await this.db
+			.select({ total: sql<number>`count(*)::int` })
+			.from(pmLedger)
+			.where(where)
+
+		return { rows: rows.map((r) => this.toGlobalLedgerRow(r)), total }
+	}
+
+	async getGlobalMarketHistory(opts?: MarketHistoryOpts): Promise<Paged<MarketHistoryRow>> {
+		const limit = Math.min(Math.max(opts?.limit ?? 50, 1), 200)
+		const offset = Math.max(opts?.offset ?? 0, 0)
+		const since = parseDateOrNull(opts?.since)
+		const until = parseDateOrNull(opts?.until)
+		const where = and(
+			opts?.marketId ? eq(pmMarketHistory.marketId, opts.marketId) : undefined,
+			// Default to public-only; internal rows (e.g. bet_placed) carry bettor identity.
+			opts?.includeInternal ? undefined : eq(pmMarketHistory.visibility, 'public'),
+			since ? gte(pmMarketHistory.createdAt, since) : undefined,
+			until ? lte(pmMarketHistory.createdAt, until) : undefined
+		)
+
+		const rows = await this.db
+			.select()
+			.from(pmMarketHistory)
+			.where(where)
+			.orderBy(desc(pmMarketHistory.createdAt), desc(pmMarketHistory.id))
+			.limit(limit)
+			.offset(offset)
+		const [{ total }] = await this.db
+			.select({ total: sql<number>`count(*)::int` })
+			.from(pmMarketHistory)
+			.where(where)
+
+		return { rows: rows.map((r) => this.toMarketHistoryRow(r)), total }
+	}
+
+	async getMarketHistory(
+		marketId: string,
+		opts?: { includeInternal?: boolean; limit?: number; offset?: number }
+	): Promise<Paged<MarketHistoryRow>> {
+		return this.getGlobalMarketHistory({
+			marketId,
+			includeInternal: opts?.includeInternal ?? false,
+			limit: opts?.limit,
+			offset: opts?.offset,
+		})
+	}
+
 	// =====================================================================
 	// Writes
 	// =====================================================================
 
-	async grantPoints(input: GrantPointsInput): Promise<{ balance: string }> {
+	async grantPoints(input: GrantPointsInput): Promise<{ balance: string; deduped: boolean }> {
 		if (!isPositiveIntegerString(input.amount)) {
 			throw new Error('INVALID_AMOUNT')
 		}
+		if (!input.reason?.trim()) {
+			throw new Error('REASON_REQUIRED')
+		}
+		// Defense-in-depth: the route also blocks this, but never let an admin fund their own wallet.
+		if (input.actorUserId === input.targetUserId) {
+			throw new Error('SELF_TARGET_FORBIDDEN')
+		}
 		try {
 			return await this.db.transaction(async (tx) => {
-				// Idempotent grant: if this key already credited, return current balance.
+				// Idempotent grant: a repeated key must match the original (user, amount, type),
+				// otherwise a reused/forged key would silently drop a real deposit.
 				if (input.idempotencyKey) {
 					const [existing] = await tx
-						.select({ id: pmLedger.id })
+						.select()
 						.from(pmLedger)
 						.where(eq(pmLedger.idempotencyKey, input.idempotencyKey))
 						.limit(1)
 					if (existing) {
+						const same =
+							existing.type === 'grant' &&
+							existing.userId === input.targetUserId &&
+							parseAmount(existing.amount) === parseAmount(input.amount)
+						if (!same) {
+							throw new Error('IDEMPOTENCY_KEY_CONFLICT')
+						}
 						const [wallet] = await tx
 							.select({ balance: pmWallets.balance })
 							.from(pmWallets)
 							.where(eq(pmWallets.userId, input.targetUserId))
 							.limit(1)
-						return { balance: wallet?.balance ?? '0' }
+						return { balance: wallet?.balance ?? '0', deduped: true }
 					}
 				}
 
@@ -230,7 +356,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					metadata: { actorUserId: input.actorUserId, reason: input.reason },
 				})
 
-				return { balance: credited.balance }
+				return { balance: credited.balance, deduped: false }
 			})
 		} catch (error) {
 			captureException(error as Error, {
@@ -970,6 +1096,35 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			visibility: entry.visibility ?? 'public',
 			metadata: entry.metadata ?? null,
 		})
+	}
+
+	private toGlobalLedgerRow(r: PmLedgerRow): GlobalLedgerRow {
+		return {
+			id: r.id,
+			userId: r.userId,
+			amount: r.amount,
+			type: r.type,
+			marketId: r.marketId,
+			betId: r.betId,
+			balanceAfter: r.balanceAfter,
+			idempotencyKey: r.idempotencyKey,
+			metadata: r.metadata,
+			createdAt: r.createdAt.toISOString(),
+		}
+	}
+
+	private toMarketHistoryRow(r: PmMarketHistoryRow): MarketHistoryRow {
+		return {
+			id: r.id,
+			marketId: r.marketId,
+			actorUserId: r.actorUserId,
+			action: r.action,
+			previousStatus: r.previousStatus,
+			newStatus: r.newStatus,
+			visibility: r.visibility,
+			metadata: r.metadata,
+			createdAt: r.createdAt.toISOString(),
+		}
 	}
 
 	private toBetResult(bet: PmBet): BetResult {

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -138,6 +138,70 @@ export interface ListMarketsFilter {
 }
 
 // ---------------------------------------------------------------------------
+// Admin views (wallets + audit)
+// ---------------------------------------------------------------------------
+
+export interface WalletRow {
+	userId: string
+	balance: string
+	updatedAt: string
+}
+
+/** A ledger row with its owning user id (the base `LedgerRow` omits it) + idempotency key for audit. */
+export interface GlobalLedgerRow extends LedgerRow {
+	userId: string | null
+	idempotencyKey: string | null
+}
+
+export interface MarketHistoryRow {
+	id: string
+	marketId: string
+	actorUserId: string | null
+	action: string
+	previousStatus: MarketStatus | null
+	newStatus: MarketStatus | null
+	visibility: Visibility
+	metadata: unknown
+	createdAt: string
+}
+
+export interface Paged<T> {
+	rows: T[]
+	total: number
+}
+
+export interface ListWalletsOpts {
+	/** Restrict to these user ids (used by the admin route to apply a name search). */
+	userIds?: string[]
+	sort?: 'balance' | 'updatedAt' | 'userId'
+	order?: 'asc' | 'desc'
+	limit?: number
+	offset?: number
+}
+
+export interface GlobalLedgerOpts {
+	userId?: string
+	type?: LedgerType
+	marketId?: string
+	/** ISO-8601 lower bound (inclusive). */
+	since?: string
+	/** ISO-8601 upper bound (inclusive). */
+	until?: string
+	limit?: number
+	offset?: number
+}
+
+export interface MarketHistoryOpts {
+	marketId?: string
+	/** Admin-only: include `internal`-visibility rows. Defaults false. */
+	includeInternal?: boolean
+	since?: string
+	until?: string
+	limit?: number
+	offset?: number
+}
+
+// ---------------------------------------------------------------------------
 // RPC interface
 // ---------------------------------------------------------------------------
 
@@ -150,8 +214,18 @@ export interface PredictionMarkets {
 	getLeaderboard(opts?: { window?: 'all' | '30d'; limit?: number }): Promise<LeaderboardRow[]>
 	getLedger(userId: string, opts?: { limit?: number; cursor?: string }): Promise<LedgerRow[]>
 
+	// admin reads (offset + total)
+	listWallets(opts?: ListWalletsOpts): Promise<Paged<WalletRow>>
+	/** Global financial audit feed; also serves the per-user ledger via `{ userId }`. */
+	getGlobalLedger(opts?: GlobalLedgerOpts): Promise<Paged<GlobalLedgerRow>>
+	getGlobalMarketHistory(opts?: MarketHistoryOpts): Promise<Paged<MarketHistoryRow>>
+	getMarketHistory(
+		marketId: string,
+		opts?: { includeInternal?: boolean; limit?: number; offset?: number }
+	): Promise<Paged<MarketHistoryRow>>
+
 	// writes
-	grantPoints(input: GrantPointsInput): Promise<{ balance: string }>
+	grantPoints(input: GrantPointsInput): Promise<{ balance: string; deduped: boolean }>
 	createMarket(input: CreateMarketInput): Promise<MarketDetail>
 	placeBet(input: PlaceBetInput): Promise<BetResult>
 	closeMarket(input: { actorUserId: string; marketId: string }): Promise<void>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,6 +494,9 @@ importers:
       '@repo/paste':
         specifier: workspace:*
         version: link:../../packages/paste
+      '@repo/prediction-markets':
+        specifier: workspace:*
+        version: link:../../packages/prediction-markets
       '@repo/skills':
         specifier: workspace:*
         version: link:../../packages/skills


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-07-07

* **PR #446 (THIS ONE)**:
  `main` ← `prediction-markets-discord-admin`

    * PR #448:
      `prediction-markets-discord-admin` ← `prediction-markets-ui`

<!-- end git-machete generated -->

<!-- claude:begin -->
## Summary

Adds an admin API and supporting Durable Object methods for managing the prediction-markets subsystem from the `core` worker. Admins can browse wallets, grant points (deposits), and read the global financial and market-lifecycle audit feeds.

## Changes

- **New admin route** (`apps/core/src/routes/prediction-markets-admin.ts`): mounts `/api/admin/prediction-markets` with wallet listing/lookup, per-user and global ledger reads, market-history audit, and a deposit (credit-only) endpoint. Guarded router-wide by `requireAuth()` + `requireAdmin()`, enriches user ids with character names, and validates deposit input with Zod.
- **Wire-up in core**: registers the `PREDICTION_MARKETS` Durable Object binding in `context.ts` and `wrangler.jsonc`, mounts the new route in `index.ts`, and adds the `@repo/prediction-markets` workspace dependency.
- **New DO admin-read methods** (`PredictionMarketsDO`): `listWallets`, `getGlobalLedger`, `getGlobalMarketHistory`, and `getMarketHistory`, all returning `Paged<T>` (rows + total) with offset pagination, sorting, and date-range/type/market filters. Market-history reads default to public-only rows unless `includeInternal` is set.
- **Hardened `grantPoints`**: now requires a non-empty reason, rejects self-target grants (`SELF_TARGET_FORBIDDEN`), returns a `deduped` flag, and treats a reused idempotency key with mismatched (user, amount, type) as a conflict (`IDEMPOTENCY_KEY_CONFLICT`) instead of silently dropping the deposit.
- **New shared types** in `@repo/prediction-markets`: `WalletRow`, `GlobalLedgerRow`, `MarketHistoryRow`, `Paged<T>`, and the `*Opts` option types, plus the corresponding additions to the `PredictionMarkets` RPC interface.
- **DB migration** `0001_hard_reavers`: adds `(created_at, id)` btree indexes on `pm_ledger` and `pm_market_history` to back the global audit feeds' `ORDER BY created_at DESC, id DESC`.
<!-- claude:end -->