### PR TITLE
feat(prediction-markets): allow creators to bet on their own market

### DIFF
--- a/apps/core/src/routes/prediction-markets.ts
+++ b/apps/core/src/routes/prediction-markets.ts
@@ -29,8 +29,9 @@ const app = new Hono<App>()
 app.use('*', requireAuth())
 
 // POST /markets — a member with urn:markets:creator (or manager/admin) creates a market. `createdBy`
-// comes from the session, never the client. The creator can neither bet on nor resolve it (enforced
-// in the PM DO: CREATOR_CANNOT_BET / CREATOR_CANNOT_RESOLVE), so open creation is self-dealing-safe.
+// comes from the session, never the client. The creator may bet on their own market but can't resolve
+// it (enforced in the PM DO: CREATOR_CANNOT_RESOLVE / RESOLVER_HAS_POSITION), so they hold no power
+// over the outcome and open creation stays self-dealing-safe.
 app.post('/markets', async (c) => {
 	const db = c.get('db')
 	if (!db) return c.json({ error: 'Database not initialized' }, 500)

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -83,7 +83,6 @@ const ERROR_MESSAGES: Record<string, string> = {
 	MARKET_NOT_FOUND: 'That market no longer exists.',
 	MARKET_NOT_OPEN: 'This market is not open for betting.',
 	MARKET_CLOSED: 'Betting has closed on this market.',
-	CREATOR_CANNOT_BET: 'You created this market, so you can’t bet on it.',
 	OUTCOME_NOT_FOUND: 'That outcome is no longer available.',
 	STAKE_BELOW_MIN: 'Your stake is below the minimum for this market.',
 	STAKE_ABOVE_MAX: 'Your stake is above the maximum for this market.',

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -82,7 +82,6 @@ const EXPECTED_BET_ERRORS = new Set([
 	'MARKET_NOT_FOUND',
 	'MARKET_NOT_OPEN',
 	'MARKET_CLOSED',
-	'CREATOR_CANNOT_BET',
 	'OUTCOME_NOT_FOUND',
 	'STAKE_BELOW_MIN',
 	'STAKE_ABOVE_MAX',
@@ -871,9 +870,9 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				if (!market) throw new Error('MARKET_NOT_FOUND')
 				if (market.status !== 'open') throw new Error('MARKET_NOT_OPEN')
 				if (market.closesAt.getTime() <= Date.now()) throw new Error('MARKET_CLOSED')
-				// Governance: a creator can't take a position on their own market (mirrors the
-				// creator-can't-resolve / resolver-holds-no-position guards elsewhere).
-				if (market.createdBy === input.userId) throw new Error('CREATOR_CANNOT_BET')
+				// A creator MAY bet on their own market — they just can't resolve it (enforced by the
+				// CREATOR_CANNOT_RESOLVE / RESOLVER_HAS_POSITION guards), so they hold no power over the
+				// outcome and can't self-deal.
 
 				const [outcome] = await tx
 					.select({ id: pmMarketOutcomes.id })
@@ -1324,6 +1323,14 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.for('update')
 				if (!market) throw new Error('MARKET_NOT_FOUND')
 				if (isTerminal(market.status)) throw new Error('MARKET_TERMINAL')
+
+				// Voiding is a terminal settlement, so it carries the same conflict-of-interest guards as
+				// resolve/approve: a creator can't void their own market, and a resolver holding a position
+				// can't void one they have a stake in.
+				if (market.createdBy === input.actorUserId) throw new Error('CREATOR_CANNOT_RESOLVE')
+				if (await this.hasPosition(tx, input.marketId, input.actorUserId)) {
+					throw new Error('RESOLVER_HAS_POSITION')
+				}
 
 				// Contested markets (bets on 2+ outcomes) require a distinct second approver.
 				const [distinctRow] = await tx

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-create.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-create.tsx
@@ -27,8 +27,8 @@ export default function PredictionMarketCreate() {
 					<h1 className="text-3xl font-bold gradient-text">Prediction Markets</h1>
 					<p className="mt-1 max-w-2xl text-muted-foreground">
 						Create a market for the community. It’s posted to the predictions forum channel, where
-						members place bets and a resolver settles it. You can’t bet on or resolve a market you
-						create.
+						members place bets and a resolver settles it. You can bet on your own market, but you
+						can’t resolve it.
 					</p>
 				</div>
 				{canCreate ? (


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Allows prediction-market creators to place bets on markets they created (previously blocked by a `CREATOR_CANNOT_BET` guard), while keeping settlement in the hands of an independent resolver. Since a creator still can't resolve or void their own market, they hold no power over the outcome, so open creation stays self-dealing-safe.

## Changes

- Remove the `CREATOR_CANNOT_BET` guard from `placeBet` in the prediction-markets Durable Object so creators can bet on their own markets.
- Drop the now-unused `CREATOR_CANNOT_BET` entries from `EXPECTED_BET_ERRORS` (DO) and `ERROR_MESSAGES` (Discord components service).
- Add `CREATOR_CANNOT_RESOLVE` / `RESOLVER_HAS_POSITION` conflict-of-interest guards to `voidMarket`, matching the existing resolve/approve paths since voiding is a terminal settlement.
- Update the route comment and the market-create UI copy to reflect that creators can bet but not resolve.

## Testing

- Typecheck (PM app + core + UI), lint, and the existing 18 PM + 4 command tests pass per the commit; not exercised against a live database.
<!-- claude:end -->