### PR TITLE
feat(prediction-markets): rate-limit member market creation (Phase 2 guardrail)

### DIFF
--- a/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
+++ b/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
@@ -76,7 +76,7 @@ describe('member prediction-markets create route', () => {
 		expect(mocks.createAndPublishMarket).not.toHaveBeenCalled()
 	})
 
-	it('creates for a permitted user, with createdBy taken from the session (not the client)', async () => {
+	it('creates for a permitted user, createdBy from session, rate-limited for a non-admin', async () => {
 		mocks.hasMarketPermission.mockResolvedValue(true)
 		// Even if the client tries to spoof createdBy, the route ignores it.
 		const res = await post(createApp(makeUser({ id: 'user-1' })), { ...validBody, createdBy: 'evil' })
@@ -86,8 +86,29 @@ describe('member prediction-markets create route', () => {
 			expect.anything(),
 			env,
 			'user-1',
-			expect.objectContaining({ question: 'Will it rain tomorrow?' })
+			expect.objectContaining({ question: 'Will it rain tomorrow?' }),
+			{ enforceRateLimit: true }
 		)
+	})
+
+	it('does not rate-limit a site admin using the member route', async () => {
+		mocks.hasMarketPermission.mockResolvedValue(true)
+		await post(createApp(makeUser({ is_admin: true })), validBody)
+		expect(mocks.createAndPublishMarket).toHaveBeenCalledWith(
+			expect.anything(),
+			env,
+			'user-1',
+			expect.anything(),
+			{ enforceRateLimit: false }
+		)
+	})
+
+	it('429s when the per-user creation rate budget is exhausted', async () => {
+		mocks.hasMarketPermission.mockResolvedValue(true)
+		mocks.createAndPublishMarket.mockRejectedValue(new Error('RATE_LIMITED:5000'))
+		const res = await post(createApp(makeUser()), validBody)
+		expect(res.status).toBe(429)
+		expect(await res.json()).toMatchObject({ retryAfterMs: 5000 })
 	})
 
 	it('400s an invalid body (validation) even when permitted', async () => {

--- a/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
+++ b/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
@@ -69,15 +69,23 @@ describe('member prediction-markets create route', () => {
 		})
 	})
 
+	// hasMarketPermission is called per-tier: ('creator') gates the route, ('manager') picks the
+	// schema + rate-limit exemption. Resolve per the tier argument.
+	function mockTiers(creator: boolean, manager: boolean) {
+		mocks.hasMarketPermission.mockImplementation((_env, _userId, tier) =>
+			Promise.resolve(tier === 'manager' ? manager : creator)
+		)
+	}
+
 	it('403s a user without urn:markets:creator and never creates', async () => {
-		mocks.hasMarketPermission.mockResolvedValue(false)
+		mockTiers(false, false)
 		const res = await post(createApp(makeUser()), validBody)
 		expect(res.status).toBe(403)
 		expect(mocks.createAndPublishMarket).not.toHaveBeenCalled()
 	})
 
-	it('creates for a permitted user, createdBy from session, rate-limited for a non-admin', async () => {
-		mocks.hasMarketPermission.mockResolvedValue(true)
+	it('creator (non-manager): 201, createdBy from session, rate-limited', async () => {
+		mockTiers(true, false)
 		// Even if the client tries to spoof createdBy, the route ignores it.
 		const res = await post(createApp(makeUser({ id: 'user-1' })), { ...validBody, createdBy: 'evil' })
 		expect(res.status).toBe(201)
@@ -91,20 +99,30 @@ describe('member prediction-markets create route', () => {
 		)
 	})
 
-	it('does not rate-limit a site admin using the member route', async () => {
-		mocks.hasMarketPermission.mockResolvedValue(true)
-		await post(createApp(makeUser({ is_admin: true })), validBody)
+	it('creator: slim schema strips economic params (they default from config)', async () => {
+		mockTiers(true, false)
+		await post(createApp(makeUser()), { ...validBody, rakeBps: 1500, minStake: '50', twoOfN: true })
+		const body = mocks.createAndPublishMarket.mock.calls[0][3]
+		expect(body).not.toHaveProperty('rakeBps')
+		expect(body).not.toHaveProperty('minStake')
+		expect(body).not.toHaveProperty('twoOfN')
+		expect(body).toMatchObject({ question: 'Will it rain tomorrow?' })
+	})
+
+	it('manager/admin: full schema, uncapped (economic params pass through)', async () => {
+		mockTiers(true, true)
+		await post(createApp(makeUser()), { ...validBody, rakeBps: 1500 })
 		expect(mocks.createAndPublishMarket).toHaveBeenCalledWith(
 			expect.anything(),
 			env,
 			'user-1',
-			expect.anything(),
+			expect.objectContaining({ rakeBps: 1500 }),
 			{ enforceRateLimit: false }
 		)
 	})
 
 	it('429s when the per-user creation rate budget is exhausted', async () => {
-		mocks.hasMarketPermission.mockResolvedValue(true)
+		mockTiers(true, false)
 		mocks.createAndPublishMarket.mockRejectedValue(new Error('RATE_LIMITED:5000'))
 		const res = await post(createApp(makeUser()), validBody)
 		expect(res.status).toBe(429)
@@ -112,7 +130,7 @@ describe('member prediction-markets create route', () => {
 	})
 
 	it('400s an invalid body (validation) even when permitted', async () => {
-		mocks.hasMarketPermission.mockResolvedValue(true)
+		mockTiers(true, true)
 		const res = await post(createApp(makeUser()), { question: 'x', outcomes: ['only one'] })
 		expect(res.status).toBe(400)
 		expect(mocks.createAndPublishMarket).not.toHaveBeenCalled()

--- a/apps/core/src/routes/prediction-markets.ts
+++ b/apps/core/src/routes/prediction-markets.ts
@@ -39,7 +39,11 @@ app.post('/markets', async (c) => {
 	}
 	try {
 		const body = createMarketSchema.parse(await c.req.json())
-		const result = await createAndPublishMarket(db, c.env, user.id, body)
+		// Rate-limit non-admin member creation so a creator can't flood the forum; site admins
+		// using this route are uncapped (they're fully trusted and could use the admin route anyway).
+		const result = await createAndPublishMarket(db, c.env, user.id, body, {
+			enforceRateLimit: !user.is_admin,
+		})
 		logger.info('[PMMember] market created', {
 			actorId: user.id,
 			marketId: result.market.id,

--- a/apps/core/src/routes/prediction-markets.ts
+++ b/apps/core/src/routes/prediction-markets.ts
@@ -16,6 +16,7 @@ import { hasMarketPermission } from '../lib/market-permissions'
 import { requireAuth } from '../middleware/session'
 import {
 	createAndPublishMarket,
+	createMarketCreatorSchema,
 	createMarketSchema,
 	mapMarketCreateError,
 } from '../services/market-create.service'
@@ -37,12 +38,15 @@ app.post('/markets', async (c) => {
 	if (!(await hasMarketPermission(c.env, user.id, 'creator', user.is_admin))) {
 		return c.json({ error: 'You don’t have permission to create markets' }, 403)
 	}
+	// Trust tiers: managers/admins get the full param set and are uncapped; a lower-trust
+	// creator gets the slim schema (economic params default from pmConfig) and is rate-limited so
+	// they can't distort the parimutuel/rake economy or flood the forum.
+	const isManager = await hasMarketPermission(c.env, user.id, 'manager', user.is_admin)
 	try {
-		const body = createMarketSchema.parse(await c.req.json())
-		// Rate-limit non-admin member creation so a creator can't flood the forum; site admins
-		// using this route are uncapped (they're fully trusted and could use the admin route anyway).
+		const schema = isManager ? createMarketSchema : createMarketCreatorSchema
+		const body = schema.parse(await c.req.json())
 		const result = await createAndPublishMarket(db, c.env, user.id, body, {
-			enforceRateLimit: !user.is_admin,
+			enforceRateLimit: !isManager,
 		})
 		logger.info('[PMMember] market created', {
 			actorId: user.id,

--- a/apps/core/src/services/market-create.service.ts
+++ b/apps/core/src/services/market-create.service.ts
@@ -52,6 +52,19 @@ export const createMarketSchema = z.object({
 
 export type CreateMarketBody = z.infer<typeof createMarketSchema>
 
+/**
+ * Slim schema for lower-trust `urn:markets:creator` users: question/outcomes/close only. The
+ * economic params (rakeBps, min/max stake, per-user cap, twoOfN) are omitted — a creator can't set
+ * them (zod strips any that are sent), so they fall back to the pmConfig defaults in createMarket.
+ * Managers/admins use the full createMarketSchema. Its output is a subset of CreateMarketBody.
+ */
+export const createMarketCreatorSchema = createMarketSchema.pick({
+	question: true,
+	description: true,
+	outcomes: true,
+	closesAt: true,
+})
+
 /** createMarket domain errors that are the caller's fault (bad input) → 400, not a server 500. */
 export const CREATE_MARKET_BAD_REQUEST_CODES = [
 	'AT_LEAST_TWO_OUTCOMES',

--- a/apps/core/src/services/market-create.service.ts
+++ b/apps/core/src/services/market-create.service.ts
@@ -67,12 +67,19 @@ export const CREATE_MARKET_BAD_REQUEST_CODES = [
 
 const CREATE_BAD_REQUEST_SET = new Set<string>(CREATE_MARKET_BAD_REQUEST_CODES)
 
-/** Map a create-market error to the right HTTP status (shared by the admin + member routes). */
+/** Map a create-market error to the right HTTP status (used by the member create route). */
 export function mapMarketCreateError(c: Context<App>, error: unknown) {
 	if (error instanceof z.ZodError) {
 		return c.json({ error: 'Validation failed', issues: error.issues }, 400)
 	}
 	const msg = error instanceof Error ? error.message : String(error)
+	if (msg.startsWith('RATE_LIMITED')) {
+		const retryAfterMs = Number(msg.split(':')[1]) || 0
+		return c.json(
+			{ error: 'You’re creating markets too fast — try again shortly.', retryAfterMs },
+			429
+		)
+	}
 	if (CREATE_BAD_REQUEST_SET.has(msg)) {
 		return c.json({ error: msg }, 400)
 	}
@@ -95,10 +102,15 @@ export async function createAndPublishMarket(
 	db: CoreDb,
 	env: CreateMarketEnv,
 	createdBy: string,
-	input: CreateMarketBody
+	input: CreateMarketBody,
+	opts?: { enforceRateLimit?: boolean }
 ): Promise<CreateMarketResult> {
 	const prediction = getStub<PredictionMarkets>(env.PREDICTION_MARKETS, 'default')
-	const market = await prediction.createMarket({ createdBy, ...input })
+	const market = await prediction.createMarket({
+		createdBy,
+		...input,
+		enforceRateLimit: opts?.enforceRateLimit,
+	})
 
 	let post: { threadId: string; messageId: string } | null = null
 	let postError: string | null = null

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -595,6 +595,14 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			throw new Error('INVALID_PER_USER_CAP')
 		}
 
+		// Rate limit member-created markets (opt-in per request; admin creation is uncapped). Consume
+		// the budget after input validation but before any write; a rejected create still counts
+		// (anti-spam), same as placeBet. `create_market` throttles the public forum-post fan-out.
+		if (input.enforceRateLimit) {
+			const rate = await this.consumeRateBudget(input.createdBy, 'create_market')
+			if (!rate.allowed) throw new Error(`RATE_LIMITED:${rate.retryAfterMs}`)
+		}
+
 		try {
 			return await this.db.transaction(async (tx) => {
 				const [cfg] = await tx

--- a/apps/prediction-markets/src/lib/rate-limit.ts
+++ b/apps/prediction-markets/src/lib/rate-limit.ts
@@ -11,9 +11,14 @@ export interface RateBudget {
 	windowMs: number
 }
 
-/** Per-command budgets. Bets are the spammable path; other commands aren't rate-limited yet. */
+/**
+ * Per-command budgets. Bets are the spammable member path; `create_market` throttles member-created
+ * markets (each spawns a public forum post) so a creator-tier user can't flood the channel. Admin
+ * creation is uncapped (the caller opts in per-request). Other commands aren't rate-limited yet.
+ */
 export const RATE_BUDGETS: Record<string, RateBudget> = {
 	bet: { limit: 5, windowMs: 10_000 },
+	create_market: { limit: 10, windowMs: 3_600_000 }, // 10 markets/hour per user
 }
 
 export interface RateState {

--- a/apps/ui/src/client/features/prediction-markets/components/create-market-dialog.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/create-market-dialog.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
 import { Plus, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { z } from 'zod'
 
+import { Button } from '@/components/ui/button'
 import {
 	Dialog,
 	DialogContent,
@@ -10,7 +11,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -51,11 +51,22 @@ export interface CreateMarketDialogProps {
 	onOpenChange: (open: boolean) => void
 	/** Which endpoint to create through: 'admin' (default) or 'member' (urn:markets:creator). */
 	scope?: 'admin' | 'member'
+	/**
+	 * Show the economic params (rake / stakes / cap / two-of-N). Default true. Hidden for a
+	 * lower-trust `urn:markets:creator` — the server strips those anyway and defaults from config,
+	 * so showing them would just be ignored input.
+	 */
+	showAdvanced?: boolean
 }
 
 const digitsOnly = (v: string) => v.replace(/\D/g, '')
 
-export function CreateMarketDialog({ open, onOpenChange, scope = 'admin' }: CreateMarketDialogProps) {
+export function CreateMarketDialog({
+	open,
+	onOpenChange,
+	scope = 'admin',
+	showAdvanced = true,
+}: CreateMarketDialogProps) {
 	const [question, setQuestion] = useState('')
 	const [description, setDescription] = useState('')
 	const [outcomes, setOutcomes] = useState<string[]>(['Yes', 'No'])
@@ -217,71 +228,75 @@ export function CreateMarketDialog({ open, onOpenChange, scope = 'admin' }: Crea
 						/>
 					</div>
 
-					<div className="grid grid-cols-2 gap-3">
-						<div className="space-y-2">
-							<Label htmlFor="pm-rake">Rake (bps, optional)</Label>
-							<Input
-								id="pm-rake"
-								type="text"
-								inputMode="numeric"
-								placeholder="default"
-								value={rakeBps}
-								onChange={(e) => setRakeBps(digitsOnly(e.target.value))}
-								disabled={create.isPending}
-							/>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="pm-min">Min stake (optional)</Label>
-							<Input
-								id="pm-min"
-								type="text"
-								inputMode="numeric"
-								placeholder="default"
-								value={minStake}
-								onChange={(e) => setMinStake(digitsOnly(e.target.value))}
-								disabled={create.isPending}
-							/>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="pm-max">Max stake (optional)</Label>
-							<Input
-								id="pm-max"
-								type="text"
-								inputMode="numeric"
-								placeholder="none"
-								value={maxStake}
-								onChange={(e) => setMaxStake(digitsOnly(e.target.value))}
-								disabled={create.isPending}
-							/>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="pm-cap">Per-user cap (optional)</Label>
-							<Input
-								id="pm-cap"
-								type="text"
-								inputMode="numeric"
-								placeholder="none"
-								value={perUserCap}
-								onChange={(e) => setPerUserCap(digitsOnly(e.target.value))}
-								disabled={create.isPending}
-							/>
-						</div>
-					</div>
+					{showAdvanced ? (
+						<>
+							<div className="grid grid-cols-2 gap-3">
+								<div className="space-y-2">
+									<Label htmlFor="pm-rake">Rake (bps, optional)</Label>
+									<Input
+										id="pm-rake"
+										type="text"
+										inputMode="numeric"
+										placeholder="default"
+										value={rakeBps}
+										onChange={(e) => setRakeBps(digitsOnly(e.target.value))}
+										disabled={create.isPending}
+									/>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="pm-min">Min stake (optional)</Label>
+									<Input
+										id="pm-min"
+										type="text"
+										inputMode="numeric"
+										placeholder="default"
+										value={minStake}
+										onChange={(e) => setMinStake(digitsOnly(e.target.value))}
+										disabled={create.isPending}
+									/>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="pm-max">Max stake (optional)</Label>
+									<Input
+										id="pm-max"
+										type="text"
+										inputMode="numeric"
+										placeholder="none"
+										value={maxStake}
+										onChange={(e) => setMaxStake(digitsOnly(e.target.value))}
+										disabled={create.isPending}
+									/>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="pm-cap">Per-user cap (optional)</Label>
+									<Input
+										id="pm-cap"
+										type="text"
+										inputMode="numeric"
+										placeholder="none"
+										value={perUserCap}
+										onChange={(e) => setPerUserCap(digitsOnly(e.target.value))}
+										disabled={create.isPending}
+									/>
+								</div>
+							</div>
 
-					<div className="flex items-center justify-between rounded-md border border-border p-3">
-						<div>
-							<Label htmlFor="pm-twoofn">Require two-of-N resolution</Label>
-							<p className="text-xs text-muted-foreground">
-								A second resolver must approve before this market resolves.
-							</p>
-						</div>
-						<Switch
-							id="pm-twoofn"
-							checked={twoOfN}
-							onCheckedChange={setTwoOfN}
-							disabled={create.isPending}
-						/>
-					</div>
+							<div className="flex items-center justify-between rounded-md border border-border p-3">
+								<div>
+									<Label htmlFor="pm-twoofn">Require two-of-N resolution</Label>
+									<p className="text-xs text-muted-foreground">
+										A second resolver must approve before this market resolves.
+									</p>
+								</div>
+								<Switch
+									id="pm-twoofn"
+									checked={twoOfN}
+									onCheckedChange={setTwoOfN}
+									disabled={create.isPending}
+								/>
+							</div>
+						</>
+					) : null}
 
 					<DialogFooter>
 						<Button

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-create.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-create.tsx
@@ -16,6 +16,9 @@ export default function PredictionMarketCreate() {
 	const [createOpen, setCreateOpen] = useState(false)
 	const { hasAnyPermission } = useUserPermissions()
 	const canCreate = hasAnyPermission('urn:markets:creator', 'urn:markets:manager')
+	// Managers/admins get the full param set; a lower-trust creator sees only question/outcomes/close
+	// (economic params default from config server-side).
+	const isManager = hasAnyPermission('urn:markets:manager')
 
 	return (
 		<div className="space-y-6">
@@ -42,7 +45,12 @@ export default function PredictionMarketCreate() {
 				</p>
 			) : null}
 
-			<CreateMarketDialog open={createOpen} onOpenChange={setCreateOpen} scope="member" />
+			<CreateMarketDialog
+				open={createOpen}
+				onOpenChange={setCreateOpen}
+				scope="member"
+				showAdvanced={isManager}
+			/>
 		</div>
 	)
 }

--- a/docs/prediction-markets-content-moderation.md
+++ b/docs/prediction-markets-content-moderation.md
@@ -1,0 +1,203 @@
+# Prediction Markets — Content Moderation (Design)
+
+**Status:** Draft / Proposed
+**Date:** 2026-07-07
+**Scope:** Moderating the free-text content of member-created prediction markets.
+**Related:** non-admin market creation (PR #463), creation guardrails — rate limit + economic-param clamping (PR #464). This doc covers the remaining `Phase 3` guardrail.
+
+---
+
+## Table of Contents
+
+- [Context & Problem](#context--problem)
+- [Goals / Non-Goals](#goals--non-goals)
+- [What Exists Today](#what-exists-today)
+- [Options Considered](#options-considered)
+- [Recommendation](#recommendation)
+- [Implementation Sketch](#implementation-sketch)
+- [Phasing](#phasing)
+- [Open Decisions](#open-decisions)
+- [Risks & Limitations](#risks--limitations)
+- [Future Work](#future-work)
+
+---
+
+## Context & Problem
+
+Members holding the `urn:markets:creator` tier can now create prediction markets (PR #463). A market's
+**free-text `question`, `description`, and `outcome` labels** are posted **immediately** to a public
+forum channel — `createMarket` sets `status: 'open'` (`apps/prediction-markets/src/durable-object.ts`),
+and `createAndPublishMarket` publishes the forum thread synchronously. There is **no review gate**.
+
+**Risk:** offensive, abusive, harassing, NSFW, or doxxing text reaches the channel before any moderator
+sees it.
+
+**Mitigating context that shapes the right answer:**
+
+- Creators are an **admin-granted, semi-trusted cohort** — not the open internet.
+- The forum is an **internal** corp/alliance Discord (known membership).
+- Every market is **attributable** (`createdBy`) and the **creator tier is revocable**.
+
+That argues against heavy prevention machinery and for **fast, clean takedown + accountability** as the
+primary control, with cheap prevention as a speed bump.
+
+---
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Give moderators a fast, clean way to **remove** an inappropriate market (text gone from the channel,
+  bettors refunded, action audited).
+- Catch the **obvious** bad content automatically, at create time, without friction for clean content.
+- Preserve the existing trust hierarchy: managers/admins are unaffected; only lower-trust `creator`
+  submissions are filtered.
+
+**Non-Goals (v1)**
+
+- Perfect prevention of all inappropriate text (infeasible for free text; see [Limitations](#risks--limitations)).
+- A full pre-publish moderation queue (kept as an optional escalation, not the default).
+- AI/ML moderation (a clean future upgrade behind the same seam).
+
+---
+
+## What Exists Today
+
+| Capability | State | Relevance |
+| --- | --- | --- |
+| `draft` market status + `draft → open` / `draft → voided` transitions | Exists (`lib/state-machine.ts`), unused by `createMarket` | Enables a pre-publish review path if we ever want Option 2 |
+| `voidMarket` | Refunds all bets, archives + locks the thread, applies the Voided tag | **Not a takedown** — the offensive text stays visible in the archived thread |
+| Discord DO forum methods | `createMarketForumPost`, `updateMarketPostMessage`, `lockThread`, `deleteMessage` | No `deleteThread` yet — a real takedown needs `DELETE /channels/{threadId}` |
+| `urn:markets:manager` tier + P3 forum-button pattern | Exists | The moderator role + the UI pattern to hang a "Remove" button on |
+| Audit log (`pm_market_history`, `visibility: 'internal'`) | Exists | Where takedowns/rejections get recorded |
+
+Key gap: **Void ≠ takedown.** Void keeps the thread (locked/archived); removing offensive content
+requires deleting the thread channel.
+
+---
+
+## Options Considered
+
+| # | Option | Prevents bad content? | Creator friction | Effort |
+| --- | --- | --- | --- | --- |
+| 1 | **Reactive takedown only** | No — removes after the fact | None | Low–Med |
+| 2 | **Pre-publish approval** (`draft` → manager approves → publish) | Yes — nothing publishes unreviewed | High (every market waits on a human) | Med–High |
+| 3 | **Automated filter at create** (blocklist / AI moderation) | Partial — catches the obvious | None for clean text | Med |
+| 4 | **Hybrid: cheap auto-filter + reactive takedown** | Catches obvious + removes the rest fast | None | Med |
+
+---
+
+## Recommendation
+
+**Option 4 — Hybrid (cheap automated pre-filter + reactive takedown).**
+
+Full pre-publish approval (Option 2) is real friction and a moderation queue that is overkill *until abuse
+actually materializes* in a semi-trusted, known-membership community. The pragmatic stack:
+
+**A. Cheap automated pre-filter (create time, creators only).** A configurable **blocklist**
+(case-insensitive, word-boundary phrases) applied to `question` + `description` + `outcomes` inside the
+create flow; reject with a coded error → HTTP 400. Managers/admins bypass (same tier split as the
+economic-param clamping). A list, **not** an AI call, for v1 — no latency/cost/external dependency.
+
+**B. Reactive takedown — the actual backstop (manager-gated).** A **"Remove market"** action distinct
+from Void: void the market (refund everyone — reuse `voidMarket`) **and delete the Discord thread** so the
+text is gone, not just locked. Audit-logged with moderator + reason.
+
+**C. Report affordance (optional).** A "Report" button on the post (visible to all) that logs a report /
+pings the manager group, so the community flags what moderators miss.
+
+**D. Accountability (already present, the real deterrent).** Markets are attributable and the creator tier
+is revocable; combined with fast takedown, a repeat offender loses the ability to create. In a
+known-membership community this deters abuse more than any text filter.
+
+---
+
+## Implementation Sketch
+
+### A. Blocklist pre-filter
+
+- Add `moderateMarketText({ question, description, outcomes })` (pure, unit-testable) that scans for
+  blocklisted phrases (case-insensitive, `\b` word boundaries) and returns the first offending term or
+  `null`.
+- Call it in the **member create path only** (creators; managers/admins bypass, mirroring the tier split
+  already in `apps/core/src/routes/prediction-markets.ts`). On a hit, throw/return a coded
+  `MARKET_CONTENT_REJECTED` → 400 with a generic "your market contains disallowed content" message (do
+  **not** echo the matched term).
+- **Blocklist source:** see [Open Decisions](#open-decisions) — a core `vars` entry or a small config row
+  is preferred over a code constant so it's tunable without a deploy.
+
+### B. Takedown (highest value — build first)
+
+- **Discord DO:** new `deleteThread(threadId): Promise<{ success; error? }>` → `DELETE /channels/{threadId}`
+  (mirrors the other forum methods; best-effort with `{success,error}`).
+- **Core service:** a `removeMarket(db, env, actorUserId, marketId, reason)` that:
+  1. `voidMarket({ actorUserId, marketId, reason })` (refunds; reuses the existing, adversarially-reviewed
+     void path);
+  2. `deleteThread(discordThreadId)` (best-effort — the void already stands if Discord fails);
+  3. logs a `pm_market_history` row (`action: 'removed'`, `visibility: 'internal'`, moderator + reason).
+- **Permission gate:** `hasMarketPermission(env, userId, 'manager', isAdmin)` (managers/admins only), same
+  server-side pattern as the resolver gate in `discord-components.service.ts`.
+- **Surfaces (reuse existing patterns):**
+  - a manager **"Remove" button** on the forum post (P3 button pattern — `mkt:remove:<marketId>` custom id,
+    deferred component, opens a reason modal); and/or
+  - a **Remove action** in the admin/manager markets UI.
+
+### C. Report button (optional)
+
+- A `Report` button (visible to all) on the post → records a lightweight report (a history row or a ping
+  to the manager group). No refund/state change. Low effort; defer if not needed.
+
+### Audit & error hygiene
+
+- Takedown/rejection are **expected** outcomes — add `MARKET_CONTENT_REJECTED` to the create path's
+  bad-request set (400, not 500) and keep takedown errors out of Sentry (like the existing resolver
+  expected-error allowlist).
+
+---
+
+## Phasing
+
+1. **Takedown** (B) — the highest-value piece; gives moderators real teeth immediately. `deleteThread` +
+   `removeMarket` + a manager-gated button, audit-logged.
+2. **Blocklist filter** (A) — cheap add once the create seam exists.
+3. **Report button** (C) — optional.
+4. **Pre-publish approval** (Option 2) — only if reactive moderation proves insufficient; a larger,
+   separate effort built on the existing `draft` state (create-as-draft for creators → manager review
+   queue → approve/publish or reject).
+
+---
+
+## Open Decisions
+
+1. **First pass: takedown alone, or takedown + blocklist?** (Recommended: both — B then A.)
+2. **Where is the blocklist configured?** Options: a code constant (simplest, needs a deploy to change),
+   a core `vars` entry (tunable per env, no deploy), or a DB config row an admin edits in the UI (most
+   flexible, most work). Recommended: `vars` for v1.
+3. **Does takedown hard-delete the thread, or delete-and-repost a tombstone?** (Recommended: hard delete —
+   simplest and fully removes the content; the audit row preserves the record.)
+4. **Should `creator`-tier submissions ever require pre-publish approval** (Option 2 as a per-config or
+   sub-tier escalation), or is reactive-only acceptable to start? (Recommended: reactive-only to start.)
+
+---
+
+## Risks & Limitations
+
+- **Blocklists are evadable.** Creators can spell around a word list; it is a speed bump for the obvious,
+  **not** the real defense. Do not oversell it. The real controls are takedown + tier revocation.
+- **Reactive means a window of exposure.** Between publish and takedown, offensive content is visible.
+  Acceptable given the semi-trusted cohort; unacceptable communities should adopt Option 2.
+- **Thread deletion is destructive + best-effort.** If the Discord delete fails after the void, the market
+  is still voided/refunded but the thread lingers — the audit row + a retry/monitor (or the existing
+  reconcile sweep) should flag it.
+- **False positives** from an aggressive blocklist frustrate legit creators — keep the list conservative
+  and the reject message generic-but-actionable.
+
+---
+
+## Future Work
+
+- **AI/LLM moderation** at create time (a moderation-endpoint call) behind the same `moderateMarketText`
+  seam — better recall than a blocklist, at the cost of latency/dependency/cost.
+- **Pre-publish approval** (Option 2) as an opt-in escalation on the existing `draft` state.
+- **Reputation/auto-trust:** promote long-clean creators to reduced filtering; auto-suspend on repeated
+  takedowns.

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -43,6 +43,12 @@ export interface CreateMarketInput {
 	maxStake?: string
 	perUserCap?: string
 	twoOfN?: boolean
+	/**
+	 * When true, consume the per-user `create_market` rate budget and reject (RATE_LIMITED) if it's
+	 * exhausted. Server-set policy flag — the member create route sets it for non-admins; admin
+	 * creation leaves it unset (uncapped). Never populated from client input.
+	 */
+	enforceRateLimit?: boolean
 }
 
 export interface PlaceBetInput {


### PR DESCRIPTION
> **Stacked on #463** (non-admin market creation MVP). Review/merge that first; this targets `pm-research-user-market-creation` and rebases onto `main` once #463 lands.

## What

Phase 2 guardrail for non-admin market creation: a **per-user creation rate limit**, so a creator-tier user can't flood the predictions forum. Reuses the existing `pm_rate_limits` primitive that already throttles bets — **no migration** (the `command` column is free-form text).

## Changes

- **`rate-limit.ts`** — new `create_market` budget: **10 markets/hour per user** (a single tunable constant).
- **`createMarket`** — gains an opt-in `enforceRateLimit` flag (server-set policy, never from client input — zod strips it). When set, it consumes the `create_market` budget after validation and before any write, throwing `RATE_LIMITED` if exhausted — the same anti-spam pattern as `placeBet`.
- **Member route** — sets `enforceRateLimit = !is_admin`, so non-admin creators are capped while site admins on this route stay uncapped (the admin route is uncapped too). `mapMarketCreateError` maps `RATE_LIMITED` → **429** with `retryAfterMs`.

## Why it's safe

- The flag is server-authoritative — a client can't send `enforceRateLimit: false` to bypass (zod strips unknown keys; the route sets it explicitly).
- Reuses the already-proven, race-safe atomic upsert (`consumeRateBudget`) — no new concurrency surface.
- Admin creation is unaffected.

## Verification

Typecheck green (core + PM app/pkg); **5 member-route tests** (non-admin capped, admin uncapped, 429-on-exhaustion) + 18 PM unit tests; lint clean.

## Still deferred (Phase 2/3)

Dedicated-tier catalog registration, economic-param clamping for lower-trust creators, content moderation for public forum text, and the "resolver pool must exceed {creator}" check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude:begin -->
## Summary

Adds trust-tier guardrails for non-admin ("member") prediction-market creation, plus a design doc for the next phase. A per-user **creation rate limit** stops a `urn:markets:creator` user from flooding the predictions forum, and **tier-based economic-param clamping** prevents lower-trust creators from setting the parimutuel/rake economics. Both reuse existing primitives, so no schema migration is required — managers/admins keep the full param set and stay uncapped.

## Changes

- **Rate limit:** Add a `create_market` budget (10 markets/hour per user) to `RATE_BUDGETS` in `apps/prediction-markets/src/lib/rate-limit.ts`, and an opt-in `enforceRateLimit` flag on `CreateMarketInput` (`packages/prediction-markets`). When set, `PredictionMarketsDO.createMarket` consumes the budget after validation and before any write, throwing `RATE_LIMITED:<retryAfterMs>` if exhausted.
- **Error mapping:** Thread `enforceRateLimit` through `createAndPublishMarket` in `market-create.service.ts`, and have `mapMarketCreateError` map `RATE_LIMITED` errors to HTTP 429 with a `retryAfterMs` field.
- **Tier-based schema:** Add `createMarketCreatorSchema` (a `createMarketSchema.pick` of question/description/outcomes/closesAt) — a slim schema that strips the economic params (`rakeBps`, min/max stake, per-user cap, `twoOfN`) so they default from `pmConfig`.
- **Member route (`prediction-markets.ts`):** Gate on `urn:markets:creator` (403 otherwise), then check `manager`. Managers/admins get the full schema and are uncapped; creators get the slim schema and are rate-limited (`enforceRateLimit: !isManager`).
- **UI:** `CreateMarketDialog` gains a `showAdvanced` prop (default `true`); the member create page hides the economic-param fields for non-managers (cosmetic — the server strips them regardless).
- **Docs:** Add `docs/prediction-markets-content-moderation.md`, a design doc for the Phase 3 content-moderation guardrail (recommends a hybrid blocklist pre-filter + manager-gated takedown).

## Testing

- Member-route tests: 403 without `urn:markets:creator`; creator gets 201 with `createdBy` from session, slim schema (economic params stripped), and `enforceRateLimit: true`; manager/admin gets the full schema with `enforceRateLimit: false`; 429 (`retryAfterMs`) when the per-user creation budget is exhausted; 400 on invalid body.
<!-- claude:end -->
