### PR TITLE
feat(prediction-markets): admin market editing (close time / question / description)

### DIFF
--- a/apps/core/src/__tests__/market-embed.test.ts
+++ b/apps/core/src/__tests__/market-embed.test.ts
@@ -5,6 +5,7 @@ import {
 	buildMarketCloseAnnouncement,
 	buildMarketEmbed,
 	buildMarketResolveAnnouncement,
+	buildMarketUpdateAnnouncement,
 	buildMarketVoidAnnouncement,
 	buildWagerResultDm,
 	formatMarketPoints,
@@ -120,6 +121,23 @@ describe('close / resolve / void announcements', () => {
 
 	it('void announcement states the refunded total', () => {
 		expect(buildMarketVoidAnnouncement('5000')).toContain('5,000 points')
+	})
+
+	it('update announcement renders a closesAt change as a Discord timestamp', () => {
+		const msg = buildMarketUpdateAnnouncement({ closesAt: '2030-01-01T00:00:00.000Z' })
+		expect(msg).toContain('Market updated')
+		expect(msg).toMatch(/<t:\d+:F>/)
+	})
+
+	it('update announcement notes question / description changes', () => {
+		const msg = buildMarketUpdateAnnouncement({ question: true, description: true })
+		expect(msg).toContain('Question updated')
+		expect(msg).toContain('Description updated')
+	})
+
+	it('update announcement is null when nothing changed', () => {
+		expect(buildMarketUpdateAnnouncement({})).toBeNull()
+		expect(buildMarketUpdateAnnouncement({ question: false })).toBeNull()
 	})
 
 	it('close announcement mentions closed', () => {

--- a/apps/core/src/lib/market-embed.ts
+++ b/apps/core/src/lib/market-embed.ts
@@ -66,6 +66,28 @@ export function buildMarketVoidAnnouncement(totalRefunded: string): string {
 }
 
 /**
+ * Posted to the thread when an admin edits a market — one bullet per changed field. `closesAt` (the
+ * new ISO time, present iff it changed) renders as an absolute + relative Discord timestamp;
+ * question/description just note that they changed (the refreshed embed shows the new values).
+ * Returns null when nothing actually changed, so the caller can skip announcing a no-op edit.
+ */
+export function buildMarketUpdateAnnouncement(changes: {
+	closesAt?: string
+	question?: boolean
+	description?: boolean
+}): string | null {
+	const lines: string[] = []
+	if (changes.closesAt) {
+		const unix = Math.floor(new Date(changes.closesAt).getTime() / 1000)
+		lines.push(`Closing time is now <t:${unix}:F> (<t:${unix}:R>)`)
+	}
+	if (changes.question) lines.push('Question updated')
+	if (changes.description) lines.push('Description updated')
+	if (lines.length === 0) return null
+	return `📣 **Market updated**\n${lines.map((l) => `• ${l}`).join('\n')}`
+}
+
+/**
  * The DM sent to one participant with the result of their wagers on a settled market. `net` is a
  * signed integer-point string (negative = net loss). `outcomeLabel` is the winning outcome, or null
  * on a void. Question/outcome are truncated to keep the DM within Discord's message limit.

--- a/apps/core/src/routes/prediction-markets-admin.ts
+++ b/apps/core/src/routes/prediction-markets-admin.ts
@@ -20,6 +20,7 @@ import {
 	createAndPublishMarket,
 	createMarketSchema,
 } from '../services/market-create.service'
+import { updateAndAnnounceMarket, updateMarketSchema } from '../services/market-update.service'
 import { userCharacters, users } from '../db/schema'
 
 import type { createDb } from '../db'
@@ -109,6 +110,9 @@ const BAD_REQUEST_CODES = new Set<string>([
 	'REASON_REQUIRED',
 	// create path (shared with the member create route)
 	...CREATE_MARKET_BAD_REQUEST_CODES,
+	// edit path (updateMarket) — INVALID_CLOSES_AT / QUESTION_REQUIRED are already in the create set
+	'MARKET_NOT_EDITABLE',
+	'CLOSES_AT_NOT_EDITABLE',
 ])
 
 // -------------------------------------------------------------------------
@@ -272,6 +276,26 @@ app.post('/markets', async (c) => {
 		return c.json(result, 201)
 	} catch (error) {
 		return fail(c, error, 'create market')
+	}
+})
+
+// PATCH /markets/:id — edit a market's safe fields (close time / question / description), then
+// refresh its forum post and announce the change in the thread.
+app.patch('/markets/:id', async (c) => {
+	try {
+		const db = c.get('db')
+		if (!db) return c.json({ error: 'Database not initialized' }, 500)
+		const marketId = c.req.param('id')
+		const actorId = c.get('user')!.id
+		const body = updateMarketSchema.parse(await c.req.json())
+		const result = await updateAndAnnounceMarket(db, c.env, actorId, marketId, body)
+		logger.info('[PMAdmin] market updated', { actorId, marketId })
+		return c.json(result, 200)
+	} catch (error) {
+		if (error instanceof Error && error.message === 'MARKET_NOT_FOUND') {
+			return c.json({ error: 'Market not found' }, 404)
+		}
+		return fail(c, error, 'update market')
 	}
 })
 

--- a/apps/core/src/services/__tests__/market-update.service.test.ts
+++ b/apps/core/src/services/__tests__/market-update.service.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { updateAndAnnounceMarket } from '../market-update.service'
+
+import type { UpdateMarketEnv } from '../market-update.service'
+import type { MarketDetail } from '@repo/prediction-markets'
+
+const hoisted = vi.hoisted(() => ({
+	predictionBinding: {} as DurableObjectNamespace,
+	discordBinding: {} as DurableObjectNamespace,
+	prediction: { updateMarket: vi.fn() },
+	post: { updateMarketPostFromDetail: vi.fn() },
+	notify: { announceMarketUpdated: vi.fn() },
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn((binding: DurableObjectNamespace) =>
+		binding === hoisted.predictionBinding ? hoisted.prediction : {}
+	),
+}))
+vi.mock('../discord-market-post.service', () => ({
+	updateMarketPostFromDetail: hoisted.post.updateMarketPostFromDetail,
+}))
+vi.mock('../discord-market-notify.service', () => ({
+	announceMarketUpdated: hoisted.notify.announceMarketUpdated,
+}))
+
+const db = {} as unknown as Parameters<typeof updateAndAnnounceMarket>[0]
+const env = {
+	PREDICTION_MARKETS: hoisted.predictionBinding,
+	DISCORD: hoisted.discordBinding,
+	PM_FORUM_GUILD_ID: 'g1',
+} as unknown as UpdateMarketEnv
+
+function market(overrides: Partial<MarketDetail> = {}): MarketDetail {
+	return {
+		id: 'm1',
+		question: 'Q1',
+		status: 'open',
+		closesAt: '2030-01-01T00:00:00.000Z',
+		totalPool: '0',
+		outcomeCount: 2,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		discordThreadId: 'thread1',
+		discordMessageId: 'msg1',
+		description: 'D',
+		createdBy: 'u',
+		rakeBps: 0,
+		minStake: '1',
+		maxStake: null,
+		perUserCap: null,
+		twoOfN: false,
+		resolvedOutcomeId: null,
+		resolvedBy: null,
+		resolvedAt: null,
+		voidReason: null,
+		outcomes: [],
+		...overrides,
+	}
+}
+
+const NO_CHANGE = { closesAt: false, question: false, description: false }
+
+describe('updateAndAnnounceMarket', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		hoisted.post.updateMarketPostFromDetail.mockResolvedValue({ success: true })
+		hoisted.notify.announceMarketUpdated.mockResolvedValue(undefined)
+	})
+
+	it('passes the actor to updateMarket and refreshes + announces the changed fields', async () => {
+		hoisted.prediction.updateMarket.mockResolvedValue({
+			market: market({ closesAt: '2031-01-01T00:00:00.000Z' }),
+			changed: { ...NO_CHANGE, closesAt: true },
+		})
+
+		const res = await updateAndAnnounceMarket(db, env, 'admin-1', 'm1', {
+			closesAt: '2031-01-01T00:00:00.000Z',
+		})
+
+		expect(hoisted.prediction.updateMarket).toHaveBeenCalledWith('m1', 'admin-1', {
+			closesAt: '2031-01-01T00:00:00.000Z',
+		})
+		expect(res.market.closesAt).toBe('2031-01-01T00:00:00.000Z')
+		expect(hoisted.post.updateMarketPostFromDetail).toHaveBeenCalledTimes(1)
+		expect(hoisted.notify.announceMarketUpdated).toHaveBeenCalledWith(expect.anything(), 'g1', expect.anything(), {
+			closesAt: '2031-01-01T00:00:00.000Z',
+			question: false,
+			description: false,
+		})
+	})
+
+	it('announces question + description (not closesAt) when only those changed', async () => {
+		hoisted.prediction.updateMarket.mockResolvedValue({
+			market: market({ question: 'Q2', description: null }),
+			changed: { closesAt: false, question: true, description: true },
+		})
+
+		await updateAndAnnounceMarket(db, env, 'admin-1', 'm1', { question: 'Q2', description: null })
+
+		expect(hoisted.notify.announceMarketUpdated).toHaveBeenCalledWith(expect.anything(), 'g1', expect.anything(), {
+			closesAt: undefined,
+			question: true,
+			description: true,
+		})
+	})
+
+	it('propagates MARKET_NOT_FOUND from updateMarket', async () => {
+		hoisted.prediction.updateMarket.mockRejectedValue(new Error('MARKET_NOT_FOUND'))
+		await expect(
+			updateAndAnnounceMarket(db, env, 'admin-1', 'x', { question: 'new' })
+		).rejects.toThrow('MARKET_NOT_FOUND')
+	})
+
+	it('does not fail the edit when the Discord side effects throw', async () => {
+		hoisted.prediction.updateMarket.mockResolvedValue({
+			market: market({ question: 'Q2' }),
+			changed: { ...NO_CHANGE, question: true },
+		})
+		hoisted.post.updateMarketPostFromDetail.mockRejectedValue(new Error('discord down'))
+
+		const res = await updateAndAnnounceMarket(db, env, 'admin-1', 'm1', { question: 'Q2' })
+		expect(res.market.question).toBe('Q2') // the committed edit is still returned
+	})
+})

--- a/apps/core/src/services/discord-market-notify.service.ts
+++ b/apps/core/src/services/discord-market-notify.service.ts
@@ -13,6 +13,7 @@ import { logger } from '@repo/hono-helpers'
 import {
 	buildMarketCloseAnnouncement,
 	buildMarketResolveAnnouncement,
+	buildMarketUpdateAnnouncement,
 	buildMarketVoidAnnouncement,
 	buildWagerResultDm,
 } from '../lib/market-embed'
@@ -33,6 +34,28 @@ export async function announceMarketClosed(
 	})
 	if (!res.success) {
 		logger.warn('[PMNotify] close announcement failed', { marketId: market.id, error: res.error })
+	}
+}
+
+/**
+ * Post an "market updated" notice to the thread — one bullet per changed field. No-op if the market
+ * has no post or nothing actually changed. Best-effort.
+ */
+export async function announceMarketUpdated(
+	discord: Discord,
+	guildId: string,
+	market: MarketDetail,
+	changes: { closesAt?: string; question?: boolean; description?: boolean }
+): Promise<void> {
+	if (!market.discordThreadId) return
+	const content = buildMarketUpdateAnnouncement(changes)
+	if (!content) return
+	const res = await discord.sendMessage(guildId, market.discordThreadId, {
+		content,
+		allowEveryone: false,
+	})
+	if (!res.success) {
+		logger.warn('[PMNotify] update announcement failed', { marketId: market.id, error: res.error })
 	}
 }
 

--- a/apps/core/src/services/market-update.service.ts
+++ b/apps/core/src/services/market-update.service.ts
@@ -1,0 +1,85 @@
+/**
+ * Admin market edit → apply the change, refresh the forum post embed, and announce what changed in
+ * the thread. Core is the sole Discord orchestrator; the PM DO never calls Discord. The DB write is
+ * source-of-truth; the Discord side effects are best-effort (a failure never rolls back the edit).
+ */
+
+import { z } from 'zod'
+
+import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
+
+import { announceMarketUpdated } from './discord-market-notify.service'
+import { updateMarketPostFromDetail } from './discord-market-post.service'
+
+import type { createDb } from '../db'
+import type { Env } from '../context'
+import type { Discord } from '@repo/discord'
+import type { MarketDetail, PredictionMarkets } from '@repo/prediction-markets'
+
+type CoreDb = ReturnType<typeof createDb>
+
+export type UpdateMarketEnv = Pick<Env, 'PREDICTION_MARKETS' | 'DISCORD' | 'PM_FORUM_GUILD_ID'>
+
+/**
+ * Partial market edit — the safe-to-change fields only. At least one must be present.
+ * `description: null` clears the description; economic params + outcomes are not editable.
+ */
+export const updateMarketSchema = z
+	.object({
+		closesAt: z
+			.string()
+			.datetime()
+			.refine((s) => new Date(s).getTime() > Date.now(), 'closesAt must be in the future')
+			.optional(),
+		question: z.string().trim().min(3).max(500).optional(),
+		description: z.string().trim().max(2000).nullable().optional(),
+	})
+	.refine(
+		(v) => v.closesAt !== undefined || v.question !== undefined || v.description !== undefined,
+		'at least one field to update is required'
+	)
+
+export type UpdateMarketBody = z.infer<typeof updateMarketSchema>
+
+export interface UpdateMarketResult {
+	market: MarketDetail
+}
+
+/**
+ * Apply an admin edit to a market, then (best-effort) refresh its forum-post embed and post a
+ * "market updated" notice listing the fields that actually changed. `updateMarket` throws
+ * MARKET_NOT_FOUND when the market doesn't exist; other domain rejections (MARKET_NOT_EDITABLE /
+ * CLOSES_AT_NOT_EDITABLE / INVALID_CLOSES_AT / …) propagate to the caller's error mapping. The
+ * changed-field set is computed atomically inside the DO (under the row lock), so the announcement
+ * can't be mis-attributed by a concurrent edit. `db` is unused today but kept for signature parity.
+ */
+export async function updateAndAnnounceMarket(
+	_db: CoreDb,
+	env: UpdateMarketEnv,
+	actorUserId: string,
+	marketId: string,
+	updates: UpdateMarketBody
+): Promise<UpdateMarketResult> {
+	const prediction = getStub<PredictionMarkets>(env.PREDICTION_MARKETS, 'default')
+	const { market, changed } = await prediction.updateMarket(marketId, actorUserId, updates)
+
+	// Best-effort Discord side effects: refresh the pinned embed (reflects new close time / text),
+	// then post the change notice. Never fails the edit — the DB write already committed.
+	try {
+		const discord = getStub<Discord>(env.DISCORD, 'default')
+		await updateMarketPostFromDetail(discord, market)
+		await announceMarketUpdated(discord, env.PM_FORUM_GUILD_ID ?? '', market, {
+			closesAt: changed.closesAt ? market.closesAt : undefined,
+			question: changed.question,
+			description: changed.description,
+		})
+	} catch (err) {
+		logger.warn('[MarketUpdate] post refresh / announce failed', {
+			marketId,
+			error: err instanceof Error ? err.message : String(err),
+		})
+	}
+
+	return { market }
+}

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -41,9 +41,11 @@ import type {
 	MarketSummary,
 	Paged,
 	PendingProposalView,
+	MarketUpdateResult,
 	PlaceBetInput,
 	PredictionMarkets,
 	ResolveResult,
+	UpdateMarketInput,
 	Visibility,
 	WalletRow,
 } from '@repo/prediction-markets'
@@ -121,6 +123,15 @@ const EXPECTED_RESOLVER_ERRORS = new Set([
 	'PROPOSAL_NOT_PENDING',
 	'CONTESTED_VOID_REQUIRES_APPROVER',
 	'VOID_REASON_REQUIRED',
+])
+
+/** updateMarket throws these on normal caller-input rejections — not paged to Sentry. */
+const EXPECTED_MARKET_EDIT_ERRORS = new Set([
+	'MARKET_NOT_FOUND',
+	'MARKET_NOT_EDITABLE',
+	'CLOSES_AT_NOT_EDITABLE',
+	'INVALID_CLOSES_AT',
+	'QUESTION_REQUIRED',
 ])
 
 /** True for expected resolver rejections, incl. the raw assertTransition (stale-state) string. */
@@ -648,6 +659,98 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 	}
 
 	/**
+	 * Edit a non-terminal market's safe fields (closesAt / question / description). Rejects a
+	 * resolved/voided market (MARKET_NOT_EDITABLE); `closesAt` is editable only while the market is
+	 * open (CLOSES_AT_NOT_EDITABLE otherwise — the close time is meaningless on a closed/resolving
+	 * market) and must be in the future (INVALID_CLOSES_AT). Only fields that ACTUALLY differ from
+	 * the row are written — computed under the FOR UPDATE lock, so the returned `changed` flags can't
+	 * be corrupted by a concurrent edit. Records the acting admin + the new values in the audit log.
+	 */
+	async updateMarket(
+		marketId: string,
+		actorUserId: string,
+		updates: UpdateMarketInput
+	): Promise<MarketUpdateResult> {
+		try {
+			return await this.db.transaction(async (tx) => {
+				const [market] = await tx
+					.select()
+					.from(pmMarkets)
+					.where(eq(pmMarkets.id, marketId))
+					.for('update')
+				if (!market) throw new Error('MARKET_NOT_FOUND')
+				if (isTerminal(market.status)) throw new Error('MARKET_NOT_EDITABLE')
+
+				const set: Partial<typeof pmMarkets.$inferInsert> = {}
+				// New values for the fields that genuinely changed — the audit metadata.
+				const changes: Record<string, unknown> = {}
+
+				if (updates.closesAt !== undefined) {
+					// The close time only governs an OPEN market; editing it on a closed/resolving one
+					// would falsely read as "betting reopened" while status stays closed.
+					if (market.status !== 'open') throw new Error('CLOSES_AT_NOT_EDITABLE')
+					const closesAt = parseDateOrNull(updates.closesAt)
+					if (!closesAt || closesAt.getTime() <= Date.now()) throw new Error('INVALID_CLOSES_AT')
+					if (closesAt.getTime() !== market.closesAt.getTime()) {
+						set.closesAt = closesAt
+						changes.closesAt = closesAt.toISOString()
+					}
+				}
+				if (updates.question !== undefined) {
+					const question = updates.question.trim()
+					if (!question) throw new Error('QUESTION_REQUIRED')
+					if (question !== market.question) {
+						set.question = question
+						changes.question = question
+					}
+				}
+				if (updates.description !== undefined) {
+					const description = updates.description?.trim() || null
+					if (description !== market.description) {
+						set.description = description
+						changes.description = description
+					}
+				}
+
+				// Only write + audit when something actually changed (a no-op edit is idempotent).
+				if (Object.keys(changes).length > 0) {
+					set.updatedAt = new Date()
+					await tx.update(pmMarkets).set(set).where(eq(pmMarkets.id, marketId))
+					await this.logHistory(tx, {
+						marketId,
+						actorUserId,
+						action: 'updated',
+						previousStatus: market.status,
+						newStatus: market.status,
+						visibility: 'internal',
+						metadata: { changes },
+					})
+				}
+
+				const detail = await this.buildMarketDetail(tx, marketId)
+				if (!detail) throw new Error('MARKET_NOT_FOUND')
+				return {
+					market: detail,
+					changed: {
+						closesAt: 'closesAt' in changes,
+						question: 'question' in changes,
+						description: 'description' in changes,
+					},
+				}
+			})
+		} catch (error) {
+			// Caller-input rejections are expected outcomes — don't page on them.
+			const msg = error instanceof Error ? error.message : String(error)
+			if (!EXPECTED_MARKET_EDIT_ERRORS.has(msg)) {
+				captureException(error as Error, {
+					tags: { durableObject: 'PredictionMarketsDO', method: 'updateMarket' },
+				})
+			}
+			throw error
+		}
+	}
+
+	/**
 	 * Persist the Discord forum post mapping after Core creates the post. Pure UPDATE —
 	 * the PM DO never calls Discord; Core orchestrates the post and writes the ids back here.
 	 */
@@ -914,8 +1017,10 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				.limit(bounded)
 			if (due.length === 0) return { closedMarketIds: [] }
 
-			// Re-guard status='open' in the UPDATE so a market that transitioned between the select
-			// and the update isn't clobbered; RETURNING yields the ids actually closed.
+			// Re-guard BOTH the status AND the due condition in the UPDATE: a market that transitioned
+			// (status) or had its close time extended (admin updateMarket) between the select and the
+			// update must not be clobbered. Re-checking closes_at <= now() makes an extended market
+			// drop out. RETURNING yields the ids actually closed.
 			const closed = await this.db
 				.update(pmMarkets)
 				.set({ status: 'closed', updatedAt: new Date() })
@@ -925,7 +1030,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 							pmMarkets.id,
 							due.map((d) => d.id)
 						),
-						eq(pmMarkets.status, 'open')
+						eq(pmMarkets.status, 'open'),
+						sql`${pmMarkets.closesAt} <= now()`
 					)
 				)
 				.returning({ id: pmMarkets.id })

--- a/apps/ui/src/client/features/prediction-markets/api.ts
+++ b/apps/ui/src/client/features/prediction-markets/api.ts
@@ -22,6 +22,8 @@ import type {
 	MarketsFilters,
 	MarketsResponse,
 	Paged,
+	UpdateMarketRequest,
+	UpdateMarketResponse,
 	WalletDetail,
 	WalletsFilters,
 } from './types'
@@ -112,6 +114,14 @@ export async function getMarkets(filters?: MarketsFilters): Promise<MarketsRespo
 /** POST /markets — create a market; the bot best-effort publishes its forum post. */
 export async function createMarket(body: CreateMarketRequest): Promise<CreateMarketResponse> {
 	return apiClient.post<CreateMarketResponse>(`${BASE}/markets`, body)
+}
+
+/** PATCH /markets/:id — edit a market's safe fields; the bot refreshes + announces the change. */
+export async function updateMarket(
+	id: string,
+	body: UpdateMarketRequest
+): Promise<UpdateMarketResponse> {
+	return apiClient.patch<UpdateMarketResponse>(`${BASE}/markets/${id}`, body)
 }
 
 /**

--- a/apps/ui/src/client/features/prediction-markets/components/edit-market-dialog.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/edit-market-dialog.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+import { useUpdateMarket } from '../hooks'
+
+import type { UpdateMarketRequest } from '../types'
+import type { MarketSummary } from '@repo/prediction-markets'
+
+/** ISO (UTC) → a `datetime-local` value (local wall-clock, minute precision). */
+function toLocalInput(iso: string): string {
+	const d = new Date(iso)
+	const local = new Date(d.getTime() - d.getTimezoneOffset() * 60_000)
+	return local.toISOString().slice(0, 16)
+}
+
+export interface EditMarketDialogProps {
+	/** The market being edited, or null when the dialog is closed. */
+	market: MarketSummary | null
+	open: boolean
+	onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Edit a market's safe fields (closing time + question). Only fields the admin actually changed are
+ * sent; the server refreshes the forum post and announces the change in the thread. Outcomes and
+ * economic params are intentionally not editable.
+ */
+export function EditMarketDialog({ market, open, onOpenChange }: EditMarketDialogProps) {
+	const [question, setQuestion] = useState('')
+	const [closesAt, setClosesAt] = useState('')
+	const [initialClosesAt, setInitialClosesAt] = useState('')
+	const update = useUpdateMarket()
+
+	// The close time only governs an open market — the server rejects editing it once betting closed.
+	const canEditClose = market?.status === 'open'
+
+	useEffect(() => {
+		if (open && market) {
+			setQuestion(market.question)
+			const local = toLocalInput(market.closesAt)
+			setClosesAt(local)
+			setInitialClosesAt(local)
+		}
+	}, [open, market])
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault()
+		if (!market) return
+
+		// Send only what changed (compare against the prefilled values).
+		const body: UpdateMarketRequest = {}
+		if (question.trim() !== market.question) body.question = question.trim()
+		if (canEditClose && closesAt && closesAt !== initialClosesAt) {
+			body.closesAt = new Date(closesAt).toISOString()
+		}
+
+		if (Object.keys(body).length === 0) {
+			onOpenChange(false) // nothing changed — nothing to do
+			return
+		}
+		await update.mutateAsync({ id: market.id, body })
+		onOpenChange(false)
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Edit market</DialogTitle>
+					<DialogDescription>
+						Changes are announced in the forum thread and reflected in the post. Outcomes and stakes
+						can’t be edited.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor="edit-question">Question</Label>
+						<Input
+							id="edit-question"
+							value={question}
+							onChange={(e) => setQuestion(e.target.value)}
+							maxLength={500}
+							disabled={update.isPending}
+							required
+						/>
+					</div>
+
+					{canEditClose ? (
+						<div className="space-y-2">
+							<Label htmlFor="edit-closes">Closes at</Label>
+							<Input
+								id="edit-closes"
+								type="datetime-local"
+								value={closesAt}
+								onChange={(e) => setClosesAt(e.target.value)}
+								disabled={update.isPending}
+								required
+							/>
+						</div>
+					) : null}
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="cancel"
+							showIcon={false}
+							onClick={() => onOpenChange(false)}
+							disabled={update.isPending}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" variant="primary" loading={update.isPending} loadingText="Saving…">
+							Save changes
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/hooks.ts
+++ b/apps/ui/src/client/features/prediction-markets/hooks.ts
@@ -12,6 +12,7 @@ import {
 	getUserLedger,
 	getWallet,
 	getWallets,
+	updateMarket,
 } from './api'
 import { pmKeys } from './query-keys'
 
@@ -22,6 +23,7 @@ import type {
 	LedgerFilters,
 	MarketHistoryFilters,
 	MarketsFilters,
+	UpdateMarketRequest,
 	WalletsFilters,
 } from './types'
 
@@ -100,6 +102,22 @@ export function useCreateMarket(scope: 'admin' | 'member' = 'admin') {
 				: 'Market created and posted to the forum.',
 		onSuccess: () => {
 			// Broad key so every markets-list variant (any filter) refetches.
+			queryClient.invalidateQueries({ queryKey: [...pmKeys.all, 'markets'] })
+		},
+	})
+}
+
+/**
+ * PATCH /markets/:id — edit a market's safe fields; the bot refreshes the forum post + announces
+ * the change. Toasts on success, invalidates the markets list.
+ */
+export function useUpdateMarket() {
+	const queryClient = useQueryClient()
+
+	return useApiMutation({
+		mutationFn: ({ id, body }: { id: string; body: UpdateMarketRequest }) => updateMarket(id, body),
+		successMessage: 'Market updated.',
+		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: [...pmKeys.all, 'markets'] })
 		},
 	})

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-markets.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-markets.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Pencil } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -15,10 +15,12 @@ import { usePageTitle } from '@/hooks/usePageTitle'
 import { formatPoints } from '@/lib/format-utils'
 
 import { CreateMarketDialog } from '../components/create-market-dialog'
+import { EditMarketDialog } from '../components/edit-market-dialog'
 import { useMarkets } from '../hooks'
 
 import type { BadgeVariant } from '@/components/ui/badge'
 import type { MarketStatus } from '../types'
+import type { MarketSummary } from '@repo/prediction-markets'
 
 const STATUS_VARIANT: Record<MarketStatus, BadgeVariant> = {
 	draft: 'secondary',
@@ -32,6 +34,7 @@ const STATUS_VARIANT: Record<MarketStatus, BadgeVariant> = {
 export default function PredictionMarketMarkets() {
 	usePageTitle('Admin - Prediction Markets')
 	const [createOpen, setCreateOpen] = useState(false)
+	const [editMarket, setEditMarket] = useState<MarketSummary | null>(null)
 	const { data, isLoading, error } = useMarkets({ limit: 50 })
 
 	const markets = data?.markets ?? []
@@ -70,18 +73,19 @@ export default function PredictionMarketMarkets() {
 							<TableHead>Pool</TableHead>
 							<TableHead>Closes</TableHead>
 							<TableHead>Forum</TableHead>
+							<TableHead className="text-right">Actions</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
 						{isLoading ? (
 							<TableRow>
-								<TableCell colSpan={6} className="text-center text-muted-foreground">
+								<TableCell colSpan={7} className="text-center text-muted-foreground">
 									Loading…
 								</TableCell>
 							</TableRow>
 						) : markets.length === 0 ? (
 							<TableRow>
-								<TableCell colSpan={6} className="text-center text-muted-foreground">
+								<TableCell colSpan={7} className="text-center text-muted-foreground">
 									No markets yet.
 								</TableCell>
 							</TableRow>
@@ -113,6 +117,19 @@ export default function PredictionMarketMarkets() {
 												</span>
 											)}
 										</TableCell>
+										<TableCell className="text-right">
+											{/* Editable while non-terminal; a resolved/voided market is frozen. */}
+											{m.status !== 'resolved' && m.status !== 'voided' ? (
+												<Button
+													variant="secondary"
+													showIcon={false}
+													size="sm"
+													onClick={() => setEditMarket(m)}
+												>
+													<Pencil className="mr-1 h-3.5 w-3.5" /> Edit
+												</Button>
+											) : null}
+										</TableCell>
 									</TableRow>
 								)
 							})
@@ -122,6 +139,13 @@ export default function PredictionMarketMarkets() {
 			</div>
 
 			<CreateMarketDialog open={createOpen} onOpenChange={setCreateOpen} />
+			<EditMarketDialog
+				market={editMarket}
+				open={editMarket !== null}
+				onOpenChange={(o) => {
+					if (!o) setEditMarket(null)
+				}}
+			/>
 		</div>
 	)
 }

--- a/apps/ui/src/client/features/prediction-markets/types.ts
+++ b/apps/ui/src/client/features/prediction-markets/types.ts
@@ -125,6 +125,18 @@ export interface CreateMarketResponse {
 	postError: string | null
 }
 
+/** Partial admin edit of a market's safe fields. At least one must be present. */
+export interface UpdateMarketRequest {
+	/** ISO-8601; must be in the future. */
+	closesAt?: string
+	question?: string
+	description?: string | null
+}
+
+export interface UpdateMarketResponse {
+	market: MarketDetail
+}
+
 export interface MarketsFilters {
 	status?: MarketStatus
 	limit?: number

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -45,6 +45,25 @@ export interface CreateMarketInput {
 	twoOfN?: boolean
 }
 
+/**
+ * A partial edit to a non-terminal market. Only the provided fields change; omitted fields are left
+ * as-is (pass `description: null` to clear it). Only the safe-to-change fields are editable —
+ * economic params (rake/stakes/cap) and outcomes are deliberately excluded.
+ */
+export interface UpdateMarketInput {
+	/** New betting-close time (ISO-8601); must be in the future and the market must be open. */
+	closesAt?: string
+	question?: string
+	/** New description, or `null` to clear it. */
+	description?: string | null
+}
+
+export interface MarketUpdateResult {
+	market: MarketDetail
+	/** Which safe fields actually changed (computed under the row lock) — drives the thread notice. */
+	changed: { closesAt: boolean; question: boolean; description: boolean }
+}
+
 export interface PlaceBetInput {
 	userId: string
 	marketId: string
@@ -311,6 +330,17 @@ export interface PredictionMarkets {
 		userId: string
 	): Promise<{ balance: string; granted: string; alreadyOnboarded: boolean }>
 	createMarket(input: CreateMarketInput): Promise<MarketDetail>
+	/**
+	 * Edit a non-terminal market's safe fields (closing time / question / description). `closesAt` is
+	 * only editable while the market is open. Only fields that actually change are applied; the audit
+	 * row records the acting admin. Returns the updated market plus which fields changed (computed
+	 * atomically under the row lock) so the caller can refresh the post + announce exactly the changes.
+	 */
+	updateMarket(
+		marketId: string,
+		actorUserId: string,
+		updates: UpdateMarketInput
+	): Promise<MarketUpdateResult>
 	/**
 	 * Place a bet. `deduped` is true when this was a duplicate delivery of an already-recorded
 	 * bet (same idempotency key) — the prior bet is returned and no money moved. Callers must


### PR DESCRIPTION
## What

Admins can edit a **non-terminal** market's safe fields — **closing time** (primary), question, description — from the admin markets page. The change is **reflected in the forum post embed** and **announced in the thread** ("📣 Market updated — Closing time is now …"). Outcomes and economic params (rake/stakes/cap) stay immutable — changing them after bets exist would be unfair.

Independent of the creation stack (#463/#464); branches directly off `main`.

## Changes

- **`updateMarket(marketId, actorUserId, updates)`** (PM DO) — `FOR UPDATE`; rejects terminal markets (`MARKET_NOT_EDITABLE`); `closesAt` is editable **only while open** (`CLOSES_AT_NOT_EDITABLE`) and must be in the future; writes **only fields that genuinely differ**; audits the acting admin + the new values; returns `{ market, changed }` (the change-set computed atomically under the row lock).
- **Core** — `buildMarketUpdateAnnouncement` + `announceMarketUpdated` (thread notice) + `updateAndAnnounceMarket` (edit → best-effort embed refresh + announce exactly the changed fields; a Discord failure never rolls back the committed edit).
- **Admin route** — `PATCH /api/admin/prediction-markets/markets/:id` (admin-only), with 404 / 400 error mapping.
- **UI** — `EditMarketDialog` + a per-row **Edit** action (hidden for resolved/voided; the close-time field hides once a market is closed, matching the server gate).

No migration.

## Adversarial review

Ran a multi-agent adversarial review (3 lenses — DO safety, orchestration/diff, route/mass-assignment — each finding verified by a refute-first agent). **4 confirmed findings fixed:**

1. **`closeDueMarkets` re-guard** — its UPDATE re-guarded only `status='open'`, so the reconcile cron could **silently re-close** a market an admin had just extended. Now re-guards `closes_at <= now()` too (a correctness improvement to that cron regardless — the old status-only guard was only safe while `closesAt` was immutable).
2. **Audit actor** — the edit now records **which admin** made it (was `actorUserId: null`).
3. **closesAt-on-open gate** — editing the close time of a closed market no longer produces a false "betting reopened" notice / future close-time.
4. **Diff race** — changed-field detection moved **inside** the DO's locked transaction, so a concurrent edit can't mis-attribute the announcement.

(A nit — "a post-refresh failure suppresses the announce" — was ruled not-a-defect.)

## Verification

- Typecheck green (PM app/pkg + core + UI); **31 core + 18 PM tests** pass; lint clean.
- ⚠️ Not yet exercised against a live Neon DB or real Discord — reviewed by reading + tests, not an end-to-end run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude:begin -->
## Summary

Adds admin market editing for prediction markets: admins can change a non-terminal market's safe fields — closing time (only while open), question, and description — from the admin markets page. The change is written to the DB (source of truth), then the forum post embed is refreshed and a "Market updated" notice is posted to the thread. Outcomes and economic params (rake/stakes/cap) remain immutable.

## Changes

- **PM Durable Object** — new `updateMarket(marketId, actorUserId, updates)`: selects the row `FOR UPDATE`, rejects terminal markets (`MARKET_NOT_EDITABLE`), gates `closesAt` edits to open markets (`CLOSES_AT_NOT_EDITABLE`) requiring a future time (`INVALID_CLOSES_AT`), writes only fields that actually differ, audits the acting admin + new values, and returns `{ market, changed }` computed under the lock.
- **`closeDueMarkets` cron** — its re-guarding UPDATE now also checks `closes_at <= now()` so a market an admin just extended isn't silently re-closed.
- **Core services** — `buildMarketUpdateAnnouncement` / `announceMarketUpdated` for the thread notice, and `updateAndAnnounceMarket` which applies the edit then best-effort refreshes the embed and announces exactly the changed fields (Discord failures never roll back the edit).
- **Admin route** — `PATCH /markets/:id` (admin-only) with Zod validation and 404 / 400 error mapping.
- **Shared package** — new `UpdateMarketInput` / `MarketUpdateResult` types and `updateMarket` on the `PredictionMarkets` interface.
- **UI** — `EditMarketDialog`, a `useUpdateMarket` hook + `updateMarket` API call, and a per-row **Edit** action on the markets table (hidden for resolved/voided; close-time field hidden once the market is closed).

## Testing

- New unit tests for `updateAndAnnounceMarket` (actor forwarding, changed-field announcement, `MARKET_NOT_FOUND` propagation, Discord side-effect failures not failing the edit).
- New `buildMarketUpdateAnnouncement` tests (closesAt Discord timestamp rendering, question/description notes, null on no-op).
- Author reports typecheck green and full test suite (31 core + 18 PM) passing; not yet exercised against a live DB or Discord.
<!-- claude:end -->
