### PR TITLE
feat(prediction-markets): creator rake-reward share on resolution

### DIFF
--- a/apps/core/src/routes/__tests__/prediction-markets-admin.config.route.test.ts
+++ b/apps/core/src/routes/__tests__/prediction-markets-admin.config.route.test.ts
@@ -59,11 +59,19 @@ function req(app: ReturnType<typeof createApp>, method: string, path: string, bo
 	)
 }
 
-const validBody = { defaultRakeBps: 100, defaultMinStake: '1', twoOfNThreshold: '5000' }
+const validBody = {
+	defaultRakeBps: 100,
+	defaultMinStake: '1',
+	twoOfNThreshold: '5000',
+	creatorRewardMinBps: 0,
+	creatorRewardMaxBps: 0,
+}
 const configView = {
 	defaultRakeBps: 100,
 	defaultMinStake: '1',
 	twoOfNThreshold: '5000',
+	creatorRewardMinBps: 0,
+	creatorRewardMaxBps: 0,
 	effectiveFrom: '2026-07-08T00:00:00.000Z',
 	actorUserId: 'admin-1',
 	changeNote: null,
@@ -128,6 +136,38 @@ describe('admin prediction-markets /config', () => {
 			twoOfNThreshold: '0',
 		})
 		expect(res.status).toBe(400)
+	})
+
+	it('PATCH /config accepts a creator-reward band and forwards it', async () => {
+		const res = await req(createApp(makeUser()), 'PATCH', '/config', {
+			...validBody,
+			creatorRewardMinBps: 1000,
+			creatorRewardMaxBps: 5000,
+		})
+		expect(res.status).toBe(200)
+		expect(stub.updateConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ creatorRewardMinBps: 1000, creatorRewardMaxBps: 5000 })
+		)
+	})
+
+	it('PATCH /config 400s a creator-reward band above 100% (zod max)', async () => {
+		const res = await req(createApp(makeUser()), 'PATCH', '/config', {
+			...validBody,
+			creatorRewardMinBps: 0,
+			creatorRewardMaxBps: 10001,
+		})
+		expect(res.status).toBe(400)
+		expect(stub.updateConfig).not.toHaveBeenCalled()
+	})
+
+	it('PATCH /config 400s an inverted creator-reward band (min > max)', async () => {
+		const res = await req(createApp(makeUser()), 'PATCH', '/config', {
+			...validBody,
+			creatorRewardMinBps: 6000,
+			creatorRewardMaxBps: 5000,
+		})
+		expect(res.status).toBe(400)
+		expect(stub.updateConfig).not.toHaveBeenCalled()
 	})
 
 	it('PATCH /config maps THRESHOLD_WOULD_STRAND to 400', async () => {

--- a/apps/core/src/routes/prediction-markets-admin.ts
+++ b/apps/core/src/routes/prediction-markets-admin.ts
@@ -318,20 +318,29 @@ app.patch('/markets/:id', async (c) => {
 // Full-replace: all three defaults required (a supersession INSERT needs a complete row, and it
 // collapses the empty-table "create first config" and the "edit" cases into one path). threshold
 // null = disable pool-based two-of-N; '0'/'' are rejected (would force two-of-N on every market).
-const configSchema = z.object({
-	defaultRakeBps: z.number().int().min(0).max(2000),
-	// Gate BigInt() behind the digit test in ONE refine: a chained `.regex().refine(BigInt())` still
-	// runs BigInt() on a non-digit string (a failed regex only marks the field "dirty", not "aborted"),
-	// which throws a SyntaxError that escapes as a 500 instead of a clean 400.
-	defaultMinStake: z
-		.string()
-		.refine((v) => /^\d+$/.test(v) && BigInt(v) > 0n, 'min stake must be a positive integer'),
-	twoOfNThreshold: z
-		.string()
-		.refine((v) => /^\d+$/.test(v) && BigInt(v) > 0n, 'threshold must be a positive integer')
-		.nullable(),
-	changeNote: z.string().trim().max(500).optional(),
-})
+const configSchema = z
+	.object({
+		defaultRakeBps: z.number().int().min(0).max(2000),
+		// Gate BigInt() behind the digit test in ONE refine: a chained `.regex().refine(BigInt())` still
+		// runs BigInt() on a non-digit string (a failed regex only marks the field "dirty", not "aborted"),
+		// which throws a SyntaxError that escapes as a 500 instead of a clean 400.
+		defaultMinStake: z
+			.string()
+			.refine((v) => /^\d+$/.test(v) && BigInt(v) > 0n, 'min stake must be a positive integer'),
+		twoOfNThreshold: z
+			.string()
+			.refine((v) => /^\d+$/.test(v) && BigInt(v) > 0n, 'threshold must be a positive integer')
+			.nullable(),
+		// Creator rake-reward band, as a fraction of the rake in bps (0–10000). Both 0 disables it.
+		creatorRewardMinBps: z.number().int().min(0).max(10_000),
+		creatorRewardMaxBps: z.number().int().min(0).max(10_000),
+		changeNote: z.string().trim().max(500).optional(),
+	})
+	// Cross-field: the band must be well-ordered so the settlement draw can never exceed 100% of rake.
+	.refine((v) => v.creatorRewardMinBps <= v.creatorRewardMaxBps, {
+		message: 'creator reward min must be ≤ max',
+		path: ['creatorRewardMinBps'],
+	})
 
 // GET /config — the active config defaults (runtime fallbacks with configured:false when unseeded).
 app.get('/config', async (c) => {
@@ -388,6 +397,7 @@ const LEDGER_TYPES: readonly LedgerType[] = [
 	'rake',
 	'burn',
 	'adjustment',
+	'creator_reward',
 ]
 
 // GET /audit/ledger?userId=&type=&marketId=&since=&until=&limit=&offset=

--- a/apps/prediction-markets/.migrations/0008_public_demogoblin.sql
+++ b/apps/prediction-markets/.migrations/0008_public_demogoblin.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "public"."pm_ledger_type" ADD VALUE 'creator_reward';--> statement-breakpoint
+ALTER TABLE "pm_config" ADD COLUMN "creator_reward_min_bps" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "pm_config" ADD COLUMN "creator_reward_max_bps" integer DEFAULT 0 NOT NULL;

--- a/apps/prediction-markets/.migrations/meta/0008_snapshot.json
+++ b/apps/prediction-markets/.migrations/meta/0008_snapshot.json
@@ -1,0 +1,1060 @@
+{
+  "id": "ee413e29-fda1-48f0-9fec-b98d8e94bab9",
+  "prevId": "8d78fb85-cfc8-4b1b-87af-2504ffd63d20",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pm_bets": {
+      "name": "pm_bets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_bet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payout_amount": {
+          "name": "payout_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_bets_idempotency_key_uq": {
+          "name": "pm_bets_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_user_idx": {
+          "name": "pm_bets_market_user_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_user_created_idx": {
+          "name": "pm_bets_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_bets_market_outcome_idx": {
+          "name": "pm_bets_market_outcome_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_config": {
+      "name": "pm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_rake_bps": {
+          "name": "default_rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "default_min_stake": {
+          "name": "default_min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "two_of_n_threshold": {
+          "name": "two_of_n_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_reward_min_bps": {
+          "name": "creator_reward_min_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creator_reward_max_bps": {
+          "name": "creator_reward_max_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_ledger": {
+      "name": "pm_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pm_ledger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bet_id": {
+          "name": "bet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_ledger_bet_type_uq": {
+          "name": "pm_ledger_bet_type_uq",
+          "columns": [
+            {
+              "expression": "bet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_idempotency_key_uq": {
+          "name": "pm_ledger_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pm_ledger\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_user_created_idx": {
+          "name": "pm_ledger_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_market_idx": {
+          "name": "pm_ledger_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_ledger_created_id_idx": {
+          "name": "pm_ledger_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_history": {
+      "name": "pm_market_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "pm_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_market_history_market_created_idx": {
+          "name": "pm_market_history_market_created_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_history_created_id_idx": {
+          "name": "pm_market_history_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_market_outcomes": {
+      "name": "pm_market_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_amount": {
+          "name": "pool_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "pm_market_outcomes_market_label_uq": {
+          "name": "pm_market_outcomes_market_label_uq",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_market_outcomes_market_idx": {
+          "name": "pm_market_outcomes_market_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_markets": {
+      "name": "pm_markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_market_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolves_on": {
+          "name": "resolves_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_outcome_id": {
+          "name": "resolved_outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pool": {
+          "name": "total_pool",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "rake_bps": {
+          "name": "rake_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_stake": {
+          "name": "min_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "max_stake": {
+          "name": "max_stake",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "per_user_cap": {
+          "name": "per_user_cap",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_of_n": {
+          "name": "two_of_n",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "designated_resolvers": {
+          "name": "designated_resolvers",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_thread_id": {
+          "name": "discord_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_announced_at": {
+          "name": "settlement_announced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pm_markets_status_closes_idx": {
+          "name": "pm_markets_status_closes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_thread_uq": {
+          "name": "pm_markets_thread_uq",
+          "columns": [
+            {
+              "expression": "discord_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pm_markets_settle_unannounced_idx": {
+          "name": "pm_markets_settle_unannounced_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pm_markets\".\"settlement_announced_at\" is null and \"pm_markets\".\"status\" in ('resolved', 'voided')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_rate_limits": {
+      "name": "pm_rate_limits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pm_rate_limits_user_id_command_pk": {
+          "name": "pm_rate_limits_user_id_command_pk",
+          "columns": [
+            "user_id",
+            "command"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_resolution_proposals": {
+      "name": "pm_resolution_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_id": {
+          "name": "outcome_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pm_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pm_resolution_proposals_market_status_idx": {
+          "name": "pm_resolution_proposals_market_status_idx",
+          "columns": [
+            {
+              "expression": "market_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_wallets": {
+      "name": "pm_wallets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pm_bet_status": {
+      "name": "pm_bet_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "won",
+        "lost",
+        "refunded"
+      ]
+    },
+    "public.pm_ledger_type": {
+      "name": "pm_ledger_type",
+      "schema": "public",
+      "values": [
+        "grant",
+        "wager",
+        "refund",
+        "payout",
+        "rake",
+        "burn",
+        "adjustment",
+        "creator_reward"
+      ]
+    },
+    "public.pm_market_status": {
+      "name": "pm_market_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "open",
+        "closed",
+        "resolving",
+        "resolved",
+        "voided"
+      ]
+    },
+    "public.pm_proposal_status": {
+      "name": "pm_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.pm_visibility": {
+      "name": "pm_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "internal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/prediction-markets/.migrations/meta/_journal.json
+++ b/apps/prediction-markets/.migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1783529218025,
       "tag": "0007_pale_brood",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1783530528952,
+      "tag": "0008_public_demogoblin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/prediction-markets/src/db/schema.ts
+++ b/apps/prediction-markets/src/db/schema.ts
@@ -37,6 +37,9 @@ export const pmLedgerType = pgEnum('pm_ledger_type', [
 	'rake',
 	'burn',
 	'adjustment',
+	// A random slice of a resolved market's rake paid to the market's creator (see
+	// creator_reward_{min,max}_bps on pm_config). The remaining rake still books as a 'rake' line.
+	'creator_reward',
 ])
 
 export const pmProposalStatus = pgEnum('pm_proposal_status', [
@@ -259,6 +262,15 @@ export const pmConfig = pgTable('pm_config', {
 	defaultMinStake: numeric('default_min_stake').notNull().default('1'),
 	/** Markets with total_pool ≥ this require two-of-N settlement. NULL disables. */
 	twoOfNThreshold: numeric('two_of_n_threshold'),
+	/**
+	 * Creator rake-reward band, as a fraction OF THE RAKE in basis points (0–10000 = 0–100%). On a
+	 * successful resolution the market's creator is paid a random slice of the rake drawn uniformly
+	 * from [min, max] bps; the remainder stays with the house. Both 0 (the default) disables the
+	 * feature entirely — legacy/unseeded configs keep the pre-feature "all rake to house" behavior.
+	 * Invariant (enforced on write): 0 ≤ min ≤ max ≤ 10000.
+	 */
+	creatorRewardMinBps: integer('creator_reward_min_bps').notNull().default(0),
+	creatorRewardMaxBps: integer('creator_reward_max_bps').notNull().default(0),
 	/** Admin who wrote this generation (null for pre-editor / seed rows). Durable WHO audit. */
 	actorUserId: uuid('actor_user_id'),
 	/** Optional free-text reason the admin gave for this config change. */

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -24,7 +24,7 @@ import {
 	normalizeDesignatedResolvers,
 } from './lib/designated-resolvers'
 import { formatAmount, isPositiveIntegerString, negateAmount, parseAmount } from './lib/money'
-import { computeResolution } from './lib/payout'
+import { computeResolution, pickCreatorRewardBps, splitCreatorReward } from './lib/payout'
 import { RATE_BUDGETS } from './lib/rate-limit'
 import { assertTransition, isTerminal } from './lib/state-machine'
 import { bucketThresholdImpact, thresholdEqual } from './lib/threshold-impact'
@@ -1606,6 +1606,28 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			BigInt(market.rakeBps)
 		)
 
+		// Creator rake-reward: on a successful resolution the market's creator earns a random slice of
+		// the rake (band configured on pm_config.creator_reward_{min,max}_bps; both 0 disables it). Read
+		// the band under this same tx snapshot, draw the share, and split — creatorReward + houseRake ==
+		// rake, so pool conservation is unchanged and only how the rake is *attributed* moves. A fresh
+		// draw per attempt is safe: the whole resolution is one atomic, status-guarded transaction, so
+		// only the committing attempt's draw ever persists.
+		const [rewardCfg] = await tx
+			.select({
+				minBps: pmConfig.creatorRewardMinBps,
+				maxBps: pmConfig.creatorRewardMaxBps,
+			})
+			.from(pmConfig)
+			.where(eq(pmConfig.isActive, true))
+			.orderBy(desc(pmConfig.effectiveFrom))
+			.limit(1)
+		const creatorShareBps = pickCreatorRewardBps(
+			rewardCfg?.minBps ?? 0,
+			rewardCfg?.maxBps ?? 0,
+			Math.random()
+		)
+		const { creatorReward, houseRake } = splitCreatorReward(rake, creatorShareBps)
+
 		// Credit winners in deterministic user order (multi-wallet deadlock-safe).
 		for (const p of payouts) {
 			const updated = await tx
@@ -1644,27 +1666,54 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				)
 			)
 
-		// House cut (rake) and rounding dust (burn) accumulate in the system wallet rather than
-		// leaving circulation via a null-user sink — the points stay conserved and recoverable.
-		// Each is a distinct, attributed ledger line carrying the wallet's running balanceAfter.
-		if (rake > 0n || dust > 0n) {
+		// Creator rake-reward: pay the market's creator their drawn slice of the rake. The creator is a
+		// real user (never the system wallet; by CREATOR_CANNOT_RESOLVE never the resolver) but may have
+		// no wallet yet if they never bet, so lazily create it. Booked as its own attributed line whose
+		// metadata records the draw for audit; the remaining houseRake still books as 'rake' below.
+		if (creatorReward > 0n) {
+			await tx
+				.insert(pmWallets)
+				.values({ userId: market.createdBy, balance: '0' })
+				.onConflictDoNothing()
+			const [credited] = await tx
+				.update(pmWallets)
+				.set({
+					balance: sql`${pmWallets.balance} + ${formatAmount(creatorReward)}::numeric`,
+					updatedAt: new Date(),
+				})
+				.where(eq(pmWallets.userId, market.createdBy))
+				.returning({ balance: pmWallets.balance })
+			await tx.insert(pmLedger).values({
+				userId: market.createdBy,
+				amount: formatAmount(creatorReward),
+				type: 'creator_reward',
+				marketId: market.id,
+				balanceAfter: credited?.balance ?? null,
+				metadata: { shareBps: creatorShareBps, rakeBase: formatAmount(rake) },
+			})
+		}
+
+		// House cut (net rake, after any creator reward) and rounding dust (burn) accumulate in the
+		// system wallet rather than leaving circulation via a null-user sink — the points stay conserved
+		// and recoverable. Each is a distinct, attributed ledger line carrying the running balanceAfter.
+		if (houseRake > 0n || dust > 0n) {
 			await tx
 				.insert(pmWallets)
 				.values({ userId: SYSTEM_WALLET_USER_ID, balance: '0' })
 				.onConflictDoNothing()
 		}
-		if (rake > 0n) {
+		if (houseRake > 0n) {
 			const [credited] = await tx
 				.update(pmWallets)
 				.set({
-					balance: sql`${pmWallets.balance} + ${formatAmount(rake)}::numeric`,
+					balance: sql`${pmWallets.balance} + ${formatAmount(houseRake)}::numeric`,
 					updatedAt: new Date(),
 				})
 				.where(eq(pmWallets.userId, SYSTEM_WALLET_USER_ID))
 				.returning({ balance: pmWallets.balance })
 			await tx.insert(pmLedger).values({
 				userId: SYSTEM_WALLET_USER_ID,
-				amount: formatAmount(rake),
+				amount: formatAmount(houseRake),
 				type: 'rake',
 				marketId: market.id,
 				balanceAfter: credited.balance,
@@ -1711,6 +1760,9 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				totalPool: formatAmount(totalPool),
 				poolW: formatAmount(poolW),
 				rake: formatAmount(rake),
+				creatorReward: formatAmount(creatorReward),
+				creatorRewardBps: creatorShareBps,
+				houseRake: formatAmount(houseRake),
 				dust: formatAmount(dust),
 				...(viaOverride ? { viaOverride: true } : {}),
 			},
@@ -1826,6 +1878,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			defaultRakeBps: row.defaultRakeBps,
 			defaultMinStake: row.defaultMinStake,
 			twoOfNThreshold: row.twoOfNThreshold,
+			creatorRewardMinBps: row.creatorRewardMinBps,
+			creatorRewardMaxBps: row.creatorRewardMaxBps,
 			effectiveFrom: row.effectiveFrom.toISOString(),
 			actorUserId: row.actorUserId,
 			changeNote: row.changeNote,
@@ -1845,6 +1899,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				defaultRakeBps: 0,
 				defaultMinStake: '1',
 				twoOfNThreshold: null,
+				creatorRewardMinBps: 0,
+				creatorRewardMaxBps: 0,
 				effectiveFrom: null,
 				actorUserId: null,
 				changeNote: null,
@@ -1901,6 +1957,20 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		if (input.twoOfNThreshold !== null && !isPositiveIntegerString(input.twoOfNThreshold)) {
 			throw new Error('INVALID_THRESHOLD')
 		}
+		// Creator rake-reward band: both bounds whole bps in [0, 10000] (fraction of the rake) and
+		// min ≤ max. Both 0 disables the feature. Enforced here (route also validates) so the stored
+		// invariant the settlement draw relies on can never be violated.
+		if (
+			!Number.isInteger(input.creatorRewardMinBps) ||
+			!Number.isInteger(input.creatorRewardMaxBps) ||
+			input.creatorRewardMinBps < 0 ||
+			input.creatorRewardMaxBps < 0 ||
+			input.creatorRewardMinBps > 10_000 ||
+			input.creatorRewardMaxBps > 10_000 ||
+			input.creatorRewardMinBps > input.creatorRewardMaxBps
+		) {
+			throw new Error('INVALID_CREATOR_REWARD')
+		}
 		// DO owns the invariant (the route caps at 500 too). Bound the free-text note defensively.
 		if (input.changeNote != null && input.changeNote.length > 500) {
 			throw new Error('INVALID_CHANGE_NOTE')
@@ -1922,6 +1992,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					cur.defaultRakeBps === input.defaultRakeBps &&
 					parseAmount(cur.defaultMinStake) === parseAmount(input.defaultMinStake) &&
 					thresholdEqual(curThreshold, input.twoOfNThreshold) &&
+					cur.creatorRewardMinBps === input.creatorRewardMinBps &&
+					cur.creatorRewardMaxBps === input.creatorRewardMaxBps &&
 					(cur.changeNote ?? null) === (input.changeNote ?? null)
 				) {
 					return this.toConfigView(cur) // no-op: skip a value-identical generation
@@ -1954,6 +2026,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						defaultRakeBps: input.defaultRakeBps,
 						defaultMinStake: input.defaultMinStake,
 						twoOfNThreshold: input.twoOfNThreshold,
+						creatorRewardMinBps: input.creatorRewardMinBps,
+						creatorRewardMaxBps: input.creatorRewardMaxBps,
 						actorUserId: input.actorUserId,
 						changeNote: input.changeNote ?? null,
 					})

--- a/apps/prediction-markets/src/lib/__tests__/payout.test.ts
+++ b/apps/prediction-markets/src/lib/__tests__/payout.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { computeResolution, computeWinnings } from '../payout'
+import {
+	computeResolution,
+	computeWinnings,
+	pickCreatorRewardBps,
+	splitCreatorReward,
+} from '../payout'
 
 describe('computeWinnings', () => {
 	it('does not truncate to zero for a sub-pool stake (numerator-first)', () => {
@@ -115,5 +120,69 @@ describe('computeResolution', () => {
 		expect(() =>
 			computeResolution([{ betId: 'a', userId: 'u1', stake: 200n }], 100n, 200n, 0n)
 		).toThrow()
+	})
+})
+
+describe('pickCreatorRewardBps', () => {
+	it('maps the ends of [0,1) to the band endpoints (inclusive)', () => {
+		expect(pickCreatorRewardBps(1000, 5000, 0)).toBe(1000) // rand=0 → low
+		expect(pickCreatorRewardBps(1000, 5000, 0.999999)).toBe(5000) // rand→1 → high (inclusive)
+	})
+
+	it('stays within the band across the unit interval', () => {
+		for (const r of [0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.999999]) {
+			const v = pickCreatorRewardBps(1000, 5000, r)
+			expect(v).toBeGreaterThanOrEqual(1000)
+			expect(v).toBeLessThanOrEqual(5000)
+		}
+	})
+
+	it('returns the point when the band collapses (min == max)', () => {
+		expect(pickCreatorRewardBps(2500, 2500, 0)).toBe(2500)
+		expect(pickCreatorRewardBps(2500, 2500, 0.5)).toBe(2500)
+	})
+
+	it('treats an all-zero band as disabled (always 0)', () => {
+		expect(pickCreatorRewardBps(0, 0, 0)).toBe(0)
+		expect(pickCreatorRewardBps(0, 0, 0.99)).toBe(0)
+	})
+
+	it('normalizes an inverted band and clamps out-of-range input', () => {
+		// swapped bounds behave like the ordered band
+		expect(pickCreatorRewardBps(5000, 1000, 0)).toBe(1000)
+		// negatives clamp to 0, > 10000 clamps to 10000
+		expect(pickCreatorRewardBps(-500, 20_000, 0)).toBe(0)
+		expect(pickCreatorRewardBps(-500, 20_000, 0.999999)).toBe(10_000)
+	})
+
+	it('guards against an out-of-range rand', () => {
+		expect(pickCreatorRewardBps(1000, 5000, 1)).toBe(1000) // rand≥1 treated as 0
+		expect(pickCreatorRewardBps(1000, 5000, -1)).toBe(1000)
+	})
+})
+
+describe('splitCreatorReward', () => {
+	it('splits the rake and conserves it exactly (floor-first)', () => {
+		const { creatorReward, houseRake } = splitCreatorReward(1000n, 2500) // 25%
+		expect(creatorReward).toBe(250n)
+		expect(houseRake).toBe(750n)
+		expect(creatorReward + houseRake).toBe(1000n)
+	})
+
+	it('floors the creator slice so the house never goes negative', () => {
+		const { creatorReward, houseRake } = splitCreatorReward(7n, 3333) // 33.33% of 7 = 2.33
+		expect(creatorReward).toBe(2n)
+		expect(houseRake).toBe(5n)
+		expect(creatorReward + houseRake).toBe(7n)
+	})
+
+	it('pays nothing when the share is 0 or the rake is 0 (feature disabled / no rake)', () => {
+		expect(splitCreatorReward(1000n, 0)).toEqual({ creatorReward: 0n, houseRake: 1000n })
+		expect(splitCreatorReward(0n, 5000)).toEqual({ creatorReward: 0n, houseRake: 0n })
+	})
+
+	it('can pay the whole rake at 100% and clamps beyond it', () => {
+		expect(splitCreatorReward(1000n, 10_000)).toEqual({ creatorReward: 1000n, houseRake: 0n })
+		expect(splitCreatorReward(1000n, 99_999)).toEqual({ creatorReward: 1000n, houseRake: 0n })
 	})
 })

--- a/apps/prediction-markets/src/lib/payout.ts
+++ b/apps/prediction-markets/src/lib/payout.ts
@@ -43,6 +43,43 @@ export function computePayout(
 	return stake + computeWinnings(stake, losingPool, poolW, rakeBps)
 }
 
+/**
+ * Pick a creator-reward share (a fraction of the rake, in basis points) uniformly from the inclusive
+ * band [minBps, maxBps]. `rand` is a caller-supplied uniform in [0, 1) (i.e. `Math.random()`) so this
+ * stays pure and testable — the randomness is injected, not sourced here.
+ *
+ * The band is normalized defensively: values are clamped to [0, 10000] and swapped if inverted, so a
+ * mis-ordered or out-of-range config can never produce a share above 100% of the rake. When the band
+ * collapses to a single point (min == max) that point is returned with no draw.
+ */
+export function pickCreatorRewardBps(minBps: number, maxBps: number, rand: number): number {
+	const lo = Math.min(Math.max(Math.trunc(minBps), 0), 10_000)
+	const hi = Math.min(Math.max(Math.trunc(maxBps), 0), 10_000)
+	const [low, high] = lo <= hi ? [lo, hi] : [hi, lo]
+	if (high <= 0) return 0
+	if (low === high) return low
+	const span = high - low + 1
+	const r = rand >= 0 && rand < 1 ? rand : 0
+	return low + Math.min(Math.floor(r * span), span - 1)
+}
+
+/**
+ * Split a market's rake into the creator's slice and the house remainder, given a share in basis
+ * points (fraction of the rake). Floor-first keeps the creator slice ≤ rake, so the house remainder is
+ * always ≥ 0 and creatorReward + houseRake == rake exactly (no points created or lost).
+ */
+export function splitCreatorReward(
+	rake: bigint,
+	shareBps: number
+): { creatorReward: bigint; houseRake: bigint } {
+	if (rake <= 0n || shareBps <= 0) {
+		return { creatorReward: 0n, houseRake: rake > 0n ? rake : 0n }
+	}
+	const clamped = BigInt(Math.min(Math.trunc(shareBps), 10_000))
+	const creatorReward = (rake * clamped) / BPS_DENOMINATOR
+	return { creatorReward, houseRake: rake - creatorReward }
+}
+
 export interface ResolutionBet {
 	betId: string
 	userId: string

--- a/apps/ui/src/client/features/prediction-markets/components/ledger-table.tsx
+++ b/apps/ui/src/client/features/prediction-markets/components/ledger-table.tsx
@@ -21,8 +21,8 @@ import { characterPortraitUrl } from '@/lib/eve-images'
 import { formatPoints } from '@/lib/format-utils'
 import { cn } from '@/lib/utils'
 
-import type { AdminLedgerRow, LedgerType } from '../types'
 import type { BadgeVariant } from '@/components/ui/badge'
+import type { AdminLedgerRow, LedgerType } from '../types'
 
 const LEDGER_TYPE_VARIANTS: Record<LedgerType, BadgeVariant> = {
 	grant: 'success',
@@ -32,14 +32,14 @@ const LEDGER_TYPE_VARIANTS: Record<LedgerType, BadgeVariant> = {
 	rake: 'special',
 	burn: 'destructive',
 	adjustment: 'ghost',
+	creator_reward: 'gold',
 }
 
 const COL_COUNT = 8
 
 function hasMetadata(metadata: unknown): boolean {
 	return (
-		metadata != null &&
-		(typeof metadata !== 'object' || Object.keys(metadata as object).length > 0)
+		metadata != null && (typeof metadata !== 'object' || Object.keys(metadata as object).length > 0)
 	)
 }
 

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-audit.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-audit.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react'
 
-import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { usePageTitle } from '@/hooks/usePageTitle'
 
 import { LedgerTable } from '../components/ledger-table'
@@ -22,6 +22,7 @@ const LEDGER_TYPE_OPTIONS = [
 	{ value: 'rake', label: 'Rake' },
 	{ value: 'burn', label: 'Burn' },
 	{ value: 'adjustment', label: 'Adjustment' },
+	{ value: 'creator_reward', label: 'Creator reward' },
 ]
 
 /** A YYYY-MM-DD date-input value → an ISO instant (start or end of day, UTC). */

--- a/apps/ui/src/client/features/prediction-markets/routes/prediction-market-config.tsx
+++ b/apps/ui/src/client/features/prediction-markets/routes/prediction-market-config.tsx
@@ -26,6 +26,9 @@ export default function PredictionMarketConfig() {
 	const [minStake, setMinStake] = useState('')
 	const [twoOfNEnabled, setTwoOfNEnabled] = useState(false)
 	const [threshold, setThreshold] = useState('')
+	const [creatorRewardEnabled, setCreatorRewardEnabled] = useState(false)
+	const [creatorRewardMin, setCreatorRewardMin] = useState('')
+	const [creatorRewardMax, setCreatorRewardMax] = useState('')
 	const [changeNote, setChangeNote] = useState('')
 
 	// Prefill from the TRUTHFUL runtime values getConfig reports (rake 0 on an unseeded table) — never
@@ -37,6 +40,9 @@ export default function PredictionMarketConfig() {
 		setMinStake(data.defaultMinStake)
 		setTwoOfNEnabled(data.twoOfNThreshold !== null)
 		setThreshold(data.twoOfNThreshold ?? '')
+		setCreatorRewardEnabled(data.creatorRewardMaxBps > 0)
+		setCreatorRewardMin(String(data.creatorRewardMinBps))
+		setCreatorRewardMax(String(data.creatorRewardMaxBps))
 		setChangeNote('')
 	}, [data])
 
@@ -61,10 +67,41 @@ export default function PredictionMarketConfig() {
 			return
 		}
 
+		// Creator rake-reward band (fraction of the rake in bps). Disabled ⇒ 0/0.
+		let creatorMin = 0
+		let creatorMax = 0
+		if (creatorRewardEnabled) {
+			creatorMin = Number(creatorRewardMin)
+			creatorMax = Number(creatorRewardMax)
+			if (
+				!Number.isInteger(creatorMin) ||
+				!Number.isInteger(creatorMax) ||
+				creatorMin < 0 ||
+				creatorMax < 0 ||
+				creatorMin > 10000 ||
+				creatorMax > 10000
+			) {
+				toast.error(
+					'Creator reward bounds must be whole basis points between 0 and 10000 (0–100%).'
+				)
+				return
+			}
+			if (creatorMax === 0) {
+				toast.error('Enable creator reward with a maximum above 0, or turn it off.')
+				return
+			}
+			if (creatorMin > creatorMax) {
+				toast.error('Creator reward minimum must be less than or equal to the maximum.')
+				return
+			}
+		}
+
 		const body = {
 			defaultRakeBps: rake,
 			defaultMinStake: minStake,
 			twoOfNThreshold: candidate,
+			creatorRewardMinBps: creatorMin,
+			creatorRewardMaxBps: creatorMax,
 			changeNote: changeNote.trim() || undefined,
 		}
 		const submit = async () => {
@@ -73,6 +110,8 @@ export default function PredictionMarketConfig() {
 
 		const thresholdChanged = candidate !== data.twoOfNThreshold
 		const rakeChanged = rake !== data.defaultRakeBps
+		const creatorRewardChanged =
+			creatorMin !== data.creatorRewardMinBps || creatorMax !== data.creatorRewardMaxBps
 
 		// A threshold change is read at SETTLE time — retroactive on existing markets. Fetch the exact
 		// impact; hard-block if it would strand a single-resolver market (the server enforces this too).
@@ -120,6 +159,28 @@ export default function PredictionMarketConfig() {
 				description:
 					`New markets will take ${bps(rake)} rake (was ${bps(data.defaultRakeBps)}). ` +
 					`Existing markets keep their frozen rake. Continue?`,
+				confirmLabel: 'Apply',
+				cancelLabel: 'Cancel',
+				intent: 'destructive',
+				confirmButtonVariant: 'danger',
+				confirmDelaySeconds: 5,
+				onConfirm: submit,
+			})
+			return
+		}
+
+		// Creator rake reward redirects part of the house's rake to market creators at settlement.
+		// Rake is frozen per market, so this only affects FUTURE settlements — but it's an economic
+		// change worth confirming (and a same-submit rake/threshold change already confirmed above).
+		if (creatorRewardChanged) {
+			requestConfirmation({
+				title: 'Change creator rake reward?',
+				description:
+					creatorMax > 0
+						? `On each successful resolution, the market's creator will receive a random ` +
+							`${bps(creatorMin)}–${bps(creatorMax)} of that market's rake (drawn per settlement). ` +
+							`This reduces the house's share of the rake. Continue?`
+						: `Creator rake reward will be disabled — all rake returns to the house. Continue?`,
 				confirmLabel: 'Apply',
 				cancelLabel: 'Cancel',
 				intent: 'destructive',
@@ -238,6 +299,69 @@ export default function PredictionMarketConfig() {
 					) : (
 						<p className="text-sm text-muted-foreground">
 							Disabled — no market requires two-of-N by pool size.
+						</p>
+					)}
+				</section>
+
+				<section className="space-y-4 rounded-md border border-border p-4">
+					<div className="flex items-center justify-between gap-4">
+						<div>
+							<h2 className="text-lg font-semibold">Creator rake reward</h2>
+							<p className="text-sm text-muted-foreground">
+								On a successful resolution, pay the market's creator a{' '}
+								<strong>random slice of that market's rake</strong>, drawn uniformly from the band
+								below; the house keeps the rest. Affects future settlements only — a market's rake
+								itself is frozen at creation.
+							</p>
+						</div>
+						<Switch
+							checked={creatorRewardEnabled}
+							onCheckedChange={setCreatorRewardEnabled}
+							disabled={busy || isLoading}
+							aria-label="Enable creator rake reward"
+						/>
+					</div>
+
+					{creatorRewardEnabled ? (
+						<div className="grid gap-4 sm:grid-cols-2">
+							<div className="space-y-2">
+								<Label htmlFor="pm-cfg-creator-min">Minimum (basis points)</Label>
+								<Input
+									id="pm-cfg-creator-min"
+									type="text"
+									inputMode="numeric"
+									pattern="\d*"
+									placeholder="1000"
+									value={creatorRewardMin}
+									onChange={(e) => setCreatorRewardMin(digitsOnly(e.target.value))}
+									disabled={busy || isLoading}
+								/>
+								<p className="text-xs text-muted-foreground">
+									Share of the rake, 0–10000 bps.{' '}
+									{creatorRewardMin !== '' ? `= ${bps(Number(creatorRewardMin) || 0)}` : null}
+								</p>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="pm-cfg-creator-max">Maximum (basis points)</Label>
+								<Input
+									id="pm-cfg-creator-max"
+									type="text"
+									inputMode="numeric"
+									pattern="\d*"
+									placeholder="5000"
+									value={creatorRewardMax}
+									onChange={(e) => setCreatorRewardMax(digitsOnly(e.target.value))}
+									disabled={busy || isLoading}
+								/>
+								<p className="text-xs text-muted-foreground">
+									Must be ≥ minimum.{' '}
+									{creatorRewardMax !== '' ? `= ${bps(Number(creatorRewardMax) || 0)}` : null}
+								</p>
+							</div>
+						</div>
+					) : (
+						<p className="text-sm text-muted-foreground">
+							Disabled — the full rake goes to the house on every resolution.
 						</p>
 					)}
 				</section>

--- a/apps/ui/src/client/features/prediction-markets/types.ts
+++ b/apps/ui/src/client/features/prediction-markets/types.ts
@@ -169,5 +169,8 @@ export interface UpdateConfigRequest {
 	defaultRakeBps: number
 	defaultMinStake: string
 	twoOfNThreshold: string | null
+	/** Creator rake-reward band as a fraction of the rake in bps (0–10000). Both 0 disables it. */
+	creatorRewardMinBps: number
+	creatorRewardMaxBps: number
 	changeNote?: string
 }

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -10,7 +10,15 @@
 
 export type MarketStatus = 'draft' | 'open' | 'closed' | 'resolving' | 'resolved' | 'voided'
 export type BetStatus = 'active' | 'won' | 'lost' | 'refunded'
-export type LedgerType = 'grant' | 'wager' | 'refund' | 'payout' | 'rake' | 'burn' | 'adjustment'
+export type LedgerType =
+	| 'grant'
+	| 'wager'
+	| 'refund'
+	| 'payout'
+	| 'rake'
+	| 'burn'
+	| 'adjustment'
+	| 'creator_reward'
 export type ProposalStatus = 'pending' | 'approved' | 'rejected' | 'superseded'
 export type Visibility = 'public' | 'internal'
 
@@ -319,6 +327,12 @@ export interface PmConfigView {
 	defaultMinStake: string
 	/** NULL disables pool-based two-of-N. */
 	twoOfNThreshold: string | null
+	/**
+	 * Creator rake-reward band, as a fraction of the rake in basis points (0–10000). On a successful
+	 * resolution the creator is paid a random slice of the rake in [min, max] bps. Both 0 disables it.
+	 */
+	creatorRewardMinBps: number
+	creatorRewardMaxBps: number
 	/** ISO-8601 when this generation took effect, or null when unseeded. */
 	effectiveFrom: string | null
 	/** Admin who wrote the active generation, or null (unseeded / pre-audit rows). */
@@ -334,6 +348,9 @@ export interface UpdateConfigInput {
 	defaultMinStake: string
 	/** NULL disables pool-based two-of-N. '' / '0' are rejected — send real null to disable. */
 	twoOfNThreshold: string | null
+	/** Creator rake-reward band as a fraction of the rake in bps. Both 0 disables. 0 ≤ min ≤ max ≤ 10000. */
+	creatorRewardMinBps: number
+	creatorRewardMaxBps: number
 	changeNote?: string | null
 }
 


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds an admin-configurable "creator rake reward": on a successful market resolution, a random slice of the rake (drawn from a configurable basis-point band) is now paid to the market's creator instead of going entirely to the house.

## Changes
- **Schema/migration:** add `creator_reward` to the `pm_ledger_type` enum and `creator_reward_min_bps`/`creator_reward_max_bps` columns (default 0, i.e. disabled) to `pm_config`.
- **Payout logic (`apps/prediction-markets/src/lib/payout.ts`):** new pure helpers `pickCreatorRewardBps` (uniformly draws a share from `[min, max]` bps, normalizing inverted/out-of-range input) and `splitCreatorReward` (floor-first split of a rake into `creatorReward` + `houseRake`, exactly conserving the total).
- **Durable object (`durable-object.ts`):** on resolution, reads the active config's reward band inside the settlement transaction, draws the creator's share, credits it to the creator's wallet (lazily created if needed) as a new `creator_reward` ledger line, and books the remainder as `houseRake` under the existing `rake` line; the draw and rake base are recorded in ledger/history metadata for audit. Also validates the band (`0 ≤ min ≤ max ≤ 10000`) on config writes.
- **Admin route (`prediction-markets-admin.ts`):** extends the `/config` PATCH zod schema with `creatorRewardMinBps`/`creatorRewardMaxBps` (0–10000) plus a cross-field refine enforcing `min ≤ max`; adds `creator_reward` to the recognized ledger types for the audit endpoint.
- **UI:** new "Creator rake reward" section in the prediction-market config editor (enable switch + min/max bps inputs, validation, and a confirmation dialog since it's an economic change affecting future settlements); `creator_reward` added as a ledger type filter option and badge variant in the audit ledger table.
- **Shared types (`packages/prediction-markets`):** `LedgerType`, `PmConfigView`, and `UpdateConfigInput` updated with the new field/variant.

## Testing
- Added unit tests for `pickCreatorRewardBps` and `splitCreatorReward` covering band normalization, clamping, collapsed bands, and exact conservation of the split.
- Added route tests for the admin `/config` endpoint covering accepting a valid creator-reward band, rejecting bounds above 100%, and rejecting an inverted (`min > max`) band.
<!-- claude:end -->