### PR TITLE
feat(prediction-markets): rake + burn accumulate in a system wallet

### DIFF
--- a/apps/core/src/routes/prediction-markets-admin.ts
+++ b/apps/core/src/routes/prediction-markets-admin.ts
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import { eq, ilike, inArray } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
+import { SYSTEM_WALLET_USER_ID } from '@repo/prediction-markets'
 
 import { requireAdmin, requireAuth } from '../middleware/session'
 import {
@@ -30,6 +31,8 @@ import type { LedgerType, MarketStatus, PredictionMarkets } from '@repo/predicti
 type CoreDb = ReturnType<typeof createDb>
 
 const NULL_NAME = { userName: null as string | null, mainCharacterId: null as string | null }
+/** Display label for the house/system wallet (nil-UUID owner, not a real user). */
+const SYSTEM_NAME = { userName: 'System', mainCharacterId: null as string | null }
 
 const app = new Hono<App>()
 
@@ -80,6 +83,7 @@ function nameOf(
 	names: Map<string, { userName: string | null; mainCharacterId: string | null }>,
 	userId: string | null
 ): { userName: string | null; mainCharacterId: string | null } {
+	if (userId === SYSTEM_WALLET_USER_ID) return SYSTEM_NAME
 	return userId ? (names.get(userId) ?? NULL_NAME) : NULL_NAME
 }
 
@@ -90,6 +94,9 @@ function fail(c: Context<App>, error: unknown, what: string) {
 	const msg = error instanceof Error ? error.message : String(error)
 	if (msg === 'SELF_TARGET_FORBIDDEN') {
 		return c.json({ error: 'Cannot deposit to your own wallet' }, 400)
+	}
+	if (msg === 'SYSTEM_TARGET_FORBIDDEN') {
+		return c.json({ error: 'Cannot deposit to the system wallet' }, 400)
 	}
 	if (msg === 'IDEMPOTENCY_KEY_CONFLICT') {
 		return c.json({ error: 'Idempotency key already used with different parameters' }, 409)

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -2,6 +2,7 @@ import { DurableObject } from 'cloudflare:workers'
 
 import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lte, ne, sql } from '@repo/db-utils'
 import { captureException, logger } from '@repo/hono-helpers'
+import { SYSTEM_WALLET_USER_ID } from '@repo/prediction-markets'
 import { parseDateOrNull } from '@repo/worker-utils'
 
 import { createDb } from './db'
@@ -332,6 +333,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					0
 				) as "netProfit"
 			from pm_wallets w
+			where w.user_id != ${SYSTEM_WALLET_USER_ID}
 			order by w.balance desc
 			limit ${limit}
 		`)
@@ -378,7 +380,13 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					? pmWallets.userId
 					: pmWallets.balance
 		const direction = opts?.order === 'asc' ? asc : desc
-		const where = opts?.userIds?.length ? inArray(pmWallets.userId, opts.userIds) : undefined
+		// The house/system wallet is an internal accumulator, not a user wallet — keep it out of the
+		// admin wallet grid (and its deposit/ledger actions). Its rake/burn entries still appear,
+		// labeled "System", in the audit ledger.
+		const excludeSystem = ne(pmWallets.userId, SYSTEM_WALLET_USER_ID)
+		const where = opts?.userIds?.length
+			? and(inArray(pmWallets.userId, opts.userIds), excludeSystem)
+			: excludeSystem
 
 		const rows = await this.db
 			.select()
@@ -484,6 +492,11 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		// Defense-in-depth: the route also blocks this, but never let an admin fund their own wallet.
 		if (input.actorUserId === input.targetUserId) {
 			throw new Error('SELF_TARGET_FORBIDDEN')
+		}
+		// The house/system wallet is an accumulator for rake + dust; keep its balance meaningful by
+		// forbidding manual deposits into it (so house balance == Σ collected rake/dust).
+		if (input.targetUserId === SYSTEM_WALLET_USER_ID) {
+			throw new Error('SYSTEM_TARGET_FORBIDDEN')
 		}
 		try {
 			return await this.db.transaction(async (tx) => {
@@ -1305,21 +1318,47 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				)
 			)
 
-		// House cut and rounding dust are recorded as distinct sink lines (both leave circulation).
+		// House cut (rake) and rounding dust (burn) accumulate in the system wallet rather than
+		// leaving circulation via a null-user sink — the points stay conserved and recoverable.
+		// Each is a distinct, attributed ledger line carrying the wallet's running balanceAfter.
+		if (rake > 0n || dust > 0n) {
+			await tx
+				.insert(pmWallets)
+				.values({ userId: SYSTEM_WALLET_USER_ID, balance: '0' })
+				.onConflictDoNothing()
+		}
 		if (rake > 0n) {
+			const [credited] = await tx
+				.update(pmWallets)
+				.set({
+					balance: sql`${pmWallets.balance} + ${formatAmount(rake)}::numeric`,
+					updatedAt: new Date(),
+				})
+				.where(eq(pmWallets.userId, SYSTEM_WALLET_USER_ID))
+				.returning({ balance: pmWallets.balance })
 			await tx.insert(pmLedger).values({
-				userId: null,
+				userId: SYSTEM_WALLET_USER_ID,
 				amount: formatAmount(rake),
 				type: 'rake',
 				marketId: market.id,
+				balanceAfter: credited.balance,
 			})
 		}
 		if (dust > 0n) {
+			const [credited] = await tx
+				.update(pmWallets)
+				.set({
+					balance: sql`${pmWallets.balance} + ${formatAmount(dust)}::numeric`,
+					updatedAt: new Date(),
+				})
+				.where(eq(pmWallets.userId, SYSTEM_WALLET_USER_ID))
+				.returning({ balance: pmWallets.balance })
 			await tx.insert(pmLedger).values({
-				userId: null,
+				userId: SYSTEM_WALLET_USER_ID,
 				amount: formatAmount(dust),
 				type: 'burn',
 				marketId: market.id,
+				balanceAfter: credited.balance,
 			})
 		}
 

--- a/apps/ui/src/client/features/prediction-markets/components/ledger-table.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/ledger-table.tsx
@@ -2,6 +2,8 @@ import { ChevronDown } from 'lucide-react'
 import { Fragment, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { SYSTEM_WALLET_USER_ID } from '@repo/prediction-markets'
+
 import { JsonViewer } from '@/components/json-viewer'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -109,7 +111,8 @@ export function LedgerTable({ rows, isLoading, error }: LedgerTableProps) {
 										{row.balanceAfter != null ? formatPoints(row.balanceAfter) : '—'}
 									</TableCell>
 									<TableCell>
-										{row.userId ? (
+										{/* Nil-UUID system wallet renders as a plain "System" label, not a broken user link. */}
+										{row.userId && row.userId !== SYSTEM_WALLET_USER_ID ? (
 											<Link
 												to={`/admin/users/${row.userId}`}
 												className="flex items-center gap-2 text-primary hover:underline"

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -14,6 +14,14 @@ export type LedgerType = 'grant' | 'wager' | 'refund' | 'payout' | 'rake' | 'bur
 export type ProposalStatus = 'pending' | 'approved' | 'rejected' | 'superseded'
 export type Visibility = 'public' | 'internal'
 
+/**
+ * The house/system wallet. On resolution, the rake (house cut) and rounding dust accumulate here
+ * instead of leaving circulation — the points stay conserved and recoverable. The nil UUID is a
+ * valid `uuid` that `defaultRandom()` never mints, so it can never collide with a real user id.
+ * Surfaced as "System" in admin views and excluded from the member leaderboard.
+ */
+export const SYSTEM_WALLET_USER_ID = '00000000-0000-0000-0000-000000000000'
+
 // ---------------------------------------------------------------------------
 // Write inputs
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

On prediction-market resolution, the house cut (**rake**) and rounding dust (**burn**) now accumulate in a single **system wallet** instead of leaving circulation via null-user ledger lines. Points become conserved and recoverable: \`Σpayouts + systemWallet == totalPool\`.

## Changes

- Add \`SYSTEM_WALLET_USER_ID\` (nil UUID \`00000000-0000-0000-0000-000000000000\`) exported from \`@repo/prediction-markets\`.
- On resolution, credit rake and dust to the system wallet (lazily created via insert-on-conflict) as distinct \`rake\`/\`burn\` ledger lines carrying the running \`balanceAfter\`, all inside the resolution transaction — replacing the previous \`userId: null\` sink rows.
- Exclude the system wallet from \`getLeaderboard\` and \`listWallets\` (it's an internal accumulator, not a user wallet).
- Reject deposits to the system wallet in \`grantPoints\` with \`SYSTEM_TARGET_FORBIDDEN\` → HTTP 400.
- Label the nil UUID as "System" in admin views (\`nameOf\`), and render the system ledger row as plain "System" text instead of a broken \`/admin/users/<nil-uuid>\` link.

## Testing

- Typecheck, lint, and the 18 prediction-markets tests pass.
- Not yet exercised against a live database (reviewed via reading + tests, not an end-to-end resolution run).
<!-- claude:end -->