### PR TITLE
add features schema to support feature-user-flags

### DIFF
--- a/apps/features/.migrations/0001_early_cable.sql
+++ b/apps/features/.migrations/0001_early_cable.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "user_feature_flags" (
+	"id" text PRIMARY KEY NOT NULL,
+	"feature_flag_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_feature_flags" ADD CONSTRAINT "user_feature_flags_feature_flag_id_feature_flags_id_fk" FOREIGN KEY ("feature_flag_id") REFERENCES "public"."feature_flags"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_feature_flags_pk" ON "user_feature_flags" USING btree ("feature_flag_id","user_id");--> statement-breakpoint
+CREATE INDEX "user_feature_flags_user_id_enabled_idx" ON "user_feature_flags" USING btree ("user_id","enabled");--> statement-breakpoint
+CREATE INDEX "user_feature_flags_feature_flag_id_enabled_idx" ON "user_feature_flags" USING btree ("feature_flag_id","enabled");

--- a/apps/features/.migrations/meta/0001_snapshot.json
+++ b/apps/features/.migrations/meta/0001_snapshot.json
@@ -1,0 +1,244 @@
+{
+  "id": "bfaddf2f-6d4c-49d7-9a55-e816d25403a8",
+  "prevId": "abd53fd3-cfe0-4fdc-b319-481d85cdb6e5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_type": {
+          "name": "value_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "boolean_value": {
+          "name": "boolean_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "json_value": {
+          "name": "json_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feature_flags_tags_idx": {
+          "name": "feature_flags_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_flags": {
+      "name": "user_feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_feature_flags_pk": {
+          "name": "user_feature_flags_pk",
+          "columns": [
+            {
+              "expression": "feature_flag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_feature_flags_user_id_enabled_idx": {
+          "name": "user_feature_flags_user_id_enabled_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_feature_flags_feature_flag_id_enabled_idx": {
+          "name": "user_feature_flags_feature_flag_id_enabled_idx",
+          "columns": [
+            {
+              "expression": "feature_flag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_feature_flags_feature_flag_id_feature_flags_id_fk": {
+          "name": "user_feature_flags_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "user_feature_flags",
+          "tableTo": "feature_flags",
+          "columnsFrom": [
+            "feature_flag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/features/.migrations/meta/_journal.json
+++ b/apps/features/.migrations/meta/_journal.json
@@ -1,13 +1,20 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1761684671407,
-			"tag": "0000_orange_star_brand",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1761684671407,
+      "tag": "0000_orange_star_brand",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783440093132,
+      "tag": "0001_early_cable",
+      "breakpoints": true
+    }
+  ]
 }

--- a/apps/features/src/db/schema.ts
+++ b/apps/features/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { boolean, index, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { boolean, index, jsonb, pgTable, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core'
 
 /**
  * Feature flags table
@@ -42,7 +42,37 @@ export const featureFlags = pgTable(
 	})
 )
 
+export const userFeatureFlags = pgTable(
+	'user_feature_flags',
+	{
+		// Primary identifier
+		id: text('id')
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+
+		featureFlagId: text('feature_flag_id')
+			.notNull()
+			.references(() => featureFlags.id),
+
+		userId: text('user_id').notNull(),
+
+		enabled: boolean('enabled').notNull().default(false),
+
+		createdAt: timestamp('created_at').notNull().defaultNow(),
+		updatedAt: timestamp('updated_at').notNull().defaultNow(),
+	},
+	(table) => ({
+		pk: uniqueIndex('user_feature_flags_pk').on(table.featureFlagId, table.userId),
+		userIdEnabledIdx: index('user_feature_flags_user_id_enabled_idx').on(table.userId, table.enabled),
+		featureFlagIdEnabledIdx: index('user_feature_flags_feature_flag_id_enabled_idx').on(
+			table.featureFlagId,
+			table.enabled
+		),
+	})
+)
+
 // Export schema object for Drizzle
 export const schema = {
 	featureFlags,
+	userFeatureFlags,
 }


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-07-07

* **PR #451 (THIS ONE)**:
  `main` ← `feature-user-flags`

    * PR #453:
      `feature-user-flags` ← `feature-user-flags-rpc`

<!-- end git-machete generated -->

<!-- claude:begin -->
## Summary

Adds a `user_feature_flags` table to the `features` app so feature flags can be enabled or disabled on a per-user basis, complementing the existing global `feature_flags` table.

## Changes

- Add `userFeatureFlags` Drizzle table in `apps/features/src/db/schema.ts` with `id`, `featureFlagId` (FK to `feature_flags.id`), `userId`, `enabled` (default `false`), and `createdAt`/`updatedAt` timestamps.
- Enforce a unique index on `(feature_flag_id, user_id)` and add supporting indexes on `(user_id, enabled)` and `(feature_flag_id, enabled)`.
- Export `userFeatureFlags` from the schema object.
- Add migration `0001_early_cable.sql` plus updated journal/snapshot metadata to create the table, foreign key, and indexes.

## Testing

Schema and migration change only; no automated tests are included in the diff. Migrations run automatically via the standard `db:migrate` workflow.
<!-- claude:end -->