### PR TITLE
add multi-level-role assign to discord attachments

### DIFF
--- a/apps/core/.migrations/0041_motionless_emma_frost.sql
+++ b/apps/core/.migrations/0041_motionless_emma_frost.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "corporation_discord_servers" ADD COLUMN "corp_member_role_id" uuid;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD COLUMN "corp_member_auto_apply" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD COLUMN "alliance_guest_role_id" uuid;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD COLUMN "alliance_guest_auto_apply" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD COLUMN "non_alliance_guest_role_id" uuid;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD COLUMN "non_alliance_guest_auto_apply" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD CONSTRAINT "corporation_discord_servers_corp_member_role_id_discord_roles_id_fk" FOREIGN KEY ("corp_member_role_id") REFERENCES "public"."discord_roles"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD CONSTRAINT "corporation_discord_servers_alliance_guest_role_id_discord_roles_id_fk" FOREIGN KEY ("alliance_guest_role_id") REFERENCES "public"."discord_roles"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" ADD CONSTRAINT "corporation_discord_servers_non_alliance_guest_role_id_discord_roles_id_fk" FOREIGN KEY ("non_alliance_guest_role_id") REFERENCES "public"."discord_roles"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/core/.migrations/meta/0041_snapshot.json
+++ b/apps/core/.migrations/meta/0041_snapshot.json
@@ -1,0 +1,4832 @@
+{
+  "id": "b27e190d-f5e3-41bb-be06-b5b66ca402d9",
+  "prevId": "695fc7c0-b0a0-49df-9316-673e31d4b30b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_destinations": {
+      "name": "alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_destinations_scope_idx": {
+          "name": "alert_destinations_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_alert_type_idx": {
+          "name": "alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_type_idx": {
+          "name": "alert_destinations_type_idx",
+          "columns": [
+            {
+              "expression": "destination_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_enabled_idx": {
+          "name": "alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_core_user_id_users_id_fk": {
+          "name": "alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_created_by_users_id_fk": {
+          "name": "alert_destinations_created_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_updated_by_users_id_fk": {
+          "name": "alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_configs": {
+      "name": "corporation_alert_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_ids": {
+          "name": "destination_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_alert_configs_corp_idx": {
+          "name": "corporation_alert_configs_corp_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_alert_type_idx": {
+          "name": "corporation_alert_configs_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_enabled_idx": {
+          "name": "corporation_alert_configs_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_corp_alert_type_idx": {
+          "name": "corporation_alert_configs_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_configs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_alert_configs_corp_alert_type_unique": {
+          "name": "corporation_alert_configs_corp_alert_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "alert_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_destinations": {
+      "name": "corporation_alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_alert_destinations_corp_id_idx": {
+          "name": "corp_alert_destinations_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_alert_type_idx": {
+          "name": "corp_alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_enabled_idx": {
+          "name": "corp_alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_corp_alert_type_idx": {
+          "name": "corp_alert_destinations_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_core_user_id_users_id_fk": {
+          "name": "corporation_alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_created_by_users_id_fk": {
+          "name": "corporation_alert_destinations_created_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_updated_by_users_id_fk": {
+          "name": "corporation_alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_invites": {
+      "name": "corporation_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_discord_invites_corp_id_idx": {
+          "name": "corporation_discord_invites_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_user_id_idx": {
+          "name": "corporation_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_server_id_idx": {
+          "name": "corporation_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_created_at_idx": {
+          "name": "corporation_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_user_id_users_id_fk": {
+          "name": "corporation_discord_invites_user_id_users_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_roles": {
+      "name": "corporation_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_roles_attachment_idx": {
+          "name": "corp_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_role": {
+          "name": "unique_corp_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_servers": {
+      "name": "corporation_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "corp_member_role_id": {
+          "name": "corp_member_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corp_member_auto_apply": {
+          "name": "corp_member_auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "alliance_guest_role_id": {
+          "name": "alliance_guest_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_guest_auto_apply": {
+          "name": "alliance_guest_auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "non_alliance_guest_role_id": {
+          "name": "non_alliance_guest_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_alliance_guest_auto_apply": {
+          "name": "non_alliance_guest_auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_servers_corp_id_idx": {
+          "name": "corp_discord_servers_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_id_idx": {
+          "name": "corp_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_auto_assign_idx": {
+          "name": "corp_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"corporation_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_discord_servers_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_corp_member_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_servers_corp_member_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "corp_member_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_alliance_guest_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_servers_alliance_guest_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "alliance_guest_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_non_alliance_guest_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_servers_non_alliance_guest_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "non_alliance_guest_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server": {
+          "name": "unique_corp_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_categories": {
+      "name": "discord_command_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_categories_sort_order_idx": {
+          "name": "discord_command_categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_categories_name_unique": {
+          "name": "discord_command_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_permissions": {
+      "name": "discord_command_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_permissions_command_id_idx": {
+          "name": "discord_command_permissions_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_command_permissions_permission_id_idx": {
+          "name": "discord_command_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_command_permissions_command_id_discord_commands_id_fk": {
+          "name": "discord_command_permissions_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_command_permissions",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_permissions_command_permission_unique": {
+          "name": "discord_command_permissions_command_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_commands": {
+      "name": "discord_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static_response'"
+        },
+        "response_template": {
+          "name": "response_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_commands_name_idx": {
+          "name": "discord_commands_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_type_idx": {
+          "name": "discord_commands_type_idx",
+          "columns": [
+            {
+              "expression": "command_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_is_active_idx": {
+          "name": "discord_commands_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_category_id_idx": {
+          "name": "discord_commands_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_commands_category_id_discord_command_categories_id_fk": {
+          "name": "discord_commands_category_id_discord_command_categories_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "discord_command_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discord_commands_created_by_users_id_fk": {
+          "name": "discord_commands_created_by_users_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_commands_name_unique": {
+          "name": "discord_commands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_rows": {
+      "name": "discord_member_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discriminator": {
+          "name": "discriminator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_ids": {
+          "name": "role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "linked": {
+          "name": "linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_rows_run_linked_user_idx": {
+          "name": "discord_member_audit_rows_run_linked_user_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk": {
+          "name": "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "discord_member_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_rows_core_user_id_users_id_fk": {
+          "name": "discord_member_audit_rows_core_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_rows_run_discord_user_unique": {
+          "name": "discord_member_audit_rows_run_discord_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_runs": {
+      "name": "discord_member_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_count": {
+          "name": "linked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unlinked_count": {
+          "name": "unlinked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_runs_server_started_idx": {
+          "name": "discord_member_audit_runs_server_started_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_member_audit_runs_status_idx": {
+          "name": "discord_member_audit_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_runs_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_member_audit_runs_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "discord_member_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_runs_workflow_instance_id_unique": {
+          "name": "discord_member_audit_runs_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_roles": {
+      "name": "discord_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_roles_server_id_idx": {
+          "name": "discord_roles_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_roles_server_auto_apply_active_idx": {
+          "name": "discord_roles_server_auto_apply_active_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_apply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_roles\".\"auto_apply\" = true AND \"discord_roles\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_roles_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_roles_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_roles",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_discord_server_role": {
+          "name": "unique_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_server_commands": {
+      "name": "discord_server_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_command_id": {
+          "name": "discord_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_server_commands_server_id_idx": {
+          "name": "discord_server_commands_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_server_commands_command_id_idx": {
+          "name": "discord_server_commands_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_server_commands_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_server_commands_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_command_id_discord_commands_id_fk": {
+          "name": "discord_server_commands_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_created_by_users_id_fk": {
+          "name": "discord_server_commands_created_by_users_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_server_commands_server_command_unique": {
+          "name": "discord_server_commands_server_command_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "command_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_servers": {
+      "name": "discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "manage_nicknames": {
+          "name": "manage_nicknames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_servers_guild_id_idx": {
+          "name": "discord_servers_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_servers_active_idx": {
+          "name": "discord_servers_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_servers\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_servers_created_by_users_id_fk": {
+          "name": "discord_servers_created_by_users_id_fk",
+          "tableFrom": "discord_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_servers_guild_id_unique": {
+          "name": "discord_servers_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guild_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_decay_config": {
+      "name": "dkp_decay_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_decay_config_active_idx": {
+          "name": "dkp_decay_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dkp_decay_config\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_decay_config_effective_from_idx": {
+          "name": "dkp_decay_config_effective_from_idx",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_decay_config_created_by_users_id_fk": {
+          "name": "dkp_decay_config_created_by_users_id_fk",
+          "tableFrom": "dkp_decay_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_transactions": {
+      "name": "dkp_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_reason": {
+          "name": "award_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_transactions_user_earned_idx": {
+          "name": "dkp_transactions_user_earned_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_user_source_idx": {
+          "name": "dkp_transactions_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_character_earned_idx": {
+          "name": "dkp_transactions_character_earned_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_corp_earned_idx": {
+          "name": "dkp_transactions_corp_earned_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_earned_at_idx": {
+          "name": "dkp_transactions_earned_at_idx",
+          "columns": [
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_type_idx": {
+          "name": "dkp_transactions_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_id_idx": {
+          "name": "dkp_transactions_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_awarded_by_idx": {
+          "name": "dkp_transactions_awarded_by_idx",
+          "columns": [
+            {
+              "expression": "awarded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_transactions_user_id_users_id_fk": {
+          "name": "dkp_transactions_user_id_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "dkp_transactions_awarded_by_users_id_fk": {
+          "name": "dkp_transactions_awarded_by_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "awarded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_corporations": {
+      "name": "managed_corporations",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_character_id": {
+          "name": "assigned_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_character_name": {
+          "name": "assigned_character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "healthy_director_count": {
+          "name": "healthy_director_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_member_corporation": {
+          "name": "is_member_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_alt_corp": {
+          "name": "is_alt_corp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_special_purpose": {
+          "name": "is_special_purpose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recruiting": {
+          "name": "is_recruiting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_corporations_name_idx": {
+          "name": "managed_corporations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_ticker_idx": {
+          "name": "managed_corporations_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_assigned_character_id_idx": {
+          "name": "managed_corporations_assigned_character_id_idx",
+          "columns": [
+            {
+              "expression": "assigned_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_is_active_idx": {
+          "name": "managed_corporations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_background_refresh_idx": {
+          "name": "managed_corporations_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_structure_asset_sync_idx": {
+          "name": "managed_corporations_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_member_idx": {
+          "name": "managed_corporations_corporation_id_is_member_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_member_corporation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_alt_idx": {
+          "name": "managed_corporations_corporation_id_is_alt_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_alt_corp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_special_purpose_idx": {
+          "name": "managed_corporations_corporation_id_is_special_purpose_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_special_purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_corporations_configured_by_users_id_fk": {
+          "name": "managed_corporations_configured_by_users_id_fk",
+          "tableFrom": "managed_corporations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_credential_handoffs": {
+      "name": "mumble_tempop_credential_handoffs",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mumble_tempop_credential_handoffs_expires_at_idx": {
+          "name": "mumble_tempop_credential_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_credential_handoffs",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_guests": {
+      "name": "mumble_tempop_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corp_ticker": {
+          "name": "corp_ticker",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_name": {
+          "name": "login_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mumble_tempop_guests_tempop_id_idx": {
+          "name": "mumble_tempop_guests_tempop_id_idx",
+          "columns": [
+            {
+              "expression": "tempop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_guests",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempop_guests_subject_id_unique": {
+          "name": "mumble_tempop_guests_subject_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id"
+          ]
+        },
+        "mumble_tempop_guests_tempop_character_uq": {
+          "name": "mumble_tempop_guests_tempop_character_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tempop_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempops": {
+      "name": "mumble_tempops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mumble_tempops_status_expires_at_idx": {
+          "name": "mumble_tempops_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mumble_tempops_creator_user_id_idx": {
+          "name": "mumble_tempops_creator_user_id_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempops_creator_user_id_users_id_fk": {
+          "name": "mumble_tempops_creator_user_id_users_id_fk",
+          "tableFrom": "mumble_tempops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempops_short_code_unique": {
+          "name": "mumble_tempops_short_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_code"
+          ]
+        },
+        "mumble_tempops_key_hash_unique": {
+          "name": "mumble_tempops_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_type": {
+          "name": "flow_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_forum_config": {
+      "name": "pm_forum_config",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forum_channel_id": {
+          "name": "forum_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_open_id": {
+          "name": "tag_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_closed_id": {
+          "name": "tag_closed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_resolved_id": {
+          "name": "tag_resolved_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_voided_id": {
+          "name": "tag_voided_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_services": {
+      "name": "core_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_services_enabled_idx": {
+          "name": "core_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_name_idx": {
+          "name": "core_services_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_slug_idx": {
+          "name": "core_services_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_external_links": {
+      "name": "sidebar_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidebar_external_links_sort_order_idx": {
+          "name": "sidebar_external_links_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_log": {
+      "name": "user_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_activity_log_user_id_idx": {
+          "name": "user_activity_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_action_idx": {
+          "name": "user_activity_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_timestamp_idx": {
+          "name": "user_activity_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_log_user_id_users_id_fk": {
+          "name": "user_activity_log_user_id_users_id_fk",
+          "tableFrom": "user_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_characters": {
+      "name": "user_characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_owner_hash": {
+          "name": "character_owner_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_character_refresh": {
+          "name": "last_character_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_characters_user_id_idx": {
+          "name": "user_characters_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_character_id_idx": {
+          "name": "user_characters_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_is_primary_idx": {
+          "name": "user_characters_is_primary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_status_idx": {
+          "name": "user_characters_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_deleted_idx": {
+          "name": "user_characters_deleted_idx",
+          "columns": [
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_id_idx": {
+          "name": "user_characters_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_id_idx": {
+          "name": "user_characters_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_name_idx": {
+          "name": "user_characters_corporation_name_idx",
+          "columns": [
+            {
+              "expression": "corporation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_name_idx": {
+          "name": "user_characters_alliance_name_idx",
+          "columns": [
+            {
+              "expression": "alliance_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_characters_user_id_users_id_fk": {
+          "name": "user_characters_user_id_users_id_fk",
+          "tableFrom": "user_characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_characters_character_id_unique": {
+          "name": "user_characters_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fingerprints": {
+      "name": "user_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_fingerprints_user_id_idx": {
+          "name": "user_fingerprints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_fingerprint_idx": {
+          "name": "user_fingerprints_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_user_id_fingerprint_idx": {
+          "name": "user_fingerprints_user_id_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fingerprints_user_id_users_id_fk": {
+          "name": "user_fingerprints_user_id_users_id_fk",
+          "tableFrom": "user_fingerprints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ip_addresses": {
+      "name": "user_ip_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addr": {
+          "name": "addr",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address_hash": {
+          "name": "ip_address_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_ip_addresses_user_id_idx": {
+          "name": "user_ip_addresses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_ip_addresses_ip_address_idx": {
+          "name": "user_ip_addresses_ip_address_idx",
+          "columns": [
+            {
+              "expression": "addr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ip_addresses_user_id_users_id_fk": {
+          "name": "user_ip_addresses_user_id_users_id_fk",
+          "tableFrom": "user_ip_addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_ip_addresses_user_ip_unique": {
+          "name": "user_ip_addresses_user_ip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "addr"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_user_services": {
+      "name": "core_user_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_user_services_user_id_idx": {
+          "name": "core_user_services_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_service_id_idx": {
+          "name": "core_user_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_user_id_service_id_idx": {
+          "name": "core_user_services_user_id_service_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_enabled_idx": {
+          "name": "core_user_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "core_user_services_user_id_users_id_fk": {
+          "name": "core_user_services_user_id_users_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "core_user_services_service_id_core_services_id_fk": {
+          "name": "core_user_services_service_id_core_services_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "core_services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_user_services_user_id_service_id_unique": {
+          "name": "core_user_services_user_id_service_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "service_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_session_token_idx": {
+          "name": "user_sessions_session_token_idx",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sessions_session_token_unique": {
+          "name": "user_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "immunitas": {
+          "name": "immunitas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_discord_refresh": {
+          "name": "last_discord_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "legacy_auth_user_id": {
+          "name": "legacy_auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_username": {
+          "name": "legacy_auth_user_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_email_hash": {
+          "name": "legacy_auth_user_email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow": {
+          "name": "last_refresh_workflow",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow_attempt": {
+          "name": "last_refresh_workflow_attempt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_main_character_id_idx": {
+          "name": "users_main_character_id_idx",
+          "columns": [
+            {
+              "expression": "main_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_discord_user_id_idx": {
+          "name": "users_discord_user_id_idx",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_discord_refresh_idx": {
+          "name": "users_last_discord_refresh_idx",
+          "columns": [
+            {
+              "expression": "last_discord_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_id_idx": {
+          "name": "users_legacy_auth_user_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_username_idx": {
+          "name": "users_legacy_auth_user_username_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_email_hash_idx": {
+          "name": "users_legacy_auth_user_email_hash_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_idx": {
+          "name": "users_last_refresh_workflow_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_attempt_idx": {
+          "name": "users_last_refresh_workflow_attempt_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow_attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_main_character_id_unique": {
+          "name": "users_main_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "main_character_id"
+          ]
+        },
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_user_id"
+          ]
+        },
+        "users_legacy_auth_user_id_unique": {
+          "name": "users_legacy_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_id"
+          ]
+        },
+        "users_legacy_auth_user_username_unique": {
+          "name": "users_legacy_auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_username"
+          ]
+        },
+        "users_legacy_auth_user_email_hash_unique": {
+          "name": "users_legacy_auth_user_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/.migrations/meta/_journal.json
+++ b/apps/core/.migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1783438177210,
       "tag": "0040_common_tinkerer",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1783503885537,
+      "tag": "0041_motionless_emma_frost",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/db/schema.ts
+++ b/apps/core/src/db/schema.ts
@@ -601,6 +601,25 @@ export const corporationDiscordServers = pgTable(
 		autoInvite: boolean('auto_invite').default(false).notNull(),
 		/** Whether to automatically assign roles on invite */
 		autoAssignRoles: boolean('auto_assign_roles').default(false).notNull(),
+		/** Scenario role for corp members */
+		corpMemberRoleId: uuid('corp_member_role_id').references(() => discordRoles.id, {
+			onDelete: 'set null',
+		}),
+		/** Whether to auto-apply the corp member scenario role */
+		corpMemberAutoApply: boolean('corp_member_auto_apply').default(false).notNull(),
+		/** Scenario role for alliance guests */
+		allianceGuestRoleId: uuid('alliance_guest_role_id').references(() => discordRoles.id, {
+			onDelete: 'set null',
+		}),
+		/** Whether to auto-apply the alliance guest scenario role */
+		allianceGuestAutoApply: boolean('alliance_guest_auto_apply').default(false).notNull(),
+		/** Scenario role for non-alliance guests */
+		nonAllianceGuestRoleId: uuid('non_alliance_guest_role_id').references(
+			() => discordRoles.id,
+			{ onDelete: 'set null' }
+		),
+		/** Whether to auto-apply the non-alliance guest scenario role */
+		nonAllianceGuestAutoApply: boolean('non_alliance_guest_auto_apply').default(false).notNull(),
 		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},

--- a/apps/core/src/routes/__tests__/groups.discord-role.route.test.ts
+++ b/apps/core/src/routes/__tests__/groups.discord-role.route.test.ts
@@ -1,0 +1,106 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getStub } from '@repo/do-utils'
+
+import groupsRoutes from '../groups'
+
+import type { SessionUser } from '../../context'
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn(),
+}))
+
+vi.mock('../../middleware/session', () => ({
+	requireAuth:
+		() =>
+			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+				await next()
+			},
+	requireAdmin:
+		() =>
+			async (c: any, next: () => Promise<void>): Promise<Response | void> => {
+				const user = c.get('user')
+				if (!user?.is_admin) {
+					return c.json({ error: 'Forbidden' }, 403)
+				}
+				await next()
+			},
+}))
+
+const getStubMock = vi.mocked(getStub)
+
+function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'admin-user',
+		mainCharacterId: 'main-1',
+		sessionId: 'session-1',
+		characters: [],
+		is_admin: true,
+		roles: [],
+		discordUserId: null,
+		...overrides,
+	}
+}
+
+function createApp(user: SessionUser) {
+	const app = new Hono<{
+		Bindings: any
+		Variables: {
+			user?: SessionUser
+		}
+	}>()
+
+	app.use('*', async (c, next) => {
+		c.set('user', user)
+		await next()
+	})
+
+	app.route('/api/groups', groupsRoutes)
+	return app
+}
+
+describe('groups discord role assignment routes', () => {
+	const env = {
+		GROUPS: { name: 'GROUPS' },
+	} as any
+
+	let groupsStub: {
+		assignRoleToDiscordServer: ReturnType<typeof vi.fn>
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		groupsStub = {
+			assignRoleToDiscordServer: vi.fn(),
+		}
+
+		getStubMock.mockImplementation((binding: unknown) => {
+			if (binding === env.GROUPS) return groupsStub as any
+			throw new Error('Unexpected binding')
+		})
+	})
+
+	it('rejects invalid membership types instead of coercing them to member', async () => {
+		const app = createApp(makeUser())
+
+		const res = await app.request(
+			'/api/groups/group-1/discord-servers/attachment-1/roles',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					discordRoleId: 'role-db-1',
+					membershipType: 'not-a-real-type',
+				}),
+			},
+			env
+		)
+
+		expect(res.status).toBe(400)
+		await expect(res.json()).resolves.toEqual({
+			error: "membershipType must be 'member' or 'owner_admin'",
+		})
+		expect(groupsStub.assignRoleToDiscordServer).not.toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/routes/corporations/discord-routes.ts
+++ b/apps/core/src/routes/corporations/discord-routes.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 
-import { and, desc, eq } from '@repo/db-utils'
+import { and, desc, eq, inArray } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
@@ -17,6 +17,32 @@ import type { Core } from '@repo/core'
 import type { App } from '../../context'
 
 const app = new Hono<App>()
+
+async function validateScenarioRoleSelections(
+	db: any,
+	discordServerId: string,
+	roleIds: Array<string | null | undefined>
+): Promise<void> {
+	const uniqueRoleIds = Array.from(new Set(roleIds.filter((roleId): roleId is string => !!roleId)))
+	if (uniqueRoleIds.length === 0) {
+		return
+	}
+
+	const roles = await db.query.discordRoles.findMany({
+		where: inArray(discordRoles.id, uniqueRoleIds),
+		columns: { id: true, discordServerId: true },
+	})
+
+	for (const roleId of uniqueRoleIds) {
+		const role = roles.find((candidate: { id: string; discordServerId: string }) => candidate.id === roleId)
+		if (!role) {
+			throw new Error(`Role ${roleId} not found`)
+		}
+		if (role.discordServerId !== discordServerId) {
+			throw new Error(`Role ${roleId} does not belong to this Discord server`)
+		}
+	}
+}
 
 /**
  * GET /corporations/:corporationId/discord-servers
@@ -68,8 +94,15 @@ app.post('/:corporationId/discord-servers', requireAuth(), requireAdmin(), async
 	}
 
 	try {
-		const body = await c.req.json()
-		const { discordServerId, autoInvite = false, autoAssignRoles = false } = body
+		const body = (await c.req.json()) as Record<string, unknown>
+		const discordServerId = body.discordServerId as string | undefined
+		const autoInvite = body.autoInvite as boolean | undefined
+		const autoAssignRoles = body.autoAssignRoles as boolean | undefined
+		const scenarioRoleIds = [
+			body.corpMemberRoleId as string | null | undefined,
+			body.allianceGuestRoleId as string | null | undefined,
+			body.nonAllianceGuestRoleId as string | null | undefined,
+		]
 
 		if (!discordServerId) {
 			return c.json({ error: 'discordServerId is required' }, 400)
@@ -94,13 +127,22 @@ app.post('/:corporationId/discord-servers', requireAuth(), requireAdmin(), async
 			return c.json({ error: 'Discord server already attached to this corporation' }, 409)
 		}
 
+		await validateScenarioRoleSelections(db, server.id, scenarioRoleIds)
+
 		const [attachment] = await db
 			.insert(corporationDiscordServers)
 			.values({
 				corporationId,
 				discordServerId,
-				autoInvite,
-				autoAssignRoles,
+				autoInvite: autoInvite ?? false,
+				autoAssignRoles: autoAssignRoles ?? false,
+				corpMemberRoleId: body.corpMemberRoleId as string | null | undefined,
+				corpMemberAutoApply: (body.corpMemberAutoApply as boolean | undefined) ?? false,
+				allianceGuestRoleId: body.allianceGuestRoleId as string | null | undefined,
+				allianceGuestAutoApply: (body.allianceGuestAutoApply as boolean | undefined) ?? false,
+				nonAllianceGuestRoleId: body.nonAllianceGuestRoleId as string | null | undefined,
+				nonAllianceGuestAutoApply:
+					(body.nonAllianceGuestAutoApply as boolean | undefined) ?? false,
 			})
 			.returning()
 
@@ -109,6 +151,10 @@ app.post('/:corporationId/discord-servers', requireAuth(), requireAdmin(), async
 		return c.json(attachment, 201)
 	} catch (error) {
 		logger.error('Error attaching Discord server to corporation:', error)
+		const message = error instanceof Error ? error.message : ''
+		if (message.startsWith('Role ')) {
+			return c.json({ error: message }, 400)
+		}
 		return c.json({ error: 'Failed to attach Discord server' }, 500)
 	}
 })
@@ -177,22 +223,57 @@ app.put(
 		}
 
 		try {
-			const body = await c.req.json()
-			const { autoInvite, autoAssignRoles } = body
+			const body = (await c.req.json()) as Record<string, unknown>
+			const autoInvite = body.autoInvite as boolean | undefined
+			const autoAssignRoles = body.autoAssignRoles as boolean | undefined
+			const scenarioRoleIds = [
+				body.corpMemberRoleId as string | null | undefined,
+				body.allianceGuestRoleId as string | null | undefined,
+				body.nonAllianceGuestRoleId as string | null | undefined,
+			]
 
 			const existing = await db.query.corporationDiscordServers.findFirst({
 				where: eq(corporationDiscordServers.id, attachmentId),
+				with: {
+					discordServer: {
+						columns: { id: true },
+					},
+				},
 			})
 
 			if (!existing) {
 				return c.json({ error: 'Discord server attachment not found' }, 404)
 			}
 
+			await validateScenarioRoleSelections(
+				db,
+				existing.discordServer.id,
+				scenarioRoleIds
+			)
+
 			const [updated] = await db
 				.update(corporationDiscordServers)
 				.set({
 					...(autoInvite !== undefined && { autoInvite }),
 					...(autoAssignRoles !== undefined && { autoAssignRoles }),
+					...(body.corpMemberRoleId !== undefined && {
+						corpMemberRoleId: body.corpMemberRoleId as string | null,
+					}),
+					...(body.corpMemberAutoApply !== undefined && {
+						corpMemberAutoApply: body.corpMemberAutoApply as boolean,
+					}),
+					...(body.allianceGuestRoleId !== undefined && {
+						allianceGuestRoleId: body.allianceGuestRoleId as string | null,
+					}),
+					...(body.allianceGuestAutoApply !== undefined && {
+						allianceGuestAutoApply: body.allianceGuestAutoApply as boolean,
+					}),
+					...(body.nonAllianceGuestRoleId !== undefined && {
+						nonAllianceGuestRoleId: body.nonAllianceGuestRoleId as string | null,
+					}),
+					...(body.nonAllianceGuestAutoApply !== undefined && {
+						nonAllianceGuestAutoApply: body.nonAllianceGuestAutoApply as boolean,
+					}),
 					updatedAt: new Date(),
 				})
 				.where(eq(corporationDiscordServers.id, attachmentId))
@@ -201,6 +282,10 @@ app.put(
 			return c.json(updated)
 		} catch (error) {
 			logger.error('Error updating Discord server attachment:', error)
+			const message = error instanceof Error ? error.message : ''
+			if (message.startsWith('Role ')) {
+				return c.json({ error: message }, 400)
+			}
 			return c.json({ error: 'Failed to update Discord server attachment' }, 500)
 		}
 	}

--- a/apps/core/src/routes/groups.ts
+++ b/apps/core/src/routes/groups.ts
@@ -28,6 +28,18 @@ import type { App } from '../context'
 const groups = new Hono<App>()
 groups.use('*', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }))
 
+function parseDiscordRoleMembershipType(value: unknown): 'member' | 'owner_admin' | null {
+	if (value === undefined) {
+		return 'member'
+	}
+
+	if (value === 'member' || value === 'owner_admin') {
+		return value
+	}
+
+	return null
+}
+
 const groupsListQuerySchema = z.object({
 	limit: z.coerce.number().int().min(1).max(100).optional().default(100),
 	offset: z.coerce.number().int().min(0).optional().default(0),
@@ -1837,6 +1849,7 @@ groups.get(
  *   discordServerId: string (UUID from registry)
  *   autoInvite?: boolean
  *   autoAssignRoles?: boolean
+ *   membershipType?: 'member' | 'owner_admin'
  * }
  */
 groups.post(
@@ -1948,7 +1961,19 @@ groups.post(
 		}
 
 		try {
-			const result = await groupsDO.assignRoleToDiscordServer(attachmentId, body.discordRoleId)
+			const membershipType = parseDiscordRoleMembershipType(body.membershipType)
+			if (!membershipType) {
+				return c.json(
+					{ error: "membershipType must be 'member' or 'owner_admin'" },
+					400
+				)
+			}
+
+			const result = await groupsDO.assignRoleToDiscordServer(
+				attachmentId,
+				body.discordRoleId,
+				membershipType
+			)
 			return c.json(result, 201)
 		} catch (error) {
 			if (error instanceof Error) {

--- a/apps/core/src/services/__tests__/discord-role-sync.test.ts
+++ b/apps/core/src/services/__tests__/discord-role-sync.test.ts
@@ -8,6 +8,7 @@ import {
 	getExpectedManagedRoleIdsByGuild,
 	inspectUserDiscordAccess,
 	inviteUserToDiscordServers,
+	refreshServerMembers,
 	syncUserDiscordAccess,
 	updateUserDiscordRoles,
 	updateUserDiscordNickname,
@@ -43,6 +44,7 @@ const discordStubMethods = {
 const groupsStubMethods = {
 	getGroupsWithDiscordAutoInvite: vi.fn(),
 	getGroupMemberUserIds: vi.fn(),
+	getGroupOwnerAndAdminUserIds: vi.fn(),
 	getGroupsByDiscordServer: vi.fn(),
 	getDiscordServerAttachmentConfig: vi.fn(),
 	insertDiscordInviteAuditRecords: vi.fn(),
@@ -66,6 +68,7 @@ const dbQueryMocks: Record<
 	discordServers: { findMany: vi.fn(), findFirst: vi.fn() },
 	discordRoles: { findMany: vi.fn(), findFirst: vi.fn() },
 	corporationDiscordServers: { findMany: vi.fn(), findFirst: vi.fn() },
+	managedCorporations: { findMany: vi.fn(), findFirst: vi.fn() },
 }
 
 const dbInsertMock = vi.fn(() => ({
@@ -198,6 +201,13 @@ function makeCorpAttachment(
 		guildId?: string
 		guildName?: string
 		corpName?: string
+		isMemberCorporation?: boolean
+		corpMemberRoleId?: string | null
+		corpMemberAutoApply?: boolean
+		allianceGuestRoleId?: string | null
+		allianceGuestAutoApply?: boolean
+		nonAllianceGuestRoleId?: string | null
+		nonAllianceGuestAutoApply?: boolean
 		roleIds?: string[]
 	} = {}
 ) {
@@ -214,7 +224,17 @@ function makeCorpAttachment(
 		discordServerId: dsId,
 		autoInvite: overrides.autoInvite ?? true,
 		autoAssignRoles: overrides.autoAssignRoles ?? true,
-		corporation: { id: corpId, name: overrides.corpName ?? 'Test Corp' },
+		corpMemberRoleId: overrides.corpMemberRoleId ?? null,
+		corpMemberAutoApply: overrides.corpMemberAutoApply ?? false,
+		allianceGuestRoleId: overrides.allianceGuestRoleId ?? null,
+		allianceGuestAutoApply: overrides.allianceGuestAutoApply ?? false,
+		nonAllianceGuestRoleId: overrides.nonAllianceGuestRoleId ?? null,
+		nonAllianceGuestAutoApply: overrides.nonAllianceGuestAutoApply ?? false,
+		corporation: {
+			id: corpId,
+			name: overrides.corpName ?? 'Test Corp',
+			isMemberCorporation: overrides.isMemberCorporation ?? false,
+		},
 		discordServer: { id: dsId, guildId, guildName, isActive: true },
 		roles: roleData,
 	}
@@ -229,6 +249,8 @@ function makeGroupWithDiscord(
 			autoInvite?: boolean
 			autoAssignRoles?: boolean
 			roleIds?: string[]
+			memberRoleIds?: string[]
+			ownerAdminRoleIds?: string[]
 		}>
 	} = {}
 ) {
@@ -241,6 +263,8 @@ function makeGroupWithDiscord(
 				autoInvite: true,
 				autoAssignRoles: true,
 				roleIds: [],
+				memberRoleIds: [],
+				ownerAdminRoleIds: [],
 			},
 		],
 	}
@@ -249,7 +273,22 @@ function makeGroupWithDiscord(
 // ─── Reset ───────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-	vi.clearAllMocks()
+	for (const stub of [
+		discordStubMethods,
+		groupsStubMethods,
+		hrStubMethods,
+		eveCorpStubMethods,
+	]) {
+		for (const value of Object.values(stub)) {
+			value.mockReset()
+		}
+	}
+	for (const tableMocks of Object.values(dbQueryMocks)) {
+		tableMocks.findMany.mockReset()
+		tableMocks.findFirst.mockReset()
+	}
+	dbInsertMock.mockReset()
+	mockedGetStub.mockReset()
 	setupGetStubRouting()
 
 	// Default: user exists with Discord linked
@@ -263,8 +302,10 @@ beforeEach(() => {
 	// Default: empty groups
 	groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
 	groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
+	groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue([])
 	// Default: empty auto-apply roles
 	dbQueryMocks.discordRoles.findMany.mockResolvedValue([])
+	dbQueryMocks.managedCorporations.findMany.mockResolvedValue([])
 	// Default: Discord stubs return success
 	discordStubMethods.updateUserRoles.mockResolvedValue([])
 	discordStubMethods.updateUserNickname.mockResolvedValue(undefined)
@@ -312,7 +353,9 @@ describe('updateUserDiscordRoles', () => {
 					}),
 				])
 				// Second call: corp-gating check (any corp attachment exists for this guild)
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+				])
 
 			// Group attached to same guild with group-role-1
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
@@ -370,7 +413,9 @@ describe('updateUserDiscordRoles', () => {
 			// No corp attachments for this user's corps
 			dbQueryMocks.corporationDiscordServers.findMany
 				.mockResolvedValueOnce([]) // user's corp attachments: none
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }]) // corp-gating: guild IS corp-gated
+				.mockResolvedValueOnce([
+					makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+				]) // corp-gating: guild IS corp-gated
 
 			// Group attached to guild-1 with group roles
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
@@ -503,6 +548,92 @@ describe('updateUserDiscordRoles', () => {
 			expect(discordStubMethods.updateUserRoles).not.toHaveBeenCalled()
 			expect(result.totalUpdated).toBe(0)
 		})
+
+		it('should grant owner/admin roles even when the user is not a member', async () => {
+			setupUserInGuild('guild-2')
+
+			dbQueryMocks.corporationDiscordServers.findMany
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([])
+
+			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
+				makeGroupWithDiscord({
+					groupId: 'group-2',
+					discordServers: [
+						{
+							discordServerId: 'ds-2',
+							autoInvite: true,
+							autoAssignRoles: true,
+							ownerAdminRoleIds: ['dr-owner-2'],
+						},
+					],
+				}),
+			])
+			groupsStubMethods.getGroupMemberUserIds.mockResolvedValue([])
+			groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue(['user-1'])
+			dbQueryMocks.discordServers.findFirst.mockResolvedValue(
+				makeDiscordServer({ id: 'ds-2', guildId: 'guild-2' })
+			)
+			dbQueryMocks.discordRoles.findMany
+				.mockResolvedValueOnce([{ roleId: 'owner-role-2', isActive: true }])
+				.mockResolvedValueOnce([])
+
+			groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
+			discordStubMethods.updateUserRoles.mockResolvedValue([
+				{ guildId: 'guild-2', success: true, rolesAdded: ['owner-role-2'], rolesRemoved: [] },
+			])
+
+			await updateUserDiscordRoles(mockEnv, 'user-1')
+
+			expect(discordStubMethods.updateUserRoles).toHaveBeenCalled()
+			const requests = discordStubMethods.updateUserRoles.mock.calls[0][1]
+			expect(requests[0].roleIds).toEqual(expect.arrayContaining(['owner-role-2']))
+		})
+
+		it('should grant both member and owner/admin roles additively', async () => {
+			setupUserInGuild('guild-2')
+
+			dbQueryMocks.corporationDiscordServers.findMany
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([])
+
+			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
+				makeGroupWithDiscord({
+					groupId: 'group-2',
+					discordServers: [
+						{
+							discordServerId: 'ds-2',
+							autoInvite: true,
+							autoAssignRoles: true,
+							memberRoleIds: ['dr-member-2'],
+							ownerAdminRoleIds: ['dr-owner-2'],
+						},
+					],
+				}),
+			])
+			groupsStubMethods.getGroupMemberUserIds.mockResolvedValue(['user-1'])
+			groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue(['user-1'])
+			dbQueryMocks.discordServers.findFirst.mockResolvedValue(
+				makeDiscordServer({ id: 'ds-2', guildId: 'guild-2' })
+			)
+			dbQueryMocks.discordRoles.findMany
+				.mockResolvedValueOnce([
+					{ roleId: 'member-role-2', isActive: true },
+					{ roleId: 'owner-role-2', isActive: true },
+				])
+				.mockResolvedValueOnce([])
+
+			groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
+			discordStubMethods.updateUserRoles.mockResolvedValue([
+				{ guildId: 'guild-2', success: true, rolesAdded: ['member-role-2', 'owner-role-2'], rolesRemoved: [] },
+			])
+
+			await updateUserDiscordRoles(mockEnv, 'user-1')
+
+			expect(discordStubMethods.updateUserRoles).toHaveBeenCalled()
+			const requests = discordStubMethods.updateUserRoles.mock.calls[0][1]
+			expect(requests[0].roleIds).toEqual(expect.arrayContaining(['member-role-2', 'owner-role-2']))
+		})
 	})
 
 	describe('Corp-gated removal: user loses corp, group roles on corp guild also removed', () => {
@@ -512,7 +643,9 @@ describe('updateUserDiscordRoles', () => {
 			// User has no corp attachment (lost it)
 			dbQueryMocks.corporationDiscordServers.findMany
 				.mockResolvedValueOnce([]) // user's corp attachments: none
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }]) // corp-gating: guild IS corp-gated
+				.mockResolvedValueOnce([
+					makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+				]) // corp-gating: guild IS corp-gated
 
 			// User is still in a group attached to guild-1
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
@@ -637,7 +770,9 @@ describe('updateUserDiscordRoles', () => {
 						roleIds: ['corp-role-should-not-be-assigned'],
 					}),
 				])
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+				])
 
 			// Group role should still apply because corp entitlement exists for this guild
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
@@ -722,7 +857,9 @@ describe('updateUserDiscordRoles', () => {
 						roleIds: ['managed-role-1'],
 					}),
 				])
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+				])
 
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
 			dbQueryMocks.discordRoles.findMany.mockResolvedValue([]) // auto-apply
@@ -757,7 +894,14 @@ describe('updateUserDiscordRoles', () => {
 
 			dbQueryMocks.corporationDiscordServers.findMany
 				.mockResolvedValueOnce([])
-				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({
+						corporationId: 'corp-1',
+						discordServerId: 'ds-1',
+						guildId: 'guild-1',
+						roleIds: ['old-managed-role'],
+					}),
+				])
 
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
 			dbQueryMocks.discordRoles.findMany.mockResolvedValue([])
@@ -796,7 +940,14 @@ describe('updateUserDiscordRoles', () => {
 					}),
 				])
 				// corp-gating check
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({
+						corporationId: 'corp-1',
+						discordServerId: 'ds-1',
+						guildId: 'guild-1',
+						roleIds: ['corp-role-1'],
+					}),
+				])
 				// getAllManagedRolesForGuild: corp-managed roles query
 				.mockResolvedValueOnce([
 					makeCorpAttachment({
@@ -884,7 +1035,14 @@ describe('updateUserDiscordRoles', () => {
 						roleIds: ['corp-role-1', '1431816436640256060'],
 					}),
 				])
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({
+						corporationId: 'corp-1',
+						discordServerId: 'ds-1',
+						guildId: 'guild-1',
+						roleIds: ['corp-role-1', '1431816436640256060'],
+					}),
+				])
 				.mockResolvedValueOnce([
 					makeCorpAttachment({
 						corporationId: 'corp-1',
@@ -921,7 +1079,14 @@ describe('updateUserDiscordRoles', () => {
 			// User has no corp entitlement, but guild is corp-gated
 			dbQueryMocks.corporationDiscordServers.findMany
 				.mockResolvedValueOnce([]) // user's corp attachments
-				.mockResolvedValueOnce([{ discordServerId: 'ds-1' }]) // corp-gating check
+				.mockResolvedValueOnce([
+					makeCorpAttachment({
+						corporationId: 'corp-1',
+						discordServerId: 'ds-1',
+						guildId: 'guild-1',
+						roleIds: ['corp-role-1'],
+					}),
+				]) // corp-gating check
 				.mockResolvedValueOnce([
 					// getAllManagedRolesForGuild: configured corp-managed roles on this guild
 					makeCorpAttachment({
@@ -1095,7 +1260,13 @@ describe('updateUserDiscordRoles', () => {
 			dbQueryMocks.corporationDiscordServers.findMany
 				.mockResolvedValueOnce([]) // user's corp attachments: none
 				// Corp-gating: guild-corp IS corp-gated, guild-group is NOT
-				.mockResolvedValueOnce([{ discordServerId: 'ds-corp' }])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({
+						corporationId: 'corp-1',
+						discordServerId: 'ds-corp',
+						guildId: 'guild-corp',
+					}),
+				])
 
 			// User is in a group attached to BOTH guilds
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
@@ -1128,10 +1299,10 @@ describe('updateUserDiscordRoles', () => {
 					makeDiscordServer({ id: 'ds-group', guildId: 'guild-group', guildName: 'Group Server' })
 				)
 
-			dbQueryMocks.discordRoles.findMany
-				// Group role for guild-group (corp guild skipped by corp-gating)
-				.mockResolvedValueOnce([{ roleId: 'group-role-grp', isActive: true }])
-				.mockResolvedValueOnce([]) // auto-apply
+				dbQueryMocks.discordRoles.findMany
+					// Group role for guild-group (corp guild skipped by corp-gating)
+					.mockResolvedValueOnce([])
+					.mockResolvedValueOnce([{ roleId: 'group-role-grp', isActive: true }])
 
 			groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
 			discordStubMethods.updateUserRoles.mockResolvedValue([
@@ -1168,7 +1339,13 @@ describe('updateUserDiscordRoles', () => {
 			// No corp entitlement
 			dbQueryMocks.corporationDiscordServers.findMany
 				.mockResolvedValueOnce([])
-				.mockResolvedValueOnce([{ discordServerId: 'ds-corp' }])
+				.mockResolvedValueOnce([
+					makeCorpAttachment({
+						corporationId: 'corp-1',
+						discordServerId: 'ds-corp',
+						guildId: 'guild-corp',
+					}),
+				])
 
 			// User in group attached to both
 			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
@@ -1196,9 +1373,9 @@ describe('updateUserDiscordRoles', () => {
 				.mockResolvedValueOnce(makeDiscordServer({ id: 'ds-corp', guildId: 'guild-corp' }))
 				.mockResolvedValueOnce(makeDiscordServer({ id: 'ds-group', guildId: 'guild-group' }))
 
-			dbQueryMocks.discordRoles.findMany
-				.mockResolvedValueOnce([{ roleId: 'group-role-grp', isActive: true }])
-				.mockResolvedValueOnce([])
+				dbQueryMocks.discordRoles.findMany
+					.mockResolvedValueOnce([])
+					.mockResolvedValueOnce([{ roleId: 'group-role-grp', isActive: true }])
 
 			groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
 			discordStubMethods.updateUserRoles.mockResolvedValue([
@@ -1490,8 +1667,22 @@ describe('syncUserDiscordAccess', () => {
 					roleIds: ['corp-role-ignored'],
 				}),
 			])
-			.mockResolvedValueOnce([{ discordServerId: 'ds-1' }])
-			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+					roleIds: ['corp-role-ignored'],
+				}),
+			])
+			.mockResolvedValueOnce([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+					roleIds: ['corp-role-ignored'],
+				}),
+			])
 
 		dbQueryMocks.discordRoles.findMany.mockResolvedValue([])
 		dbQueryMocks.discordServers.findFirst.mockResolvedValue(
@@ -1547,7 +1738,9 @@ describe('inspectUserDiscordAccess', () => {
 
 		dbQueryMocks.corporationDiscordServers.findMany
 			.mockResolvedValueOnce([]) // expected corp roles from user entitlement
-			.mockResolvedValueOnce([{ discordServerId: 'ds-1' }]) // corp-gated scan
+			.mockResolvedValueOnce([
+				makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+			]) // corp-gated scan
 			.mockResolvedValueOnce([
 				// getAllManagedRolesForGuild: configured managed roles
 				makeCorpAttachment({
@@ -1622,7 +1815,9 @@ describe('inspectUserDiscordAccess', () => {
 					roleIds: ['corp-role-db'],
 				}),
 			])
-			.mockResolvedValueOnce([{ discordServerId: 'ds-1' }]) // corp-gating scan
+			.mockResolvedValueOnce([
+				makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+			]) // corp-gating scan
 			.mockResolvedValueOnce([]) // invite-capable corp scan
 
 		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
@@ -1798,7 +1993,9 @@ describe('getExpectedManagedRoleIdsByGuild', () => {
 					roleIds: ['corp-role-db'],
 				}),
 			])
-			.mockResolvedValueOnce([{ discordServerId: 'ds-1' }])
+			.mockResolvedValueOnce([
+				makeCorpAttachment({ corporationId: 'corp-1', discordServerId: 'ds-1', guildId: 'guild-1' }),
+			])
 		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
 			makeGroupWithDiscord({
 				groupId: 'group-1',
@@ -1827,6 +2024,287 @@ describe('getExpectedManagedRoleIdsByGuild', () => {
 		expect(result.get('guild-1')).toBeDefined()
 		expect(Array.from(result.get('guild-1') ?? [])).toEqual(
 			expect.arrayContaining(['corp-role-db', 'group-role-1', 'auto-apply-role'])
+		)
+	})
+
+	it('should prefer corp-member scenarios over alliance guest scenarios', async () => {
+		dbQueryMocks.discordServers.findMany.mockResolvedValue([
+			makeDiscordServer({ id: 'ds-1', guildId: 'guild-1', guildName: 'Guild One' }),
+		])
+		dbQueryMocks.userCharacters.findMany.mockResolvedValue([
+			{
+				userId: 'user-1',
+				characterId: 'char-1',
+			},
+		] as any)
+		eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({
+			'char-1': 'corp-target',
+		})
+		dbQueryMocks.managedCorporations.findMany.mockResolvedValue([
+			{ corporationId: 'corp-target' },
+		] as any)
+		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+			makeCorpAttachment({
+				corporationId: 'corp-target',
+				discordServerId: 'ds-1',
+				guildId: 'guild-1',
+				isMemberCorporation: true,
+				corpMemberRoleId: 'corp-role-db',
+				corpMemberAutoApply: true,
+				allianceGuestRoleId: 'alliance-role-db',
+				allianceGuestAutoApply: true,
+				nonAllianceGuestRoleId: 'guest-role-db',
+				nonAllianceGuestAutoApply: true,
+			}),
+		])
+		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
+		groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
+		dbQueryMocks.discordRoles.findMany
+			.mockResolvedValueOnce([
+				{ id: 'corp-role-db', roleId: 'corp-role', isActive: true },
+				{ id: 'alliance-role-db', roleId: 'alliance-role', isActive: true },
+				{ id: 'guest-role-db', roleId: 'guest-role', isActive: true },
+			] as any)
+			.mockResolvedValueOnce([] as any)
+
+		const result = await getExpectedManagedRoleIdsByGuild(mockEnv, 'user-1')
+
+		expect(Array.from(result.get('guild-1') ?? [])).toEqual(['corp-role'])
+	})
+
+	it('should use alliance guest scenarios for linked users affiliated through member corps', async () => {
+		dbQueryMocks.discordServers.findMany.mockResolvedValue([
+			makeDiscordServer({ id: 'ds-1', guildId: 'guild-1', guildName: 'Guild One' }),
+		])
+		dbQueryMocks.userCharacters.findMany.mockResolvedValue([
+			{
+				userId: 'user-1',
+				characterId: 'char-1',
+			},
+		] as any)
+		eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({
+			'char-1': 'corp-affiliated',
+		})
+		dbQueryMocks.managedCorporations.findMany.mockResolvedValue([
+			{ corporationId: 'corp-affiliated' },
+		] as any)
+		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+			makeCorpAttachment({
+				corporationId: 'corp-target',
+				discordServerId: 'ds-1',
+				guildId: 'guild-1',
+				isMemberCorporation: true,
+				corpMemberRoleId: 'corp-role-db',
+				corpMemberAutoApply: false,
+				allianceGuestRoleId: 'alliance-role-db',
+				allianceGuestAutoApply: true,
+				nonAllianceGuestRoleId: 'guest-role-db',
+				nonAllianceGuestAutoApply: true,
+			}),
+		])
+		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
+		groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
+		dbQueryMocks.discordRoles.findMany
+			.mockResolvedValueOnce([
+				{ id: 'alliance-role-db', roleId: 'alliance-role', isActive: true },
+				{ id: 'guest-role-db', roleId: 'guest-role', isActive: true },
+			] as any)
+			.mockResolvedValueOnce([] as any)
+
+		const result = await getExpectedManagedRoleIdsByGuild(mockEnv, 'user-1')
+
+		expect(Array.from(result.get('guild-1') ?? [])).toEqual(['alliance-role'])
+	})
+
+	it('should include corp roles and both group membership buckets when building expected managed roles', async () => {
+		dbQueryMocks.discordServers.findMany.mockReset()
+		dbQueryMocks.userCharacters.findMany.mockReset()
+		dbQueryMocks.corporationDiscordServers.findMany.mockReset()
+		dbQueryMocks.discordRoles.findMany.mockReset()
+		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockReset()
+		groupsStubMethods.getGroupMemberUserIds.mockReset()
+		groupsStubMethods.getGroupOwnerAndAdminUserIds.mockReset()
+		discordStubMethods.getGuildRoles.mockReset()
+
+		dbQueryMocks.discordServers.findMany.mockResolvedValue([
+			makeDiscordServer({ id: 'ds-1', guildId: 'guild-1', guildName: 'Guild One' }),
+		])
+		dbQueryMocks.userCharacters.findMany.mockResolvedValue([
+			{
+				userId: 'user-1',
+				characterId: 'char-1',
+			},
+		] as any)
+		eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({
+			'char-1': 'corp-1',
+		})
+		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+			makeCorpAttachment({
+				corporationId: 'corp-1',
+				discordServerId: 'ds-1',
+				guildId: 'guild-1',
+				autoAssignRoles: true,
+				corpMemberRoleId: 'corp-member-db',
+				corpMemberAutoApply: true,
+				roleIds: ['corp-managed-role-db'],
+			}),
+		])
+		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
+			makeGroupWithDiscord({
+				groupId: 'group-1',
+				discordServers: [
+					{
+						discordServerId: 'ds-1',
+						autoInvite: true,
+						autoAssignRoles: true,
+						memberRoleIds: ['group-member-db'],
+						ownerAdminRoleIds: ['group-owner-db'],
+					},
+				],
+			}),
+		])
+		groupsStubMethods.getGroupMemberUserIds.mockResolvedValue(['user-1'])
+		groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue(['user-1'])
+		dbQueryMocks.discordRoles.findMany
+			.mockResolvedValueOnce([
+				{ id: 'corp-member-db', roleId: 'corp-member-role', isActive: true },
+				{ id: 'corp-managed-role-db', roleId: 'corp-managed-role', isActive: true },
+			] as any)
+			.mockResolvedValueOnce([
+				{ id: 'group-member-db', roleId: 'group-member-role', isActive: true },
+				{ id: 'group-owner-db', roleId: 'group-owner-role', isActive: true },
+			] as any)
+			.mockResolvedValueOnce([] as any)
+		discordStubMethods.getGuildRoles.mockResolvedValue([{ id: 'some-other-role' }])
+
+		const result = await getExpectedManagedRoleIdsByGuild(mockEnv, 'user-1')
+
+		expect(Array.from(result.get('guild-1') ?? [])).toEqual(
+			expect.arrayContaining([
+				'corp-member-role',
+				'corp-managed-role-db',
+				'group-member-role',
+				'group-owner-role',
+			])
+		)
+	})
+})
+
+describe('refreshServerMembers', () => {
+	it('should build refresh role sets from corp and group assignments additively', async () => {
+		dbQueryMocks.discordServers.findFirst.mockReset()
+		dbQueryMocks.userCharacters.findFirst.mockReset()
+		dbQueryMocks.userCharacters.findMany.mockReset()
+		dbQueryMocks.managedCorporations.findMany.mockReset()
+		dbQueryMocks.corporationDiscordServers.findMany.mockReset()
+		dbQueryMocks.discordRoles.findMany.mockReset()
+		groupsStubMethods.getGroupsByDiscordServer.mockReset()
+		groupsStubMethods.getDiscordServerAttachmentConfig.mockReset()
+		groupsStubMethods.getGroupMemberUserIds.mockReset()
+		groupsStubMethods.getGroupOwnerAndAdminUserIds.mockReset()
+		discordStubMethods.getGuildRoles.mockReset()
+		discordStubMethods.joinUserToServers.mockReset()
+		discordStubMethods.updateUserRoles.mockReset()
+
+		dbQueryMocks.discordServers.findFirst.mockResolvedValue(
+			makeDiscordServer({
+				id: 'ds-1',
+				guildId: 'guild-1',
+				guildName: 'Guild One',
+				manageNicknames: false,
+			})
+		)
+		dbQueryMocks.userCharacters.findFirst.mockResolvedValue(
+			makeCharacter({
+				userId: 'user-1',
+				characterId: 'char-1',
+				characterName: 'Test Pilot',
+				is_primary: true,
+			})
+		)
+		dbQueryMocks.userCharacters.findMany.mockResolvedValue([
+			makeCharacter({
+				userId: 'user-1',
+				characterId: 'char-1',
+				characterName: 'Test Pilot',
+				is_primary: true,
+			}),
+		])
+		eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({
+			'char-1': 'corp-1',
+		})
+		dbQueryMocks.managedCorporations.findMany.mockResolvedValue([])
+		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+			makeCorpAttachment({
+				corporationId: 'corp-1',
+				discordServerId: 'ds-1',
+				guildId: 'guild-1',
+				autoAssignRoles: true,
+				corpMemberRoleId: 'corp-member-role',
+				corpMemberAutoApply: true,
+				roleIds: ['corp-managed-role'],
+			}),
+		])
+		groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([
+			{
+				groupId: 'group-1',
+				groupName: 'Group One',
+				id: 'group-attachment-1',
+				autoAssignRoles: true,
+			},
+		])
+		groupsStubMethods.getGroupMemberUserIds.mockResolvedValue(['user-1'])
+		groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue(['user-1'])
+		groupsStubMethods.getDiscordServerAttachmentConfig.mockResolvedValue({
+			groupId: 'group-1',
+			guildId: 'guild-1',
+			roleIds: ['group-member-role', 'group-owner-role'],
+			ownerAdminRoleIds: ['group-owner-role'],
+		})
+		dbQueryMocks.discordRoles.findMany
+			.mockResolvedValueOnce([
+				{ id: 'corp-member-role', roleId: 'corp-member-role', isActive: true },
+			] as any)
+			.mockResolvedValueOnce([
+				{ id: 'group-member-role', roleId: 'group-member-role', isActive: true },
+				{ id: 'group-owner-role', roleId: 'group-owner-role', isActive: true },
+			] as any)
+			.mockResolvedValueOnce([] as any)
+			.mockResolvedValueOnce([] as any)
+			.mockResolvedValueOnce([
+				{ id: 'corp-member-role', roleId: 'corp-member-role', isActive: true },
+			] as any)
+			.mockResolvedValueOnce([
+				{ id: 'group-member-role', roleId: 'group-member-role', isActive: true },
+				{ id: 'group-owner-role', roleId: 'group-owner-role', isActive: true },
+			] as any)
+		discordStubMethods.getGuildRoles.mockResolvedValue([])
+		discordStubMethods.joinUserToServers.mockResolvedValue([
+			{ guildId: 'guild-1', success: true, rolesAdded: [], rolesRemoved: [] },
+		])
+		discordStubMethods.getDiscordUserStatus.mockResolvedValue(null)
+		discordStubMethods.updateUserRoles.mockResolvedValue([
+			{
+				guildId: 'guild-1',
+				success: true,
+				rolesAdded: ['corp-member-role', 'corp-managed-role', 'group-member-role', 'group-owner-role'],
+				rolesRemoved: [],
+			},
+		])
+
+		const result = await refreshServerMembers(mockEnv, 'ds-1', ['user-1'])
+
+		expect(result.successCount).toBe(1)
+		expect(result.failCount).toBe(0)
+		expect(discordStubMethods.updateUserRoles).toHaveBeenCalledTimes(1)
+		const requests = discordStubMethods.updateUserRoles.mock.calls[0][1]
+		expect(requests[0].roleIds).toEqual(
+			expect.arrayContaining([
+				'corp-member-role',
+				'corp-managed-role',
+				'group-member-role',
+				'group-owner-role',
+			])
 		)
 	})
 })

--- a/apps/core/src/services/discord.service.ts
+++ b/apps/core/src/services/discord.service.ts
@@ -11,6 +11,7 @@ import {
 	corporationDiscordServers,
 	discordRoles,
 	discordServers,
+	managedCorporations,
 	oauthStates,
 	userCharacters,
 	users,
@@ -398,14 +399,19 @@ async function getAllManagedRolesForGuild(
 		managedRoleIds.add(role.roleId)
 	}
 
-	// Query 2: Corporation-managed roles
-	// Uses: corp_discord_servers_server_auto_assign_idx (new index)
+	// Query 2: Corporation-managed roles and scenario roles
 	const corpAttachments = await db.query.corporationDiscordServers.findMany({
-		where: and(
-			eq(corporationDiscordServers.discordServerId, discordServerId),
-			eq(corporationDiscordServers.autoAssignRoles, true)
-		),
-		columns: { id: true },
+		where: eq(corporationDiscordServers.discordServerId, discordServerId),
+		columns: {
+			id: true,
+			autoAssignRoles: true,
+			corpMemberRoleId: true,
+			corpMemberAutoApply: true,
+			allianceGuestRoleId: true,
+			allianceGuestAutoApply: true,
+			nonAllianceGuestRoleId: true,
+			nonAllianceGuestAutoApply: true,
+		},
 		with: {
 			roles: {
 				with: {
@@ -417,12 +423,33 @@ async function getAllManagedRolesForGuild(
 		},
 	})
 
+	const scenarioRoleDbIds = new Set<string>()
 	for (const attachment of corpAttachments) {
-		for (const roleAssignment of attachment.roles) {
-			// Only include active roles
-			if (roleAssignment.discordRole.isActive) {
-				managedRoleIds.add(roleAssignment.discordRole.roleId)
+		if (attachment.autoAssignRoles) {
+			for (const roleAssignment of attachment.roles) {
+				// Only include active roles
+				if (roleAssignment.discordRole.isActive) {
+					managedRoleIds.add(roleAssignment.discordRole.roleId)
+				}
 			}
+		}
+
+		for (const roleDbId of getScenarioManagedRoleDbIds(attachment)) {
+			scenarioRoleDbIds.add(roleDbId)
+		}
+	}
+
+	if (scenarioRoleDbIds.size > 0) {
+		const scenarioRoles = await db.query.discordRoles.findMany({
+			where: and(
+				inArray(discordRoles.id, Array.from(scenarioRoleDbIds)),
+				eq(discordRoles.isActive, true)
+			),
+			columns: { roleId: true },
+		})
+
+		for (const role of scenarioRoles) {
+			managedRoleIds.add(role.roleId)
 		}
 	}
 
@@ -437,7 +464,7 @@ async function getAllManagedRolesForGuild(
 		for (const attachment of groupAttachments) {
 			if (attachment.autoAssignRoles) {
 				const config = await groupsStub.getDiscordServerAttachmentConfig(attachment.id)
-				groupDiscordRoleIds.push(...config.roleIds)
+				groupDiscordRoleIds.push(...getGroupManagedRoleDbIds(config))
 			}
 		}
 
@@ -547,6 +574,146 @@ async function getUserCorporationIds(env: Env, characterIds: string[]): Promise<
 	}
 }
 
+type CorpAttachmentScenarioKey = 'corp-member' | 'alliance-guest' | 'non-alliance-guest'
+
+type CorporationDiscordAttachmentScenarioFields = {
+	corporationId: string
+	corpMemberRoleId: string | null
+	corpMemberAutoApply: boolean
+	allianceGuestRoleId: string | null
+	allianceGuestAutoApply: boolean
+	nonAllianceGuestRoleId: string | null
+	nonAllianceGuestAutoApply: boolean
+}
+
+type CorporationDiscordScenarioRoleFields = Pick<
+	CorporationDiscordAttachmentScenarioFields,
+	| 'corpMemberRoleId'
+	| 'corpMemberAutoApply'
+	| 'allianceGuestRoleId'
+	| 'allianceGuestAutoApply'
+	| 'nonAllianceGuestRoleId'
+	| 'nonAllianceGuestAutoApply'
+>
+
+async function getUserAllianceMemberCorporationIds(
+	db: ReturnType<typeof createDb>,
+	userCorporationIds: Set<string>
+): Promise<Set<string>> {
+	if (userCorporationIds.size === 0) {
+		return new Set()
+	}
+
+	const memberCorporations = await db.query.managedCorporations.findMany({
+		where: and(
+			inArray(managedCorporations.corporationId, Array.from(userCorporationIds)),
+			eq(managedCorporations.isActive, true),
+			eq(managedCorporations.isMemberCorporation, true)
+		),
+		columns: { corporationId: true },
+	})
+
+	return new Set(memberCorporations.map((corporation) => corporation.corporationId))
+}
+
+function resolveScenarioRoleId(
+	attachment: CorporationDiscordAttachmentScenarioFields,
+	isCorpMember: boolean,
+	isAllianceMember: boolean,
+	attachmentIsMemberCorp: boolean,
+	activeRoleIdByDbId: Map<string, string>
+): { roleId: string | null; scenario: CorpAttachmentScenarioKey | null } {
+	if (isCorpMember && attachment.corpMemberAutoApply && attachment.corpMemberRoleId) {
+		const roleId = activeRoleIdByDbId.get(attachment.corpMemberRoleId) ?? null
+		if (roleId) {
+			return { roleId, scenario: 'corp-member' }
+		}
+	}
+
+	if (
+		attachmentIsMemberCorp &&
+		isAllianceMember &&
+		attachment.allianceGuestAutoApply &&
+		attachment.allianceGuestRoleId
+	) {
+		const roleId = activeRoleIdByDbId.get(attachment.allianceGuestRoleId) ?? null
+		if (roleId) {
+			return { roleId, scenario: 'alliance-guest' }
+		}
+	}
+
+	if (attachment.nonAllianceGuestAutoApply && attachment.nonAllianceGuestRoleId) {
+		const roleId = activeRoleIdByDbId.get(attachment.nonAllianceGuestRoleId) ?? null
+		if (roleId) {
+			return { roleId, scenario: 'non-alliance-guest' }
+		}
+	}
+
+	return { roleId: null, scenario: null }
+}
+
+function getScenarioManagedRoleDbIds(attachment: CorporationDiscordScenarioRoleFields): string[] {
+	const roleIds = [
+		attachment.corpMemberAutoApply ? attachment.corpMemberRoleId : null,
+		attachment.allianceGuestAutoApply ? attachment.allianceGuestRoleId : null,
+		attachment.nonAllianceGuestAutoApply ? attachment.nonAllianceGuestRoleId : null,
+	].filter((roleId): roleId is string => !!roleId)
+
+	return roleIds
+}
+
+type GroupDiscordRoleConfig = {
+	roleIds?: string[]
+	memberRoleIds?: string[]
+	ownerAdminRoleIds?: string[]
+	autoAssignRoles?: boolean
+}
+
+function getGroupMemberRoleDbIds(config: GroupDiscordRoleConfig): string[] {
+	return config.memberRoleIds ?? config.roleIds ?? []
+}
+
+function getGroupOwnerAdminRoleDbIds(config: GroupDiscordRoleConfig): string[] {
+	return config.ownerAdminRoleIds ?? []
+}
+
+function getGroupManagedRoleDbIds(config: GroupDiscordRoleConfig): string[] {
+	return [...new Set([...getGroupMemberRoleDbIds(config), ...getGroupOwnerAdminRoleDbIds(config)])]
+}
+
+function mapDiscordRoleIdsByDbId(
+	roleDbIds: string[],
+	roleRows: Array<{ id?: string; roleId: string }>
+): Map<string, string> {
+	const roleIdByDbId = new Map<string, string>()
+
+	for (let index = 0; index < roleRows.length; index += 1) {
+		const row = roleRows[index]
+		const dbId = row.id ?? roleDbIds[index]
+		if (dbId) {
+			roleIdByDbId.set(dbId, row.roleId)
+		}
+	}
+
+	return roleIdByDbId
+}
+
+async function getGroupMembershipFlags(
+	groupsStub: Groups,
+	groupId: string,
+	userId: string
+): Promise<{ isMember: boolean; isOwnerAdmin: boolean }> {
+	const [memberUserIds, ownerAdminUserIds] = await Promise.all([
+		groupsStub.getGroupMemberUserIds(groupId),
+		groupsStub.getGroupOwnerAndAdminUserIds(groupId),
+	])
+
+	return {
+		isMember: memberUserIds.includes(userId),
+		isOwnerAdmin: ownerAdminUserIds.includes(userId),
+	}
+}
+
 /**
  * Build the set of managed roles a user is expected to have per guild based on core grants.
  * This intentionally does not query Discord membership state.
@@ -583,33 +750,88 @@ export async function getExpectedManagedRoleIdsByGuild(
 	})
 	const characterIds = userChars.map((char) => char.characterId)
 	const userCorporationIds = await getUserCorporationIds(env, characterIds)
+	const userAllianceMemberCorporationIds = await getUserAllianceMemberCorporationIds(
+		db,
+		userCorporationIds
+	)
+	const isAllianceMember = userAllianceMemberCorporationIds.size > 0
 
 	const corpAttachments =
-		userCorporationIds.size > 0 && knownServerDbIds.length > 0
+		knownServerDbIds.length > 0
 			? await db.query.corporationDiscordServers.findMany({
-					where: and(
-						inArray(corporationDiscordServers.corporationId, Array.from(userCorporationIds)),
-						inArray(corporationDiscordServers.discordServerId, knownServerDbIds)
-					),
+					where: inArray(corporationDiscordServers.discordServerId, knownServerDbIds),
+					columns: {
+						corporationId: true,
+						autoAssignRoles: true,
+						corpMemberRoleId: true,
+						corpMemberAutoApply: true,
+						allianceGuestRoleId: true,
+						allianceGuestAutoApply: true,
+						nonAllianceGuestRoleId: true,
+						nonAllianceGuestAutoApply: true,
+					},
 					with: {
+						corporation: {
+							columns: { isMemberCorporation: true },
+						},
 						discordServer: true,
 						roles: {
 							with: {
-								discordRole: true,
+								discordRole: {
+									columns: { id: true, roleId: true, isActive: true },
+								},
 							},
 						},
 					},
 				})
 			: []
 
+	const scenarioRoleDbIds = new Set<string>()
+	for (const attachment of corpAttachments) {
+		for (const roleDbId of getScenarioManagedRoleDbIds(attachment)) {
+			scenarioRoleDbIds.add(roleDbId)
+		}
+	}
+
+	let scenarioRoleIdByDbId = new Map<string, string>()
+	if (scenarioRoleDbIds.size > 0) {
+		const scenarioRoles = await db.query.discordRoles.findMany({
+			where: and(
+				inArray(discordRoles.id, Array.from(scenarioRoleDbIds)),
+				eq(discordRoles.isActive, true)
+			),
+			columns: { id: true, roleId: true },
+		})
+		scenarioRoleIdByDbId = new Map(scenarioRoles.map((role) => [role.id, role.roleId]))
+	}
+
 	const userEntitledGuildIds = new Set<string>()
+	const corpGatedGuildIds = new Set<string>()
+
 	for (const attachment of corpAttachments) {
 		if (!attachment.discordServer.isActive) continue
 
 		const guildId = attachment.discordServer.guildId
-		userEntitledGuildIds.add(guildId)
+		corpGatedGuildIds.add(guildId)
 
-		if (!attachment.autoAssignRoles) continue
+		const isCorpMember = userCorporationIds.has(attachment.corporationId)
+		const { roleId: scenarioRoleId } = resolveScenarioRoleId(
+			attachment,
+			isCorpMember,
+			isAllianceMember,
+			attachment.corporation.isMemberCorporation,
+			scenarioRoleIdByDbId
+		)
+
+		if (isCorpMember || scenarioRoleId) {
+			userEntitledGuildIds.add(guildId)
+		}
+
+		if (scenarioRoleId) {
+			ensureExpectedSet(guildId).add(scenarioRoleId)
+		}
+
+		if (!isCorpMember || !attachment.autoAssignRoles) continue
 
 		const expectedSet = ensureExpectedSet(guildId)
 		for (const roleAssignment of attachment.roles) {
@@ -619,31 +841,22 @@ export async function getExpectedManagedRoleIdsByGuild(
 		}
 	}
 
-	const corpGatedGuildIds = new Set<string>()
-	if (knownServerDbIds.length > 0) {
-		const corpGatedRecords = await db.query.corporationDiscordServers.findMany({
-			where: inArray(corporationDiscordServers.discordServerId, knownServerDbIds),
-			columns: { discordServerId: true },
-		})
-		for (const record of corpGatedRecords) {
-			const server = serverByDbId.get(record.discordServerId)
-			if (server) {
-				corpGatedGuildIds.add(server.guildId)
-			}
-		}
-	}
-
 	try {
 		const groupsStub = getStub<Groups>(env.GROUPS, 'default')
 		const groupsWithDiscord = await groupsStub.getGroupsWithDiscordAutoInvite()
 
-		const pendingGroupRoleLookups: Array<{ guildId: string; roleDbIds: string[] }> = []
+		const pendingGroupRoleLookups: Array<{
+			guildId: string
+			isMember: boolean
+			isOwnerAdmin: boolean
+			memberRoleDbIds: string[]
+			ownerAdminRoleDbIds: string[]
+		}> = []
 		const groupRoleDbIds = new Set<string>()
 
 		for (const group of groupsWithDiscord) {
-			const memberUserIds = await groupsStub.getGroupMemberUserIds(group.groupId)
-			const isMember = memberUserIds.includes(userId)
-			if (!isMember) continue
+			const membership = await getGroupMembershipFlags(groupsStub, group.groupId, userId)
+			if (!membership.isMember && !membership.isOwnerAdmin) continue
 
 			for (const attachment of group.discordServers) {
 				if (!attachment.autoAssignRoles) continue
@@ -655,12 +868,16 @@ export async function getExpectedManagedRoleIdsByGuild(
 					corpGatedGuildIds.has(server.guildId) && !userEntitledGuildIds.has(server.guildId)
 				if (isCorpGatedWithoutEntitlement) continue
 
-				const roleDbIds = attachment.roleIds ?? []
+				const memberRoleDbIds = getGroupMemberRoleDbIds(attachment)
+				const ownerAdminRoleDbIds = getGroupOwnerAdminRoleDbIds(attachment)
 				pendingGroupRoleLookups.push({
 					guildId: server.guildId,
-					roleDbIds,
+					isMember: membership.isMember,
+					isOwnerAdmin: membership.isOwnerAdmin,
+					memberRoleDbIds,
+					ownerAdminRoleDbIds,
 				})
-				for (const roleDbId of roleDbIds) {
+				for (const roleDbId of getGroupManagedRoleDbIds(attachment)) {
 					groupRoleDbIds.add(roleDbId)
 				}
 			}
@@ -676,15 +893,25 @@ export async function getExpectedManagedRoleIdsByGuild(
 				),
 				columns: { id: true, roleId: true },
 			})
-			roleIdByDbId = new Map(roleRows.map((row) => [row.id, row.roleId]))
+			roleIdByDbId = mapDiscordRoleIdsByDbId(uniqueGroupRoleDbIds, roleRows)
 		}
 
 		for (const lookup of pendingGroupRoleLookups) {
 			const expectedSet = ensureExpectedSet(lookup.guildId)
-			for (const roleDbId of lookup.roleDbIds) {
-				const resolvedRoleId = roleIdByDbId.get(roleDbId)
-				if (resolvedRoleId) {
-					expectedSet.add(resolvedRoleId)
+			if (lookup.isMember) {
+				for (const roleDbId of lookup.memberRoleDbIds) {
+					const resolvedRoleId = roleIdByDbId.get(roleDbId)
+					if (resolvedRoleId) {
+						expectedSet.add(resolvedRoleId)
+					}
+				}
+			}
+			if (lookup.isOwnerAdmin) {
+				for (const roleDbId of lookup.ownerAdminRoleDbIds) {
+					const resolvedRoleId = roleIdByDbId.get(roleDbId)
+					if (resolvedRoleId) {
+						expectedSet.add(resolvedRoleId)
+					}
 				}
 			}
 		}
@@ -846,26 +1073,41 @@ export async function inviteUserToDiscordServers(
 		})
 	}
 
+	const userAllianceMemberCorporationIds = await getUserAllianceMemberCorporationIds(
+		db,
+		userCorporationIds
+	)
+	const isAllianceMember = userAllianceMemberCorporationIds.size > 0
+
 	// === CHECK CORPORATIONS (ONLY autoInvite=true) ===
-	// Only fetch attachments for corporations the user is actually in
-	const corpAttachments =
-		userCorporationIds.size > 0
-			? await db.query.corporationDiscordServers.findMany({
-					where: and(
-						eq(corporationDiscordServers.autoInvite, true), // ONLY auto-invite servers
-						inArray(corporationDiscordServers.corporationId, Array.from(userCorporationIds))
-					),
-					with: {
-						corporation: true,
-						discordServer: true,
-						roles: {
-							with: {
-								discordRole: true,
-							},
-						},
+	// Fetch all corporation attachments that may apply to this user via corp, alliance, or guest fallback.
+	const corpAttachments = await db.query.corporationDiscordServers.findMany({
+		where: eq(corporationDiscordServers.autoInvite, true),
+		columns: {
+			corporationId: true,
+			discordServerId: true,
+			autoAssignRoles: true,
+			corpMemberRoleId: true,
+			corpMemberAutoApply: true,
+			allianceGuestRoleId: true,
+			allianceGuestAutoApply: true,
+			nonAllianceGuestRoleId: true,
+			nonAllianceGuestAutoApply: true,
+		},
+		with: {
+			corporation: {
+				columns: { name: true, isMemberCorporation: true },
+			},
+			discordServer: true,
+			roles: {
+				with: {
+					discordRole: {
+						columns: { id: true, roleId: true, isActive: true },
 					},
-				})
-			: []
+				},
+			},
+		},
+	})
 
 	logger.debug('[Discord] inviteUserToDiscordServers: Corporation attachments found', {
 		userId,
@@ -883,6 +1125,25 @@ export async function inviteUserToDiscordServers(
 	const activeCorpAttachments = corpAttachments.filter(
 		(attachment) => attachment.discordServer.isActive
 	)
+
+	const scenarioRoleDbIds = new Set<string>()
+	for (const attachment of activeCorpAttachments) {
+		for (const roleDbId of getScenarioManagedRoleDbIds(attachment)) {
+			scenarioRoleDbIds.add(roleDbId)
+		}
+	}
+
+	let scenarioRoleIdByDbId = new Map<string, string>()
+	if (scenarioRoleDbIds.size > 0) {
+		const scenarioRoles = await db.query.discordRoles.findMany({
+			where: and(
+				inArray(discordRoles.id, Array.from(scenarioRoleDbIds)),
+				eq(discordRoles.isActive, true)
+			),
+			columns: { id: true, roleId: true },
+		})
+		scenarioRoleIdByDbId = new Map(scenarioRoles.map((role) => [role.id, role.roleId]))
+	}
 
 	logger.debug('[Discord] inviteUserToDiscordServers: Active corporation attachments', {
 		userId,
@@ -902,15 +1163,43 @@ export async function inviteUserToDiscordServers(
 		roleIds?: string[]
 	}> = []
 
-	// Add corporation attachments - no need to check membership, we already filtered by corporation ID
+	// Add corporation attachments - evaluate corp/alliance/guest scenarios per attachment.
 	for (const attachment of activeCorpAttachments) {
-		// User is definitely a member since we filtered attachments by their corporation IDs
-		// Collect role IDs if auto-assign is enabled
-		const roleIds = attachment.autoAssignRoles
-			? attachment.roles
-					.filter((r) => r.discordRole.isActive) // SECURITY: Only active roles
-					.map((r) => r.discordRole.roleId)
-			: []
+		const isCorpMember = userCorporationIds.has(attachment.corporationId)
+		const { roleId: scenarioRoleId, scenario } = resolveScenarioRoleId(
+			attachment,
+			isCorpMember,
+			isAllianceMember,
+			attachment.corporation.isMemberCorporation,
+			scenarioRoleIdByDbId
+		)
+
+		const roleIds: string[] = []
+		if (isCorpMember && attachment.autoAssignRoles) {
+			for (const roleAssignment of attachment.roles) {
+				if (roleAssignment.discordRole.isActive) {
+					roleIds.push(roleAssignment.discordRole.roleId)
+				}
+			}
+		}
+		if (scenarioRoleId) {
+			roleIds.push(scenarioRoleId)
+		}
+
+		const shouldInvite = isCorpMember || scenarioRoleId !== null
+		if (!shouldInvite) {
+			logger.debug('[Discord] inviteUserToDiscordServers: Skipping corporation attachment', {
+				userId,
+				guildId: attachment.discordServer.guildId,
+				guildName: attachment.discordServer.guildName,
+				corporationId: attachment.corporationId,
+				corporationName: attachment.corporation.name,
+				isCorpMember,
+				isAllianceMember,
+				scenario,
+			})
+			continue
+		}
 
 		logger.debug('[Discord] inviteUserToDiscordServers: Adding corporation guild to join', {
 			userId,
@@ -920,6 +1209,9 @@ export async function inviteUserToDiscordServers(
 			corporationName: attachment.corporation.name,
 			roleIds,
 			roleCount: roleIds.length,
+			isCorpMember,
+			isAllianceMember,
+			scenario,
 		})
 
 		guildsToJoin.push({
@@ -947,18 +1239,17 @@ export async function inviteUserToDiscordServers(
 
 		for (const group of groupsWithDiscord) {
 			try {
-				const memberUserIds = await groupsStub.getGroupMemberUserIds(group.groupId)
-				const isMember = memberUserIds.includes(userId)
+				const membership = await getGroupMembershipFlags(groupsStub, group.groupId, userId)
 
 				logger.debug('[Discord] inviteUserToDiscordServers: Checking group membership', {
 					userId,
 					groupId: group.groupId,
 					groupName: group.groupName,
-					isMember,
-					memberCount: memberUserIds.length,
+					isMember: membership.isMember,
+					isOwnerAdmin: membership.isOwnerAdmin,
 				})
 
-				if (isMember) {
+				if (membership.isMember || membership.isOwnerAdmin) {
 					for (const discordServer of group.discordServers) {
 						// ONLY process servers with autoInvite=true
 						if (!discordServer.autoInvite) {
@@ -981,20 +1272,24 @@ export async function inviteUserToDiscordServers(
 						})
 
 						if (serverInfo) {
-							let actualRoleIds: string[] = []
-
-							if (
-								discordServer.roleIds &&
-								discordServer.roleIds.length > 0 &&
-								discordServer.autoAssignRoles
-							) {
+							const memberRoleDbIds =
+								discordServer.autoAssignRoles && membership.isMember
+									? getGroupMemberRoleDbIds(discordServer)
+									: []
+							const ownerAdminRoleDbIds =
+								discordServer.autoAssignRoles && membership.isOwnerAdmin
+									? getGroupOwnerAdminRoleDbIds(discordServer)
+									: []
+							const roleDbIds = [...new Set([...memberRoleDbIds, ...ownerAdminRoleDbIds])]
+							const actualRoleIds: string[] = []
+							if (roleDbIds.length > 0) {
 								const roleRecords = await db.query.discordRoles.findMany({
 									where: and(
-										inArray(discordRoles.id, discordServer.roleIds),
+										inArray(discordRoles.id, roleDbIds),
 										eq(discordRoles.isActive, true)
 									),
 								})
-								actualRoleIds = roleRecords.map((r) => r.roleId)
+								actualRoleIds.push(...roleRecords.map((r) => r.roleId))
 							}
 
 							logger.debug('[Discord] inviteUserToDiscordServers: Adding group guild to join', {
@@ -1005,6 +1300,8 @@ export async function inviteUserToDiscordServers(
 								groupName: group.groupName,
 								roleIds: actualRoleIds,
 								roleCount: actualRoleIds.length,
+								isMember: membership.isMember,
+								isOwnerAdmin: membership.isOwnerAdmin,
 							})
 
 							guildsToJoin.push({
@@ -1436,43 +1733,100 @@ export async function updateUserDiscordRoles(
 		}
 
 		// === CHECK CORPORATION ROLES (all attachments, not just auto-invite) ===
-		// Get user's corporation IDs first to filter efficiently
+		// Resolve the user's corp/alliance memberships once, then evaluate every
+		// attached corporation on the target guilds with the exclusive scenario order.
 		const userCorporationIds = await getUserCorporationIds(env, characterIds)
+		const userAllianceMemberCorporationIds = await getUserAllianceMemberCorporationIds(
+			db,
+			userCorporationIds
+		)
+		const isAllianceMember = userAllianceMemberCorporationIds.size > 0
 
-		// Only fetch attachments for corporations the user is actually in
+		const targetServerRecords = await db.query.discordServers.findMany({
+			where: and(inArray(discordServers.guildId, serversToUpdate), eq(discordServers.isActive, true)),
+			columns: { id: true, guildId: true, guildName: true },
+		})
+		const targetServerDbIds = targetServerRecords.map((s) => s.id)
+
 		const corpAttachments =
-			userCorporationIds.size > 0
+			targetServerDbIds.length > 0
 				? await db.query.corporationDiscordServers.findMany({
-						where: inArray(corporationDiscordServers.corporationId, Array.from(userCorporationIds)),
+						where: inArray(corporationDiscordServers.discordServerId, targetServerDbIds),
+						columns: {
+							corporationId: true,
+							autoAssignRoles: true,
+							corpMemberRoleId: true,
+							corpMemberAutoApply: true,
+							allianceGuestRoleId: true,
+							allianceGuestAutoApply: true,
+							nonAllianceGuestRoleId: true,
+							nonAllianceGuestAutoApply: true,
+						},
 						with: {
-							corporation: true,
+							corporation: {
+								columns: { name: true, isMemberCorporation: true },
+							},
 							discordServer: true,
 							roles: {
 								with: {
-									discordRole: true,
+									discordRole: {
+										columns: { id: true, roleId: true, isActive: true },
+									},
 								},
 							},
 						},
 					})
 				: []
 
-		// Filter to only active Discord servers in the servers we're updating
-		const relevantCorpAttachments = corpAttachments.filter(
-			(attachment) =>
-				attachment.discordServer.isActive &&
-				serversToUpdate.includes(attachment.discordServer.guildId)
-		)
+		const scenarioRoleDbIds = new Set<string>()
+		for (const attachment of corpAttachments) {
+			for (const roleDbId of getScenarioManagedRoleDbIds(attachment)) {
+				scenarioRoleDbIds.add(roleDbId)
+			}
+		}
 
-		for (const attachment of relevantCorpAttachments) {
-			// User is definitely a member since we filtered attachments by their corporation IDs
-			if (attachment.autoAssignRoles) {
-				const roleIds = attachment.roles
-					.filter((r) => r.discordRole.isActive) // SECURITY: Only active roles
-					.map((r) => r.discordRole.roleId)
+		let scenarioRoleIdByDbId = new Map<string, string>()
+		if (scenarioRoleDbIds.size > 0) {
+			const scenarioRoles = await db.query.discordRoles.findMany({
+				where: and(
+					inArray(discordRoles.id, Array.from(scenarioRoleDbIds)),
+					eq(discordRoles.isActive, true)
+				),
+				columns: { id: true, roleId: true },
+			})
+			scenarioRoleIdByDbId = new Map(scenarioRoles.map((role) => [role.id, role.roleId]))
+		}
 
-				const guildData = rolesByGuild.get(attachment.discordServer.guildId)
+		const userEntitledGuildIds = new Set<string>()
+		const corpGatedGuildIds = new Set<string>()
+
+		for (const attachment of corpAttachments) {
+			if (!attachment.discordServer.isActive) continue
+
+			const guildId = attachment.discordServer.guildId
+			corpGatedGuildIds.add(guildId)
+
+			const isCorpMember = userCorporationIds.has(attachment.corporationId)
+			const { roleId: scenarioRoleId } = resolveScenarioRoleId(
+				attachment,
+				isCorpMember,
+				isAllianceMember,
+				attachment.corporation.isMemberCorporation,
+				scenarioRoleIdByDbId
+			)
+
+			if (isCorpMember || scenarioRoleId) {
+				userEntitledGuildIds.add(guildId)
+			}
+
+			if (isCorpMember && attachment.autoAssignRoles) {
+				const guildData = rolesByGuild.get(guildId)
 				if (guildData) {
-					guildData.expectedRoleIds.push(...roleIds)
+					for (const roleAssignment of attachment.roles) {
+						if (roleAssignment.discordRole.isActive) {
+							guildData.expectedRoleIds.push(roleAssignment.discordRole.roleId)
+						}
+					}
 					guildData.sources.push({
 						type: 'corporation',
 						name: attachment.corporation.name,
@@ -1480,32 +1834,17 @@ export async function updateUserDiscordRoles(
 					guildData.guildName = attachment.discordServer.guildName
 				}
 			}
-		}
 
-		// Track guilds where this user has valid corp/alliance entitlement
-		const userEntitledGuildIds = new Set<string>(
-			relevantCorpAttachments.map((a) => a.discordServer.guildId)
-		)
-
-		// Determine which of the target guilds are corp-gated (have ANY corp attachment, not just the user's).
-		// Group roles are not granted on corp-gated guilds where the user has no corp/alliance entitlement —
-		// losing corp access should also remove group roles on that guild.
-		const targetServerRecords = await db.query.discordServers.findMany({
-			where: and(inArray(discordServers.guildId, serversToUpdate), eq(discordServers.isActive, true)),
-			columns: { id: true, guildId: true },
-		})
-		const dbIdToGuildId = new Map(targetServerRecords.map((s) => [s.id, s.guildId]))
-		const targetServerDbIds = targetServerRecords.map((s) => s.id)
-
-		const corpGatedGuildIds = new Set<string>()
-		if (targetServerDbIds.length > 0) {
-			const corpGatedRecords = await db.query.corporationDiscordServers.findMany({
-				where: inArray(corporationDiscordServers.discordServerId, targetServerDbIds),
-				columns: { discordServerId: true },
-			})
-			for (const record of corpGatedRecords) {
-				const guildId = dbIdToGuildId.get(record.discordServerId)
-				if (guildId) corpGatedGuildIds.add(guildId)
+			if (scenarioRoleId) {
+				const guildData = rolesByGuild.get(guildId)
+				if (guildData) {
+					guildData.expectedRoleIds.push(scenarioRoleId)
+					guildData.sources.push({
+						type: 'corporation',
+						name: attachment.corporation.name,
+					})
+					guildData.guildName = attachment.discordServer.guildName
+				}
 			}
 		}
 
@@ -1517,10 +1856,9 @@ export async function updateUserDiscordRoles(
 
 			for (const group of groupsWithDiscord) {
 				try {
-					const memberUserIds = await groupsStub.getGroupMemberUserIds(group.groupId)
-					const isMember = memberUserIds.includes(userId)
+					const membership = await getGroupMembershipFlags(groupsStub, group.groupId, userId)
 
-					if (isMember) {
+					if (membership.isMember || membership.isOwnerAdmin) {
 						for (const discordServer of group.discordServers) {
 							// Check ALL servers, not just auto-invite
 							const serverInfo = await db.query.discordServers.findFirst({
@@ -1545,10 +1883,20 @@ export async function updateUserDiscordRoles(
 							) {
 								let actualRoleIds: string[] = []
 
-								if (discordServer.roleIds && discordServer.roleIds.length > 0) {
+								const memberRoleDbIds =
+									discordServer.autoAssignRoles && membership.isMember
+										? getGroupMemberRoleDbIds(discordServer)
+										: []
+								const ownerAdminRoleDbIds =
+									discordServer.autoAssignRoles && membership.isOwnerAdmin
+										? getGroupOwnerAdminRoleDbIds(discordServer)
+										: []
+								const roleDbIds = [...new Set([...memberRoleDbIds, ...ownerAdminRoleDbIds])]
+
+								if (roleDbIds.length > 0) {
 									const roleRecords = await db.query.discordRoles.findMany({
 										where: and(
-											inArray(discordRoles.id, discordServer.roleIds),
+											inArray(discordRoles.id, roleDbIds),
 											eq(discordRoles.isActive, true)
 										),
 									})
@@ -2283,30 +2631,76 @@ async function calculateUserRolesForServer(
 
 	// Get user's corporation IDs
 	const userCorporationIds = await getUserCorporationIds(env, characterIds)
+	const userAllianceMemberCorporationIds = await getUserAllianceMemberCorporationIds(
+		db,
+		userCorporationIds
+	)
+	const isAllianceMember = userAllianceMemberCorporationIds.size > 0
 
 	// === CORPORATION ROLES ===
-	if (userCorporationIds.size > 0) {
-		const corpAttachments = await db.query.corporationDiscordServers.findMany({
-			where: and(
-				eq(corporationDiscordServers.discordServerId, serverId),
-				eq(corporationDiscordServers.autoAssignRoles, true),
-				inArray(corporationDiscordServers.corporationId, Array.from(userCorporationIds))
-			),
-			with: {
-				roles: {
-					with: {
-						discordRole: true,
-					},
+	const corpAttachments = await db.query.corporationDiscordServers.findMany({
+		where: eq(corporationDiscordServers.discordServerId, serverId),
+		columns: {
+			corporationId: true,
+			autoAssignRoles: true,
+			corpMemberRoleId: true,
+			corpMemberAutoApply: true,
+			allianceGuestRoleId: true,
+			allianceGuestAutoApply: true,
+			nonAllianceGuestRoleId: true,
+			nonAllianceGuestAutoApply: true,
+		},
+		with: {
+			corporation: {
+				columns: { isMemberCorporation: true },
+			},
+			roles: {
+				with: {
+					discordRole: true,
 				},
 			},
-		})
+		},
+	})
 
-		for (const attachment of corpAttachments) {
+	const scenarioRoleDbIds = new Set<string>()
+	for (const attachment of corpAttachments) {
+		for (const roleDbId of getScenarioManagedRoleDbIds(attachment)) {
+			scenarioRoleDbIds.add(roleDbId)
+		}
+	}
+
+	let scenarioRoleIdByDbId = new Map<string, string>()
+	if (scenarioRoleDbIds.size > 0) {
+		const scenarioRoles = await db.query.discordRoles.findMany({
+			where: and(
+				inArray(discordRoles.id, Array.from(scenarioRoleDbIds)),
+				eq(discordRoles.isActive, true)
+			),
+			columns: { id: true, roleId: true },
+		})
+		scenarioRoleIdByDbId = new Map(scenarioRoles.map((role) => [role.id, role.roleId]))
+	}
+
+	for (const attachment of corpAttachments) {
+		const isCorpMember = userCorporationIds.has(attachment.corporationId)
+		const { roleId: scenarioRoleId } = resolveScenarioRoleId(
+			attachment,
+			isCorpMember,
+			isAllianceMember,
+			attachment.corporation.isMemberCorporation,
+			scenarioRoleIdByDbId
+		)
+
+		if (isCorpMember && attachment.autoAssignRoles) {
 			for (const roleAssignment of attachment.roles) {
 				if (roleAssignment.discordRole.isActive) {
 					roleIds.add(roleAssignment.discordRole.roleId)
 				}
 			}
+		}
+
+		if (scenarioRoleId) {
+			roleIds.add(scenarioRoleId)
 		}
 	}
 
@@ -2318,17 +2712,22 @@ async function calculateUserRolesForServer(
 		const groupsWithServer = await groupsStub.getGroupsByDiscordServer(serverId)
 
 		for (const groupAttachment of groupsWithServer) {
-			// Check if user is a member of this group
-			const memberUserIds = await groupsStub.getGroupMemberUserIds(groupAttachment.groupId)
-			const isMember = memberUserIds.includes(userId)
+			const membership = await getGroupMembershipFlags(groupsStub, groupAttachment.groupId, userId)
 
-			if (isMember && groupAttachment.autoAssignRoles) {
+			if ((membership.isMember || membership.isOwnerAdmin) && groupAttachment.autoAssignRoles) {
 				// Get roles for this group attachment
 				try {
 					const attachmentConfig = await groupsStub.getDiscordServerAttachmentConfig(
 						groupAttachment.id
 					)
-					for (const roleId of attachmentConfig.roleIds) {
+					for (const roleId of membership.isMember
+						? getGroupMemberRoleDbIds(attachmentConfig)
+						: []) {
+						roleIds.add(roleId)
+					}
+					for (const roleId of membership.isOwnerAdmin
+						? getGroupOwnerAdminRoleDbIds(attachmentConfig)
+						: []) {
 						roleIds.add(roleId)
 					}
 				} catch (e) {

--- a/apps/groups/.migrations/0021_glossy_slapstick.sql
+++ b/apps/groups/.migrations/0021_glossy_slapstick.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."group_discord_server_membership_type" AS ENUM('member', 'owner_admin');--> statement-breakpoint
+ALTER TABLE "group_discord_server_roles" ADD COLUMN "membership_type" "group_discord_server_membership_type" DEFAULT 'member' NOT NULL;--> statement-breakpoint
+CREATE INDEX "group_discord_server_roles_membership_type_idx" ON "group_discord_server_roles" USING btree ("membership_type");

--- a/apps/groups/.migrations/meta/0021_snapshot.json
+++ b/apps/groups/.migrations/meta/0021_snapshot.json
@@ -1,0 +1,2223 @@
+{
+  "id": "c19da600-e716-4c9c-887c-f877aee9432e",
+  "prevId": "bb76ef45-ec3c-489b-850d-02c2bb78c988",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "allow_group_creation": {
+          "name": "allow_group_creation",
+          "type": "category_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'anyone'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_visibility_idx": {
+          "name": "categories_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_permissions": {
+      "name": "corporation_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_permissions_corp_id_idx": {
+          "name": "corporation_permissions_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_permissions_permission_id_idx": {
+          "name": "corporation_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_permissions_permission_id_permissions_id_fk": {
+          "name": "corporation_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "corporation_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corporation_permission": {
+          "name": "unique_corporation_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_admins": {
+      "name": "group_admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "designated_at": {
+          "name": "designated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_admins_group_id_idx": {
+          "name": "group_admins_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_admins_user_id_idx": {
+          "name": "group_admins_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_admins_user_group_idx": {
+          "name": "group_admins_user_group_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_admins_group_id_groups_id_fk": {
+          "name": "group_admins_group_id_groups_id_fk",
+          "tableFrom": "group_admins",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_admin": {
+          "name": "unique_group_admin",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_discord_invites": {
+      "name": "group_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_discord_server_id": {
+          "name": "group_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_discord_invites_group_id_idx": {
+          "name": "group_discord_invites_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_invites_server_id_idx": {
+          "name": "group_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "group_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_invites_user_id_idx": {
+          "name": "group_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_invites_created_at_idx": {
+          "name": "group_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_discord_invites_group_id_groups_id_fk": {
+          "name": "group_discord_invites_group_id_groups_id_fk",
+          "tableFrom": "group_discord_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_discord_invites_group_discord_server_id_group_discord_servers_id_fk": {
+          "name": "group_discord_invites_group_discord_server_id_group_discord_servers_id_fk",
+          "tableFrom": "group_discord_invites",
+          "tableTo": "group_discord_servers",
+          "columnsFrom": [
+            "group_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_discord_server_roles": {
+      "name": "group_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_discord_server_id": {
+          "name": "group_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_type": {
+          "name": "membership_type",
+          "type": "group_discord_server_membership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_discord_server_roles_attachment_idx": {
+          "name": "group_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "group_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_server_roles_membership_type_idx": {
+          "name": "group_discord_server_roles_membership_type_idx",
+          "columns": [
+            {
+              "expression": "membership_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_discord_server_roles_group_discord_server_id_group_discord_servers_id_fk": {
+          "name": "group_discord_server_roles_group_discord_server_id_group_discord_servers_id_fk",
+          "tableFrom": "group_discord_server_roles",
+          "tableTo": "group_discord_servers",
+          "columnsFrom": [
+            "group_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_discord_server_role": {
+          "name": "unique_group_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_discord_servers": {
+      "name": "group_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_discord_servers_group_id_idx": {
+          "name": "group_discord_servers_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_servers_server_id_idx": {
+          "name": "group_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_servers_auto_invite_idx": {
+          "name": "group_discord_servers_auto_invite_idx",
+          "columns": [
+            {
+              "expression": "auto_invite",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_servers_server_auto_assign_idx": {
+          "name": "group_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"group_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_discord_servers_group_id_groups_id_fk": {
+          "name": "group_discord_servers_group_id_groups_id_fk",
+          "tableFrom": "group_discord_servers",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_discord_server": {
+          "name": "unique_group_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invitations": {
+      "name": "group_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_main_character_id": {
+          "name": "invitee_main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "group_invitations_group_id_idx": {
+          "name": "group_invitations_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invitations_invitee_user_id_idx": {
+          "name": "group_invitations_invitee_user_id_idx",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invitations_status_idx": {
+          "name": "group_invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invitations_expires_at_idx": {
+          "name": "group_invitations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invitations_group_id_groups_id_fk": {
+          "name": "group_invitations_group_id_groups_id_fk",
+          "tableFrom": "group_invitations",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invite_code_redemptions": {
+      "name": "group_invite_code_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invite_code_id": {
+          "name": "invite_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_invite_code_redemptions_invite_code_id_idx": {
+          "name": "group_invite_code_redemptions_invite_code_id_idx",
+          "columns": [
+            {
+              "expression": "invite_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invite_code_redemptions_user_id_idx": {
+          "name": "group_invite_code_redemptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invite_code_redemptions_invite_code_id_group_invite_codes_id_fk": {
+          "name": "group_invite_code_redemptions_invite_code_id_group_invite_codes_id_fk",
+          "tableFrom": "group_invite_code_redemptions",
+          "tableTo": "group_invite_codes",
+          "columnsFrom": [
+            "invite_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_code_redemption": {
+          "name": "unique_code_redemption",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invite_codes": {
+      "name": "group_invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_uses": {
+          "name": "current_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "group_invite_codes_group_id_idx": {
+          "name": "group_invite_codes_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invite_codes_code_idx": {
+          "name": "group_invite_codes_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invite_codes_expires_at_idx": {
+          "name": "group_invite_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invite_codes_group_id_groups_id_fk": {
+          "name": "group_invite_codes_group_id_groups_id_fk",
+          "tableFrom": "group_invite_codes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invite_codes_code_unique": {
+          "name": "group_invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_join_requests": {
+      "name": "group_join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "group_join_requests_group_id_idx": {
+          "name": "group_join_requests_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_join_requests_user_id_idx": {
+          "name": "group_join_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_join_requests_status_idx": {
+          "name": "group_join_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_join_requests_group_user_status_idx": {
+          "name": "group_join_requests_group_user_status_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pending_join_request": {
+          "name": "unique_pending_join_request",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_join_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_join_requests_group_id_groups_id_fk": {
+          "name": "group_join_requests_group_id_groups_id_fk",
+          "tableFrom": "group_join_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_members_group_id_idx": {
+          "name": "group_members_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_members_user_id_idx": {
+          "name": "group_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_members_user_group_idx": {
+          "name": "group_members_user_group_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_member": {
+          "name": "unique_group_member",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_permissions": {
+      "name": "group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_urn": {
+          "name": "custom_urn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_description": {
+          "name": "custom_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "permission_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_permissions_group_id_idx": {
+          "name": "group_permissions_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_permissions_permission_id_idx": {
+          "name": "group_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_permissions_custom_urn_idx": {
+          "name": "group_permissions_custom_urn_idx",
+          "columns": [
+            {
+              "expression": "custom_urn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_permissions_group_id_groups_id_fk": {
+          "name": "group_permissions_group_id_groups_id_fk",
+          "tableFrom": "group_permissions",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_permissions_permission_id_permissions_id_fk": {
+          "name": "group_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "group_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_permission": {
+          "name": "unique_group_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "join_mode": {
+          "name": "join_mode",
+          "type": "join_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "mumble_sync_enabled": {
+          "name": "mumble_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mumble_ticker": {
+          "name": "mumble_ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_category_id_idx": {
+          "name": "groups_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_owner_id_idx": {
+          "name": "groups_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_visibility_idx": {
+          "name": "groups_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_category_id_categories_id_fk": {
+          "name": "groups_category_id_categories_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_name_per_category": {
+          "name": "unique_group_name_per_category",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_categories": {
+      "name": "permission_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permission_categories_name_idx": {
+          "name": "permission_categories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permission_categories_name_unique": {
+          "name": "permission_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "urn": {
+          "name": "urn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_urn_idx": {
+          "name": "permissions_urn_idx",
+          "columns": [
+            {
+              "expression": "urn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_category_id_idx": {
+          "name": "permissions_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_category_id_permission_categories_id_fk": {
+          "name": "permissions_category_id_permission_categories_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "permission_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_urn_unique": {
+          "name": "permissions_urn_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "urn"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups_role_attachments": {
+      "name": "groups_role_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attached_to_type": {
+          "name": "attached_to_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attached_to_id": {
+          "name": "attached_to_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_meta": {
+          "name": "resource_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_role_attachments_role_id_idx": {
+          "name": "groups_role_attachments_role_id_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_attached_to_type_idx": {
+          "name": "groups_role_attachments_attached_to_type_idx",
+          "columns": [
+            {
+              "expression": "attached_to_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_attached_to_id_idx": {
+          "name": "groups_role_attachments_attached_to_id_idx",
+          "columns": [
+            {
+              "expression": "attached_to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_resource_id_idx": {
+          "name": "groups_role_attachments_resource_id_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_resource_type_idx": {
+          "name": "groups_role_attachments_resource_type_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_role_attachments_role_id_groups_roles_id_fk": {
+          "name": "groups_role_attachments_role_id_groups_roles_id_fk",
+          "tableFrom": "groups_role_attachments",
+          "tableTo": "groups_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_role_attachment": {
+          "name": "unique_group_role_attachment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_id",
+            "attached_to_type",
+            "attached_to_id",
+            "resource_id",
+            "resource_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups_roles": {
+      "name": "groups_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owned_by": {
+          "name": "owned_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_roles_owned_by_idx": {
+          "name": "groups_roles_owned_by_idx",
+          "columns": [
+            {
+              "expression": "owned_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_roles_name_idx": {
+          "name": "groups_roles_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_role": {
+          "name": "unique_group_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.category_permission": {
+      "name": "category_permission",
+      "schema": "public",
+      "values": [
+        "anyone",
+        "admin_only"
+      ]
+    },
+    "public.group_discord_server_membership_type": {
+      "name": "group_discord_server_membership_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "owner_admin"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "expired",
+        "cancelled"
+      ]
+    },
+    "public.join_mode": {
+      "name": "join_mode",
+      "schema": "public",
+      "values": [
+        "open",
+        "approval",
+        "invitation_only"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.permission_target": {
+      "name": "permission_target",
+      "schema": "public",
+      "values": [
+        "all_members",
+        "all_admins",
+        "owner_only",
+        "owner_and_admins"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "hidden",
+        "system"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/groups/.migrations/meta/_journal.json
+++ b/apps/groups/.migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1781917583091,
       "tag": "0020_redundant_whistler",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1783503889730,
+      "tag": "0021_glossy_slapstick",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/groups/src/db/schema.ts
+++ b/apps/groups/src/db/schema.ts
@@ -45,6 +45,12 @@ export const joinRequestStatusEnum = pgEnum('join_request_status', [
 	'cancelled',
 ])
 
+/** Discord group role target */
+export const groupDiscordServerMembershipTypeEnum = pgEnum('group_discord_server_membership_type', [
+	'member',
+	'owner_admin',
+])
+
 /** Permission target - defines who receives the permission */
 export const permissionTargetEnum = pgEnum('permission_target', [
 	'all_members',
@@ -354,12 +360,17 @@ export const groupDiscordServerRoles = pgTable(
 			.references(() => groupDiscordServers.id, { onDelete: 'cascade' }),
 		/** Which role from the Discord server (references core.discord_roles.id) */
 		discordRoleId: uuid('discord_role_id').notNull(),
+		/** Which group membership bucket receives this role */
+		membershipType: groupDiscordServerMembershipTypeEnum('membership_type')
+			.notNull()
+			.default('member'),
 		/** Role name cached for display */
 		roleName: text('role_name').notNull(),
 		createdAt: timestamp('created_at').defaultNow().notNull(),
 	},
 	(table) => [
 		index('group_discord_server_roles_attachment_idx').on(table.groupDiscordServerId),
+		index('group_discord_server_roles_membership_type_idx').on(table.membershipType),
 		unique('unique_group_discord_server_role').on(table.groupDiscordServerId, table.discordRoleId),
 	]
 )

--- a/apps/groups/src/durable-object.ts
+++ b/apps/groups/src/durable-object.ts
@@ -32,7 +32,7 @@ import {
 	findUserByMainCharacterName,
 } from './services/character-lookup'
 import { generateInviteCode } from './services/code-generator'
-import { GroupsDOCache } from './services/groups-do-cache' // Added
+import { GROUPS_WITH_DISCORD_CACHE_KEY, GroupsDOCache } from './services/groups-do-cache' // Added
 import {
 	mapCategory,
 	mapGroup,
@@ -1813,6 +1813,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 				return {
 					id: roleAssignment.id,
 					discordRoleId: roleAssignment.discordRoleId,
+					membershipType: roleAssignment.membershipType,
 					discordRole: roleDetails || {
 						id: roleAssignment.discordRoleId,
 						roleName: roleAssignment.roleName,
@@ -1941,8 +1942,9 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 	 */
 	async assignRoleToDiscordServer(
 		attachmentId: string,
-		discordRoleId: string
-	): Promise<{ id: string; discordRoleId: string }> {
+		discordRoleId: string,
+		membershipType: 'member' | 'owner_admin' = 'member'
+	): Promise<{ id: string; discordRoleId: string; membershipType: 'member' | 'owner_admin' }> {
 		// Verify attachment exists
 		const attachment = await this.db.query.groupDiscordServers.findFirst({
 			where: eq(groupDiscordServers.id, attachmentId),
@@ -1979,6 +1981,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			.values({
 				groupDiscordServerId: attachmentId,
 				discordRoleId,
+				membershipType,
 				roleName: roleDetails.roleName,
 			})
 			.returning()
@@ -1989,6 +1992,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		return {
 			id: roleAssignment.id,
 			discordRoleId: roleAssignment.discordRoleId,
+			membershipType: roleAssignment.membershipType,
 		}
 	}
 
@@ -2136,13 +2140,15 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 				id: string
 				discordServerId: string
 				roleIds?: string[]
+				memberRoleIds?: string[]
+				ownerAdminRoleIds?: string[]
 				autoInvite?: boolean
 				autoAssignRoles?: boolean
 			}>
 		}>
 	> {
 		// Try to get from DO storage cache
-		const cacheKey = 'groups-with-discord-servers' // Updated cache key
+		const cacheKey = GROUPS_WITH_DISCORD_CACHE_KEY
 		const cached = await this.state.storage.get<{
 			data: any[]
 			expires: number
@@ -2172,6 +2178,8 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 					id: string
 					discordServerId: string
 					roleIds?: string[]
+					memberRoleIds?: string[]
+					ownerAdminRoleIds?: string[]
 					autoInvite?: boolean
 					autoAssignRoles?: boolean
 				}>
@@ -2188,13 +2196,24 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 				})
 			}
 
-			// Collect role IDs if auto-assign is enabled
-			const roleIds = server.autoAssignRoles ? server.roles.map((r) => r.discordRoleId) : []
+			// Collect role IDs by membership bucket if auto-assign is enabled.
+			const memberRoleIds = server.autoAssignRoles
+				? server.roles
+						.filter((role) => role.membershipType === 'member')
+						.map((role) => role.discordRoleId)
+				: []
+			const ownerAdminRoleIds = server.autoAssignRoles
+				? server.roles
+						.filter((role) => role.membershipType === 'owner_admin')
+						.map((role) => role.discordRoleId)
+				: []
 
 			groupsMap.get(groupId)!.discordServers.push({
 				id: server.id,
 				discordServerId: server.discordServerId,
-				roleIds,
+				roleIds: [...new Set([...memberRoleIds, ...ownerAdminRoleIds])],
+				memberRoleIds,
+				ownerAdminRoleIds,
 				autoInvite: server.autoInvite, // Include autoInvite flag
 				autoAssignRoles: server.autoAssignRoles, // Include autoAssignRoles flag
 			})
@@ -2264,6 +2283,8 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		groupId: string
 		guildId: string
 		roleIds: string[]
+		memberRoleIds?: string[]
+		ownerAdminRoleIds?: string[]
 	}> {
 		// Fetch the attachment with its role assignments
 		const attachment = await this.db.query.groupDiscordServers.findFirst({
@@ -2287,22 +2308,34 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		}
 
 		// Extract role IDs from the Discord role details
-		const roleIds = await Promise.all(
+		const resolvedRoles = await Promise.all(
 			(attachment.roles || []).map(async (roleAssignment) => {
 				const roleDetails = await this.coreDb.query.discordRoles.findFirst({
 					where: eq(discordRoles.id, roleAssignment.discordRoleId),
 				})
-				return roleDetails?.roleId || null
+				return {
+					membershipType: roleAssignment.membershipType,
+					roleId: roleDetails?.roleId || null,
+				}
 			})
 		)
 
-		// Filter out null values (in case some roles weren't found)
-		const validRoleIds = roleIds.filter((id): id is string => id !== null)
+		const memberRoleIds = resolvedRoles
+			.filter((role) => role.membershipType === 'member')
+			.map((role) => role.roleId)
+			.filter((id): id is string => id !== null)
+		const ownerAdminRoleIds = resolvedRoles
+			.filter((role) => role.membershipType === 'owner_admin')
+			.map((role) => role.roleId)
+			.filter((id): id is string => id !== null)
+		const validRoleIds = [...new Set([...memberRoleIds, ...ownerAdminRoleIds])]
 
 		return {
 			groupId: attachment.groupId,
 			guildId: discordServer.guildId,
 			roleIds: validRoleIds,
+			memberRoleIds,
+			ownerAdminRoleIds,
 		}
 	}
 
@@ -3611,11 +3644,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 	 */
 
 	/**
-	 * Invalidate the groups with Discord auto-invite cache in DO storage
+	 * Invalidate the groups with Discord attachment cache in DO storage
 	 */
 	private async invalidateGroupsWithDiscordCache(): Promise<void> {
-		const cacheKey = 'groups-with-discord-auto-invite'
-		await this.state.storage.delete(cacheKey)
+		await this.state.storage.delete(GROUPS_WITH_DISCORD_CACHE_KEY)
 	}
 
 	/**

--- a/apps/groups/src/services/__tests__/discord-service.test.ts
+++ b/apps/groups/src/services/__tests__/discord-service.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DiscordService } from '../discord-service'
+
+import type { ServiceContext } from '../context'
+
+function createServiceContext() {
+	const db = {
+		query: {
+			groups: {
+				findFirst: vi.fn(),
+			},
+			groupAdmins: {
+				findFirst: vi.fn(),
+			},
+			groupDiscordServers: {
+				findMany: vi.fn(),
+				findFirst: vi.fn(),
+			},
+			groupDiscordServerRoles: {
+				findFirst: vi.fn(),
+			},
+		},
+		insert: vi.fn(() => ({
+			values: vi.fn(() => ({
+				returning: vi.fn(),
+			})),
+		})),
+		delete: vi.fn(),
+	}
+
+	const coreDb = {
+		query: {
+			discordServers: {
+				findMany: vi.fn(),
+				findFirst: vi.fn(),
+			},
+			discordRoles: {
+				findMany: vi.fn(),
+				findFirst: vi.fn(),
+			},
+		},
+	}
+
+	const groupsDOCache = {
+		invalidateGroupsWithDiscordCache: vi.fn(),
+	}
+
+	return {
+		db,
+		coreDb,
+		env: {} as any,
+		state: {} as any,
+		groupsDOCache,
+	} as unknown as ServiceContext & {
+		db: typeof db
+		coreDb: typeof coreDb
+		groupsDOCache: typeof groupsDOCache
+	}
+}
+
+describe('DiscordService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns separate member and owner/admin role buckets for grouped Discord servers', async () => {
+		const ctx = createServiceContext()
+		const service = new DiscordService(ctx)
+
+		ctx.db.query.groupDiscordServers.findMany.mockResolvedValue([
+			{
+				id: 'attachment-1',
+				groupId: 'group-1',
+				discordServerId: 'discord-server-1',
+				autoInvite: true,
+				autoAssignRoles: true,
+				createdAt: new Date('2026-07-08T00:00:00.000Z'),
+				group: { name: 'Group One' },
+				roles: [
+					{
+						id: 'assign-member',
+						discordRoleId: 'db-role-member',
+						membershipType: 'member',
+						roleName: 'Member role',
+					},
+					{
+						id: 'assign-owner',
+						discordRoleId: 'db-role-owner',
+						membershipType: 'owner_admin',
+						roleName: 'Owner role',
+					},
+				],
+			},
+		])
+		ctx.coreDb.query.discordServers.findMany.mockResolvedValue([
+			{
+				id: 'discord-server-1',
+				guildId: 'guild-1',
+				guildName: 'Guild One',
+				roles: [],
+			},
+		])
+		ctx.coreDb.query.discordRoles.findMany.mockResolvedValue([
+			{
+				id: 'db-role-member',
+				roleId: 'discord-role-member',
+				roleName: 'Member role',
+			},
+			{
+				id: 'db-role-owner',
+				roleId: 'discord-role-owner',
+				roleName: 'Owner role',
+			},
+		])
+
+		const servers = await service.getDiscordServers('group-1')
+
+		expect(servers).toHaveLength(1)
+		expect(servers[0].roles).toEqual([
+			expect.objectContaining({
+				membershipType: 'member',
+				discordRole: expect.objectContaining({
+					roleId: 'discord-role-member',
+				}),
+			}),
+			expect.objectContaining({
+				membershipType: 'owner_admin',
+				discordRole: expect.objectContaining({
+					roleId: 'discord-role-owner',
+				}),
+			}),
+		])
+	})
+
+	it('stores member role assignments by default when attaching Discord roles', async () => {
+		const ctx = createServiceContext()
+		const service = new DiscordService(ctx)
+
+		ctx.db.query.groups.findFirst.mockResolvedValue({ id: 'group-1', ownerId: 'user-1' })
+		ctx.db.query.groupAdmins.findFirst.mockResolvedValue(null)
+		ctx.db.query.groupDiscordServers.findFirst.mockResolvedValue({
+			id: 'attachment-1',
+			groupId: 'group-1',
+			discordServerId: 'discord-server-1',
+		})
+		ctx.coreDb.query.discordRoles.findFirst.mockResolvedValue({
+			id: 'db-role-member',
+			roleId: 'discord-role-member',
+			roleName: 'Member role',
+		})
+		ctx.db.query.groupDiscordServerRoles.findFirst.mockResolvedValue(null)
+		const values = vi.fn(() => ({
+			returning: vi.fn().mockResolvedValue([
+				{
+					id: 'assignment-1',
+					groupDiscordServerId: 'attachment-1',
+					discordRoleId: 'db-role-member',
+					membershipType: 'member',
+					roleName: 'Member role',
+				},
+			]),
+		}))
+		ctx.db.insert.mockReturnValue({
+			values,
+		})
+
+		const result = await service.attachDiscordRole(
+			'group-1',
+			'discord-server-1',
+			'db-role-member',
+			'Member role',
+			'user-1'
+		)
+
+		expect(values).toHaveBeenCalledWith({
+			groupDiscordServerId: 'attachment-1',
+			discordRoleId: 'db-role-member',
+			membershipType: 'member',
+			roleName: 'Member role',
+		})
+		expect(result).toBeUndefined()
+	})
+
+	it('stores owner/admin role assignments when explicitly requested', async () => {
+		const ctx = createServiceContext()
+		const service = new DiscordService(ctx)
+
+		ctx.db.query.groups.findFirst.mockResolvedValue({ id: 'group-1', ownerId: 'user-1' })
+		ctx.db.query.groupAdmins.findFirst.mockResolvedValue(null)
+		ctx.db.query.groupDiscordServers.findFirst.mockResolvedValue({
+			id: 'attachment-1',
+			groupId: 'group-1',
+			discordServerId: 'discord-server-1',
+		})
+		ctx.coreDb.query.discordRoles.findFirst.mockResolvedValue({
+			id: 'db-role-owner',
+			roleId: 'discord-role-owner',
+			roleName: 'Owner role',
+		})
+		ctx.db.query.groupDiscordServerRoles.findFirst.mockResolvedValue(null)
+		const values = vi.fn(() => ({
+			returning: vi.fn().mockResolvedValue([
+				{
+					id: 'assignment-2',
+					groupDiscordServerId: 'attachment-1',
+					discordRoleId: 'db-role-owner',
+					membershipType: 'owner_admin',
+					roleName: 'Owner role',
+				},
+			]),
+		}))
+		ctx.db.insert.mockReturnValue({
+			values,
+		})
+
+		const result = await service.attachDiscordRole(
+			'group-1',
+			'discord-server-1',
+			'db-role-owner',
+			'Owner role',
+			'user-1',
+			'owner_admin'
+		)
+
+		expect(values).toHaveBeenCalledWith({
+			groupDiscordServerId: 'attachment-1',
+			discordRoleId: 'db-role-owner',
+			membershipType: 'owner_admin',
+			roleName: 'Owner role',
+		})
+		expect(result).toBeUndefined()
+	})
+})

--- a/apps/groups/src/services/discord-service.ts
+++ b/apps/groups/src/services/discord-service.ts
@@ -82,6 +82,7 @@ export class DiscordService {
 				return {
 					id: roleAssignment.id,
 					discordRoleId: roleAssignment.discordRoleId,
+					membershipType: roleAssignment.membershipType,
 					discordRole: roleDetails || {
 						id: roleAssignment.discordRoleId,
 						roleName: roleAssignment.roleName,
@@ -189,6 +190,7 @@ export class DiscordService {
 		discordRoleId: string,
 		roleName: string,
 		addedBy: string,
+		membershipType: 'member' | 'owner_admin' = 'member',
 		isAdmin: boolean = false
 	): Promise<void> {
 		const group = await this.ctx.db.query.groups.findFirst({
@@ -244,6 +246,7 @@ export class DiscordService {
 		await this.ctx.db.insert(groupDiscordServerRoles).values({
 			groupDiscordServerId: groupDiscordServer.id,
 			discordRoleId,
+			membershipType,
 			roleName,
 		})
 	}

--- a/apps/groups/src/services/group-service.ts
+++ b/apps/groups/src/services/group-service.ts
@@ -10,6 +10,7 @@ import {
 	canViewGroup,
 } from './permissions'
 import { getGroupMemberCount, isUserGroupAdmin, isUserMember } from './query-helpers'
+import { GROUPS_WITH_DISCORD_CACHE_KEY } from './groups-do-cache'
 
 import type {
 	CreateGroupRequest,
@@ -45,13 +46,12 @@ export class GroupService {
 	constructor(private ctx: ServiceContext) {}
 
 	/**
-	 * Invalidate the groups with Discord auto-invite cache in DO storage
+	 * Invalidate the groups with Discord attachment cache in DO storage
 	 * Note: This duplicates logic from the DO, but we can't easily access the DO's private method.
 	 * We should consider moving this to a shared cache service eventually.
 	 */
 	private async invalidateGroupsWithDiscordCache(): Promise<void> {
-		const cacheKey = 'groups-with-discord-auto-invite'
-		await this.ctx.state.storage.delete(cacheKey)
+		await this.ctx.state.storage.delete(GROUPS_WITH_DISCORD_CACHE_KEY)
 	}
 
 	/**

--- a/apps/groups/src/services/groups-do-cache.ts
+++ b/apps/groups/src/services/groups-do-cache.ts
@@ -1,5 +1,7 @@
 import type { UserPermission } from '@repo/groups'
 
+export const GROUPS_WITH_DISCORD_CACHE_KEY = 'groups-with-discord-servers'
+
 export class GroupsDOCache {
 	private readonly CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 	private readonly MAX_CACHE_ENTRIES = 1000
@@ -41,11 +43,10 @@ export class GroupsDOCache {
 	}
 
 	/**
-	 * Invalidate the groups with Discord auto-invite cache in DO storage
+	 * Invalidate the groups with Discord attachment cache in DO storage
 	 */
 	async invalidateGroupsWithDiscordCache(): Promise<void> {
-		const cacheKey = 'groups-with-discord-auto-invite'
-		await this.state.storage.delete(cacheKey)
+		await this.state.storage.delete(GROUPS_WITH_DISCORD_CACHE_KEY)
 	}
 
 	/**

--- a/apps/ui/src/client/components/admin/corporation-alerts-card.tsx
+++ b/apps/ui/src/client/components/admin/corporation-alerts-card.tsx
@@ -301,7 +301,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 													isExisting
 													saveButtonVariant="primary"
 													removeButtonVariant="destructive"
-													className="rounded-md border bg-muted/20 p-3"
+													className="rounded-md border border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
 												/>
 											)
 										})}
@@ -318,7 +318,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 												onRemove={() => handleClearNew(row.id)}
 												isSaving={createDestination.isPending}
 												removeButtonVariant="cancel"
-												className="rounded-md border border-dashed bg-muted/10 p-3"
+												className="rounded-md border border-dashed border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
 											/>
 										))}
 									</div>
@@ -371,7 +371,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 												isExisting
 												saveButtonVariant="primary"
 												removeButtonVariant="destructive"
-												className="rounded-md border bg-muted/20 p-3"
+												className="rounded-md border border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
 											/>
 										)
 									})}
@@ -388,7 +388,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 											onRemove={() => handleClearNew(row.id)}
 											isSaving={createDestination.isPending}
 											removeButtonVariant="cancel"
-											className="rounded-md border border-dashed bg-muted/10 p-3"
+											className="rounded-md border border-dashed border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
 										/>
 									))}
 								</div>

--- a/apps/ui/src/client/hooks/useDiscord.ts
+++ b/apps/ui/src/client/hooks/useDiscord.ts
@@ -104,6 +104,18 @@ export function useDiscordServers() {
 }
 
 /**
+ * Fetch a specific Discord server with its roles
+ */
+export function useDiscordServer(serverId: string) {
+	return useQuery({
+		queryKey: [...discordKeys.servers(), 'server', serverId] as const,
+		queryFn: () => apiClient.getDiscordServer(serverId),
+		enabled: !!serverId,
+		staleTime: 1000 * 60 * 5, // 5 minutes
+	})
+}
+
+/**
  * Create a new Discord server in the registry
  */
 export function useCreateDiscordServer() {

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -359,6 +359,7 @@ export interface GroupDiscordServer {
 	roles?: Array<{
 		id: string
 		discordRoleId: string
+		membershipType: 'member' | 'owner_admin'
 		discordRole: DiscordRole
 	}>
 }
@@ -640,6 +641,12 @@ export interface CorporationDiscordServer {
 	discordServerId: string
 	autoInvite: boolean
 	autoAssignRoles: boolean
+	corpMemberRoleId: string | null
+	corpMemberAutoApply: boolean
+	allianceGuestRoleId: string | null
+	allianceGuestAutoApply: boolean
+	nonAllianceGuestRoleId: string | null
+	nonAllianceGuestAutoApply: boolean
 	createdAt: string
 	updatedAt: string
 	discordServer?: DiscordServerWithRoles
@@ -1126,15 +1133,28 @@ export interface AttachDiscordServerRequest {
 	discordServerId: string
 	autoInvite?: boolean
 	autoAssignRoles?: boolean
+	corpMemberRoleId?: string | null
+	corpMemberAutoApply?: boolean
+	allianceGuestRoleId?: string | null
+	allianceGuestAutoApply?: boolean
+	nonAllianceGuestRoleId?: string | null
+	nonAllianceGuestAutoApply?: boolean
 }
 
 export interface UpdateDiscordServerAttachmentRequest {
 	autoInvite?: boolean
 	autoAssignRoles?: boolean
+	corpMemberRoleId?: string | null
+	corpMemberAutoApply?: boolean
+	allianceGuestRoleId?: string | null
+	allianceGuestAutoApply?: boolean
+	nonAllianceGuestRoleId?: string | null
+	nonAllianceGuestAutoApply?: boolean
 }
 
 export interface AssignRoleRequest {
 	discordRoleId: string
+	membershipType?: 'member' | 'owner_admin'
 }
 
 export interface RefreshDiscordServerMembersResponse {

--- a/apps/ui/src/client/routes/admin/corporation-detail.tsx
+++ b/apps/ui/src/client/routes/admin/corporation-detail.tsx
@@ -29,6 +29,12 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from '@/components/ui/accordion'
+import {
 	Dialog,
 	DialogContent,
 	DialogDescription,
@@ -81,6 +87,16 @@ const ACCESS_ROLE_GROUPS = [
 	},
 	{ label: 'Factory Manager', roles: ['Factory_Manager'] },
 ] as const
+
+const DEFAULT_ATTACHMENT_SETTINGS = {
+	autoInvite: false,
+	autoAssignRoles: false,
+} as const
+
+type AttachmentSettingsState = {
+	autoInvite: boolean
+	autoAssignRoles: boolean
+}
 
 export default function CorporationDetailPage() {
 	const { corporationId } = useParams<{ corporationId: string }>()
@@ -148,14 +164,36 @@ export default function CorporationDetailPage() {
 	const [showAddServerDialog, setShowAddServerDialog] = useState(false)
 	const [selectedServerId, setSelectedServerId] = useState('')
 	const [pendingRoleSelections, setPendingRoleSelections] = useState<Record<string, string>>({})
-	const [attachmentSettings, setAttachmentSettings] = useState({
-		autoInvite: false,
-		autoAssignRoles: false,
+	const [attachmentSettings, setAttachmentSettings] = useState<AttachmentSettingsState>({
+		...DEFAULT_ATTACHMENT_SETTINGS,
 	})
 
 	// Permission UI state
 	const [showAttachPermissionDialog, setShowAttachPermissionDialog] = useState(false)
 	const [selectedPermissionId, setSelectedPermissionId] = useState('')
+	const noneScenarioRoleValue = '__none__'
+
+	useEffect(() => {
+		setAttachmentSettings({ ...DEFAULT_ATTACHMENT_SETTINGS })
+	}, [selectedServerId])
+
+	const updateDiscordAttachment = async (
+		attachmentId: string,
+		data: Parameters<typeof updateAttachment.mutateAsync>[0]['data'],
+		successMessage: string,
+		errorMessage: string
+	) => {
+		try {
+			await updateAttachment.mutateAsync({
+				corporationId: corpId,
+				attachmentId,
+				data,
+			})
+			showSuccess(successMessage)
+		} catch (error) {
+			showError(error instanceof Error ? error.message : errorMessage)
+		}
+	}
 
 	// Handlers for Discord servers
 	const handleAttachServer = async () => {
@@ -172,7 +210,7 @@ export default function CorporationDetailPage() {
 			})
 			setShowAddServerDialog(false)
 			setSelectedServerId('')
-			setAttachmentSettings({ autoInvite: false, autoAssignRoles: false })
+			setAttachmentSettings({ ...DEFAULT_ATTACHMENT_SETTINGS })
 			showSuccess('Discord server attached successfully!')
 		} catch (error) {
 			showError(error instanceof Error ? error.message : 'Failed to attach Discord server')
@@ -198,31 +236,21 @@ export default function CorporationDetailPage() {
 	}
 
 	const handleToggleAutoInvite = async (attachmentId: string, currentValue: boolean) => {
-		try {
-			await updateAttachment.mutateAsync({
-				corporationId: corpId,
-				attachmentId,
-				data: { autoInvite: !currentValue },
-			})
-			showSuccess('Auto-invite setting updated!')
-		} catch (error) {
-			showError(error instanceof Error ? error.message : 'Failed to update auto-invite setting')
-		}
+		await updateDiscordAttachment(
+			attachmentId,
+			{ autoInvite: !currentValue },
+			'Auto-invite setting updated!',
+			'Failed to update auto-invite setting'
+		)
 	}
 
 	const handleToggleAutoAssignRoles = async (attachmentId: string, currentValue: boolean) => {
-		try {
-			await updateAttachment.mutateAsync({
-				corporationId: corpId,
-				attachmentId,
-				data: { autoAssignRoles: !currentValue },
-			})
-			showSuccess('Auto-assign roles setting updated!')
-		} catch (error) {
-			showError(
-				error instanceof Error ? error.message : 'Failed to update auto-assign roles setting'
-			)
-		}
+		await updateDiscordAttachment(
+			attachmentId,
+			{ autoAssignRoles: !currentValue },
+			'Auto-assign roles setting updated!',
+			'Failed to update auto-assign roles setting'
+		)
 	}
 
 	const handleAssignRole = async (attachmentId: string, discordRoleId: string) => {
@@ -236,6 +264,36 @@ export default function CorporationDetailPage() {
 		} catch (error) {
 			showError(error instanceof Error ? error.message : 'Failed to assign role')
 		}
+	}
+
+	const handleScenarioRoleChange = async (
+		attachmentId: string,
+		field: 'corpMemberRoleId' | 'allianceGuestRoleId' | 'nonAllianceGuestRoleId',
+		nextValue: string
+	) => {
+		await updateDiscordAttachment(
+			attachmentId,
+			{
+				[field]: nextValue === noneScenarioRoleValue ? null : nextValue,
+			} as Parameters<typeof updateAttachment.mutateAsync>[0]['data'],
+			'Scenario role updated!',
+			'Failed to update scenario role'
+		)
+	}
+
+	const handleScenarioAutoApplyToggle = async (
+		attachmentId: string,
+		field: 'corpMemberAutoApply' | 'allianceGuestAutoApply' | 'nonAllianceGuestAutoApply',
+		currentValue: boolean
+	) => {
+		await updateDiscordAttachment(
+			attachmentId,
+			{
+				[field]: !currentValue,
+			} as Parameters<typeof updateAttachment.mutateAsync>[0]['data'],
+			'Scenario auto-apply updated!',
+			'Failed to update scenario auto-apply'
+		)
 	}
 
 	const handleUnassignRole = async (attachmentId: string, roleAssignmentId: string) => {
@@ -385,6 +443,62 @@ export default function CorporationDetailPage() {
 	const formatDate = (date: string | Date | null) => {
 		if (!date) return 'Never'
 		return formatDistanceToNow(new Date(date), { addSuffix: true })
+	}
+
+	const scenarioRoleConfigs = [
+		{
+			label: 'Corp Member',
+			description: 'Members of this corporation',
+			roleIdKey: 'corpMemberRoleId' as const,
+			autoApplyKey: 'corpMemberAutoApply' as const,
+		},
+		{
+			label: 'Alliance Guest',
+			description: 'Guest access for users affiliated with member corporations',
+			roleIdKey: 'allianceGuestRoleId' as const,
+			autoApplyKey: 'allianceGuestAutoApply' as const,
+		},
+		{
+			label: 'Non-Alliance Guest',
+			description: 'Guest access for linked users outside the alliance',
+			roleIdKey: 'nonAllianceGuestRoleId' as const,
+			autoApplyKey: 'nonAllianceGuestAutoApply' as const,
+		},
+	] as const
+
+	const getAttachmentUsedRoleIds = (attachment: (typeof corporationDiscordServers)[number]) => {
+		const roleIds = new Set<string>()
+		for (const roleAssignment of attachment.roles ?? []) {
+			roleIds.add(roleAssignment.discordRole.id)
+		}
+		if (attachment.corpMemberRoleId) roleIds.add(attachment.corpMemberRoleId)
+		if (attachment.allianceGuestRoleId) roleIds.add(attachment.allianceGuestRoleId)
+		if (attachment.nonAllianceGuestRoleId) roleIds.add(attachment.nonAllianceGuestRoleId)
+		return roleIds
+	}
+
+	const buildRoleOptions = (
+		attachment: (typeof corporationDiscordServers)[number],
+		currentRoleId?: string | null
+	) => {
+		const usedRoleIds = getAttachmentUsedRoleIds(attachment)
+		const options = [
+			{
+				value: noneScenarioRoleValue,
+				label: 'None',
+			},
+		]
+
+		for (const role of attachment.discordServer?.roles ?? []) {
+			if (role.id === currentRoleId || !usedRoleIds.has(role.id)) {
+				options.push({
+					value: role.id,
+					label: role.roleName,
+				})
+			}
+		}
+
+		return options
 	}
 
 	if (isLoading) {
@@ -803,144 +917,231 @@ export default function CorporationDetailPage() {
 									)}
 								</div>
 							) : (
-								<div className="space-y-4">
+								<Accordion
+									type="multiple"
+									defaultValue={[]}
+									className="space-y-4"
+								>
 									{corporationDiscordServers.map((attachment) => (
-										<div key={attachment.id} className="rounded-lg border p-4 space-y-3">
-											<div className="flex items-start justify-between">
+										<AccordionItem
+											key={attachment.id}
+											value={attachment.id}
+											className="overflow-hidden rounded-lg border border-border/90 bg-card shadow-md ring-1 ring-border/50"
+										>
+											<AccordionTrigger className="px-4 py-4 text-left hover:bg-muted/40">
 												<div>
 													<h4 className="font-medium">{attachment.discordServer?.guildName}</h4>
 													<p className="text-xs text-muted-foreground">
 														ID: {attachment.discordServer?.guildId}
 													</p>
 													{attachment.discordServer?.description && (
-														<p className="text-sm text-muted-foreground mt-1">
+														<p className="mt-1 text-sm text-muted-foreground">
 															{attachment.discordServer.description}
 														</p>
 													)}
 												</div>
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={() => handleDetachServer(attachment.id)}
-												>
-													<Trash2 className="h-4 w-4 text-destructive" />
-												</Button>
-											</div>
+											</AccordionTrigger>
+											<AccordionContent className="px-4">
+												<div className="space-y-4">
+													<div className="flex justify-end">
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() => handleDetachServer(attachment.id)}
+														>
+															<Trash2 className="h-4 w-4 text-destructive" />
+														</Button>
+													</div>
 
-											<div className="flex gap-4">
-												<div className="flex items-center space-x-2">
-													<Switch
-														id={`auto-invite-${attachment.id}`}
-														checked={attachment.autoInvite}
-														onCheckedChange={() =>
-															handleToggleAutoInvite(attachment.id, attachment.autoInvite)
-														}
-													/>
-													<Label
-														htmlFor={`auto-invite-${attachment.id}`}
-														className="cursor-pointer"
-													>
-														Auto-Invite
-													</Label>
-												</div>
-
-												<div className="flex items-center space-x-2">
-													<Switch
-														id={`auto-assign-${attachment.id}`}
-														checked={attachment.autoAssignRoles}
-														onCheckedChange={() =>
-															handleToggleAutoAssignRoles(attachment.id, attachment.autoAssignRoles)
-														}
-													/>
-													<Label
-														htmlFor={`auto-assign-${attachment.id}`}
-														className="cursor-pointer"
-													>
-														Auto-Assign Roles
-													</Label>
-												</div>
-											</div>
-
-											{/* Role Management */}
-											{attachment.discordServer?.roles &&
-												attachment.discordServer.roles.length > 0 && (
-													<div className="space-y-2">
-														<p className="text-sm font-medium">Assigned Roles</p>
-														<div className="flex flex-wrap gap-2">
-															{attachment.roles?.map((roleAssignment) => (
-																<div
-																	key={roleAssignment.id}
-																	className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-primary/10 text-sm"
-																>
-																	<span>{roleAssignment.discordRole.roleName}</span>
-																	<button
-																		onClick={() =>
-																			handleUnassignRole(attachment.id, roleAssignment.id)
-																		}
-																		className="ml-1 hover:text-destructive"
-																	>
-																		<X className="h-3 w-3" />
-																	</button>
-																</div>
-															))}
+													<div className="flex gap-4">
+														<div className="flex items-center space-x-2">
+															<Switch
+																id={`auto-invite-${attachment.id}`}
+																checked={attachment.autoInvite}
+																onCheckedChange={() =>
+																	handleToggleAutoInvite(
+																		attachment.id,
+																		attachment.autoInvite
+																	)
+																}
+															/>
+															<Label
+																htmlFor={`auto-invite-${attachment.id}`}
+																className="cursor-pointer"
+															>
+																Auto-Invite
+															</Label>
 														</div>
 
-														{/* Role Selection */}
-														{attachment.discordServer.roles.filter(
-															(role) =>
-																!attachment.roles?.some(
-																	(ra) => ra.discordRole.roleId === role.roleId
-																)
-														).length > 0 && (
-															<div className="flex gap-2 items-center">
-																<Select
-																	value=""
-																	onValueChange={(nextValue) => {
-																		if (!nextValue) {
-																			return
-																		}
-																		void handleAssignRole(attachment.id, nextValue).finally(() => {
-																			setPendingRoleSelections((prev) => {
-																				const { [attachment.id]: _, ...rest } = prev
-																				return rest
-																			})
-																		})
-																	}}
-																	query={pendingRoleSelections[attachment.id] ?? ''}
-																	onQueryChange={(value) =>
-																		setPendingRoleSelections((prev) => ({
-																			...prev,
-																			[attachment.id]: value,
-																		}))
-																	}
-																	searchable
-																	options={attachment.discordServer.roles
-																		.filter(
-																			(role) =>
-																				!attachment.roles?.some(
-																					(ra) => ra.discordRole.roleId === role.roleId
-																				)
-																		)
-																		.map((role) => ({ value: role.id,
-																			label: role.roleName,
-																		}))}
-																	placeholder="Add role..."
-																	emptyText="No matching roles found"
-																	className="w-full"
-																	contentClassName="w-[min(90vw,36rem)]"
-																	inputClassName="h-9"
-																/>
-															</div>
-														)}
+														<div className="flex items-center space-x-2">
+															<Switch
+																id={`auto-assign-${attachment.id}`}
+																checked={attachment.autoAssignRoles}
+																onCheckedChange={() =>
+																	handleToggleAutoAssignRoles(
+																		attachment.id,
+																		attachment.autoAssignRoles
+																	)
+																}
+															/>
+															<Label
+																htmlFor={`auto-assign-${attachment.id}`}
+																className="cursor-pointer"
+															>
+																Auto-Assign Roles
+															</Label>
+														</div>
 													</div>
-												)}
-										</div>
+
+													<div className="space-y-4">
+														<div className="space-y-2 rounded-md border border-dashed p-3">
+															<p className="text-sm font-medium">All Members</p>
+															<div className="flex flex-wrap gap-2">
+																{attachment.roles?.map((roleAssignment) => (
+																	<div
+																		key={roleAssignment.id}
+																		className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-sm"
+																	>
+																		<span>{roleAssignment.discordRole.roleName}</span>
+																		<button
+																			onClick={() =>
+																				handleUnassignRole(attachment.id, roleAssignment.id)
+																			}
+																			className="ml-1 hover:text-destructive"
+																		>
+																			<X className="h-3 w-3" />
+																		</button>
+																	</div>
+																))}
+															</div>
+															{(attachment.discordServer?.roles ?? []).filter(
+																(role) =>
+																	!getAttachmentUsedRoleIds(attachment).has(role.roleId)
+															).length > 0 && (
+																<div className="flex items-center gap-2">
+																	<Select
+																		value=""
+																		onValueChange={(nextValue) => {
+																			if (!nextValue) {
+																				return
+																			}
+																			void handleAssignRole(attachment.id, nextValue).finally(() => {
+																				setPendingRoleSelections((prev) => {
+																					const { [attachment.id]: _, ...rest } = prev
+																					return rest
+																				})
+																			})
+																		}}
+																		query={pendingRoleSelections[attachment.id] ?? ''}
+																		onQueryChange={(value) =>
+																			setPendingRoleSelections((prev) => ({
+																				...prev,
+																				[attachment.id]: value,
+																			}))
+																		}
+																		searchable
+																		options={buildRoleOptions(attachment).filter(
+																			(option) => option.value !== noneScenarioRoleValue
+																		)}
+																		placeholder="Add role..."
+																		emptyText="No matching roles found"
+																		className="w-full"
+																		contentClassName="w-[min(90vw,36rem)]"
+																		inputClassName="h-9"
+																	/>
+																</div>
+															)}
+														</div>
+
+														{scenarioRoleConfigs.map((config) => {
+															const currentRoleId = attachment[config.roleIdKey]
+															const currentRoleLabel =
+																attachment.discordServer?.roles?.find(
+																	(role) => role.id === currentRoleId
+																)?.roleName ?? 'None'
+															const currentValue = currentRoleId ?? noneScenarioRoleValue
+
+															return (
+																<div
+																	key={`${attachment.id}-${config.roleIdKey}`}
+																	className="space-y-2 rounded-md border border-dashed p-3"
+																>
+																	<div className="flex items-start justify-between gap-3">
+																		<div>
+																			<p className="text-sm font-medium">
+																				{config.label}
+																			</p>
+																			<p className="text-xs text-muted-foreground">
+																				{config.description}
+																			</p>
+																		</div>
+																		<div className="flex items-center space-x-2">
+																			<Switch
+																				id={`${config.autoApplyKey}-${attachment.id}`}
+																				checked={attachment[config.autoApplyKey]}
+																				onCheckedChange={() =>
+																					handleScenarioAutoApplyToggle(
+																						attachment.id,
+																						config.autoApplyKey,
+																						attachment[config.autoApplyKey]
+																					)
+																				}
+																			/>
+																			<Label
+																				htmlFor={`${config.autoApplyKey}-${attachment.id}`}
+																				className="cursor-pointer"
+																			>
+																				Auto-apply
+																			</Label>
+																		</div>
+																	</div>
+																	<div className="space-y-1">
+																		<Select
+																			value={currentValue}
+																			onValueChange={(nextValue) =>
+																				void handleScenarioRoleChange(
+																					attachment.id,
+																					config.roleIdKey,
+																					nextValue
+																				)
+																			}
+																			searchable
+																			options={buildRoleOptions(
+																				attachment,
+																				currentRoleId
+																			)}
+																			placeholder="Select a role..."
+																			emptyText="No roles available"
+																			className="w-full"
+																			contentClassName="w-[min(90vw,36rem)]"
+																			inputClassName="h-9"
+																		/>
+																		<p className="text-xs text-muted-foreground">
+																			Currently {currentRoleLabel}
+																		</p>
+																	</div>
+																</div>
+															)
+														})}
+													</div>
+												</div>
+											</AccordionContent>
+										</AccordionItem>
 									))}
-								</div>
+								</Accordion>
 							)}
 
 							{/* Add Server Dialog */}
-							<Dialog open={showAddServerDialog} onOpenChange={setShowAddServerDialog}>
+							<Dialog
+								open={showAddServerDialog}
+								onOpenChange={(open) => {
+									setShowAddServerDialog(open)
+									if (!open) {
+										setSelectedServerId('')
+										setAttachmentSettings({ ...DEFAULT_ATTACHMENT_SETTINGS })
+									}
+								}}
+							>
 								<DialogContent>
 									<DialogHeader>
 										<DialogTitle>Attach Discord Server</DialogTitle>
@@ -1000,6 +1201,10 @@ export default function CorporationDetailPage() {
 													Auto-Assign Roles
 												</Label>
 											</div>
+											<p className="text-xs text-muted-foreground">
+												When enabled, the roles assigned on the main page for this attachment
+												are applied to all matching members.
+											</p>
 										</div>
 									</div>
 

--- a/apps/ui/src/client/routes/admin/group-detail.tsx
+++ b/apps/ui/src/client/routes/admin/group-detail.tsx
@@ -37,6 +37,12 @@ import { TransferOwnershipDialog } from '@/components/transfer-ownership-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from '@/components/ui/accordion'
+import {
 	Dialog,
 	DialogContent,
 	DialogDescription,
@@ -78,6 +84,10 @@ import {
 } from '@/hooks/useInviteCodes'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { apiClient } from '@/lib/api'
+import {
+	groupDiscordRoleAssignmentSections,
+	groupDiscordRoleAssignmentSummary,
+} from './group-discord-role-sections'
 
 import type { GroupDiscordServer, GroupPermissionWithDetails } from '@/lib/api'
 
@@ -352,14 +362,18 @@ export default function GroupDetailPage() {
 		}
 	}
 
-	const handleAssignRole = async (attachmentId: string, discordRoleId: string) => {
+	const handleAssignRole = async (
+		attachmentId: string,
+		discordRoleId: string,
+		membershipType: 'member' | 'owner_admin'
+	) => {
 		if (!groupId) return
 
 		try {
 			await assignRole.mutateAsync({
 				groupId,
 				attachmentId,
-				data: { discordRoleId },
+				data: { discordRoleId, membershipType },
 			})
 			setMessage({ type: 'success', text: 'Role assigned successfully!' })
 			setTimeout(() => setMessage(null), 3000)
@@ -586,7 +600,6 @@ export default function GroupDetailPage() {
 	// Calculate stats
 	const memberCount = members?.length || 0
 	const adminCount = adminUserIds.size
-
 	return (
 		<div className="space-y-6">
 			{/* Back Button */}
@@ -876,7 +889,8 @@ export default function GroupDetailPage() {
 								<CardTitle>Discord Servers</CardTitle>
 							</div>
 							<CardDescription>
-								Attach Discord servers from the registry to enable auto-invite for group members.
+								Attach Discord servers from the registry to enable auto-invite and split role
+								assignment for members versus owners/admins.
 							</CardDescription>
 						</div>
 						<Button
@@ -906,146 +920,210 @@ export default function GroupDetailPage() {
 							)}
 						</div>
 					) : (
-						<div className="space-y-4">
+						<Accordion
+							type="multiple"
+							defaultValue={[]}
+							className="space-y-4"
+						>
 							{groupDiscordServers.map((attachment) => (
-								<div key={attachment.id} className="rounded-lg border p-4 space-y-3">
-									<div className="flex items-start justify-between">
+								<AccordionItem
+									key={attachment.id}
+									value={attachment.id}
+									className="overflow-hidden rounded-lg border border-border/90 bg-card shadow-md ring-1 ring-border/50"
+								>
+									<AccordionTrigger className="px-4 py-4 text-left hover:bg-muted/40">
 										<div>
 											<h4 className="font-medium">{attachment.discordServer?.guildName}</h4>
 											<p className="text-xs text-muted-foreground">
 												ID: {attachment.discordServer?.guildId}
 											</p>
 											{attachment.discordServer?.description && (
-												<p className="text-sm text-muted-foreground mt-1">
+												<p className="mt-1 text-sm text-muted-foreground">
 													{attachment.discordServer.description}
 												</p>
 											)}
 										</div>
-										<div className="flex gap-1">
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => handleRefreshServerRoles(attachment.id)}
-												disabled={
-													refreshServerRoles.isPending || (attachment.roles?.length ?? 0) === 0
-												}
-												title={
-													(attachment.roles?.length ?? 0) === 0
-														? 'No roles configured'
-														: 'Refresh role assignments for all group members'
-												}
-											>
-												<RefreshCw
-													className={`h-4 w-4 ${refreshServerRoles.isPending ? 'animate-spin' : ''}`}
-												/>
-											</Button>
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => handleDetachServer(attachment.id)}
-											>
-												<Trash2 className="h-4 w-4 text-destructive" />
-											</Button>
-										</div>
-									</div>
-
-									<div className="flex gap-4">
-										<div className="flex items-center space-x-2">
-											<Switch
-												id={`auto-invite-${attachment.id}`}
-												checked={attachment.autoInvite}
-												onCheckedChange={() =>
-													handleToggleAutoInvite(attachment.id, attachment.autoInvite)
-												}
-											/>
-											<Label htmlFor={`auto-invite-${attachment.id}`} className="cursor-pointer">
-												Auto-Invite
-											</Label>
-										</div>
-
-										<div className="flex items-center space-x-2">
-											<Switch
-												id={`auto-assign-${attachment.id}`}
-												checked={attachment.autoAssignRoles}
-												onCheckedChange={() =>
-													handleToggleAutoAssignRoles(attachment.id, attachment.autoAssignRoles)
-												}
-											/>
-											<Label htmlFor={`auto-assign-${attachment.id}`} className="cursor-pointer">
-												Auto-Assign Roles
-											</Label>
-										</div>
-									</div>
-
-									{/* Role Management */}
-									{attachment.discordServer?.roles && attachment.discordServer.roles.length > 0 && (
-										<div className="space-y-2">
-											<p className="text-sm font-medium">Assigned Roles</p>
-											<div className="flex flex-wrap gap-2">
-												{attachment.roles?.map((roleAssignment) => (
-													<div
-														key={roleAssignment.id}
-														className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-primary/10 text-sm"
-													>
-														<span>{roleAssignment.discordRole.roleName}</span>
-														<button
-															onClick={() => handleUnassignRole(attachment.id, roleAssignment.id)}
-															className="ml-1 hover:text-destructive"
-														>
-															<X className="h-3 w-3" />
-														</button>
-													</div>
-												))}
+									</AccordionTrigger>
+									<AccordionContent className="px-4">
+										<div className="space-y-4">
+											<div className="flex justify-end gap-1">
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={() => handleRefreshServerRoles(attachment.id)}
+													disabled={
+														refreshServerRoles.isPending || (attachment.roles?.length ?? 0) === 0
+													}
+													title={
+														(attachment.roles?.length ?? 0) === 0
+															? 'No roles configured'
+															: 'Refresh role assignments for all group members'
+													}
+												>
+													<RefreshCw
+														className={`h-4 w-4 ${refreshServerRoles.isPending ? 'animate-spin' : ''}`}
+													/>
+												</Button>
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={() => handleDetachServer(attachment.id)}
+												>
+													<Trash2 className="h-4 w-4 text-destructive" />
+												</Button>
 											</div>
 
-											{/* Role Selection */}
-											{attachment.discordServer.roles.filter(
-												(role) =>
-													!attachment.roles?.some((ra) => ra.discordRole.roleId === role.roleId)
-											).length > 0 && (
-												<div className="flex gap-2 items-center">
-													<Select
-														value=""
-														onValueChange={(nextValue) => {
-															if (!nextValue) {
-																return
-															}
-															void handleAssignRole(attachment.id, nextValue).finally(() => {
-																setPendingRoleSelections((prev) => {
-																	const { [attachment.id]: _, ...rest } = prev
-																	return rest
-																})
-															})
-														}}
-														query={pendingRoleSelections[attachment.id] ?? ''}
-														onQueryChange={(value) =>
-															setPendingRoleSelections((prev) => ({
-																...prev,
-																[attachment.id]: value,
-															}))
+											<div className="flex gap-4">
+												<div className="flex items-center space-x-2">
+													<Switch
+														id={`auto-invite-${attachment.id}`}
+														checked={attachment.autoInvite}
+														onCheckedChange={() =>
+															handleToggleAutoInvite(attachment.id, attachment.autoInvite)
 														}
-														searchable
-														options={attachment.discordServer.roles
-															.filter(
+													/>
+													<Label htmlFor={`auto-invite-${attachment.id}`} className="cursor-pointer">
+														Auto-Invite
+													</Label>
+												</div>
+
+												<div className="flex items-center space-x-2">
+													<Switch
+														id={`auto-assign-${attachment.id}`}
+														checked={attachment.autoAssignRoles}
+														onCheckedChange={() =>
+															handleToggleAutoAssignRoles(attachment.id, attachment.autoAssignRoles)
+														}
+													/>
+													<Label htmlFor={`auto-assign-${attachment.id}`} className="cursor-pointer">
+														Auto-Assign Roles
+													</Label>
+												</div>
+											</div>
+
+											{/* Role Management */}
+											{(() => {
+												const discordServer = attachment.discordServer
+												if (!discordServer?.roles || discordServer.roles.length === 0) {
+													return null
+												}
+
+												return (
+													<div className="space-y-4">
+														<p className="text-xs text-muted-foreground">
+															{groupDiscordRoleAssignmentSummary}
+														</p>
+														{groupDiscordRoleAssignmentSections.map((section) => {
+															const sectionAssignments = (attachment.roles ?? []).filter(
+																(roleAssignment) => roleAssignment.membershipType === section.membershipType
+															)
+															const selectionKey = `${attachment.id}:${section.membershipType}`
+															const availableRoles = discordServer.roles.filter(
 																(role) =>
 																	!attachment.roles?.some(
-																		(ra) => ra.discordRole.roleId === role.roleId
+																		(roleAssignment) => roleAssignment.discordRole.roleId === role.roleId
 																	)
 															)
-															.map((role) => ({ value: role.id, label: role.roleName }))}
-														placeholder="Add role..."
-														emptyText="No matching roles found"
-														className="w-full"
-														contentClassName="w-[min(90vw,36rem)]"
-														inputClassName="h-9"
-													/>
-												</div>
-											)}
+
+															return (
+																<div
+																	key={`${attachment.id}-${section.membershipType}`}
+																	className="space-y-3 rounded-md border border-dashed border-border/70 p-3"
+																>
+																	<div className="flex items-start justify-between gap-3">
+																		<div>
+																			<p className="text-sm font-medium">{section.label}</p>
+																			<p className="text-xs text-muted-foreground">
+																				{section.description}
+																			</p>
+																		</div>
+																		<p className="text-xs text-muted-foreground">
+																			{sectionAssignments.length} assigned
+																		</p>
+																	</div>
+
+																	<div className="flex flex-wrap gap-2">
+																		{sectionAssignments.length === 0 ? (
+																			<p className="text-sm text-muted-foreground">
+																				No roles assigned.
+																			</p>
+																		) : (
+																			sectionAssignments.map((roleAssignment) => (
+																				<div
+																					key={roleAssignment.id}
+																					className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-sm"
+																				>
+																					<span>{roleAssignment.discordRole.roleName}</span>
+																					<button
+																						onClick={() =>
+																							handleUnassignRole(
+																								attachment.id,
+																								roleAssignment.id
+																							)
+																						}
+																						className="ml-1 hover:text-destructive"
+																					>
+																						<X className="h-3 w-3" />
+																					</button>
+																				</div>
+																			))
+																		)}
+																	</div>
+
+																	{availableRoles.length > 0 ? (
+																		<div className="flex items-center gap-2">
+																			<Select
+																				value=""
+																				onValueChange={(nextValue) => {
+																					if (!nextValue) {
+																						return
+																					}
+																					void handleAssignRole(
+																						attachment.id,
+																						nextValue,
+																						section.membershipType
+																					).finally(() => {
+																						setPendingRoleSelections((prev) => {
+																							const { [selectionKey]: _, ...rest } = prev
+																							return rest
+																						})
+																					})
+																				}}
+																				query={pendingRoleSelections[selectionKey] ?? ''}
+																				onQueryChange={(value) =>
+																					setPendingRoleSelections((prev) => ({
+																						...prev,
+																						[selectionKey]: value,
+																					}))
+																				}
+																				searchable
+																				options={availableRoles.map((role) => ({
+																					value: role.id,
+																					label: role.roleName,
+																				}))}
+																				placeholder="Add role..."
+																				emptyText="No matching roles found"
+																				className="w-full"
+																				contentClassName="w-[min(90vw,36rem)]"
+																				inputClassName="h-9"
+																			/>
+																		</div>
+																	) : (
+																		<p className="text-xs text-muted-foreground">
+																			No available roles left to assign.
+																		</p>
+																	)}
+															</div>
+																)
+															})}
+													</div>
+												)
+											})()}
 										</div>
-									)}
-								</div>
+									</AccordionContent>
+								</AccordionItem>
 							))}
-						</div>
+						</Accordion>
 					)}
 
 					{/* Add Server Dialog */}

--- a/apps/ui/src/client/routes/admin/group-discord-role-sections.ts
+++ b/apps/ui/src/client/routes/admin/group-discord-role-sections.ts
@@ -1,0 +1,15 @@
+export const groupDiscordRoleAssignmentSections = [
+	{
+		membershipType: 'member' as const,
+		label: 'Members',
+		description: 'Roles for everyone in the group.',
+	},
+	{
+		membershipType: 'owner_admin' as const,
+		label: 'Owners/Admins',
+		description: 'Roles for group owners and admins. These stack with member roles.',
+	},
+] as const
+
+export const groupDiscordRoleAssignmentSummary =
+	'Member roles apply to every group member. Owner/Admin roles stack on top for group owners and admins.'

--- a/apps/ui/src/test/unit/routes/admin/group-discord-role-sections.unit.test.ts
+++ b/apps/ui/src/test/unit/routes/admin/group-discord-role-sections.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	groupDiscordRoleAssignmentSections,
+	groupDiscordRoleAssignmentSummary,
+} from '@/routes/admin/group-discord-role-sections'
+
+describe('group Discord role assignment sections', () => {
+	it('documents the member and owner/admin buckets explicitly', () => {
+		expect(groupDiscordRoleAssignmentSections).toEqual([
+			{
+				membershipType: 'member',
+				label: 'Members',
+				description: 'Roles for everyone in the group.',
+			},
+			{
+				membershipType: 'owner_admin',
+				label: 'Owners/Admins',
+				description: 'Roles for group owners and admins. These stack with member roles.',
+			},
+		])
+		expect(groupDiscordRoleAssignmentSummary).toContain('Member roles apply to every group member')
+		expect(groupDiscordRoleAssignmentSummary).toContain('Owner/Admin roles stack on top')
+	})
+})

--- a/packages/groups/src/index.ts
+++ b/packages/groups/src/index.ts
@@ -52,6 +52,7 @@ export type CategoryPermission = 'anyone' | 'admin_only'
 export type JoinMode = 'open' | 'approval' | 'invitation_only'
 export type InvitationStatus = 'pending' | 'accepted' | 'declined' | 'expired' | 'cancelled'
 export type JoinRequestStatus = 'pending' | 'approved' | 'rejected' | 'cancelled'
+export type GroupDiscordMembershipType = 'member' | 'owner_admin'
 
 /**
  * Data types matching database tables
@@ -504,8 +505,9 @@ export interface Groups {
 	/** Assign a Discord role to a group Discord server attachment */
 	assignRoleToDiscordServer(
 		attachmentId: string,
-		discordRoleId: string
-	): Promise<{ id: string; discordRoleId: string }>
+		discordRoleId: string,
+		membershipType?: GroupDiscordMembershipType
+	): Promise<{ id: string; discordRoleId: string; membershipType: GroupDiscordMembershipType }>
 
 	/** Unassign a Discord role from a group Discord server attachment */
 	unassignRoleFromDiscordServer(roleAssignmentId: string): Promise<void>
@@ -518,6 +520,8 @@ export interface Groups {
 		groupId: string
 		guildId: string
 		roleIds: string[]
+		memberRoleIds?: string[]
+		ownerAdminRoleIds?: string[]
 	}>
 
 	/** Get groups with Discord auto-invite enabled */


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds multi-level Discord role assignment for corporation Discord attachments and group Discord attachments. Corporations can now auto-apply distinct Discord roles based on a member's relationship to the corp (corp member, alliance guest, or non-alliance guest), and groups can assign separate Discord roles to regular members versus owners/admins, with roles stacking additively.

## Changes
- **Corporation Discord attachments**: add `corpMemberRoleId`/`allianceGuestRoleId`/`nonAllianceGuestRoleId` (with matching `*AutoApply` flags) to `corporation_discord_servers`, with validation that selected roles belong to the attached Discord server.
- **`discord.service.ts`**: rework role-resolution logic to evaluate corp/alliance/guest scenarios per attachment (`resolveScenarioRoleId`), determine alliance membership via `managed_corporations.is_member_corporation`, and grant scenario roles even to non-corp-members (e.g. alliance/non-alliance guests) instead of requiring corp membership.
- **Group Discord role assignments**: add a `membership_type` enum (`member` | `owner_admin`) column on `group_discord_server_roles`; `assignRoleToDiscordServer` now accepts a `membershipType` and role sync grants member and owner/admin roles additively based on `getGroupOwnerAndAdminUserIds`/`getGroupMemberUserIds`.
- **API routes**: `POST /corporations/:id/discord-servers` and `PUT .../discord-servers/:id` accept/validate the new scenario role fields; `POST /groups/.../discord-servers/:id/roles` validates and accepts `membershipType`.
- **UI**: corporation detail page gains an accordion with per-scenario role pickers and auto-apply toggles; group detail page organizes Discord role assignment into "Members" vs "Owners/Admins" sections (`group-discord-role-sections.ts`).
- Adds new Drizzle migrations for both `core` and `groups` apps reflecting the schema changes.

## Testing
- Updated/added unit tests for `discord-role-sync.test.ts` covering owner/admin-only role grants and additive member + owner/admin role grants.
- Added `groups.discord-role.route.test.ts` covering membership type validation on the role-assignment route.
- Added `group-discord-role-sections.unit.test.ts` for the new UI section metadata.
<!-- claude:end -->