### PR TITLE
fix(prediction-markets): site admins can void any market

### DIFF
--- a/apps/core/src/services/__tests__/discord-components.void.test.ts
+++ b/apps/core/src/services/__tests__/discord-components.void.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { executeDiscordModalSubmit } from '../discord-components.service'
+
+// Verifies Core threads the site-admin `adminOverride` capability into voidMarket: a plain resolver
+// and a (non-admin) manager pass adminOverride:false — they stay bound by the void conflict-of-interest
+// guards — while an is_admin voider passes adminOverride:true, letting them void ANY market (including
+// one they created or bet on). bypassDesignated (admin OR manager) is threaded independently.
+
+const hoisted = vi.hoisted(() => ({
+	predictionBinding: {} as DurableObjectNamespace,
+	prediction: {
+		voidMarket: vi.fn().mockResolvedValue(undefined),
+		// getMarket → null so refreshPost / announceSettlement are no-ops (no post/notify service runs).
+		getMarket: vi.fn().mockResolvedValue(null),
+	},
+	hasMarketPermission: vi.fn(),
+	findFirst: vi.fn(),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn((binding: DurableObjectNamespace) =>
+		binding === hoisted.predictionBinding ? hoisted.prediction : {}
+	),
+}))
+vi.mock('../../lib/market-permissions', () => ({
+	hasMarketPermission: hoisted.hasMarketPermission,
+}))
+vi.mock('../../lib/market-custom-id', () => ({
+	customIdAction: () => 'voidmodal',
+	decodeSingleMarketId: () => 'm1',
+	VOID_REASON_INPUT_ID: 'reason',
+}))
+// Downstream post/notify services aren't reached (getMarket→null), but mock them so the module under
+// test loads without pulling their transitive deps.
+vi.mock('../discord-market-post.service', () => ({
+	updateMarketPostFromDetail: vi.fn(),
+	applyMarketPostStatus: vi.fn(),
+	announceBetPlaced: vi.fn(),
+}))
+vi.mock('../discord-market-notify.service', () => ({
+	announceMarketClosed: vi.fn(),
+	announceMarketResolved: vi.fn(),
+	dmWagerResults: vi.fn(),
+}))
+
+const db = { query: { users: { findFirst: hoisted.findFirst } } } as any
+const env = {
+	PREDICTION_MARKETS: hoisted.predictionBinding,
+	DISCORD: {},
+	GROUPS: {},
+	PM_FORUM_GUILD_ID: 'g1',
+} as any
+const input = {
+	customId: 'voidmodal:m1',
+	discordUserId: 'd1',
+	fields: { reason: 'settling manually' },
+	interactionId: 'i1',
+} as any
+
+function mockTiers(isAdmin: boolean, manager: boolean) {
+	hoisted.findFirst.mockResolvedValue({ id: 'u1', is_admin: isAdmin })
+	// requireResolver checks 'resolver'; canBypassDesignated checks 'manager'.
+	hoisted.hasMarketPermission.mockImplementation((_e: unknown, _u: unknown, tier: string) =>
+		Promise.resolve(tier === 'manager' ? manager : true)
+	)
+}
+
+describe('executeDiscordModalSubmit — adminOverride threading (void)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		hoisted.prediction.getMarket.mockResolvedValue(null)
+	})
+
+	it('a plain resolver passes adminOverride:false and bypassDesignated:false', async () => {
+		mockTiers(false, false)
+		await executeDiscordModalSubmit(db, env, input)
+		expect(hoisted.prediction.voidMarket).toHaveBeenCalledWith(
+			expect.objectContaining({
+				actorUserId: 'u1',
+				marketId: 'm1',
+				reason: 'settling manually',
+				bypassDesignated: false,
+				adminOverride: false,
+			})
+		)
+	})
+
+	it('a non-admin manager passes adminOverride:false but bypassDesignated:true', async () => {
+		mockTiers(false, true)
+		await executeDiscordModalSubmit(db, env, input)
+		expect(hoisted.prediction.voidMarket).toHaveBeenCalledWith(
+			expect.objectContaining({ bypassDesignated: true, adminOverride: false })
+		)
+	})
+
+	it('an admin passes adminOverride:true (and bypassDesignated:true)', async () => {
+		mockTiers(true, false)
+		await executeDiscordModalSubmit(db, env, input)
+		expect(hoisted.prediction.voidMarket).toHaveBeenCalledWith(
+			expect.objectContaining({ bypassDesignated: true, adminOverride: true })
+		)
+	})
+})

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -547,6 +547,10 @@ async function handleVoidModal(
 			marketId,
 			reason,
 			bypassDesignated: await canBypassDesignated(env, user),
+			// A site admin may void ANY market, including one they created or bet on (a void only refunds,
+			// so there's no self-dealing risk). is_admin-only — managers keep the conflict-of-interest
+			// guards. The DO trusts this flag unverified, so it MUST come straight from is_admin.
+			adminOverride: user.is_admin,
 		})
 		await refreshPost(db, env, prediction, marketId)
 		const background = await announceSettlement(env, prediction, marketId)

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -1475,6 +1475,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		reason: string
 		approverId?: string
 		bypassDesignated?: boolean
+		adminOverride?: boolean
 	}): Promise<void> {
 		if (!input.reason.trim()) throw new Error('VOID_REASON_REQUIRED')
 		try {
@@ -1487,35 +1488,46 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				if (!market) throw new Error('MARKET_NOT_FOUND')
 				if (isTerminal(market.status)) throw new Error('MARKET_TERMINAL')
 
-				// Voiding is a terminal settlement, so it carries the same conflict-of-interest guards as
-				// resolve/approve: a creator can't void their own market, and a resolver holding a position
-				// can't void one they have a stake in.
-				if (market.createdBy === input.actorUserId) throw new Error('CREATOR_CANNOT_RESOLVE')
-				if (await this.hasPosition(tx, input.marketId, input.actorUserId)) {
-					throw new Error('RESOLVER_HAS_POSITION')
-				}
 				const bypass = input.bypassDesignated ?? false
-				if (!canResolveDesignated(market.designatedResolvers, input.actorUserId, bypass)) {
-					throw new Error('NOT_DESIGNATED_RESOLVER')
-				}
-
-				// Contested markets (bets on 2+ outcomes) require a distinct second approver.
-				const [distinctRow] = await tx
-					.select({ n: sql<number>`count(distinct ${pmBets.outcomeId})::int` })
-					.from(pmBets)
-					.where(and(eq(pmBets.marketId, input.marketId), eq(pmBets.status, 'active')))
-				const contested = (distinctRow?.n ?? 0) >= 2
-				if (contested && (!input.approverId || input.approverId === input.actorUserId)) {
-					throw new Error('CONTESTED_VOID_REQUIRES_APPROVER')
-				}
-				// On a designated market, the contested-void second approver must ALSO be a designated
-				// member (unless overriding). NOTE: the DO cannot verify approverId's resolver TIER — Core
-				// authenticates only the initiating actor. The Discord path never supplies approverId, so
-				// this seat is currently unreachable; any future admin contested-void route MUST Core-side
-				// tier-validate approverId before calling, exactly as it does for the initiating actor.
-				if (contested && input.approverId && !bypass) {
-					if (!canResolveDesignated(market.designatedResolvers, input.approverId, false)) {
+				// A site admin (adminOverride) may void ANY market unconditionally. A void refunds every
+				// active bet at its exact stake, so — unlike resolve/approve, where picking an outcome can
+				// enrich a position — voiding carries no self-dealing risk, and an admin is the trust root
+				// for settlement. So the admin path skips every conflict-of-interest guard below (creator,
+				// position, designated membership, and the contested second-approver rule). adminOverride
+				// is a trusted, DO-unverifiable capability: Core derives it solely from is_admin, never a
+				// client literal. Every non-admin actor stays fully bound by these guards.
+				const adminOverride = input.adminOverride ?? false
+				if (!adminOverride) {
+					// Voiding is a terminal settlement, so it carries the same conflict-of-interest guards as
+					// resolve/approve: a creator can't void their own market, and a resolver holding a
+					// position can't void one they have a stake in.
+					if (market.createdBy === input.actorUserId) throw new Error('CREATOR_CANNOT_RESOLVE')
+					if (await this.hasPosition(tx, input.marketId, input.actorUserId)) {
+						throw new Error('RESOLVER_HAS_POSITION')
+					}
+					if (!canResolveDesignated(market.designatedResolvers, input.actorUserId, bypass)) {
 						throw new Error('NOT_DESIGNATED_RESOLVER')
+					}
+
+					// Contested markets (bets on 2+ outcomes) require a distinct second approver.
+					const [distinctRow] = await tx
+						.select({ n: sql<number>`count(distinct ${pmBets.outcomeId})::int` })
+						.from(pmBets)
+						.where(and(eq(pmBets.marketId, input.marketId), eq(pmBets.status, 'active')))
+					const contested = (distinctRow?.n ?? 0) >= 2
+					if (contested && (!input.approverId || input.approverId === input.actorUserId)) {
+						throw new Error('CONTESTED_VOID_REQUIRES_APPROVER')
+					}
+					// On a designated market, the contested-void second approver must ALSO be a designated
+					// member (unless overriding). NOTE: the DO cannot verify approverId's resolver TIER —
+					// Core authenticates only the initiating actor. The Discord path never supplies
+					// approverId, so this seat is currently unreachable; any future admin contested-void
+					// route MUST Core-side tier-validate approverId before calling, exactly as it does for
+					// the initiating actor.
+					if (contested && input.approverId && !bypass) {
+						if (!canResolveDesignated(market.designatedResolvers, input.approverId, false)) {
+							throw new Error('NOT_DESIGNATED_RESOLVER')
+						}
 					}
 				}
 
@@ -1529,7 +1541,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					market,
 					input.actorUserId,
 					input.reason.trim(),
-					viaOverride
+					viaOverride,
+					adminOverride
 				)
 			})
 		} catch (error) {
@@ -1776,7 +1789,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		market: PmMarket,
 		actorUserId: string,
 		reason: string,
-		viaOverride = false
+		viaOverride = false,
+		adminOverride = false
 	): Promise<void> {
 		const bets = await tx
 			.select()
@@ -1822,7 +1836,11 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			previousStatus: market.status,
 			newStatus: 'voided',
 			visibility: 'public',
-			metadata: { reason, ...(viaOverride ? { viaOverride: true } : {}) },
+			metadata: {
+				reason,
+				...(viaOverride ? { viaOverride: true } : {}),
+				...(adminOverride ? { adminOverride: true } : {}),
+			},
 		})
 	}
 

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -525,6 +525,15 @@ export interface PredictionMarkets {
 		approverId?: string
 		/** See proposeResolution.bypassDesignated. */
 		bypassDesignated?: boolean
+		/**
+		 * When true, void this market UNCONDITIONALLY — skip every conflict-of-interest guard (creator
+		 * ≠ voider, no-position, designated membership, AND the contested-void second-approver rule). A
+		 * void refunds every bet at its stake, so it carries no self-dealing risk; this is the site-admin
+		 * escape hatch to settle any market. Unlike bypassDesignated (held by admins AND managers, waiving
+		 * ONLY the membership check), adminOverride is is_admin-only. Core sets it solely from is_admin — a
+		 * trusted, DO-unverifiable capability, never a client literal.
+		 */
+		adminOverride?: boolean
 	}): Promise<void>
 	/**
 	 * Persist the Discord forum post mapping after Core creates the post.


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Site admins were previously blocked from voiding a prediction market they created or held a position in, because `voidMarket` applied the same conflict-of-interest guards as resolution. Since voiding just refunds every active bet at its original stake (no self-dealing risk), this PR adds an admin-only override that lets site admins void any market unconditionally.

## Changes
- Add an `adminOverride` flag to `PredictionMarketsDO.voidMarket` that, when true, skips all conflict-of-interest checks: creator-cannot-resolve, resolver-has-position, designated-resolver membership, and the contested-void second-approver rule.
- `Core`'s `handleVoidModal` sets `adminOverride` directly from `user.is_admin` (never a client-supplied value), so non-admin managers still go through the existing guards via `bypassDesignated`.
- Record `adminOverride: true` in the market-history audit trail metadata when an admin-override void occurs.
- Update the shared `PredictionMarkets` interface (`packages/prediction-markets/src/index.ts`) with the new `adminOverride` option and documentation of its trust boundary.

## Testing
- Added `apps/core/src/services/__tests__/discord-components.void.test.ts`, verifying that a plain resolver and a non-admin manager pass `adminOverride: false` (still bound by the void guards), while an `is_admin` voider passes `adminOverride: true` and `bypassDesignated` is threaded independently of admin status.
<!-- claude:end -->