### PR TITLE
feat(prediction-markets): M2.5 forum-post reconciliation cron

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -4,7 +4,7 @@ import { useWorkersLogger } from 'workers-tagged-logger'
 
 import { and, eq, inArray, ne } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import { logger, withNotFound, withOnError, withSentry } from '@repo/hono-helpers'
+import { captureException, logger, withNotFound, withOnError, withSentry } from '@repo/hono-helpers'
 
 import { createDb } from './db'
 import { waitUntilWithTelemetry } from './lib/background-task'
@@ -75,6 +75,7 @@ import {
 	type ExecuteComponentInput,
 	type ExecuteModalSubmitInput,
 } from './services/discord-components.service'
+import { reconcileMarketPosts } from './services/discord-market-reconcile.service'
 import { DkpService } from './services/dkp.service'
 
 import type {
@@ -183,7 +184,7 @@ const sentryApp = withSentry(app)
 
 export default {
 	fetch: sentryApp.fetch.bind(sentryApp),
-	async scheduled(event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
+	async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
 		const coreStub = getStub<Core>(env.CORE, 'default')
 		if (event.cron === '3-58/5 * * * *') {
 			const result = await coreStub.processPendingDiscordRefreshes()
@@ -195,6 +196,19 @@ export default {
 			if (tempopResult.expired > 0) {
 				console.log('[Core:Scheduled] Expired Mumble temp-ops', tempopResult)
 			}
+
+			// Prediction-markets forum-post drift sweep: auto-close due markets + refresh/backfill
+			// posts. Best-effort and out-of-band so a slow Discord run never delays the cron; a real
+			// failure is paged, not swallowed.
+			ctx.waitUntil(
+				reconcileMarketPosts(createDb(env.DATABASE_URL), env)
+					.then((r) => {
+						if (r.closed > 0 || r.refreshed > 0 || r.posted > 0 || r.failed > 0) {
+							console.log('[Core:Scheduled] Prediction-market reconcile', r)
+						}
+					})
+					.catch((error) => captureException(error as Error, { tags: { job: 'pm-reconcile' } }))
+			)
 		}
 
 		if (event.cron === TOKEN_INVALID_ALERT_DRAIN_CRON) {

--- a/apps/core/src/services/__tests__/discord-market-reconcile.test.ts
+++ b/apps/core/src/services/__tests__/discord-market-reconcile.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { reconcileMarketPosts } from '../discord-market-reconcile.service'
+
+import type { ReconcileEnv } from '../discord-market-reconcile.service'
+import type { MarketDetail } from '@repo/prediction-markets'
+
+const hoisted = vi.hoisted(() => ({
+	predictionBinding: {} as DurableObjectNamespace,
+	discordBinding: {} as DurableObjectNamespace,
+	prediction: {
+		closeDueMarkets: vi.fn(),
+		listMarketsToRefresh: vi.fn(),
+		getMarket: vi.fn(),
+		listMarketsNeedingPost: vi.fn(),
+	},
+	post: {
+		updateMarketPostFromDetail: vi.fn(),
+		applyMarketPostStatus: vi.fn(),
+		publishMarketPost: vi.fn(),
+	},
+}))
+
+// getStub returns the PM stub for the PREDICTION_MARKETS binding; the Discord stub is an opaque
+// object the (mocked) post-service functions ignore.
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn((binding: DurableObjectNamespace) =>
+		binding === hoisted.predictionBinding ? hoisted.prediction : {}
+	),
+}))
+
+vi.mock('../discord-market-post.service', () => ({
+	updateMarketPostFromDetail: hoisted.post.updateMarketPostFromDetail,
+	applyMarketPostStatus: hoisted.post.applyMarketPostStatus,
+	publishMarketPost: hoisted.post.publishMarketPost,
+}))
+
+const db = {} as unknown as Parameters<typeof reconcileMarketPosts>[0]
+
+function makeEnv(overrides?: Partial<ReconcileEnv>): ReconcileEnv {
+	return {
+		PREDICTION_MARKETS: hoisted.predictionBinding,
+		DISCORD: hoisted.discordBinding,
+		PM_FORUM_GUILD_ID: 'g1',
+		PM_FORUM_CATEGORY_ID: 'c1',
+		...overrides,
+	} as ReconcileEnv
+}
+
+function market(id: string, status: MarketDetail['status'] = 'closed'): MarketDetail {
+	return {
+		id,
+		question: 'Q',
+		status,
+		closesAt: '2020-01-01T00:00:00.000Z',
+		totalPool: '0',
+		outcomeCount: 2,
+		createdAt: '2020-01-01T00:00:00.000Z',
+		discordThreadId: 't',
+		discordMessageId: 'm',
+		description: null,
+		createdBy: 'u',
+		rakeBps: 0,
+		minStake: '1',
+		maxStake: null,
+		perUserCap: null,
+		twoOfN: false,
+		resolvedOutcomeId: null,
+		resolvedBy: null,
+		resolvedAt: null,
+		voidReason: null,
+		outcomes: [],
+	}
+}
+
+describe('reconcileMarketPosts', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		hoisted.prediction.closeDueMarkets.mockResolvedValue({ closedMarketIds: [] })
+		hoisted.prediction.listMarketsToRefresh.mockResolvedValue([])
+		hoisted.prediction.getMarket.mockImplementation((id: string) => Promise.resolve(market(id)))
+		hoisted.prediction.listMarketsNeedingPost.mockResolvedValue([])
+		hoisted.post.updateMarketPostFromDetail.mockResolvedValue({ success: true })
+		hoisted.post.applyMarketPostStatus.mockResolvedValue(undefined)
+		hoisted.post.publishMarketPost.mockResolvedValue({ threadId: 't', messageId: 'm' })
+	})
+
+	it('no-ops when the forum guild/category is not configured', async () => {
+		const res = await reconcileMarketPosts(db, makeEnv({ PM_FORUM_GUILD_ID: undefined }))
+		expect(res).toEqual({ closed: 0, refreshed: 0, posted: 0, failed: 0, skipped: true })
+		expect(hoisted.prediction.closeDueMarkets).not.toHaveBeenCalled()
+		expect(hoisted.prediction.listMarketsToRefresh).not.toHaveBeenCalled()
+		expect(hoisted.prediction.listMarketsNeedingPost).not.toHaveBeenCalled()
+	})
+
+	it('reports the count of auto-closed markets', async () => {
+		hoisted.prediction.closeDueMarkets.mockResolvedValue({ closedMarketIds: ['a', 'b', 'c'] })
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.closed).toBe(3)
+		// Auto-close is bounded to keep the run inside the cron budget.
+		expect(hoisted.prediction.closeDueMarkets).toHaveBeenCalledWith(expect.any(Number))
+	})
+
+	it('refreshes each drifted post (embed + tag/lock) from the self-healing refresh list', async () => {
+		hoisted.prediction.listMarketsToRefresh.mockResolvedValue(['a', 'b'])
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.refreshed).toBe(2)
+		expect(hoisted.post.updateMarketPostFromDetail).toHaveBeenCalledTimes(2)
+		expect(hoisted.post.applyMarketPostStatus).toHaveBeenCalledTimes(2)
+	})
+
+	it('re-reads state and skips a market that went terminal mid-sweep (no clobber)', async () => {
+		hoisted.prediction.listMarketsToRefresh.mockResolvedValue(['a'])
+		// Snapshot said "changed recently", but it resolved before we got to it — leave it alone.
+		hoisted.prediction.getMarket.mockResolvedValue(market('a', 'resolved'))
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.refreshed).toBe(0)
+		expect(res.failed).toBe(0)
+		expect(hoisted.post.updateMarketPostFromDetail).not.toHaveBeenCalled()
+	})
+
+	it('counts a soft refresh failure and skips the tag/lock step (retried next tick)', async () => {
+		hoisted.prediction.listMarketsToRefresh.mockResolvedValue(['a'])
+		hoisted.post.updateMarketPostFromDetail.mockResolvedValue({ success: false, error: 'no post' })
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.failed).toBe(1)
+		expect(res.refreshed).toBe(0)
+		expect(hoisted.post.applyMarketPostStatus).not.toHaveBeenCalled()
+	})
+
+	it('isolates a throwing refresh and still processes the rest', async () => {
+		hoisted.prediction.listMarketsToRefresh.mockResolvedValue(['a', 'b'])
+		hoisted.post.updateMarketPostFromDetail
+			.mockRejectedValueOnce(new Error('discord 500'))
+			.mockResolvedValueOnce({ success: true })
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.failed).toBe(1)
+		expect(res.refreshed).toBe(1)
+	})
+
+	it('backfills posts for non-terminal markets missing one', async () => {
+		hoisted.prediction.listMarketsNeedingPost.mockResolvedValue([market('x'), market('y')])
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.posted).toBe(2)
+		expect(hoisted.post.publishMarketPost).toHaveBeenCalledTimes(2)
+	})
+
+	it('isolates a failing backfill and still processes the rest', async () => {
+		hoisted.prediction.listMarketsNeedingPost.mockResolvedValue([market('x'), market('y')])
+		hoisted.post.publishMarketPost
+			.mockRejectedValueOnce(new Error('discord 500'))
+			.mockResolvedValueOnce({ threadId: 't', messageId: 'm' })
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.failed).toBe(1)
+		expect(res.posted).toBe(1)
+		expect(hoisted.post.publishMarketPost).toHaveBeenCalledTimes(2)
+	})
+})

--- a/apps/core/src/services/discord-market-post.service.ts
+++ b/apps/core/src/services/discord-market-post.service.ts
@@ -134,12 +134,15 @@ export async function publishMarketPost(
 	const cfg = await ensureForumChannel(db, discord, guildId, categoryId)
 	if (!cfg.forumChannelId) throw new ForumInitInProgressError()
 
+	// Tag by the market's actual status, not a hardcoded "Open": a reconcile backfill can publish a
+	// market that has already auto-closed, which must land under the Closed tag, not Open.
+	const tagId = statusTagId(cfg, market.status)
 	const post = await discord.createMarketForumPost(cfg.forumChannelId, {
 		// Forum thread name max is 100 chars; the full question lives in the embed title.
 		name: truncateForEmbed(market.question, 100),
 		embeds: [buildMarketEmbed(market)],
 		components: buildMarketComponents(market),
-		...(cfg.tagOpenId ? { appliedTagIds: [cfg.tagOpenId] } : {}),
+		...(tagId ? { appliedTagIds: [tagId] } : {}),
 	})
 	await prediction.attachDiscordPost({
 		marketId: market.id,

--- a/apps/core/src/services/discord-market-reconcile.service.ts
+++ b/apps/core/src/services/discord-market-reconcile.service.ts
@@ -1,0 +1,132 @@
+/**
+ * Prediction-markets forum-post reconciliation (the M2.5 sweep).
+ *
+ * The Discord side of a market is best-effort: a bet/resolve refresh, the initial post, and
+ * auto-close on `closesAt` can all fail silently, leaving the DB and the forum posts drifting.
+ * This periodic sweep (driven by Core's cron — Core is the only worker binding both the PM DO and
+ * the Discord DO; the PM DO must never call Discord) heals that drift in three bounded passes:
+ *
+ *   (a) auto-close markets past their close time (bounded; a backlog drains over ticks);
+ *   (b) refresh drifted posts — embed + status-appropriate buttons + tag/lock — driven by a
+ *       self-shrinking "recently changed, has a post" list, NOT by the one-shot close result, so a
+ *       refresh that fails (a just-closed market's tag flip, or a failed live bet/resolve refresh)
+ *       is retried on later ticks until it lands;
+ *   (c) backfill posts for non-terminal markets that never got one.
+ *
+ * Every pass is bounded and per-market isolated: one bad market never aborts the run.
+ */
+
+import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
+
+import {
+	applyMarketPostStatus,
+	publishMarketPost,
+	updateMarketPostFromDetail,
+} from './discord-market-post.service'
+
+import type { createDb } from '../db'
+import type { Env } from '../context'
+import type { Discord } from '@repo/discord'
+import type { PredictionMarkets } from '@repo/prediction-markets'
+
+type CoreDb = ReturnType<typeof createDb>
+
+/** Bindings + config the reconcile sweep needs. */
+export type ReconcileEnv = Pick<
+	Env,
+	'PREDICTION_MARKETS' | 'DISCORD' | 'PM_FORUM_GUILD_ID' | 'PM_FORUM_CATEGORY_ID'
+>
+
+export interface ReconcileResult {
+	/** Markets auto-closed this pass (past their close time). */
+	closed: number
+	/** Posts refreshed (embed + buttons + tag/lock) this pass. */
+	refreshed: number
+	/** Missing posts successfully backfilled this pass. */
+	posted: number
+	/** Per-market failures (refresh or backfill) that were isolated and skipped. */
+	failed: number
+	/** True when the sweep was skipped because the forum guild/category isn't configured. */
+	skipped: boolean
+}
+
+/** Per-pass caps — keep a run inside the cron's wall-clock budget; backlogs drain over ticks. */
+const CLOSE_LIMIT = 25
+const REFRESH_LIMIT = 25
+const BACKFILL_LIMIT = 25
+/** Only refresh posts touched within this window — bounds the heal pass to actually-drifted posts. */
+const REFRESH_SINCE_MINUTES = 15
+
+export async function reconcileMarketPosts(db: CoreDb, env: ReconcileEnv): Promise<ReconcileResult> {
+	const result: ReconcileResult = { closed: 0, refreshed: 0, posted: 0, failed: 0, skipped: false }
+
+	// Without a configured forum guild + category there is nowhere to post; do nothing.
+	if (!env.PM_FORUM_GUILD_ID || !env.PM_FORUM_CATEGORY_ID) {
+		result.skipped = true
+		return result
+	}
+	const guildId = env.PM_FORUM_GUILD_ID
+	const categoryId = env.PM_FORUM_CATEGORY_ID
+
+	const prediction = getStub<PredictionMarkets>(env.PREDICTION_MARKETS, 'default')
+	const discord = getStub<Discord>(env.DISCORD, 'default')
+
+	// (a) Auto-close due markets (bounded). Their posts are refreshed by pass (b): a just-closed
+	// market's `updatedAt` is fresh, so it lands in the refresh list below on this same tick.
+	const { closedMarketIds } = await prediction.closeDueMarkets(CLOSE_LIMIT)
+	result.closed = closedMarketIds.length
+
+	// (b) Refresh drifted posts (embed + status buttons + tag/lock). Driven by a self-shrinking
+	// "recently changed, has a post" list rather than the one-shot close result, so a refresh that
+	// failed on a prior tick is retried here until it lands — this is what makes the sweep heal.
+	const refreshIds = await prediction.listMarketsToRefresh(REFRESH_SINCE_MINUTES, REFRESH_LIMIT)
+	for (const marketId of refreshIds) {
+		try {
+			// Re-read current state just before editing: the market may have changed since the list
+			// was built. Terminal (resolved/voided) markets are owned by the live resolve/void path,
+			// which archives+locks the post — never let a stale heal edit clobber it back to an
+			// active state (and a terminal market leaves this list, so such a clobber wouldn't heal).
+			const market = await prediction.getMarket(marketId)
+			if (!market || market.status === 'resolved' || market.status === 'voided') continue
+			const edit = await updateMarketPostFromDetail(discord, market)
+			if (edit.success) {
+				await applyMarketPostStatus(db, discord, guildId, market)
+				result.refreshed++
+			} else {
+				// Soft failure (e.g. the Discord edit 4xx/5xx'd and was swallowed). Count it and leave
+				// the market in the refresh set (its updatedAt is unchanged) so a later tick retries.
+				result.failed++
+			}
+		} catch (error) {
+			result.failed++
+			logger.warn('[PMReconcile] failed to refresh market post', {
+				marketId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	// (c) Backfill posts for non-terminal markets that never got one (e.g. publishMarketPost failed
+	// at create time). Grace-filtered so it won't race a create-route publish still in flight.
+	const missing = await prediction.listMarketsNeedingPost(BACKFILL_LIMIT)
+	for (const market of missing) {
+		try {
+			await publishMarketPost(db, discord, prediction, guildId, categoryId, market)
+			result.posted++
+		} catch (error) {
+			result.failed++
+			// Known v1 hazard: publishMarketPost creates the thread THEN attaches it to the market. If
+			// the attach fails, the market keeps a null thread id and reappears here next tick — so a
+			// *persistently* failing attach re-posts every pass, not just once. Accepted for v1 (matches
+			// the create route); logged loudly so an operator can spot and clean up duplicates. A claim
+			// row (reserve the thread id before creating) is the durable fix, deferred to a follow-up.
+			logger.warn('[PMReconcile] failed to backfill market post', {
+				marketId: market.id,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	return result
+}

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from 'cloudflare:workers'
 
-import { and, asc, desc, eq, gte, inArray, lte, ne, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lte, ne, sql } from '@repo/db-utils'
 import { captureException, logger } from '@repo/hono-helpers'
 import { parseDateOrNull } from '@repo/worker-utils'
 
@@ -833,12 +833,33 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 	}
 
 	/** Cron sweep: close all open markets whose close time has passed. */
-	async closeDueMarkets(): Promise<{ closed: number }> {
+	async closeDueMarkets(limit = 25): Promise<{ closedMarketIds: string[] }> {
+		const bounded = Math.min(Math.max(limit, 1), 100)
 		try {
+			// Bound the batch so a backlog of due markets can't blow the reconcile cron's wall-clock
+			// budget; a large backlog drains over successive ticks.
+			const due = await this.db
+				.select({ id: pmMarkets.id })
+				.from(pmMarkets)
+				.where(and(eq(pmMarkets.status, 'open'), sql`${pmMarkets.closesAt} <= now()`))
+				.orderBy(asc(pmMarkets.closesAt))
+				.limit(bounded)
+			if (due.length === 0) return { closedMarketIds: [] }
+
+			// Re-guard status='open' in the UPDATE so a market that transitioned between the select
+			// and the update isn't clobbered; RETURNING yields the ids actually closed.
 			const closed = await this.db
 				.update(pmMarkets)
 				.set({ status: 'closed', updatedAt: new Date() })
-				.where(and(eq(pmMarkets.status, 'open'), sql`${pmMarkets.closesAt} <= now()`))
+				.where(
+					and(
+						inArray(
+							pmMarkets.id,
+							due.map((d) => d.id)
+						),
+						eq(pmMarkets.status, 'open')
+					)
+				)
 				.returning({ id: pmMarkets.id })
 
 			for (const market of closed) {
@@ -850,13 +871,76 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					metadata: { auto: true },
 				})
 			}
-			return { closed: closed.length }
+			return { closedMarketIds: closed.map((m) => m.id) }
 		} catch (error) {
 			captureException(error as Error, {
 				tags: { durableObject: 'PredictionMarketsDO', method: 'closeDueMarkets' },
 			})
 			throw error
 		}
+	}
+
+	/**
+	 * Non-terminal markets with no forum post yet (`discord_thread_id IS NULL`), oldest first,
+	 * bounded — the reconcile cron's backfill work-list. Drafts and terminal (resolved/voided)
+	 * markets are excluded. `minAgeMinutes` skips very fresh markets whose create-route publish may
+	 * still be in flight, so the sweep doesn't race it into a duplicate post.
+	 */
+	async listMarketsNeedingPost(limit = 25, minAgeMinutes = 2): Promise<MarketDetail[]> {
+		const bounded = Math.min(Math.max(limit, 1), 100)
+		const maxCreatedAt = new Date(Date.now() - Math.max(minAgeMinutes, 0) * 60_000)
+		const rows = await this.db
+			.select({ id: pmMarkets.id })
+			.from(pmMarkets)
+			.where(
+				and(
+					isNull(pmMarkets.discordThreadId),
+					inArray(pmMarkets.status, ['open', 'closed', 'resolving']),
+					lte(pmMarkets.createdAt, maxCreatedAt)
+				)
+			)
+			.orderBy(asc(pmMarkets.createdAt))
+			.limit(bounded)
+
+		return this.buildMarketDetails(rows.map((r) => r.id))
+	}
+
+	/**
+	 * Ids of non-terminal markets that HAVE a forum post and were updated within the last
+	 * `sinceMinutes`, newest first, bounded — the reconcile cron's self-healing refresh work-list.
+	 * A post whose refresh failed (auto-close tag flip, or a live bet/resolve refresh) keeps a fresh
+	 * `updated_at`, so it stays in this set and is retried on the next tick until the edit lands.
+	 * Self-shrinking: once markets stop changing they age out of the window. Returns ids (not details)
+	 * so the caller re-reads current state just before editing — a stale detail could otherwise clobber
+	 * a market that went terminal mid-sweep.
+	 */
+	async listMarketsToRefresh(sinceMinutes = 15, limit = 25): Promise<string[]> {
+		const bounded = Math.min(Math.max(limit, 1), 100)
+		const cutoff = new Date(Date.now() - Math.max(sinceMinutes, 1) * 60_000)
+		const rows = await this.db
+			.select({ id: pmMarkets.id })
+			.from(pmMarkets)
+			.where(
+				and(
+					isNotNull(pmMarkets.discordThreadId),
+					inArray(pmMarkets.status, ['open', 'closed', 'resolving']),
+					gte(pmMarkets.updatedAt, cutoff)
+				)
+			)
+			.orderBy(desc(pmMarkets.updatedAt))
+			.limit(bounded)
+
+		return rows.map((r) => r.id)
+	}
+
+	/** Build full details for a list of market ids, skipping any that vanished. */
+	private async buildMarketDetails(marketIds: string[]): Promise<MarketDetail[]> {
+		const details: MarketDetail[] = []
+		for (const id of marketIds) {
+			const detail = await this.buildMarketDetail(this.db, id)
+			if (detail) details.push(detail)
+		}
+		return details
 	}
 
 	async proposeResolution(input: {

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -234,6 +234,19 @@ export interface PredictionMarkets {
 	getWalletBalance(userId: string): Promise<{ balance: string }>
 	listMarkets(filter?: ListMarketsFilter): Promise<MarketSummary[]>
 	getMarket(marketId: string): Promise<MarketDetail | null>
+	/**
+	 * Non-terminal markets (open/closed/resolving) that have no forum post yet
+	 * (`discordThreadId IS NULL`), oldest first, bounded — the reconcile cron's backfill work-list.
+	 * `minAgeMinutes` skips very fresh markets whose create-route publish may still be in flight.
+	 */
+	listMarketsNeedingPost(limit?: number, minAgeMinutes?: number): Promise<MarketDetail[]>
+	/**
+	 * Ids of non-terminal markets that HAVE a post and changed within the last `sinceMinutes`, newest
+	 * first, bounded — the reconcile cron's self-healing refresh work-list. A failed post refresh keeps
+	 * a fresh `updatedAt`, so it stays here and is retried each tick until the edit lands. Returns ids
+	 * (not details) so the caller re-reads current state just before editing.
+	 */
+	listMarketsToRefresh(sinceMinutes?: number, limit?: number): Promise<string[]>
 	getUserBets(userId: string, opts?: { marketId?: string; activeOnly?: boolean }): Promise<BetView[]>
 	/** A user's bets joined to market question + outcome label (for `/market mybets`). */
 	getUserBetsDetailed(
@@ -272,7 +285,12 @@ export interface PredictionMarkets {
 	 */
 	placeBet(input: PlaceBetInput): Promise<BetResult & { deduped: boolean }>
 	closeMarket(input: { actorUserId: string; marketId: string }): Promise<void>
-	closeDueMarkets(): Promise<{ closed: number }>
+	/**
+	 * Auto-close up to `limit` open markets whose close time has passed (bounded so a backlog
+	 * can't blow the reconcile cron's budget; it drains over ticks). Returns the closed ids
+	 * (empty on a no-op re-run). Idempotent.
+	 */
+	closeDueMarkets(limit?: number): Promise<{ closedMarketIds: string[] }>
 	proposeResolution(input: {
 		resolverId: string
 		marketId: string


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Adds a periodic Core cron sweep that reconciles prediction-market state between the database and Discord forum posts. Core is the only worker bound to both the prediction-markets (PM) and Discord Durable Objects, so it drives the healing while keeping the PM DO from ever calling Discord directly.

## Changes

- **Reconcile service (`discord-market-reconcile.service.ts`)**: new `reconcileMarketPosts` with three bounded, per-market-isolated passes — auto-close due markets, refresh drifted posts (embed + status buttons + tag/lock), and backfill posts for non-terminal markets that never got one. One bad market never aborts the run.
- **Cron wiring (`apps/core/src/index.ts`)**: runs the sweep out-of-band via `ctx.waitUntil` in the `3-58/5 * * * *` branch, logging non-zero results and capturing failures to Sentry.
- **PM DO methods (`apps/prediction-markets/src/durable-object.ts`)**:
  - `closeDueMarkets(limit)` is now bounded (SELECT ids + guarded UPDATE) and returns the closed market ids instead of a count.
  - `listMarketsToRefresh(sinceMinutes, limit)` — self-healing refresh work-list; a failed refresh keeps a fresh `updated_at` so it stays in the set and retries until it lands. Returns ids so the caller re-reads fresh state before editing.
  - `listMarketsNeedingPost(limit, minAgeMinutes)` — backfill work-list, grace-filtered so it can't race an in-flight create-route publish.
- **Post publishing (`discord-market-post.service.ts`)**: `publishMarketPost` now tags by `market.status` (via `statusTagId`) rather than a hardcoded Open tag, so a backfilled already-closed market lands under the Closed tag.
- **Interface (`packages/prediction-markets/src/index.ts`)**: updated `closeDueMarkets` signature and added the two new list methods with docs.

## Testing

- New unit tests in `discord-market-reconcile.test.ts` cover the no-op-when-unconfigured path, auto-close counts, refresh success/soft-failure/terminal-skip/throw-isolation, and backfill success/failure-isolation.
- Per the commit: typecheck passes (PM app + package + core), 8 reconcile + 18 PM unit tests pass, and lint is clean. No migration; reuses existing `pmMarkets` columns.
<!-- claude:end -->
