### PR TITLE
feat(prediction-markets): close/resolve thread notifications + per-user result DMs; public (named) bets

### DIFF
--- a/apps/core/src/__tests__/market-embed.test.ts
+++ b/apps/core/src/__tests__/market-embed.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	buildBetAnnouncement,
+	buildMarketCloseAnnouncement,
 	buildMarketEmbed,
+	buildMarketResolveAnnouncement,
+	buildMarketVoidAnnouncement,
+	buildWagerResultDm,
 	formatMarketPoints,
 	truncateForEmbed,
 } from '../lib/market-embed'
@@ -89,20 +93,72 @@ describe('formatMarketPoints', () => {
 })
 
 describe('buildBetAnnouncement', () => {
-	it('reports the amount and outcome and no bettor identity', () => {
-		const msg = buildBetAnnouncement('1000', 'Yes')
-		expect(msg).toBe('🎲 A bet of **1,000 points** was placed on **Yes**.')
+	it('names the bettor with the amount and outcome', () => {
+		const msg = buildBetAnnouncement('<@42>', '1000', 'Yes')
+		expect(msg).toBe('🎲 <@42> bet **1,000 points** on **Yes**.')
 	})
 
 	it('groups the amount using formatMarketPoints', () => {
-		expect(buildBetAnnouncement('1234567', 'No')).toContain('1,234,567 points')
+		expect(buildBetAnnouncement('<@1>', '1234567', 'No')).toContain('1,234,567 points')
 	})
 
 	it('truncates an over-long outcome label so the message stays within limits', () => {
 		const long = 'x'.repeat(300)
-		const msg = buildBetAnnouncement('5', long)
+		const msg = buildBetAnnouncement('<@1>', '5', long)
 		expect(msg).toContain('…')
 		expect(msg).not.toContain('x'.repeat(300))
+	})
+})
+
+describe('close / resolve / void announcements', () => {
+	it('resolve announcement carries the outcome and aggregate totals', () => {
+		const msg = buildMarketResolveAnnouncement('Yes', '10000', '4000')
+		expect(msg).toContain('Yes')
+		expect(msg).toContain('10,000 points')
+		expect(msg).toContain('4,000 points')
+	})
+
+	it('void announcement states the refunded total', () => {
+		expect(buildMarketVoidAnnouncement('5000')).toContain('5,000 points')
+	})
+
+	it('close announcement mentions closed', () => {
+		expect(buildMarketCloseAnnouncement().toLowerCase()).toContain('closed')
+	})
+})
+
+describe('buildWagerResultDm', () => {
+	const base = { question: 'Will it rain?', voided: false, outcomeLabel: 'Yes' }
+
+	it('frames a net win with a + sign', () => {
+		const msg = buildWagerResultDm({ ...base, staked: '1000', returned: '1500', net: '500' })
+		expect(msg).toContain('net **+500 points**')
+		expect(msg).toContain('🎉')
+	})
+
+	it('frames a net loss with the signed (negative) amount', () => {
+		const msg = buildWagerResultDm({ ...base, staked: '1000', returned: '0', net: '-1000' })
+		expect(msg).toContain('net **-1,000 points**')
+		expect(msg).toContain('😔')
+	})
+
+	it('frames break-even', () => {
+		const msg = buildWagerResultDm({ ...base, staked: '1000', returned: '1000', net: '0' })
+		expect(msg).toContain('🤝')
+		expect(msg).toContain('net **0 points**')
+	})
+
+	it('reports a refund on a void', () => {
+		const msg = buildWagerResultDm({
+			...base,
+			voided: true,
+			outcomeLabel: null,
+			staked: '750',
+			returned: '750',
+			net: '0',
+		})
+		expect(msg).toContain('voided')
+		expect(msg).toContain('750 points')
 	})
 })
 

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -985,6 +985,11 @@ export class CoreWorker extends WorkerEntrypoint<Env> {
 				reason: result.reason,
 			})
 		}
+		// Deferred work (the settlement DM fan-out) runs AFTER we return the confirmation, so a
+		// large market's rate-limited DMs never delay/time-out the resolver's ephemeral reply.
+		if (result.background) {
+			waitUntilWithTelemetry(this.ctx, 'pm-settlement-dms', result.background)
+		}
 		return {
 			ok,
 			response: result.response,
@@ -1005,6 +1010,10 @@ export class CoreWorker extends WorkerEntrypoint<Env> {
 	}> {
 		const db = createDb(this.env.DATABASE_URL)
 		const result = await executeDiscordComponent(db, this.env, input)
+		// Deferred settlement DM fan-out runs off the confirmation path (see executeDiscordModalSubmit).
+		if (result.background) {
+			waitUntilWithTelemetry(this.ctx, 'pm-settlement-dms', result.background)
+		}
 		return {
 			ok: result.reason === 'ok',
 			response: result.response,

--- a/apps/core/src/lib/market-embed.ts
+++ b/apps/core/src/lib/market-embed.ts
@@ -31,16 +31,70 @@ export function truncateForEmbed(value: string, max: number): string {
 }
 
 /**
- * The public message posted to a market's forum thread when a bet lands. Deliberately
- * anonymous — it carries the amount and chosen outcome ONLY, never any bettor identity.
- * The outcome label is truncated so a long label can't blow past Discord's 2000-char message
- * limit; mention suppression is handled by the caller (allowed_mentions).
+ * The public message posted to a market's forum thread when a bet lands. Names the bettor
+ * (`bettor` is a Discord mention like `<@id>`, which renders the username; the caller keeps
+ * allowed_mentions empty so it displays without pinging). The outcome label is truncated so a
+ * long label can't blow past Discord's 2000-char message limit.
  */
-export function buildBetAnnouncement(amount: string, outcomeLabel: string): string {
-	return `🎲 A bet of **${formatMarketPoints(amount)}** was placed on **${truncateForEmbed(
+export function buildBetAnnouncement(bettor: string, amount: string, outcomeLabel: string): string {
+	return `🎲 ${bettor} bet **${formatMarketPoints(amount)}** on **${truncateForEmbed(
 		outcomeLabel,
 		256
 	)}**.`
+}
+
+/** Posted to the thread when a market closes to betting (manual Close or auto-close on time). */
+export function buildMarketCloseAnnouncement(): string {
+	return '🔒 Betting is now closed on this market. Awaiting resolution.'
+}
+
+/** Posted to the thread when a market resolves: the winning outcome + aggregate paid-out/lost. */
+export function buildMarketResolveAnnouncement(
+	outcomeLabel: string,
+	totalPaidOut: string,
+	totalLost: string
+): string {
+	return (
+		`✅ Market resolved: **${truncateForEmbed(outcomeLabel, 256)}**.\n` +
+		`**${formatMarketPoints(totalPaidOut)}** paid out to winners · **${formatMarketPoints(totalLost)}** lost.`
+	)
+}
+
+/** Posted to the thread when a market is voided (no winner): everyone's stake is refunded. */
+export function buildMarketVoidAnnouncement(totalRefunded: string): string {
+	return `⚖️ Market voided — no winner. All **${formatMarketPoints(totalRefunded)}** in stakes refunded.`
+}
+
+/**
+ * The DM sent to one participant with the result of their wagers on a settled market. `net` is a
+ * signed integer-point string (negative = net loss). `outcomeLabel` is the winning outcome, or null
+ * on a void. Question/outcome are truncated to keep the DM within Discord's message limit.
+ */
+export function buildWagerResultDm(input: {
+	question: string
+	voided: boolean
+	outcomeLabel: string | null
+	staked: string
+	returned: string
+	net: string
+}): string {
+	const question = truncateForEmbed(input.question, 200)
+	if (input.voided) {
+		return `⚖️ The market “${question}” was voided — your **${formatMarketPoints(
+			input.staked
+		)}** stake was refunded.`
+	}
+	const negative = input.net.trim().startsWith('-')
+	const zero = input.net.trim().replace(/^0+(?=\d)/, '') === '0'
+	const emoji = zero ? '🤝' : negative ? '😔' : '🎉'
+	const netDisplay = negative || zero ? formatMarketPoints(input.net) : `+${formatMarketPoints(input.net)}`
+	const outcome = input.outcomeLabel ? `**${truncateForEmbed(input.outcomeLabel, 256)}**` : 'the market'
+	return (
+		`${emoji} “${question}” resolved: ${outcome}.\n` +
+		`You staked **${formatMarketPoints(input.staked)}**, got back **${formatMarketPoints(
+			input.returned
+		)}** — net **${netDisplay}**.`
+	)
 }
 
 /**

--- a/apps/core/src/services/__tests__/discord-market-notify.test.ts
+++ b/apps/core/src/services/__tests__/discord-market-notify.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	announceMarketClosed,
+	announceMarketResolved,
+	dmWagerResults,
+} from '../discord-market-notify.service'
+
+import type { Discord } from '@repo/discord'
+import type { MarketDetail, MarketSettlement } from '@repo/prediction-markets'
+
+const sendMessage = vi.fn()
+const sendDirectMessage = vi.fn()
+const discord = { sendMessage, sendDirectMessage } as unknown as Discord
+
+function market(overrides: Partial<MarketDetail> = {}): MarketDetail {
+	return {
+		id: 'm1',
+		question: 'Will it rain?',
+		status: 'resolved',
+		closesAt: '2030-01-01T00:00:00.000Z',
+		totalPool: '0',
+		outcomeCount: 2,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		discordThreadId: 'thread1',
+		discordMessageId: 'msg1',
+		description: null,
+		createdBy: 'creator',
+		rakeBps: 0,
+		minStake: '1',
+		maxStake: null,
+		perUserCap: null,
+		twoOfN: false,
+		resolvedOutcomeId: 'o1',
+		resolvedBy: 'r',
+		resolvedAt: '2026-01-02T00:00:00.000Z',
+		voidReason: null,
+		outcomes: [
+			{ id: 'o1', label: 'Yes', poolAmount: '0', sortOrder: 0, impliedOddsBps: null },
+			{ id: 'o2', label: 'No', poolAmount: '0', sortOrder: 1, impliedOddsBps: null },
+		],
+		...overrides,
+	}
+}
+
+function settlement(overrides: Partial<MarketSettlement> = {}): MarketSettlement {
+	return {
+		marketId: 'm1',
+		status: 'resolved',
+		resolvedOutcomeId: 'o1',
+		totalStaked: '3000',
+		totalPaidOut: '1800',
+		totalLost: '1000',
+		users: [
+			{ userId: 'winner', staked: '1000', returned: '1800', net: '800' },
+			{ userId: 'loser', staked: '1000', returned: '0', net: '-1000' },
+		],
+		...overrides,
+	}
+}
+
+describe('announceMarketClosed', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('posts the close notice to the thread', async () => {
+		sendMessage.mockResolvedValue({ success: true })
+		await announceMarketClosed(discord, 'g1', market({ status: 'closed' }))
+		expect(sendMessage).toHaveBeenCalledTimes(1)
+		const [, channelId, message] = sendMessage.mock.calls[0]
+		expect(channelId).toBe('thread1')
+		expect(message.content.toLowerCase()).toContain('closed')
+	})
+
+	it('no-ops when the market has no forum post', async () => {
+		await announceMarketClosed(discord, 'g1', market({ discordThreadId: null }))
+		expect(sendMessage).not.toHaveBeenCalled()
+	})
+})
+
+describe('announceMarketResolved (thread post — aggregate only)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		sendMessage.mockResolvedValue({ success: true })
+	})
+
+	it('posts the winning outcome + aggregate totals, and never DMs', async () => {
+		await announceMarketResolved(discord, 'g1', market(), settlement())
+		expect(sendMessage).toHaveBeenCalledTimes(1)
+		const threadContent = sendMessage.mock.calls[0][2].content
+		expect(threadContent).toContain('Yes')
+		expect(threadContent).toContain('1,800 points')
+		expect(threadContent).toContain('1,000 points')
+		// Per-user results are private — the thread post must not fan out DMs.
+		expect(sendDirectMessage).not.toHaveBeenCalled()
+	})
+
+	it('posts a void notice when the market voided', async () => {
+		await announceMarketResolved(
+			discord,
+			'g1',
+			market({ status: 'voided', resolvedOutcomeId: null }),
+			settlement({ status: 'voided', resolvedOutcomeId: null, totalPaidOut: '3000', totalLost: '0' })
+		)
+		expect(sendMessage.mock.calls[0][2].content.toLowerCase()).toContain('voided')
+	})
+
+	it('no-ops when the market has no forum post', async () => {
+		await announceMarketResolved(discord, 'g1', market({ discordThreadId: null }), settlement())
+		expect(sendMessage).not.toHaveBeenCalled()
+	})
+})
+
+describe('dmWagerResults (per-user private DMs)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		sendDirectMessage.mockResolvedValue({ success: true })
+	})
+
+	it('DMs each participant their signed net result, by core user id', async () => {
+		await dmWagerResults(discord, market(), settlement())
+		expect(sendDirectMessage).toHaveBeenCalledTimes(2)
+		expect(sendDirectMessage.mock.calls.map((c) => c[0])).toEqual(['winner', 'loser'])
+		const winnerDm = sendDirectMessage.mock.calls.find((c) => c[0] === 'winner')?.[1].content
+		expect(winnerDm).toContain('+800 points')
+	})
+
+	it('DMs everyone even if one DM fails (best-effort, isolated)', async () => {
+		sendDirectMessage.mockRejectedValueOnce(new Error('user has DMs closed'))
+		await dmWagerResults(discord, market(), settlement())
+		expect(sendDirectMessage).toHaveBeenCalledTimes(2)
+	})
+
+	it('sends refund DMs on a void', async () => {
+		await dmWagerResults(
+			discord,
+			market({ status: 'voided', resolvedOutcomeId: null }),
+			settlement({
+				status: 'voided',
+				resolvedOutcomeId: null,
+				users: [{ userId: 'u1', staked: '500', returned: '500', net: '0' }],
+			})
+		)
+		expect(sendDirectMessage.mock.calls[0][1].content.toLowerCase()).toContain('voided')
+	})
+})

--- a/apps/core/src/services/__tests__/discord-market-reconcile.test.ts
+++ b/apps/core/src/services/__tests__/discord-market-reconcile.test.ts
@@ -19,6 +19,9 @@ const hoisted = vi.hoisted(() => ({
 		applyMarketPostStatus: vi.fn(),
 		publishMarketPost: vi.fn(),
 	},
+	notify: {
+		announceMarketClosed: vi.fn(),
+	},
 }))
 
 // getStub returns the PM stub for the PREDICTION_MARKETS binding; the Discord stub is an opaque
@@ -33,6 +36,10 @@ vi.mock('../discord-market-post.service', () => ({
 	updateMarketPostFromDetail: hoisted.post.updateMarketPostFromDetail,
 	applyMarketPostStatus: hoisted.post.applyMarketPostStatus,
 	publishMarketPost: hoisted.post.publishMarketPost,
+}))
+
+vi.mock('../discord-market-notify.service', () => ({
+	announceMarketClosed: hoisted.notify.announceMarketClosed,
 }))
 
 const db = {} as unknown as Parameters<typeof reconcileMarketPosts>[0]
@@ -83,6 +90,7 @@ describe('reconcileMarketPosts', () => {
 		hoisted.post.updateMarketPostFromDetail.mockResolvedValue({ success: true })
 		hoisted.post.applyMarketPostStatus.mockResolvedValue(undefined)
 		hoisted.post.publishMarketPost.mockResolvedValue({ threadId: 't', messageId: 'm' })
+		hoisted.notify.announceMarketClosed.mockResolvedValue(undefined)
 	})
 
 	it('no-ops when the forum guild/category is not configured', async () => {
@@ -93,12 +101,14 @@ describe('reconcileMarketPosts', () => {
 		expect(hoisted.prediction.listMarketsNeedingPost).not.toHaveBeenCalled()
 	})
 
-	it('reports the count of auto-closed markets', async () => {
+	it('auto-closes markets and announces each close to its thread', async () => {
 		hoisted.prediction.closeDueMarkets.mockResolvedValue({ closedMarketIds: ['a', 'b', 'c'] })
 		const res = await reconcileMarketPosts(db, makeEnv())
 		expect(res.closed).toBe(3)
 		// Auto-close is bounded to keep the run inside the cron budget.
 		expect(hoisted.prediction.closeDueMarkets).toHaveBeenCalledWith(expect.any(Number))
+		// Each just-closed market gets a "betting closed" post (once per market).
+		expect(hoisted.notify.announceMarketClosed).toHaveBeenCalledTimes(3)
 	})
 
 	it('refreshes each drifted post (embed + tag/lock) from the self-healing refresh list', async () => {

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -28,6 +28,11 @@ import {
 import { formatMarketPoints } from '../lib/market-embed'
 import { hasMarketPermission } from '../lib/market-permissions'
 import {
+	announceMarketClosed,
+	announceMarketResolved,
+	dmWagerResults,
+} from './discord-market-notify.service'
+import {
 	announceBetPlaced,
 	applyMarketPostStatus,
 	updateMarketPostFromDetail,
@@ -50,6 +55,13 @@ export interface DiscordComponentResult {
 	response: { type: number; data: { content: string; flags?: number; embeds?: DiscordEmbed[] } }
 	coreUserId: string | null
 	reason: string
+	/**
+	 * Optional out-of-band work to run AFTER the user's confirmation is delivered — the RPC layer
+	 * (executeDiscord* in index.ts) runs it in `ctx.waitUntil`. Used for the settlement DM fan-out,
+	 * which is too slow (one rate-limited DM per participant) to block the resolver's confirmation.
+	 * Never serialized to the interactions worker; consumed in-process by the RPC method.
+	 */
+	background?: () => Promise<void>
 }
 
 export interface ExecuteComponentInput {
@@ -95,9 +107,15 @@ const ERROR_MESSAGES: Record<string, string> = {
 function ephemeral(
 	content: string,
 	reason: string,
-	coreUserId: string | null = null
+	coreUserId: string | null = null,
+	background?: () => Promise<void>
 ): DiscordComponentResult {
-	return { response: { type: 4, data: { content, flags: EPHEMERAL_FLAG } }, coreUserId, reason }
+	return {
+		response: { type: 4, data: { content, flags: EPHEMERAL_FLAG } },
+		coreUserId,
+		reason,
+		...(background ? { background } : {}),
+	}
 }
 
 /** Pull the underlying driver error off a Drizzle "Failed query: …" wrapper (the real cause). */
@@ -181,6 +199,55 @@ async function refreshPost(
 	}
 }
 
+/** Post the "betting closed" notice to a market's thread. Best-effort — never fails the close. */
+async function notifyClose(
+	env: ComponentEnv,
+	prediction: PredictionMarkets,
+	marketId: string
+): Promise<void> {
+	try {
+		const market = await prediction.getMarket(marketId)
+		if (!market) return
+		const discord = getStub<Discord>(env.DISCORD, 'default')
+		await announceMarketClosed(discord, env.PM_FORUM_GUILD_ID ?? '', market)
+	} catch (err) {
+		logger.warn('[DiscordComponents] close notify failed', {
+			marketId,
+			error: err instanceof Error ? err.message : String(err),
+		})
+	}
+}
+
+/**
+ * Announce a just-settled (resolved/voided) market to its thread NOW (fast, one message) and
+ * return a thunk that DMs each participant their result. The DM fan-out is returned — not awaited —
+ * so the caller runs it in the RPC's `ctx.waitUntil`, off the resolver's confirmation path (one
+ * rate-limited DM per participant would otherwise make a large market's confirmation hang or time
+ * out). Best-effort; returns undefined when there's nothing to notify. The resolution already
+ * committed, so a Discord failure here is never fatal.
+ */
+async function announceSettlement(
+	env: ComponentEnv,
+	prediction: PredictionMarkets,
+	marketId: string
+): Promise<(() => Promise<void>) | undefined> {
+	try {
+		const market = await prediction.getMarket(marketId)
+		if (!market) return undefined
+		const settlement = await prediction.getMarketSettlement(marketId)
+		if (!settlement) return undefined
+		const discord = getStub<Discord>(env.DISCORD, 'default')
+		await announceMarketResolved(discord, env.PM_FORUM_GUILD_ID ?? '', market, settlement)
+		return () => dmWagerResults(discord, market, settlement)
+	} catch (err) {
+		logger.warn('[DiscordComponents] settlement announce failed', {
+			marketId,
+			error: err instanceof Error ? err.message : String(err),
+		})
+		return undefined
+	}
+}
+
 async function requireResolver(
 	db: ReturnType<typeof createDb>,
 	env: ComponentEnv,
@@ -221,6 +288,7 @@ export async function executeDiscordComponent(
 		if (decoded.action === 'close') {
 			await prediction.closeMarket({ actorUserId: user.id, marketId: decoded.marketId })
 			await refreshPost(db, env, prediction, decoded.marketId)
+			await notifyClose(env, prediction, decoded.marketId)
 			return ephemeral('Market closed.', 'ok', user.id)
 		}
 		// approve
@@ -232,10 +300,15 @@ export async function executeDiscordComponent(
 			proposalId: proposal.id,
 		})
 		await refreshPost(db, env, prediction, decoded.marketId)
+		let background: (() => Promise<void>) | undefined
+		if (result.status === 'resolved' || result.status === 'voided') {
+			background = await announceSettlement(env, prediction, decoded.marketId)
+		}
 		return ephemeral(
 			result.status === 'voided' ? 'Resolution approved — market voided.' : 'Resolution approved.',
 			'ok',
-			user.id
+			user.id,
+			background
 		)
 	} catch (error) {
 		return mapError(error, user.id, { action: decoded.action, marketId: decoded.marketId })
@@ -316,11 +389,19 @@ async function handleBetModal(
 				outcomeLabel = market.outcomes.find((o) => o.id === target.outcomeId)?.label ?? ''
 				const discord = getStub<Discord>(env.DISCORD, 'default')
 				await updateMarketPostFromDetail(discord, market)
-				// Announce the bet publicly in the market's forum thread — amount + outcome only,
-				// never the bettor's identity. Best-effort (sibling to the embed refresh above).
-				// Skip on a deduped (duplicate-delivery) bet so a retried interaction can't post twice.
+				// Announce the bet publicly in the market's forum thread — who bet, how much, on which
+				// outcome. Best-effort (sibling to the embed refresh above). Skip on a deduped
+				// (duplicate-delivery) bet so a retried interaction can't post twice. `<@id>` renders
+				// the bettor's name without pinging (allowed_mentions stays empty).
 				if (!bet.deduped) {
-					await announceBetPlaced(discord, env.PM_FORUM_GUILD_ID ?? '', market, bet.amount, outcomeLabel)
+					await announceBetPlaced(
+						discord,
+						env.PM_FORUM_GUILD_ID ?? '',
+						market,
+						`<@${input.discordUserId}>`,
+						bet.amount,
+						outcomeLabel
+					)
 				}
 			}
 		} catch (err) {
@@ -370,11 +451,20 @@ async function handleResolveModal(
 			outcomeId: outcome.id,
 		})
 		await refreshPost(db, env, prediction, marketId)
+		let background: (() => Promise<void>) | undefined
+		if (result.status === 'resolved' || result.status === 'voided') {
+			background = await announceSettlement(env, prediction, marketId)
+		}
 		if (result.status === 'resolved') {
-			return ephemeral(`Market resolved: **${outcome.label}**.`, 'ok', user.id)
+			return ephemeral(`Market resolved: **${outcome.label}**.`, 'ok', user.id, background)
 		}
 		if (result.status === 'voided') {
-			return ephemeral('Market resolved with no winning bets — everyone refunded.', 'ok', user.id)
+			return ephemeral(
+				'Market resolved with no winning bets — everyone refunded.',
+				'ok',
+				user.id,
+				background
+			)
 		}
 		// resolving (two-of-N): a second resolver must approve.
 		return ephemeral(
@@ -408,7 +498,8 @@ async function handleVoidModal(
 	try {
 		await prediction.voidMarket({ actorUserId: user.id, marketId, reason })
 		await refreshPost(db, env, prediction, marketId)
-		return ephemeral('Market voided and all bets refunded.', 'ok', user.id)
+		const background = await announceSettlement(env, prediction, marketId)
+		return ephemeral('Market voided and all bets refunded.', 'ok', user.id, background)
 	} catch (error) {
 		return mapError(error, user.id, { action: 'void', marketId })
 	}

--- a/apps/core/src/services/discord-market-notify.service.ts
+++ b/apps/core/src/services/discord-market-notify.service.ts
@@ -1,0 +1,129 @@
+/**
+ * Prediction-markets lifecycle notifications: forum-thread posts on close/resolve/void, plus a
+ * private DM to each participant with their wager result. Core is the sole Discord orchestrator
+ * (the PM DO never calls Discord); these are best-effort — a Discord failure never rolls back the
+ * already-committed market state.
+ *
+ * Thread posts carry only aggregate numbers (never per-user amounts); the individual breakdown
+ * goes to each bettor privately via DM.
+ */
+
+import { logger } from '@repo/hono-helpers'
+
+import {
+	buildMarketCloseAnnouncement,
+	buildMarketResolveAnnouncement,
+	buildMarketVoidAnnouncement,
+	buildWagerResultDm,
+} from '../lib/market-embed'
+
+import type { Discord } from '@repo/discord'
+import type { MarketDetail, MarketSettlement } from '@repo/prediction-markets'
+
+/** Post the "betting is closed" notice to a market's forum thread. No-op if it has no post. */
+export async function announceMarketClosed(
+	discord: Discord,
+	guildId: string,
+	market: MarketDetail
+): Promise<void> {
+	if (!market.discordThreadId) return
+	const res = await discord.sendMessage(guildId, market.discordThreadId, {
+		content: buildMarketCloseAnnouncement(),
+		allowEveryone: false,
+	})
+	if (!res.success) {
+		logger.warn('[PMNotify] close announcement failed', { marketId: market.id, error: res.error })
+	}
+}
+
+/** The winning-outcome label for a settled market, or null on a void / if unresolvable. */
+function winningOutcomeLabel(market: MarketDetail, settlement: MarketSettlement): string | null {
+	if (settlement.status === 'voided') return null
+	return market.outcomes.find((o) => o.id === settlement.resolvedOutcomeId)?.label ?? null
+}
+
+/**
+ * Post the settled market's outcome + aggregate totals to its thread (aggregate only — never a
+ * per-user amount; those go out privately via DM). Best-effort; no-op if the market has no post.
+ * Fast (one message) so it can stay on the interactive resolve path.
+ */
+export async function announceMarketResolved(
+	discord: Discord,
+	guildId: string,
+	market: MarketDetail,
+	settlement: MarketSettlement
+): Promise<void> {
+	if (!market.discordThreadId) return
+	const content =
+		settlement.status === 'voided'
+			? buildMarketVoidAnnouncement(settlement.totalStaked)
+			: buildMarketResolveAnnouncement(
+					winningOutcomeLabel(market, settlement) ?? 'the winning outcome',
+					settlement.totalPaidOut,
+					settlement.totalLost
+				)
+	const res = await discord.sendMessage(guildId, market.discordThreadId, {
+		content,
+		allowEveryone: false,
+	})
+	if (!res.success) {
+		logger.warn('[PMNotify] resolve announcement failed', { marketId: market.id, error: res.error })
+	}
+}
+
+/**
+ * Cap on how many result DMs one settlement sends. A settlement fans out one DM per participant;
+ * this bounds the work against Discord's aggressive DM-open rate limit and the Worker subrequest
+ * budget. Realistic markets are far below it; a market past the cap logs its overflow.
+ */
+const MAX_RESULT_DMS = 400
+
+/**
+ * DM each participant their private wager result. Fans out (one DM per user), so callers run this
+ * OFF the interactive path (e.g. in the RPC's `ctx.waitUntil`) — Discord rate-limits DM-opens
+ * hard, so a large market's loop is slow and must never block the resolver's confirmation. Each DM
+ * is independently guarded so one closed inbox never blocks the rest.
+ */
+export async function dmWagerResults(
+	discord: Discord,
+	market: MarketDetail,
+	settlement: MarketSettlement
+): Promise<void> {
+	const voided = settlement.status === 'voided'
+	const outcomeLabel = winningOutcomeLabel(market, settlement)
+	const recipients = settlement.users.slice(0, MAX_RESULT_DMS)
+	if (settlement.users.length > 0) {
+		logger.info('[PMNotify] DMing wager results', {
+			marketId: market.id,
+			participants: settlement.users.length,
+			dming: recipients.length,
+			overflow: settlement.users.length - recipients.length,
+		})
+	}
+	for (const user of recipients) {
+		const content = buildWagerResultDm({
+			question: market.question,
+			voided,
+			outcomeLabel,
+			staked: user.staked,
+			returned: user.returned,
+			net: user.net,
+		})
+		try {
+			const res = await discord.sendDirectMessage(user.userId, { content, allowEveryone: false })
+			if (!res.success) {
+				logger.warn('[PMNotify] result DM failed', {
+					marketId: market.id,
+					userId: user.userId,
+					error: res.error,
+				})
+			}
+		} catch (error) {
+			logger.warn('[PMNotify] result DM threw', {
+				marketId: market.id,
+				userId: user.userId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+}

--- a/apps/core/src/services/discord-market-post.service.ts
+++ b/apps/core/src/services/discord-market-post.service.ts
@@ -171,10 +171,10 @@ export async function updateMarketPostFromDetail(
 }
 
 /**
- * Post an anonymized "bet placed" announcement into a market's forum thread — the amount and
- * chosen outcome only, never who placed it. Sent as a regular thread message (a thread is a
- * channel), reusing sendMessage's rate-limit retry; mentions are suppressed so a user-authored
- * outcome label can't ping anyone. Best-effort: no-op if the market has no post yet, and the
+ * Post a public "bet placed" announcement into a market's forum thread — who bet, how much, on
+ * which outcome. `bettor` is a Discord mention (`<@id>`) that renders the username; mentions stay
+ * suppressed (allowed_mentions empty) so the name shows without pinging, and a user-authored
+ * outcome label can't ping either. Best-effort: no-op if the market has no post yet, and the
  * returned {success,error} is for logging only — a failed announcement must never fail the bet.
  * `guildId` is used only for the DO's log context (sendMessage POSTs by channel/thread id).
  */
@@ -182,13 +182,14 @@ export async function announceBetPlaced(
 	discord: Discord,
 	guildId: string,
 	market: MarketDetail,
+	bettor: string,
 	amount: string,
 	outcomeLabel: string
 ): Promise<SendMessageResult> {
 	if (!market.discordThreadId) return { success: false, error: 'no post' }
 	if (!outcomeLabel) return { success: false, error: 'no outcome' }
 	return discord.sendMessage(guildId, market.discordThreadId, {
-		content: buildBetAnnouncement(amount, outcomeLabel),
+		content: buildBetAnnouncement(bettor, amount, outcomeLabel),
 		allowEveryone: false,
 	})
 }

--- a/apps/core/src/services/discord-market-reconcile.service.ts
+++ b/apps/core/src/services/discord-market-reconcile.service.ts
@@ -19,6 +19,7 @@
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
+import { announceMarketClosed } from './discord-market-notify.service'
 import {
 	applyMarketPostStatus,
 	publishMarketPost,
@@ -76,6 +77,20 @@ export async function reconcileMarketPosts(db: CoreDb, env: ReconcileEnv): Promi
 	// market's `updatedAt` is fresh, so it lands in the refresh list below on this same tick.
 	const { closedMarketIds } = await prediction.closeDueMarkets(CLOSE_LIMIT)
 	result.closed = closedMarketIds.length
+	// Announce each auto-close to its thread. closedMarketIds only holds markets that transitioned
+	// open→closed this pass, so this fires once per market. Best-effort and per-market isolated.
+	for (const marketId of closedMarketIds) {
+		try {
+			const market = await prediction.getMarket(marketId)
+			if (market) await announceMarketClosed(discord, guildId, market)
+		} catch (error) {
+			result.failed++
+			logger.warn('[PMReconcile] auto-close announcement failed', {
+				marketId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
 
 	// (b) Refresh drifted posts (embed + status buttons + tag/lock). Driven by a self-shrinking
 	// "recently changed, has a post" list rather than the one-shot close result, so a refresh that

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -36,6 +36,7 @@ import type {
 	MarketDetail,
 	MarketHistoryOpts,
 	MarketHistoryRow,
+	MarketSettlement,
 	MarketStatus,
 	MarketSummary,
 	Paged,
@@ -249,6 +250,73 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			payoutAmount: r.payoutAmount,
 			createdAt: r.createdAt.toISOString(),
 		}))
+	}
+
+	/**
+	 * Aggregate a market's financial settlement: overall totals + one net-result row per
+	 * participant. Reads every bet on the market (bounded by market size) and folds them by user —
+	 * a won bet returns its `payoutAmount`, a refunded bet returns its stake, a lost bet returns
+	 * nothing. Intended for a resolved/voided market; returns null if the market doesn't exist.
+	 */
+	async getMarketSettlement(marketId: string): Promise<MarketSettlement | null> {
+		const [market] = await this.db
+			.select({
+				status: pmMarkets.status,
+				resolvedOutcomeId: pmMarkets.resolvedOutcomeId,
+			})
+			.from(pmMarkets)
+			.where(eq(pmMarkets.id, marketId))
+			.limit(1)
+		if (!market) return null
+
+		const bets = await this.db
+			.select({
+				userId: pmBets.userId,
+				amount: pmBets.amount,
+				status: pmBets.status,
+				payoutAmount: pmBets.payoutAmount,
+			})
+			.from(pmBets)
+			.where(eq(pmBets.marketId, marketId))
+			.orderBy(pmBets.userId)
+
+		let totalStaked = 0n
+		let totalPaidOut = 0n
+		let totalLost = 0n
+		const byUser = new Map<string, { staked: bigint; returned: bigint }>()
+		for (const bet of bets) {
+			const stake = parseAmount(bet.amount)
+			// Money returned to the bettor: full payout for a win, stake back for a refund, nothing
+			// for a loss. (An 'active' bet on an unsettled market returns nothing here.)
+			let returned = 0n
+			if (bet.status === 'won') returned = parseAmount(bet.payoutAmount)
+			else if (bet.status === 'refunded') returned = stake
+			else if (bet.status === 'lost') totalLost += stake
+
+			totalStaked += stake
+			totalPaidOut += returned
+			const acc = byUser.get(bet.userId) ?? { staked: 0n, returned: 0n }
+			acc.staked += stake
+			acc.returned += returned
+			byUser.set(bet.userId, acc)
+		}
+
+		const users = Array.from(byUser, ([userId, acc]) => ({
+			userId,
+			staked: formatAmount(acc.staked),
+			returned: formatAmount(acc.returned),
+			net: formatAmount(acc.returned - acc.staked),
+		}))
+
+		return {
+			marketId,
+			status: market.status,
+			resolvedOutcomeId: market.resolvedOutcomeId,
+			totalStaked: formatAmount(totalStaked),
+			totalPaidOut: formatAmount(totalPaidOut),
+			totalLost: formatAmount(totalLost),
+			users,
+		}
 	}
 
 	async getLeaderboard(opts?: {

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -129,6 +129,33 @@ export interface ResolveResult {
 	resolvedOutcomeId?: string | null
 }
 
+/** One participant's net result on a settled (resolved/voided) market — the DM target. */
+export interface SettlementUser {
+	/** Core user id (also the DM target). */
+	userId: string
+	/** Total staked across this user's bets on the market. */
+	staked: string
+	/** Total returned to this user (winning payouts, or refunds on a void). */
+	returned: string
+	/** `returned - staked` (positive = net win, negative = net loss); may be negative. */
+	net: string
+}
+
+/** The financial outcome of a settled market — drives the resolve thread post + per-user DMs. */
+export interface MarketSettlement {
+	marketId: string
+	status: MarketStatus
+	resolvedOutcomeId: string | null
+	/** Sum of all stakes on the market (the total pool). */
+	totalStaked: string
+	/** Sum returned to users (winner payouts, or all stakes on a void). */
+	totalPaidOut: string
+	/** Sum of stakes on losing outcomes (0 for a void). */
+	totalLost: string
+	/** Per-user aggregates, one row per participant. */
+	users: SettlementUser[]
+}
+
 export interface PendingProposalView {
 	id: string
 	/** Proposed winning outcome, or null for a proposed void. */
@@ -253,6 +280,12 @@ export interface PredictionMarkets {
 		userId: string,
 		opts?: { activeOnly?: boolean }
 	): Promise<DetailedBetView[]>
+	/**
+	 * The financial settlement of a market (totals + per-user net results). Intended for a market
+	 * that has resolved/voided; the caller uses it to post the outcome to the thread and DM each
+	 * participant. Returns null if the market doesn't exist.
+	 */
+	getMarketSettlement(marketId: string): Promise<MarketSettlement | null>
 	getLeaderboard(opts?: { window?: 'all' | '30d'; limit?: number }): Promise<LeaderboardRow[]>
 	getLedger(userId: string, opts?: { limit?: number; cursor?: string }): Promise<LedgerRow[]>
 


### PR DESCRIPTION
Notify the market forum thread and participants across the lifecycle, and de-anonymize
bets (user request: make wagers public, name the bettor).

Forum thread posts (aggregate only — never a per-user amount):
- bet placed: now NAMES the bettor via <@id> mention (renders the username, allowed_mentions
  stays empty so it shows without pinging). Reverses the earlier anonymization.
- market closed (manual Close button + reconcile auto-close): "betting is now closed".
- market resolved: winning outcome + total paid out to winners + total lost.
- market voided: all stakes refunded, no winner.

Per-user private DMs: each participant is DMed their own result (staked / returned / signed net),
or a refund notice on a void.

Implementation:
- PM: getMarketSettlement(marketId) — per-user aggregates (staked/returned/net) + totals
  (paid out, lost), folding won→payout, refunded→stake, lost→0. Pure read, PM DO never calls Discord.
- Core: discord-market-notify.service (announceMarketClosed, announceMarketResolved [thread],
  dmWagerResults [fan-out]) + market-embed builders. Triggers wired into close/approve/resolve/void
  handlers and the reconcile auto-close path.

Hardened via an adversarial review round (confirmed medium fixed): the settlement DM fan-out
(one rate-limited DM per participant) is decoupled from the resolver's confirmation — the public
thread post stays synchronous, the DM loop runs in the Core RPC's ctx.waitUntil (capped at 400) so a
large market can't hang/time-out the confirmation. Retries on retry are blocked by the state machine
(a re-delivered resolve/close hits a state guard → no double-notify).

Known follow-up (documented): settlement notifications have no cross-eviction self-heal — if Core is
evicted mid-notify the resolve post + DMs are lost. Full healing needs a persisted "announced" flag +
a reconcile pass (migration); deferred.

Typecheck green (PM app + pkg + core); 32 core (embed/notify/reconcile) + 18 PM tests; lint clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>