### PR TITLE
fix(prediction-markets): block a market creator from betting on their own market

### DIFF
--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -71,6 +71,7 @@ const ERROR_MESSAGES: Record<string, string> = {
 	MARKET_NOT_FOUND: 'That market no longer exists.',
 	MARKET_NOT_OPEN: 'This market is not open for betting.',
 	MARKET_CLOSED: 'Betting has closed on this market.',
+	CREATOR_CANNOT_BET: 'You created this market, so you can’t bet on it.',
 	OUTCOME_NOT_FOUND: 'That outcome is no longer available.',
 	STAKE_BELOW_MIN: 'Your stake is below the minimum for this market.',
 	STAKE_ABOVE_MAX: 'Your stake is above the maximum for this market.',

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -78,6 +78,7 @@ const EXPECTED_BET_ERRORS = new Set([
 	'MARKET_NOT_FOUND',
 	'MARKET_NOT_OPEN',
 	'MARKET_CLOSED',
+	'CREATOR_CANNOT_BET',
 	'OUTCOME_NOT_FOUND',
 	'STAKE_BELOW_MIN',
 	'STAKE_ABOVE_MAX',
@@ -662,6 +663,9 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				if (!market) throw new Error('MARKET_NOT_FOUND')
 				if (market.status !== 'open') throw new Error('MARKET_NOT_OPEN')
 				if (market.closesAt.getTime() <= Date.now()) throw new Error('MARKET_CLOSED')
+				// Governance: a creator can't take a position on their own market (mirrors the
+				// creator-can't-resolve / resolver-holds-no-position guards elsewhere).
+				if (market.createdBy === input.userId) throw new Error('CREATOR_CANNOT_BET')
 
 				const [outcome] = await tx
 					.select({ id: pmMarketOutcomes.id })


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

`placeBet` validated market state, stakes, caps, and funds but never checked who created the market, so a market's creator could bet on their own market. This adds a `CREATOR_CANNOT_BET` guard that blocks that.

## Changes

- Add a `CREATOR_CANNOT_BET` check inside the locked bet transaction in `placeBet`, rejecting bets where `market.createdBy === input.userId` (mirrors the existing creator-can't-resolve / resolver-holds-no-position governance guards).
- Add `CREATOR_CANNOT_BET` to `EXPECTED_BET_ERRORS` so the rejection is treated as an expected user error and not paged to Sentry.
- Add a friendly ephemeral Discord message for `CREATOR_CANNOT_BET` in `discord-components.service.ts`.

## Testing

- Typecheck passes for the prediction-markets and core apps.
- 18 prediction-markets unit tests pass.
<!-- claude:end -->