### PR TITLE
docs(CLAUDE.md): require all branch work be registered in git machete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git Workflow
+
+**CRITICAL: 100% of git branch work is managed with `git machete` — every branch MUST appear in `git machete status`.**
+- Register each branch immediately on creation: `git machete add <branch> --onto <parent>` (e.g. `--onto main`).
+- Branches created indirectly by tooling (`git worktree add -b`, the EnterWorktree tool) do NOT auto-register in machete's definition file — add them manually right after creation or they're invisible to machete.
+- Never leave a branch created with bare `git checkout -b` / `git branch` unregistered.
+
 ## Project Overview
 
 This is a Cloudflare Workers monorepo built with:


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Documents a new git workflow requirement in `CLAUDE.md`: all branch work must be tracked with `git machete`, so Claude Code registers branches it creates instead of leaving them invisible to the tool.

## Changes
- Add a "Git Workflow" section to `CLAUDE.md` stating every branch must appear in `git machete status`.
- Instruct registering each branch on creation with `git machete add <branch> --onto <parent>`.
- Call out that branches created indirectly (`git worktree add -b`, the `EnterWorktree` tool) don't auto-register and must be added manually.
- Prohibit leaving branches created via bare `git checkout -b` / `git branch` unregistered.
<!-- claude:end -->