### PR TITLE
feat(prediction-markets): self-heal settlement notifications across Core eviction

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -109,6 +109,7 @@ db-generate-all:
   cd apps/eve-character-data && bun run db:generate
   cd apps/eve-token-store && bun run db:generate
   cd apps/moon-scan && bun run db:generate
+  cd apps/prediction-markets && bun run db:generate
 
 # Push schema changes to database (for development)
 [group('2. database')]
@@ -163,12 +164,11 @@ db-migrate-all:
   cd apps/esi && bun run db:migrate
   cd apps/corporation-tax && bun run db:migrate
   cd apps/donations && bun run db:migrate
-  cd apps/postman && bun run db:migrate
-  cd apps/mumble && bun run db:migrate
   cd apps/eve-corporation-data && bun run db:migrate
   cd apps/eve-character-data && bun run db:migrate
   cd apps/eve-token-store && bun run db:migrate
   cd apps/moon-scan && bun run db:migrate
+  cd apps/prediction-markets && bun run db:migrate
 
 # Seed moon permissions into groups DB
 [group('2. database')]

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -205,7 +205,7 @@ export default {
 			ctx.waitUntil(
 				reconcileMarketPosts(createDb(env.DATABASE_URL), env)
 					.then((r) => {
-						if (r.closed > 0 || r.refreshed > 0 || r.posted > 0 || r.failed > 0) {
+						if (r.closed > 0 || r.refreshed > 0 || r.posted > 0 || r.notified > 0 || r.failed > 0) {
 							console.log('[Core:Scheduled] Prediction-market reconcile', r)
 						}
 					})

--- a/apps/core/src/services/__tests__/discord-market-reconcile.test.ts
+++ b/apps/core/src/services/__tests__/discord-market-reconcile.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { reconcileMarketPosts } from '../discord-market-reconcile.service'
 
 import type { ReconcileEnv } from '../discord-market-reconcile.service'
-import type { MarketDetail } from '@repo/prediction-markets'
+import type { MarketDetail, MarketSettlement } from '@repo/prediction-markets'
 
 const hoisted = vi.hoisted(() => ({
 	predictionBinding: {} as DurableObjectNamespace,
@@ -13,6 +13,9 @@ const hoisted = vi.hoisted(() => ({
 		listMarketsToRefresh: vi.fn(),
 		getMarket: vi.fn(),
 		listMarketsNeedingPost: vi.fn(),
+		listMarketsNeedingSettlementNotice: vi.fn(),
+		getMarketSettlement: vi.fn(),
+		markSettlementAnnounced: vi.fn(),
 	},
 	post: {
 		updateMarketPostFromDetail: vi.fn(),
@@ -21,6 +24,8 @@ const hoisted = vi.hoisted(() => ({
 	},
 	notify: {
 		announceMarketClosed: vi.fn(),
+		announceMarketResolved: vi.fn(),
+		dmWagerResults: vi.fn(),
 	},
 }))
 
@@ -40,6 +45,8 @@ vi.mock('../discord-market-post.service', () => ({
 
 vi.mock('../discord-market-notify.service', () => ({
 	announceMarketClosed: hoisted.notify.announceMarketClosed,
+	announceMarketResolved: hoisted.notify.announceMarketResolved,
+	dmWagerResults: hoisted.notify.dmWagerResults,
 }))
 
 const db = {} as unknown as Parameters<typeof reconcileMarketPosts>[0]
@@ -80,6 +87,18 @@ function market(id: string, status: MarketDetail['status'] = 'closed'): MarketDe
 	}
 }
 
+function settlement(marketId: string): MarketSettlement {
+	return {
+		marketId,
+		status: 'resolved',
+		resolvedOutcomeId: 'o1',
+		totalStaked: '100',
+		totalPaidOut: '90',
+		totalLost: '10',
+		users: [{ userId: 'u1', staked: '10', returned: '18', net: '8' }],
+	}
+}
+
 describe('reconcileMarketPosts', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
@@ -87,18 +106,27 @@ describe('reconcileMarketPosts', () => {
 		hoisted.prediction.listMarketsToRefresh.mockResolvedValue([])
 		hoisted.prediction.getMarket.mockImplementation((id: string) => Promise.resolve(market(id)))
 		hoisted.prediction.listMarketsNeedingPost.mockResolvedValue([])
+		hoisted.prediction.listMarketsNeedingSettlementNotice.mockResolvedValue([])
+		hoisted.prediction.getMarketSettlement.mockImplementation((id: string) =>
+			Promise.resolve(settlement(id))
+		)
+		hoisted.prediction.markSettlementAnnounced.mockResolvedValue(undefined)
 		hoisted.post.updateMarketPostFromDetail.mockResolvedValue({ success: true })
 		hoisted.post.applyMarketPostStatus.mockResolvedValue(undefined)
 		hoisted.post.publishMarketPost.mockResolvedValue({ threadId: 't', messageId: 'm' })
 		hoisted.notify.announceMarketClosed.mockResolvedValue(undefined)
+		// announceMarketResolved returns whether the thread post landed; default = posted.
+		hoisted.notify.announceMarketResolved.mockResolvedValue(true)
+		hoisted.notify.dmWagerResults.mockResolvedValue(undefined)
 	})
 
 	it('no-ops when the forum guild/category is not configured', async () => {
 		const res = await reconcileMarketPosts(db, makeEnv({ PM_FORUM_GUILD_ID: undefined }))
-		expect(res).toEqual({ closed: 0, refreshed: 0, posted: 0, failed: 0, skipped: true })
+		expect(res).toEqual({ closed: 0, refreshed: 0, posted: 0, notified: 0, failed: 0, skipped: true })
 		expect(hoisted.prediction.closeDueMarkets).not.toHaveBeenCalled()
 		expect(hoisted.prediction.listMarketsToRefresh).not.toHaveBeenCalled()
 		expect(hoisted.prediction.listMarketsNeedingPost).not.toHaveBeenCalled()
+		expect(hoisted.prediction.listMarketsNeedingSettlementNotice).not.toHaveBeenCalled()
 	})
 
 	it('auto-closes markets and announces each close to its thread', async () => {
@@ -164,5 +192,85 @@ describe('reconcileMarketPosts', () => {
 		expect(res.failed).toBe(1)
 		expect(res.posted).toBe(1)
 		expect(hoisted.post.publishMarketPost).toHaveBeenCalledTimes(2)
+	})
+
+	it('re-sends the settlement notification for terminal markets that never completed it', async () => {
+		hoisted.prediction.listMarketsNeedingSettlementNotice.mockResolvedValue([
+			market('a', 'resolved'),
+			market('b', 'voided'),
+		])
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.notified).toBe(2)
+		// grace + max-age window is passed through to the work-list query.
+		expect(hoisted.prediction.listMarketsNeedingSettlementNotice).toHaveBeenCalledWith(
+			expect.any(Number),
+			expect.any(Number),
+			expect.any(Number)
+		)
+		expect(hoisted.notify.announceMarketResolved).toHaveBeenCalledTimes(2)
+		expect(hoisted.notify.dmWagerResults).toHaveBeenCalledTimes(2)
+		// Only marked announced AFTER the post + DM fan-out both ran.
+		expect(hoisted.prediction.markSettlementAnnounced).toHaveBeenCalledTimes(2)
+	})
+
+	it('marks a terminal market announced without sending when its settlement data is missing', async () => {
+		hoisted.prediction.listMarketsNeedingSettlementNotice.mockResolvedValue([
+			market('a', 'resolved'),
+		])
+		hoisted.prediction.getMarketSettlement.mockResolvedValue(null)
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.notified).toBe(0)
+		expect(hoisted.notify.announceMarketResolved).not.toHaveBeenCalled()
+		expect(hoisted.notify.dmWagerResults).not.toHaveBeenCalled()
+		// Still flagged so the work-list stops re-selecting it every tick.
+		expect(hoisted.prediction.markSettlementAnnounced).toHaveBeenCalledWith('a')
+	})
+
+	it('leaves the market un-announced and skips DMs when the thread post soft-fails (retried next tick)', async () => {
+		hoisted.prediction.listMarketsNeedingSettlementNotice.mockResolvedValue([market('a', 'resolved')])
+		hoisted.notify.announceMarketResolved.mockResolvedValue(false)
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.notified).toBe(0)
+		expect(res.failed).toBe(1)
+		// Not marked → a later tick retries (at-least-once). No DM spam against a market whose post failed.
+		expect(hoisted.prediction.markSettlementAnnounced).not.toHaveBeenCalled()
+		expect(hoisted.notify.dmWagerResults).not.toHaveBeenCalled()
+	})
+
+	it('marks BEFORE the DM fan-out and only after the post lands', async () => {
+		const calls: string[] = []
+		hoisted.prediction.listMarketsNeedingSettlementNotice.mockResolvedValue([market('a', 'resolved')])
+		hoisted.notify.announceMarketResolved.mockImplementation(async () => {
+			calls.push('post')
+			return true
+		})
+		hoisted.prediction.markSettlementAnnounced.mockImplementation(async () => {
+			calls.push('mark')
+		})
+		hoisted.notify.dmWagerResults.mockImplementation(async () => {
+			calls.push('dm')
+		})
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.notified).toBe(1)
+		// Post delivered → mark the flag → THEN best-effort DMs (so a DM failure can't un-mark/re-post).
+		expect(calls).toEqual(['post', 'mark', 'dm'])
+	})
+
+	it('isolates a throwing settlement self-heal and does not mark that market announced', async () => {
+		hoisted.prediction.listMarketsNeedingSettlementNotice.mockResolvedValue([
+			market('a', 'resolved'),
+			market('b', 'voided'),
+		])
+		// A thrown post (e.g. Discord DO unreachable) on the first market must isolate it, leave it NULL
+		// for retry, and not block the second.
+		hoisted.notify.announceMarketResolved
+			.mockRejectedValueOnce(new Error('discord 500'))
+			.mockResolvedValueOnce(true)
+		const res = await reconcileMarketPosts(db, makeEnv())
+		expect(res.failed).toBe(1)
+		expect(res.notified).toBe(1)
+		// The failed market is NOT marked, so a later tick retries it (self-heal).
+		expect(hoisted.prediction.markSettlementAnnounced).toHaveBeenCalledTimes(1)
+		expect(hoisted.prediction.markSettlementAnnounced).toHaveBeenCalledWith('b')
 	})
 })

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -218,12 +218,22 @@ async function notifyClose(
 }
 
 /**
- * Announce a just-settled (resolved/voided) market to its thread NOW (fast, one message) and
- * return a thunk that DMs each participant their result. The DM fan-out is returned — not awaited —
- * so the caller runs it in the RPC's `ctx.waitUntil`, off the resolver's confirmation path (one
- * rate-limited DM per participant would otherwise make a large market's confirmation hang or time
- * out). Best-effort; returns undefined when there's nothing to notify. The resolution already
- * committed, so a Discord failure here is never fatal.
+ * Announce a just-settled (resolved/voided) market to its thread NOW (fast, one message), mark it
+ * settlement-announced the instant that post lands, and return a thunk that DMs each participant their
+ * result. The DM fan-out is returned — not awaited — so the caller runs it in the RPC's `ctx.waitUntil`,
+ * off the resolver's confirmation path (one rate-limited DM per participant would otherwise make a large
+ * market's confirmation hang or time out). The resolution already committed, so a Discord failure here
+ * is never fatal.
+ *
+ * The `settlementAnnounced` flag is set here, SYNCHRONOUSLY, right after the thread post succeeds — NOT
+ * after the DM fan-out. That is deliberate:
+ *   - it makes the public aggregate result at-least-once: if the post fails we leave the flag NULL and
+ *     return undefined, so the reconcile sweep re-posts it later;
+ *   - it closes the race the fan-out would otherwise open — marking after a multi-minute DM loop leaves
+ *     the flag NULL throughout, so a reconcile tick could fire mid-fan-out and double-notify. Marking
+ *     before the fan-out means a healthy live path is already flagged done before any tick sees it.
+ * The trade-off: per-participant DMs are best-effort (an eviction mid-fan-out drops the rest) — the same
+ * best-effort guarantee they already had. The reconcile sweep self-heals the thread post, not the DMs.
  */
 async function announceSettlement(
 	env: ComponentEnv,
@@ -236,7 +246,11 @@ async function announceSettlement(
 		const settlement = await prediction.getMarketSettlement(marketId)
 		if (!settlement) return undefined
 		const discord = getStub<Discord>(env.DISCORD, 'default')
-		await announceMarketResolved(discord, env.PM_FORUM_GUILD_ID ?? '', market, settlement)
+		const posted = await announceMarketResolved(discord, env.PM_FORUM_GUILD_ID ?? '', market, settlement)
+		// Post failed → leave the flag NULL so the reconcile sweep re-posts (and re-DMs) later; don't
+		// half-notify by DMing now against a market whose public result never landed.
+		if (!posted) return undefined
+		await prediction.markSettlementAnnounced(marketId)
 		return () => dmWagerResults(discord, market, settlement)
 	} catch (err) {
 		logger.warn('[DiscordComponents] settlement announce failed', {

--- a/apps/core/src/services/discord-market-notify.service.ts
+++ b/apps/core/src/services/discord-market-notify.service.ts
@@ -69,14 +69,19 @@ function winningOutcomeLabel(market: MarketDetail, settlement: MarketSettlement)
  * Post the settled market's outcome + aggregate totals to its thread (aggregate only — never a
  * per-user amount; those go out privately via DM). Best-effort; no-op if the market has no post.
  * Fast (one message) so it can stay on the interactive resolve path.
+ *
+ * Returns whether the aggregate result is now in the thread — `true` when the post landed (or there's
+ * no thread to post to, i.e. nothing owed), `false` when the send failed. Callers gate the persisted
+ * `settlementAnnounced` flag on this: a `false` leaves the market un-announced so the reconcile sweep
+ * re-posts it (at-least-once delivery of the public result).
  */
 export async function announceMarketResolved(
 	discord: Discord,
 	guildId: string,
 	market: MarketDetail,
 	settlement: MarketSettlement
-): Promise<void> {
-	if (!market.discordThreadId) return
+): Promise<boolean> {
+	if (!market.discordThreadId) return true
 	const content =
 		settlement.status === 'voided'
 			? buildMarketVoidAnnouncement(settlement.totalStaked)
@@ -92,6 +97,7 @@ export async function announceMarketResolved(
 	if (!res.success) {
 		logger.warn('[PMNotify] resolve announcement failed', { marketId: market.id, error: res.error })
 	}
+	return res.success
 }
 
 /**

--- a/apps/core/src/services/discord-market-reconcile.service.ts
+++ b/apps/core/src/services/discord-market-reconcile.service.ts
@@ -4,14 +4,18 @@
  * The Discord side of a market is best-effort: a bet/resolve refresh, the initial post, and
  * auto-close on `closesAt` can all fail silently, leaving the DB and the forum posts drifting.
  * This periodic sweep (driven by Core's cron — Core is the only worker binding both the PM DO and
- * the Discord DO; the PM DO must never call Discord) heals that drift in three bounded passes:
+ * the Discord DO; the PM DO must never call Discord) heals that drift in four bounded passes:
  *
  *   (a) auto-close markets past their close time (bounded; a backlog drains over ticks);
  *   (b) refresh drifted posts — embed + status-appropriate buttons + tag/lock — driven by a
  *       self-shrinking "recently changed, has a post" list, NOT by the one-shot close result, so a
  *       refresh that fails (a just-closed market's tag flip, or a failed live bet/resolve refresh)
  *       is retried on later ticks until it lands;
- *   (c) backfill posts for non-terminal markets that never got one.
+ *   (c) backfill posts for non-terminal markets that never got one;
+ *   (d) re-post the terminal (resolved/voided) aggregate result to the thread for markets whose live
+ *       path never landed it (Core evicted before the post), keyed off a persisted
+ *       `settlementAnnouncedAt` flag. At-least-once for the public post (marked only once the post
+ *       succeeds); per-participant DMs are re-sent alongside but stay best-effort (not tracked).
  *
  * Every pass is bounded and per-market isolated: one bad market never aborts the run.
  */
@@ -19,7 +23,11 @@
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
-import { announceMarketClosed } from './discord-market-notify.service'
+import {
+	announceMarketClosed,
+	announceMarketResolved,
+	dmWagerResults,
+} from './discord-market-notify.service'
 import {
 	applyMarketPostStatus,
 	publishMarketPost,
@@ -46,7 +54,9 @@ export interface ReconcileResult {
 	refreshed: number
 	/** Missing posts successfully backfilled this pass. */
 	posted: number
-	/** Per-market failures (refresh or backfill) that were isolated and skipped. */
+	/** Terminal-settlement notifications re-sent this pass (cross-eviction self-heal). */
+	notified: number
+	/** Per-market failures (refresh, backfill, or settlement notify) that were isolated and skipped. */
 	failed: number
 	/** True when the sweep was skipped because the forum guild/category isn't configured. */
 	skipped: boolean
@@ -56,11 +66,33 @@ export interface ReconcileResult {
 const CLOSE_LIMIT = 25
 const REFRESH_LIMIT = 25
 const BACKFILL_LIMIT = 25
+const SETTLEMENT_NOTICE_LIMIT = 10
 /** Only refresh posts touched within this window — bounds the heal pass to actually-drifted posts. */
 const REFRESH_SINCE_MINUTES = 15
+/**
+ * Settlement self-heal grace: only self-heal once a market has been terminal at least this long. The
+ * live path marks the flag synchronously right after its thread post, so a NULL flag on a market this
+ * old means that post genuinely never landed (evicted / failed) — not that a resolve request is still
+ * in flight. Comfortably clears any in-flight live request.
+ */
+const SETTLEMENT_GRACE_MINUTES = 15
+/**
+ * Settlement self-heal ceiling: ignore markets that went terminal longer ago than this. Bounds retries
+ * of a permanently-failing post (e.g. its thread was deleted) so it ages out instead of re-posting
+ * forever, and bounds the one-time first-deploy re-post of markets settled by the pre-column live path
+ * to this trailing window.
+ */
+const SETTLEMENT_MAX_AGE_MINUTES = 360
 
 export async function reconcileMarketPosts(db: CoreDb, env: ReconcileEnv): Promise<ReconcileResult> {
-	const result: ReconcileResult = { closed: 0, refreshed: 0, posted: 0, failed: 0, skipped: false }
+	const result: ReconcileResult = {
+		closed: 0,
+		refreshed: 0,
+		posted: 0,
+		notified: 0,
+		failed: 0,
+		skipped: false,
+	}
 
 	// Without a configured forum guild + category there is nowhere to post; do nothing.
 	if (!env.PM_FORUM_GUILD_ID || !env.PM_FORUM_CATEGORY_ID) {
@@ -137,6 +169,58 @@ export async function reconcileMarketPosts(db: CoreDb, env: ReconcileEnv): Promi
 			// the create route); logged loudly so an operator can spot and clean up duplicates. A claim
 			// row (reserve the thread id before creating) is the durable fix, deferred to a follow-up.
 			logger.warn('[PMReconcile] failed to backfill market post', {
+				marketId: market.id,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	// (d) Settlement self-heal. The live resolve/void path posts the aggregate result to the thread and
+	// marks the market announced the instant that post lands (see announceSettlement); a Core eviction
+	// before that post leaves `settlementAnnouncedAt IS NULL`, with no other trace. This pass re-posts
+	// the result for any terminal market still NULL past the grace window and marks it done ONLY once the
+	// post actually succeeds — so a market is never abandoned by a transient Discord failure (it stays
+	// NULL and a later tick retries, until it lands or ages past maxAge). Order matters: mark BEFORE the
+	// DM fan-out, exactly like the live path, so the flag reflects "public result delivered" and a slow
+	// fan-out can't hold it open for a concurrent tick to re-fire on.
+	//
+	// Guarantees & residuals: the thread post is at-least-once (healed across eviction/transient
+	// failure). Per-participant DMs are best-effort — sent once here after the post lands, not tracked or
+	// retried per-recipient. Because the mark is gated on the post (not the fan-out) and set before the
+	// DMs, the double-notify window shrinks to a single post call; two ticks overlapping within it (rare
+	// — 5-min cron, sub-second window) at worst duplicate one thread post. First-deploy caveat: terminal
+	// markets already announced by the pre-column live path have a NULL flag and will be re-posted once
+	// if they resolved within maxAge of the migration (bounded, one-time; empty in practice until the
+	// feature is actually deployed).
+	const unannounced = await prediction.listMarketsNeedingSettlementNotice(
+		SETTLEMENT_NOTICE_LIMIT,
+		SETTLEMENT_GRACE_MINUTES,
+		SETTLEMENT_MAX_AGE_MINUTES
+	)
+	for (const market of unannounced) {
+		try {
+			const settlement = await prediction.getMarketSettlement(market.id)
+			if (!settlement) {
+				// Terminal market with no settlement data (shouldn't happen) — mark it so the work-list
+				// stops re-selecting it rather than spinning every tick.
+				await prediction.markSettlementAnnounced(market.id)
+				continue
+			}
+			const posted = await announceMarketResolved(discord, guildId, market, settlement)
+			// Post failed (Discord 4xx/5xx/rate-limit) — count it and leave the flag NULL so a later tick
+			// retries (until it lands or ages past maxAge). Don't DM against a market whose public result
+			// never landed (avoids re-DM spam on a broken thread). Mirrors pass (b)'s soft-failure handling.
+			if (!posted) {
+				result.failed++
+				continue
+			}
+			await prediction.markSettlementAnnounced(market.id)
+			result.notified++
+			// Best-effort per-recipient; runs after the mark, so a DM failure never un-marks / re-posts.
+			await dmWagerResults(discord, market, settlement)
+		} catch (error) {
+			result.failed++
+			logger.warn('[PMReconcile] settlement self-heal failed', {
 				marketId: market.id,
 				error: error instanceof Error ? error.message : String(error),
 			})

--- a/apps/prediction-markets/.migrations/0004_abandoned_justice.sql
+++ b/apps/prediction-markets/.migrations/0004_abandoned_justice.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pm_markets" ADD COLUMN "settlement_announced_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "pm_markets_settle_unannounced_idx" ON "pm_markets" USING btree ("updated_at") WHERE "pm_markets"."settlement_announced_at" is null and "pm_markets"."status" in ('resolved', 'voided');

--- a/apps/prediction-markets/.migrations/meta/0004_snapshot.json
+++ b/apps/prediction-markets/.migrations/meta/0004_snapshot.json
@@ -1,0 +1,1021 @@
+{
+  "id": "e60ffb47-ab97-4ac2-b707-bfb53913218a",
+  "prevId": "f15b859a-2e1e-4ffd-a5c0-d4052df4915f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pm_bets": {
+      "name": "pm_bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_bet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_bets_idempotency_key_uq": {
+          "name": "pm_bets_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_user_idx": {
+          "name": "pm_bets_market_user_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_user_created_idx": {
+          "name": "pm_bets_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_outcome_idx": {
+          "name": "pm_bets_market_outcome_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_config": {
+      "name": "pm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_rake_bps": {
+          "name": "default_rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "default_min_stake": {
+          "name": "default_min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "two_of_n_threshold": {
+          "name": "two_of_n_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_ledger": {
+      "name": "pm_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pm_ledger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_ledger_bet_type_uq": {
+          "name": "pm_ledger_bet_type_uq",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_idempotency_key_uq": {
+          "name": "pm_ledger_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pm_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_user_created_idx": {
+          "name": "pm_ledger_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_market_idx": {
+          "name": "pm_ledger_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_created_id_idx": {
+          "name": "pm_ledger_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_history": {
+      "name": "pm_market_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "pm_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_market_history_market_created_idx": {
+          "name": "pm_market_history_market_created_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_history_created_id_idx": {
+          "name": "pm_market_history_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_outcomes": {
+      "name": "pm_market_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "pm_market_outcomes_market_label_uq": {
+          "name": "pm_market_outcomes_market_label_uq",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_outcomes_market_idx": {
+          "name": "pm_market_outcomes_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_markets": {
+      "name": "pm_markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_outcome_id": {
+          "name": "resolved_outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pool": {
+          "name": "total_pool",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "rake_bps": {
+          "name": "rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stake": {
+          "name": "min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "max_stake": {
+          "name": "max_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_user_cap": {
+          "name": "per_user_cap",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_of_n": {
+          "name": "two_of_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discord_thread_id": {
+          "name": "discord_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_announced_at": {
+          "name": "settlement_announced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_markets_status_closes_idx": {
+          "name": "pm_markets_status_closes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_thread_uq": {
+          "name": "pm_markets_thread_uq",
+          "columns": [
+            {
+              "expression": "discord_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_settle_unannounced_idx": {
+          "name": "pm_markets_settle_unannounced_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pm_markets\".\"settlement_announced_at\" is null and \"pm_markets\".\"status\" in ('resolved', 'voided')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_rate_limits": {
+      "name": "pm_rate_limits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pm_rate_limits_user_id_command_pk": {
+          "name": "pm_rate_limits_user_id_command_pk",
+          "columns": [
+            "user_id",
+            "command"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_resolution_proposals": {
+      "name": "pm_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pm_resolution_proposals_market_status_idx": {
+          "name": "pm_resolution_proposals_market_status_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_wallets": {
+      "name": "pm_wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pm_bet_status": {
+      "name": "pm_bet_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "won",
+        "lost",
+        "refunded"
+      ]
+    },
+    "public.pm_ledger_type": {
+      "name": "pm_ledger_type",
+      "schema": "public",
+      "values": [
+        "grant",
+        "wager",
+        "refund",
+        "payout",
+        "rake",
+        "burn",
+        "adjustment"
+      ]
+    },
+    "public.pm_market_status": {
+      "name": "pm_market_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "resolving",
+        "resolved",
+        "voided"
+      ]
+    },
+    "public.pm_proposal_status": {
+      "name": "pm_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.pm_visibility": {
+      "name": "pm_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "internal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/prediction-markets/.migrations/meta/_journal.json
+++ b/apps/prediction-markets/.migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783439551480,
       "tag": "0003_fancy_hairball",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1783476955001,
+      "tag": "0004_abandoned_justice",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/prediction-markets/src/db/schema.ts
+++ b/apps/prediction-markets/src/db/schema.ts
@@ -116,6 +116,14 @@ export const pmMarkets = pgTable(
 		discordThreadId: text('discord_thread_id'),
 		/** Discord starter-message id of the forum post (equals the thread id for forum posts). */
 		discordMessageId: text('discord_message_id'),
+		/**
+		 * When the terminal (resolved/voided) settlement notification — the thread result post +
+		 * per-participant result DMs — finished. NULL until then. The live resolve/void path sets it
+		 * after its `waitUntil` fan-out completes; the reconcile sweep re-sends any terminal market
+		 * still NULL past a grace window (cross-eviction self-heal: Core dying mid-notify drops the
+		 * best-effort `waitUntil` work with no other trace).
+		 */
+		settlementAnnouncedAt: timestamp('settlement_announced_at', { withTimezone: true }),
 		createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 	},
@@ -124,6 +132,12 @@ export const pmMarkets = pgTable(
 		// One market per forum thread. NULLs are distinct in Postgres b-tree, so many
 		// pre-post markets can coexist.
 		uniqueIndex('pm_markets_thread_uq').on(t.discordThreadId),
+		// Partial index over the settlement self-heal work-list: only terminal markets whose
+		// notification never completed. Keeps the reconcile scan O(pending failures), not
+		// O(all resolved markets ever) as terminal markets accumulate.
+		index('pm_markets_settle_unannounced_idx')
+			.on(t.updatedAt)
+			.where(sql`${t.settlementAnnouncedAt} is null and ${t.status} in ('resolved', 'voided')`),
 	]
 )
 

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -1143,6 +1143,65 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		return rows.map((r) => r.id)
 	}
 
+	/**
+	 * Terminal markets whose settlement result was never posted — the reconcile cron's settlement
+	 * self-heal work-list. Selects resolved/voided markets that have a forum post, are still
+	 * `settlementAnnouncedAt IS NULL`, and were last touched within `[now − maxAgeMinutes, now − minAgeMinutes]`.
+	 * The lower bound clears any in-flight live resolve request (the live path marks the flag right after
+	 * its post); the upper bound caps retries of a permanently-failing post and bounds the first-deploy
+	 * re-post window. Keyed off `updatedAt` as a proxy for the terminal-transition time: it's set at the
+	 * transition and normally not touched again for a terminal market (the refresh pass skips terminal
+	 * markets), the one exception being a rare `attachDiscordPost` backfill landing on a market that went
+	 * terminal mid-create — which only nudges `updatedAt` forward by ~one tick (both window bounds move
+	 * together), so it can delay a self-heal by seconds but never drop it.
+	 */
+	async listMarketsNeedingSettlementNotice(
+		limit = 25,
+		minAgeMinutes = 15,
+		maxAgeMinutes = 360
+	): Promise<MarketDetail[]> {
+		const bounded = Math.min(Math.max(limit, 1), 100)
+		const now = Date.now()
+		const newestAllowed = new Date(now - Math.max(minAgeMinutes, 0) * 60_000)
+		const oldestAllowed = new Date(now - Math.max(maxAgeMinutes, minAgeMinutes) * 60_000)
+		const rows = await this.db
+			.select({ id: pmMarkets.id })
+			.from(pmMarkets)
+			.where(
+				and(
+					isNull(pmMarkets.settlementAnnouncedAt),
+					isNotNull(pmMarkets.discordThreadId),
+					inArray(pmMarkets.status, ['resolved', 'voided']),
+					lte(pmMarkets.updatedAt, newestAllowed),
+					gte(pmMarkets.updatedAt, oldestAllowed)
+				)
+			)
+			.orderBy(asc(pmMarkets.updatedAt))
+			.limit(bounded)
+
+		return this.buildMarketDetails(rows.map((r) => r.id))
+	}
+
+	/**
+	 * Mark a terminal market's settlement notification as delivered. Idempotent and self-guarding:
+	 * the `settlementAnnouncedAt IS NULL` + terminal-status predicate means a live-path completion and a
+	 * racing reconcile self-heal converge on one flag, and it can never be set on a non-terminal market.
+	 * Deliberately does NOT bump `updatedAt` — the self-heal work-list keys off `updatedAt` as the
+	 * terminal-transition time, which must stay stable.
+	 */
+	async markSettlementAnnounced(marketId: string): Promise<void> {
+		await this.db
+			.update(pmMarkets)
+			.set({ settlementAnnouncedAt: new Date() })
+			.where(
+				and(
+					eq(pmMarkets.id, marketId),
+					isNull(pmMarkets.settlementAnnouncedAt),
+					inArray(pmMarkets.status, ['resolved', 'voided'])
+				)
+			)
+	}
+
 	/** Build full details for a list of market ids, skipping any that vanished. */
 	private async buildMarketDetails(marketIds: string[]): Promise<MarketDetail[]> {
 		const details: MarketDetail[] = []

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -319,6 +319,25 @@ export interface PredictionMarkets {
 	 * participant. Returns null if the market doesn't exist.
 	 */
 	getMarketSettlement(marketId: string): Promise<MarketSettlement | null>
+	/**
+	 * Terminal (resolved/voided) markets that HAVE a forum post but whose settlement notification never
+	 * completed (`settlementAnnouncedAt IS NULL`) — the reconcile cron's settlement self-heal work-list.
+	 * Bounded to markets that went terminal within `[now − maxAgeMinutes, now − minAgeMinutes]`: the
+	 * lower bound (`minAgeMinutes`) avoids racing a healthy live-path DM fan-out still in flight; the
+	 * upper bound (`maxAgeMinutes`) keeps this forward-only (deep history never re-fires) and stops
+	 * retrying a permanently-failing market forever. Oldest first, bounded.
+	 */
+	listMarketsNeedingSettlementNotice(
+		limit?: number,
+		minAgeMinutes?: number,
+		maxAgeMinutes?: number
+	): Promise<MarketDetail[]>
+	/**
+	 * Mark a terminal market's settlement notification (thread result post + result DMs) as delivered.
+	 * Idempotent: sets `settlementAnnouncedAt` only when currently NULL and the market is terminal, so a
+	 * live-path completion and a racing reconcile pass converge to the same single flag.
+	 */
+	markSettlementAnnounced(marketId: string): Promise<void>
 	getLeaderboard(opts?: { window?: 'all' | '30d'; limit?: number }): Promise<LeaderboardRow[]>
 	getLedger(userId: string, opts?: { limit?: number; cursor?: string }): Promise<LedgerRow[]>
 


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

The prediction-markets settlement flow (posting the resolved/voided outcome to the market's Discord thread and DMing participants) ran only as best-effort `waitUntil` work, so a Core eviction between resolution and that post could drop the public announcement with no trace and no retry. This PR adds a persisted checkpoint and a reconcile pass that self-heals any terminal market whose settlement notification never completed.

## Changes

- Add `pm_markets.settlement_announced_at` column plus a partial index (`pm_markets_settle_unannounced_idx`) over unannounced terminal markets (migration `0004_abandoned_justice`).
- `announceMarketResolved` now returns whether the thread post actually landed (`Promise<boolean>`), so callers can gate the persisted flag on real delivery instead of assuming success.
- Live resolve/void path (`announceSettlement`) marks `settlementAnnounced` synchronously right after the thread post succeeds — before the DM fan-out — so a healthy resolve is flagged done before any reconcile tick can race it, and an eviction before the post leaves it `NULL`.
- New reconcile pass (d) in `reconcileMarketPosts`: `listMarketsNeedingSettlementNotice` selects terminal markets past a grace window (`SETTLEMENT_GRACE_MINUTES` = 15) and under a max age (`SETTLEMENT_MAX_AGE_MINUTES` = 360), re-posts via `announceMarketResolved`, marks via `markSettlementAnnounced` only on success, and re-sends DMs via `dmWagerResults` (best-effort, not tracked). Failures are isolated per-market and counted.
- New `ReconcileResult.notified` counter, threaded into the scheduled-handler logging condition in `apps/core/src/index.ts`.
- New DO methods `listMarketsNeedingSettlementNotice` and `markSettlementAnnounced` on `PredictionMarketsDO`, exposed on the `PredictionMarkets` interface in `@repo/prediction-markets`.
- Fix `Justfile`'s `db-generate-all`/`db-migrate-all` targets: add the (previously missing) `apps/prediction-markets` step, and drop stale `apps/postman`/`apps/mumble` migrate steps for apps that no longer have a `db:migrate` script.

## Testing

Added/extended unit tests in `apps/core/src/services/__tests__/discord-market-reconcile.test.ts` covering: re-sending notifications for un-announced terminal markets, marking-without-notifying when settlement data is missing, leaving a market un-announced on a soft-failed post (retried next tick), the mark-before-DM ordering, and isolating a thrown error on one market from others in the same pass.
<!-- claude:end -->
