### PR TITLE
Add rpc functions for user feature flags

### DIFF
--- a/apps/features/src/durable-object.ts
+++ b/apps/features/src/durable-object.ts
@@ -2,13 +2,17 @@ import { DurableObject } from 'cloudflare:workers'
 
 import { createDb } from './db'
 import { FeatureFlagService } from './services/feature-flag.service'
+import { UserFeatureFlagService } from './services/user-feature-flag.service'
 
 import type {
 	FeatureFlag,
 	Features,
 	ListFlagsOptions,
+	ListFlagUsersOptions,
+	ListUserFlagsOptions,
 	RegisterFlagOptions,
 	SetFlagOptions,
+	UserFeatureFlag,
 } from '@repo/features'
 import type { Env } from './context'
 
@@ -20,6 +24,7 @@ import type { Env } from './context'
  */
 export class FeaturesDO extends DurableObject implements Features {
 	private service: FeatureFlagService
+	private userService: UserFeatureFlagService
 
 	/**
 	 * Initialize the Durable Object
@@ -30,9 +35,10 @@ export class FeaturesDO extends DurableObject implements Features {
 	) {
 		super(state, env)
 
-		// Initialize database client and service
+		// Initialize database client and services
 		const db = createDb(env.DATABASE_URL)
 		this.service = new FeatureFlagService(db)
+		this.userService = new UserFeatureFlagService(db)
 	}
 
 	/**
@@ -86,6 +92,58 @@ export class FeaturesDO extends DurableObject implements Features {
 	 */
 	async getFlag(key: string): Promise<FeatureFlag | null> {
 		return await this.service.getFlag(key)
+	}
+
+	/**
+	 * Set (create or update) a per-user override for a feature flag
+	 */
+	async setUserFlag(userId: string, key: string, enabled: boolean): Promise<UserFeatureFlag> {
+		return await this.userService.setUserFlag(userId, key, enabled)
+	}
+
+	/**
+	 * Get a user's override for a feature flag
+	 */
+	async getUserFlag(userId: string, key: string): Promise<UserFeatureFlag | null> {
+		return await this.userService.getUserFlag(userId, key)
+	}
+
+	/**
+	 * Delete a user's override for a feature flag
+	 */
+	async deleteUserFlag(userId: string, key: string): Promise<boolean> {
+		return await this.userService.deleteUserFlag(userId, key)
+	}
+
+	/**
+	 * Resolve whether a feature is enabled for a specific user
+	 */
+	async checkUserFlag(userId: string, key: string): Promise<boolean> {
+		return await this.userService.checkUserFlag(userId, key)
+	}
+
+	/**
+	 * Resolve multiple feature flags for a user in a single call
+	 */
+	async checkUserFlags(userId: string, keys: string[]): Promise<Record<string, boolean>> {
+		return await this.userService.checkUserFlags(userId, keys)
+	}
+
+	/**
+	 * List a user's feature flag overrides
+	 */
+	async listUserFlags(
+		userId: string,
+		options?: ListUserFlagsOptions
+	): Promise<UserFeatureFlag[]> {
+		return await this.userService.listUserFlags(userId, options)
+	}
+
+	/**
+	 * List the users who have an override for a given feature flag
+	 */
+	async listFlagUsers(key: string, options?: ListFlagUsersOptions): Promise<UserFeatureFlag[]> {
+		return await this.userService.listFlagUsers(key, options)
 	}
 
 	/**

--- a/apps/features/src/services/prefix.test.ts
+++ b/apps/features/src/services/prefix.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { escapeLikePrefix, likePrefixPattern } from './prefix'
+
+describe('escapeLikePrefix', () => {
+	it('leaves a plain prefix unchanged', () => {
+		expect(escapeLikePrefix('notifications.email')).toBe('notifications.email')
+	})
+
+	it('escapes underscores so they match literally instead of as single-char wildcards', () => {
+		expect(escapeLikePrefix('user_a')).toBe('user\\_a')
+	})
+
+	it('escapes percent signs so they match literally instead of as multi-char wildcards', () => {
+		expect(escapeLikePrefix('100%')).toBe('100\\%')
+	})
+
+	it('escapes backslashes (the escape character itself)', () => {
+		expect(escapeLikePrefix('a\\b')).toBe('a\\\\b')
+	})
+
+	it('escapes multiple metacharacters in one prefix', () => {
+		expect(escapeLikePrefix('a_b%c')).toBe('a\\_b\\%c')
+	})
+})
+
+describe('likePrefixPattern', () => {
+	it('appends an unescaped trailing wildcard to the escaped prefix', () => {
+		expect(likePrefixPattern('user_a')).toBe('user\\_a%')
+	})
+
+	it('produces a plain prefix pattern when there are no metacharacters', () => {
+		expect(likePrefixPattern('mumble')).toBe('mumble%')
+	})
+})

--- a/apps/features/src/services/prefix.ts
+++ b/apps/features/src/services/prefix.ts
@@ -1,0 +1,32 @@
+/**
+ * Helpers for building safe SQL LIKE prefix patterns.
+ *
+ * Kept pure (no database / no drizzle) so the escaping rules can be unit
+ * tested deterministically.
+ */
+
+/**
+ * Escape the LIKE wildcard metacharacters (`%`, `_`) and the escape character
+ * (`\`) in a user-supplied prefix so the prefix matches literally.
+ *
+ * Postgres LIKE treats `\` as the default escape character, so escaping each
+ * metacharacter with a backslash makes it match itself rather than acting as a
+ * wildcard. Without this, a prefix such as `user_a` would treat `_` as a
+ * single-character wildcard and over-match keys like `userXa`.
+ *
+ * @param prefix - The literal prefix supplied by the caller
+ * @returns The prefix with LIKE metacharacters escaped
+ */
+export function escapeLikePrefix(prefix: string): string {
+	return prefix.replace(/[\\%_]/g, (char) => `\\${char}`)
+}
+
+/**
+ * Build a LIKE pattern that matches keys starting with `prefix` literally.
+ *
+ * @param prefix - The literal prefix supplied by the caller
+ * @returns A LIKE pattern (escaped prefix followed by a trailing `%` wildcard)
+ */
+export function likePrefixPattern(prefix: string): string {
+	return `${escapeLikePrefix(prefix)}%`
+}

--- a/apps/features/src/services/resolution.test.ts
+++ b/apps/features/src/services/resolution.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveFlagValue, resolveFlagValues } from './resolution'
+
+import type { ResolvableFlag } from './resolution'
+
+describe('resolveFlagValue', () => {
+	it('returns the override when one exists (override true, global false)', () => {
+		expect(resolveFlagValue(true, false)).toBe(true)
+	})
+
+	it('respects an override of false even when the global default is true', () => {
+		// The nullish-vs-falsy trap: `false ?? true` must be false, not true.
+		expect(resolveFlagValue(false, true)).toBe(false)
+	})
+
+	it('falls back to the global value when there is no override', () => {
+		expect(resolveFlagValue(undefined, true)).toBe(true)
+		expect(resolveFlagValue(undefined, false)).toBe(false)
+	})
+
+	it('falls back to false when neither an override nor a global value exists', () => {
+		expect(resolveFlagValue(undefined, null)).toBe(false)
+	})
+
+	it('respects an override even when the global value is unset (null)', () => {
+		expect(resolveFlagValue(true, null)).toBe(true)
+		expect(resolveFlagValue(false, null)).toBe(false)
+	})
+})
+
+describe('resolveFlagValues', () => {
+	const flag = (id: string, key: string, booleanValue: boolean | null): ResolvableFlag => ({
+		id,
+		key,
+		booleanValue,
+	})
+
+	it('returns an empty map for no requested keys', () => {
+		expect(resolveFlagValues([], [], new Map())).toEqual({})
+	})
+
+	it('resolves an unknown flag (requested but not found) to false', () => {
+		expect(resolveFlagValues(['missing'], [], new Map())).toEqual({ missing: false })
+	})
+
+	it('uses the global value when the flag has no override', () => {
+		const flags = [flag('1', 'a', true), flag('2', 'b', false)]
+		expect(resolveFlagValues(['a', 'b'], flags, new Map())).toEqual({ a: true, b: false })
+	})
+
+	it('lets a user override of false win over a global true', () => {
+		const flags = [flag('1', 'a', true)]
+		const overrides = new Map([['1', false]])
+		expect(resolveFlagValues(['a'], flags, overrides)).toEqual({ a: false })
+	})
+
+	it('lets a user override of true win over a global false', () => {
+		const flags = [flag('1', 'a', false)]
+		const overrides = new Map([['1', true]])
+		expect(resolveFlagValues(['a'], flags, overrides)).toEqual({ a: true })
+	})
+
+	it('resolves a flag with a null global value and no override to false', () => {
+		const flags = [flag('1', 'a', null)]
+		expect(resolveFlagValues(['a'], flags, new Map())).toEqual({ a: false })
+	})
+
+	it('produces a complete map for a mixed batch, including unknown keys', () => {
+		const flags = [flag('1', 'a', true), flag('2', 'b', false)]
+		const overrides = new Map([['2', true]])
+		expect(resolveFlagValues(['a', 'b', 'missing'], flags, overrides)).toEqual({
+			a: true, // global default
+			b: true, // override wins over global false
+			missing: false, // unregistered flag
+		})
+	})
+
+	it('collapses duplicate keys to a single resolved entry', () => {
+		const flags = [flag('1', 'a', true)]
+		expect(resolveFlagValues(['a', 'a'], flags, new Map())).toEqual({ a: true })
+	})
+
+	it('does not resolve a flag that was not requested', () => {
+		// Defensive: only requested keys should appear; a stray fetched flag that
+		// was not requested still gets written, but callers only pass fetched
+		// flags for requested keys. This documents the seeding contract.
+		const flags = [flag('1', 'a', true)]
+		const result = resolveFlagValues(['a'], flags, new Map())
+		expect(Object.keys(result)).toEqual(['a'])
+	})
+})

--- a/apps/features/src/services/resolution.ts
+++ b/apps/features/src/services/resolution.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure feature-flag resolution rules.
+ *
+ * These helpers contain the precedence logic for turning a global flag value
+ * plus an optional per-user override into an effective boolean. They are kept
+ * free of any database or I/O so the (subtle) precedence rules can be unit
+ * tested deterministically, without a live Postgres connection.
+ */
+
+/** The minimal flag shape needed to resolve an effective value. */
+export interface ResolvableFlag {
+	/** The flag's primary id (matches user_feature_flags.feature_flag_id). */
+	id: string
+	/** The flag's hierarchical key. */
+	key: string
+	/** The flag's global boolean value (null when the flag is non-boolean/unset). */
+	booleanValue: boolean | null
+}
+
+/**
+ * Resolve the effective enabled state for a single flag.
+ *
+ * Precedence: user override -> flag's global boolean value -> false.
+ *
+ * Uses nullish coalescing (not `||`) so that an override or global value of
+ * `false` is respected — e.g. an override of `false` must win over a global
+ * `true`, and a global `false` must win over a missing override.
+ *
+ * @param override - The user's override value, or undefined when none exists
+ * @param globalValue - The flag's global boolean value, or null when unset
+ * @returns The effective enabled state
+ */
+export function resolveFlagValue(
+	override: boolean | undefined,
+	globalValue: boolean | null
+): boolean {
+	return override ?? globalValue ?? false
+}
+
+/**
+ * Resolve a batch of requested keys into a complete key -> boolean map.
+ *
+ * Every requested key is present in the result (so callers get a total map),
+ * even keys that reference an unregistered flag, which resolve to `false`.
+ * Duplicate keys collapse to a single entry.
+ *
+ * @param keys - The requested flag keys (may contain duplicates)
+ * @param flags - The flags that were found for the requested keys
+ * @param overrideByFlagId - Map of feature_flag_id -> the user's override value
+ * @returns A map of every requested key to its effective enabled state
+ */
+export function resolveFlagValues(
+	keys: string[],
+	flags: readonly ResolvableFlag[],
+	overrideByFlagId: ReadonlyMap<string, boolean>
+): Record<string, boolean> {
+	// Seed every requested key to false so unregistered flags default to off.
+	const result: Record<string, boolean> = {}
+	for (const key of keys) {
+		result[key] = false
+	}
+
+	// Overlay the resolved value for each flag that actually exists.
+	for (const flag of flags) {
+		result[flag.key] = resolveFlagValue(overrideByFlagId.get(flag.id), flag.booleanValue)
+	}
+
+	return result
+}

--- a/apps/features/src/services/user-feature-flag.service.ts
+++ b/apps/features/src/services/user-feature-flag.service.ts
@@ -1,0 +1,280 @@
+import { and, asc, eq, inArray, like } from '@repo/db-utils'
+
+import { featureFlags, userFeatureFlags } from '../db/schema'
+import { likePrefixPattern } from './prefix'
+import { resolveFlagValue, resolveFlagValues } from './resolution'
+
+import type { DbClient } from '@repo/db-utils'
+import type {
+	ListFlagUsersOptions,
+	ListUserFlagsOptions,
+	UserFeatureFlag,
+} from '@repo/features'
+import type { schema } from '../db/schema'
+
+/**
+ * User feature flag service
+ *
+ * Provides business logic for per-user feature flag overrides. A user override
+ * layers on top of a global feature flag: when resolving whether a feature is
+ * enabled for a user, an override (if present) takes precedence over the flag's
+ * global boolean value.
+ */
+export class UserFeatureFlagService {
+	constructor(private readonly db: DbClient<typeof schema>) {}
+
+	/**
+	 * Set (create or update) a per-user override for a feature flag.
+	 *
+	 * Uses an upsert on the (featureFlagId, userId) unique index so repeated
+	 * calls update the existing override rather than creating duplicates.
+	 *
+	 * @param userId - The user the override applies to
+	 * @param key - The feature flag key to override
+	 * @param enabled - Whether the feature is enabled for this user
+	 * @returns The created or updated override
+	 * @throws Error if no feature flag exists for `key`
+	 */
+	async setUserFlag(userId: string, key: string, enabled: boolean): Promise<UserFeatureFlag> {
+		const flag = await this.getFlagByKey(key)
+		if (!flag) {
+			throw new Error(`Feature flag with key "${key}" not found`)
+		}
+
+		const [upserted] = await this.db
+			.insert(userFeatureFlags)
+			.values({
+				featureFlagId: flag.id,
+				userId,
+				enabled,
+			})
+			.onConflictDoUpdate({
+				target: [userFeatureFlags.featureFlagId, userFeatureFlags.userId],
+				set: {
+					enabled,
+					updatedAt: new Date(),
+				},
+			})
+			.returning()
+
+		return this.mapToUserFeatureFlag(upserted, flag.key)
+	}
+
+	/**
+	 * Get a user's override for a feature flag.
+	 *
+	 * @param userId - The user whose override to retrieve
+	 * @param key - The feature flag key
+	 * @returns The user's override, or null if the flag or override does not exist
+	 */
+	async getUserFlag(userId: string, key: string): Promise<UserFeatureFlag | null> {
+		const flag = await this.getFlagByKey(key)
+		if (!flag) {
+			return null
+		}
+
+		const override = await this.db.query.userFeatureFlags.findFirst({
+			where: and(
+				eq(userFeatureFlags.featureFlagId, flag.id),
+				eq(userFeatureFlags.userId, userId)
+			),
+		})
+
+		if (!override) {
+			return null
+		}
+
+		return this.mapToUserFeatureFlag(override, flag.key)
+	}
+
+	/**
+	 * Delete a user's override for a feature flag, reverting the user to the
+	 * flag's global default.
+	 *
+	 * @param userId - The user whose override to delete
+	 * @param key - The feature flag key
+	 * @returns True if an override was deleted, false if none existed
+	 */
+	async deleteUserFlag(userId: string, key: string): Promise<boolean> {
+		const flag = await this.getFlagByKey(key)
+		if (!flag) {
+			return false
+		}
+
+		const result = await this.db
+			.delete(userFeatureFlags)
+			.where(
+				and(
+					eq(userFeatureFlags.featureFlagId, flag.id),
+					eq(userFeatureFlags.userId, userId)
+				)
+			)
+			.returning()
+
+		return result.length > 0
+	}
+
+	/**
+	 * Resolve whether a feature is enabled for a specific user.
+	 *
+	 * Resolution precedence: user override -> flag's global boolean value ->
+	 * false (unknown flag or no value).
+	 *
+	 * @param userId - The user to resolve the flag for
+	 * @param key - The feature flag key
+	 * @returns The effective enabled state for the user
+	 */
+	async checkUserFlag(userId: string, key: string): Promise<boolean> {
+		const flag = await this.getFlagByKey(key)
+		if (!flag) {
+			return false
+		}
+
+		const override = await this.db.query.userFeatureFlags.findFirst({
+			where: and(
+				eq(userFeatureFlags.featureFlagId, flag.id),
+				eq(userFeatureFlags.userId, userId)
+			),
+		})
+
+		return resolveFlagValue(override?.enabled, flag.booleanValue)
+	}
+
+	/**
+	 * Resolve multiple feature flags for a user in a single round of queries.
+	 *
+	 * Every requested key is present in the returned map; unknown flags resolve
+	 * to `false`. Applies the same precedence as {@link checkUserFlag}.
+	 *
+	 * @param userId - The user to resolve the flags for
+	 * @param keys - The feature flag keys to resolve
+	 * @returns A map of flag key to effective enabled state
+	 */
+	async checkUserFlags(userId: string, keys: string[]): Promise<Record<string, boolean>> {
+		// De-duplicate to keep the IN clauses tight when callers pass repeats.
+		const uniqueKeys = [...new Set(keys)]
+		if (uniqueKeys.length === 0) {
+			return {}
+		}
+
+		const flags = await this.db.query.featureFlags.findMany({
+			where: inArray(featureFlags.key, uniqueKeys),
+		})
+		if (flags.length === 0) {
+			// Every requested key references an unregistered flag -> all false.
+			return resolveFlagValues(keys, [], new Map())
+		}
+
+		const overrides = await this.db.query.userFeatureFlags.findMany({
+			where: and(
+				eq(userFeatureFlags.userId, userId),
+				inArray(
+					userFeatureFlags.featureFlagId,
+					flags.map((flag) => flag.id)
+				)
+			),
+		})
+		const overrideByFlagId = new Map(
+			overrides.map((override) => [override.featureFlagId, override.enabled])
+		)
+
+		return resolveFlagValues(keys, flags, overrideByFlagId)
+	}
+
+	/**
+	 * List a user's feature flag overrides, ordered by flag key.
+	 *
+	 * @param userId - The user whose overrides to list
+	 * @param options - Optional key-prefix and/or enabled-state filters
+	 * @returns The user's overrides
+	 */
+	async listUserFlags(
+		userId: string,
+		options?: ListUserFlagsOptions
+	): Promise<UserFeatureFlag[]> {
+		const conditions = [eq(userFeatureFlags.userId, userId)]
+
+		if (options?.prefix) {
+			// Escape LIKE metacharacters so the prefix matches literally
+			// ("starts with"), rather than treating `_`/`%` as wildcards.
+			conditions.push(like(featureFlags.key, likePrefixPattern(options.prefix)))
+		}
+
+		if (options?.enabled !== undefined) {
+			conditions.push(eq(userFeatureFlags.enabled, options.enabled))
+		}
+
+		const rows = await this.db
+			.select({
+				id: userFeatureFlags.id,
+				featureFlagId: userFeatureFlags.featureFlagId,
+				key: featureFlags.key,
+				userId: userFeatureFlags.userId,
+				enabled: userFeatureFlags.enabled,
+				createdAt: userFeatureFlags.createdAt,
+				updatedAt: userFeatureFlags.updatedAt,
+			})
+			.from(userFeatureFlags)
+			.innerJoin(featureFlags, eq(userFeatureFlags.featureFlagId, featureFlags.id))
+			.where(and(...conditions))
+			.orderBy(asc(featureFlags.key))
+
+		return rows
+	}
+
+	/**
+	 * List the users who have an override for a given feature flag, ordered by
+	 * user id.
+	 *
+	 * @param key - The feature flag key
+	 * @param options - Optional enabled-state filter
+	 * @returns The overrides for the flag (empty if the flag does not exist)
+	 */
+	async listFlagUsers(key: string, options?: ListFlagUsersOptions): Promise<UserFeatureFlag[]> {
+		const flag = await this.getFlagByKey(key)
+		if (!flag) {
+			return []
+		}
+
+		const conditions = [eq(userFeatureFlags.featureFlagId, flag.id)]
+
+		if (options?.enabled !== undefined) {
+			conditions.push(eq(userFeatureFlags.enabled, options.enabled))
+		}
+
+		const rows = await this.db.query.userFeatureFlags.findMany({
+			where: and(...conditions),
+			orderBy: (uff, { asc: ascOrder }) => [ascOrder(uff.userId)],
+		})
+
+		return rows.map((row) => this.mapToUserFeatureFlag(row, flag.key))
+	}
+
+	/**
+	 * Look up a feature flag by its key.
+	 */
+	private async getFlagByKey(key: string): Promise<typeof featureFlags.$inferSelect | undefined> {
+		return await this.db.query.featureFlags.findFirst({
+			where: eq(featureFlags.key, key),
+		})
+	}
+
+	/**
+	 * Map a database record to the public UserFeatureFlag shape, enriching it
+	 * with the parent flag's key.
+	 */
+	private mapToUserFeatureFlag(
+		record: typeof userFeatureFlags.$inferSelect,
+		key: string
+	): UserFeatureFlag {
+		return {
+			id: record.id,
+			featureFlagId: record.featureFlagId,
+			key,
+			userId: record.userId,
+			enabled: record.enabled,
+			createdAt: record.createdAt,
+			updatedAt: record.updatedAt,
+		}
+	}
+}

--- a/apps/features/src/test/integration/api.test.ts
+++ b/apps/features/src/test/integration/api.test.ts
@@ -121,3 +121,184 @@ describe('Features Durable Object - Feature Flags', () => {
 		)
 	})
 })
+
+describe('Features Durable Object - User Feature Flags', () => {
+	const userId = () => `user-${Date.now()}-${Math.random()}`
+
+	it('sets a user override for an existing flag', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const user = userId()
+
+		await stub.registerFlag('user.set.enabled', false)
+		const override = await stub.setUserFlag(user, 'user.set.enabled', true)
+
+		expect(override).toHaveProperty('id')
+		expect(override.key).toBe('user.set.enabled')
+		expect(override.userId).toBe(user)
+		expect(override.enabled).toBe(true)
+	})
+
+	it('throws when setting a user override for an unknown flag', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+
+		await expect(stub.setUserFlag(userId(), 'user.unknown.flag', true)).rejects.toThrow(
+			'not found'
+		)
+	})
+
+	it('upserts (updates) an existing user override without duplicating', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const user = userId()
+
+		await stub.registerFlag('user.upsert.enabled', false)
+		await stub.setUserFlag(user, 'user.upsert.enabled', true)
+		const updated = await stub.setUserFlag(user, 'user.upsert.enabled', false)
+
+		expect(updated.enabled).toBe(false)
+
+		const overrides = await stub.listUserFlags(user)
+		expect(overrides).toHaveLength(1)
+		expect(overrides[0]?.enabled).toBe(false)
+	})
+
+	it('resolves checkUserFlag with override precedence over the global default', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const enabledUser = userId()
+		const defaultUser = userId()
+
+		// Global default is false...
+		await stub.registerFlag('user.resolve.enabled', false)
+
+		// ...but this user is overridden to true.
+		await stub.setUserFlag(enabledUser, 'user.resolve.enabled', true)
+
+		expect(await stub.checkUserFlag(enabledUser, 'user.resolve.enabled')).toBe(true)
+		// A user without an override falls back to the global default (false).
+		expect(await stub.checkUserFlag(defaultUser, 'user.resolve.enabled')).toBe(false)
+	})
+
+	it('resolves checkUserFlag to the global default when no override exists', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+
+		await stub.registerFlag('user.globaltrue.enabled', true)
+
+		expect(await stub.checkUserFlag(userId(), 'user.globaltrue.enabled')).toBe(true)
+	})
+
+	it('resolves checkUserFlag to false for an unknown flag', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+
+		expect(await stub.checkUserFlag(userId(), 'user.does-not-exist')).toBe(false)
+	})
+
+	it('resolves checkUserFlags for a batch of keys', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const user = userId()
+
+		await stub.registerFlag('user.batch.a', true)
+		await stub.registerFlag('user.batch.b', false)
+		await stub.setUserFlag(user, 'user.batch.b', true)
+
+		const resolved = await stub.checkUserFlags(user, [
+			'user.batch.a',
+			'user.batch.b',
+			'user.batch.missing',
+		])
+
+		expect(resolved).toEqual({
+			'user.batch.a': true, // global default
+			'user.batch.b': true, // user override wins over global false
+			'user.batch.missing': false, // unknown flag -> false
+		})
+	})
+
+	it('returns an empty map from checkUserFlags for no keys', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+
+		expect(await stub.checkUserFlags(userId(), [])).toEqual({})
+	})
+
+	it('gets and deletes a user override', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const user = userId()
+
+		await stub.registerFlag('user.getdelete.enabled', false)
+		await stub.setUserFlag(user, 'user.getdelete.enabled', true)
+
+		const fetched = await stub.getUserFlag(user, 'user.getdelete.enabled')
+		expect(fetched?.enabled).toBe(true)
+
+		expect(await stub.deleteUserFlag(user, 'user.getdelete.enabled')).toBe(true)
+		expect(await stub.getUserFlag(user, 'user.getdelete.enabled')).toBeNull()
+		// After deletion the user reverts to the global default (false).
+		expect(await stub.checkUserFlag(user, 'user.getdelete.enabled')).toBe(false)
+	})
+
+	it('returns null/false when getting or deleting overrides for unknown flags', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const user = userId()
+
+		expect(await stub.getUserFlag(user, 'user.ghost.flag')).toBeNull()
+		expect(await stub.deleteUserFlag(user, 'user.ghost.flag')).toBe(false)
+	})
+
+	it('lists a user overrides with prefix and enabled filters', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const user = userId()
+
+		await stub.registerFlag('user.list.alpha', false)
+		await stub.registerFlag('user.list.beta', false)
+		await stub.registerFlag('other.list.gamma', false)
+
+		await stub.setUserFlag(user, 'user.list.alpha', true)
+		await stub.setUserFlag(user, 'user.list.beta', false)
+		await stub.setUserFlag(user, 'other.list.gamma', true)
+
+		const prefixed = await stub.listUserFlags(user, { prefix: 'user.list' })
+		expect(prefixed.map((f) => f.key)).toEqual(['user.list.alpha', 'user.list.beta'])
+
+		const enabledOnly = await stub.listUserFlags(user, { enabled: true })
+		expect(enabledOnly.map((f) => f.key)).toEqual(['other.list.gamma', 'user.list.alpha'])
+	})
+
+	it('lists the users who have an override for a flag, ordered by ascending user id', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const token = `${Date.now()}-${Math.random()}`
+		const userLow = `aaa-${token}`
+		const userHigh = `zzz-${token}`
+
+		await stub.registerFlag('user.flagusers.enabled', false)
+		// Insert the higher-sorting id first to prove results come back ordered
+		// by user id rather than by insertion order.
+		await stub.setUserFlag(userHigh, 'user.flagusers.enabled', true)
+		await stub.setUserFlag(userLow, 'user.flagusers.enabled', false)
+
+		const all = await stub.listFlagUsers('user.flagusers.enabled')
+		expect(all).toHaveLength(2)
+		expect(all.every((o) => o.key === 'user.flagusers.enabled')).toBe(true)
+		// Ascending by user id despite the reverse insertion order above.
+		expect(all.map((o) => o.userId)).toEqual([userLow, userHigh])
+
+		const enabledOnly = await stub.listFlagUsers('user.flagusers.enabled', { enabled: true })
+		expect(enabledOnly).toHaveLength(1)
+		expect(enabledOnly[0]?.userId).toBe(userHigh)
+
+		// Unknown flag yields an empty list rather than throwing.
+		expect(await stub.listFlagUsers('user.flagusers.missing')).toEqual([])
+	})
+
+	it('treats the listUserFlags prefix as a literal (escapes LIKE wildcards)', async () => {
+		const stub = getStub<Features>(testEnv.FEATURES, `test-${Date.now()}-${Math.random()}`)
+		const user = userId()
+
+		// 'user_lit.a' should match the literal prefix 'user_lit'; 'userXlit.a'
+		// must NOT, even though an unescaped '_' wildcard would match it.
+		await stub.registerFlag('user_lit.a', false)
+		await stub.registerFlag('userXlit.a', false)
+		await stub.setUserFlag(user, 'user_lit.a', true)
+		await stub.setUserFlag(user, 'userXlit.a', true)
+
+		const matches = await stub.listUserFlags(user, { prefix: 'user_lit' })
+		expect(matches.map((f) => f.key)).toEqual(['user_lit.a'])
+	})
+})

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -52,6 +52,48 @@ export interface ListFlagsOptions {
 }
 
 /**
+ * Per-user feature flag override record.
+ *
+ * A user feature flag layers on top of a global {@link FeatureFlag}: when a
+ * user override exists it takes precedence over the flag's global value when
+ * resolving whether the feature is enabled for that user.
+ *
+ * The parent flag's `key` is included for convenience so callers don't need to
+ * resolve `featureFlagId` back to a key themselves.
+ */
+export interface UserFeatureFlag {
+	id: string
+	/** Foreign key to the parent {@link FeatureFlag}. */
+	featureFlagId: string
+	/** The parent flag's hierarchical key (e.g. "mumble.enabled"). */
+	key: string
+	/** The user this override applies to. */
+	userId: string
+	/** Whether the feature is enabled for this user. */
+	enabled: boolean
+	createdAt: Date
+	updatedAt: Date
+}
+
+/**
+ * Options for listing a user's feature flag overrides.
+ */
+export interface ListUserFlagsOptions {
+	/** Only include overrides whose flag key starts with this prefix. */
+	prefix?: string
+	/** Only include overrides with this enabled state. */
+	enabled?: boolean
+}
+
+/**
+ * Options for listing the users who have an override for a given flag.
+ */
+export interface ListFlagUsersOptions {
+	/** Only include overrides with this enabled state. */
+	enabled?: boolean
+}
+
+/**
  * Public RPC interface for Features worker
  *
  * All public methods defined here will be available to call via RPC
@@ -126,4 +168,84 @@ export interface Features extends DurableObject {
 	 * @returns The feature flag or null if not found
 	 */
 	getFlag(key: string): Promise<FeatureFlag | null>
+
+	/**
+	 * Set (create or update) a per-user override for a feature flag.
+	 *
+	 * Idempotent: repeated calls for the same `userId`/`key` update the existing
+	 * override rather than creating duplicates.
+	 *
+	 * @param userId - The user the override applies to
+	 * @param key - The feature flag key to override
+	 * @param enabled - Whether the feature is enabled for this user
+	 * @returns The created or updated user feature flag override
+	 * @throws Error if no feature flag exists for `key`
+	 */
+	setUserFlag(userId: string, key: string, enabled: boolean): Promise<UserFeatureFlag>
+
+	/**
+	 * Get a user's override for a feature flag.
+	 *
+	 * @param userId - The user whose override to retrieve
+	 * @param key - The feature flag key
+	 * @returns The user's override, or null if the flag or override does not exist
+	 */
+	getUserFlag(userId: string, key: string): Promise<UserFeatureFlag | null>
+
+	/**
+	 * Delete a user's override for a feature flag, reverting the user to the
+	 * flag's global default.
+	 *
+	 * @param userId - The user whose override to delete
+	 * @param key - The feature flag key
+	 * @returns True if an override was deleted, false if none existed
+	 */
+	deleteUserFlag(userId: string, key: string): Promise<boolean>
+
+	/**
+	 * Resolve whether a feature is enabled for a specific user.
+	 *
+	 * Resolution precedence:
+	 *  1. The user's override, if one exists.
+	 *  2. Otherwise the flag's global boolean value.
+	 *  3. Otherwise (unknown flag or no value) `false`.
+	 *
+	 * Always resolves to a boolean so callers can gate features directly.
+	 *
+	 * @param userId - The user to resolve the flag for
+	 * @param key - The feature flag key
+	 * @returns The effective enabled state for the user
+	 */
+	checkUserFlag(userId: string, key: string): Promise<boolean>
+
+	/**
+	 * Resolve multiple feature flags for a user in a single call.
+	 *
+	 * Applies the same precedence as {@link checkUserFlag} to each key. Every
+	 * requested key is present in the result; unknown flags resolve to `false`.
+	 *
+	 * @param userId - The user to resolve the flags for
+	 * @param keys - The feature flag keys to resolve
+	 * @returns A map of flag key to effective enabled state
+	 */
+	checkUserFlags(userId: string, keys: string[]): Promise<Record<string, boolean>>
+
+	/**
+	 * List a user's feature flag overrides, ordered by flag key.
+	 *
+	 * @param userId - The user whose overrides to list
+	 * @param options - Optional key-prefix and/or enabled-state filters
+	 * @returns The user's overrides
+	 */
+	listUserFlags(userId: string, options?: ListUserFlagsOptions): Promise<UserFeatureFlag[]>
+
+	/**
+	 * List the users who have an override for a given feature flag, ordered by
+	 * user id.
+	 *
+	 * @param key - The feature flag key
+	 * @param options - Optional enabled-state filter
+	 * @returns The overrides for the flag (empty if the flag does not exist)
+	 */
+	listFlagUsers(key: string, options?: ListFlagUsersOptions): Promise<UserFeatureFlag[]>
 }


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #451

## Chain of upstream PRs as of 2026-07-07

* PR #451:
  `main` ← `feature-user-flags`

  * **PR #453 (THIS ONE)**:
    `feature-user-flags` ← `feature-user-flags-rpc`

<!-- end git-machete generated -->

<!-- claude:begin -->
## Summary

Adds per-user feature flag overrides to the `features` worker. A per-user override layers on top of a global feature flag and takes precedence when resolving whether a feature is enabled for a specific user.

## Changes

- Add `UserFeatureFlagService` with methods to set (upsert), get, delete, check, batch-check, and list per-user overrides, plus list the users who override a given flag.
- Expose these as RPC methods on `FeaturesDO` and add them to the public `Features` interface in `@repo/features`, along with new `UserFeatureFlag`, `ListUserFlagsOptions`, and `ListFlagUsersOptions` types.
- Add pure, DB-free resolution helpers (`resolveFlagValue` / `resolveFlagValues`) implementing the precedence `user override → global value → false`, using nullish coalescing so an override of `false` correctly wins over a global `true`.
- Add `escapeLikePrefix` / `likePrefixPattern` helpers that escape SQL `LIKE` metacharacters (`%`, `_`, `\`) so list prefix filters match literally instead of treating `_`/`%` as wildcards.

## Testing

- Unit tests for the `prefix` (metacharacter escaping) and `resolution` (single and batch precedence) helpers.
- Integration tests covering set/upsert, get, delete, single and batch resolution, prefix and enabled-state list filters, ascending ordering, unknown-flag handling, and literal prefix matching.
<!-- claude:end -->