### PR TITLE
feat(prediction-markets): M2 Phase 2 — bet via forum buttons + modal

### DIFF
--- a/apps/core/src/__tests__/market-custom-id.test.ts
+++ b/apps/core/src/__tests__/market-custom-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	customIdAction,
+	decodeBetTarget,
+	encodeBetButtonId,
+	encodeBetModalId,
+} from '../lib/market-custom-id'
+
+const MKT = '11111111-1111-1111-1111-111111111111'
+const OUT = '22222222-2222-2222-2222-222222222222'
+
+describe('market custom_id', () => {
+	it('encodes bet button + modal ids under the 100-char limit', () => {
+		const btn = encodeBetButtonId(MKT, OUT)
+		const modal = encodeBetModalId(MKT, OUT)
+		expect(btn).toBe(`bet:${MKT}:${OUT}`)
+		expect(modal).toBe(`betmodal:${MKT}:${OUT}`)
+		expect(btn.length).toBeLessThanOrEqual(100)
+		expect(modal.length).toBeLessThanOrEqual(100)
+	})
+
+	it('round-trips bet + betmodal ids to their targets', () => {
+		expect(decodeBetTarget(encodeBetButtonId(MKT, OUT))).toEqual({ marketId: MKT, outcomeId: OUT })
+		expect(decodeBetTarget(encodeBetModalId(MKT, OUT))).toEqual({ marketId: MKT, outcomeId: OUT })
+	})
+
+	it('returns null for malformed / foreign custom_ids', () => {
+		expect(decodeBetTarget('bet:only-two')).toBeNull() // 2 segments
+		expect(decodeBetTarget(`mkt:close:${MKT}`)).toBeNull() // wrong action
+		expect(decodeBetTarget(`bet::${OUT}`)).toBeNull() // empty marketId
+		expect(decodeBetTarget('')).toBeNull()
+	})
+
+	it('extracts the action prefix', () => {
+		expect(customIdAction('betmodal:a:b')).toBe('betmodal')
+		expect(customIdAction('nocolon')).toBe('nocolon')
+	})
+})

--- a/apps/core/src/__tests__/market-embed.test.ts
+++ b/apps/core/src/__tests__/market-embed.test.ts
@@ -14,6 +14,7 @@ function market(overrides: Partial<MarketDetail> = {}): MarketDetail {
 		outcomeCount: 2,
 		createdAt: '2026-01-01T00:00:00.000Z',
 		discordThreadId: null,
+		discordMessageId: null,
 		description: null,
 		createdBy: 'u1',
 		rakeBps: 0,

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -69,6 +69,10 @@ import {
 	type DiscordInteractionRouting,
 	type ExecuteDiscordSlashCommandInput,
 } from './services/discord-commands.service'
+import {
+	executeDiscordModalSubmit,
+	type ExecuteModalSubmitInput,
+} from './services/discord-components.service'
 import { DkpService } from './services/dkp.service'
 
 import type {
@@ -936,6 +940,26 @@ export class CoreWorker extends WorkerEntrypoint<Env> {
 			coreUserId: result.coreUserId,
 			authorized: result.authorized,
 			commandId: result.commandId,
+			reason: result.reason,
+		}
+	}
+
+	/**
+	 * Handle a Discord modal submit (P2: a prediction-market bet). Resolves the core user,
+	 * runs placeBet, refreshes the public forum post, and returns an ephemeral confirmation.
+	 */
+	async executeDiscordModalSubmit(input: ExecuteModalSubmitInput): Promise<{
+		ok: boolean
+		response: { type: number; data?: { content: string; flags?: number; embeds?: unknown[] } }
+		coreUserId: string | null
+		reason: string
+	}> {
+		const db = createDb(this.env.DATABASE_URL)
+		const result = await executeDiscordModalSubmit(db, this.env, input)
+		return {
+			ok: result.reason === 'ok',
+			response: result.response,
+			coreUserId: result.coreUserId,
 			reason: result.reason,
 		}
 	}

--- a/apps/core/src/lib/market-components.ts
+++ b/apps/core/src/lib/market-components.ts
@@ -1,0 +1,40 @@
+/**
+ * Builds the message-component (button) rows shown on a market's forum post.
+ * P2: one "bet on <outcome>" button per outcome (open markets only).
+ */
+
+import { DISCORD_BUTTON_STYLE, DISCORD_COMPONENT_TYPE } from '@repo/discord'
+
+import { encodeBetButtonId } from './market-custom-id'
+import { truncateForEmbed } from './market-embed'
+
+import type { DiscordActionRow, DiscordButtonComponent } from '@repo/discord'
+import type { MarketDetail } from '@repo/prediction-markets'
+
+const MAX_BUTTONS_PER_ROW = 5
+const MAX_ROWS = 5
+const MAX_BUTTONS = MAX_BUTTONS_PER_ROW * MAX_ROWS // Discord: 25 buttons/message
+
+/**
+ * Bet buttons for an open market (empty for closed/resolved/voided — the post shows no
+ * betting controls). Outcomes are capped at 25; markets are validated to ≤20 outcomes.
+ */
+export function buildMarketComponents(market: MarketDetail): DiscordActionRow[] {
+	if (market.status !== 'open') return []
+
+	const buttons: DiscordButtonComponent[] = market.outcomes.slice(0, MAX_BUTTONS).map((o) => ({
+		type: DISCORD_COMPONENT_TYPE.BUTTON,
+		style: DISCORD_BUTTON_STYLE.PRIMARY,
+		label: truncateForEmbed(o.label, 80),
+		custom_id: encodeBetButtonId(market.id, o.id),
+	}))
+
+	const rows: DiscordActionRow[] = []
+	for (let i = 0; i < buttons.length; i += MAX_BUTTONS_PER_ROW) {
+		rows.push({
+			type: DISCORD_COMPONENT_TYPE.ACTION_ROW,
+			components: buttons.slice(i, i + MAX_BUTTONS_PER_ROW),
+		})
+	}
+	return rows
+}

--- a/apps/core/src/lib/market-custom-id.ts
+++ b/apps/core/src/lib/market-custom-id.ts
@@ -1,0 +1,44 @@
+/**
+ * Encode/decode Discord `custom_id` strings for prediction-market interactions.
+ *
+ * Scheme is `:`-delimited and carries UUIDs directly (≤100-char limit; a bet id is ~77).
+ * P2 uses the bet flow; resolver ids (close/resolve/void) arrive in P3.
+ */
+
+export interface BetTarget {
+	marketId: string
+	outcomeId: string
+}
+
+/** Bet button (on the post): `bet:<marketId>:<outcomeId>`. Clicking opens the stake modal. */
+export function encodeBetButtonId(marketId: string, outcomeId: string): string {
+	return `bet:${marketId}:${outcomeId}`
+}
+
+/**
+ * Stake modal (opened by the bet button): `betmodal:<marketId>:<outcomeId>`.
+ * Note: the interactions worker (apps/discord) builds this same string inline when opening
+ * the modal (it can't import core); keep the two in sync. `decodeBetTarget` parses both.
+ */
+export function encodeBetModalId(marketId: string, outcomeId: string): string {
+	return `betmodal:${marketId}:${outcomeId}`
+}
+
+/** The action prefix of a custom_id (the segment before the first ':'). */
+export function customIdAction(customId: string): string {
+	const idx = customId.indexOf(':')
+	return idx === -1 ? customId : customId.slice(0, idx)
+}
+
+/** Parse a `bet:`/`betmodal:` custom_id into its target ids; null if malformed. */
+export function decodeBetTarget(customId: string): BetTarget | null {
+	const parts = customId.split(':')
+	if (parts.length !== 3) return null
+	const [action, marketId, outcomeId] = parts
+	if (action !== 'bet' && action !== 'betmodal') return null
+	if (!marketId || !outcomeId) return null
+	return { marketId, outcomeId }
+}
+
+/** The text-input custom_id inside the stake modal (its own 100-char budget). */
+export const BET_AMOUNT_INPUT_ID = 'amount'

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -1,0 +1,142 @@
+/**
+ * Discord component / modal-submit handling for prediction markets.
+ *
+ * P2 handles the bet flow's modal submit: a member clicks a "bet" button (the interactions
+ * worker opens the stake modal inline), enters an amount, and this runs `placeBet`, refreshes
+ * the public post embed, and returns an ephemeral confirmation. Resolver component actions
+ * (close/resolve/void) arrive in P3. Core is the sole Discord orchestrator.
+ */
+
+import { eq } from '@repo/db-utils'
+import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
+
+import { users } from '../db/schema'
+import { BET_AMOUNT_INPUT_ID, customIdAction, decodeBetTarget } from '../lib/market-custom-id'
+import { formatMarketPoints } from '../lib/market-embed'
+import { updateMarketPostFromDetail } from './discord-market-post.service'
+
+import type { createDb } from '../db'
+import type { Env } from '../context'
+import type { Discord, DiscordEmbed } from '@repo/discord'
+import type { PredictionMarkets } from '@repo/prediction-markets'
+
+const EPHEMERAL_FLAG = 1 << 6
+
+/** Bindings the component/modal path needs (money DO + Discord DO for the post refresh). */
+export type ComponentEnv = Pick<Env, 'DISCORD' | 'PREDICTION_MARKETS'>
+
+export interface DiscordComponentResult {
+	response: { type: number; data: { content: string; flags?: number; embeds?: DiscordEmbed[] } }
+	coreUserId: string | null
+	reason: string
+}
+
+export interface ExecuteModalSubmitInput {
+	customId: string
+	/** Modal text-input values keyed by their custom_id. */
+	fields: Record<string, string>
+	discordUserId: string
+	/** The modal-submit interaction id — the idempotency key for placeBet. */
+	interactionId?: string | null
+	guildId?: string | null
+	channelId?: string | null
+}
+
+const BET_ERROR_MESSAGES: Record<string, string> = {
+	MARKET_NOT_FOUND: 'That market no longer exists.',
+	MARKET_NOT_OPEN: 'This market is not open for betting.',
+	MARKET_CLOSED: 'Betting has closed on this market.',
+	OUTCOME_NOT_FOUND: 'That outcome is no longer available.',
+	STAKE_BELOW_MIN: 'Your stake is below the minimum for this market.',
+	STAKE_ABOVE_MAX: 'Your stake is above the maximum for this market.',
+	PER_USER_CAP_EXCEEDED: 'That would exceed your per-user cap on this market.',
+	INSUFFICIENT_FUNDS: 'Not enough points — ask an admin for a grant, or lower your stake.',
+	INVALID_AMOUNT: 'Enter a whole number of points.',
+}
+
+function ephemeral(
+	content: string,
+	reason: string,
+	coreUserId: string | null = null
+): DiscordComponentResult {
+	return { response: { type: 4, data: { content, flags: EPHEMERAL_FLAG } }, coreUserId, reason }
+}
+
+/**
+ * Handle a modal submit. Deferred (ephemeral) by the interactions worker, so this may take
+ * >3s; the returned `response.data.content` is delivered as the followup.
+ */
+export async function executeDiscordModalSubmit(
+	db: ReturnType<typeof createDb>,
+	env: ComponentEnv,
+	input: ExecuteModalSubmitInput
+): Promise<DiscordComponentResult> {
+	if (customIdAction(input.customId) !== 'betmodal') {
+		return ephemeral('Unsupported modal.', 'invalid-component')
+	}
+
+	const target = decodeBetTarget(input.customId)
+	if (!target) return ephemeral('Could not read this bet. Please try again.', 'invalid-component')
+
+	if (!input.interactionId) {
+		// Real interactions always carry an id; guard so a bet is never placed without a key.
+		return ephemeral('Could not process this bet. Please try again.', 'invalid-component')
+	}
+
+	const user = await db.query.users.findFirst({
+		where: eq(users.discordUserId, input.discordUserId),
+		columns: { id: true },
+	})
+	if (!user) {
+		return ephemeral(
+			'Your Discord account is not linked to a core user. Link it in the app first.',
+			'not-linked'
+		)
+	}
+
+	const amountRaw = (input.fields[BET_AMOUNT_INPUT_ID] ?? '').trim()
+	if (!/^\d+$/.test(amountRaw) || BigInt(amountRaw) <= 0n) {
+		return ephemeral('Enter a whole number of points greater than zero.', 'invalid-amount', user.id)
+	}
+
+	const prediction = getStub<PredictionMarkets>(env.PREDICTION_MARKETS, 'default')
+	try {
+		const bet = await prediction.placeBet({
+			userId: user.id,
+			marketId: target.marketId,
+			outcomeId: target.outcomeId,
+			amount: amountRaw,
+			idempotencyKey: input.interactionId,
+		})
+
+		// Refresh the public post embed (pools/odds) + grab the outcome label — best-effort.
+		let outcomeLabel = ''
+		try {
+			const market = await prediction.getMarket(target.marketId)
+			if (market) {
+				outcomeLabel = market.outcomes.find((o) => o.id === target.outcomeId)?.label ?? ''
+				await updateMarketPostFromDetail(getStub<Discord>(env.DISCORD, 'default'), market)
+			}
+		} catch (err) {
+			logger.warn('[DiscordComponents] post refresh after bet failed', {
+				marketId: target.marketId,
+				error: err instanceof Error ? err.message : String(err),
+			})
+		}
+
+		const on = outcomeLabel ? ` on **${outcomeLabel}**` : ''
+		return ephemeral(`Bet placed: ${formatMarketPoints(bet.amount)}${on}.`, 'ok', user.id)
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error)
+		if (msg.startsWith('RATE_LIMITED')) {
+			const ms = Number(msg.split(':')[1]) || 0
+			const secs = Math.max(1, Math.ceil(ms / 1000))
+			return ephemeral(`Slow down — try again in ${secs}s.`, 'rate-limited', user.id)
+		}
+		const friendly = BET_ERROR_MESSAGES[msg]
+		if (friendly) return ephemeral(friendly, 'bet-error', user.id)
+		logger.error('[DiscordComponents] placeBet failed', { marketId: target.marketId, error: msg })
+		return ephemeral('Could not place your bet. Please try again later.', 'error', user.id)
+	}
+}

--- a/apps/core/src/services/discord-market-post.service.ts
+++ b/apps/core/src/services/discord-market-post.service.ts
@@ -9,6 +9,7 @@
 import { eq } from '@repo/db-utils'
 
 import { pmForumConfig } from '../db/schema'
+import { buildMarketComponents } from '../lib/market-components'
 import { buildMarketEmbed, truncateForEmbed } from '../lib/market-embed'
 
 import type { createDb } from '../db'
@@ -137,6 +138,7 @@ export async function publishMarketPost(
 		// Forum thread name max is 100 chars; the full question lives in the embed title.
 		name: truncateForEmbed(market.question, 100),
 		embeds: [buildMarketEmbed(market)],
+		components: buildMarketComponents(market),
 		...(cfg.tagOpenId ? { appliedTagIds: [cfg.tagOpenId] } : {}),
 	})
 	await prediction.attachDiscordPost({
@@ -145,4 +147,20 @@ export async function publishMarketPost(
 		messageId: post.messageId,
 	})
 	return post
+}
+
+/**
+ * Refresh a market's forum post embed in place after state changes (e.g. a new bet). Leaves
+ * the bet buttons intact (components omitted). No-op if the market has no post yet.
+ */
+export async function updateMarketPostFromDetail(
+	discord: Discord,
+	market: MarketDetail
+): Promise<{ success: boolean; error?: string }> {
+	if (!market.discordThreadId || !market.discordMessageId) {
+		return { success: false, error: 'no post' }
+	}
+	return discord.updateMarketPostMessage(market.discordThreadId, market.discordMessageId, {
+		embeds: [buildMarketEmbed(market)],
+	})
 }

--- a/apps/discord/src/context.ts
+++ b/apps/discord/src/context.ts
@@ -71,6 +71,25 @@ export type Env = SharedHonoEnv & {
 			commandId?: string
 			reason: string
 		}>
+		executeDiscordModalSubmit(input: {
+			customId: string
+			fields: Record<string, string>
+			discordUserId: string
+			interactionId?: string | null
+			guildId?: string | null
+			channelId?: string | null
+		}): Promise<{
+			ok: boolean
+			response: {
+				type: number
+				data?: {
+					content: string
+					flags?: number
+				}
+			}
+			coreUserId: string | null
+			reason: string
+		}>
 		getDiscordInteractionRouting(): Promise<DiscordInteractionRouting>
 		syncUserDiscordAccess(userId: string): Promise<{
 			ok: boolean

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -16,7 +16,10 @@ import type { App, DiscordInteractionOption, DiscordInteractionRouting } from '.
 
 const DISCORD_INTERACTION_PING = 1
 const DISCORD_INTERACTION_APPLICATION_COMMAND = 2
-const DISCORD_INTERACTION_DEFERRED_RESPONSE = 5
+const DISCORD_INTERACTION_MESSAGE_COMPONENT = 3
+const DISCORD_INTERACTION_MODAL_SUBMIT = 5
+const DISCORD_INTERACTION_DEFERRED_RESPONSE = 5 // response type: DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+const DISCORD_RESPONSE_MODAL = 9 // response type: MODAL
 const DISCORD_EPHEMERAL_FLAG = 1 << 6
 const DISCORD_REPLAY_WINDOW_SECONDS = 5 * 60
 const DISCORD_ROUTING_CACHE_TTL_MS = 60_000
@@ -39,7 +42,18 @@ interface DiscordInteractionPayload {
 	data?: {
 		name?: string
 		options?: DiscordInteractionOption[]
+		/** Present on MESSAGE_COMPONENT (type 3) + MODAL_SUBMIT (type 5). */
+		custom_id?: string
+		component_type?: number
+		values?: string[]
+		/** Modal-submit action rows → text inputs. */
+		components?: Array<{
+			type: number
+			components?: Array<{ type: number; custom_id?: string; value?: string }>
+		}>
 	}
+	/** Source message on a component interaction (unreliable on modal submit). */
+	message?: { id: string }
 }
 
 interface RoutingCacheState {
@@ -139,6 +153,62 @@ async function runDeferredCommand(
 			const stub = getStub<Discord>(env.DISCORD, 'default')
 			await stub.editOriginalInteractionResponse(ctx.token, {
 				content: 'Command execution failed. Please try again later.',
+			})
+		} catch {
+			// Best-effort delivery; nothing more we can do.
+		}
+	}
+}
+
+interface DeferredModalSubmitContext {
+	interactionId: string
+	token: string
+	customId: string
+	fields: Record<string, string>
+	discordUserId: string
+	guildId: string | null
+	channelId: string | null
+}
+
+/**
+ * Run a deferred modal submit (a bet) after the type:5 ephemeral ACK: call core (which runs
+ * placeBet + refreshes the public post) and deliver the ephemeral confirmation by editing the
+ * original interaction response. Failures deliver an error so the user never sees "thinking…".
+ */
+async function runDeferredModalSubmit(
+	env: App['Bindings'],
+	ctx: DeferredModalSubmitContext
+): Promise<void> {
+	const startedAt = Date.now()
+	try {
+		const execution = await env.CORE.executeDiscordModalSubmit({
+			customId: ctx.customId,
+			fields: ctx.fields,
+			discordUserId: ctx.discordUserId,
+			interactionId: ctx.interactionId,
+			guildId: ctx.guildId,
+			channelId: ctx.channelId,
+		})
+		const content = execution.response.data?.content ?? '​'
+		const stub = getStub<Discord>(env.DISCORD, 'default')
+		const result = await stub.editOriginalInteractionResponse(ctx.token, { content })
+		if (!result.success) {
+			logger.error('[DiscordInteractions] Failed to deliver modal-submit response', {
+				interactionId: ctx.interactionId,
+				error: result.error,
+				durationMs: Date.now() - startedAt,
+			})
+		}
+	} catch (error) {
+		logger.error('[DiscordInteractions] Deferred modal submit failed', {
+			interactionId: ctx.interactionId,
+			error: error instanceof Error ? error.message : String(error),
+			durationMs: Date.now() - startedAt,
+		})
+		try {
+			const stub = getStub<Discord>(env.DISCORD, 'default')
+			await stub.editOriginalInteractionResponse(ctx.token, {
+				content: 'Could not process your bet. Please try again later.',
 			})
 		} catch {
 			// Best-effort delivery; nothing more we can do.
@@ -250,6 +320,82 @@ const app = new Hono<App>()
 		if (interaction.type === DISCORD_INTERACTION_PING) {
 			logger.info('[DiscordInteractions] Ping interaction', { requestId, interactionId: interaction.id })
 			return c.json({ type: DISCORD_INTERACTION_PING })
+		}
+
+		// Component (button) interactions. A "bet" button opens the stake modal inline
+		// (zero I/O — trivially within the 3s ACK). Other component actions arrive in P3.
+		if (interaction.type === DISCORD_INTERACTION_MESSAGE_COMPONENT) {
+			const customId = interaction.data?.custom_id ?? ''
+			const parts = customId.split(':')
+			if (parts[0] === 'bet' && parts.length === 3) {
+				return c.json({
+					type: DISCORD_RESPONSE_MODAL,
+					data: {
+						custom_id: `betmodal:${parts[1]}:${parts[2]}`,
+						title: 'Place a bet',
+						components: [
+							{
+								type: 1, // ACTION_ROW
+								components: [
+									{
+										type: 4, // TEXT_INPUT
+										custom_id: 'amount',
+										style: 1, // SHORT
+										label: 'Stake (points)',
+										min_length: 1,
+										max_length: 12,
+										required: true,
+										placeholder: '100',
+									},
+								],
+							},
+						],
+					},
+				})
+			}
+			logger.warn('[DiscordInteractions] Unsupported component', {
+				requestId,
+				interactionId: interaction.id,
+				customId,
+			})
+			return c.json({
+				type: 4,
+				data: { content: 'This action is not available.', flags: DISCORD_EPHEMERAL_FLAG },
+			})
+		}
+
+		// Modal submits. A "betmodal" submit places the bet: defer (ephemeral) then run
+		// placeBet out-of-band, since it hits Neon + the money DO and may exceed 3s.
+		if (interaction.type === DISCORD_INTERACTION_MODAL_SUBMIT) {
+			const customId = interaction.data?.custom_id ?? ''
+			const modalUserId = interaction.member?.user?.id ?? interaction.user?.id ?? null
+			if (customId.split(':')[0] !== 'betmodal' || !modalUserId) {
+				return c.json({
+					type: 4,
+					data: { content: 'This action is not available.', flags: DISCORD_EPHEMERAL_FLAG },
+				})
+			}
+			const fields: Record<string, string> = {}
+			for (const row of interaction.data?.components ?? []) {
+				for (const comp of row.components ?? []) {
+					if (comp.custom_id) fields[comp.custom_id] = comp.value ?? ''
+				}
+			}
+			c.executionCtx.waitUntil(
+				runDeferredModalSubmit(c.env, {
+					interactionId: interaction.id,
+					token: interaction.token,
+					customId,
+					fields,
+					discordUserId: modalUserId,
+					guildId: interaction.guild_id ?? null,
+					channelId: interaction.channel_id ?? null,
+				})
+			)
+			return c.json({
+				type: DISCORD_INTERACTION_DEFERRED_RESPONSE,
+				data: { flags: DISCORD_EPHEMERAL_FLAG },
+			})
 		}
 
 		if (interaction.type !== DISCORD_INTERACTION_APPLICATION_COMMAND || !interaction.data?.name) {

--- a/apps/prediction-markets/.migrations/0003_fancy_hairball.sql
+++ b/apps/prediction-markets/.migrations/0003_fancy_hairball.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "pm_rate_limits" (
+	"user_id" uuid NOT NULL,
+	"command" text NOT NULL,
+	"window_start" timestamp with time zone DEFAULT now() NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "pm_rate_limits_user_id_command_pk" PRIMARY KEY("user_id","command")
+);

--- a/apps/prediction-markets/.migrations/meta/0003_snapshot.json
+++ b/apps/prediction-markets/.migrations/meta/0003_snapshot.json
@@ -1,0 +1,999 @@
+{
+  "id": "f15b859a-2e1e-4ffd-a5c0-d4052df4915f",
+  "prevId": "ef7e5cc3-2f50-4252-8045-11d6d2ed881e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pm_bets": {
+      "name": "pm_bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_bet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_bets_idempotency_key_uq": {
+          "name": "pm_bets_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_user_idx": {
+          "name": "pm_bets_market_user_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_user_created_idx": {
+          "name": "pm_bets_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_outcome_idx": {
+          "name": "pm_bets_market_outcome_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_config": {
+      "name": "pm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_rake_bps": {
+          "name": "default_rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "default_min_stake": {
+          "name": "default_min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "two_of_n_threshold": {
+          "name": "two_of_n_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_ledger": {
+      "name": "pm_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pm_ledger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_ledger_bet_type_uq": {
+          "name": "pm_ledger_bet_type_uq",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_idempotency_key_uq": {
+          "name": "pm_ledger_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pm_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_user_created_idx": {
+          "name": "pm_ledger_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_market_idx": {
+          "name": "pm_ledger_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_created_id_idx": {
+          "name": "pm_ledger_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_history": {
+      "name": "pm_market_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "pm_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_market_history_market_created_idx": {
+          "name": "pm_market_history_market_created_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_history_created_id_idx": {
+          "name": "pm_market_history_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_outcomes": {
+      "name": "pm_market_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "pm_market_outcomes_market_label_uq": {
+          "name": "pm_market_outcomes_market_label_uq",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_outcomes_market_idx": {
+          "name": "pm_market_outcomes_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_markets": {
+      "name": "pm_markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_outcome_id": {
+          "name": "resolved_outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pool": {
+          "name": "total_pool",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "rake_bps": {
+          "name": "rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stake": {
+          "name": "min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "max_stake": {
+          "name": "max_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_user_cap": {
+          "name": "per_user_cap",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_of_n": {
+          "name": "two_of_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_thread_id": {
+          "name": "discord_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_markets_status_closes_idx": {
+          "name": "pm_markets_status_closes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_thread_uq": {
+          "name": "pm_markets_thread_uq",
+          "columns": [
+            {
+              "expression": "discord_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_rate_limits": {
+      "name": "pm_rate_limits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pm_rate_limits_user_id_command_pk": {
+          "name": "pm_rate_limits_user_id_command_pk",
+          "columns": [
+            "user_id",
+            "command"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_resolution_proposals": {
+      "name": "pm_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pm_resolution_proposals_market_status_idx": {
+          "name": "pm_resolution_proposals_market_status_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_wallets": {
+      "name": "pm_wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pm_bet_status": {
+      "name": "pm_bet_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "won",
+        "lost",
+        "refunded"
+      ]
+    },
+    "public.pm_ledger_type": {
+      "name": "pm_ledger_type",
+      "schema": "public",
+      "values": [
+        "grant",
+        "wager",
+        "refund",
+        "payout",
+        "rake",
+        "burn",
+        "adjustment"
+      ]
+    },
+    "public.pm_market_status": {
+      "name": "pm_market_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "resolving",
+        "resolved",
+        "voided"
+      ]
+    },
+    "public.pm_proposal_status": {
+      "name": "pm_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.pm_visibility": {
+      "name": "pm_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "internal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/prediction-markets/.migrations/meta/_journal.json
+++ b/apps/prediction-markets/.migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783438171157,
       "tag": "0002_exotic_captain_cross",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1783439551480,
+      "tag": "0003_fancy_hairball",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/prediction-markets/src/db/schema.ts
+++ b/apps/prediction-markets/src/db/schema.ts
@@ -7,6 +7,7 @@ import {
 	numeric,
 	pgEnum,
 	pgTable,
+	primaryKey,
 	text,
 	timestamp,
 	uniqueIndex,
@@ -139,6 +140,23 @@ export const pmMarketOutcomes = pgTable(
 		uniqueIndex('pm_market_outcomes_market_label_uq').on(t.marketId, t.label),
 		index('pm_market_outcomes_market_idx').on(t.marketId),
 	]
+)
+
+/**
+ * Per-user fixed-window rate limit counters (one row per user+command). Written by an
+ * atomic committed upsert inside the money DO — the single Postgres row serializes
+ * concurrent bets by the same user (DO input gates open across Neon awaits, so a DO-storage
+ * counter would race). A rejected bet still consumes budget (anti-spam).
+ */
+export const pmRateLimits = pgTable(
+	'pm_rate_limits',
+	{
+		userId: uuid('user_id').notNull(),
+		command: text('command').notNull(),
+		windowStart: timestamp('window_start', { withTimezone: true }).notNull().defaultNow(),
+		count: integer('count').notNull().default(0),
+	},
+	(t) => [primaryKey({ columns: [t.userId, t.command] })]
 )
 
 export const pmBets = pgTable(

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -12,10 +12,12 @@ import {
 	pmMarketHistory,
 	pmMarketOutcomes,
 	pmMarkets,
+	pmRateLimits,
 	pmResolutionProposals,
 	pmWallets,
 } from './db/schema'
 import { formatAmount, isPositiveIntegerString, negateAmount, parseAmount } from './lib/money'
+import { RATE_BUDGETS } from './lib/rate-limit'
 import { computeResolution } from './lib/payout'
 import { assertTransition, isTerminal } from './lib/state-machine'
 
@@ -58,6 +60,18 @@ interface HistoryEntry {
 	visibility?: Visibility
 	metadata?: unknown
 }
+
+/** placeBet throws these on normal user-facing rejections — not paged to Sentry. */
+const EXPECTED_BET_ERRORS = new Set([
+	'MARKET_NOT_FOUND',
+	'MARKET_NOT_OPEN',
+	'MARKET_CLOSED',
+	'OUTCOME_NOT_FOUND',
+	'STAKE_BELOW_MIN',
+	'STAKE_ABOVE_MAX',
+	'PER_USER_CAP_EXCEEDED',
+	'INSUFFICIENT_FUNDS',
+])
 
 /**
  * Prediction Markets Durable Object.
@@ -461,9 +475,55 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			.where(eq(pmMarkets.id, input.marketId))
 	}
 
+	/**
+	 * Consume one unit of a user's fixed-window budget for `command`. Atomic committed upsert
+	 * (a single Postgres row per user+command, row-lock-serialized) — safe under the DO's
+	 * yield-at-await concurrency. SQL mirrors `nextRateState`. Unknown command ⇒ unlimited.
+	 */
+	private async consumeRateBudget(
+		userId: string,
+		command: string
+	): Promise<{ allowed: boolean; retryAfterMs: number }> {
+		const budget = RATE_BUDGETS[command]
+		if (!budget) return { allowed: true, retryAfterMs: 0 }
+		// `<=` (not `<`) so this exactly mirrors nextRateState's `elapsed >= windowMs` at the boundary.
+		const expired = sql`${pmRateLimits.windowStart} <= now() - (interval '1 millisecond' * ${budget.windowMs})`
+		const [row] = await this.db
+			.insert(pmRateLimits)
+			.values({ userId, command, windowStart: new Date(), count: 1 })
+			.onConflictDoUpdate({
+				target: [pmRateLimits.userId, pmRateLimits.command],
+				set: {
+					count: sql`case when ${expired} then 1 else ${pmRateLimits.count} + 1 end`,
+					windowStart: sql`case when ${expired} then now() else ${pmRateLimits.windowStart} end`,
+				},
+			})
+			.returning({ count: pmRateLimits.count, windowStart: pmRateLimits.windowStart })
+		const allowed = row.count <= budget.limit
+		const retryAfterMs = allowed
+			? 0
+			: Math.max(0, row.windowStart.getTime() + budget.windowMs - Date.now())
+		return { allowed, retryAfterMs }
+	}
+
 	async placeBet(input: PlaceBetInput): Promise<BetResult> {
 		if (!isPositiveIntegerString(input.amount)) throw new Error('INVALID_AMOUNT')
 		const amount = parseAmount(input.amount)
+
+		// Dedupe pre-check (outside the txn): a duplicate delivery (same interaction id) returns
+		// the prior bet WITHOUT consuming rate budget. The in-txn onConflictDoNothing below is the
+		// race backstop for two identical deliveries that both pass this check.
+		const [priorBet] = await this.db
+			.select()
+			.from(pmBets)
+			.where(eq(pmBets.idempotencyKey, input.idempotencyKey))
+			.limit(1)
+		if (priorBet) return this.toBetResult(priorBet)
+
+		// Rate limit (committed atomic upsert, before the bet txn): a rejected bet still consumes
+		// budget (anti-spam); idempotent retries never reach here (handled above).
+		const rate = await this.consumeRateBudget(input.userId, 'bet')
+		if (!rate.allowed) throw new Error(`RATE_LIMITED:${rate.retryAfterMs}`)
 
 		try {
 			return await this.db.transaction(async (tx) => {
@@ -583,13 +643,18 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				return this.toBetResult(bet)
 			})
 		} catch (error) {
-			captureException(error as Error, {
-				tags: {
-					durableObject: 'PredictionMarketsDO',
-					method: 'placeBet',
-					marketId: input.marketId,
-				},
-			})
+			const msg = error instanceof Error ? error.message : String(error)
+			// Business rejections (insufficient funds, market closed, …) are normal user-facing
+			// outcomes, not server errors — don't page Sentry on them.
+			if (!EXPECTED_BET_ERRORS.has(msg)) {
+				captureException(error as Error, {
+					tags: {
+						durableObject: 'PredictionMarketsDO',
+						method: 'placeBet',
+						marketId: input.marketId,
+					},
+				})
+			}
 			throw error
 		}
 	}
@@ -1089,6 +1154,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			outcomeCount: outcomes.length,
 			createdAt: market.createdAt.toISOString(),
 			discordThreadId: market.discordThreadId,
+			discordMessageId: market.discordMessageId,
 			rakeBps: market.rakeBps,
 			minStake: market.minStake,
 			maxStake: market.maxStake,

--- a/apps/prediction-markets/src/lib/__tests__/rate-limit.test.ts
+++ b/apps/prediction-markets/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { nextRateState } from '../rate-limit'
+
+const budget = { limit: 5, windowMs: 10_000 }
+
+describe('nextRateState (fixed-window)', () => {
+	it('starts a fresh window when the previous one expired', () => {
+		const s = nextRateState(1_000, 5, 20_000, budget) // 19s later, > 10s window
+		expect(s.newWindowStartMs).toBe(20_000)
+		expect(s.newCount).toBe(1)
+		expect(s.allowed).toBe(true)
+		expect(s.retryAfterMs).toBe(0)
+	})
+
+	it('increments within the window and allows up to the limit', () => {
+		const s = nextRateState(1_000, 4, 5_000, budget) // count 4 → 5 (== limit)
+		expect(s.newCount).toBe(5)
+		expect(s.allowed).toBe(true)
+		expect(s.newWindowStartMs).toBe(1_000)
+	})
+
+	it('rejects past the limit and reports retryAfter to the window end', () => {
+		const now = 5_000
+		const s = nextRateState(1_000, 5, now, budget) // count 5 → 6 (> limit)
+		expect(s.newCount).toBe(6)
+		expect(s.allowed).toBe(false)
+		expect(s.retryAfterMs).toBe(1_000 + 10_000 - now) // 6000ms until window end
+	})
+
+	it('resets exactly at the window boundary', () => {
+		const s = nextRateState(0, 5, 10_000, budget) // now - start === windowMs ⇒ expired
+		expect(s.newCount).toBe(1)
+		expect(s.allowed).toBe(true)
+	})
+})

--- a/apps/prediction-markets/src/lib/rate-limit.ts
+++ b/apps/prediction-markets/src/lib/rate-limit.ts
@@ -1,0 +1,42 @@
+/**
+ * Fixed-window rate-limit budgets + the pure window computation.
+ *
+ * The DO applies this as an atomic Postgres upsert (SQL mirrors `nextRateState`); this
+ * module exists so the window math is unit-testable without a database.
+ */
+
+export interface RateBudget {
+	/** Max allowed occurrences within the window. */
+	limit: number
+	windowMs: number
+}
+
+/** Per-command budgets. Bets are the spammable path; other commands aren't rate-limited yet. */
+export const RATE_BUDGETS: Record<string, RateBudget> = {
+	bet: { limit: 5, windowMs: 10_000 },
+}
+
+export interface RateState {
+	newWindowStartMs: number
+	newCount: number
+	allowed: boolean
+	retryAfterMs: number
+}
+
+/**
+ * Given the stored window start + count and the current time, compute the post-increment
+ * state: reset the window if it has expired, else increment; allow while count ≤ limit.
+ */
+export function nextRateState(
+	windowStartMs: number,
+	count: number,
+	nowMs: number,
+	budget: RateBudget
+): RateState {
+	const expired = nowMs - windowStartMs >= budget.windowMs
+	const newWindowStartMs = expired ? nowMs : windowStartMs
+	const newCount = expired ? 1 : count + 1
+	const allowed = newCount <= budget.limit
+	const retryAfterMs = allowed ? 0 : Math.max(0, newWindowStartMs + budget.windowMs - nowMs)
+	return { newWindowStartMs, newCount, allowed, retryAfterMs }
+}

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -81,6 +81,8 @@ export interface MarketSummary {
 
 export interface MarketDetail extends MarketSummary {
 	description: string | null
+	/** Discord starter-message id of the forum post (for in-place embed updates). */
+	discordMessageId: string | null
 	createdBy: string
 	rakeBps: number
 	minStake: string


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-07-07

* **PR #452 (THIS ONE)**:
  `main` ← `pm-m2-p2-bet-modal`

    * PR #454:
      `pm-m2-p2-bet-modal` ← `pm-m2-p3-resolver-buttons`

<!-- end git-machete generated -->

<!-- claude:begin -->
## Summary

Phase 2 of the prediction-markets M2 milestone: members place bets directly from a market's Discord forum post. Clicking a per-outcome **bet** button opens a stake modal, and submitting it places the bet, refreshes the post's pools/odds embed, and returns an ephemeral confirmation. Core remains the sole Discord orchestrator; bets are idempotent and rate-limited.

## Changes

- **Interactions worker (`apps/discord`)**: routes `MESSAGE_COMPONENT` (type 3) `bet:*` buttons to open the stake modal inline (response type 9), and `MODAL_SUBMIT` (type 5) `betmodal:*` submits by ACKing ephemerally then running `placeBet` out-of-band (Neon + money DO may exceed the 3s window). Adds the `executeDiscordModalSubmit` binding to the core RPC surface.
- **Core (`apps/core`)**: new `executeDiscordModalSubmit` service + `CoreWorker` RPC method (resolve linked user → `placeBet` → refresh post embed → friendly error/rate-limit messages); `market-custom-id` encode/decode helpers; `buildMarketComponents` renders bet buttons on open markets; `publishMarketPost` now attaches those buttons and `updateMarketPostFromDetail` refreshes the embed in place after a bet.
- **Prediction-markets DO (`apps/prediction-markets`)**: new `pm_rate_limits` table (migration `0003`) and `consumeRateBudget` atomic committed upsert (5 bets / 10s); `placeBet` restructured to dedupe → rate-limit → bet so idempotent retries never double-charge or burn budget, while rejected bets still consume budget (anti-spam). Expected business rejections (insufficient funds, market closed, …) are no longer paged to Sentry.
- **Shared `@repo/prediction-markets`**: `MarketDetail` gains `discordMessageId` (the forum post's starter-message id) to support in-place embed updates.

## Testing

- New unit tests: `market-custom-id.test.ts` (encode/decode round-trips, malformed ids, 100-char limit) and `rate-limit.test.ts` (fixed-window `nextRateState`: fresh window, increment-to-limit, rejection + `retryAfter`, boundary reset).
- `market-embed.test.ts` updated for the new `discordMessageId` field.
<!-- claude:end -->
