### PR TITLE
feat(prediction-markets): non-admin market creation (urn:markets:creator) — Phase 1 MVP

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -20,6 +20,7 @@ import adminStructuresRoutes from './routes/admin/structures'
 import authRoutes from './routes/auth'
 import billsAdminRoutes from './routes/bills-admin'
 import predictionMarketsAdminRoutes from './routes/prediction-markets-admin'
+import predictionMarketsRoutes from './routes/prediction-markets'
 import billsUserRoutes from './routes/bills-user'
 import broadcastsRoutes from './routes/broadcasts'
 import charactersRoutes from './routes/characters'
@@ -153,6 +154,7 @@ const app = new Hono<App>()
 	.route('/api/discord-commands', discordCommandsRoutes)
 	.route('/api/dkp', dkpRoutes)
 	.route('/api/doctrines', doctrinesRoutes)
+	.route('/api/prediction-markets', predictionMarketsRoutes) // Member prediction-markets API (create)
 	.route('/api/entities', entitiesRoutes)
 	.route('/api/esi', esiRoutes)
 	.route('/api/skills', skillsRoutes)

--- a/apps/core/src/lib/market-permissions.ts
+++ b/apps/core/src/lib/market-permissions.ts
@@ -4,19 +4,33 @@
  * Resolver-only actions (close / resolve / void) self-gate in the component handler on the
  * stable `urn:markets:resolver` URN — buttons are visible to everyone in the forum thread, so
  * gating must be server-side, never by hiding the button. `is_admin` bypasses the tier.
+ *
+ * Tiers (each independent, `manager` is the superset of all):
+ * - `creator`  — may create markets (member-facing create route).
+ * - `resolver` — may close/resolve/void markets.
+ * - `manager`  — full control; satisfies every tier.
  */
 
 import { getCachedUserPermissions } from './groups-cache'
 
-export type MarketTier = 'resolver' | 'manager'
+export type MarketTier = 'resolver' | 'manager' | 'creator'
 
-export const MARKET_ROLE_URNS = ['urn:markets:resolver', 'urn:markets:manager'] as const
+export const MARKET_ROLE_URNS = [
+	'urn:markets:resolver',
+	'urn:markets:manager',
+	'urn:markets:creator',
+] as const
 
-/** URNs that satisfy `tier` (manager is a superset of resolver). */
+/** URNs that satisfy `tier` — `manager` is a superset of both `resolver` and `creator`. */
 export function getMarketTierPermissions(tier: MarketTier): string[] {
-	return tier === 'manager'
-		? ['urn:markets:manager']
-		: ['urn:markets:resolver', 'urn:markets:manager']
+	switch (tier) {
+		case 'manager':
+			return ['urn:markets:manager']
+		case 'resolver':
+			return ['urn:markets:resolver', 'urn:markets:manager']
+		case 'creator':
+			return ['urn:markets:creator', 'urn:markets:manager']
+	}
 }
 
 export async function hasMarketPermission(

--- a/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
+++ b/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
@@ -1,0 +1,99 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import predictionMarketsRoutes from '../prediction-markets'
+
+import type { SessionUser } from '../../context'
+
+const mocks = vi.hoisted(() => ({
+	hasMarketPermission: vi.fn(),
+	createAndPublishMarket: vi.fn(),
+}))
+
+// requireAuth → pass-through; the test injects the session user directly.
+vi.mock('../../middleware/session', () => ({
+	requireAuth: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+vi.mock('../../lib/market-permissions', () => ({
+	hasMarketPermission: mocks.hasMarketPermission,
+}))
+// Keep createMarketSchema + mapMarketCreateError real; only stub the write.
+vi.mock('../../services/market-create.service', async (orig) => ({
+	...(await (orig() as Promise<Record<string, unknown>>)),
+	createAndPublishMarket: mocks.createAndPublishMarket,
+}))
+
+function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'user-1',
+		mainCharacterId: 'main-1',
+		sessionId: 'session-1',
+		characters: [],
+		is_admin: false,
+		roles: [],
+		discordUserId: null,
+		...overrides,
+	}
+}
+
+function createApp(user: SessionUser) {
+	const app = new Hono<{ Bindings: any; Variables: { user?: SessionUser; db?: unknown } }>()
+	app.use('*', async (c, next) => {
+		c.set('user', user)
+		c.set('db', {})
+		await next()
+	})
+	app.route('/api/prediction-markets', predictionMarketsRoutes)
+	return app
+}
+
+const futureIso = new Date(Date.now() + 86_400_000).toISOString()
+const validBody = { question: 'Will it rain tomorrow?', outcomes: ['Yes', 'No'], closesAt: futureIso }
+const env = { GROUPS: {}, PREDICTION_MARKETS: {}, DISCORD: {} } as any
+
+function post(app: ReturnType<typeof createApp>, body: unknown) {
+	return app.request(
+		'/api/prediction-markets/markets',
+		{ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
+		env
+	)
+}
+
+describe('member prediction-markets create route', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.createAndPublishMarket.mockResolvedValue({
+			market: { id: 'm1' },
+			post: null,
+			postError: null,
+		})
+	})
+
+	it('403s a user without urn:markets:creator and never creates', async () => {
+		mocks.hasMarketPermission.mockResolvedValue(false)
+		const res = await post(createApp(makeUser()), validBody)
+		expect(res.status).toBe(403)
+		expect(mocks.createAndPublishMarket).not.toHaveBeenCalled()
+	})
+
+	it('creates for a permitted user, with createdBy taken from the session (not the client)', async () => {
+		mocks.hasMarketPermission.mockResolvedValue(true)
+		// Even if the client tries to spoof createdBy, the route ignores it.
+		const res = await post(createApp(makeUser({ id: 'user-1' })), { ...validBody, createdBy: 'evil' })
+		expect(res.status).toBe(201)
+		expect(mocks.hasMarketPermission).toHaveBeenCalledWith(env, 'user-1', 'creator', false)
+		expect(mocks.createAndPublishMarket).toHaveBeenCalledWith(
+			expect.anything(),
+			env,
+			'user-1',
+			expect.objectContaining({ question: 'Will it rain tomorrow?' })
+		)
+	})
+
+	it('400s an invalid body (validation) even when permitted', async () => {
+		mocks.hasMarketPermission.mockResolvedValue(true)
+		const res = await post(createApp(makeUser()), { question: 'x', outcomes: ['only one'] })
+		expect(res.status).toBe(400)
+		expect(mocks.createAndPublishMarket).not.toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/routes/prediction-markets-admin.ts
+++ b/apps/core/src/routes/prediction-markets-admin.ts
@@ -15,13 +15,16 @@ import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { requireAdmin, requireAuth } from '../middleware/session'
-import { publishMarketPost } from '../services/discord-market-post.service'
+import {
+	CREATE_MARKET_BAD_REQUEST_CODES,
+	createAndPublishMarket,
+	createMarketSchema,
+} from '../services/market-create.service'
 import { userCharacters, users } from '../db/schema'
 
 import type { createDb } from '../db'
 import type { App } from '../context'
 import type { Context } from 'hono'
-import type { Discord } from '@repo/discord'
 import type { LedgerType, MarketStatus, PredictionMarkets } from '@repo/prediction-markets'
 
 type CoreDb = ReturnType<typeof createDb>
@@ -37,8 +40,6 @@ app.use('*', requireAuth(), requireAdmin())
 
 const stubOf = (c: Context<App>): PredictionMarkets =>
 	getStub<PredictionMarkets>(c.env.PREDICTION_MARKETS, 'default')
-
-const discordStubOf = (c: Context<App>): Discord => getStub<Discord>(c.env.DISCORD, 'default')
 
 function parsePage(
 	limitRaw: string | undefined,
@@ -102,18 +103,12 @@ function fail(c: Context<App>, error: unknown, what: string) {
 }
 
 /** PM DO error codes that are the caller's fault (bad input) rather than a server error. */
-const BAD_REQUEST_CODES = new Set([
+const BAD_REQUEST_CODES = new Set<string>([
+	// deposit path (grantPoints)
 	'INVALID_AMOUNT',
 	'REASON_REQUIRED',
-	'AT_LEAST_TWO_OUTCOMES',
-	'TOO_MANY_OUTCOMES',
-	'DUPLICATE_OUTCOMES',
-	'QUESTION_REQUIRED',
-	'INVALID_CLOSES_AT',
-	'INVALID_RAKE',
-	'INVALID_MIN_STAKE',
-	'INVALID_MAX_STAKE',
-	'INVALID_PER_USER_CAP',
+	// create path (shared with the member create route)
+	...CREATE_MARKET_BAD_REQUEST_CODES,
 ])
 
 // -------------------------------------------------------------------------
@@ -237,31 +232,6 @@ app.post('/deposits', async (c) => {
 // Markets (create → forum post)
 // -------------------------------------------------------------------------
 
-const positiveIntString = z
-	.string()
-	.regex(/^\d+$/, 'must be a positive integer')
-	.refine((v) => BigInt(v) > 0n, 'must be greater than 0')
-
-const createMarketSchema = z.object({
-	question: z.string().trim().min(3).max(500),
-	description: z.string().trim().max(2000).optional(),
-	outcomes: z
-		.array(z.string().trim().min(1).max(100))
-		.min(2)
-		.max(20)
-		// case-insensitive dedupe: the PM DO rejects DUPLICATE_OUTCOMES the same way
-		.refine((o) => new Set(o.map((s) => s.toLowerCase())).size === o.length, 'outcomes must be distinct'),
-	closesAt: z
-		.string()
-		.datetime()
-		.refine((s) => new Date(s).getTime() > Date.now(), 'closesAt must be in the future'),
-	rakeBps: z.number().int().min(0).max(2000).optional(),
-	minStake: positiveIntString.optional(),
-	maxStake: positiveIntString.optional(),
-	perUserCap: positiveIntString.optional(),
-	twoOfN: z.boolean().optional(),
-})
-
 const MARKET_STATUSES: readonly MarketStatus[] = [
 	'draft',
 	'open',
@@ -293,41 +263,13 @@ app.post('/markets', async (c) => {
 		if (!db) return c.json({ error: 'Database not initialized' }, 500)
 		const user = c.get('user')!
 		const body = createMarketSchema.parse(await c.req.json())
-
-		// Market is source-of-truth first; the forum post is best-effort second.
-		const market = await stubOf(c).createMarket({ createdBy: user.id, ...body })
-
-		let post: { threadId: string; messageId: string } | null = null
-		let postError: string | null = null
-		const guildId = c.env.PM_FORUM_GUILD_ID
-		const categoryId = c.env.PM_FORUM_CATEGORY_ID
-		if (!guildId || !categoryId) {
-			postError = 'PM_FORUM_GUILD_ID / PM_FORUM_CATEGORY_ID not configured'
-		} else {
-			try {
-				post = await publishMarketPost(
-					db,
-					discordStubOf(c),
-					stubOf(c),
-					guildId,
-					categoryId,
-					market
-				)
-			} catch (err) {
-				postError = err instanceof Error ? err.message : String(err)
-				logger.error('[PMAdmin] market forum post failed', {
-					marketId: market.id,
-					error: postError,
-				})
-			}
-		}
-
+		const result = await createAndPublishMarket(db, c.env, user.id, body)
 		logger.info('[PMAdmin] market created', {
 			actorId: user.id,
-			marketId: market.id,
-			posted: Boolean(post),
+			marketId: result.market.id,
+			posted: Boolean(result.post),
 		})
-		return c.json({ market, post, postError }, 201)
+		return c.json(result, 201)
 	} catch (error) {
 		return fail(c, error, 'create market')
 	}

--- a/apps/core/src/routes/prediction-markets.ts
+++ b/apps/core/src/routes/prediction-markets.ts
@@ -1,0 +1,54 @@
+/**
+ * Prediction Markets — member API (non-admin).
+ *
+ * Mounted OUTSIDE /api/admin/* (so it is NOT is_admin-gated). Creation is gated on the
+ * `urn:markets:creator` tier via hasMarketPermission — the permissions path (getUserPermissions),
+ * NOT is_admin and NOT the requireAuth role system. `manager` and site admins also pass. The
+ * create flow itself is shared verbatim with the admin route (market-create.service), so both
+ * stay in lockstep. Client-side gating is cosmetic; this server check is the real gate.
+ */
+
+import { Hono } from 'hono'
+
+import { logger } from '@repo/hono-helpers'
+
+import { hasMarketPermission } from '../lib/market-permissions'
+import { requireAuth } from '../middleware/session'
+import {
+	createAndPublishMarket,
+	createMarketSchema,
+	mapMarketCreateError,
+} from '../services/market-create.service'
+
+import type { App } from '../context'
+
+const app = new Hono<App>()
+
+// A valid session is required for every member endpoint (the per-tier gate is per-route below).
+app.use('*', requireAuth())
+
+// POST /markets — a member with urn:markets:creator (or manager/admin) creates a market. `createdBy`
+// comes from the session, never the client. The creator can neither bet on nor resolve it (enforced
+// in the PM DO: CREATOR_CANNOT_BET / CREATOR_CANNOT_RESOLVE), so open creation is self-dealing-safe.
+app.post('/markets', async (c) => {
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not initialized' }, 500)
+	const user = c.get('user')!
+	if (!(await hasMarketPermission(c.env, user.id, 'creator', user.is_admin))) {
+		return c.json({ error: 'You don’t have permission to create markets' }, 403)
+	}
+	try {
+		const body = createMarketSchema.parse(await c.req.json())
+		const result = await createAndPublishMarket(db, c.env, user.id, body)
+		logger.info('[PMMember] market created', {
+			actorId: user.id,
+			marketId: result.market.id,
+			posted: Boolean(result.post),
+		})
+		return c.json(result, 201)
+	} catch (error) {
+		return mapMarketCreateError(c, error)
+	}
+})
+
+export default app

--- a/apps/core/src/services/market-create.service.ts
+++ b/apps/core/src/services/market-create.service.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared prediction-market creation: validate → createMarket (source of truth) → best-effort
+ * publish the forum post. Used by BOTH the admin route and the member (urn:markets:creator) route
+ * so the two stay in lockstep. Core is the sole Discord orchestrator; the PM DO never calls Discord.
+ */
+
+import { z } from 'zod'
+
+import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
+
+import { publishMarketPost } from './discord-market-post.service'
+
+import type { createDb } from '../db'
+import type { App, Env } from '../context'
+import type { Context } from 'hono'
+import type { Discord } from '@repo/discord'
+import type { MarketDetail, PredictionMarkets } from '@repo/prediction-markets'
+
+type CoreDb = ReturnType<typeof createDb>
+
+/** Bindings + forum config the create flow needs. */
+export type CreateMarketEnv = Pick<
+	Env,
+	'PREDICTION_MARKETS' | 'DISCORD' | 'PM_FORUM_GUILD_ID' | 'PM_FORUM_CATEGORY_ID'
+>
+
+const positiveIntString = z
+	.string()
+	.regex(/^\d+$/, 'must be a positive integer')
+	.refine((v) => BigInt(v) > 0n, 'must be greater than 0')
+
+export const createMarketSchema = z.object({
+	question: z.string().trim().min(3).max(500),
+	description: z.string().trim().max(2000).optional(),
+	outcomes: z
+		.array(z.string().trim().min(1).max(100))
+		.min(2)
+		.max(20)
+		// case-insensitive dedupe: the PM DO rejects DUPLICATE_OUTCOMES the same way.
+		.refine((o) => new Set(o.map((s) => s.toLowerCase())).size === o.length, 'outcomes must be distinct'),
+	closesAt: z
+		.string()
+		.datetime()
+		.refine((s) => new Date(s).getTime() > Date.now(), 'closesAt must be in the future'),
+	rakeBps: z.number().int().min(0).max(2000).optional(),
+	minStake: positiveIntString.optional(),
+	maxStake: positiveIntString.optional(),
+	perUserCap: positiveIntString.optional(),
+	twoOfN: z.boolean().optional(),
+})
+
+export type CreateMarketBody = z.infer<typeof createMarketSchema>
+
+/** createMarket domain errors that are the caller's fault (bad input) → 400, not a server 500. */
+export const CREATE_MARKET_BAD_REQUEST_CODES = [
+	'AT_LEAST_TWO_OUTCOMES',
+	'TOO_MANY_OUTCOMES',
+	'DUPLICATE_OUTCOMES',
+	'QUESTION_REQUIRED',
+	'INVALID_CLOSES_AT',
+	'INVALID_RAKE',
+	'INVALID_MIN_STAKE',
+	'INVALID_MAX_STAKE',
+	'INVALID_PER_USER_CAP',
+] as const
+
+const CREATE_BAD_REQUEST_SET = new Set<string>(CREATE_MARKET_BAD_REQUEST_CODES)
+
+/** Map a create-market error to the right HTTP status (shared by the admin + member routes). */
+export function mapMarketCreateError(c: Context<App>, error: unknown) {
+	if (error instanceof z.ZodError) {
+		return c.json({ error: 'Validation failed', issues: error.issues }, 400)
+	}
+	const msg = error instanceof Error ? error.message : String(error)
+	if (CREATE_BAD_REQUEST_SET.has(msg)) {
+		return c.json({ error: msg }, 400)
+	}
+	logger.error('[MarketCreate] create failed', { error: msg })
+	return c.json({ error: msg }, 500)
+}
+
+export interface CreateMarketResult {
+	market: MarketDetail
+	post: { threadId: string; messageId: string } | null
+	postError: string | null
+}
+
+/**
+ * Create a market (source of truth first), then best-effort publish its forum post. Never throws
+ * for a Discord failure — it surfaces as `postError` (the market already exists, so a post failure
+ * is recoverable, never a lost market). `createdBy` MUST come from the session, never the client.
+ */
+export async function createAndPublishMarket(
+	db: CoreDb,
+	env: CreateMarketEnv,
+	createdBy: string,
+	input: CreateMarketBody
+): Promise<CreateMarketResult> {
+	const prediction = getStub<PredictionMarkets>(env.PREDICTION_MARKETS, 'default')
+	const market = await prediction.createMarket({ createdBy, ...input })
+
+	let post: { threadId: string; messageId: string } | null = null
+	let postError: string | null = null
+	if (!env.PM_FORUM_GUILD_ID || !env.PM_FORUM_CATEGORY_ID) {
+		postError = 'PM_FORUM_GUILD_ID / PM_FORUM_CATEGORY_ID not configured'
+	} else {
+		try {
+			post = await publishMarketPost(
+				db,
+				getStub<Discord>(env.DISCORD, 'default'),
+				prediction,
+				env.PM_FORUM_GUILD_ID,
+				env.PM_FORUM_CATEGORY_ID,
+				market
+			)
+		} catch (err) {
+			postError = err instanceof Error ? err.message : String(err)
+			logger.error('[MarketCreate] forum post failed', { marketId: market.id, error: postError })
+		}
+	}
+	return { market, post, postError }
+}

--- a/apps/ui/src/client/App.tsx
+++ b/apps/ui/src/client/App.tsx
@@ -74,6 +74,9 @@ const HrLegacyHistoryDetailPage = lazy(() => import('./routes/hr-legacy-history-
 const StructuresPage = lazy(() => import('./routes/structures'))
 const StructuresDetailPage = lazy(() => import('./routes/structures-detail'))
 const StructuresConfigPage = lazy(() => import('./routes/structures-config'))
+const PredictionMarketCreatePage = lazy(
+	() => import('./features/prediction-markets/routes/prediction-market-create')
+)
 
 // Lazy load the Skill Plans feature for code splitting
 const TrackingSessionsList = lazy(
@@ -297,6 +300,7 @@ export default function App() {
 							/>
 							<Route path="/my-groups" element={<MyGroupsPage />} />
 							<Route path="/mumble" element={<MumblePage />} />
+							<Route path="/prediction-markets" element={<PredictionMarketCreatePage />} />
 							<Route path="/pastes" element={<PastesPage />} />
 							<Route path="/pastes/:id/edit" element={<PasteEditPage />} />
 

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -442,6 +442,15 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 			icon: FileText,
 		})
 
+		// Prediction markets: visible to anyone who can create one (managers + admins also pass).
+		if (hasAnyPermission('urn:markets:creator', 'urn:markets:manager')) {
+			navItems.push({
+				label: 'Prediction Markets',
+				href: '/prediction-markets',
+				icon: CircleDollarSign,
+			})
+		}
+
 		const externalLinkChildren = resolvedSidebarExternalLinks.map((link) => ({
 			label: link.displayName,
 			href: link.url,

--- a/apps/ui/src/client/features/prediction-markets/api.ts
+++ b/apps/ui/src/client/features/prediction-markets/api.ts
@@ -113,3 +113,13 @@ export async function getMarkets(filters?: MarketsFilters): Promise<MarketsRespo
 export async function createMarket(body: CreateMarketRequest): Promise<CreateMarketResponse> {
 	return apiClient.post<CreateMarketResponse>(`${BASE}/markets`, body)
 }
+
+/**
+ * Member (non-admin) create — the /api/prediction-markets router, gated on urn:markets:creator.
+ * Same request/response shape as the admin create; different endpoint + permission.
+ */
+export async function createMarketAsMember(
+	body: CreateMarketRequest
+): Promise<CreateMarketResponse> {
+	return apiClient.post<CreateMarketResponse>('/prediction-markets/markets', body)
+}

--- a/apps/ui/src/client/features/prediction-markets/components/create-market-dialog.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/create-market-dialog.tsx
@@ -49,11 +49,13 @@ const schema = z.object({
 export interface CreateMarketDialogProps {
 	open: boolean
 	onOpenChange: (open: boolean) => void
+	/** Which endpoint to create through: 'admin' (default) or 'member' (urn:markets:creator). */
+	scope?: 'admin' | 'member'
 }
 
 const digitsOnly = (v: string) => v.replace(/\D/g, '')
 
-export function CreateMarketDialog({ open, onOpenChange }: CreateMarketDialogProps) {
+export function CreateMarketDialog({ open, onOpenChange, scope = 'admin' }: CreateMarketDialogProps) {
 	const [question, setQuestion] = useState('')
 	const [description, setDescription] = useState('')
 	const [outcomes, setOutcomes] = useState<string[]>(['Yes', 'No'])
@@ -64,7 +66,7 @@ export function CreateMarketDialog({ open, onOpenChange }: CreateMarketDialogPro
 	const [perUserCap, setPerUserCap] = useState('')
 	const [twoOfN, setTwoOfN] = useState(false)
 
-	const create = useCreateMarket()
+	const create = useCreateMarket(scope)
 
 	useEffect(() => {
 		if (open) {

--- a/apps/ui/src/client/features/prediction-markets/hooks.ts
+++ b/apps/ui/src/client/features/prediction-markets/hooks.ts
@@ -5,6 +5,7 @@ import { useApiMutation } from '@/hooks/useApiMutation'
 import {
 	createDeposit,
 	createMarket,
+	createMarketAsMember,
 	getAuditLedger,
 	getMarketHistory,
 	getMarkets,
@@ -87,11 +88,12 @@ export function useMarkets(filters?: MarketsFilters) {
  * POST /markets — creates the market + best-effort forum post. Toasts on success (noting
  * a `postError` if the post failed), invalidates the markets list.
  */
-export function useCreateMarket() {
+export function useCreateMarket(scope: 'admin' | 'member' = 'admin') {
 	const queryClient = useQueryClient()
+	const submit = scope === 'member' ? createMarketAsMember : createMarket
 
 	return useApiMutation({
-		mutationFn: (body: CreateMarketRequest) => createMarket(body),
+		mutationFn: (body: CreateMarketRequest) => submit(body),
 		successMessage: (res) =>
 			res.postError
 				? `Market created, but the forum post failed: ${res.postError}`

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-create.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-create.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { useUserPermissions } from '@/hooks/useUserPermissions'
+
+import { CreateMarketDialog } from '../components/create-market-dialog'
+
+/**
+ * Member-facing market creation. Gated on `urn:markets:creator` (managers + site admins also pass);
+ * this is cosmetic — the /api/prediction-markets/markets route is the real gate. Created markets are
+ * posted to the predictions forum channel where members bet and a resolver settles them.
+ */
+export default function PredictionMarketCreate() {
+	usePageTitle('Prediction Markets')
+	const [createOpen, setCreateOpen] = useState(false)
+	const { hasAnyPermission } = useUserPermissions()
+	const canCreate = hasAnyPermission('urn:markets:creator', 'urn:markets:manager')
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="text-3xl font-bold gradient-text">Prediction Markets</h1>
+					<p className="mt-1 max-w-2xl text-muted-foreground">
+						Create a market for the community. It’s posted to the predictions forum channel, where
+						members place bets and a resolver settles it. You can’t bet on or resolve a market you
+						create.
+					</p>
+				</div>
+				{canCreate ? (
+					<Button variant="primary" onClick={() => setCreateOpen(true)}>
+						New market
+					</Button>
+				) : null}
+			</div>
+
+			{!canCreate ? (
+				<p className="text-sm text-muted-foreground">
+					You don’t have permission to create prediction markets. Ask an admin for the “markets
+					creator” role.
+				</p>
+			) : null}
+
+			<CreateMarketDialog open={createOpen} onOpenChange={setCreateOpen} scope="member" />
+		</div>
+	)
+}


### PR DESCRIPTION
## What

Lets a permissioned (non-admin) user create prediction markets, gated on a new `urn:markets:creator` tier. Previously creation was admin-only. This is the **Phase 1 MVP** from the feasibility research.

It leans entirely on existing invariants — the PM DO enforces `CREATOR_CANNOT_BET` + `CREATOR_CANNOT_RESOLVE` regardless of who created the market — so opening creation is **self-dealing-safe** (a creator can neither bet on nor resolve their own market).

## Changes

**Backend**
- **`market-permissions.ts`** — new `creator` tier (`manager` is a superset; `is_admin` bypasses). `MARKET_ROLE_URNS` has no consumer beyond its own declaration, so no existing gate is broadened.
- **`services/market-create.service.ts`** (new) — extracts the create+publish flow (`createMarketSchema`, `createAndPublishMarket`, `mapMarketCreateError`) so the admin and member routes stay in lockstep. The admin route is refactored onto it with **no behavior change**.
- **`routes/prediction-markets.ts`** (new) — `POST /api/prediction-markets/markets`, mounted **outside** `/api/admin/*` so permissions load; gated on `hasMarketPermission('creator')`. `createdBy` comes from the session, never the client (zod strips unknown keys → no mass-assignment).

**UI**
- Gated member page + sidebar nav (`hasAnyPermission('urn:markets:creator', 'urn:markets:manager')`; admins bypass), reusing `CreateMarketDialog` via a `scope='member'` hook that hits the member endpoint, with self-exclusion copy.

## Verification

- Typecheck green (core + PM app/pkg + UI); **39 core PM + 18 PM-pkg tests** pass; lint clean.
- New route tests: 403 without the tier, 201 with it (`createdBy` from session), 400 on invalid body.
- **Adversarial security review: 0 confirmed defects** — no gate bypass, no mass-assignment, `createdBy` server-authoritative, no privilege broadening, faithful refactor.

## Operational prereq (before it works in prod)

Create the `urn:markets:creator` permission and grant it to a group via the admin UI (exactly like `urn:markets:resolver`).

## Deferred to Phase 2/3

Dedicated-tier catalog registration, per-user creation rate limit (reuse `pm_rate_limits`), economic-param clamping for lower-trust creators, content moderation for public forum text, and a "resolver pool must exceed {creator}" operational check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude:begin -->
## Summary

Allows a permissioned non-admin user to create prediction markets, gated on a new `urn:markets:creator` permission tier (previously creation was admin-only). Creation is self-dealing-safe: the PM Durable Object already blocks the creator from betting on or resolving their own market.

## Changes

- **`lib/market-permissions.ts`** — adds a `creator` tier to `MarketTier` / `MARKET_ROLE_URNS`; `manager` is a superset and `is_admin` bypasses.
- **`services/market-create.service.ts`** (new) — extracts the shared create+publish flow (`createMarketSchema`, `createAndPublishMarket`, `mapMarketCreateError`, `CREATE_MARKET_BAD_REQUEST_CODES`) used by both admin and member routes.
- **`routes/prediction-markets.ts`** (new) — member `POST /api/prediction-markets/markets`, mounted outside `/api/admin/*` and gated on `hasMarketPermission('creator')`; `createdBy` is taken from the session, not the client.
- **`routes/prediction-markets-admin.ts`** — refactored onto the shared service (no behavior change); `BAD_REQUEST_CODES` now reuses the shared create codes.
- **`index.ts`** — registers the new `/api/prediction-markets` router.
- **UI** — new gated `/prediction-markets` member page + sidebar nav entry (`urn:markets:creator`/`urn:markets:manager`), a `createMarketAsMember` API call, and a `scope` prop on `CreateMarketDialog`/`useCreateMarket` to target the member endpoint.

## Testing

- New `prediction-markets.member.route.test.ts`: 403 without the tier (and no create call), 201 when permitted with `createdBy` sourced from the session (client spoof ignored), and 400 on an invalid body.
<!-- claude:end -->
