### PR TITLE
feat(prediction-markets): admin config editor (rake / min stake / two-of-N threshold)

### DIFF
--- a/apps/core/src/routes/__tests__/prediction-markets-admin.config.route.test.ts
+++ b/apps/core/src/routes/__tests__/prediction-markets-admin.config.route.test.ts
@@ -1,0 +1,156 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import adminRoutes from '../prediction-markets-admin'
+
+import type { SessionUser } from '../../context'
+
+// Admin config endpoints (GET/PATCH /config, GET /config/threshold-impact). The router-wide
+// requireAuth()+requireAdmin() guard is mocked to a pass-through; the PM DO stub is mocked so we test
+// the route's schema, error mapping, and actor threading — not the DO logic.
+
+const stub = vi.hoisted(() => ({
+	getConfig: vi.fn(),
+	updateConfig: vi.fn(),
+	previewTwoOfNThreshold: vi.fn(),
+}))
+
+vi.mock('../../middleware/session', () => ({
+	requireAuth: () => async (_c: unknown, next: () => Promise<void>) => next(),
+	requireAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+vi.mock('@repo/do-utils', () => ({ getStub: () => stub }))
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'admin-1',
+		mainCharacterId: 'm',
+		sessionId: 's',
+		characters: [],
+		is_admin: true,
+		roles: [],
+		discordUserId: null,
+		...over,
+	}
+}
+
+function createApp(user: SessionUser) {
+	const app = new Hono<{ Bindings: any; Variables: { user?: SessionUser; db?: unknown } }>()
+	app.use('*', async (c, next) => {
+		c.set('user', user)
+		c.set('db', {})
+		await next()
+	})
+	app.route('/api/admin/prediction-markets', adminRoutes)
+	return app
+}
+
+const env = { PREDICTION_MARKETS: {} } as any
+
+function req(app: ReturnType<typeof createApp>, method: string, path: string, body?: unknown) {
+	return app.request(
+		`/api/admin/prediction-markets${path}`,
+		{
+			method,
+			headers: { 'Content-Type': 'application/json' },
+			...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+		},
+		env
+	)
+}
+
+const validBody = { defaultRakeBps: 100, defaultMinStake: '1', twoOfNThreshold: '5000' }
+const configView = {
+	defaultRakeBps: 100,
+	defaultMinStake: '1',
+	twoOfNThreshold: '5000',
+	effectiveFrom: '2026-07-08T00:00:00.000Z',
+	actorUserId: 'admin-1',
+	changeNote: null,
+	configured: true,
+}
+
+describe('admin prediction-markets /config', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		stub.getConfig.mockResolvedValue(configView)
+		stub.updateConfig.mockResolvedValue(configView)
+		stub.previewTwoOfNThreshold.mockResolvedValue({
+			newlyRequiringCount: 0,
+			noLongerRequiringCount: 0,
+			strandedCandidates: [],
+		})
+	})
+
+	it('GET /config returns the active config view', async () => {
+		const res = await req(createApp(makeUser()), 'GET', '/config')
+		expect(res.status).toBe(200)
+		expect(await res.json()).toMatchObject({ configured: true, defaultRakeBps: 100 })
+	})
+
+	it('PATCH /config threads the session actor (spread last — body cannot forge it)', async () => {
+		await req(createApp(makeUser({ id: 'admin-1' })), 'PATCH', '/config', {
+			...validBody,
+			actorUserId: 'attacker',
+		})
+		expect(stub.updateConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				actorUserId: 'admin-1',
+				defaultRakeBps: 100,
+				twoOfNThreshold: '5000',
+			})
+		)
+	})
+
+	it('PATCH /config accepts a null threshold (disable)', async () => {
+		const res = await req(createApp(makeUser()), 'PATCH', '/config', {
+			...validBody,
+			twoOfNThreshold: null,
+		})
+		expect(res.status).toBe(200)
+		expect(stub.updateConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ twoOfNThreshold: null })
+		)
+	})
+
+	it('PATCH /config 400s an out-of-range rake (zod)', async () => {
+		const res = await req(createApp(makeUser()), 'PATCH', '/config', {
+			...validBody,
+			defaultRakeBps: 2001,
+		})
+		expect(res.status).toBe(400)
+		expect(stub.updateConfig).not.toHaveBeenCalled()
+	})
+
+	it('PATCH /config 400s a "0" threshold (zod refine > 0)', async () => {
+		const res = await req(createApp(makeUser()), 'PATCH', '/config', {
+			...validBody,
+			twoOfNThreshold: '0',
+		})
+		expect(res.status).toBe(400)
+	})
+
+	it('PATCH /config maps THRESHOLD_WOULD_STRAND to 400', async () => {
+		stub.updateConfig.mockRejectedValue(new Error('THRESHOLD_WOULD_STRAND'))
+		const res = await req(createApp(makeUser()), 'PATCH', '/config', validBody)
+		expect(res.status).toBe(400)
+		expect(await res.json()).toMatchObject({ error: 'THRESHOLD_WOULD_STRAND' })
+	})
+
+	it('GET /config/threshold-impact proxies the preview for a valid threshold', async () => {
+		const res = await req(createApp(makeUser()), 'GET', '/config/threshold-impact?threshold=5000')
+		expect(res.status).toBe(200)
+		expect(stub.previewTwoOfNThreshold).toHaveBeenCalledWith('5000')
+	})
+
+	it('GET /config/threshold-impact treats empty as null (disable preview)', async () => {
+		await req(createApp(makeUser()), 'GET', '/config/threshold-impact?threshold=')
+		expect(stub.previewTwoOfNThreshold).toHaveBeenCalledWith(null)
+	})
+
+	it('GET /config/threshold-impact 400s a non-integer threshold without hitting the DO', async () => {
+		const res = await req(createApp(makeUser()), 'GET', '/config/threshold-impact?threshold=abc')
+		expect(res.status).toBe(400)
+		expect(stub.previewTwoOfNThreshold).not.toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/routes/prediction-markets-admin.ts
+++ b/apps/core/src/routes/prediction-markets-admin.ts
@@ -15,6 +15,7 @@ import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { SYSTEM_WALLET_USER_ID } from '@repo/prediction-markets'
 
+import { userCharacters, users } from '../db/schema'
 import { requireAdmin, requireAuth } from '../middleware/session'
 import {
 	CREATE_MARKET_BAD_REQUEST_CODES,
@@ -22,12 +23,11 @@ import {
 	createMarketSchema,
 } from '../services/market-create.service'
 import { updateAndAnnounceMarket, updateMarketSchema } from '../services/market-update.service'
-import { userCharacters, users } from '../db/schema'
 
-import type { createDb } from '../db'
-import type { App } from '../context'
 import type { Context } from 'hono'
 import type { LedgerType, MarketStatus, PredictionMarkets } from '@repo/prediction-markets'
+import type { App } from '../context'
+import type { createDb } from '../db'
 
 type CoreDb = ReturnType<typeof createDb>
 
@@ -120,6 +120,10 @@ const BAD_REQUEST_CODES = new Set<string>([
 	// edit path (updateMarket) — INVALID_CLOSES_AT / QUESTION_REQUIRED are already in the create set
 	'MARKET_NOT_EDITABLE',
 	'CLOSES_AT_NOT_EDITABLE',
+	// config path (updateConfig) — INVALID_RAKE / INVALID_MIN_STAKE already flow in via the create set
+	'INVALID_THRESHOLD',
+	'INVALID_CHANGE_NOTE',
+	'THRESHOLD_WOULD_STRAND',
 ])
 
 // -------------------------------------------------------------------------
@@ -204,10 +208,11 @@ app.get('/wallets/:userId/ledger', async (c) => {
 
 const depositSchema = z.object({
 	targetUserId: z.string().uuid(),
+	// Single refine so BigInt() never runs on a non-digit string (see configSchema note) — a chained
+	// regex+refine would 500 on e.g. "1.5" instead of returning a clean 400.
 	amount: z
 		.string()
-		.regex(/^\d+$/, 'amount must be a positive integer')
-		.refine((v) => BigInt(v) > 0n, 'amount must be greater than 0'),
+		.refine((v) => /^\d+$/.test(v) && BigInt(v) > 0n, 'amount must be a positive integer'),
 	reason: z.string().trim().min(3).max(500),
 	idempotencyKey: z.string().min(8).max(200).optional(),
 })
@@ -303,6 +308,71 @@ app.patch('/markets/:id', async (c) => {
 			return c.json({ error: 'Market not found' }, 404)
 		}
 		return fail(c, error, 'update market')
+	}
+})
+
+// -------------------------------------------------------------------------
+// Config (defaults: rake / min stake / two-of-N threshold)
+// -------------------------------------------------------------------------
+
+// Full-replace: all three defaults required (a supersession INSERT needs a complete row, and it
+// collapses the empty-table "create first config" and the "edit" cases into one path). threshold
+// null = disable pool-based two-of-N; '0'/'' are rejected (would force two-of-N on every market).
+const configSchema = z.object({
+	defaultRakeBps: z.number().int().min(0).max(2000),
+	// Gate BigInt() behind the digit test in ONE refine: a chained `.regex().refine(BigInt())` still
+	// runs BigInt() on a non-digit string (a failed regex only marks the field "dirty", not "aborted"),
+	// which throws a SyntaxError that escapes as a 500 instead of a clean 400.
+	defaultMinStake: z
+		.string()
+		.refine((v) => /^\d+$/.test(v) && BigInt(v) > 0n, 'min stake must be a positive integer'),
+	twoOfNThreshold: z
+		.string()
+		.refine((v) => /^\d+$/.test(v) && BigInt(v) > 0n, 'threshold must be a positive integer')
+		.nullable(),
+	changeNote: z.string().trim().max(500).optional(),
+})
+
+// GET /config — the active config defaults (runtime fallbacks with configured:false when unseeded).
+app.get('/config', async (c) => {
+	try {
+		return c.json(await stubOf(c).getConfig())
+	} catch (error) {
+		return fail(c, error, 'get config')
+	}
+})
+
+// GET /config/threshold-impact?threshold= — read-only retroactive impact of a candidate threshold
+// (empty/absent => null = disable). Validated like PATCH so a bad value 400s instead of 500ing.
+app.get('/config/threshold-impact', async (c) => {
+	try {
+		const raw = c.req.query('threshold')
+		const candidate = raw == null || raw === '' ? null : raw
+		if (candidate !== null && !(/^\d+$/.test(candidate) && BigInt(candidate) > 0n)) {
+			return c.json({ error: 'INVALID_THRESHOLD' }, 400)
+		}
+		return c.json(await stubOf(c).previewTwoOfNThreshold(candidate))
+	} catch (error) {
+		return fail(c, error, 'threshold impact')
+	}
+})
+
+// PATCH /config — full-replace the active config (temporal supersession). Hard-rejects a threshold
+// change that would strand a size-1 designated market (THRESHOLD_WOULD_STRAND -> 400). The
+// session-derived actor is spread LAST so a stray body field can never forge attribution.
+app.patch('/config', async (c) => {
+	try {
+		const body = configSchema.parse(await c.req.json())
+		const actorId = c.get('user')!.id
+		const result = await stubOf(c).updateConfig({ ...body, actorUserId: actorId })
+		logger.info('[PMAdmin] config updated', {
+			actorId,
+			defaultRakeBps: body.defaultRakeBps,
+			twoOfNThreshold: body.twoOfNThreshold,
+		})
+		return c.json(result, 200)
+	} catch (error) {
+		return fail(c, error, 'update config')
 	}
 })
 

--- a/apps/prediction-markets/.migrations/0006_silky_mandroid.sql
+++ b/apps/prediction-markets/.migrations/0006_silky_mandroid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pm_config" ADD COLUMN "actor_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "pm_config" ADD COLUMN "change_note" text;

--- a/apps/prediction-markets/.migrations/meta/0006_snapshot.json
+++ b/apps/prediction-markets/.migrations/meta/0006_snapshot.json
@@ -1,0 +1,1039 @@
+{
+  "id": "fad2c8f8-dbc6-4910-9891-1ca1e9db349f",
+  "prevId": "0d577c21-04ab-4a6c-ad87-5e710e0505f0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pm_bets": {
+      "name": "pm_bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_bet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_bets_idempotency_key_uq": {
+          "name": "pm_bets_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_user_idx": {
+          "name": "pm_bets_market_user_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_user_created_idx": {
+          "name": "pm_bets_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_outcome_idx": {
+          "name": "pm_bets_market_outcome_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_config": {
+      "name": "pm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_rake_bps": {
+          "name": "default_rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "default_min_stake": {
+          "name": "default_min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "two_of_n_threshold": {
+          "name": "two_of_n_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_ledger": {
+      "name": "pm_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pm_ledger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_ledger_bet_type_uq": {
+          "name": "pm_ledger_bet_type_uq",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_idempotency_key_uq": {
+          "name": "pm_ledger_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pm_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_user_created_idx": {
+          "name": "pm_ledger_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_market_idx": {
+          "name": "pm_ledger_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_created_id_idx": {
+          "name": "pm_ledger_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_history": {
+      "name": "pm_market_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "pm_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_market_history_market_created_idx": {
+          "name": "pm_market_history_market_created_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_history_created_id_idx": {
+          "name": "pm_market_history_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_outcomes": {
+      "name": "pm_market_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "pm_market_outcomes_market_label_uq": {
+          "name": "pm_market_outcomes_market_label_uq",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_outcomes_market_idx": {
+          "name": "pm_market_outcomes_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_markets": {
+      "name": "pm_markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_outcome_id": {
+          "name": "resolved_outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pool": {
+          "name": "total_pool",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "rake_bps": {
+          "name": "rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stake": {
+          "name": "min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "max_stake": {
+          "name": "max_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_user_cap": {
+          "name": "per_user_cap",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_of_n": {
+          "name": "two_of_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "designated_resolvers": {
+          "name": "designated_resolvers",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_thread_id": {
+          "name": "discord_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_announced_at": {
+          "name": "settlement_announced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_markets_status_closes_idx": {
+          "name": "pm_markets_status_closes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_thread_uq": {
+          "name": "pm_markets_thread_uq",
+          "columns": [
+            {
+              "expression": "discord_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_settle_unannounced_idx": {
+          "name": "pm_markets_settle_unannounced_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pm_markets\".\"settlement_announced_at\" is null and \"pm_markets\".\"status\" in ('resolved', 'voided')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_rate_limits": {
+      "name": "pm_rate_limits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pm_rate_limits_user_id_command_pk": {
+          "name": "pm_rate_limits_user_id_command_pk",
+          "columns": [
+            "user_id",
+            "command"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_resolution_proposals": {
+      "name": "pm_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pm_resolution_proposals_market_status_idx": {
+          "name": "pm_resolution_proposals_market_status_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_wallets": {
+      "name": "pm_wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pm_bet_status": {
+      "name": "pm_bet_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "won",
+        "lost",
+        "refunded"
+      ]
+    },
+    "public.pm_ledger_type": {
+      "name": "pm_ledger_type",
+      "schema": "public",
+      "values": [
+        "grant",
+        "wager",
+        "refund",
+        "payout",
+        "rake",
+        "burn",
+        "adjustment"
+      ]
+    },
+    "public.pm_market_status": {
+      "name": "pm_market_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "resolving",
+        "resolved",
+        "voided"
+      ]
+    },
+    "public.pm_proposal_status": {
+      "name": "pm_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.pm_visibility": {
+      "name": "pm_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "internal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/prediction-markets/.migrations/meta/_journal.json
+++ b/apps/prediction-markets/.migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783513747069,
       "tag": "0005_faithful_shatterstar",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1783523517575,
+      "tag": "0006_silky_mandroid",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/prediction-markets/src/db/schema.ts
+++ b/apps/prediction-markets/src/db/schema.ts
@@ -240,7 +240,12 @@ export const pmMarketHistory = pgTable(
 	]
 )
 
-/** Single-active-config for defaults. */
+/**
+ * Config defaults, versioned by temporal supersession: each edit closes the current active row
+ * (is_active=false, effective_to=now()) and inserts a fresh active row, giving an append-only,
+ * queryable value-history. Readers always take the single newest active row
+ * (WHERE is_active ORDER BY effective_from DESC LIMIT 1).
+ */
 export const pmConfig = pgTable('pm_config', {
 	id: uuid('id').primaryKey().defaultRandom(),
 	isActive: boolean('is_active').notNull().default(true),
@@ -248,6 +253,10 @@ export const pmConfig = pgTable('pm_config', {
 	defaultMinStake: numeric('default_min_stake').notNull().default('1'),
 	/** Markets with total_pool ≥ this require two-of-N settlement. NULL disables. */
 	twoOfNThreshold: numeric('two_of_n_threshold'),
+	/** Admin who wrote this generation (null for pre-editor / seed rows). Durable WHO audit. */
+	actorUserId: uuid('actor_user_id'),
+	/** Optional free-text reason the admin gave for this config change. */
+	changeNote: text('change_note'),
 	effectiveFrom: timestamp('effective_from', { withTimezone: true }).notNull().defaultNow(),
 	effectiveTo: timestamp('effective_to', { withTimezone: true }),
 })

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -27,6 +27,7 @@ import { formatAmount, isPositiveIntegerString, negateAmount, parseAmount } from
 import { computeResolution } from './lib/payout'
 import { RATE_BUDGETS } from './lib/rate-limit'
 import { assertTransition, isTerminal } from './lib/state-machine'
+import { bucketThresholdImpact, thresholdEqual } from './lib/threshold-impact'
 
 import type {
 	BetResult,
@@ -50,14 +51,17 @@ import type {
 	Paged,
 	PendingProposalView,
 	PlaceBetInput,
+	PmConfigView,
 	PredictionMarkets,
 	ResolveResult,
+	ThresholdImpact,
+	UpdateConfigInput,
 	UpdateMarketInput,
 	Visibility,
 	WalletRow,
 } from '@repo/prediction-markets'
 import type { Env } from './context'
-import type { PmBet, PmLedgerRow, PmMarket, PmMarketHistoryRow } from './db/schema'
+import type { PmBet, PmConfig, PmLedgerRow, PmMarket, PmMarketHistoryRow } from './db/schema'
 
 type PmDatabase = ReturnType<typeof createDb>
 type PmTransaction = Parameters<Parameters<PmDatabase['transaction']>[0]>[0]
@@ -644,6 +648,21 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			throw new Error('INVALID_PER_USER_CAP')
 		}
 
+		// Read the active config ONCE and reuse it for the size-1 designated guard AND the market's frozen
+		// rake/minStake below. Reading it twice (a separate threshold read here + another inside the tx)
+		// let a concurrent updateConfig commit land between them and slip a size-1 designated market past
+		// the guard under a threshold the market was then created with. This read sits before the tx's
+		// try/catch, so wrap it to keep DO-level Sentry context on an infra failure (e.g. unmigrated table).
+		let cfg
+		try {
+			cfg = await this.readActiveConfig()
+		} catch (error) {
+			captureException(error as Error, {
+				tags: { durableObject: 'PredictionMarketsDO', method: 'createMarket' },
+			})
+			throw error
+		}
+
 		// Designated resolvers (optional). Core has already validated tier-membership + creator-exclusion
 		// (it alone can read GROUPS); the DO re-enforces only the structural invariants as a backstop.
 		// These throws are OUTSIDE the try below, so they surface to the caller without paging Sentry.
@@ -666,8 +685,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			// do NOT weaken requiresTwoOfN for small designated sets, so the two-of-N safeguard on large
 			// pools is never silently skipped by designating a single resolver.
 			if (designatedResolvers.length < 2) {
-				const twoOfNPossible =
-					(input.twoOfN ?? false) || (await this.activeTwoOfNThreshold()) != null
+				const twoOfNPossible = (input.twoOfN ?? false) || (cfg?.twoOfNThreshold ?? null) != null
 				if (twoOfNPossible) throw new Error('DESIGNATED_RESOLVERS_INSUFFICIENT_FOR_TWO_OF_N')
 			}
 		}
@@ -682,13 +700,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 
 		try {
 			return await this.db.transaction(async (tx) => {
-				const [cfg] = await tx
-					.select()
-					.from(pmConfig)
-					.where(eq(pmConfig.isActive, true))
-					.orderBy(desc(pmConfig.effectiveFrom))
-					.limit(1)
-
+				// Defaults come from the single `cfg` snapshot read above (same snapshot as the guard).
 				const rakeBps = input.rakeBps ?? cfg?.defaultRakeBps ?? 0
 				const minStake = input.minStake ?? cfg?.defaultMinStake ?? '1'
 
@@ -1785,19 +1797,173 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		return false
 	}
 
-	/**
-	 * The active config's two-of-N pool threshold, or null when unset. Read outside a transaction for
-	 * the create-time designated-set sizing check: a configured threshold means two-of-N can trigger
-	 * dynamically as bets accumulate, so a designated set must be able to supply two distinct approvers.
-	 */
-	private async activeTwoOfNThreshold(): Promise<string | null> {
+	/** The single active config row (WHERE is_active ORDER BY effective_from DESC LIMIT 1), or undefined. */
+	private async readActiveConfig(): Promise<PmConfig | undefined> {
 		const [cfg] = await this.db
-			.select({ threshold: pmConfig.twoOfNThreshold })
+			.select()
 			.from(pmConfig)
 			.where(eq(pmConfig.isActive, true))
 			.orderBy(desc(pmConfig.effectiveFrom))
 			.limit(1)
-		return cfg?.threshold ?? null
+		return cfg
+	}
+
+	private toConfigView(row: PmConfig): PmConfigView {
+		return {
+			defaultRakeBps: row.defaultRakeBps,
+			defaultMinStake: row.defaultMinStake,
+			twoOfNThreshold: row.twoOfNThreshold,
+			effectiveFrom: row.effectiveFrom.toISOString(),
+			actorUserId: row.actorUserId,
+			changeNote: row.changeNote,
+			configured: true,
+		}
+	}
+
+	/**
+	 * The active config defaults. With no active row, returns the RUNTIME-EFFECTIVE fallbacks the readers
+	 * actually use (rake 0 — createMarket's `?? 0`, minStake '1', threshold null) with configured:false —
+	 * NOT the column defaults (100/'1') — so the admin UI reports what markets truly get today.
+	 */
+	async getConfig(): Promise<PmConfigView> {
+		const cfg = await this.readActiveConfig()
+		if (!cfg) {
+			return {
+				defaultRakeBps: 0,
+				defaultMinStake: '1',
+				twoOfNThreshold: null,
+				effectiveFrom: null,
+				actorUserId: null,
+				changeNote: null,
+				configured: false,
+			}
+		}
+		return this.toConfigView(cfg)
+	}
+
+	/**
+	 * Read-only retroactive impact of setting twoOfNThreshold to `candidate` (null = disable). Excludes
+	 * 'resolving' markets (a threshold change is inert once committed to the two-signer flow) and
+	 * terminal markets. Delegates the pure bucketing to lib/threshold-impact.
+	 */
+	private async computeThresholdImpact(candidate: string | null): Promise<ThresholdImpact> {
+		if (candidate !== null && !isPositiveIntegerString(candidate))
+			throw new Error('INVALID_THRESHOLD')
+		const cfg = await this.readActiveConfig()
+		const rows = await this.db
+			.select({
+				id: pmMarkets.id,
+				question: pmMarkets.question,
+				status: pmMarkets.status,
+				totalPool: pmMarkets.totalPool,
+				twoOfN: pmMarkets.twoOfN,
+				designatedResolvers: pmMarkets.designatedResolvers,
+			})
+			.from(pmMarkets)
+			.where(inArray(pmMarkets.status, ['open', 'closed']))
+		return bucketThresholdImpact(rows, cfg?.twoOfNThreshold ?? null, candidate)
+	}
+
+	async previewTwoOfNThreshold(candidateThreshold: string | null): Promise<ThresholdImpact> {
+		return this.computeThresholdImpact(candidateThreshold)
+	}
+
+	/**
+	 * Replace the active config via temporal supersession (close current active row + insert a fresh
+	 * one), recording the acting admin (durable WHO audit). Input validation runs OUTSIDE the tx (no
+	 * Sentry page); the stranding hard-block runs INSIDE the tx under the advisory lock (authoritative —
+	 * a concurrent config write can't leave it stale) and throws the expected THRESHOLD_WOULD_STRAND
+	 * which the catch surfaces without paging. A no-op (all values AND the note equal the active row,
+	 * compared by numeric VALUE not raw string) writes no new generation.
+	 */
+	async updateConfig(input: UpdateConfigInput): Promise<PmConfigView> {
+		if (
+			!Number.isInteger(input.defaultRakeBps) ||
+			input.defaultRakeBps < 0 ||
+			input.defaultRakeBps > 2000
+		) {
+			throw new Error('INVALID_RAKE')
+		}
+		if (!isPositiveIntegerString(input.defaultMinStake)) throw new Error('INVALID_MIN_STAKE')
+		if (input.twoOfNThreshold !== null && !isPositiveIntegerString(input.twoOfNThreshold)) {
+			throw new Error('INVALID_THRESHOLD')
+		}
+		// DO owns the invariant (the route caps at 500 too). Bound the free-text note defensively.
+		if (input.changeNote != null && input.changeNote.length > 500) {
+			throw new Error('INVALID_CHANGE_NOTE')
+		}
+
+		try {
+			const view = await this.db.transaction(async (tx) => {
+				// Serialize concurrent config writes so supersession can't leave two active rows.
+				await tx.execute(sql`select pg_advisory_xact_lock(hashtext('pm_config'))`)
+				const [cur] = await tx
+					.select()
+					.from(pmConfig)
+					.where(eq(pmConfig.isActive, true))
+					.orderBy(desc(pmConfig.effectiveFrom))
+					.limit(1)
+				const curThreshold = cur?.twoOfNThreshold ?? null
+				if (
+					cur &&
+					cur.defaultRakeBps === input.defaultRakeBps &&
+					parseAmount(cur.defaultMinStake) === parseAmount(input.defaultMinStake) &&
+					thresholdEqual(curThreshold, input.twoOfNThreshold) &&
+					(cur.changeNote ?? null) === (input.changeNote ?? null)
+				) {
+					return this.toConfigView(cur) // no-op: skip a value-identical generation
+				}
+				// Authoritative stranding hard-block: re-evaluated UNDER the lock against the CURRENT
+				// active threshold, so a concurrent config write can't move `current` out from under the
+				// pre-lock UI check. Only runs when the threshold actually moves.
+				if (!thresholdEqual(curThreshold, input.twoOfNThreshold)) {
+					const marketRows = await tx
+						.select({
+							id: pmMarkets.id,
+							question: pmMarkets.question,
+							status: pmMarkets.status,
+							totalPool: pmMarkets.totalPool,
+							twoOfN: pmMarkets.twoOfN,
+							designatedResolvers: pmMarkets.designatedResolvers,
+						})
+						.from(pmMarkets)
+						.where(inArray(pmMarkets.status, ['open', 'closed']))
+					const impact = bucketThresholdImpact(marketRows, curThreshold, input.twoOfNThreshold)
+					if (impact.strandedCandidates.length > 0) throw new Error('THRESHOLD_WOULD_STRAND')
+				}
+				await tx
+					.update(pmConfig)
+					.set({ isActive: false, effectiveTo: sql`now()` })
+					.where(eq(pmConfig.isActive, true))
+				const [row] = await tx
+					.insert(pmConfig)
+					.values({
+						defaultRakeBps: input.defaultRakeBps,
+						defaultMinStake: input.defaultMinStake,
+						twoOfNThreshold: input.twoOfNThreshold,
+						actorUserId: input.actorUserId,
+						changeNote: input.changeNote ?? null,
+					})
+					.returning()
+				return this.toConfigView(row)
+			})
+			logger.info('[PredictionMarkets] config updated', {
+				actorUserId: input.actorUserId,
+				defaultRakeBps: input.defaultRakeBps,
+				defaultMinStake: input.defaultMinStake,
+				twoOfNThreshold: input.twoOfNThreshold,
+			})
+			return view
+		} catch (error) {
+			// THRESHOLD_WOULD_STRAND is an expected governance rejection (thrown in-tx) — surface it
+			// without paging; everything else is an infra failure worth capturing.
+			if (!(error instanceof Error && error.message === 'THRESHOLD_WOULD_STRAND')) {
+				captureException(error as Error, {
+					tags: { durableObject: 'PredictionMarketsDO', method: 'updateConfig' },
+				})
+			}
+			throw error
+		}
 	}
 
 	private async buildMarketDetail(

--- a/apps/prediction-markets/src/lib/__tests__/threshold-impact.test.ts
+++ b/apps/prediction-markets/src/lib/__tests__/threshold-impact.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+
+import { bucketThresholdImpact, thresholdEqual } from '../threshold-impact'
+
+import type { ThresholdMarketRow } from '../threshold-impact'
+
+const R1 = '11111111-1111-1111-1111-111111111111'
+const R2 = '22222222-2222-2222-2222-222222222222'
+
+function mkt(over: Partial<ThresholdMarketRow> & { id: string }): ThresholdMarketRow {
+	return {
+		question: 'Q',
+		status: 'open',
+		totalPool: '0',
+		twoOfN: false,
+		designatedResolvers: null,
+		...over,
+	}
+}
+
+describe('thresholdEqual', () => {
+	it('treats both-null as equal, null vs value as unequal', () => {
+		expect(thresholdEqual(null, null)).toBe(true)
+		expect(thresholdEqual(null, '5')).toBe(false)
+		expect(thresholdEqual('5', null)).toBe(false)
+	})
+	it('compares numerically, not by raw string (leading zeros equal)', () => {
+		expect(thresholdEqual('100', '0100')).toBe(true)
+		expect(thresholdEqual('100', '200')).toBe(false)
+	})
+})
+
+describe('bucketThresholdImpact — flip counts', () => {
+	it('counts a closed market crossing the raised candidate as newly-requiring', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'closed', totalPool: '500' })],
+			null,
+			'400'
+		)
+		expect(r.newlyRequiringCount).toBe(1)
+		expect(r.noLongerRequiringCount).toBe(0)
+	})
+	it('counts a market that no longer crosses when the threshold is raised', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'closed', totalPool: '500' })],
+			'400',
+			'600'
+		)
+		expect(r.newlyRequiringCount).toBe(0)
+		expect(r.noLongerRequiringCount).toBe(1)
+	})
+	it('nulling the threshold moves everything to no-longer-requiring', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'closed', totalPool: '500' })],
+			'400',
+			null
+		)
+		expect(r.noLongerRequiringCount).toBe(1)
+	})
+	it('excludes markets already flagged twoOfN=true from flip counts', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'closed', totalPool: '500', twoOfN: true })],
+			null,
+			'400'
+		)
+		expect(r.newlyRequiringCount).toBe(0)
+	})
+})
+
+describe('bucketThresholdImpact — stranding (size-1 designated)', () => {
+	it('strands an OPEN size-1 market under ANY positive candidate (pool can grow)', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'open', totalPool: '10', designatedResolvers: [R1] })],
+			null,
+			'1000000'
+		)
+		expect(r.strandedCandidates.map((s) => s.marketId)).toEqual(['a'])
+	})
+	it('does NOT strand a CLOSED size-1 market whose frozen pool is below the candidate', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'closed', totalPool: '10', designatedResolvers: [R1] })],
+			null,
+			'1000000'
+		)
+		expect(r.strandedCandidates).toEqual([])
+	})
+	it('strands a CLOSED size-1 market whose frozen pool crosses the candidate', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'closed', totalPool: '5000', designatedResolvers: [R1] })],
+			null,
+			'400'
+		)
+		expect(r.strandedCandidates.map((s) => s.marketId)).toEqual(['a'])
+	})
+	it('does NOT re-strand a market already at-risk under the current threshold', () => {
+		// open size-1, current threshold already set → already at-risk → change is not NEWLY stranding
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'open', totalPool: '10', designatedResolvers: [R1] })],
+			'500',
+			'400'
+		)
+		expect(r.strandedCandidates).toEqual([])
+	})
+	it('does not strand size-0 or size-2+ designated sets', () => {
+		const r = bucketThresholdImpact(
+			[
+				mkt({ id: 'a', status: 'open', totalPool: '10', designatedResolvers: null }),
+				mkt({ id: 'b', status: 'open', totalPool: '10', designatedResolvers: [R1, R2] }),
+			],
+			null,
+			'1000'
+		)
+		expect(r.strandedCandidates).toEqual([])
+	})
+	it('never strands when the candidate is null (disable)', () => {
+		const r = bucketThresholdImpact(
+			[mkt({ id: 'a', status: 'open', totalPool: '10', designatedResolvers: [R1] })],
+			'500',
+			null
+		)
+		expect(r.strandedCandidates).toEqual([])
+	})
+})

--- a/apps/prediction-markets/src/lib/threshold-impact.ts
+++ b/apps/prediction-markets/src/lib/threshold-impact.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure retroactive-impact bucketing for a candidate two-of-N pool threshold. The threshold is read at
+ * SETTLE time (requiresTwoOfN), so changing it re-evaluates which EXISTING markets need two-of-N. This
+ * module is the DB-free core of that calculation (the DO fetches the market rows and calls in).
+ *
+ * Key asymmetry: a CLOSED market's pool is frozen, so it crosses a threshold only if pool >= threshold
+ * right now; an OPEN market is still taking bets, so its pool can only grow — any positive threshold is
+ * reachable. That's why the "stranding" test treats every open size-1-designated market as at-risk
+ * under any non-null candidate, while the flip COUNTS use the current-pool snapshot.
+ */
+
+import { parseAmount } from './money'
+
+import type { MarketStatus, StrandedMarket, ThresholdImpact } from '@repo/prediction-markets'
+
+export interface ThresholdMarketRow {
+	id: string
+	question: string
+	status: MarketStatus
+	totalPool: string
+	twoOfN: boolean
+	designatedResolvers: string[] | null
+}
+
+/** BigInt-aware equality for a nullable numeric threshold (null = disabled). Avoids raw-string `===`. */
+export function thresholdEqual(a: string | null, b: string | null): boolean {
+	if (a === null || b === null) return a === b
+	return parseAmount(a) === parseAmount(b)
+}
+
+/**
+ * Bucket the retroactive impact of moving the two-of-N threshold from `current` to `candidate`.
+ * Callers MUST pass only non-terminal, non-`resolving` markets (open/closed): a `resolving` market is
+ * already committed to the two-signer flow, so a threshold change is inert for it and it must not be
+ * counted here. Markets with `twoOfN === true` already require two-of-N unconditionally and never flip.
+ */
+export function bucketThresholdImpact(
+	markets: readonly ThresholdMarketRow[],
+	current: string | null,
+	candidate: string | null
+): ThresholdImpact {
+	// Flip counts: snapshot at the CURRENT pool (closed pools are final; open pools are a lower bound).
+	const requiresNow = (pool: string, t: string | null) =>
+		t !== null && parseAmount(pool) >= parseAmount(t)
+	// Stranding risk: closed = frozen pool must already cross; open = any positive threshold is reachable.
+	const atRisk = (m: ThresholdMarketRow, t: string | null) => {
+		if (t === null) return false
+		return m.status === 'open' ? true : parseAmount(m.totalPool) >= parseAmount(t)
+	}
+
+	let newlyRequiringCount = 0
+	let noLongerRequiringCount = 0
+	const strandedCandidates: StrandedMarket[] = []
+	for (const m of markets) {
+		if (m.twoOfN) continue // already two-of-N regardless of threshold
+		const curReq = requiresNow(m.totalPool, current)
+		const candReq = requiresNow(m.totalPool, candidate)
+		if (!curReq && candReq) newlyRequiringCount++
+		if (curReq && !candReq) noLongerRequiringCount++
+		// A market with exactly ONE designated resolver can't reach two-of-N (no distinct second signer);
+		// count it as newly stranded only if the change moves it from not-at-risk to at-risk.
+		if ((m.designatedResolvers?.length ?? 0) === 1 && !atRisk(m, current) && atRisk(m, candidate)) {
+			strandedCandidates.push({
+				marketId: m.id,
+				question: m.question,
+				totalPool: m.totalPool,
+				status: m.status,
+				designatedResolverIds: m.designatedResolvers,
+			})
+		}
+	}
+	return { newlyRequiringCount, noLongerRequiringCount, strandedCandidates }
+}

--- a/apps/ui/src/client/components/admin-nav.tsx
+++ b/apps/ui/src/client/components/admin-nav.tsx
@@ -1,12 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
 import {
-	ArrowLeft,
 	ArchiveRestore,
+	ArrowLeft,
 	Building2,
 	ChevronDown,
 	ChevronRight,
 	Coins,
-	FileText,
 	Factory,
+	FileText,
 	FolderKanban,
 	Key,
 	Link2,
@@ -15,12 +16,11 @@ import {
 	Receipt,
 	ScrollText,
 	ShieldBan,
-	Wallet,
-	Waypoints,
 	UserCircle,
 	Users,
+	Wallet,
+	Waypoints,
 } from 'lucide-react'
-import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 
@@ -128,6 +128,7 @@ export function AdminNav({ onNavigate }: AdminNavProps) {
 				{ label: 'Markets', href: '/admin/prediction-markets/markets' },
 				{ label: 'Wallets', href: '/admin/prediction-markets/wallets' },
 				{ label: 'Audit Log', href: '/admin/prediction-markets/audit' },
+				{ label: 'Config', href: '/admin/prediction-markets/config' },
 			],
 		},
 		{

--- a/apps/ui/src/client/features/prediction-markets/api.ts
+++ b/apps/ui/src/client/features/prediction-markets/api.ts
@@ -22,6 +22,9 @@ import type {
 	MarketsFilters,
 	MarketsResponse,
 	Paged,
+	PmConfigView,
+	ThresholdImpact,
+	UpdateConfigRequest,
 	UpdateMarketRequest,
 	UpdateMarketResponse,
 	WalletDetail,
@@ -132,4 +135,20 @@ export async function createMarketAsMember(
 	body: CreateMarketRequest
 ): Promise<CreateMarketResponse> {
 	return apiClient.post<CreateMarketResponse>('/prediction-markets/markets', body)
+}
+
+/** GET /config — active config defaults (configured:false + runtime fallbacks when unseeded). */
+export async function getConfig(): Promise<PmConfigView> {
+	return apiClient.get<PmConfigView>(`${BASE}/config`)
+}
+
+/** GET /config/threshold-impact — retroactive impact of a candidate threshold (null = disable). */
+export async function getThresholdImpact(threshold: string | null): Promise<ThresholdImpact> {
+	const query = threshold === null ? '' : `?threshold=${encodeURIComponent(threshold)}`
+	return apiClient.get<ThresholdImpact>(`${BASE}/config/threshold-impact${query}`)
+}
+
+/** PATCH /config — full-replace the active config. 400 on bad value / stranding threshold. */
+export async function updateConfig(body: UpdateConfigRequest): Promise<PmConfigView> {
+	return apiClient.patch<PmConfigView>(`${BASE}/config`, body)
 }

--- a/apps/ui/src/client/features/prediction-markets/hooks.ts
+++ b/apps/ui/src/client/features/prediction-markets/hooks.ts
@@ -7,11 +7,13 @@ import {
 	createMarket,
 	createMarketAsMember,
 	getAuditLedger,
+	getConfig,
 	getMarketHistory,
 	getMarkets,
 	getUserLedger,
 	getWallet,
 	getWallets,
+	updateConfig,
 	updateMarket,
 } from './api'
 import { pmKeys } from './query-keys'
@@ -23,6 +25,7 @@ import type {
 	LedgerFilters,
 	MarketHistoryFilters,
 	MarketsFilters,
+	UpdateConfigRequest,
 	UpdateMarketRequest,
 	WalletsFilters,
 } from './types'
@@ -119,6 +122,29 @@ export function useUpdateMarket() {
 		successMessage: 'Market updated.',
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: [...pmKeys.all, 'markets'] })
+		},
+	})
+}
+
+/** GET /config — the active config defaults. */
+export function useConfig() {
+	return useQuery({
+		queryKey: pmKeys.config(),
+		queryFn: getConfig,
+		staleTime: STALE_TIME,
+		gcTime: GC_TIME,
+	})
+}
+
+/** PATCH /config — full-replace the active config; toasts on success, invalidates the config query. */
+export function useUpdateConfig() {
+	const queryClient = useQueryClient()
+
+	return useApiMutation({
+		mutationFn: (body: UpdateConfigRequest) => updateConfig(body),
+		successMessage: 'Configuration updated.',
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: pmKeys.config() })
 		},
 	})
 }

--- a/apps/ui/src/client/features/prediction-markets/query-keys.ts
+++ b/apps/ui/src/client/features/prediction-markets/query-keys.ts
@@ -20,4 +20,5 @@ export const pmKeys = {
 	marketHistory: (filters?: MarketHistoryFilters) =>
 		[...pmKeys.all, 'marketHistory', filters] as const,
 	markets: (filters?: MarketsFilters) => [...pmKeys.all, 'markets', filters] as const,
+	config: () => [...pmKeys.all, 'config'] as const,
 }

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-config.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-config.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import { useConfirmationDialog } from '@/hooks/useConfirmationDialog'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import toast from '@/lib/toast'
+
+import { getThresholdImpact } from '../api'
+import { useConfig, useUpdateConfig } from '../hooks'
+
+const digitsOnly = (v: string) => v.replace(/\D/g, '')
+const bps = (n: number) => `${(n / 100).toFixed(n % 100 === 0 ? 0 : 2)}%`
+
+export default function PredictionMarketConfig() {
+	usePageTitle('Admin - Prediction Market Config')
+
+	const { data, isLoading, error } = useConfig()
+	const update = useUpdateConfig()
+	const { requestConfirmation, confirmationDialog } = useConfirmationDialog()
+
+	const [rakeBps, setRakeBps] = useState('')
+	const [minStake, setMinStake] = useState('')
+	const [twoOfNEnabled, setTwoOfNEnabled] = useState(false)
+	const [threshold, setThreshold] = useState('')
+	const [changeNote, setChangeNote] = useState('')
+
+	// Prefill from the TRUTHFUL runtime values getConfig reports (rake 0 on an unseeded table) — never
+	// a "suggested" seed, so an untouched Save is a genuine no-op and the fields never lie about
+	// current behavior.
+	useEffect(() => {
+		if (!data) return
+		setRakeBps(String(data.defaultRakeBps))
+		setMinStake(data.defaultMinStake)
+		setTwoOfNEnabled(data.twoOfNThreshold !== null)
+		setThreshold(data.twoOfNThreshold ?? '')
+		setChangeNote('')
+	}, [data])
+
+	const busy = update.isPending
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault()
+		if (!data) return
+
+		const rake = Number(rakeBps)
+		if (!Number.isInteger(rake) || rake < 0 || rake > 2000) {
+			toast.error('Rake must be a whole number of basis points between 0 and 2000 (0–20%).')
+			return
+		}
+		if (!/^\d+$/.test(minStake) || BigInt(minStake) <= 0n) {
+			toast.error('Minimum stake must be a positive whole number.')
+			return
+		}
+		const candidate = twoOfNEnabled && threshold.trim() !== '' ? threshold.trim() : null
+		if (candidate !== null && BigInt(candidate) <= 0n) {
+			toast.error('Two-of-N threshold must be a positive whole number, or disable it.')
+			return
+		}
+
+		const body = {
+			defaultRakeBps: rake,
+			defaultMinStake: minStake,
+			twoOfNThreshold: candidate,
+			changeNote: changeNote.trim() || undefined,
+		}
+		const submit = async () => {
+			await update.mutateAsync(body)
+		}
+
+		const thresholdChanged = candidate !== data.twoOfNThreshold
+		const rakeChanged = rake !== data.defaultRakeBps
+
+		// A threshold change is read at SETTLE time — retroactive on existing markets. Fetch the exact
+		// impact; hard-block if it would strand a single-resolver market (the server enforces this too).
+		if (thresholdChanged) {
+			let impact
+			try {
+				impact = await getThresholdImpact(candidate)
+			} catch {
+				toast.error('Could not compute the threshold impact — try again.')
+				return
+			}
+			if (impact.strandedCandidates.length > 0) {
+				const names = impact.strandedCandidates.map((s) => `“${s.question}”`).join(', ')
+				toast.error(
+					`Blocked: ${impact.strandedCandidates.length} market(s) would become unsettleable ` +
+						`(a lone designated resolver can't reach two-of-N): ${names}. ` +
+						`Resolve/void them or widen their resolver set, then retry.`
+				)
+				return
+			}
+			requestConfirmation({
+				title: 'Change the two-of-N threshold?',
+				description:
+					`This is read at settlement time, so it retroactively re-evaluates existing markets: ` +
+					`${impact.newlyRequiringCount} will newly require two-of-N and ` +
+					`${impact.noLongerRequiringCount} will no longer.` +
+					(rakeChanged
+						? ` New-market rake also changes to ${bps(rake)} (was ${bps(data.defaultRakeBps)}).`
+						: '') +
+					` Continue?`,
+				confirmLabel: 'Apply',
+				cancelLabel: 'Cancel',
+				intent: 'destructive',
+				confirmButtonVariant: 'danger',
+				confirmDelaySeconds: 5,
+				onConfirm: submit,
+			})
+			return
+		}
+
+		// Rake affects the economics of every future market — confirm even without a threshold change.
+		if (rakeChanged) {
+			requestConfirmation({
+				title: 'Change the default rake?',
+				description:
+					`New markets will take ${bps(rake)} rake (was ${bps(data.defaultRakeBps)}). ` +
+					`Existing markets keep their frozen rake. Continue?`,
+				confirmLabel: 'Apply',
+				cancelLabel: 'Cancel',
+				intent: 'destructive',
+				confirmButtonVariant: 'danger',
+				confirmDelaySeconds: 5,
+				onConfirm: submit,
+			})
+			return
+		}
+
+		// Only min-stake changed (or nothing) — no retroactive/economic footgun; save directly.
+		await submit()
+	}
+
+	return (
+		<div className="space-y-6">
+			<div>
+				<h1 className="text-3xl font-bold gradient-text">Prediction Market Config</h1>
+				<p className="mt-1 text-muted-foreground">
+					Defaults applied to new markets, plus the pool threshold that triggers two-of-N
+					settlement.
+				</p>
+			</div>
+
+			{error ? (
+				<p className="text-sm text-destructive">
+					Failed to load config: {(error as Error).message}
+				</p>
+			) : null}
+
+			{data && !data.configured ? (
+				<div className="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm">
+					No active config yet — new markets currently take <strong>0% rake</strong>, a{' '}
+					<strong>minimum stake of 1</strong>, and <strong>two-of-N disabled</strong>. Saving writes
+					the values below as the active defaults.
+				</div>
+			) : null}
+
+			<form onSubmit={handleSubmit} className="space-y-6">
+				<section className="space-y-4 rounded-md border border-border p-4">
+					<div>
+						<h2 className="text-lg font-semibold">Market defaults</h2>
+						<p className="text-sm text-muted-foreground">
+							Applied when a market is created and frozen onto it — changes affect new markets only.
+						</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="pm-cfg-rake">Default rake (basis points)</Label>
+						<Input
+							id="pm-cfg-rake"
+							type="text"
+							inputMode="numeric"
+							pattern="\d*"
+							placeholder="100"
+							value={rakeBps}
+							onChange={(e) => setRakeBps(digitsOnly(e.target.value))}
+							disabled={busy || isLoading}
+						/>
+						<p className="text-xs text-muted-foreground">
+							0–2000 bps (0–20%). {rakeBps !== '' ? `= ${bps(Number(rakeBps) || 0)}` : null}
+						</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="pm-cfg-min">Default minimum stake</Label>
+						<Input
+							id="pm-cfg-min"
+							type="text"
+							inputMode="numeric"
+							pattern="\d*"
+							placeholder="1"
+							value={minStake}
+							onChange={(e) => setMinStake(digitsOnly(e.target.value))}
+							disabled={busy || isLoading}
+						/>
+						<p className="text-xs text-muted-foreground">Whole points only.</p>
+					</div>
+				</section>
+
+				<section className="space-y-4 rounded-md border border-border p-4">
+					<div className="flex items-center justify-between gap-4">
+						<div>
+							<h2 className="text-lg font-semibold">Two-of-N settlement threshold</h2>
+							<p className="text-sm text-muted-foreground">
+								Markets whose pool reaches this require a second distinct resolver to settle. Read
+								at settlement time —{' '}
+								<strong>changing it retroactively affects existing markets</strong>.
+							</p>
+						</div>
+						<Switch
+							checked={twoOfNEnabled}
+							onCheckedChange={setTwoOfNEnabled}
+							disabled={busy || isLoading}
+							aria-label="Enable pool two-of-N"
+						/>
+					</div>
+
+					{twoOfNEnabled ? (
+						<div className="space-y-2">
+							<Label htmlFor="pm-cfg-threshold">Pool threshold</Label>
+							<Input
+								id="pm-cfg-threshold"
+								type="text"
+								inputMode="numeric"
+								pattern="\d*"
+								placeholder="5000"
+								value={threshold}
+								onChange={(e) => setThreshold(digitsOnly(e.target.value))}
+								disabled={busy || isLoading}
+							/>
+							<p className="text-xs text-muted-foreground">
+								Whole points. Turn the switch off to disable.
+							</p>
+						</div>
+					) : (
+						<p className="text-sm text-muted-foreground">
+							Disabled — no market requires two-of-N by pool size.
+						</p>
+					)}
+				</section>
+
+				<section className="space-y-2 rounded-md border border-border p-4">
+					<Label htmlFor="pm-cfg-note">Change note (optional)</Label>
+					<Textarea
+						id="pm-cfg-note"
+						placeholder="Why is this changing? (recorded in the config audit history)"
+						value={changeNote}
+						onChange={(e) => setChangeNote(e.target.value)}
+						rows={2}
+						maxLength={500}
+						disabled={busy || isLoading}
+					/>
+				</section>
+
+				<div className="flex justify-end">
+					<Button
+						type="submit"
+						variant="primary"
+						loading={busy}
+						loadingText="Saving…"
+						disabled={isLoading}
+					>
+						Save configuration
+					</Button>
+				</div>
+			</form>
+
+			{confirmationDialog}
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/prediction-markets/types.ts
+++ b/apps/ui/src/client/features/prediction-markets/types.ts
@@ -13,6 +13,9 @@ import type {
 	MarketHistoryRow,
 	MarketStatus,
 	MarketSummary,
+	PmConfigView,
+	StrandedMarket,
+	ThresholdImpact,
 	WalletRow,
 } from '@repo/prediction-markets'
 
@@ -23,6 +26,9 @@ export type {
 	MarketHistoryRow,
 	MarketStatus,
 	MarketSummary,
+	PmConfigView,
+	StrandedMarket,
+	ThresholdImpact,
 	WalletRow,
 }
 
@@ -152,4 +158,14 @@ export interface MarketsResponse {
 	markets: MarketSummary[]
 	/** Configured markets guild id, for building forum thread deep-links. */
 	guildId: string | null
+}
+
+// --- config ----------------------------------------------------------------
+
+/** Full-replace config write. Monetary fields are integer strings; threshold null = disable two-of-N. */
+export interface UpdateConfigRequest {
+	defaultRakeBps: number
+	defaultMinStake: string
+	twoOfNThreshold: string | null
+	changeNote?: string
 }

--- a/apps/ui/src/client/routes/route-groups/admin-routes.tsx
+++ b/apps/ui/src/client/routes/route-groups/admin-routes.tsx
@@ -3,12 +3,11 @@ import { Navigate, Route } from 'react-router-dom'
 
 import { LoadingPage } from '@/components/ui/loading'
 import AdminActivityLogPage from '@/routes/admin/activity-log'
-import DevComponentsPage from '@/routes/admin/dev-components'
 import AdminBillsPage from '@/routes/admin/bills'
 import AdminBillsDashboardPage from '@/routes/admin/bills-dashboard'
 import AdminBillsDetailPage from '@/routes/admin/bills-detail'
-import AdminBillsGroupDetailPage from '@/routes/admin/bills-group-detail'
 import AdminBillsEditPage from '@/routes/admin/bills-edit'
+import AdminBillsGroupDetailPage from '@/routes/admin/bills-group-detail'
 import AdminBillsGroupEditPage from '@/routes/admin/bills-group-edit'
 import AdminBillsNewPage from '@/routes/admin/bills-new'
 import AdminBillsSchedulesPage from '@/routes/admin/bills-schedules'
@@ -25,11 +24,10 @@ import AdminBroadcastTemplatesPage from '@/routes/admin/broadcasts-templates'
 import AdminCategoriesPage from '@/routes/admin/categories'
 import AdminCorporationDetailPage from '@/routes/admin/corporation-detail'
 import AdminCorporationsPage from '@/routes/admin/corporations'
-import AdminStructuresPage from '@/routes/admin/structures'
+import DevComponentsPage from '@/routes/admin/dev-components'
+import AdminDiscordAuditPage from '@/routes/admin/discord-audit'
 import AdminDiscordCommandCategoriesPage from '@/routes/admin/discord-command-categories'
 import AdminDiscordCommandsPage from '@/routes/admin/discord-commands'
-import AdminDiscordAuditPage from '@/routes/admin/discord-audit'
-import AdminEveCharacterSyncPage from '@/routes/admin/eve-character-sync'
 import AdminDiscordServerCommandsPage from '@/routes/admin/discord-server-commands'
 import AdminDiscordServerRolesPage from '@/routes/admin/discord-server-roles'
 import AdminDiscordServersPage from '@/routes/admin/discord-servers'
@@ -37,22 +35,24 @@ import AdminDkpAwardsPage from '@/routes/admin/dkp-awards'
 import AdminDkpDashboardPage from '@/routes/admin/dkp-dashboard'
 import AdminDkpHistoryPage from '@/routes/admin/dkp-history'
 import AdminDkpLeaderboardsPage from '@/routes/admin/dkp-leaderboards'
+import AdminEveCharacterSyncPage from '@/routes/admin/eve-character-sync'
+import AdminExternalLinksPage from '@/routes/admin/external-links'
 import AdminGroupDetailPage from '@/routes/admin/group-detail'
 import AdminGroupsPage from '@/routes/admin/groups'
+import AdminIpHistoryInspectionPage from '@/routes/admin/ip-history-inspection'
 import AdminLayout from '@/routes/admin/layout'
-import AdminLegacyMigrationsPage from '@/routes/admin/legacy-migrations'
 import AdminLegacyMigrationDetailPage from '@/routes/admin/legacy-migration-detail'
+import AdminLegacyMigrationsPage from '@/routes/admin/legacy-migrations'
 import AdminPastesPage from '@/routes/admin/pastes'
 import AdminPermissionCategoriesPage from '@/routes/admin/permissions/categories'
 import AdminGlobalPermissionsPage from '@/routes/admin/permissions/global'
+import AdminStructuresPage from '@/routes/admin/structures'
+import AdminThirdPartyAppsPage from '@/routes/admin/third-party-apps'
 import AdminUserActivityPage from '@/routes/admin/user-activity'
 import AdminUserDetailPage from '@/routes/admin/user-detail'
 import AdminUserDiscordAccessPage from '@/routes/admin/user-discord-access'
 import AdminUserGroupsPage from '@/routes/admin/user-groups'
 import AdminUsersPage from '@/routes/admin/users'
-import AdminIpHistoryInspectionPage from '@/routes/admin/ip-history-inspection'
-import AdminExternalLinksPage from '@/routes/admin/external-links'
-import AdminThirdPartyAppsPage from '@/routes/admin/third-party-apps'
 
 const UserHrNotes = lazy(() => import('@/features/applications/routes/user-hr-notes'))
 const IndustryProvidersPage = lazy(() => import('@/features/industry/routes/industry-providers'))
@@ -76,6 +76,9 @@ const PredictionMarketWalletDetailPage = lazy(
 )
 const PredictionMarketAuditPage = lazy(
 	() => import('@/features/prediction-markets/routes/prediction-market-audit')
+)
+const PredictionMarketConfigPage = lazy(
+	() => import('@/features/prediction-markets/routes/prediction-market-config')
 )
 
 export const adminRouteElements = (
@@ -206,6 +209,14 @@ export const adminRouteElements = (
 				element={
 					<Suspense fallback={<LoadingPage />}>
 						<PredictionMarketAuditPage />
+					</Suspense>
+				}
+			/>
+			<Route
+				path="config"
+				element={
+					<Suspense fallback={<LoadingPage />}>
+						<PredictionMarketConfigPage />
 					</Suspense>
 				}
 			/>

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -301,6 +301,62 @@ export interface MarketHistoryOpts {
 }
 
 // ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * The active config as seen by the admin editor. Money fields are decimal strings. `configured` is
+ * false when no active row exists yet — the fields then carry the RUNTIME-EFFECTIVE fallbacks the
+ * readers actually use today (rake 0, minStake '1', threshold null), NOT the column defaults, so the
+ * admin sees the truth about current behavior.
+ */
+export interface PmConfigView {
+	defaultRakeBps: number
+	defaultMinStake: string
+	/** NULL disables pool-based two-of-N. */
+	twoOfNThreshold: string | null
+	/** ISO-8601 when this generation took effect, or null when unseeded. */
+	effectiveFrom: string | null
+	/** Admin who wrote the active generation, or null (unseeded / pre-audit rows). */
+	actorUserId: string | null
+	changeNote: string | null
+	configured: boolean
+}
+
+/** Full-replace config write. `actorUserId` is server-derived (session), never client-supplied. */
+export interface UpdateConfigInput {
+	actorUserId: string
+	defaultRakeBps: number
+	defaultMinStake: string
+	/** NULL disables pool-based two-of-N. '' / '0' are rejected — send real null to disable. */
+	twoOfNThreshold: string | null
+	changeNote?: string | null
+}
+
+/** A market a threshold change would strand (a lone designated resolver can't reach two-of-N). */
+export interface StrandedMarket {
+	marketId: string
+	question: string
+	totalPool: string
+	status: MarketStatus
+	designatedResolverIds: string[] | null
+}
+
+/**
+ * The retroactive impact of a candidate `twoOfNThreshold`. Counts are a snapshot at CURRENT pools for
+ * closed markets (frozen) — open-market pools can still grow, so `strandedCandidates` flags any
+ * size-1 designated open market whenever the candidate is non-null, independent of its current pool.
+ */
+export interface ThresholdImpact {
+	/** twoOfN=false markets (open/closed) that flip false→true at current pools. */
+	newlyRequiringCount: number
+	/** twoOfN=false markets (open/closed) that flip true→false at current pools. */
+	noLongerRequiringCount: number
+	/** Size-1 designated markets the change would newly strand — updateConfig hard-rejects if non-empty. */
+	strandedCandidates: StrandedMarket[]
+}
+
+// ---------------------------------------------------------------------------
 // RPC interface
 // ---------------------------------------------------------------------------
 
@@ -365,6 +421,16 @@ export interface PredictionMarkets {
 		marketId: string,
 		opts?: { includeInternal?: boolean; limit?: number; offset?: number }
 	): Promise<Paged<MarketHistoryRow>>
+	/** The active config defaults (or runtime fallbacks with `configured:false` when unseeded). */
+	getConfig(): Promise<PmConfigView>
+	/**
+	 * Read-only impact of changing `twoOfNThreshold` to `candidateThreshold` (null = disable). Because
+	 * the threshold is read at SETTLE time, changing it retroactively re-evaluates which existing open/
+	 * closed markets need two-of-N. Returns the flip counts plus the markets that would be STRANDED (a
+	 * lone designated resolver can't supply a second signer). `updateConfig` hard-rejects a change with
+	 * any stranded candidate — this preview drives the UI's block message.
+	 */
+	previewTwoOfNThreshold(candidateThreshold: string | null): Promise<ThresholdImpact>
 
 	// writes
 	grantPoints(input: GrantPointsInput): Promise<{ balance: string; deduped: boolean }>
@@ -389,6 +455,13 @@ export interface PredictionMarkets {
 		actorUserId: string,
 		updates: UpdateMarketInput
 	): Promise<MarketUpdateResult>
+	/**
+	 * Replace the active config (temporal supersession: closes the current active row, inserts a new
+	 * active one — an append-only audited value-history). Full-replace: all three defaults are required.
+	 * Hard-rejects (THRESHOLD_WOULD_STRAND) a threshold change that would leave a size-1 designated
+	 * market unable to reach two-of-N. A no-op (values equal the active row) writes no new generation.
+	 */
+	updateConfig(input: UpdateConfigInput): Promise<PmConfigView>
 	/**
 	 * Place a bet. `deduped` is true when this was a duplicate delivery of an already-recorded
 	 * bet (same idempotency key) — the prior bet is returned and no money moved. Callers must


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds an admin editor for prediction-markets config defaults (rake, min stake, two-of-N pool threshold), backed by a temporal-supersession audit trail (actor + change note) and a server-enforced hard-block against threshold changes that would strand size-1 designated markets. Also fixes a race in `createMarket` where the active config could be read twice against different snapshots.

## Changes
- **Migration `0006`**: adds `actor_user_id` and `change_note` columns to `pm_config` for a durable WHO/WHY audit trail on each config generation.
- **Durable Object (`PredictionMarketsDO`)**: adds `getConfig`, `previewTwoOfNThreshold`, and `updateConfig` RPCs; `updateConfig` performs a temporal-supersession write (close current active row + insert new one) under an advisory lock, skips no-op writes, and hard-rejects (`THRESHOLD_WOULD_STRAND`) threshold changes that would strand a size-1 designated market. `createMarket` now reads the active config once and reuses that snapshot for both the two-of-N designated-resolver guard and the market's frozen rake/minStake, closing a race where a concurrent `updateConfig` could slip a market past the guard.
- **`lib/threshold-impact.ts`**: new pure module (`bucketThresholdImpact`, `thresholdEqual`) computing retroactive flip counts and stranded-market candidates for a candidate threshold; unit tested.
- **Core routes (`prediction-markets-admin.ts`)**: adds `GET /config`, `GET /config/threshold-impact`, and `PATCH /config`, with Zod validation (single-refine `BigInt` guards to avoid 500s on non-digit input) and server-derived `actorUserId` attribution.
- **`@repo/prediction-markets` types**: adds `PmConfigView`, `UpdateConfigInput`, `StrandedMarket`, `ThresholdImpact`, and the corresponding RPC signatures.
- **UI**: new admin Config page/route (`prediction-market-config.tsx`), nav entry, API client, hooks, and query keys for viewing/editing the config and previewing threshold impact.

## Testing
- Added unit tests for `bucketThresholdImpact`/`thresholdEqual` (`lib/__tests__/threshold-impact.test.ts`).
- Added route tests for the new `GET/PATCH /config` and `GET /config/threshold-impact` endpoints (`prediction-markets-admin.config.route.test.ts`), covering schema validation, error mapping, and actor threading.
<!-- claude:end -->