### PR TITLE
feat(prediction-markets): onboarding grant 5 -> 50 points

### DIFF
--- a/apps/core/src/services/discord-programmatic-commands/__tests__/market.test.ts
+++ b/apps/core/src/services/discord-programmatic-commands/__tests__/market.test.ts
@@ -45,14 +45,14 @@ describe('MARKET_PROGRAMMATIC_COMMAND', () => {
 	describe('onboard', () => {
 		it('welcomes a fresh member with the deposited amount and new balance', async () => {
 			hoisted.onboardUser.mockResolvedValue({
-				balance: '5',
-				granted: '5',
+				balance: '50',
+				granted: '50',
 				alreadyOnboarded: false,
 			})
 			const res = await MARKET_PROGRAMMATIC_COMMAND.handler(ctx('onboard'))
 			expect(hoisted.onboardUser).toHaveBeenCalledWith('u1')
 			expect(res.data?.content).toContain('Welcome')
-			expect(res.data?.content).toContain('5 points')
+			expect(res.data?.content).toContain('50 points')
 			// Self-only content must be ephemeral even on a sync fallback.
 			expect(res.data?.flags).toBe(EPHEMERAL_FLAG)
 		})

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -65,7 +65,7 @@ interface HistoryEntry {
 }
 
 /** One-time starting grant deposited on a member's first `/market onboard`. */
-const ONBOARDING_GRANT = '5'
+const ONBOARDING_GRANT = '50'
 /** Ledger reason recorded for the onboarding grant. */
 const ONBOARDING_REASON = 'Initial onboarding'
 /**
@@ -544,9 +544,13 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				return { balance: credited.balance, deduped: false }
 			})
 		} catch (error) {
-			captureException(error as Error, {
-				tags: { durableObject: 'PredictionMarketsDO', method: 'grantPoints' },
-			})
+			// A mismatched idempotency key is a caller-side outcome (the admin route maps it to 409;
+			// onboardUser handles it), not an infra failure — don't page on it.
+			if (!(error instanceof Error && error.message === 'IDEMPOTENCY_KEY_CONFLICT')) {
+				captureException(error as Error, {
+					tags: { durableObject: 'PredictionMarketsDO', method: 'grantPoints' },
+				})
+			}
 			throw error
 		}
 	}
@@ -556,18 +560,30 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 	 * Built on grantPoints as a system-actor grant keyed on `onboard:{userId}`, so it inherits
 	 * wallet creation, the atomic credit, and idempotency — and is once-per-user: a repeat call
 	 * (`deduped`) grants nothing and reports `alreadyOnboarded: true`.
+	 *
+	 * If a member already onboarded when ONBOARDING_GRANT was a DIFFERENT size, the repeat grant
+	 * collides on the key at a mismatched amount (IDEMPOTENCY_KEY_CONFLICT). Once-per-user still
+	 * holds — treat it as already onboarded rather than erroring or topping up.
 	 */
 	async onboardUser(
 		userId: string
 	): Promise<{ balance: string; granted: string; alreadyOnboarded: boolean }> {
-		const { balance, deduped } = await this.grantPoints({
-			actorUserId: SYSTEM_ACTOR,
-			targetUserId: userId,
-			amount: ONBOARDING_GRANT,
-			reason: ONBOARDING_REASON,
-			idempotencyKey: `onboard:${userId}`,
-		})
-		return { balance, granted: deduped ? '0' : ONBOARDING_GRANT, alreadyOnboarded: deduped }
+		try {
+			const { balance, deduped } = await this.grantPoints({
+				actorUserId: SYSTEM_ACTOR,
+				targetUserId: userId,
+				amount: ONBOARDING_GRANT,
+				reason: ONBOARDING_REASON,
+				idempotencyKey: `onboard:${userId}`,
+			})
+			return { balance, granted: deduped ? '0' : ONBOARDING_GRANT, alreadyOnboarded: deduped }
+		} catch (error) {
+			if (error instanceof Error && error.message === 'IDEMPOTENCY_KEY_CONFLICT') {
+				const { balance } = await this.getWalletBalance(userId)
+				return { balance, granted: '0', alreadyOnboarded: true }
+			}
+			throw error
+		}
 	}
 
 	async createMarket(input: CreateMarketInput): Promise<MarketDetail> {


### PR DESCRIPTION
## What

Bump the one-time `/market onboard` starting grant from **5 → 50 points**. Single source of truth (`ONBOARDING_GRANT`); the welcome message renders the value dynamically.

## Migration edge handled

The onboarding grant is idempotency-keyed on `onboard:{userId}` **and** the amount. So a member who already onboarded at 5 and re-runs `/market onboard` after this deploy would otherwise hit `IDEMPOTENCY_KEY_CONFLICT` — a confusing "command failed" + a Sentry page. Two small fixes:

- **`onboardUser`** now treats that conflict as **already-onboarded** — once-per-user still holds, so no top-up to 50 and no error. Existing members keep their original grant; only new members get 50.
- **`grantPoints`** no longer pages Sentry on the expected mismatched-key case (the admin deposit route already maps it to 409).

## Verification

Typecheck green (PM app/pkg + core); **18 PM + 4 onboard-command tests** pass; lint clean. No migration.

Independent change off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude:begin -->
## Summary

Increases the one-time `/market onboard` starting grant from 5 to 50 points, and hardens the onboarding path so members who already onboarded at the old amount do not hit a confusing error when re-running the command.

## Changes

- Bump `ONBOARDING_GRANT` from `'5'` to `'50'` in the prediction-markets Durable Object (single source of truth; the welcome message renders the value dynamically).
- `onboardUser` now catches `IDEMPOTENCY_KEY_CONFLICT` — which occurs when a member onboarded at a different grant size and re-runs `/market onboard` — and reports it as already-onboarded (no top-up, no error), preserving once-per-user semantics.
- `grantPoints` no longer sends `IDEMPOTENCY_KEY_CONFLICT` to Sentry, since it is an expected caller-side outcome (the admin deposit route maps it to a 409) rather than an infra failure.
- Update the onboard command test to assert the new 50-point grant and balance.

## Testing

- Updated `market.test.ts` covers the onboarding welcome flow with the new 50-point amount.
<!-- claude:end -->
