### PR TITLE
add admin ui

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -48,6 +48,7 @@
 		"@repo/structures": "workspace:*",
 		"@repo/structure-states": "workspace:*",
 		"@repo/srp": "workspace:*",
+		"@repo/prediction-markets": "workspace:*",
 		"@repo/worker-utils": "workspace:*",
 		"@tabler/icons-react": "3.40.0",
 		"@tanstack/react-query": "5.90.10",

--- a/apps/ui/src/client/components/admin-nav.tsx
+++ b/apps/ui/src/client/components/admin-nav.tsx
@@ -15,6 +15,7 @@ import {
 	Receipt,
 	ScrollText,
 	ShieldBan,
+	Wallet,
 	Waypoints,
 	UserCircle,
 	Users,
@@ -118,6 +119,15 @@ export function AdminNav({ onNavigate }: AdminNavProps) {
 			label: 'DKP',
 			href: '/admin/dkp',
 			icon: Coins,
+		},
+		{
+			label: 'Prediction Markets',
+			href: '/admin/prediction-markets',
+			icon: Wallet,
+			children: [
+				{ label: 'Wallets', href: '/admin/prediction-markets/wallets' },
+				{ label: 'Audit Log', href: '/admin/prediction-markets/audit' },
+			],
 		},
 		{
 			label: 'Industry Providers',

--- a/apps/ui/src/client/features/prediction-markets/api.ts
+++ b/apps/ui/src/client/features/prediction-markets/api.ts
@@ -1,0 +1,97 @@
+/**
+ * Prediction Markets (admin) API client methods.
+ *
+ * Base path: /admin/prediction-markets (the shared apiClient prepends /api).
+ * apiClient returns the parsed JSON body directly (no `.data` unwrap); the L1
+ * endpoints already return `{ rows, total }`, so type calls as `Paged<T>`.
+ */
+
+import { apiClient } from '@/lib/api'
+
+import type {
+	AdminLedgerRow,
+	AdminMarketHistoryRow,
+	AdminWalletRow,
+	AuditLedgerFilters,
+	DepositRequest,
+	DepositResponse,
+	LedgerFilters,
+	MarketHistoryFilters,
+	Paged,
+	WalletDetail,
+	WalletsFilters,
+} from './types'
+
+const BASE = '/admin/prediction-markets'
+
+/** GET /wallets — paginated wallet list with name search + sort. */
+export async function getWallets(filters?: WalletsFilters): Promise<Paged<AdminWalletRow>> {
+	const params = new URLSearchParams()
+	if (filters?.search) params.set('search', filters.search)
+	if (filters?.sort) params.set('sort', filters.sort)
+	if (filters?.order) params.set('order', filters.order)
+	if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
+	if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+
+	const query = params.toString()
+	return apiClient.get<Paged<AdminWalletRow>>(`${BASE}/wallets${query ? `?${query}` : ''}`)
+}
+
+/** GET /wallets/:userId — single wallet detail. */
+export async function getWallet(userId: string): Promise<WalletDetail> {
+	return apiClient.get<WalletDetail>(`${BASE}/wallets/${userId}`)
+}
+
+/** GET /wallets/:userId/ledger — one user's ledger. */
+export async function getUserLedger(
+	userId: string,
+	filters?: LedgerFilters
+): Promise<Paged<AdminLedgerRow>> {
+	const params = new URLSearchParams()
+	if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
+	if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+
+	const query = params.toString()
+	return apiClient.get<Paged<AdminLedgerRow>>(
+		`${BASE}/wallets/${userId}/ledger${query ? `?${query}` : ''}`
+	)
+}
+
+/** GET /audit/ledger — global ledger with filters. */
+export async function getAuditLedger(filters?: AuditLedgerFilters): Promise<Paged<AdminLedgerRow>> {
+	const params = new URLSearchParams()
+	if (filters?.userId) params.set('userId', filters.userId)
+	if (filters?.type) params.set('type', filters.type)
+	if (filters?.marketId) params.set('marketId', filters.marketId)
+	if (filters?.since) params.set('since', filters.since)
+	if (filters?.until) params.set('until', filters.until)
+	if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
+	if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+
+	const query = params.toString()
+	return apiClient.get<Paged<AdminLedgerRow>>(`${BASE}/audit/ledger${query ? `?${query}` : ''}`)
+}
+
+/** GET /audit/market-history — market lifecycle audit feed. */
+export async function getMarketHistory(
+	filters?: MarketHistoryFilters
+): Promise<Paged<AdminMarketHistoryRow>> {
+	const params = new URLSearchParams()
+	if (filters?.marketId) params.set('marketId', filters.marketId)
+	if (filters?.includeInternal !== undefined)
+		params.set('includeInternal', String(filters.includeInternal))
+	if (filters?.since) params.set('since', filters.since)
+	if (filters?.until) params.set('until', filters.until)
+	if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
+	if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+
+	const query = params.toString()
+	return apiClient.get<Paged<AdminMarketHistoryRow>>(
+		`${BASE}/audit/market-history${query ? `?${query}` : ''}`
+	)
+}
+
+/** POST /deposits — credit a wallet. 400 self/validation, 409 idempotency-conflict. */
+export async function createDeposit(body: DepositRequest): Promise<DepositResponse> {
+	return apiClient.post<DepositResponse>(`${BASE}/deposits`, body)
+}

--- a/apps/ui/src/client/features/prediction-markets/components/deposit-dialog.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/deposit-dialog.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react'
+import { z } from 'zod'
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { useConfirmationDialog } from '@/hooks/useConfirmationDialog'
+import { formatPoints } from '@/lib/format-utils'
+import toast from '@/lib/toast'
+
+import { useDeposit } from '../hooks'
+import { UserSearchSelect } from './user-search-select'
+
+// Client-side guard mirrors the server: string-preserving, digits-only, positive.
+const depositSchema = z.object({
+	targetUserId: z.string().uuid('Select a recipient'),
+	amount: z
+		.string()
+		.regex(/^\d+$/, 'Amount must be a whole number')
+		.refine((v) => /[1-9]/.test(v), 'Amount must be greater than 0'),
+	reason: z.string().trim().min(3, 'Reason must be at least 3 characters'),
+})
+
+export interface DepositDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	/** When set, the recipient is pre-filled and locked (opened from a specific wallet). */
+	defaultTargetUserId?: string
+	defaultTargetName?: string | null
+}
+
+export function DepositDialog({
+	open,
+	onOpenChange,
+	defaultTargetUserId,
+	defaultTargetName,
+}: DepositDialogProps) {
+	const [targetUserId, setTargetUserId] = useState(defaultTargetUserId ?? '')
+	const [targetLabel, setTargetLabel] = useState<string | null>(defaultTargetName ?? null)
+	const [amount, setAmount] = useState('')
+	const [reason, setReason] = useState('')
+
+	const deposit = useDeposit()
+	const { requestConfirmation, confirmationDialog } = useConfirmationDialog()
+
+	// Reset fields whenever the dialog opens (and pick up a new default target).
+	useEffect(() => {
+		if (open) {
+			setTargetUserId(defaultTargetUserId ?? '')
+			setTargetLabel(defaultTargetName ?? null)
+			setAmount('')
+			setReason('')
+		}
+	}, [open, defaultTargetUserId, defaultTargetName])
+
+	const close = () => onOpenChange(false)
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault()
+		const parsed = depositSchema.safeParse({ targetUserId, amount, reason })
+		if (!parsed.success) {
+			toast.error(parsed.error.issues[0]?.message ?? 'Invalid deposit')
+			return
+		}
+		const data = parsed.data
+
+		requestConfirmation({
+			title: 'Confirm deposit',
+			description: `Deposit ${formatPoints(data.amount)} to this wallet? This cannot be undone.`,
+			confirmLabel: 'Deposit',
+			cancelLabel: 'Cancel',
+			intent: 'destructive',
+			confirmButtonVariant: 'danger',
+			confirmDelaySeconds: 5,
+			onConfirm: async () => {
+				// A fresh idempotency key per confirmed submit dedupes accidental double-delivery.
+				await deposit.mutateAsync({
+					targetUserId: data.targetUserId,
+					amount: data.amount,
+					reason: data.reason,
+					idempotencyKey: crypto.randomUUID(),
+				})
+				// Success toast is handled by useDeposit (useApiMutation). Close on success;
+				// a rejection propagates and keeps the confirmation dialog open (already toasted).
+				close()
+			},
+		})
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Deposit points</DialogTitle>
+					<DialogDescription>Credit a member&apos;s prediction-market wallet.</DialogDescription>
+				</DialogHeader>
+
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor="pm-deposit-user">Recipient</Label>
+						<UserSearchSelect
+							inputId="pm-deposit-user"
+							value={targetUserId}
+							label={targetLabel}
+							disabled={deposit.isPending || !!defaultTargetUserId}
+							onChange={(userId, user) => {
+								setTargetUserId(userId)
+								setTargetLabel(user?.label ?? null)
+							}}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="pm-deposit-amount">Amount</Label>
+						<Input
+							id="pm-deposit-amount"
+							type="text"
+							inputMode="numeric"
+							pattern="\d*"
+							placeholder="1000"
+							value={amount}
+							onChange={(e) => setAmount(e.target.value.replace(/\D/g, ''))}
+							disabled={deposit.isPending}
+							required
+						/>
+						<p className="text-xs text-muted-foreground">Whole points only.</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="pm-deposit-reason">Reason</Label>
+						<Textarea
+							id="pm-deposit-reason"
+							placeholder="Reason for this deposit (min 3 characters)"
+							value={reason}
+							onChange={(e) => setReason(e.target.value)}
+							rows={3}
+							minLength={3}
+							maxLength={500}
+							disabled={deposit.isPending}
+							required
+						/>
+					</div>
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="cancel"
+							showIcon={false}
+							onClick={close}
+							disabled={deposit.isPending}
+						>
+							Cancel
+						</Button>
+						<Button
+							type="submit"
+							variant="primary"
+							loading={deposit.isPending}
+							loadingText="Depositing…"
+						>
+							Review deposit
+						</Button>
+					</DialogFooter>
+				</form>
+
+				{confirmationDialog}
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/components/ledger-table.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/ledger-table.tsx
@@ -1,0 +1,173 @@
+import { ChevronDown } from 'lucide-react'
+import { Fragment, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { JsonViewer } from '@/components/json-viewer'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
+import { formatDateTime } from '@/lib/date-utils'
+import { characterPortraitUrl } from '@/lib/eve-images'
+import { formatPoints } from '@/lib/format-utils'
+import { cn } from '@/lib/utils'
+
+import type { AdminLedgerRow, LedgerType } from '../types'
+import type { BadgeVariant } from '@/components/ui/badge'
+
+const LEDGER_TYPE_VARIANTS: Record<LedgerType, BadgeVariant> = {
+	grant: 'success',
+	wager: 'warning',
+	refund: 'secondary',
+	payout: 'gold',
+	rake: 'special',
+	burn: 'destructive',
+	adjustment: 'ghost',
+}
+
+const COL_COUNT = 8
+
+function hasMetadata(metadata: unknown): boolean {
+	return (
+		metadata != null &&
+		(typeof metadata !== 'object' || Object.keys(metadata as object).length > 0)
+	)
+}
+
+export interface LedgerTableProps {
+	rows: AdminLedgerRow[] | undefined
+	isLoading: boolean
+	error: Error | null
+}
+
+/** Append-only financial ledger table. Amounts are signed integer strings (display only). */
+export function LedgerTable({ rows, isLoading, error }: LedgerTableProps) {
+	const [expanded, setExpanded] = useState<Set<string>>(new Set())
+	const toggle = (id: string) =>
+		setExpanded((prev) => {
+			const next = new Set(prev)
+			if (next.has(id)) next.delete(id)
+			else next.add(id)
+			return next
+		})
+
+	if (error) {
+		return <p className="text-destructive">Failed to load ledger: {error.message}</p>
+	}
+	if (isLoading) {
+		return (
+			<div className="space-y-2">
+				<Skeleton className="h-12 w-full" />
+				<Skeleton className="h-12 w-full" />
+				<Skeleton className="h-12 w-full" />
+			</div>
+		)
+	}
+
+	return (
+		<div className="rounded-md border">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Created</TableHead>
+						<TableHead>Type</TableHead>
+						<TableHead className="text-right">Amount</TableHead>
+						<TableHead className="text-right">Balance After</TableHead>
+						<TableHead>User</TableHead>
+						<TableHead>Market / Bet</TableHead>
+						<TableHead>Key</TableHead>
+						<TableHead className="w-10" />
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{rows?.map((row) => {
+						const isOpen = expanded.has(row.id)
+						const meta = hasMetadata(row.metadata)
+						const negative = row.amount.trim().startsWith('-')
+						return (
+							<Fragment key={row.id}>
+								<TableRow>
+									<TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+										{formatDateTime(row.createdAt)}
+									</TableCell>
+									<TableCell>
+										<Badge variant={LEDGER_TYPE_VARIANTS[row.type]}>{row.type}</Badge>
+									</TableCell>
+									<TableCell className="text-right font-mono">
+										<span className={negative ? 'text-red-500' : 'text-green-500'}>
+											{formatPoints(row.amount)}
+										</span>
+									</TableCell>
+									<TableCell className="text-right font-mono text-muted-foreground">
+										{row.balanceAfter != null ? formatPoints(row.balanceAfter) : '—'}
+									</TableCell>
+									<TableCell>
+										{row.userId ? (
+											<Link
+												to={`/admin/users/${row.userId}`}
+												className="flex items-center gap-2 text-primary hover:underline"
+											>
+												{row.mainCharacterId ? (
+													<img
+														src={characterPortraitUrl(row.mainCharacterId, 32)}
+														alt=""
+														className="h-6 w-6 rounded-full"
+													/>
+												) : null}
+												<span className="text-sm">{row.userName ?? row.userId}</span>
+											</Link>
+										) : (
+											<span className="text-sm italic text-muted-foreground">System</span>
+										)}
+									</TableCell>
+									<TableCell className="font-mono text-xs text-muted-foreground">
+										{row.marketId ? <div>mkt: {row.marketId.slice(0, 8)}…</div> : null}
+										{row.betId ? <div>bet: {row.betId.slice(0, 8)}…</div> : null}
+										{!row.marketId && !row.betId ? '—' : null}
+									</TableCell>
+									<TableCell
+										className="max-w-[10rem] truncate font-mono text-xs text-muted-foreground"
+										title={row.idempotencyKey ?? undefined}
+									>
+										{row.idempotencyKey ?? '—'}
+									</TableCell>
+									<TableCell>
+										{meta ? (
+											<Button variant="ghost" size="sm" onClick={() => toggle(row.id)}>
+												<ChevronDown
+													className={cn('h-4 w-4 transition-transform', isOpen && 'rotate-180')}
+												/>
+											</Button>
+										) : null}
+									</TableCell>
+								</TableRow>
+								{isOpen && meta ? (
+									<TableRow>
+										<TableCell colSpan={COL_COUNT} className="bg-muted/30">
+											<div className="mb-2 text-sm font-medium">Metadata</div>
+											<JsonViewer data={row.metadata} defaultExpanded={false} maxHeight="300px" />
+										</TableCell>
+									</TableRow>
+								) : null}
+							</Fragment>
+						)
+					})}
+					{rows?.length === 0 ? (
+						<TableRow>
+							<TableCell colSpan={COL_COUNT} className="h-24 text-center text-muted-foreground">
+								No ledger entries found
+							</TableCell>
+						</TableRow>
+					) : null}
+				</TableBody>
+			</Table>
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/components/market-history-table.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/market-history-table.tsx
@@ -1,0 +1,183 @@
+import { ArrowRight, ChevronDown } from 'lucide-react'
+import { Fragment, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { JsonViewer } from '@/components/json-viewer'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
+import { formatDateTime } from '@/lib/date-utils'
+import { characterPortraitUrl } from '@/lib/eve-images'
+import { cn } from '@/lib/utils'
+
+import type { AdminMarketHistoryRow, MarketStatus } from '../types'
+import type { BadgeVariant } from '@/components/ui/badge'
+
+const VISIBILITY_VARIANTS: Record<'public' | 'internal', BadgeVariant> = {
+	public: 'secondary',
+	internal: 'warning',
+}
+
+function statusVariant(status: MarketStatus | null): BadgeVariant {
+	switch (status) {
+		case 'open':
+			return 'success'
+		case 'closed':
+		case 'resolving':
+			return 'warning'
+		case 'resolved':
+			return 'gold'
+		case 'voided':
+			return 'destructive'
+		case 'draft':
+			return 'secondary'
+		default:
+			return 'ghost'
+	}
+}
+
+const COL_COUNT = 6
+
+function hasMetadata(metadata: unknown): boolean {
+	return (
+		metadata != null &&
+		(typeof metadata !== 'object' || Object.keys(metadata as object).length > 0)
+	)
+}
+
+export interface MarketHistoryTableProps {
+	rows: AdminMarketHistoryRow[] | undefined
+	isLoading: boolean
+	error: Error | null
+}
+
+/** Immutable market-lifecycle audit table. */
+export function MarketHistoryTable({ rows, isLoading, error }: MarketHistoryTableProps) {
+	const [expanded, setExpanded] = useState<Set<string>>(new Set())
+	const toggle = (id: string) =>
+		setExpanded((prev) => {
+			const next = new Set(prev)
+			if (next.has(id)) next.delete(id)
+			else next.add(id)
+			return next
+		})
+
+	if (error) {
+		return <p className="text-destructive">Failed to load market history: {error.message}</p>
+	}
+	if (isLoading) {
+		return (
+			<div className="space-y-2">
+				<Skeleton className="h-12 w-full" />
+				<Skeleton className="h-12 w-full" />
+				<Skeleton className="h-12 w-full" />
+			</div>
+		)
+	}
+
+	return (
+		<div className="rounded-md border">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Created</TableHead>
+						<TableHead>Actor</TableHead>
+						<TableHead>Action</TableHead>
+						<TableHead>Transition</TableHead>
+						<TableHead>Visibility</TableHead>
+						<TableHead className="w-10" />
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{rows?.map((row) => {
+						const isOpen = expanded.has(row.id)
+						const meta = hasMetadata(row.metadata)
+						return (
+							<Fragment key={row.id}>
+								<TableRow>
+									<TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+										{formatDateTime(row.createdAt)}
+									</TableCell>
+									<TableCell>
+										{row.actorUserId && row.actor ? (
+											<Link
+												to={`/admin/users/${row.actorUserId}`}
+												className="flex items-center gap-2 text-primary hover:underline"
+											>
+												{row.actor.mainCharacterId ? (
+													<img
+														src={characterPortraitUrl(row.actor.mainCharacterId, 32)}
+														alt=""
+														className="h-6 w-6 rounded-full"
+													/>
+												) : null}
+												<span className="text-sm">{row.actor.userName ?? row.actorUserId}</span>
+											</Link>
+										) : (
+											<span className="text-sm italic text-muted-foreground">System</span>
+										)}
+									</TableCell>
+									<TableCell>
+										<Badge variant="default">{row.action}</Badge>
+									</TableCell>
+									<TableCell>
+										<div className="flex items-center gap-1.5">
+											{row.previousStatus ? (
+												<Badge variant={statusVariant(row.previousStatus)}>
+													{row.previousStatus}
+												</Badge>
+											) : (
+												<span className="text-xs text-muted-foreground">—</span>
+											)}
+											<ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+											{row.newStatus ? (
+												<Badge variant={statusVariant(row.newStatus)}>{row.newStatus}</Badge>
+											) : (
+												<span className="text-xs text-muted-foreground">—</span>
+											)}
+										</div>
+									</TableCell>
+									<TableCell>
+										<Badge variant={VISIBILITY_VARIANTS[row.visibility]}>{row.visibility}</Badge>
+									</TableCell>
+									<TableCell>
+										{meta ? (
+											<Button variant="ghost" size="sm" onClick={() => toggle(row.id)}>
+												<ChevronDown
+													className={cn('h-4 w-4 transition-transform', isOpen && 'rotate-180')}
+												/>
+											</Button>
+										) : null}
+									</TableCell>
+								</TableRow>
+								{isOpen && meta ? (
+									<TableRow>
+										<TableCell colSpan={COL_COUNT} className="bg-muted/30">
+											<div className="mb-2 text-sm font-medium">Metadata</div>
+											<JsonViewer data={row.metadata} defaultExpanded={false} maxHeight="300px" />
+										</TableCell>
+									</TableRow>
+								) : null}
+							</Fragment>
+						)
+					})}
+					{rows?.length === 0 ? (
+						<TableRow>
+							<TableCell colSpan={COL_COUNT} className="h-24 text-center text-muted-foreground">
+								No history entries found
+							</TableCell>
+						</TableRow>
+					) : null}
+				</TableBody>
+			</Table>
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/components/user-search-select.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/user-search-select.tsx
@@ -1,0 +1,96 @@
+import { useCallback } from 'react'
+
+import { Select } from '@/components/ui/select'
+import { api } from '@/lib/api'
+import { characterPortraitUrl } from '@/lib/eve-images'
+
+import type { SelectOption } from '@/components/ui/select'
+import type { AdminUser } from '@/lib/api'
+
+export type UserOption = SelectOption & {
+	mainCharacterId: string | null
+	discordUsername: string | null
+}
+
+export interface UserSearchSelectProps {
+	/** Selected user uuid. */
+	value: string
+	/** Known label for the current value (renders before any search). */
+	label?: string | null
+	placeholder?: string
+	disabled?: boolean
+	inputId?: string
+	onChange: (userId: string, user: UserOption | null) => void
+}
+
+function mapUser(user: AdminUser): UserOption {
+	return {
+		value: user.id,
+		label: user.mainCharacterName ?? user.id,
+		description: user.discordUsername ?? undefined,
+		mainCharacterId: user.mainCharacterId,
+		discordUsername: user.discordUsername,
+	}
+}
+
+/** Async member picker → core user uuid, backed by GET /admin/users. */
+export function UserSearchSelect({
+	value,
+	label,
+	placeholder = 'Search members by name…',
+	disabled = false,
+	inputId,
+	onChange,
+}: UserSearchSelectProps) {
+	const searchDelegate = useCallback(async (query: string): Promise<UserOption[]> => {
+		const { data } = await api.getAdminUsers({ search: query })
+		return data.map(mapUser)
+	}, [])
+
+	return (
+		<Select<UserOption>
+			inputId={inputId}
+			value={value}
+			options={
+				value ? [{ value, label: label ?? value, mainCharacterId: null, discordUsername: null }] : []
+			}
+			searchable
+			searchDelegate={searchDelegate}
+			minQueryLength={2}
+			placeholder={placeholder}
+			disabled={disabled}
+			onValueChange={(nextValue, option) => onChange(nextValue, option)}
+			loadingText="Searching members…"
+			emptyText="No matching members"
+			queryHintText="Type at least 2 characters"
+			renderOption={(option) => (
+				<div className="flex min-w-0 items-center gap-2">
+					{option.mainCharacterId ? (
+						<img
+							src={characterPortraitUrl(option.mainCharacterId, 32)}
+							alt=""
+							width={28}
+							height={28}
+							className="h-7 w-7 shrink-0 rounded-full"
+						/>
+					) : (
+						<div className="h-7 w-7 shrink-0 rounded-full bg-muted" />
+					)}
+					<div className="min-w-0">
+						<div className="truncate font-medium" title={option.label}>
+							{option.label}
+						</div>
+						{option.discordUsername ? (
+							<div
+								className="truncate text-xs text-muted-foreground"
+								title={option.discordUsername}
+							>
+								{option.discordUsername}
+							</div>
+						) : null}
+					</div>
+				</div>
+			)}
+		/>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/components/wallet-list-grid.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/wallet-list-grid.tsx
@@ -1,0 +1,117 @@
+import { createMRTColumnHelper } from 'mantine-react-table'
+import { useMemo } from 'react'
+
+import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { Button } from '@/components/ui/button'
+import { formatDateTime } from '@/lib/date-utils'
+import { characterPortraitUrl } from '@/lib/eve-images'
+import { formatPoints } from '@/lib/format-utils'
+
+import type { AdminWalletRow } from '../types'
+import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
+
+const columnHelper = createMRTColumnHelper<AdminWalletRow>()
+
+export interface WalletListGridProps {
+	rows: AdminWalletRow[]
+	loading?: boolean
+	error?: unknown
+	sorting: MRT_SortingState
+	onSortingChange: (sorting: MRT_SortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
+	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+	pageCount: number
+	rowCount: number
+	onDeposit: (wallet: AdminWalletRow) => void
+	onViewLedger: (wallet: AdminWalletRow) => void
+}
+
+export function WalletListGrid(props: WalletListGridProps) {
+	const { onDeposit, onViewLedger } = props
+
+	const columns = useMemo<Array<MRT_ColumnDef<AdminWalletRow>>>(
+		() => [
+			columnHelper.accessor((row) => row.userName || row.userId, {
+				id: 'user',
+				header: 'User',
+				enableSorting: false,
+				Cell: ({ row }) => (
+					<div className="flex items-center gap-2">
+						{row.original.mainCharacterId ? (
+							<img
+								src={characterPortraitUrl(row.original.mainCharacterId, 32)}
+								alt=""
+								width={28}
+								height={28}
+								className="h-7 w-7 shrink-0 rounded-full"
+							/>
+						) : (
+							<div className="h-7 w-7 shrink-0 rounded-full bg-muted" />
+						)}
+						<span>{row.original.userName || row.original.userId}</span>
+					</div>
+				),
+			}),
+			columnHelper.accessor('userId', {
+				id: 'userId',
+				header: 'User ID',
+				enableSorting: true,
+				Cell: ({ row }) => (
+					<span className="font-mono text-xs text-muted-foreground">{row.original.userId}</span>
+				),
+			}),
+			columnHelper.accessor('balance', {
+				id: 'balance',
+				header: 'Balance',
+				enableSorting: true,
+				mantineTableHeadCellProps: { style: { textAlign: 'right' } },
+				mantineTableBodyCellProps: { style: { textAlign: 'right' } },
+				Cell: ({ row }) => <span className="font-mono">{formatPoints(row.original.balance)}</span>,
+			}),
+			columnHelper.accessor('updatedAt', {
+				id: 'updatedAt',
+				header: 'Updated',
+				enableSorting: true,
+				Cell: ({ row }) => formatDateTime(row.original.updatedAt),
+			}),
+			columnHelper.display({
+				id: 'actions',
+				header: 'Actions',
+				enableSorting: false,
+				size: 200,
+				minSize: 180,
+				maxSize: 240,
+				mantineTableHeadCellProps: { style: { textAlign: 'center', whiteSpace: 'nowrap' } },
+				mantineTableBodyCellProps: { style: { textAlign: 'right', whiteSpace: 'nowrap' } },
+				Cell: ({ row }) => (
+					<div className="flex justify-end gap-2">
+						<Button variant="primary" size="sm" onClick={() => onDeposit(row.original)}>
+							Deposit
+						</Button>
+						<Button variant="ghost" size="sm" onClick={() => onViewLedger(row.original)}>
+							View ledger
+						</Button>
+					</div>
+				),
+			}),
+		],
+		[onDeposit, onViewLedger]
+	)
+
+	return (
+		<TaxReportDataGrid
+			columns={columns}
+			rows={props.rows}
+			loading={props.loading}
+			error={props.error}
+			emptyMessage="No wallets found."
+			sorting={props.sorting}
+			onSortingChange={props.onSortingChange}
+			pagination={props.pagination}
+			onPaginationChange={props.onPaginationChange}
+			pageCount={props.pageCount}
+			rowCount={props.rowCount}
+			pinnedRightColumnIds={['actions']}
+		/>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/hooks.ts
+++ b/apps/ui/src/client/features/prediction-markets/hooks.ts
@@ -1,0 +1,86 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { useApiMutation } from '@/hooks/useApiMutation'
+
+import {
+	createDeposit,
+	getAuditLedger,
+	getMarketHistory,
+	getUserLedger,
+	getWallet,
+	getWallets,
+} from './api'
+import { pmKeys } from './query-keys'
+
+import type {
+	AuditLedgerFilters,
+	DepositRequest,
+	LedgerFilters,
+	MarketHistoryFilters,
+	WalletsFilters,
+} from './types'
+
+const STALE_TIME = 1000 * 60 * 2 // 2 minutes
+const GC_TIME = 1000 * 60 * 5 // 5 minutes
+
+export function useWallets(filters?: WalletsFilters) {
+	return useQuery({
+		queryKey: pmKeys.wallets(filters),
+		queryFn: () => getWallets(filters),
+		staleTime: STALE_TIME,
+		gcTime: GC_TIME,
+	})
+}
+
+export function useWallet(userId: string) {
+	return useQuery({
+		queryKey: pmKeys.wallet(userId),
+		queryFn: () => getWallet(userId),
+		enabled: !!userId,
+		staleTime: STALE_TIME,
+		gcTime: GC_TIME,
+	})
+}
+
+export function useUserLedger(userId: string, filters?: LedgerFilters) {
+	return useQuery({
+		queryKey: pmKeys.userLedger(userId, filters),
+		queryFn: () => getUserLedger(userId, filters),
+		enabled: !!userId,
+		staleTime: STALE_TIME,
+		gcTime: GC_TIME,
+	})
+}
+
+export function useAuditLedger(filters?: AuditLedgerFilters) {
+	return useQuery({
+		queryKey: pmKeys.auditLedger(filters),
+		queryFn: () => getAuditLedger(filters),
+		staleTime: STALE_TIME,
+		gcTime: GC_TIME,
+	})
+}
+
+export function useMarketHistory(filters?: MarketHistoryFilters) {
+	return useQuery({
+		queryKey: pmKeys.marketHistory(filters),
+		queryFn: () => getMarketHistory(filters),
+		staleTime: STALE_TIME,
+		gcTime: GC_TIME,
+	})
+}
+
+/** POST /deposits — toasts on success/error; invalidates all PM queries + the target wallet. */
+export function useDeposit() {
+	const queryClient = useQueryClient()
+
+	return useApiMutation({
+		mutationFn: (body: DepositRequest) => createDeposit(body),
+		successMessage: (res) =>
+			res.deduped ? 'Deposit already applied (idempotent).' : 'Deposit successful.',
+		onSuccess: (_res, variables) => {
+			queryClient.invalidateQueries({ queryKey: pmKeys.all })
+			queryClient.invalidateQueries({ queryKey: pmKeys.wallet(variables.targetUserId) })
+		},
+	})
+}

--- a/apps/ui/src/client/features/prediction-markets/index.ts
+++ b/apps/ui/src/client/features/prediction-markets/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Prediction Markets feature module — admin types, API methods, and hooks.
+ */
+
+export * from './types'
+export * from './api'
+export * from './query-keys'
+export * from './hooks'

--- a/apps/ui/src/client/features/prediction-markets/query-keys.ts
+++ b/apps/ui/src/client/features/prediction-markets/query-keys.ts
@@ -1,0 +1,21 @@
+/**
+ * Query key factory for Prediction Markets admin queries.
+ */
+
+import type {
+	AuditLedgerFilters,
+	LedgerFilters,
+	MarketHistoryFilters,
+	WalletsFilters,
+} from './types'
+
+export const pmKeys = {
+	all: ['prediction-markets'] as const,
+	wallets: (filters?: WalletsFilters) => [...pmKeys.all, 'wallets', filters] as const,
+	wallet: (userId: string) => [...pmKeys.all, 'wallet', userId] as const,
+	userLedger: (userId: string, filters?: LedgerFilters) =>
+		[...pmKeys.all, 'userLedger', userId, filters] as const,
+	auditLedger: (filters?: AuditLedgerFilters) => [...pmKeys.all, 'auditLedger', filters] as const,
+	marketHistory: (filters?: MarketHistoryFilters) =>
+		[...pmKeys.all, 'marketHistory', filters] as const,
+}

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-audit.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-audit.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select } from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { usePageTitle } from '@/hooks/usePageTitle'
+
+import { LedgerTable } from '../components/ledger-table'
+import { MarketHistoryTable } from '../components/market-history-table'
+import { useAuditLedger, useMarketHistory } from '../hooks'
+
+import type { LedgerType } from '../types'
+
+const LEDGER_TYPE_OPTIONS = [
+	{ value: 'all', label: 'All types' },
+	{ value: 'grant', label: 'Grant' },
+	{ value: 'wager', label: 'Wager' },
+	{ value: 'refund', label: 'Refund' },
+	{ value: 'payout', label: 'Payout' },
+	{ value: 'rake', label: 'Rake' },
+	{ value: 'burn', label: 'Burn' },
+	{ value: 'adjustment', label: 'Adjustment' },
+]
+
+/** A YYYY-MM-DD date-input value → an ISO instant (start or end of day, UTC). */
+function toIso(dateStr: string, endOfDay = false): string | undefined {
+	if (!dateStr) return undefined
+	const d = new Date(`${dateStr}${endOfDay ? 'T23:59:59.999Z' : 'T00:00:00.000Z'}`)
+	return Number.isNaN(d.getTime()) ? undefined : d.toISOString()
+}
+
+export default function PredictionMarketAudit() {
+	usePageTitle('Admin - Prediction Market Audit')
+
+	// Financial ledger tab
+	const [ledgerType, setLedgerType] = useState('all')
+	const [ledgerSince, setLedgerSince] = useState('')
+	const [ledgerUntil, setLedgerUntil] = useState('')
+	const [ledgerPage, setLedgerPage] = useState({ limit: 50, offset: 0 })
+
+	const ledger = useAuditLedger({
+		type: ledgerType === 'all' ? undefined : (ledgerType as LedgerType),
+		since: toIso(ledgerSince),
+		until: toIso(ledgerUntil, true),
+		limit: ledgerPage.limit,
+		offset: ledgerPage.offset,
+	})
+	const ledgerTotal = ledger.data?.total ?? 0
+
+	// Market lifecycle tab
+	const [visibility, setVisibility] = useState('public')
+	const [historyPage, setHistoryPage] = useState({ limit: 50, offset: 0 })
+
+	const history = useMarketHistory({
+		includeInternal: visibility === 'all',
+		limit: historyPage.limit,
+		offset: historyPage.offset,
+	})
+	const historyTotal = history.data?.total ?? 0
+
+	return (
+		<div className="space-y-6">
+			<div>
+				<h1 className="text-3xl font-bold gradient-text">Prediction Market Audit Log</h1>
+				<p className="mt-1 text-muted-foreground">
+					Immutable financial ledger and market-lifecycle history.
+				</p>
+			</div>
+
+			<Tabs defaultValue="ledger" className="w-full">
+				<TabsList className="grid w-full max-w-md grid-cols-2">
+					<TabsTrigger value="ledger">Financial ledger</TabsTrigger>
+					<TabsTrigger value="history">Market lifecycle</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="ledger" className="space-y-4">
+					<div className="flex flex-wrap items-end gap-4">
+						<div className="w-48 space-y-2">
+							<Label htmlFor="pm-audit-type">Type</Label>
+							<Select
+								inputId="pm-audit-type"
+								value={ledgerType}
+								onValueChange={(val) => {
+									setLedgerType(val)
+									setLedgerPage((p) => ({ ...p, offset: 0 }))
+								}}
+								options={LEDGER_TYPE_OPTIONS}
+								placeholder="All types"
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="pm-audit-since">From</Label>
+							<Input
+								id="pm-audit-since"
+								type="date"
+								value={ledgerSince}
+								onChange={(e) => {
+									setLedgerSince(e.target.value)
+									setLedgerPage((p) => ({ ...p, offset: 0 }))
+								}}
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="pm-audit-until">To</Label>
+							<Input
+								id="pm-audit-until"
+								type="date"
+								value={ledgerUntil}
+								onChange={(e) => {
+									setLedgerUntil(e.target.value)
+									setLedgerPage((p) => ({ ...p, offset: 0 }))
+								}}
+							/>
+						</div>
+					</div>
+
+					<LedgerTable rows={ledger.data?.rows} isLoading={ledger.isLoading} error={ledger.error} />
+					{ledgerTotal > 0 ? (
+						<UserSearchPaginationControls
+							totalCount={ledgerTotal}
+							page={Math.floor(ledgerPage.offset / ledgerPage.limit) + 1}
+							pageSize={ledgerPage.limit}
+							itemLabel="entries"
+							nextButtonLoading={ledger.isFetching}
+							onPageChange={(next) =>
+								setLedgerPage((p) => ({ ...p, offset: (next - 1) * p.limit }))
+							}
+							onPageSizeChange={(size) => setLedgerPage({ limit: size, offset: 0 })}
+						/>
+					) : null}
+				</TabsContent>
+
+				<TabsContent value="history" className="space-y-4">
+					<div className="w-48 space-y-2">
+						<Label htmlFor="pm-audit-visibility">Visibility</Label>
+						<Select
+							inputId="pm-audit-visibility"
+							value={visibility}
+							onValueChange={(val) => {
+								setVisibility(val)
+								setHistoryPage((p) => ({ ...p, offset: 0 }))
+							}}
+							options={[
+								{ value: 'public', label: 'Public only' },
+								{ value: 'all', label: 'Include internal' },
+							]}
+						/>
+					</div>
+
+					<MarketHistoryTable
+						rows={history.data?.rows}
+						isLoading={history.isLoading}
+						error={history.error}
+					/>
+					{historyTotal > 0 ? (
+						<UserSearchPaginationControls
+							totalCount={historyTotal}
+							page={Math.floor(historyPage.offset / historyPage.limit) + 1}
+							pageSize={historyPage.limit}
+							itemLabel="events"
+							nextButtonLoading={history.isFetching}
+							onPageChange={(next) =>
+								setHistoryPage((p) => ({ ...p, offset: (next - 1) * p.limit }))
+							}
+							onPageSizeChange={(size) => setHistoryPage({ limit: size, offset: 0 })}
+						/>
+					) : null}
+				</TabsContent>
+			</Tabs>
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-wallet-detail.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-wallet-detail.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { characterPortraitUrl } from '@/lib/eve-images'
+import { formatPoints } from '@/lib/format-utils'
+
+import { DepositDialog } from '../components/deposit-dialog'
+import { LedgerTable } from '../components/ledger-table'
+import { useUserLedger, useWallet } from '../hooks'
+
+export default function PredictionMarketWalletDetail() {
+	usePageTitle('Admin - Wallet Detail')
+	const { userId = '' } = useParams()
+	const [pagination, setPagination] = useState({ limit: 50, offset: 0 })
+	const [depositOpen, setDepositOpen] = useState(false)
+
+	const wallet = useWallet(userId)
+	const ledger = useUserLedger(userId, pagination)
+	const total = ledger.data?.total ?? 0
+
+	return (
+		<div className="space-y-6">
+			<div>
+				<Link
+					to="/admin/prediction-markets/wallets"
+					className="text-sm text-muted-foreground hover:underline"
+				>
+					← Back to wallets
+				</Link>
+				<h1 className="mt-1 text-3xl font-bold gradient-text">Wallet</h1>
+			</div>
+
+			<Card>
+				<CardHeader className="flex flex-row items-center justify-between">
+					<CardTitle>Balance</CardTitle>
+					<Button variant="primary" size="sm" onClick={() => setDepositOpen(true)}>
+						Deposit
+					</Button>
+				</CardHeader>
+				<CardContent>
+					{wallet.isLoading ? (
+						<Skeleton className="h-12 w-48" />
+					) : wallet.error ? (
+						<p className="text-destructive">Failed to load wallet: {wallet.error.message}</p>
+					) : (
+						<div className="flex items-center gap-3">
+							{wallet.data?.mainCharacterId ? (
+								<img
+									src={characterPortraitUrl(wallet.data.mainCharacterId, 64)}
+									alt=""
+									className="h-12 w-12 rounded-full"
+								/>
+							) : null}
+							<div>
+								<div className="font-mono text-2xl font-bold">
+									{formatPoints(wallet.data?.balance ?? '0')}
+								</div>
+								<div className="text-sm text-muted-foreground">
+									{wallet.data?.userName ?? userId}
+								</div>
+							</div>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+
+			<div className="space-y-3">
+				<h2 className="text-xl font-semibold">Ledger</h2>
+				<LedgerTable rows={ledger.data?.rows} isLoading={ledger.isLoading} error={ledger.error} />
+				{total > 0 ? (
+					<UserSearchPaginationControls
+						totalCount={total}
+						page={Math.floor(pagination.offset / pagination.limit) + 1}
+						pageSize={pagination.limit}
+						itemLabel="entries"
+						nextButtonLoading={ledger.isFetching}
+						onPageChange={(nextPage) =>
+							setPagination((p) => ({ ...p, offset: (nextPage - 1) * p.limit }))
+						}
+						onPageSizeChange={(nextSize) => setPagination({ limit: nextSize, offset: 0 })}
+					/>
+				) : null}
+			</div>
+
+			<DepositDialog
+				open={depositOpen}
+				onOpenChange={setDepositOpen}
+				defaultTargetUserId={userId}
+				defaultTargetName={wallet.data?.userName ?? null}
+			/>
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-wallets.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-wallets.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { usePageTitle } from '@/hooks/usePageTitle'
+
+import { DepositDialog } from '../components/deposit-dialog'
+import { WalletListGrid } from '../components/wallet-list-grid'
+import { useWallets } from '../hooks'
+
+import type { AdminWalletRow } from '../types'
+import type { MRT_SortingState } from 'mantine-react-table'
+
+export default function PredictionMarketWallets() {
+	usePageTitle('Admin - Prediction Market Wallets')
+	const navigate = useNavigate()
+
+	const [search, setSearch] = useState('')
+	const [sorting, setSorting] = useState<MRT_SortingState>([{ id: 'balance', desc: true }])
+	const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 })
+	const [depositTarget, setDepositTarget] = useState<AdminWalletRow | null>(null)
+	const [depositOpen, setDepositOpen] = useState(false)
+
+	const sort = (sorting[0]?.id as 'balance' | 'updatedAt' | 'userId' | undefined) ?? 'balance'
+	const order: 'asc' | 'desc' = sorting[0]?.desc ? 'desc' : 'asc'
+
+	const { data, isLoading, error } = useWallets({
+		search: search.trim() || undefined,
+		sort,
+		order,
+		limit: pagination.pageSize,
+		offset: pagination.pageIndex * pagination.pageSize,
+	})
+
+	const total = data?.total ?? 0
+	const pageCount = Math.max(1, Math.ceil(total / Math.max(1, pagination.pageSize)))
+
+	const openDeposit = (wallet: AdminWalletRow | null) => {
+		setDepositTarget(wallet)
+		setDepositOpen(true)
+	}
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="text-3xl font-bold gradient-text">Prediction Market Wallets</h1>
+					<p className="mt-1 text-muted-foreground">
+						Search balances, make deposits, and inspect a member&apos;s ledger.
+					</p>
+				</div>
+				<Button variant="primary" onClick={() => openDeposit(null)}>
+					Deposit
+				</Button>
+			</div>
+
+			<Input
+				placeholder="Search members by character name…"
+				value={search}
+				onChange={(e) => {
+					setSearch(e.target.value)
+					setPagination((p) => ({ ...p, pageIndex: 0 }))
+				}}
+				className="max-w-sm"
+			/>
+
+			<WalletListGrid
+				rows={data?.rows ?? []}
+				loading={isLoading}
+				error={error}
+				sorting={sorting}
+				onSortingChange={(next) => {
+					setSorting(next)
+					setPagination((p) => ({ ...p, pageIndex: 0 }))
+				}}
+				pagination={pagination}
+				onPaginationChange={setPagination}
+				pageCount={pageCount}
+				rowCount={total}
+				onDeposit={(wallet) => openDeposit(wallet)}
+				onViewLedger={(wallet) => navigate(`/admin/prediction-markets/wallets/${wallet.userId}`)}
+			/>
+
+			<DepositDialog
+				open={depositOpen}
+				onOpenChange={setDepositOpen}
+				defaultTargetUserId={depositTarget?.userId}
+				defaultTargetName={depositTarget?.userName ?? null}
+			/>
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/types.ts
+++ b/apps/ui/src/client/features/prediction-markets/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Prediction Markets (admin) feature types.
+ *
+ * Re-exports shared row types from @repo/prediction-markets and defines
+ * UI-facing request/response/filter shapes for the Layer-1 admin API.
+ * All monetary fields are integer strings (numeric) — DISPLAY ONLY, never Number() math.
+ */
+
+import type {
+	GlobalLedgerRow,
+	LedgerType,
+	MarketHistoryRow,
+	MarketStatus,
+	WalletRow,
+} from '@repo/prediction-markets'
+
+export type { GlobalLedgerRow, LedgerType, MarketHistoryRow, MarketStatus, WalletRow }
+
+/** Generic paged envelope returned by every L1 list endpoint. */
+export interface Paged<T> {
+	rows: T[]
+	total: number
+}
+
+/** Enriched display identity attached to wallet/ledger rows by the core route. */
+export interface DisplayIdentity {
+	userName: string | null
+	mainCharacterId: string | null
+}
+
+export type AdminWalletRow = WalletRow & DisplayIdentity
+
+export interface WalletDetail extends DisplayIdentity {
+	userId: string
+	balance: string
+}
+
+export type AdminLedgerRow = GlobalLedgerRow & DisplayIdentity
+
+export type AdminMarketHistoryRow = MarketHistoryRow & {
+	actor: DisplayIdentity | null
+}
+
+// --- filters ---------------------------------------------------------------
+
+export interface WalletsFilters {
+	search?: string
+	sort?: 'balance' | 'updatedAt' | 'userId'
+	order?: 'asc' | 'desc'
+	limit?: number
+	offset?: number
+}
+
+export interface LedgerFilters {
+	limit?: number
+	offset?: number
+}
+
+export interface AuditLedgerFilters {
+	userId?: string
+	type?: LedgerType
+	marketId?: string
+	since?: string
+	until?: string
+	limit?: number
+	offset?: number
+}
+
+export interface MarketHistoryFilters {
+	marketId?: string
+	includeInternal?: boolean
+	since?: string
+	until?: string
+	limit?: number
+	offset?: number
+}
+
+// --- deposit mutation ------------------------------------------------------
+
+export interface DepositRequest {
+	targetUserId: string
+	/** Integer string (numeric). DISPLAY ONLY — never Number() arithmetic. */
+	amount: string
+	reason: string
+	idempotencyKey?: string
+}
+
+export interface DepositResponse {
+	/** Resulting wallet balance, integer string. */
+	balance: string
+	deduped: boolean
+}

--- a/apps/ui/src/client/lib/format-utils.ts
+++ b/apps/ui/src/client/lib/format-utils.ts
@@ -17,6 +17,25 @@ export function formatISK(value: string | number, options?: { showDecimals?: boo
 }
 
 /**
+ * Format a points amount (prediction-market currency) with comma separators + " points".
+ * Points are integer strings — display-only, never used for arithmetic. Groups the raw
+ * digit string so arbitrarily large integers keep full precision (no Number()).
+ * e.g. "1500000" → "1,500,000 points"; "-50" → "-50 points"
+ */
+export function formatPoints(value: string): string {
+	const trimmed = value.trim()
+	if (/^-?\d+$/.test(trimmed)) {
+		const negative = trimmed.startsWith('-')
+		const digits = negative ? trimmed.slice(1) : trimmed
+		const grouped = digits.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+		return `${negative ? '-' : ''}${grouped} points`
+	}
+	const num = Number(trimmed)
+	if (!Number.isFinite(num)) return '0 points'
+	return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(num) + ' points'
+}
+
+/**
  * Format an ISK amount in abbreviated form with " ISK" suffix.
  * e.g. 1500000000 → "1.50B ISK"
  */

--- a/apps/ui/src/client/routes/route-groups/admin-routes.tsx
+++ b/apps/ui/src/client/routes/route-groups/admin-routes.tsx
@@ -65,6 +65,15 @@ const IndustryProviderEditPage = lazy(
 const IndustryProviderNewPage = lazy(
 	() => import('@/features/industry/routes/industry-provider-new')
 )
+const PredictionMarketWalletsPage = lazy(
+	() => import('@/features/prediction-markets/routes/prediction-market-wallets')
+)
+const PredictionMarketWalletDetailPage = lazy(
+	() => import('@/features/prediction-markets/routes/prediction-market-wallet-detail')
+)
+const PredictionMarketAuditPage = lazy(
+	() => import('@/features/prediction-markets/routes/prediction-market-audit')
+)
 
 export const adminRouteElements = (
 	<Route path="/admin" element={<AdminLayout />}>
@@ -163,5 +172,32 @@ export const adminRouteElements = (
 				</Suspense>
 			}
 		/>
+		<Route path="prediction-markets">
+			<Route index element={<Navigate to="/admin/prediction-markets/wallets" replace />} />
+			<Route
+				path="wallets"
+				element={
+					<Suspense fallback={<LoadingPage />}>
+						<PredictionMarketWalletsPage />
+					</Suspense>
+				}
+			/>
+			<Route
+				path="wallets/:userId"
+				element={
+					<Suspense fallback={<LoadingPage />}>
+						<PredictionMarketWalletDetailPage />
+					</Suspense>
+				}
+			/>
+			<Route
+				path="audit"
+				element={
+					<Suspense fallback={<LoadingPage />}>
+						<PredictionMarketAuditPage />
+					</Suspense>
+				}
+			/>
+		</Route>
 	</Route>
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2694,6 +2694,9 @@ importers:
       '@repo/moon-scan':
         specifier: workspace:*
         version: link:../../packages/moon-scan
+      '@repo/prediction-markets':
+        specifier: workspace:*
+        version: link:../../packages/prediction-markets
       '@repo/srp':
         specifier: workspace:*
         version: link:../../packages/srp


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Adds the admin web UI for Prediction Markets to `apps/ui`, giving admins a way to browse member wallets, credit points via deposits, and audit the financial ledger and market-lifecycle history. It sits on top of the `@repo/prediction-markets` package and the Layer-1 admin API.

## Changes

- New `prediction-markets` feature module under `apps/ui/src/client/features/`: admin types, an `apiClient`-based API layer, TanStack Query hooks, and a query-key factory.
- Three lazy-loaded admin routes wired into `admin-routes.tsx`: wallet list, wallet detail (balance + per-user ledger), and an audit log with "Financial ledger" and "Market lifecycle" tabs.
- Components: a paginated/sortable wallet grid, expandable ledger and market-history tables with JSON metadata viewers, an async member picker (`UserSearchSelect`), and a confirmation-gated deposit dialog that sends a fresh idempotency key per submit.
- Adds a "Prediction Markets" entry (Wallets + Audit Log) to the admin nav.
- Adds a `formatPoints` helper that groups integer-string amounts without `Number()`, preserving precision for arbitrarily large values.
- Adds `@repo/prediction-markets` as a workspace dependency of `apps/ui`.

## Testing

No automated tests are included in the diff. The changes are UI-only and should be verified by exercising the wallets, wallet-detail, and audit pages, including the deposit flow.
<!-- claude:end -->