### PR TITLE
feat(prediction-markets): M2 Phase 1 — forum-post plumbing + market creation

### DIFF
--- a/apps/core/.migrations/0040_common_tinkerer.sql
+++ b/apps/core/.migrations/0040_common_tinkerer.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "pm_forum_config" (
+	"guild_id" text PRIMARY KEY NOT NULL,
+	"category_id" text NOT NULL,
+	"forum_channel_id" text,
+	"tag_open_id" text,
+	"tag_closed_id" text,
+	"tag_resolved_id" text,
+	"tag_voided_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/core/.migrations/meta/0040_snapshot.json
+++ b/apps/core/.migrations/meta/0040_snapshot.json
@@ -1,0 +1,4754 @@
+{
+  "id": "695fc7c0-b0a0-49df-9316-673e31d4b30b",
+  "prevId": "ab6f31e5-98a4-417e-8bc4-82e12499aee0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_destinations": {
+      "name": "alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_destinations_scope_idx": {
+          "name": "alert_destinations_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_alert_type_idx": {
+          "name": "alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_type_idx": {
+          "name": "alert_destinations_type_idx",
+          "columns": [
+            {
+              "expression": "destination_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_enabled_idx": {
+          "name": "alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_core_user_id_users_id_fk": {
+          "name": "alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_created_by_users_id_fk": {
+          "name": "alert_destinations_created_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_updated_by_users_id_fk": {
+          "name": "alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_configs": {
+      "name": "corporation_alert_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_ids": {
+          "name": "destination_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_alert_configs_corp_idx": {
+          "name": "corporation_alert_configs_corp_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_alert_type_idx": {
+          "name": "corporation_alert_configs_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_enabled_idx": {
+          "name": "corporation_alert_configs_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_corp_alert_type_idx": {
+          "name": "corporation_alert_configs_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_configs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_alert_configs_corp_alert_type_unique": {
+          "name": "corporation_alert_configs_corp_alert_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "alert_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_destinations": {
+      "name": "corporation_alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_alert_destinations_corp_id_idx": {
+          "name": "corp_alert_destinations_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_alert_type_idx": {
+          "name": "corp_alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_enabled_idx": {
+          "name": "corp_alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_corp_alert_type_idx": {
+          "name": "corp_alert_destinations_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_core_user_id_users_id_fk": {
+          "name": "corporation_alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_created_by_users_id_fk": {
+          "name": "corporation_alert_destinations_created_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_updated_by_users_id_fk": {
+          "name": "corporation_alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_invites": {
+      "name": "corporation_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_discord_invites_corp_id_idx": {
+          "name": "corporation_discord_invites_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_user_id_idx": {
+          "name": "corporation_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_server_id_idx": {
+          "name": "corporation_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_created_at_idx": {
+          "name": "corporation_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_user_id_users_id_fk": {
+          "name": "corporation_discord_invites_user_id_users_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_roles": {
+      "name": "corporation_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_roles_attachment_idx": {
+          "name": "corp_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_role": {
+          "name": "unique_corp_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_servers": {
+      "name": "corporation_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_servers_corp_id_idx": {
+          "name": "corp_discord_servers_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_id_idx": {
+          "name": "corp_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_auto_assign_idx": {
+          "name": "corp_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"corporation_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_discord_servers_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server": {
+          "name": "unique_corp_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_categories": {
+      "name": "discord_command_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_categories_sort_order_idx": {
+          "name": "discord_command_categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_categories_name_unique": {
+          "name": "discord_command_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_permissions": {
+      "name": "discord_command_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_permissions_command_id_idx": {
+          "name": "discord_command_permissions_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_command_permissions_permission_id_idx": {
+          "name": "discord_command_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_command_permissions_command_id_discord_commands_id_fk": {
+          "name": "discord_command_permissions_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_command_permissions",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_permissions_command_permission_unique": {
+          "name": "discord_command_permissions_command_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_commands": {
+      "name": "discord_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static_response'"
+        },
+        "response_template": {
+          "name": "response_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_commands_name_idx": {
+          "name": "discord_commands_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_type_idx": {
+          "name": "discord_commands_type_idx",
+          "columns": [
+            {
+              "expression": "command_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_is_active_idx": {
+          "name": "discord_commands_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_category_id_idx": {
+          "name": "discord_commands_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_commands_category_id_discord_command_categories_id_fk": {
+          "name": "discord_commands_category_id_discord_command_categories_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "discord_command_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discord_commands_created_by_users_id_fk": {
+          "name": "discord_commands_created_by_users_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_commands_name_unique": {
+          "name": "discord_commands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_rows": {
+      "name": "discord_member_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discriminator": {
+          "name": "discriminator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_ids": {
+          "name": "role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "linked": {
+          "name": "linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_rows_run_linked_user_idx": {
+          "name": "discord_member_audit_rows_run_linked_user_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk": {
+          "name": "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "discord_member_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_rows_core_user_id_users_id_fk": {
+          "name": "discord_member_audit_rows_core_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_rows_run_discord_user_unique": {
+          "name": "discord_member_audit_rows_run_discord_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_runs": {
+      "name": "discord_member_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_count": {
+          "name": "linked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unlinked_count": {
+          "name": "unlinked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_runs_server_started_idx": {
+          "name": "discord_member_audit_runs_server_started_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_member_audit_runs_status_idx": {
+          "name": "discord_member_audit_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_runs_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_member_audit_runs_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "discord_member_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_runs_workflow_instance_id_unique": {
+          "name": "discord_member_audit_runs_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_roles": {
+      "name": "discord_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_roles_server_id_idx": {
+          "name": "discord_roles_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_roles_server_auto_apply_active_idx": {
+          "name": "discord_roles_server_auto_apply_active_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_apply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_roles\".\"auto_apply\" = true AND \"discord_roles\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_roles_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_roles_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_roles",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_discord_server_role": {
+          "name": "unique_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_server_commands": {
+      "name": "discord_server_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_command_id": {
+          "name": "discord_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_server_commands_server_id_idx": {
+          "name": "discord_server_commands_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_server_commands_command_id_idx": {
+          "name": "discord_server_commands_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_server_commands_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_server_commands_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_command_id_discord_commands_id_fk": {
+          "name": "discord_server_commands_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_created_by_users_id_fk": {
+          "name": "discord_server_commands_created_by_users_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_server_commands_server_command_unique": {
+          "name": "discord_server_commands_server_command_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "command_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_servers": {
+      "name": "discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "manage_nicknames": {
+          "name": "manage_nicknames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_servers_guild_id_idx": {
+          "name": "discord_servers_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_servers_active_idx": {
+          "name": "discord_servers_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_servers\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_servers_created_by_users_id_fk": {
+          "name": "discord_servers_created_by_users_id_fk",
+          "tableFrom": "discord_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_servers_guild_id_unique": {
+          "name": "discord_servers_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guild_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_decay_config": {
+      "name": "dkp_decay_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_decay_config_active_idx": {
+          "name": "dkp_decay_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dkp_decay_config\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_decay_config_effective_from_idx": {
+          "name": "dkp_decay_config_effective_from_idx",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_decay_config_created_by_users_id_fk": {
+          "name": "dkp_decay_config_created_by_users_id_fk",
+          "tableFrom": "dkp_decay_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_transactions": {
+      "name": "dkp_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_reason": {
+          "name": "award_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_transactions_user_earned_idx": {
+          "name": "dkp_transactions_user_earned_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_user_source_idx": {
+          "name": "dkp_transactions_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_character_earned_idx": {
+          "name": "dkp_transactions_character_earned_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_corp_earned_idx": {
+          "name": "dkp_transactions_corp_earned_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_earned_at_idx": {
+          "name": "dkp_transactions_earned_at_idx",
+          "columns": [
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_type_idx": {
+          "name": "dkp_transactions_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_id_idx": {
+          "name": "dkp_transactions_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_awarded_by_idx": {
+          "name": "dkp_transactions_awarded_by_idx",
+          "columns": [
+            {
+              "expression": "awarded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_transactions_user_id_users_id_fk": {
+          "name": "dkp_transactions_user_id_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "dkp_transactions_awarded_by_users_id_fk": {
+          "name": "dkp_transactions_awarded_by_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "awarded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_corporations": {
+      "name": "managed_corporations",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_character_id": {
+          "name": "assigned_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_character_name": {
+          "name": "assigned_character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "healthy_director_count": {
+          "name": "healthy_director_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_member_corporation": {
+          "name": "is_member_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_alt_corp": {
+          "name": "is_alt_corp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_special_purpose": {
+          "name": "is_special_purpose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recruiting": {
+          "name": "is_recruiting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_corporations_name_idx": {
+          "name": "managed_corporations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_ticker_idx": {
+          "name": "managed_corporations_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_assigned_character_id_idx": {
+          "name": "managed_corporations_assigned_character_id_idx",
+          "columns": [
+            {
+              "expression": "assigned_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_is_active_idx": {
+          "name": "managed_corporations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_background_refresh_idx": {
+          "name": "managed_corporations_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_structure_asset_sync_idx": {
+          "name": "managed_corporations_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_member_idx": {
+          "name": "managed_corporations_corporation_id_is_member_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_member_corporation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_alt_idx": {
+          "name": "managed_corporations_corporation_id_is_alt_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_alt_corp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_special_purpose_idx": {
+          "name": "managed_corporations_corporation_id_is_special_purpose_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_special_purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_corporations_configured_by_users_id_fk": {
+          "name": "managed_corporations_configured_by_users_id_fk",
+          "tableFrom": "managed_corporations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_credential_handoffs": {
+      "name": "mumble_tempop_credential_handoffs",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mumble_tempop_credential_handoffs_expires_at_idx": {
+          "name": "mumble_tempop_credential_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_credential_handoffs",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_guests": {
+      "name": "mumble_tempop_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corp_ticker": {
+          "name": "corp_ticker",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_name": {
+          "name": "login_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mumble_tempop_guests_tempop_id_idx": {
+          "name": "mumble_tempop_guests_tempop_id_idx",
+          "columns": [
+            {
+              "expression": "tempop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_guests",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempop_guests_subject_id_unique": {
+          "name": "mumble_tempop_guests_subject_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id"
+          ]
+        },
+        "mumble_tempop_guests_tempop_character_uq": {
+          "name": "mumble_tempop_guests_tempop_character_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tempop_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempops": {
+      "name": "mumble_tempops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mumble_tempops_status_expires_at_idx": {
+          "name": "mumble_tempops_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mumble_tempops_creator_user_id_idx": {
+          "name": "mumble_tempops_creator_user_id_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempops_creator_user_id_users_id_fk": {
+          "name": "mumble_tempops_creator_user_id_users_id_fk",
+          "tableFrom": "mumble_tempops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempops_short_code_unique": {
+          "name": "mumble_tempops_short_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_code"
+          ]
+        },
+        "mumble_tempops_key_hash_unique": {
+          "name": "mumble_tempops_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_type": {
+          "name": "flow_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_forum_config": {
+      "name": "pm_forum_config",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forum_channel_id": {
+          "name": "forum_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_open_id": {
+          "name": "tag_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_closed_id": {
+          "name": "tag_closed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_resolved_id": {
+          "name": "tag_resolved_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_voided_id": {
+          "name": "tag_voided_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_services": {
+      "name": "core_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_services_enabled_idx": {
+          "name": "core_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_name_idx": {
+          "name": "core_services_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_slug_idx": {
+          "name": "core_services_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_external_links": {
+      "name": "sidebar_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidebar_external_links_sort_order_idx": {
+          "name": "sidebar_external_links_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_log": {
+      "name": "user_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_activity_log_user_id_idx": {
+          "name": "user_activity_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_action_idx": {
+          "name": "user_activity_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_timestamp_idx": {
+          "name": "user_activity_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_log_user_id_users_id_fk": {
+          "name": "user_activity_log_user_id_users_id_fk",
+          "tableFrom": "user_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_characters": {
+      "name": "user_characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_owner_hash": {
+          "name": "character_owner_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_character_refresh": {
+          "name": "last_character_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_characters_user_id_idx": {
+          "name": "user_characters_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_character_id_idx": {
+          "name": "user_characters_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_is_primary_idx": {
+          "name": "user_characters_is_primary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_status_idx": {
+          "name": "user_characters_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_deleted_idx": {
+          "name": "user_characters_deleted_idx",
+          "columns": [
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_id_idx": {
+          "name": "user_characters_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_id_idx": {
+          "name": "user_characters_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_name_idx": {
+          "name": "user_characters_corporation_name_idx",
+          "columns": [
+            {
+              "expression": "corporation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_name_idx": {
+          "name": "user_characters_alliance_name_idx",
+          "columns": [
+            {
+              "expression": "alliance_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_characters_user_id_users_id_fk": {
+          "name": "user_characters_user_id_users_id_fk",
+          "tableFrom": "user_characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_characters_character_id_unique": {
+          "name": "user_characters_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fingerprints": {
+      "name": "user_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_fingerprints_user_id_idx": {
+          "name": "user_fingerprints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_fingerprint_idx": {
+          "name": "user_fingerprints_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_user_id_fingerprint_idx": {
+          "name": "user_fingerprints_user_id_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fingerprints_user_id_users_id_fk": {
+          "name": "user_fingerprints_user_id_users_id_fk",
+          "tableFrom": "user_fingerprints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ip_addresses": {
+      "name": "user_ip_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addr": {
+          "name": "addr",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address_hash": {
+          "name": "ip_address_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_ip_addresses_user_id_idx": {
+          "name": "user_ip_addresses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_ip_addresses_ip_address_idx": {
+          "name": "user_ip_addresses_ip_address_idx",
+          "columns": [
+            {
+              "expression": "addr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ip_addresses_user_id_users_id_fk": {
+          "name": "user_ip_addresses_user_id_users_id_fk",
+          "tableFrom": "user_ip_addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_ip_addresses_user_ip_unique": {
+          "name": "user_ip_addresses_user_ip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "addr"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_user_services": {
+      "name": "core_user_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_user_services_user_id_idx": {
+          "name": "core_user_services_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_service_id_idx": {
+          "name": "core_user_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_user_id_service_id_idx": {
+          "name": "core_user_services_user_id_service_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_enabled_idx": {
+          "name": "core_user_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "core_user_services_user_id_users_id_fk": {
+          "name": "core_user_services_user_id_users_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "core_user_services_service_id_core_services_id_fk": {
+          "name": "core_user_services_service_id_core_services_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "core_services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_user_services_user_id_service_id_unique": {
+          "name": "core_user_services_user_id_service_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "service_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_session_token_idx": {
+          "name": "user_sessions_session_token_idx",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sessions_session_token_unique": {
+          "name": "user_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "immunitas": {
+          "name": "immunitas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_discord_refresh": {
+          "name": "last_discord_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "legacy_auth_user_id": {
+          "name": "legacy_auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_username": {
+          "name": "legacy_auth_user_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_email_hash": {
+          "name": "legacy_auth_user_email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow": {
+          "name": "last_refresh_workflow",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow_attempt": {
+          "name": "last_refresh_workflow_attempt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_main_character_id_idx": {
+          "name": "users_main_character_id_idx",
+          "columns": [
+            {
+              "expression": "main_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_discord_user_id_idx": {
+          "name": "users_discord_user_id_idx",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_discord_refresh_idx": {
+          "name": "users_last_discord_refresh_idx",
+          "columns": [
+            {
+              "expression": "last_discord_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_id_idx": {
+          "name": "users_legacy_auth_user_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_username_idx": {
+          "name": "users_legacy_auth_user_username_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_email_hash_idx": {
+          "name": "users_legacy_auth_user_email_hash_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_idx": {
+          "name": "users_last_refresh_workflow_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_attempt_idx": {
+          "name": "users_last_refresh_workflow_attempt_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow_attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_main_character_id_unique": {
+          "name": "users_main_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "main_character_id"
+          ]
+        },
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_user_id"
+          ]
+        },
+        "users_legacy_auth_user_id_unique": {
+          "name": "users_legacy_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_id"
+          ]
+        },
+        "users_legacy_auth_user_username_unique": {
+          "name": "users_legacy_auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_username"
+          ]
+        },
+        "users_legacy_auth_user_email_hash_unique": {
+          "name": "users_legacy_auth_user_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/.migrations/meta/_journal.json
+++ b/apps/core/.migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1783296420378,
       "tag": "0039_dizzy_fenris",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1783438177210,
+      "tag": "0040_common_tinkerer",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/__tests__/market-embed.test.ts
+++ b/apps/core/src/__tests__/market-embed.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildMarketEmbed, formatMarketPoints, truncateForEmbed } from '../lib/market-embed'
+
+import type { MarketDetail } from '@repo/prediction-markets'
+
+function market(overrides: Partial<MarketDetail> = {}): MarketDetail {
+	return {
+		id: 'm1',
+		question: 'Will it rain tomorrow?',
+		status: 'open',
+		closesAt: '2030-01-01T00:00:00.000Z',
+		totalPool: '0',
+		outcomeCount: 2,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		discordThreadId: null,
+		description: null,
+		createdBy: 'u1',
+		rakeBps: 0,
+		minStake: '1',
+		maxStake: null,
+		perUserCap: null,
+		twoOfN: false,
+		resolvedOutcomeId: null,
+		resolvedBy: null,
+		resolvedAt: null,
+		voidReason: null,
+		outcomes: [
+			{ id: 'o1', label: 'Yes', poolAmount: '0', sortOrder: 0, impliedOddsBps: null },
+			{ id: 'o2', label: 'No', poolAmount: '0', sortOrder: 1, impliedOddsBps: null },
+		],
+		...overrides,
+	}
+}
+
+describe('buildMarketEmbed', () => {
+	it('renders "no bets yet" for a fresh market, never 0%', () => {
+		const embed = buildMarketEmbed(market())
+		const yes = embed.fields?.find((f) => f.name === 'Yes')
+		expect(yes?.value).toContain('no bets yet')
+		expect(yes?.value).not.toContain('%')
+	})
+
+	it('renders implied odds as a percentage when bets exist', () => {
+		const embed = buildMarketEmbed(
+			market({
+				totalPool: '150',
+				outcomes: [
+					{ id: 'o1', label: 'Yes', poolAmount: '100', sortOrder: 0, impliedOddsBps: 6667 },
+					{ id: 'o2', label: 'No', poolAmount: '50', sortOrder: 1, impliedOddsBps: 3333 },
+				],
+			})
+		)
+		const yes = embed.fields?.find((f) => f.name === 'Yes')
+		expect(yes?.value).toContain('66.7%')
+		expect(yes?.value).toContain('100 points')
+	})
+
+	it('uses the question as title and includes total pool + a relative close timestamp', () => {
+		const embed = buildMarketEmbed(market({ totalPool: '1234567' }))
+		expect(embed.title).toBe('Will it rain tomorrow?')
+		const pool = embed.fields?.find((f) => f.name === 'Total pool')
+		expect(pool?.value).toBe('1,234,567 points')
+		const closes = embed.fields?.find((f) => f.name === 'Closes')
+		expect(closes?.value).toMatch(/^<t:\d+:R>$/)
+		expect(embed.footer?.text).toBe('Status: open')
+	})
+
+	it('omits description when absent and includes it when present', () => {
+		expect(buildMarketEmbed(market()).description).toBeUndefined()
+		expect(buildMarketEmbed(market({ description: 'Resolves per NWS.' })).description).toBe(
+			'Resolves per NWS.'
+		)
+	})
+})
+
+describe('formatMarketPoints', () => {
+	it('groups thousands and strips leading zeros', () => {
+		expect(formatMarketPoints('0')).toBe('0 points')
+		expect(formatMarketPoints('1000')).toBe('1,000 points')
+		expect(formatMarketPoints('000123')).toBe('123 points')
+	})
+})
+
+describe('truncateForEmbed', () => {
+	it('truncates only when over the limit', () => {
+		expect(truncateForEmbed('short', 10)).toBe('short')
+		expect(truncateForEmbed('abcdefghij', 5)).toBe('abcd…')
+	})
+})

--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -109,6 +109,10 @@ export type Env = SharedHonoEnv & {
 	SRP_PUBLIC_API_TOKEN?: string
 	/** Shared key for trusted internal legacy-worker operations */
 	LEGACY_INTERNAL_KEY?: string
+	/** Guild id hosting the prediction-markets forum channel */
+	PM_FORUM_GUILD_ID?: string
+	/** Category id under which the prediction-markets forum channel is created (perms inherited from it) */
+	PM_FORUM_CATEGORY_ID?: string
 }
 
 /** Session user data attached to request context */

--- a/apps/core/src/db/schema.ts
+++ b/apps/core/src/db/schema.ts
@@ -1325,3 +1325,26 @@ export const schema = {
 	mumbleTempopsRelations,
 	mumbleTempopGuestsRelations,
 }
+
+/**
+ * Prediction-markets Discord forum config (one row per guild).
+ *
+ * Core owns Discord orchestration, so this config lives in the core DB. The forum
+ * channel is bot-created once under the configured category (`ensureForumChannel`):
+ * a row is inserted as a "claim" (forumChannelId null) to serialize the create, then
+ * updated with the created channel id + the four status-tag ids. `guildId` as the PK
+ * makes the claim atomic (ON CONFLICT DO NOTHING) so a concurrent first-create can't
+ * spawn two forum channels.
+ */
+export const pmForumConfig = pgTable('pm_forum_config', {
+	guildId: text('guild_id').primaryKey(),
+	categoryId: text('category_id').notNull(),
+	/** Null while a create is in progress (the claim row); set once the channel exists. */
+	forumChannelId: text('forum_channel_id'),
+	tagOpenId: text('tag_open_id'),
+	tagClosedId: text('tag_closed_id'),
+	tagResolvedId: text('tag_resolved_id'),
+	tagVoidedId: text('tag_voided_id'),
+	createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+	updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+})

--- a/apps/core/src/lib/market-embed.ts
+++ b/apps/core/src/lib/market-embed.ts
@@ -1,0 +1,62 @@
+/**
+ * Builds the Discord embed shown in a prediction market's forum post.
+ * Pure (no I/O) so it is unit-testable and reusable across create/update flows.
+ */
+
+import type { DiscordEmbed } from '@repo/discord'
+import type { MarketDetail } from '@repo/prediction-markets'
+
+const STATUS_COLOR: Record<string, number> = {
+	open: 0x2ecc71, // green
+	closed: 0xe67e22, // orange
+	resolving: 0xe67e22, // orange
+	resolved: 0x3498db, // blue
+	voided: 0x95a5a6, // grey
+	draft: 0x95a5a6, // grey
+}
+
+/** Group an integer-string point amount with thousands separators (string-preserving). */
+export function formatMarketPoints(value: string): string {
+	const trimmed = value.trim()
+	const negative = trimmed.startsWith('-')
+	const digits = (negative ? trimmed.slice(1) : trimmed).replace(/^0+(?=\d)/, '')
+	const grouped = digits.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+	return `${negative ? '-' : ''}${grouped} points`
+}
+
+/** Truncate to `max` chars with an ellipsis (Discord field/title/name limits). */
+export function truncateForEmbed(value: string, max: number): string {
+	return value.length <= max ? value : `${value.slice(0, max - 1)}…`
+}
+
+/**
+ * Build the market embed. `impliedOddsBps` is null on a fresh market (no bets yet) —
+ * render "no bets yet", never 0% (null/100 would read as a real 0% probability).
+ */
+export function buildMarketEmbed(market: MarketDetail): DiscordEmbed {
+	const closesUnix = Math.floor(new Date(market.closesAt).getTime() / 1000)
+
+	const outcomeFields = market.outcomes.map((o) => ({
+		name: truncateForEmbed(o.label, 256),
+		value:
+			o.impliedOddsBps === null
+				? `${formatMarketPoints(o.poolAmount)} · no bets yet`
+				: `${formatMarketPoints(o.poolAmount)} · ${(o.impliedOddsBps / 100).toFixed(1)}%`,
+		inline: true,
+	}))
+
+	const embed: DiscordEmbed = {
+		title: truncateForEmbed(market.question, 256),
+		color: STATUS_COLOR[market.status] ?? STATUS_COLOR.draft,
+		fields: [
+			...outcomeFields,
+			{ name: 'Total pool', value: formatMarketPoints(market.totalPool), inline: false },
+			{ name: 'Closes', value: `<t:${closesUnix}:R>`, inline: false },
+		],
+		footer: { text: `Status: ${market.status}` },
+	}
+	if (market.description) {
+		embed.description = truncateForEmbed(market.description, 4000)
+	}
+	return embed
+}

--- a/apps/core/src/routes/prediction-markets-admin.ts
+++ b/apps/core/src/routes/prediction-markets-admin.ts
@@ -10,17 +10,19 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-import { and, eq, ilike, inArray } from '@repo/db-utils'
+import { eq, ilike, inArray } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { requireAdmin, requireAuth } from '../middleware/session'
+import { publishMarketPost } from '../services/discord-market-post.service'
 import { userCharacters, users } from '../db/schema'
 
 import type { createDb } from '../db'
 import type { App } from '../context'
 import type { Context } from 'hono'
-import type { LedgerType, PredictionMarkets } from '@repo/prediction-markets'
+import type { Discord } from '@repo/discord'
+import type { LedgerType, MarketStatus, PredictionMarkets } from '@repo/prediction-markets'
 
 type CoreDb = ReturnType<typeof createDb>
 
@@ -35,6 +37,8 @@ app.use('*', requireAuth(), requireAdmin())
 
 const stubOf = (c: Context<App>): PredictionMarkets =>
 	getStub<PredictionMarkets>(c.env.PREDICTION_MARKETS, 'default')
+
+const discordStubOf = (c: Context<App>): Discord => getStub<Discord>(c.env.DISCORD, 'default')
 
 function parsePage(
 	limitRaw: string | undefined,
@@ -89,12 +93,27 @@ function fail(c: Context<App>, error: unknown, what: string) {
 	if (msg === 'IDEMPOTENCY_KEY_CONFLICT') {
 		return c.json({ error: 'Idempotency key already used with different parameters' }, 409)
 	}
-	if (msg === 'INVALID_AMOUNT' || msg === 'REASON_REQUIRED') {
+	// Client-input domain errors from the PM DO → 400 (would otherwise be a misleading 500).
+	if (BAD_REQUEST_CODES.has(msg)) {
 		return c.json({ error: msg }, 400)
 	}
 	logger.error(`[PMAdmin] ${what} failed`, { error: msg })
 	return c.json({ error: msg }, 500)
 }
+
+/** PM DO error codes that are the caller's fault (bad input) rather than a server error. */
+const BAD_REQUEST_CODES = new Set([
+	'INVALID_AMOUNT',
+	'REASON_REQUIRED',
+	'AT_LEAST_TWO_OUTCOMES',
+	'DUPLICATE_OUTCOMES',
+	'QUESTION_REQUIRED',
+	'INVALID_CLOSES_AT',
+	'INVALID_RAKE',
+	'INVALID_MIN_STAKE',
+	'INVALID_MAX_STAKE',
+	'INVALID_PER_USER_CAP',
+])
 
 // -------------------------------------------------------------------------
 // Wallets
@@ -210,6 +229,106 @@ app.post('/deposits', async (c) => {
 		return c.json(result)
 	} catch (error) {
 		return fail(c, error, 'deposit')
+	}
+})
+
+// -------------------------------------------------------------------------
+// Markets (create → forum post)
+// -------------------------------------------------------------------------
+
+const positiveIntString = z
+	.string()
+	.regex(/^\d+$/, 'must be a positive integer')
+	.refine((v) => BigInt(v) > 0n, 'must be greater than 0')
+
+const createMarketSchema = z.object({
+	question: z.string().trim().min(3).max(500),
+	description: z.string().trim().max(2000).optional(),
+	outcomes: z
+		.array(z.string().trim().min(1).max(100))
+		.min(2)
+		.max(20)
+		// case-insensitive dedupe: the PM DO rejects DUPLICATE_OUTCOMES the same way
+		.refine((o) => new Set(o.map((s) => s.toLowerCase())).size === o.length, 'outcomes must be distinct'),
+	closesAt: z
+		.string()
+		.datetime()
+		.refine((s) => new Date(s).getTime() > Date.now(), 'closesAt must be in the future'),
+	rakeBps: z.number().int().min(0).max(2000).optional(),
+	minStake: positiveIntString.optional(),
+	maxStake: positiveIntString.optional(),
+	perUserCap: positiveIntString.optional(),
+	twoOfN: z.boolean().optional(),
+})
+
+const MARKET_STATUSES: readonly MarketStatus[] = [
+	'draft',
+	'open',
+	'closed',
+	'resolving',
+	'resolved',
+	'voided',
+]
+
+// GET /markets?status=&limit= — recent markets + the configured guild id (for forum links).
+app.get('/markets', async (c) => {
+	try {
+		const statusRaw = c.req.query('status')
+		const status = MARKET_STATUSES.includes(statusRaw as MarketStatus)
+			? (statusRaw as MarketStatus)
+			: undefined
+		const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '50', 10) || 50, 1), 100)
+		const markets = await stubOf(c).listMarkets({ status, limit })
+		return c.json({ markets, guildId: c.env.PM_FORUM_GUILD_ID ?? null })
+	} catch (error) {
+		return fail(c, error, 'list markets')
+	}
+})
+
+// POST /markets — create a market, then best-effort publish its forum post.
+app.post('/markets', async (c) => {
+	try {
+		const db = c.get('db')
+		if (!db) return c.json({ error: 'Database not initialized' }, 500)
+		const user = c.get('user')!
+		const body = createMarketSchema.parse(await c.req.json())
+
+		// Market is source-of-truth first; the forum post is best-effort second.
+		const market = await stubOf(c).createMarket({ createdBy: user.id, ...body })
+
+		let post: { threadId: string; messageId: string } | null = null
+		let postError: string | null = null
+		const guildId = c.env.PM_FORUM_GUILD_ID
+		const categoryId = c.env.PM_FORUM_CATEGORY_ID
+		if (!guildId || !categoryId) {
+			postError = 'PM_FORUM_GUILD_ID / PM_FORUM_CATEGORY_ID not configured'
+		} else {
+			try {
+				post = await publishMarketPost(
+					db,
+					discordStubOf(c),
+					stubOf(c),
+					guildId,
+					categoryId,
+					market
+				)
+			} catch (err) {
+				postError = err instanceof Error ? err.message : String(err)
+				logger.error('[PMAdmin] market forum post failed', {
+					marketId: market.id,
+					error: postError,
+				})
+			}
+		}
+
+		logger.info('[PMAdmin] market created', {
+			actorId: user.id,
+			marketId: market.id,
+			posted: Boolean(post),
+		})
+		return c.json({ market, post, postError }, 201)
+	} catch (error) {
+		return fail(c, error, 'create market')
 	}
 })
 

--- a/apps/core/src/services/discord-market-post.service.ts
+++ b/apps/core/src/services/discord-market-post.service.ts
@@ -1,0 +1,148 @@
+/**
+ * Prediction-markets → Discord forum-post orchestration.
+ *
+ * Core is the sole orchestrator: it reads market state from the PM DO, renders the
+ * embed, and drives the Discord DO to create/update the forum post. The PM DO never
+ * calls Discord — Core writes the post mapping back via `attachDiscordPost`.
+ */
+
+import { eq } from '@repo/db-utils'
+
+import { pmForumConfig } from '../db/schema'
+import { buildMarketEmbed, truncateForEmbed } from '../lib/market-embed'
+
+import type { createDb } from '../db'
+import type { Discord } from '@repo/discord'
+import type { MarketDetail, PredictionMarkets } from '@repo/prediction-markets'
+
+type CoreDb = ReturnType<typeof createDb>
+type ForumConfigRow = typeof pmForumConfig.$inferSelect
+
+const FORUM_CHANNEL_NAME = 'prediction-markets'
+const STATUS_TAG_NAMES = ['Open', 'Closed', 'Resolved', 'Voided'] as const
+
+export interface ForumConfig {
+	guildId: string
+	categoryId: string
+	forumChannelId: string
+	tagOpenId: string | null
+	tagClosedId: string | null
+	tagResolvedId: string | null
+	tagVoidedId: string | null
+}
+
+/** Thrown while a concurrent caller is still creating the forum channel (retryable). */
+export class ForumInitInProgressError extends Error {
+	constructor() {
+		super('FORUM_CHANNEL_INIT_IN_PROGRESS')
+		this.name = 'ForumInitInProgressError'
+	}
+}
+
+function toForumConfig(row: ForumConfigRow): ForumConfig {
+	return {
+		guildId: row.guildId,
+		categoryId: row.categoryId,
+		forumChannelId: row.forumChannelId ?? '',
+		tagOpenId: row.tagOpenId,
+		tagClosedId: row.tagClosedId,
+		tagResolvedId: row.tagResolvedId,
+		tagVoidedId: row.tagVoidedId,
+	}
+}
+
+/**
+ * Ensure the markets forum channel exists under the configured category with inherited
+ * (synced) permissions + the four status tags. Bootstrap is serialized by a claim row
+ * (`guildId` PK + ON CONFLICT DO NOTHING) so a concurrent first-create can't spawn two
+ * channels: only the insert winner calls Discord; losers read the winner's row.
+ */
+export async function ensureForumChannel(
+	db: CoreDb,
+	discord: Discord,
+	guildId: string,
+	categoryId: string
+): Promise<ForumConfig> {
+	const [existing] = await db
+		.select()
+		.from(pmForumConfig)
+		.where(eq(pmForumConfig.guildId, guildId))
+		.limit(1)
+	if (existing?.forumChannelId) return toForumConfig(existing)
+
+	// Claim the guild row; only the insert winner proceeds to create the Discord channel.
+	const claimed = await db
+		.insert(pmForumConfig)
+		.values({ guildId, categoryId })
+		.onConflictDoNothing()
+		.returning({ guildId: pmForumConfig.guildId })
+
+	if (claimed.length === 0) {
+		// A concurrent caller owns the claim; use its result if the channel already exists.
+		const [row] = await db
+			.select()
+			.from(pmForumConfig)
+			.where(eq(pmForumConfig.guildId, guildId))
+			.limit(1)
+		if (row?.forumChannelId) return toForumConfig(row)
+		throw new ForumInitInProgressError()
+	}
+
+	// We own the claim → create the forum channel under the category with the category's
+	// permission overwrites (copied verbatim = Discord "synced/inherited" perms) + status tags.
+	const category = await discord.getChannel(categoryId)
+	const created = await discord.createForumChannel(guildId, {
+		name: FORUM_CHANNEL_NAME,
+		parentId: categoryId,
+		...(category.permission_overwrites
+			? { permissionOverwrites: category.permission_overwrites }
+			: {}),
+		availableTags: STATUS_TAG_NAMES.map((name) => ({ name, moderated: true })),
+	})
+	const tagId = (name: string): string | null =>
+		created.available_tags?.find((t) => t.name === name)?.id ?? null
+
+	const [row] = await db
+		.update(pmForumConfig)
+		.set({
+			forumChannelId: created.id,
+			tagOpenId: tagId('Open'),
+			tagClosedId: tagId('Closed'),
+			tagResolvedId: tagId('Resolved'),
+			tagVoidedId: tagId('Voided'),
+			updatedAt: new Date(),
+		})
+		.where(eq(pmForumConfig.guildId, guildId))
+		.returning()
+	return toForumConfig(row)
+}
+
+/**
+ * Ensure the forum channel, post the market thread, and persist the mapping back to the
+ * PM DO. Best-effort: the caller surfaces a thrown error as `postError` (the market
+ * already exists, so a Discord failure is recoverable, never a lost market).
+ */
+export async function publishMarketPost(
+	db: CoreDb,
+	discord: Discord,
+	prediction: PredictionMarkets,
+	guildId: string,
+	categoryId: string,
+	market: MarketDetail
+): Promise<{ threadId: string; messageId: string }> {
+	const cfg = await ensureForumChannel(db, discord, guildId, categoryId)
+	if (!cfg.forumChannelId) throw new ForumInitInProgressError()
+
+	const post = await discord.createMarketForumPost(cfg.forumChannelId, {
+		// Forum thread name max is 100 chars; the full question lives in the embed title.
+		name: truncateForEmbed(market.question, 100),
+		embeds: [buildMarketEmbed(market)],
+		...(cfg.tagOpenId ? { appliedTagIds: [cfg.tagOpenId] } : {}),
+	})
+	await prediction.attachDiscordPost({
+		marketId: market.id,
+		threadId: post.threadId,
+		messageId: post.messageId,
+	})
+	return post
+}

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -32,7 +32,11 @@
 		"LEGACY_AUTH_CALLBACK_URL": "https://pleaseignore.app/api/auth/legacy-auth/callback",
 		"MUMBLE_SERVER_ID": "srv-1",
 		"MUMBLE_HOST": "numumble.pleaseignore.com",
-		"MUMBLE_PORT": "64737"
+		"MUMBLE_PORT": "64737",
+		// Prediction markets: guild + category the bot creates the markets forum channel under.
+		// Replace with the real ids per environment; the bot needs MANAGE_CHANNELS + MANAGE_ROLES.
+		"PM_FORUM_GUILD_ID": "",
+		"PM_FORUM_CATEGORY_ID": ""
 	},
 	"durable_objects": {
 		"bindings": [

--- a/apps/discord/src/durable-object.ts
+++ b/apps/discord/src/durable-object.ts
@@ -6,6 +6,7 @@ import {
 	DiscordAPIError,
 	DiscordFetch,
 	DiscordRoutes,
+	DISCORD_CHANNEL_TYPE,
 	DISCORD_EXCLUDED_AUTH_GIGACHAD_ROLE_ID,
 	discordRateLimitGuard,
 } from '@repo/discord'
@@ -22,9 +23,13 @@ import { augmentRequestedRoleIdsForRefresh, calculateRoleChanges } from './utils
 
 import type {
 	Discord,
+	DiscordActionRow,
+	DiscordChannelSummary,
 	DiscordEmbed,
+	DiscordForumTag,
 	DiscordGuildMemberSnapshot,
 	DiscordGuildMembershipDetail,
+	DiscordPermissionOverwrite,
 	DiscordRegisteredSlashCommand,
 	DiscordSlashCommandDefinition,
 	DiscordTokenResponse,
@@ -1870,6 +1875,164 @@ export class DiscordDO extends DurableObject<Env> implements Discord {
 			return {
 				success: false,
 				error: error instanceof Error ? error.message : 'Failed to edit interaction response',
+			}
+		}
+	}
+
+	// ==================== FORUM / MARKET POST METHODS ====================
+
+	/**
+	 * Read a channel (GET /channels/{id}). Used to copy a category's permission overwrites
+	 * onto a new forum channel and to read a forum's available tags.
+	 */
+	async getChannel(channelId: string): Promise<DiscordChannelSummary> {
+		const client = this.createDiscordClient()
+		return client.get<DiscordChannelSummary>(DiscordRoutes.channel(channelId))
+	}
+
+	/**
+	 * Create a GUILD_FORUM channel under a category with (synced) permission overwrites + tags.
+	 * Requires the bot to hold MANAGE_CHANNELS + MANAGE_ROLES, and it can only set overwrite
+	 * bits it itself holds — a 403 (code 50013) here means the bot lacks those permissions.
+	 */
+	async createForumChannel(
+		guildId: string,
+		input: {
+			name: string
+			parentId: string
+			permissionOverwrites?: DiscordPermissionOverwrite[]
+			availableTags?: Array<{ name: string; moderated?: boolean }>
+			topic?: string
+		}
+	): Promise<DiscordChannelSummary> {
+		const client = this.createDiscordClient()
+		return client.post<DiscordChannelSummary>(DiscordRoutes.guildChannels(guildId), {
+			name: input.name,
+			type: DISCORD_CHANNEL_TYPE.GUILD_FORUM,
+			parent_id: input.parentId,
+			...(input.topic ? { topic: input.topic } : {}),
+			...(input.permissionOverwrites
+				? { permission_overwrites: input.permissionOverwrites }
+				: {}),
+			...(input.availableTags ? { available_tags: input.availableTags } : {}),
+		})
+	}
+
+	/**
+	 * Create a forum post (thread) for a market. POST /channels/{forumChannelId}/threads.
+	 * The message must carry at least one of content/embeds/components (else Discord 400s).
+	 */
+	async createMarketForumPost(
+		forumChannelId: string,
+		input: {
+			name: string
+			content?: string
+			embeds?: DiscordEmbed[]
+			components?: DiscordActionRow[]
+			appliedTagIds?: string[]
+		}
+	): Promise<{ threadId: string; messageId: string }> {
+		if (!input.content && !input.embeds?.length && !input.components?.length) {
+			throw new Error('createMarketForumPost: message must include content, embeds, or components')
+		}
+		const client = this.createDiscordClient()
+		const message: Record<string, unknown> = { allowed_mentions: { parse: [] } }
+		if (input.content) message.content = input.content
+		if (input.embeds?.length) message.embeds = input.embeds
+		if (input.components?.length) message.components = input.components
+
+		const thread = await client.post<{ id: string; message?: { id: string } }>(
+			DiscordRoutes.forumThreads(forumChannelId),
+			{
+				name: input.name,
+				message,
+				...(input.appliedTagIds?.length ? { applied_tags: input.appliedTagIds } : {}),
+			}
+		)
+		return { threadId: thread.id, messageId: thread.message?.id ?? thread.id }
+	}
+
+	/**
+	 * Edit a forum post's starter message (embed + components) — the embed-capable
+	 * replacement for editMessage. Pass components:[] to strip buttons; omit to leave intact.
+	 */
+	async updateMarketPostMessage(
+		threadId: string,
+		messageId: string,
+		input: { content?: string; embeds?: DiscordEmbed[]; components?: DiscordActionRow[] }
+	): Promise<{ success: boolean; error?: string }> {
+		const client = this.createDiscordClient()
+		const body: Record<string, unknown> = {}
+		if (input.content !== undefined) body.content = input.content
+		if (input.embeds !== undefined) body.embeds = input.embeds
+		if (input.components !== undefined) body.components = input.components
+		try {
+			await client.patch(DiscordRoutes.channelMessageById(threadId, messageId), body)
+			return { success: true }
+		} catch (error) {
+			logger.error('[DiscordDO] Failed to update market post message', {
+				threadId,
+				messageId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : 'Failed to update market post message',
+			}
+		}
+	}
+
+	/** List a forum channel's available tags. */
+	async getForumTags(forumChannelId: string): Promise<DiscordForumTag[]> {
+		const channel = await this.getChannel(forumChannelId)
+		return channel.available_tags ?? []
+	}
+
+	/** Replace a thread's applied tag set (PATCH /channels/{threadId} { applied_tags }). */
+	async setThreadTags(
+		threadId: string,
+		appliedTagIds: string[]
+	): Promise<{ success: boolean; error?: string }> {
+		const client = this.createDiscordClient()
+		try {
+			await client.patch(DiscordRoutes.channel(threadId), { applied_tags: appliedTagIds })
+			return { success: true }
+		} catch (error) {
+			logger.error('[DiscordDO] Failed to set thread tags', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : 'Failed to set thread tags',
+			}
+		}
+	}
+
+	/**
+	 * Archive/lock a thread (optionally flipping tags) in one PATCH — combining the tag flip
+	 * with archive/lock avoids the reorder needed when a thread is already archived.
+	 */
+	async lockThread(
+		threadId: string,
+		opts: { archived?: boolean; locked?: boolean; appliedTagIds?: string[] }
+	): Promise<{ success: boolean; error?: string }> {
+		const client = this.createDiscordClient()
+		const body: Record<string, unknown> = {}
+		if (opts.appliedTagIds !== undefined) body.applied_tags = opts.appliedTagIds
+		if (opts.archived !== undefined) body.archived = opts.archived
+		if (opts.locked !== undefined) body.locked = opts.locked
+		try {
+			await client.patch(DiscordRoutes.channel(threadId), body)
+			return { success: true }
+		} catch (error) {
+			logger.error('[DiscordDO] Failed to lock thread', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : 'Failed to lock thread',
 			}
 		}
 	}

--- a/apps/prediction-markets/.migrations/0002_exotic_captain_cross.sql
+++ b/apps/prediction-markets/.migrations/0002_exotic_captain_cross.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "pm_markets" ADD COLUMN "discord_thread_id" text;--> statement-breakpoint
+ALTER TABLE "pm_markets" ADD COLUMN "discord_message_id" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "pm_markets_thread_uq" ON "pm_markets" USING btree ("discord_thread_id");

--- a/apps/prediction-markets/.migrations/meta/0002_snapshot.json
+++ b/apps/prediction-markets/.migrations/meta/0002_snapshot.json
@@ -1,0 +1,952 @@
+{
+  "id": "ef7e5cc3-2f50-4252-8045-11d6d2ed881e",
+  "prevId": "6c0a0b81-7d12-4cba-b611-200e9dfd7a4c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pm_bets": {
+      "name": "pm_bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_bet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_bets_idempotency_key_uq": {
+          "name": "pm_bets_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_user_idx": {
+          "name": "pm_bets_market_user_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_user_created_idx": {
+          "name": "pm_bets_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_outcome_idx": {
+          "name": "pm_bets_market_outcome_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_config": {
+      "name": "pm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_rake_bps": {
+          "name": "default_rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "default_min_stake": {
+          "name": "default_min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "two_of_n_threshold": {
+          "name": "two_of_n_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_ledger": {
+      "name": "pm_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pm_ledger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_ledger_bet_type_uq": {
+          "name": "pm_ledger_bet_type_uq",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_idempotency_key_uq": {
+          "name": "pm_ledger_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pm_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_user_created_idx": {
+          "name": "pm_ledger_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_market_idx": {
+          "name": "pm_ledger_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_created_id_idx": {
+          "name": "pm_ledger_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_history": {
+      "name": "pm_market_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "pm_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_market_history_market_created_idx": {
+          "name": "pm_market_history_market_created_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_history_created_id_idx": {
+          "name": "pm_market_history_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_outcomes": {
+      "name": "pm_market_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "pm_market_outcomes_market_label_uq": {
+          "name": "pm_market_outcomes_market_label_uq",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_outcomes_market_idx": {
+          "name": "pm_market_outcomes_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_markets": {
+      "name": "pm_markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_outcome_id": {
+          "name": "resolved_outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pool": {
+          "name": "total_pool",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "rake_bps": {
+          "name": "rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stake": {
+          "name": "min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "max_stake": {
+          "name": "max_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_user_cap": {
+          "name": "per_user_cap",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_of_n": {
+          "name": "two_of_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_thread_id": {
+          "name": "discord_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_markets_status_closes_idx": {
+          "name": "pm_markets_status_closes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_thread_uq": {
+          "name": "pm_markets_thread_uq",
+          "columns": [
+            {
+              "expression": "discord_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_resolution_proposals": {
+      "name": "pm_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pm_resolution_proposals_market_status_idx": {
+          "name": "pm_resolution_proposals_market_status_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_wallets": {
+      "name": "pm_wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pm_bet_status": {
+      "name": "pm_bet_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "won",
+        "lost",
+        "refunded"
+      ]
+    },
+    "public.pm_ledger_type": {
+      "name": "pm_ledger_type",
+      "schema": "public",
+      "values": [
+        "grant",
+        "wager",
+        "refund",
+        "payout",
+        "rake",
+        "burn",
+        "adjustment"
+      ]
+    },
+    "public.pm_market_status": {
+      "name": "pm_market_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "resolving",
+        "resolved",
+        "voided"
+      ]
+    },
+    "public.pm_proposal_status": {
+      "name": "pm_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.pm_visibility": {
+      "name": "pm_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "internal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/prediction-markets/.migrations/meta/_journal.json
+++ b/apps/prediction-markets/.migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783397156429,
       "tag": "0001_hard_reavers",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783438171157,
+      "tag": "0002_exotic_captain_cross",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/prediction-markets/src/db/schema.ts
+++ b/apps/prediction-markets/src/db/schema.ts
@@ -111,10 +111,19 @@ export const pmMarkets = pgTable(
 		maxStake: numeric('max_stake'),
 		perUserCap: numeric('per_user_cap'),
 		twoOfN: boolean('two_of_n').notNull().default(false),
+		/** Discord forum thread id for this market's post (null until the post is created). */
+		discordThreadId: text('discord_thread_id'),
+		/** Discord starter-message id of the forum post (equals the thread id for forum posts). */
+		discordMessageId: text('discord_message_id'),
 		createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 	},
-	(t) => [index('pm_markets_status_closes_idx').on(t.status, t.closesAt)]
+	(t) => [
+		index('pm_markets_status_closes_idx').on(t.status, t.closesAt),
+		// One market per forum thread. NULLs are distinct in Postgres b-tree, so many
+		// pre-post markets can coexist.
+		uniqueIndex('pm_markets_thread_uq').on(t.discordThreadId),
+	]
 )
 
 export const pmMarketOutcomes = pgTable(

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -101,6 +101,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				closesAt: pmMarkets.closesAt,
 				totalPool: pmMarkets.totalPool,
 				createdAt: pmMarkets.createdAt,
+				discordThreadId: pmMarkets.discordThreadId,
 				outcomeCount: sql<number>`(select count(*)::int from ${pmMarketOutcomes} where ${pmMarketOutcomes.marketId} = ${pmMarkets.id})`,
 			})
 			.from(pmMarkets)
@@ -116,6 +117,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			totalPool: r.totalPool,
 			outcomeCount: r.outcomeCount,
 			createdAt: r.createdAt.toISOString(),
+			discordThreadId: r.discordThreadId,
 		}))
 	}
 
@@ -438,6 +440,25 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			})
 			throw error
 		}
+	}
+
+	/**
+	 * Persist the Discord forum post mapping after Core creates the post. Pure UPDATE —
+	 * the PM DO never calls Discord; Core orchestrates the post and writes the ids back here.
+	 */
+	async attachDiscordPost(input: {
+		marketId: string
+		threadId: string
+		messageId: string
+	}): Promise<void> {
+		await this.db
+			.update(pmMarkets)
+			.set({
+				discordThreadId: input.threadId,
+				discordMessageId: input.messageId,
+				updatedAt: new Date(),
+			})
+			.where(eq(pmMarkets.id, input.marketId))
 	}
 
 	async placeBet(input: PlaceBetInput): Promise<BetResult> {
@@ -1067,6 +1088,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			totalPool: market.totalPool,
 			outcomeCount: outcomes.length,
 			createdAt: market.createdAt.toISOString(),
+			discordThreadId: market.discordThreadId,
 			rakeBps: market.rakeBps,
 			minStake: market.minStake,
 			maxStake: market.maxStake,

--- a/apps/ui/src/client/components/admin-nav.tsx
+++ b/apps/ui/src/client/components/admin-nav.tsx
@@ -125,6 +125,7 @@ export function AdminNav({ onNavigate }: AdminNavProps) {
 			href: '/admin/prediction-markets',
 			icon: Wallet,
 			children: [
+				{ label: 'Markets', href: '/admin/prediction-markets/markets' },
 				{ label: 'Wallets', href: '/admin/prediction-markets/wallets' },
 				{ label: 'Audit Log', href: '/admin/prediction-markets/audit' },
 			],

--- a/apps/ui/src/client/features/prediction-markets/api.ts
+++ b/apps/ui/src/client/features/prediction-markets/api.ts
@@ -13,10 +13,14 @@ import type {
 	AdminMarketHistoryRow,
 	AdminWalletRow,
 	AuditLedgerFilters,
+	CreateMarketRequest,
+	CreateMarketResponse,
 	DepositRequest,
 	DepositResponse,
 	LedgerFilters,
 	MarketHistoryFilters,
+	MarketsFilters,
+	MarketsResponse,
 	Paged,
 	WalletDetail,
 	WalletsFilters,
@@ -94,4 +98,18 @@ export async function getMarketHistory(
 /** POST /deposits — credit a wallet. 400 self/validation, 409 idempotency-conflict. */
 export async function createDeposit(body: DepositRequest): Promise<DepositResponse> {
 	return apiClient.post<DepositResponse>(`${BASE}/deposits`, body)
+}
+
+/** GET /markets — recent markets + the configured guild id (for forum links). */
+export async function getMarkets(filters?: MarketsFilters): Promise<MarketsResponse> {
+	const params = new URLSearchParams()
+	if (filters?.status) params.set('status', filters.status)
+	if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
+	const query = params.toString()
+	return apiClient.get<MarketsResponse>(`${BASE}/markets${query ? `?${query}` : ''}`)
+}
+
+/** POST /markets — create a market; the bot best-effort publishes its forum post. */
+export async function createMarket(body: CreateMarketRequest): Promise<CreateMarketResponse> {
+	return apiClient.post<CreateMarketResponse>(`${BASE}/markets`, body)
 }

--- a/apps/ui/src/client/features/prediction-markets/components/create-market-dialog.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/create-market-dialog.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useState } from 'react'
+import { Plus, X } from 'lucide-react'
+import { z } from 'zod'
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import toast from '@/lib/toast'
+
+import { useCreateMarket } from '../hooks'
+
+import type { CreateMarketRequest } from '../types'
+
+const MAX_OUTCOMES = 20
+
+// Client guard mirrors the server route (defense-in-depth; server is authoritative).
+const schema = z.object({
+	question: z.string().trim().min(3, 'Question must be at least 3 characters').max(500),
+	description: z.string().trim().max(2000).optional(),
+	outcomes: z
+		.array(z.string().trim().min(1))
+		.min(2, 'Add at least two outcomes')
+		.max(MAX_OUTCOMES)
+		.refine(
+			(o) => new Set(o.map((s) => s.toLowerCase())).size === o.length,
+			'Outcomes must be distinct'
+		),
+	closesAt: z.string().refine((s) => {
+		const t = new Date(s).getTime()
+		return Number.isFinite(t) && t > Date.now()
+	}, 'Close time must be in the future'),
+	rakeBps: z.number().int().min(0).max(2000).optional(),
+	minStake: z.string().optional(),
+	maxStake: z.string().optional(),
+	perUserCap: z.string().optional(),
+	twoOfN: z.boolean().optional(),
+})
+
+export interface CreateMarketDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+}
+
+const digitsOnly = (v: string) => v.replace(/\D/g, '')
+
+export function CreateMarketDialog({ open, onOpenChange }: CreateMarketDialogProps) {
+	const [question, setQuestion] = useState('')
+	const [description, setDescription] = useState('')
+	const [outcomes, setOutcomes] = useState<string[]>(['Yes', 'No'])
+	const [closesAt, setClosesAt] = useState('')
+	const [rakeBps, setRakeBps] = useState('')
+	const [minStake, setMinStake] = useState('')
+	const [maxStake, setMaxStake] = useState('')
+	const [perUserCap, setPerUserCap] = useState('')
+	const [twoOfN, setTwoOfN] = useState(false)
+
+	const create = useCreateMarket()
+
+	useEffect(() => {
+		if (open) {
+			setQuestion('')
+			setDescription('')
+			setOutcomes(['Yes', 'No'])
+			setClosesAt('')
+			setRakeBps('')
+			setMinStake('')
+			setMaxStake('')
+			setPerUserCap('')
+			setTwoOfN(false)
+		}
+	}, [open])
+
+	const close = () => onOpenChange(false)
+
+	const setOutcome = (i: number, value: string) =>
+		setOutcomes((prev) => prev.map((o, idx) => (idx === i ? value : o)))
+	const addOutcome = () =>
+		setOutcomes((prev) => (prev.length >= MAX_OUTCOMES ? prev : [...prev, '']))
+	const removeOutcome = (i: number) =>
+		setOutcomes((prev) => (prev.length <= 2 ? prev : prev.filter((_, idx) => idx !== i)))
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault()
+
+		const trimmedOutcomes = outcomes.map((o) => o.trim()).filter(Boolean)
+		const parsed = schema.safeParse({
+			question,
+			description: description.trim() || undefined,
+			outcomes: trimmedOutcomes,
+			closesAt,
+			rakeBps: rakeBps ? Number(rakeBps) : undefined,
+			minStake: minStake || undefined,
+			maxStake: maxStake || undefined,
+			perUserCap: perUserCap || undefined,
+			twoOfN,
+		})
+		if (!parsed.success) {
+			toast.error(parsed.error.issues[0]?.message ?? 'Invalid market')
+			return
+		}
+		const d = parsed.data
+
+		const body: CreateMarketRequest = {
+			question: d.question,
+			outcomes: d.outcomes,
+			// datetime-local (local time, no zone) → absolute ISO-8601.
+			closesAt: new Date(d.closesAt).toISOString(),
+			twoOfN: d.twoOfN,
+		}
+		if (d.description) body.description = d.description
+		if (d.rakeBps !== undefined) body.rakeBps = d.rakeBps
+		if (d.minStake) body.minStake = d.minStake
+		if (d.maxStake) body.maxStake = d.maxStake
+		if (d.perUserCap) body.perUserCap = d.perUserCap
+
+		// Success/error toast handled by useCreateMarket; close only on success.
+		await create.mutateAsync(body)
+		close()
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>New market</DialogTitle>
+					<DialogDescription>
+						Creates the market and posts it to the predictions forum channel.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor="pm-question">Question</Label>
+						<Input
+							id="pm-question"
+							placeholder="Will X happen by Y?"
+							value={question}
+							onChange={(e) => setQuestion(e.target.value)}
+							maxLength={500}
+							disabled={create.isPending}
+							required
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="pm-description">Description (optional)</Label>
+						<Textarea
+							id="pm-description"
+							placeholder="Resolution criteria, context…"
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							rows={2}
+							maxLength={2000}
+							disabled={create.isPending}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label>Outcomes</Label>
+						<div className="space-y-2">
+							{outcomes.map((outcome, i) => (
+								<div key={i} className="flex items-center gap-2">
+									<Input
+										placeholder={`Outcome ${i + 1}`}
+										value={outcome}
+										onChange={(e) => setOutcome(i, e.target.value)}
+										maxLength={100}
+										disabled={create.isPending}
+									/>
+									<Button
+										type="button"
+										variant="cancel"
+										showIcon={false}
+										size="icon"
+										onClick={() => removeOutcome(i)}
+										disabled={create.isPending || outcomes.length <= 2}
+										aria-label={`Remove outcome ${i + 1}`}
+									>
+										<X className="h-4 w-4" />
+									</Button>
+								</div>
+							))}
+						</div>
+						<Button
+							type="button"
+							variant="secondary"
+							showIcon={false}
+							size="sm"
+							onClick={addOutcome}
+							disabled={create.isPending || outcomes.length >= MAX_OUTCOMES}
+						>
+							<Plus className="mr-1 h-4 w-4" /> Add outcome
+						</Button>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="pm-closes">Closes at</Label>
+						<Input
+							id="pm-closes"
+							type="datetime-local"
+							value={closesAt}
+							onChange={(e) => setClosesAt(e.target.value)}
+							disabled={create.isPending}
+							required
+						/>
+					</div>
+
+					<div className="grid grid-cols-2 gap-3">
+						<div className="space-y-2">
+							<Label htmlFor="pm-rake">Rake (bps, optional)</Label>
+							<Input
+								id="pm-rake"
+								type="text"
+								inputMode="numeric"
+								placeholder="default"
+								value={rakeBps}
+								onChange={(e) => setRakeBps(digitsOnly(e.target.value))}
+								disabled={create.isPending}
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="pm-min">Min stake (optional)</Label>
+							<Input
+								id="pm-min"
+								type="text"
+								inputMode="numeric"
+								placeholder="default"
+								value={minStake}
+								onChange={(e) => setMinStake(digitsOnly(e.target.value))}
+								disabled={create.isPending}
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="pm-max">Max stake (optional)</Label>
+							<Input
+								id="pm-max"
+								type="text"
+								inputMode="numeric"
+								placeholder="none"
+								value={maxStake}
+								onChange={(e) => setMaxStake(digitsOnly(e.target.value))}
+								disabled={create.isPending}
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="pm-cap">Per-user cap (optional)</Label>
+							<Input
+								id="pm-cap"
+								type="text"
+								inputMode="numeric"
+								placeholder="none"
+								value={perUserCap}
+								onChange={(e) => setPerUserCap(digitsOnly(e.target.value))}
+								disabled={create.isPending}
+							/>
+						</div>
+					</div>
+
+					<div className="flex items-center justify-between rounded-md border border-border p-3">
+						<div>
+							<Label htmlFor="pm-twoofn">Require two-of-N resolution</Label>
+							<p className="text-xs text-muted-foreground">
+								A second resolver must approve before this market resolves.
+							</p>
+						</div>
+						<Switch
+							id="pm-twoofn"
+							checked={twoOfN}
+							onCheckedChange={setTwoOfN}
+							disabled={create.isPending}
+						/>
+					</div>
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="cancel"
+							showIcon={false}
+							onClick={close}
+							disabled={create.isPending}
+						>
+							Cancel
+						</Button>
+						<Button
+							type="submit"
+							variant="primary"
+							loading={create.isPending}
+							loadingText="Creating…"
+						>
+							Create market
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/hooks.ts
+++ b/apps/ui/src/client/features/prediction-markets/hooks.ts
@@ -4,8 +4,10 @@ import { useApiMutation } from '@/hooks/useApiMutation'
 
 import {
 	createDeposit,
+	createMarket,
 	getAuditLedger,
 	getMarketHistory,
+	getMarkets,
 	getUserLedger,
 	getWallet,
 	getWallets,
@@ -14,9 +16,11 @@ import { pmKeys } from './query-keys'
 
 import type {
 	AuditLedgerFilters,
+	CreateMarketRequest,
 	DepositRequest,
 	LedgerFilters,
 	MarketHistoryFilters,
+	MarketsFilters,
 	WalletsFilters,
 } from './types'
 
@@ -67,6 +71,35 @@ export function useMarketHistory(filters?: MarketHistoryFilters) {
 		queryFn: () => getMarketHistory(filters),
 		staleTime: STALE_TIME,
 		gcTime: GC_TIME,
+	})
+}
+
+export function useMarkets(filters?: MarketsFilters) {
+	return useQuery({
+		queryKey: pmKeys.markets(filters),
+		queryFn: () => getMarkets(filters),
+		staleTime: STALE_TIME,
+		gcTime: GC_TIME,
+	})
+}
+
+/**
+ * POST /markets — creates the market + best-effort forum post. Toasts on success (noting
+ * a `postError` if the post failed), invalidates the markets list.
+ */
+export function useCreateMarket() {
+	const queryClient = useQueryClient()
+
+	return useApiMutation({
+		mutationFn: (body: CreateMarketRequest) => createMarket(body),
+		successMessage: (res) =>
+			res.postError
+				? `Market created, but the forum post failed: ${res.postError}`
+				: 'Market created and posted to the forum.',
+		onSuccess: () => {
+			// Broad key so every markets-list variant (any filter) refetches.
+			queryClient.invalidateQueries({ queryKey: [...pmKeys.all, 'markets'] })
+		},
 	})
 }
 

--- a/apps/ui/src/client/features/prediction-markets/query-keys.ts
+++ b/apps/ui/src/client/features/prediction-markets/query-keys.ts
@@ -6,6 +6,7 @@ import type {
 	AuditLedgerFilters,
 	LedgerFilters,
 	MarketHistoryFilters,
+	MarketsFilters,
 	WalletsFilters,
 } from './types'
 
@@ -18,4 +19,5 @@ export const pmKeys = {
 	auditLedger: (filters?: AuditLedgerFilters) => [...pmKeys.all, 'auditLedger', filters] as const,
 	marketHistory: (filters?: MarketHistoryFilters) =>
 		[...pmKeys.all, 'marketHistory', filters] as const,
+	markets: (filters?: MarketsFilters) => [...pmKeys.all, 'markets', filters] as const,
 }

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-markets.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-markets.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { ExternalLink } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { formatPoints } from '@/lib/format-utils'
+
+import { CreateMarketDialog } from '../components/create-market-dialog'
+import { useMarkets } from '../hooks'
+
+import type { BadgeVariant } from '@/components/ui/badge'
+import type { MarketStatus } from '../types'
+
+const STATUS_VARIANT: Record<MarketStatus, BadgeVariant> = {
+	draft: 'secondary',
+	open: 'success',
+	closed: 'warning',
+	resolving: 'warning',
+	resolved: 'default',
+	voided: 'destructive',
+}
+
+export default function PredictionMarketMarkets() {
+	usePageTitle('Admin - Prediction Markets')
+	const [createOpen, setCreateOpen] = useState(false)
+	const { data, isLoading, error } = useMarkets({ limit: 50 })
+
+	const markets = data?.markets ?? []
+	const guildId = data?.guildId ?? null
+
+	const threadUrl = (threadId: string | null) =>
+		threadId && guildId ? `https://discord.com/channels/${guildId}/${threadId}` : null
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="text-3xl font-bold gradient-text">Prediction Markets</h1>
+					<p className="mt-1 text-muted-foreground">
+						Create markets and post them to the predictions forum channel.
+					</p>
+				</div>
+				<Button variant="primary" onClick={() => setCreateOpen(true)}>
+					New market
+				</Button>
+			</div>
+
+			{error ? (
+				<p className="text-sm text-destructive">
+					Failed to load markets: {(error as Error).message}
+				</p>
+			) : null}
+
+			<div className="rounded-md border border-border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Question</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>Outcomes</TableHead>
+							<TableHead>Pool</TableHead>
+							<TableHead>Closes</TableHead>
+							<TableHead>Forum</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading ? (
+							<TableRow>
+								<TableCell colSpan={6} className="text-center text-muted-foreground">
+									Loading…
+								</TableCell>
+							</TableRow>
+						) : markets.length === 0 ? (
+							<TableRow>
+								<TableCell colSpan={6} className="text-center text-muted-foreground">
+									No markets yet.
+								</TableCell>
+							</TableRow>
+						) : (
+							markets.map((m) => {
+								const url = threadUrl(m.discordThreadId)
+								return (
+									<TableRow key={m.id}>
+										<TableCell className="max-w-md truncate font-medium">{m.question}</TableCell>
+										<TableCell>
+											<Badge variant={STATUS_VARIANT[m.status]}>{m.status}</Badge>
+										</TableCell>
+										<TableCell>{m.outcomeCount}</TableCell>
+										<TableCell>{formatPoints(m.totalPool)}</TableCell>
+										<TableCell>{new Date(m.closesAt).toLocaleString()}</TableCell>
+										<TableCell>
+											{url ? (
+												<a
+													href={url}
+													target="_blank"
+													rel="noreferrer"
+													className="inline-flex items-center gap-1 text-primary hover:underline"
+												>
+													Open <ExternalLink className="h-3 w-3" />
+												</a>
+											) : (
+												<span className="text-xs text-muted-foreground">
+													{m.discordThreadId ? 'posted' : 'not posted'}
+												</span>
+											)}
+										</TableCell>
+									</TableRow>
+								)
+							})
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			<CreateMarketDialog open={createOpen} onOpenChange={setCreateOpen} />
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/types.ts
+++ b/apps/ui/src/client/features/prediction-markets/types.ts
@@ -9,12 +9,22 @@
 import type {
 	GlobalLedgerRow,
 	LedgerType,
+	MarketDetail,
 	MarketHistoryRow,
 	MarketStatus,
+	MarketSummary,
 	WalletRow,
 } from '@repo/prediction-markets'
 
-export type { GlobalLedgerRow, LedgerType, MarketHistoryRow, MarketStatus, WalletRow }
+export type {
+	GlobalLedgerRow,
+	LedgerType,
+	MarketDetail,
+	MarketHistoryRow,
+	MarketStatus,
+	MarketSummary,
+	WalletRow,
+}
 
 /** Generic paged envelope returned by every L1 list endpoint. */
 export interface Paged<T> {
@@ -89,4 +99,39 @@ export interface DepositResponse {
 	/** Resulting wallet balance, integer string. */
 	balance: string
 	deduped: boolean
+}
+
+// --- markets ---------------------------------------------------------------
+
+export interface CreateMarketRequest {
+	question: string
+	description?: string
+	outcomes: string[]
+	/** ISO-8601 timestamp when betting closes. */
+	closesAt: string
+	rakeBps?: number
+	/** Integer strings (numeric). DISPLAY ONLY — never Number() arithmetic. */
+	minStake?: string
+	maxStake?: string
+	perUserCap?: string
+	twoOfN?: boolean
+}
+
+export interface CreateMarketResponse {
+	market: MarketDetail
+	/** Discord forum post ids, or null if posting failed / not configured. */
+	post: { threadId: string; messageId: string } | null
+	/** Human-readable reason the forum post did not publish (market still created). */
+	postError: string | null
+}
+
+export interface MarketsFilters {
+	status?: MarketStatus
+	limit?: number
+}
+
+export interface MarketsResponse {
+	markets: MarketSummary[]
+	/** Configured markets guild id, for building forum thread deep-links. */
+	guildId: string | null
 }

--- a/apps/ui/src/client/routes/route-groups/admin-routes.tsx
+++ b/apps/ui/src/client/routes/route-groups/admin-routes.tsx
@@ -65,6 +65,9 @@ const IndustryProviderEditPage = lazy(
 const IndustryProviderNewPage = lazy(
 	() => import('@/features/industry/routes/industry-provider-new')
 )
+const PredictionMarketMarketsPage = lazy(
+	() => import('@/features/prediction-markets/routes/prediction-market-markets')
+)
 const PredictionMarketWalletsPage = lazy(
 	() => import('@/features/prediction-markets/routes/prediction-market-wallets')
 )
@@ -173,7 +176,15 @@ export const adminRouteElements = (
 			}
 		/>
 		<Route path="prediction-markets">
-			<Route index element={<Navigate to="/admin/prediction-markets/wallets" replace />} />
+			<Route index element={<Navigate to="/admin/prediction-markets/markets" replace />} />
+			<Route
+				path="markets"
+				element={
+					<Suspense fallback={<LoadingPage />}>
+						<PredictionMarketMarketsPage />
+					</Suspense>
+				}
+			/>
 			<Route
 				path="wallets"
 				element={

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -176,6 +176,78 @@ export function buildDiscordWebhookMessagePayload(
 }
 
 /**
+ * Message components (action rows + buttons).
+ * https://discord.com/developers/docs/interactions/message-components
+ */
+export const DISCORD_COMPONENT_TYPE = {
+	ACTION_ROW: 1,
+	BUTTON: 2,
+} as const
+
+export const DISCORD_BUTTON_STYLE = {
+	PRIMARY: 1,
+	SECONDARY: 2,
+	SUCCESS: 3,
+	DANGER: 4,
+	LINK: 5,
+} as const
+
+export type DiscordButtonStyle = (typeof DISCORD_BUTTON_STYLE)[keyof typeof DISCORD_BUTTON_STYLE]
+
+export interface DiscordButtonComponent {
+	type: 2
+	style: DiscordButtonStyle
+	/** Text label (≤80 chars). Omit only for emoji-only buttons. */
+	label?: string
+	/** Developer-defined id (≤100 chars). Required for non-link buttons. */
+	custom_id?: string
+	/** URL for LINK-style buttons. */
+	url?: string
+	disabled?: boolean
+	emoji?: { id?: string; name?: string }
+}
+
+export interface DiscordActionRow {
+	type: 1
+	components: DiscordButtonComponent[]
+}
+
+/**
+ * Discord channel type subset we use.
+ * https://discord.com/developers/docs/resources/channel#channel-object-channel-types
+ */
+export const DISCORD_CHANNEL_TYPE = {
+	GUILD_CATEGORY: 4,
+	GUILD_FORUM: 15,
+} as const
+
+/** A forum channel tag (available_tags / applied_tags). */
+export interface DiscordForumTag {
+	id: string
+	name: string
+	moderated?: boolean
+	emoji_id?: string | null
+	emoji_name?: string | null
+}
+
+/** A channel permission overwrite. type: 0 = role, 1 = member; allow/deny are stringified bitfields. */
+export interface DiscordPermissionOverwrite {
+	id: string
+	type: number
+	allow: string
+	deny: string
+}
+
+/** Minimal channel shape returned by GET /channels/{id} (category or forum). */
+export interface DiscordChannelSummary {
+	id: string
+	type: number
+	parent_id?: string | null
+	permission_overwrites?: DiscordPermissionOverwrite[]
+	available_tags?: DiscordForumTag[]
+}
+
+/**
  * Result of sending a message
  */
 export interface SendMessageResult {
@@ -641,6 +713,72 @@ export interface Discord {
 	editOriginalInteractionResponse(
 		interactionToken: string,
 		message: { content: string; embeds?: DiscordEmbed[] }
+	): Promise<{ success: boolean; error?: string }>
+
+	/**
+	 * Read a channel (GET /channels/{id}). Used to copy a category's permission
+	 * overwrites onto a new forum channel and to read a forum's available tags.
+	 */
+	getChannel(channelId: string): Promise<DiscordChannelSummary>
+
+	/**
+	 * Create a GUILD_FORUM channel under a category. `permissionOverwrites` should be the
+	 * category's overwrites (copied verbatim = Discord "synced/inherited" permissions).
+	 * `availableTags` are created with the channel; the returned channel carries their ids.
+	 * Requires the bot to hold MANAGE_CHANNELS + MANAGE_ROLES.
+	 */
+	createForumChannel(
+		guildId: string,
+		input: {
+			name: string
+			parentId: string
+			permissionOverwrites?: DiscordPermissionOverwrite[]
+			availableTags?: Array<{ name: string; moderated?: boolean }>
+			topic?: string
+		}
+	): Promise<DiscordChannelSummary>
+
+	/**
+	 * Create a forum post (thread) for a market via
+	 * POST /channels/{forumChannelId}/threads. Returns the thread id and starter message id.
+	 */
+	createMarketForumPost(
+		forumChannelId: string,
+		input: {
+			name: string
+			content?: string
+			embeds?: DiscordEmbed[]
+			components?: DiscordActionRow[]
+			appliedTagIds?: string[]
+		}
+	): Promise<{ threadId: string; messageId: string }>
+
+	/**
+	 * Edit a forum post's starter message (embed + components), the embed-capable
+	 * replacement for editMessage. Pass `components: []` to strip buttons; omit to leave intact.
+	 */
+	updateMarketPostMessage(
+		threadId: string,
+		messageId: string,
+		input: { content?: string; embeds?: DiscordEmbed[]; components?: DiscordActionRow[] }
+	): Promise<{ success: boolean; error?: string }>
+
+	/** List a forum channel's available tags (GET /channels/{id} → available_tags). */
+	getForumTags(forumChannelId: string): Promise<DiscordForumTag[]>
+
+	/** Replace a thread's applied tag set (PATCH /channels/{threadId} { applied_tags }). */
+	setThreadTags(
+		threadId: string,
+		appliedTagIds: string[]
+	): Promise<{ success: boolean; error?: string }>
+
+	/**
+	 * Archive/lock a thread (optionally flipping tags) in one PATCH — combining avoids
+	 * the reorder needed when a thread is already archived.
+	 */
+	lockThread(
+		threadId: string,
+		opts: { archived?: boolean; locked?: boolean; appliedTagIds?: string[] }
 	): Promise<{ success: boolean; error?: string }>
 }
 

--- a/packages/discord/src/routes.ts
+++ b/packages/discord/src/routes.ts
@@ -16,6 +16,32 @@ export const DiscordRoutes = {
 	channelMessages: (channelId: string) => `/channels/${channelId}/messages`,
 
 	/**
+	 * Route for a single channel (GET/PATCH)
+	 * GET/PATCH /channels/{channelId}
+	 */
+	channel: (channelId: string) => `/channels/${channelId}`,
+
+	/**
+	 * Route for a single channel message (PATCH/DELETE)
+	 * PATCH/DELETE /channels/{channelId}/messages/{messageId}
+	 * Note: distinct from the plural channelMessages (collection) above.
+	 */
+	channelMessageById: (channelId: string, messageId: string) =>
+		`/channels/${channelId}/messages/${messageId}`,
+
+	/**
+	 * Route for a guild's channels (POST creates a channel)
+	 * POST /guilds/{guildId}/channels
+	 */
+	guildChannels: (guildId: string) => `/guilds/${guildId}/channels`,
+
+	/**
+	 * Route for creating a thread in a forum/media channel
+	 * POST /channels/{channelId}/threads
+	 */
+	forumThreads: (channelId: string) => `/channels/${channelId}/threads`,
+
+	/**
 	 * Route for getting user's guilds
 	 * GET /users/@me/guilds
 	 */

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -75,6 +75,8 @@ export interface MarketSummary {
 	totalPool: string
 	outcomeCount: number
 	createdAt: string
+	/** Discord forum thread id for this market's post, or null before the post exists. */
+	discordThreadId: string | null
 }
 
 export interface MarketDetail extends MarketSummary {
@@ -245,5 +247,14 @@ export interface PredictionMarkets {
 		marketId: string
 		reason: string
 		approverId?: string
+	}): Promise<void>
+	/**
+	 * Persist the Discord forum post mapping after Core creates the post.
+	 * Pure UPDATE — the PM DO never calls Discord itself.
+	 */
+	attachDiscordPost(input: {
+		marketId: string
+		threadId: string
+		messageId: string
 	}): Promise<void>
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

M2 Phase 1 of prediction markets: renders markets as bot-managed Discord forum posts and adds a web form to create them. Markets are published as threads under a "Predictions Market" category that inherits its permission overwrites, with status tags applied per market state. Betting and resolver interactions are deferred to later phases.

## Changes

- **`@repo/discord`**: Added message-component and forum-tag types, channel/forum route constants, and `Discord` interface methods; implemented Discord DO forum methods (`getChannel`, `createForumChannel`, `createMarketForumPost`, `updateMarketPostMessage`, get/set thread tags, `lockThread`).
- **prediction-markets**: Added `discord_thread_id`/`discord_message_id` columns (with a unique index) to `pm_markets`, an `attachDiscordPost` RPC, and exposed `discordThreadId` on market views (migration 0002).
- **core**: Added the `pm_forum_config` table with a claim-row bootstrap that serializes channel creation, a null-odds-safe market embed builder, and a `discord-market-post` orchestration service (`ensureForumChannel` copies the category's overwrites for synced permissions + status tags, `publishMarketPost`). Added `POST`/`GET /markets` admin routes and `PM_FORUM_*` config bindings (migration 0040).
- **ui**: Added a New Market creation dialog and Markets admin page (nav entry + route) with deep-links to the Discord forum thread.
- Core is the sole Discord orchestrator; the prediction-markets DO never calls Discord directly.

## Testing

- Unit tests for the embed builder (`apps/core/src/__tests__/market-embed.test.ts`) cover no-bets/implied-odds rendering, title/pool/close-timestamp formatting, optional description, point formatting, and truncation.
- Deploy prerequisite: the bot needs `MANAGE_CHANNELS` + `MANAGE_ROLES` (or Administrator) for forum channel/tag creation.
<!-- claude:end -->
