### PR TITLE
pm market onboard

### DIFF
--- a/apps/core/src/services/discord-programmatic-commands/__tests__/market.test.ts
+++ b/apps/core/src/services/discord-programmatic-commands/__tests__/market.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MARKET_PROGRAMMATIC_COMMAND } from '../market'
+
+import type { ProgrammaticCommandContext, ProgrammaticCommandEnv } from '../types'
+
+const hoisted = vi.hoisted(() => ({
+	onboardUser: vi.fn(),
+	getWalletBalance: vi.fn(),
+	getUserBetsDetailed: vi.fn(),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn(() => ({
+		onboardUser: hoisted.onboardUser,
+		getWalletBalance: hoisted.getWalletBalance,
+		getUserBetsDetailed: hoisted.getUserBetsDetailed,
+	})),
+}))
+
+const EPHEMERAL_FLAG = 1 << 6
+
+function ctx(sub: string, coreUserId = 'u1'): ProgrammaticCommandContext {
+	return {
+		optionValues: {},
+		coreUserId,
+		isAdmin: false,
+		env: { PREDICTION_MARKETS: {} } as unknown as ProgrammaticCommandEnv,
+		input: { commandName: 'market', discordUserId: 'd1', options: [{ name: sub }] },
+		interactionId: 'i1',
+	}
+}
+
+describe('MARKET_PROGRAMMATIC_COMMAND', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('exposes the onboard subcommand and defers ephemerally', () => {
+		expect(MARKET_PROGRAMMATIC_COMMAND.deferral).toBe('defer-ephemeral')
+		const names = MARKET_PROGRAMMATIC_COMMAND.options?.map((o) => o.name)
+		expect(names).toContain('onboard')
+	})
+
+	describe('onboard', () => {
+		it('welcomes a fresh member with the deposited amount and new balance', async () => {
+			hoisted.onboardUser.mockResolvedValue({
+				balance: '5',
+				granted: '5',
+				alreadyOnboarded: false,
+			})
+			const res = await MARKET_PROGRAMMATIC_COMMAND.handler(ctx('onboard'))
+			expect(hoisted.onboardUser).toHaveBeenCalledWith('u1')
+			expect(res.data?.content).toContain('Welcome')
+			expect(res.data?.content).toContain('5 points')
+			// Self-only content must be ephemeral even on a sync fallback.
+			expect(res.data?.flags).toBe(EPHEMERAL_FLAG)
+		})
+
+		it('tells an already-onboarded member their balance without re-granting', async () => {
+			hoisted.onboardUser.mockResolvedValue({
+				balance: '3',
+				granted: '0',
+				alreadyOnboarded: true,
+			})
+			const res = await MARKET_PROGRAMMATIC_COMMAND.handler(ctx('onboard'))
+			expect(res.data?.content).toContain('already set up')
+			expect(res.data?.content).toContain('3 points')
+			expect(res.data?.content).not.toContain('Welcome')
+		})
+	})
+
+	it('reports balance for the balance subcommand', async () => {
+		hoisted.getWalletBalance.mockResolvedValue({ balance: '42' })
+		const res = await MARKET_PROGRAMMATIC_COMMAND.handler(ctx('balance'))
+		expect(res.data?.content).toContain('42 points')
+		expect(hoisted.onboardUser).not.toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/services/discord-programmatic-commands/market.ts
+++ b/apps/core/src/services/discord-programmatic-commands/market.ts
@@ -14,18 +14,24 @@ function formatBetLine(b: DetailedBetView): string {
 }
 
 /**
- * `/market` member commands: check your own balance and active bets. Both are ephemeral and
- * self-only (no other-user data), so no permission gate or name resolution is needed. The
- * betting/resolving surface lives on the forum posts (P2/P3), not on slash commands.
+ * `/market` member commands: onboard (claim a starting wallet), check your own balance and active
+ * bets. All are ephemeral and self-only (no other-user data), so no permission gate or name
+ * resolution is needed. The betting/resolving surface lives on the forum posts (P2/P3), not on
+ * slash commands.
  *
  * The fired subcommand is read from `input.options[0].name` — Discord nests subcommand options,
  * and the M-Enable option flattener does not surface the subcommand name in `optionValues`.
  */
 export const MARKET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 	name: 'market',
-	description: 'Prediction markets: check your balance and bets.',
+	description: 'Prediction markets: get started, check your balance and bets.',
 	deferral: 'defer-ephemeral',
 	options: [
+		{
+			type: DISCORD_SLASH_COMMAND_OPTION_TYPE.SUB_COMMAND,
+			name: 'onboard',
+			description: 'Set up your wallet and claim your one-time starting points.',
+		},
 		{
 			type: DISCORD_SLASH_COMMAND_OPTION_TYPE.SUB_COMMAND,
 			name: 'balance',
@@ -41,6 +47,19 @@ export const MARKET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 		const sub = input.options?.[0]?.name
 		const prediction = getStub<PredictionMarkets>(env.PREDICTION_MARKETS, 'default')
 
+		if (sub === 'onboard') {
+			const { balance, granted, alreadyOnboarded } = await prediction.onboardUser(coreUserId)
+			if (alreadyOnboarded) {
+				return ephemeralCommandResponse(
+					`You're already set up — your balance is **${formatMarketPoints(balance)}**.`
+				)
+			}
+			return ephemeralCommandResponse(
+				`Welcome! We've deposited **${formatMarketPoints(granted)}** to get you started. ` +
+					`Your balance is **${formatMarketPoints(balance)}**.`
+			)
+		}
+
 		if (sub === 'balance') {
 			const { balance } = await prediction.getWalletBalance(coreUserId)
 			return ephemeralCommandResponse(`Your balance: **${formatMarketPoints(balance)}**.`)
@@ -52,6 +71,8 @@ export const MARKET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 			return ephemeralCommandResponse(['**Your active bets:**', ...bets.map(formatBetLine)].join('\n'))
 		}
 
-		return ephemeralCommandResponse('Unknown subcommand. Try `/market balance` or `/market mybets`.')
+		return ephemeralCommandResponse(
+			'Unknown subcommand. Try `/market onboard`, `/market balance`, or `/market mybets`.'
+		)
 	},
 }

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -63,6 +63,16 @@ interface HistoryEntry {
 	metadata?: unknown
 }
 
+/** One-time starting grant deposited on a member's first `/market onboard`. */
+const ONBOARDING_GRANT = '5'
+/** Ledger reason recorded for the onboarding grant. */
+const ONBOARDING_REASON = 'Initial onboarding'
+/**
+ * Actor recorded for system-issued grants (e.g. onboarding). A sentinel string that is never a
+ * real user id, so grantPoints' self-target guard is not tripped when a member onboards themselves.
+ */
+const SYSTEM_ACTOR = 'system'
+
 /** placeBet throws these on normal user-facing rejections — not paged to Sentry. */
 const EXPECTED_BET_ERRORS = new Set([
 	'MARKET_NOT_FOUND',
@@ -408,6 +418,22 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		}
 		try {
 			return await this.db.transaction(async (tx) => {
+				// Ensure the wallet row exists, then lock it FOR UPDATE. Locking BEFORE the idempotency
+				// pre-check serializes concurrent grants to the same user, so a losing race sees the
+				// winner's committed ledger row here and dedupes gracefully — rather than racing past
+				// the pre-check into a ledger unique-violation (money was always safe, but the raw
+				// 23505 pages Sentry and surfaces a spurious failure to an already-granted user).
+				await tx
+					.insert(pmWallets)
+					.values({ userId: input.targetUserId, balance: '0' })
+					.onConflictDoNothing()
+				const [locked] = await tx
+					.select({ balance: pmWallets.balance })
+					.from(pmWallets)
+					.where(eq(pmWallets.userId, input.targetUserId))
+					.for('update')
+					.limit(1)
+
 				// Idempotent grant: a repeated key must match the original (user, amount, type),
 				// otherwise a reused/forged key would silently drop a real deposit.
 				if (input.idempotencyKey) {
@@ -424,19 +450,9 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						if (!same) {
 							throw new Error('IDEMPOTENCY_KEY_CONFLICT')
 						}
-						const [wallet] = await tx
-							.select({ balance: pmWallets.balance })
-							.from(pmWallets)
-							.where(eq(pmWallets.userId, input.targetUserId))
-							.limit(1)
-						return { balance: wallet?.balance ?? '0', deduped: true }
+						return { balance: locked?.balance ?? '0', deduped: true }
 					}
 				}
-
-				await tx
-					.insert(pmWallets)
-					.values({ userId: input.targetUserId, balance: '0' })
-					.onConflictDoNothing()
 
 				const [credited] = await tx
 					.update(pmWallets)
@@ -464,6 +480,25 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			})
 			throw error
 		}
+	}
+
+	/**
+	 * Onboard a member: ensure their wallet exists and deposit the one-time ONBOARDING_GRANT.
+	 * Built on grantPoints as a system-actor grant keyed on `onboard:{userId}`, so it inherits
+	 * wallet creation, the atomic credit, and idempotency — and is once-per-user: a repeat call
+	 * (`deduped`) grants nothing and reports `alreadyOnboarded: true`.
+	 */
+	async onboardUser(
+		userId: string
+	): Promise<{ balance: string; granted: string; alreadyOnboarded: boolean }> {
+		const { balance, deduped } = await this.grantPoints({
+			actorUserId: SYSTEM_ACTOR,
+			targetUserId: userId,
+			amount: ONBOARDING_GRANT,
+			reason: ONBOARDING_REASON,
+			idempotencyKey: `onboard:${userId}`,
+		})
+		return { balance, granted: deduped ? '0' : ONBOARDING_GRANT, alreadyOnboarded: deduped }
 	}
 
 	async createMarket(input: CreateMarketInput): Promise<MarketDetail> {

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -255,6 +255,15 @@ export interface PredictionMarkets {
 
 	// writes
 	grantPoints(input: GrantPointsInput): Promise<{ balance: string; deduped: boolean }>
+	/**
+	 * Onboard a member: create their wallet if it does not exist and deposit a one-time starting
+	 * grant. Idempotent per user (keyed on `onboard:{userId}`) — a repeat call grants nothing and
+	 * returns `alreadyOnboarded: true`. `granted` is the amount credited on this call ('0' when
+	 * already onboarded); `balance` is the resulting wallet balance.
+	 */
+	onboardUser(
+		userId: string
+	): Promise<{ balance: string; granted: string; alreadyOnboarded: boolean }>
 	createMarket(input: CreateMarketInput): Promise<MarketDetail>
 	/**
 	 * Place a bet. `deduped` is true when this was a duplicate delivery of an already-recorded


### PR DESCRIPTION
- **feat(prediction-markets): announce each bet anonymously in the market forum thread**
- **feat(prediction-markets): /market onboard — create wallet + one-time 5-point grant**

<!-- claude:begin -->
## Summary

Adds a `/market onboard` subcommand that gives a member a prediction-markets wallet plus a one-time 5-point starting grant. Also hardens the underlying `grantPoints` path so concurrent grants to the same user serialize instead of hitting a spurious ledger error.

## Changes

- **`onboardUser`**: new `PredictionMarkets.onboardUser(userId)` (exposed on the DO and the package interface), built on `grantPoints` as a system-actor grant keyed on `onboard:{userId}` — inherits wallet creation, the atomic credit, and idempotency. A repeat call grants nothing and returns `alreadyOnboarded: true` with `granted: 0`.
- **`/market onboard`**: new ephemeral subcommand with distinct welcome vs. already-onboarded responses; updated command description and unknown-subcommand hint.
- **`grantPoints` hardening**: ensures the wallet row exists and locks it `FOR UPDATE` *before* the idempotency pre-check, so a losing concurrent same-user grant dedupes gracefully rather than racing into a ledger unique-violation (harmless for money, but it paged Sentry and surfaced a spurious failure). Money semantics unchanged.

## Testing

- New `MARKET_PROGRAMMATIC_COMMAND` handler tests covering onboard (fresh vs. already-onboarded, ephemeral flag) and the balance subcommand.
- Per commit notes: typecheck green across core, PM app, and package; PM + command-handler unit tests pass.

**Post-deploy op:** re-sync `/market` to the guild so Discord surfaces the new `onboard` subcommand.
<!-- claude:end -->
