### PR TITLE
feat(prediction-markets): announce each bet anonymously in the market forum thread

### DIFF
--- a/apps/core/src/__tests__/market-embed.test.ts
+++ b/apps/core/src/__tests__/market-embed.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildMarketEmbed, formatMarketPoints, truncateForEmbed } from '../lib/market-embed'
+import {
+	buildBetAnnouncement,
+	buildMarketEmbed,
+	formatMarketPoints,
+	truncateForEmbed,
+} from '../lib/market-embed'
 
 import type { MarketDetail } from '@repo/prediction-markets'
 
@@ -80,6 +85,24 @@ describe('formatMarketPoints', () => {
 		expect(formatMarketPoints('0')).toBe('0 points')
 		expect(formatMarketPoints('1000')).toBe('1,000 points')
 		expect(formatMarketPoints('000123')).toBe('123 points')
+	})
+})
+
+describe('buildBetAnnouncement', () => {
+	it('reports the amount and outcome and no bettor identity', () => {
+		const msg = buildBetAnnouncement('1000', 'Yes')
+		expect(msg).toBe('🎲 A bet of **1,000 points** was placed on **Yes**.')
+	})
+
+	it('groups the amount using formatMarketPoints', () => {
+		expect(buildBetAnnouncement('1234567', 'No')).toContain('1,234,567 points')
+	})
+
+	it('truncates an over-long outcome label so the message stays within limits', () => {
+		const long = 'x'.repeat(300)
+		const msg = buildBetAnnouncement('5', long)
+		expect(msg).toContain('…')
+		expect(msg).not.toContain('x'.repeat(300))
 	})
 })
 

--- a/apps/core/src/lib/market-embed.ts
+++ b/apps/core/src/lib/market-embed.ts
@@ -1,6 +1,7 @@
 /**
- * Builds the Discord embed shown in a prediction market's forum post.
- * Pure (no I/O) so it is unit-testable and reusable across create/update flows.
+ * Rendering helpers for a prediction market's Discord forum post — the outcome/pool embed and
+ * the plain-text "bet placed" announcement. Pure (no I/O) so they are unit-testable and reusable
+ * across create/update/bet flows.
  */
 
 import type { DiscordEmbed } from '@repo/discord'
@@ -27,6 +28,19 @@ export function formatMarketPoints(value: string): string {
 /** Truncate to `max` chars with an ellipsis (Discord field/title/name limits). */
 export function truncateForEmbed(value: string, max: number): string {
 	return value.length <= max ? value : `${value.slice(0, max - 1)}…`
+}
+
+/**
+ * The public message posted to a market's forum thread when a bet lands. Deliberately
+ * anonymous — it carries the amount and chosen outcome ONLY, never any bettor identity.
+ * The outcome label is truncated so a long label can't blow past Discord's 2000-char message
+ * limit; mention suppression is handled by the caller (allowed_mentions).
+ */
+export function buildBetAnnouncement(amount: string, outcomeLabel: string): string {
+	return `🎲 A bet of **${formatMarketPoints(amount)}** was placed on **${truncateForEmbed(
+		outcomeLabel,
+		256
+	)}**.`
 }
 
 /**

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -27,7 +27,11 @@ import {
 } from '../lib/market-custom-id'
 import { formatMarketPoints } from '../lib/market-embed'
 import { hasMarketPermission } from '../lib/market-permissions'
-import { applyMarketPostStatus, updateMarketPostFromDetail } from './discord-market-post.service'
+import {
+	announceBetPlaced,
+	applyMarketPostStatus,
+	updateMarketPostFromDetail,
+} from './discord-market-post.service'
 
 import type { createDb } from '../db'
 import type { Env } from '../context'
@@ -309,7 +313,14 @@ async function handleBetModal(
 			const market = await prediction.getMarket(target.marketId)
 			if (market) {
 				outcomeLabel = market.outcomes.find((o) => o.id === target.outcomeId)?.label ?? ''
-				await updateMarketPostFromDetail(getStub<Discord>(env.DISCORD, 'default'), market)
+				const discord = getStub<Discord>(env.DISCORD, 'default')
+				await updateMarketPostFromDetail(discord, market)
+				// Announce the bet publicly in the market's forum thread — amount + outcome only,
+				// never the bettor's identity. Best-effort (sibling to the embed refresh above).
+				// Skip on a deduped (duplicate-delivery) bet so a retried interaction can't post twice.
+				if (!bet.deduped) {
+					await announceBetPlaced(discord, env.PM_FORUM_GUILD_ID ?? '', market, bet.amount, outcomeLabel)
+				}
 			}
 		} catch (err) {
 			logger.warn('[DiscordComponents] post refresh after bet failed', {

--- a/apps/core/src/services/discord-market-post.service.ts
+++ b/apps/core/src/services/discord-market-post.service.ts
@@ -10,10 +10,10 @@ import { eq } from '@repo/db-utils'
 
 import { pmForumConfig } from '../db/schema'
 import { buildMarketComponents } from '../lib/market-components'
-import { buildMarketEmbed, truncateForEmbed } from '../lib/market-embed'
+import { buildBetAnnouncement, buildMarketEmbed, truncateForEmbed } from '../lib/market-embed'
 
 import type { createDb } from '../db'
-import type { Discord } from '@repo/discord'
+import type { Discord, SendMessageResult } from '@repo/discord'
 import type { MarketDetail, PredictionMarkets } from '@repo/prediction-markets'
 
 type CoreDb = ReturnType<typeof createDb>
@@ -164,6 +164,29 @@ export async function updateMarketPostFromDetail(
 	return discord.updateMarketPostMessage(market.discordThreadId, market.discordMessageId, {
 		embeds: [buildMarketEmbed(market)],
 		components: buildMarketComponents(market),
+	})
+}
+
+/**
+ * Post an anonymized "bet placed" announcement into a market's forum thread — the amount and
+ * chosen outcome only, never who placed it. Sent as a regular thread message (a thread is a
+ * channel), reusing sendMessage's rate-limit retry; mentions are suppressed so a user-authored
+ * outcome label can't ping anyone. Best-effort: no-op if the market has no post yet, and the
+ * returned {success,error} is for logging only — a failed announcement must never fail the bet.
+ * `guildId` is used only for the DO's log context (sendMessage POSTs by channel/thread id).
+ */
+export async function announceBetPlaced(
+	discord: Discord,
+	guildId: string,
+	market: MarketDetail,
+	amount: string,
+	outcomeLabel: string
+): Promise<SendMessageResult> {
+	if (!market.discordThreadId) return { success: false, error: 'no post' }
+	if (!outcomeLabel) return { success: false, error: 'no outcome' }
+	return discord.sendMessage(guildId, market.discordThreadId, {
+		content: buildBetAnnouncement(amount, outcomeLabel),
+		allowEveryone: false,
 	})
 }
 

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -593,7 +593,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		return { allowed, retryAfterMs }
 	}
 
-	async placeBet(input: PlaceBetInput): Promise<BetResult> {
+	async placeBet(input: PlaceBetInput): Promise<BetResult & { deduped: boolean }> {
 		// The try spans the WHOLE method — the dedupe SELECT and the rate-limit upsert run before
 		// the txn and can also fail (e.g. a missing table/migration or a Neon outage). They used to
 		// throw outside any catch, so those infra errors were never logged or paged and surfaced to
@@ -610,7 +610,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				.from(pmBets)
 				.where(eq(pmBets.idempotencyKey, input.idempotencyKey))
 				.limit(1)
-			if (priorBet) return this.toBetResult(priorBet)
+			if (priorBet) return { ...this.toBetResult(priorBet), deduped: true }
 
 			// Rate limit (committed atomic upsert, before the bet txn): a rejected bet still consumes
 			// budget (anti-spam); idempotent retries never reach here (handled above).
@@ -682,7 +682,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						.from(pmBets)
 						.where(eq(pmBets.idempotencyKey, input.idempotencyKey))
 						.limit(1)
-					return this.toBetResult(existing)
+					return { ...this.toBetResult(existing), deduped: true }
 				}
 				const bet = inserted[0]
 
@@ -731,7 +731,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					metadata: { outcomeId: input.outcomeId, amount: input.amount },
 				})
 
-				return this.toBetResult(bet)
+				return { ...this.toBetResult(bet), deduped: false }
 			})
 		} catch (error) {
 			// Business rejections (insufficient funds, market closed, rate-limited, invalid amount)

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -256,7 +256,12 @@ export interface PredictionMarkets {
 	// writes
 	grantPoints(input: GrantPointsInput): Promise<{ balance: string; deduped: boolean }>
 	createMarket(input: CreateMarketInput): Promise<MarketDetail>
-	placeBet(input: PlaceBetInput): Promise<BetResult>
+	/**
+	 * Place a bet. `deduped` is true when this was a duplicate delivery of an already-recorded
+	 * bet (same idempotency key) — the prior bet is returned and no money moved. Callers must
+	 * gate any non-idempotent side effect (e.g. a public "bet placed" post) on `deduped === false`.
+	 */
+	placeBet(input: PlaceBetInput): Promise<BetResult & { deduped: boolean }>
 	closeMarket(input: { actorUserId: string; marketId: string }): Promise<void>
 	closeDueMarkets(): Promise<{ closed: number }>
 	proposeResolution(input: {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Posts an anonymized "bet placed" announcement into a prediction market's Discord forum thread whenever a bet is submitted via the bet button/modal. The message carries the amount and chosen outcome only — never the bettor's identity.

## Changes

- Added `buildBetAnnouncement(amount, outcomeLabel)` to `market-embed.ts` — a pure, unit-tested helper that formats the amount via `formatMarketPoints` and truncates the outcome label to stay within Discord's message limit.
- Added `announceBetPlaced()` to `discord-market-post.service.ts` — sends the announcement as a thread message via `sendMessage` (reusing its rate-limit retry) with mentions suppressed (`allowEveryone: false`); no-ops when the market has no post or no outcome label.
- Wired the announcement into `handleBetModal` after the embed refresh as a best-effort call that never fails the bet.
- `placeBet` now returns `BetResult & { deduped: boolean }` (mirroring `grantPoints`); the announcement is only sent when `deduped === false`, so a re-delivered interaction can't double-post.
- Updated the `PredictionMarkets` interface with the new return type and documented the `deduped` contract.

## Testing

- Added `buildBetAnnouncement` unit tests covering amount/outcome formatting, no bettor identity, thousands grouping, and long-label truncation.
- Per the commit: typecheck passes (core + PM app + package); 9 core and 18 PM unit tests pass.
<!-- claude:end -->