### PR TITLE
fix 4: typed PmError for domain errors

### DIFF
--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -61,7 +61,14 @@ import type {
 	WalletRow,
 } from '@repo/prediction-markets'
 import type { Env } from './context'
-import type { PmBet, PmConfig, PmLedgerRow, PmMarket, PmMarketHistoryRow } from './db/schema'
+import type {
+	NewPmLedgerRow,
+	PmBet,
+	PmConfig,
+	PmLedgerRow,
+	PmMarket,
+	PmMarketHistoryRow,
+} from './db/schema'
 
 type PmDatabase = ReturnType<typeof createDb>
 type PmTransaction = Parameters<Parameters<PmDatabase['transaction']>[0]>[0]
@@ -561,25 +568,17 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					}
 				}
 
-				const [credited] = await tx
-					.update(pmWallets)
-					.set({
-						balance: sql`${pmWallets.balance} + ${input.amount}::numeric`,
-						updatedAt: new Date(),
-					})
-					.where(eq(pmWallets.userId, input.targetUserId))
-					.returning({ balance: pmWallets.balance })
-
-				await tx.insert(pmLedger).values({
+				// Wallet already exists and is locked FOR UPDATE above, so skip the lazy upsert.
+				const { balanceAfter } = await this.creditWallet(tx, {
 					userId: input.targetUserId,
-					amount: input.amount,
+					amount: parseAmount(input.amount),
 					type: 'grant',
-					balanceAfter: credited.balance,
-					idempotencyKey: input.idempotencyKey ?? null,
+					idempotencyKey: input.idempotencyKey,
 					metadata: { actorUserId: input.actorUserId, reason: input.reason },
+					ensureWallet: false,
 				})
 
-				return { balance: credited.balance, deduped: false }
+				return { balance: balanceAfter ?? locked?.balance ?? '0', deduped: false }
 			})
 		} catch (error) {
 			// A mismatched idempotency key is a caller-side outcome (the admin route maps it to 409;
@@ -1650,21 +1649,14 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				.returning({ id: pmBets.id })
 			if (updated.length === 0) continue // already credited on a retry
 
-			const [credited] = await tx
-				.update(pmWallets)
-				.set({
-					balance: sql`${pmWallets.balance} + ${formatAmount(p.payout)}::numeric`,
-					updatedAt: new Date(),
-				})
-				.where(eq(pmWallets.userId, p.userId))
-				.returning({ balance: pmWallets.balance })
-			await tx.insert(pmLedger).values({
+			// Winner already has a wallet (they bet), so skip the lazy upsert.
+			await this.creditWallet(tx, {
 				userId: p.userId,
-				amount: formatAmount(p.payout),
+				amount: p.payout,
 				type: 'payout',
 				marketId: market.id,
 				betId: p.betId,
-				balanceAfter: credited?.balance ?? null,
+				ensureWallet: false,
 			})
 		}
 
@@ -1684,24 +1676,12 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		// no wallet yet if they never bet, so lazily create it. Booked as its own attributed line whose
 		// metadata records the draw for audit; the remaining houseRake still books as 'rake' below.
 		if (creatorReward > 0n) {
-			await tx
-				.insert(pmWallets)
-				.values({ userId: market.createdBy, balance: '0' })
-				.onConflictDoNothing()
-			const [credited] = await tx
-				.update(pmWallets)
-				.set({
-					balance: sql`${pmWallets.balance} + ${formatAmount(creatorReward)}::numeric`,
-					updatedAt: new Date(),
-				})
-				.where(eq(pmWallets.userId, market.createdBy))
-				.returning({ balance: pmWallets.balance })
-			await tx.insert(pmLedger).values({
+			// The creator may have no wallet yet (never bet), so lazily create it.
+			await this.creditWallet(tx, {
 				userId: market.createdBy,
-				amount: formatAmount(creatorReward),
+				amount: creatorReward,
 				type: 'creator_reward',
 				marketId: market.id,
-				balanceAfter: credited?.balance ?? null,
 				metadata: { shareBps: creatorShareBps, rakeBase: formatAmount(rake) },
 			})
 		}
@@ -1709,44 +1689,21 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		// House cut (net rake, after any creator reward) and rounding dust (burn) accumulate in the
 		// system wallet rather than leaving circulation via a null-user sink — the points stay conserved
 		// and recoverable. Each is a distinct, attributed ledger line carrying the running balanceAfter.
-		if (houseRake > 0n || dust > 0n) {
-			await tx
-				.insert(pmWallets)
-				.values({ userId: SYSTEM_WALLET_USER_ID, balance: '0' })
-				.onConflictDoNothing()
-		}
+		// creditWallet lazily upserts the system wallet, so each credit is self-contained.
 		if (houseRake > 0n) {
-			const [credited] = await tx
-				.update(pmWallets)
-				.set({
-					balance: sql`${pmWallets.balance} + ${formatAmount(houseRake)}::numeric`,
-					updatedAt: new Date(),
-				})
-				.where(eq(pmWallets.userId, SYSTEM_WALLET_USER_ID))
-				.returning({ balance: pmWallets.balance })
-			await tx.insert(pmLedger).values({
+			await this.creditWallet(tx, {
 				userId: SYSTEM_WALLET_USER_ID,
-				amount: formatAmount(houseRake),
+				amount: houseRake,
 				type: 'rake',
 				marketId: market.id,
-				balanceAfter: credited.balance,
 			})
 		}
 		if (dust > 0n) {
-			const [credited] = await tx
-				.update(pmWallets)
-				.set({
-					balance: sql`${pmWallets.balance} + ${formatAmount(dust)}::numeric`,
-					updatedAt: new Date(),
-				})
-				.where(eq(pmWallets.userId, SYSTEM_WALLET_USER_ID))
-				.returning({ balance: pmWallets.balance })
-			await tx.insert(pmLedger).values({
+			await this.creditWallet(tx, {
 				userId: SYSTEM_WALLET_USER_ID,
-				amount: formatAmount(dust),
+				amount: dust,
 				type: 'burn',
 				marketId: market.id,
-				balanceAfter: credited.balance,
 			})
 		}
 
@@ -1806,21 +1763,14 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				.returning({ id: pmBets.id })
 			if (updated.length === 0) continue
 
-			const [credited] = await tx
-				.update(pmWallets)
-				.set({
-					balance: sql`${pmWallets.balance} + ${bet.amount}::numeric`,
-					updatedAt: new Date(),
-				})
-				.where(eq(pmWallets.userId, bet.userId))
-				.returning({ balance: pmWallets.balance })
-			await tx.insert(pmLedger).values({
+			// The bettor already has a wallet (they bet), so skip the lazy upsert.
+			await this.creditWallet(tx, {
 				userId: bet.userId,
-				amount: bet.amount,
+				amount: parseAmount(bet.amount),
 				type: 'refund',
 				marketId: market.id,
 				betId: bet.id,
-				balanceAfter: credited?.balance ?? null,
+				ensureWallet: false,
 			})
 		}
 
@@ -2120,6 +2070,64 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				impliedOddsBps: total > 0n ? Number((parseAmount(o.poolAmount) * 10_000n) / total) : null,
 			})),
 		}
+	}
+
+	/**
+	 * The single audited money-credit primitive. Optionally lazily creates the wallet row, applies one
+	 * atomic balance increment, and appends the matching `pm_ledger` line carrying the running
+	 * `balanceAfter`. Every credit (payout / refund / creator_reward / rake / burn / grant) routes
+	 * through here so the credit-then-record invariant — and the balanceAfter snapshot — lives in
+	 * exactly one place rather than being hand-rolled per call site.
+	 *
+	 * `amount` is a non-negative points bigint. Because every caller has already ensured (or is about
+	 * to ensure) the wallet exists, `credited` is always present; the `?? null` fallbacks are defensive.
+	 * Returns the post-credit balance string (null only if the wallet row vanished mid-transaction).
+	 */
+	private async creditWallet(
+		tx: PmExecutor,
+		args: {
+			userId: string
+			amount: bigint
+			type: NewPmLedgerRow['type']
+			marketId?: string
+			betId?: string
+			idempotencyKey?: string
+			metadata?: unknown
+			/** Lazily `INSERT ... ON CONFLICT DO NOTHING` the wallet row first (default true). Pass false
+			 * when the caller has already created/locked the wallet in this transaction. */
+			ensureWallet?: boolean
+		}
+	): Promise<{ balanceAfter: string | null }> {
+		const {
+			userId,
+			amount,
+			type,
+			marketId,
+			betId,
+			idempotencyKey,
+			metadata,
+			ensureWallet = true,
+		} = args
+		if (ensureWallet) {
+			await tx.insert(pmWallets).values({ userId, balance: '0' }).onConflictDoNothing()
+		}
+		const formatted = formatAmount(amount)
+		const [credited] = await tx
+			.update(pmWallets)
+			.set({ balance: sql`${pmWallets.balance} + ${formatted}::numeric`, updatedAt: new Date() })
+			.where(eq(pmWallets.userId, userId))
+			.returning({ balance: pmWallets.balance })
+		await tx.insert(pmLedger).values({
+			userId,
+			amount: formatted,
+			type,
+			marketId: marketId ?? null,
+			betId: betId ?? null,
+			balanceAfter: credited?.balance ?? null,
+			idempotencyKey: idempotencyKey ?? null,
+			metadata: metadata ?? null,
+		})
+		return { balanceAfter: credited?.balance ?? null }
 	}
 
 	private async logHistory(executor: PmExecutor, entry: HistoryEntry): Promise<void> {

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -23,6 +23,7 @@ import {
 	isDesignatedResolver,
 	normalizeDesignatedResolvers,
 } from './lib/designated-resolvers'
+import { isExpectedError, PmError } from './lib/errors'
 import { formatAmount, isPositiveIntegerString, negateAmount, parseAmount } from './lib/money'
 import { computeResolution, pickCreatorRewardBps, splitCreatorReward } from './lib/payout'
 import { RATE_BUDGETS } from './lib/rate-limit'
@@ -94,29 +95,6 @@ const ONBOARDING_REASON = 'Initial onboarding'
  */
 const SYSTEM_ACTOR = 'system'
 
-/** placeBet throws these on normal user-facing rejections — not paged to Sentry. */
-const EXPECTED_BET_ERRORS = new Set([
-	'MARKET_NOT_FOUND',
-	'MARKET_NOT_OPEN',
-	'MARKET_CLOSED',
-	'OUTCOME_NOT_FOUND',
-	'STAKE_BELOW_MIN',
-	'STAKE_ABOVE_MAX',
-	'PER_USER_CAP_EXCEEDED',
-	'INSUFFICIENT_FUNDS',
-	// A designated resolver may not bet on the market they're designated to settle (position-free rule).
-	'DESIGNATED_RESOLVER_CANNOT_BET',
-])
-
-/**
- * True for expected bet rejections — the user-facing outcomes we deliberately don't page on.
- * Covers the coded domain errors above plus INVALID_AMOUNT and the RATE_LIMITED:<ms> throw.
- */
-function isExpectedBetError(error: unknown): boolean {
-	const msg = error instanceof Error ? error.message : String(error)
-	return EXPECTED_BET_ERRORS.has(msg) || msg === 'INVALID_AMOUNT' || msg.startsWith('RATE_LIMITED')
-}
-
 /**
  * Pull the underlying driver error off a Drizzle "Failed query: …" wrapper. Drizzle surfaces only
  * the SQL + params in `.message`; the real Postgres reason (e.g. `relation "pm_rate_limits" does
@@ -126,43 +104,6 @@ function dbErrorCause(error: unknown): string | undefined {
 	const cause = (error as { cause?: unknown } | null)?.cause
 	if (cause == null) return undefined
 	return cause instanceof Error ? cause.message : String(cause)
-}
-
-/** Resolver methods (close/resolve/approve/void) throw these on normal rejections — not paged. */
-const EXPECTED_RESOLVER_ERRORS = new Set([
-	'MARKET_NOT_FOUND',
-	'MARKET_NOT_CLOSED',
-	'MARKET_NOT_RESOLVING',
-	'MARKET_TERMINAL',
-	'OUTCOME_NOT_FOUND',
-	'CREATOR_CANNOT_RESOLVE',
-	'RESOLVER_HAS_POSITION',
-	'APPROVER_MUST_DIFFER',
-	'PROPOSAL_NOT_FOUND',
-	'PROPOSAL_NOT_PENDING',
-	'CONTESTED_VOID_REQUIRES_APPROVER',
-	'VOID_REASON_REQUIRED',
-	// Actor is not one of this market's designated resolvers (and holds no admin/manager override).
-	'NOT_DESIGNATED_RESOLVER',
-])
-
-/** updateMarket throws these on normal caller-input rejections — not paged to Sentry. */
-const EXPECTED_MARKET_EDIT_ERRORS = new Set([
-	'MARKET_NOT_FOUND',
-	'MARKET_NOT_EDITABLE',
-	'CLOSES_AT_NOT_EDITABLE',
-	'INVALID_CLOSES_AT',
-	'RESOLVES_ON_BEFORE_CLOSE',
-	'QUESTION_REQUIRED',
-])
-
-/** True for expected resolver rejections, incl. the raw assertTransition (stale-state) string. */
-function isExpectedResolverError(error: unknown): boolean {
-	const msg = error instanceof Error ? error.message : String(error)
-	return (
-		EXPECTED_RESOLVER_ERRORS.has(msg) ||
-		msg.startsWith('prediction-markets: invalid market transition')
-	)
 }
 
 /**
@@ -516,19 +457,19 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 
 	async grantPoints(input: GrantPointsInput): Promise<{ balance: string; deduped: boolean }> {
 		if (!isPositiveIntegerString(input.amount)) {
-			throw new Error('INVALID_AMOUNT')
+			throw new PmError('INVALID_AMOUNT')
 		}
 		if (!input.reason?.trim()) {
-			throw new Error('REASON_REQUIRED')
+			throw new PmError('REASON_REQUIRED')
 		}
 		// Defense-in-depth: the route also blocks this, but never let an admin fund their own wallet.
 		if (input.actorUserId === input.targetUserId) {
-			throw new Error('SELF_TARGET_FORBIDDEN')
+			throw new PmError('SELF_TARGET_FORBIDDEN')
 		}
 		// The house/system wallet is an accumulator for rake + dust; keep its balance meaningful by
 		// forbidding manual deposits into it (so house balance == Σ collected rake/dust).
 		if (input.targetUserId === SYSTEM_WALLET_USER_ID) {
-			throw new Error('SYSTEM_TARGET_FORBIDDEN')
+			throw new PmError('SYSTEM_TARGET_FORBIDDEN')
 		}
 		try {
 			return await this.db.transaction(async (tx) => {
@@ -562,7 +503,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 							existing.userId === input.targetUserId &&
 							parseAmount(existing.amount) === parseAmount(input.amount)
 						if (!same) {
-							throw new Error('IDEMPOTENCY_KEY_CONFLICT')
+							throw new PmError('IDEMPOTENCY_KEY_CONFLICT')
 						}
 						return { balance: locked?.balance ?? '0', deduped: true }
 					}
@@ -583,7 +524,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		} catch (error) {
 			// A mismatched idempotency key is a caller-side outcome (the admin route maps it to 409;
 			// onboardUser handles it), not an infra failure — don't page on it.
-			if (!(error instanceof Error && error.message === 'IDEMPOTENCY_KEY_CONFLICT')) {
+			if (!isExpectedError(error)) {
 				captureException(error as Error, {
 					tags: { durableObject: 'PredictionMarketsDO', method: 'grantPoints' },
 				})
@@ -625,33 +566,33 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 
 	async createMarket(input: CreateMarketInput): Promise<MarketDetail> {
 		const labels = input.outcomes.map((o) => o.trim()).filter(Boolean)
-		if (labels.length < 2) throw new Error('AT_LEAST_TWO_OUTCOMES')
+		if (labels.length < 2) throw new PmError('AT_LEAST_TWO_OUTCOMES')
 		// Cap at 20 so the embed (≤25 fields) and button rows (≤25 buttons / 5 rows) can't
 		// overflow Discord limits. The admin route enforces this too; the DO owns the invariant.
-		if (labels.length > 20) throw new Error('TOO_MANY_OUTCOMES')
+		if (labels.length > 20) throw new PmError('TOO_MANY_OUTCOMES')
 		if (new Set(labels.map((l) => l.toLowerCase())).size !== labels.length) {
-			throw new Error('DUPLICATE_OUTCOMES')
+			throw new PmError('DUPLICATE_OUTCOMES')
 		}
-		if (!input.question.trim()) throw new Error('QUESTION_REQUIRED')
+		if (!input.question.trim()) throw new PmError('QUESTION_REQUIRED')
 		const closesAt = parseDateOrNull(input.closesAt)
-		if (!closesAt) throw new Error('INVALID_CLOSES_AT')
+		if (!closesAt) throw new PmError('INVALID_CLOSES_AT')
 		// Expected resolution date: REQUIRED at create (the column is nullable only for backward-compat
 		// with pre-existing markets) and must be at or after betting close — a market can't be scheduled
 		// to resolve before its own bets stop.
 		const resolvesOn = parseDateOrNull(input.resolvesOn)
-		if (!resolvesOn) throw new Error('INVALID_RESOLVES_ON')
-		if (resolvesOn.getTime() < closesAt.getTime()) throw new Error('RESOLVES_ON_BEFORE_CLOSE')
+		if (!resolvesOn) throw new PmError('INVALID_RESOLVES_ON')
+		if (resolvesOn.getTime() < closesAt.getTime()) throw new PmError('RESOLVES_ON_BEFORE_CLOSE')
 		if (input.rakeBps != null && (input.rakeBps < 0 || input.rakeBps > 2000)) {
-			throw new Error('INVALID_RAKE')
+			throw new PmError('INVALID_RAKE')
 		}
 		if (input.minStake != null && !isPositiveIntegerString(input.minStake)) {
-			throw new Error('INVALID_MIN_STAKE')
+			throw new PmError('INVALID_MIN_STAKE')
 		}
 		if (input.maxStake != null && !isPositiveIntegerString(input.maxStake)) {
-			throw new Error('INVALID_MAX_STAKE')
+			throw new PmError('INVALID_MAX_STAKE')
 		}
 		if (input.perUserCap != null && !isPositiveIntegerString(input.perUserCap)) {
-			throw new Error('INVALID_PER_USER_CAP')
+			throw new PmError('INVALID_PER_USER_CAP')
 		}
 
 		// Read the active config ONCE and reuse it for the size-1 designated guard AND the market's frozen
@@ -675,7 +616,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		const designatedResolvers = normalizeDesignatedResolvers(input.designatedResolverIds)
 		if (designatedResolvers) {
 			if (isDesignatedResolver(designatedResolvers, input.createdBy)) {
-				throw new Error('CREATOR_IS_RESOLVER')
+				throw new PmError('CREATOR_IS_RESOLVER')
 			}
 			// Two-of-N settlement needs two DISTINCT approvers. It fires on the explicit `twoOfN` flag OR
 			// dynamically once the pool crosses the configured threshold (which happens AFTER create, as
@@ -692,7 +633,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			// pools is never silently skipped by designating a single resolver.
 			if (designatedResolvers.length < 2) {
 				const twoOfNPossible = (input.twoOfN ?? false) || (cfg?.twoOfNThreshold ?? null) != null
-				if (twoOfNPossible) throw new Error('DESIGNATED_RESOLVERS_INSUFFICIENT_FOR_TWO_OF_N')
+				if (twoOfNPossible) throw new PmError('DESIGNATED_RESOLVERS_INSUFFICIENT_FOR_TWO_OF_N')
 			}
 		}
 
@@ -701,7 +642,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		// (anti-spam), same as placeBet. `create_market` throttles the public forum-post fan-out.
 		if (input.enforceRateLimit) {
 			const rate = await this.consumeRateBudget(input.createdBy, 'create_market')
-			if (!rate.allowed) throw new Error(`RATE_LIMITED:${rate.retryAfterMs}`)
+			if (!rate.allowed) throw new PmError('RATE_LIMITED', { detail: rate.retryAfterMs })
 		}
 
 		try {
@@ -741,7 +682,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				})
 
 				const detail = await this.buildMarketDetail(tx, market.id)
-				if (!detail) throw new Error('MARKET_CREATE_FAILED')
+				// Internal invariant (the row was just inserted) — page if it ever fails.
+				if (!detail) throw new PmError('MARKET_CREATE_FAILED', { expected: false })
 				return detail
 			})
 		} catch (error) {
@@ -772,8 +714,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.from(pmMarkets)
 					.where(eq(pmMarkets.id, marketId))
 					.for('update')
-				if (!market) throw new Error('MARKET_NOT_FOUND')
-				if (isTerminal(market.status)) throw new Error('MARKET_NOT_EDITABLE')
+				if (!market) throw new PmError('MARKET_NOT_FOUND')
+				if (isTerminal(market.status)) throw new PmError('MARKET_NOT_EDITABLE')
 
 				const set: Partial<typeof pmMarkets.$inferInsert> = {}
 				// New values for the fields that genuinely changed — the audit metadata.
@@ -782,13 +724,13 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				if (updates.closesAt !== undefined) {
 					// The close time only governs an OPEN market; editing it on a closed/resolving one
 					// would falsely read as "betting reopened" while status stays closed.
-					if (market.status !== 'open') throw new Error('CLOSES_AT_NOT_EDITABLE')
+					if (market.status !== 'open') throw new PmError('CLOSES_AT_NOT_EDITABLE')
 					const closesAt = parseDateOrNull(updates.closesAt)
-					if (!closesAt || closesAt.getTime() <= Date.now()) throw new Error('INVALID_CLOSES_AT')
+					if (!closesAt || closesAt.getTime() <= Date.now()) throw new PmError('INVALID_CLOSES_AT')
 					// Preserve the create-time invariant: a market can't be scheduled to resolve before its
 					// betting closes. NULL-safe — legacy markets have no resolvesOn to violate.
 					if (market.resolvesOn && closesAt.getTime() > market.resolvesOn.getTime()) {
-						throw new Error('RESOLVES_ON_BEFORE_CLOSE')
+						throw new PmError('RESOLVES_ON_BEFORE_CLOSE')
 					}
 					if (closesAt.getTime() !== market.closesAt.getTime()) {
 						set.closesAt = closesAt
@@ -797,7 +739,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				}
 				if (updates.question !== undefined) {
 					const question = updates.question.trim()
-					if (!question) throw new Error('QUESTION_REQUIRED')
+					if (!question) throw new PmError('QUESTION_REQUIRED')
 					if (question !== market.question) {
 						set.question = question
 						changes.question = question
@@ -827,7 +769,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				}
 
 				const detail = await this.buildMarketDetail(tx, marketId)
-				if (!detail) throw new Error('MARKET_NOT_FOUND')
+				if (!detail) throw new PmError('MARKET_NOT_FOUND')
 				return {
 					market: detail,
 					changed: {
@@ -839,8 +781,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			})
 		} catch (error) {
 			// Caller-input rejections are expected outcomes — don't page on them.
-			const msg = error instanceof Error ? error.message : String(error)
-			if (!EXPECTED_MARKET_EDIT_ERRORS.has(msg)) {
+			if (!isExpectedError(error)) {
 				captureException(error as Error, {
 					tags: { durableObject: 'PredictionMarketsDO', method: 'updateMarket' },
 				})
@@ -905,7 +846,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		// throw outside any catch, so those infra errors were never logged or paged and surfaced to
 		// the member as a bare "Could not place your bet". Wrapping everything closes that gap.
 		try {
-			if (!isPositiveIntegerString(input.amount)) throw new Error('INVALID_AMOUNT')
+			if (!isPositiveIntegerString(input.amount)) throw new PmError('INVALID_AMOUNT')
 			const amount = parseAmount(input.amount)
 
 			// Dedupe pre-check (outside the txn): a duplicate delivery (same interaction id) returns
@@ -921,7 +862,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			// Rate limit (committed atomic upsert, before the bet txn): a rejected bet still consumes
 			// budget (anti-spam); idempotent retries never reach here (handled above).
 			const rate = await this.consumeRateBudget(input.userId, 'bet')
-			if (!rate.allowed) throw new Error(`RATE_LIMITED:${rate.retryAfterMs}`)
+			if (!rate.allowed) throw new PmError('RATE_LIMITED', { detail: rate.retryAfterMs })
 
 			return await this.db.transaction(async (tx) => {
 				// Lock the market row: serializes bet-vs-bet and bet-vs-resolve on this market.
@@ -930,16 +871,16 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.from(pmMarkets)
 					.where(eq(pmMarkets.id, input.marketId))
 					.for('update')
-				if (!market) throw new Error('MARKET_NOT_FOUND')
-				if (market.status !== 'open') throw new Error('MARKET_NOT_OPEN')
-				if (market.closesAt.getTime() <= Date.now()) throw new Error('MARKET_CLOSED')
+				if (!market) throw new PmError('MARKET_NOT_FOUND')
+				if (market.status !== 'open') throw new PmError('MARKET_NOT_OPEN')
+				if (market.closesAt.getTime() <= Date.now()) throw new PmError('MARKET_CLOSED')
 				// A creator MAY bet on their own market — they just can't resolve it (enforced by the
 				// CREATOR_CANNOT_RESOLVE / RESOLVER_HAS_POSITION guards), so they hold no power over the
 				// outcome and can't self-deal. A DESIGNATED resolver, however, holds settlement power over
 				// this market, so they must stay position-free: block their bet up front (otherwise the
 				// RESOLVER_HAS_POSITION guard would later strand a small/size-1 designated set).
 				if (isDesignatedResolver(market.designatedResolvers, input.userId)) {
-					throw new Error('DESIGNATED_RESOLVER_CANNOT_BET')
+					throw new PmError('DESIGNATED_RESOLVER_CANNOT_BET')
 				}
 
 				const [outcome] = await tx
@@ -952,11 +893,11 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						)
 					)
 					.limit(1)
-				if (!outcome) throw new Error('OUTCOME_NOT_FOUND')
+				if (!outcome) throw new PmError('OUTCOME_NOT_FOUND')
 
-				if (amount < parseAmount(market.minStake)) throw new Error('STAKE_BELOW_MIN')
+				if (amount < parseAmount(market.minStake)) throw new PmError('STAKE_BELOW_MIN')
 				if (market.maxStake != null && amount > parseAmount(market.maxStake)) {
-					throw new Error('STAKE_ABOVE_MAX')
+					throw new PmError('STAKE_ABOVE_MAX')
 				}
 				if (market.perUserCap != null) {
 					const [capRow] = await tx
@@ -970,7 +911,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 							)
 						)
 					if (parseAmount(capRow.total) + amount > parseAmount(market.perUserCap)) {
-						throw new Error('PER_USER_CAP_EXCEEDED')
+						throw new PmError('PER_USER_CAP_EXCEEDED')
 					}
 				}
 
@@ -1014,7 +955,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						)
 					)
 					.returning({ balance: pmWallets.balance })
-				if (debited.length === 0) throw new Error('INSUFFICIENT_FUNDS')
+				if (debited.length === 0) throw new PmError('INSUFFICIENT_FUNDS')
 
 				await tx.insert(pmLedger).values({
 					userId: input.userId,
@@ -1052,7 +993,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			// are normal user-facing outcomes — don't log or page on them. Everything else (a failed
 			// query, a missing table/migration, a Neon outage) is an infra failure: log it WITH the
 			// underlying driver cause and page Sentry, so a bet never dies as a silent "try again".
-			if (!isExpectedBetError(error)) {
+			if (!isExpectedError(error)) {
 				const cause = dbErrorCause(error)
 				logger.error('[PredictionMarkets] placeBet failed', {
 					marketId: input.marketId,
@@ -1083,7 +1024,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.from(pmMarkets)
 					.where(eq(pmMarkets.id, input.marketId))
 					.for('update')
-				if (!market) throw new Error('MARKET_NOT_FOUND')
+				if (!market) throw new PmError('MARKET_NOT_FOUND')
 				assertTransition(market.status, 'closed')
 				await tx
 					.update(pmMarkets)
@@ -1098,7 +1039,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				})
 			})
 		} catch (error) {
-			if (!isExpectedResolverError(error)) {
+			if (!isExpectedError(error)) {
 				captureException(error as Error, {
 					tags: { durableObject: 'PredictionMarketsDO', method: 'closeMarket' },
 				})
@@ -1293,8 +1234,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.from(pmMarkets)
 					.where(eq(pmMarkets.id, input.marketId))
 					.for('update')
-				if (!market) throw new Error('MARKET_NOT_FOUND')
-				if (market.status !== 'closed') throw new Error('MARKET_NOT_CLOSED')
+				if (!market) throw new PmError('MARKET_NOT_FOUND')
+				if (market.status !== 'closed') throw new PmError('MARKET_NOT_CLOSED')
 
 				const [outcome] = await tx
 					.select({ id: pmMarketOutcomes.id })
@@ -1306,15 +1247,15 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						)
 					)
 					.limit(1)
-				if (!outcome) throw new Error('OUTCOME_NOT_FOUND')
+				if (!outcome) throw new PmError('OUTCOME_NOT_FOUND')
 
-				if (market.createdBy === input.resolverId) throw new Error('CREATOR_CANNOT_RESOLVE')
+				if (market.createdBy === input.resolverId) throw new PmError('CREATOR_CANNOT_RESOLVE')
 				if (await this.hasPosition(tx, input.marketId, input.resolverId)) {
-					throw new Error('RESOLVER_HAS_POSITION')
+					throw new PmError('RESOLVER_HAS_POSITION')
 				}
 				const bypass = input.bypassDesignated ?? false
 				if (!canResolveDesignated(market.designatedResolvers, input.resolverId, bypass)) {
-					throw new Error('NOT_DESIGNATED_RESOLVER')
+					throw new PmError('NOT_DESIGNATED_RESOLVER')
 				}
 				const viaOverride = isDesignatedOverride(
 					market.designatedResolvers,
@@ -1371,7 +1312,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				}
 			})
 		} catch (error) {
-			if (!isExpectedResolverError(error)) {
+			if (!isExpectedError(error)) {
 				captureException(error as Error, {
 					tags: { durableObject: 'PredictionMarketsDO', method: 'proposeResolution' },
 				})
@@ -1393,8 +1334,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.from(pmMarkets)
 					.where(eq(pmMarkets.id, input.marketId))
 					.for('update')
-				if (!market) throw new Error('MARKET_NOT_FOUND')
-				if (market.status !== 'resolving') throw new Error('MARKET_NOT_RESOLVING')
+				if (!market) throw new PmError('MARKET_NOT_FOUND')
+				if (market.status !== 'resolving') throw new PmError('MARKET_NOT_RESOLVING')
 
 				const [proposal] = await tx
 					.select()
@@ -1402,21 +1343,21 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.where(eq(pmResolutionProposals.id, input.proposalId))
 					.limit(1)
 				if (!proposal || proposal.marketId !== input.marketId) {
-					throw new Error('PROPOSAL_NOT_FOUND')
+					throw new PmError('PROPOSAL_NOT_FOUND')
 				}
-				if (proposal.status !== 'pending') throw new Error('PROPOSAL_NOT_PENDING')
+				if (proposal.status !== 'pending') throw new PmError('PROPOSAL_NOT_PENDING')
 
 				// Two distinct resolvers, neither the creator, neither holding a position, and — when the
 				// market is designated — both the proposer (checked in proposeResolution) and this approver
 				// must be designated members (or hold the admin/manager override).
-				if (proposal.proposedBy === input.resolverId) throw new Error('APPROVER_MUST_DIFFER')
-				if (market.createdBy === input.resolverId) throw new Error('CREATOR_CANNOT_RESOLVE')
+				if (proposal.proposedBy === input.resolverId) throw new PmError('APPROVER_MUST_DIFFER')
+				if (market.createdBy === input.resolverId) throw new PmError('CREATOR_CANNOT_RESOLVE')
 				if (await this.hasPosition(tx, input.marketId, input.resolverId)) {
-					throw new Error('RESOLVER_HAS_POSITION')
+					throw new PmError('RESOLVER_HAS_POSITION')
 				}
 				const bypass = input.bypassDesignated ?? false
 				if (!canResolveDesignated(market.designatedResolvers, input.resolverId, bypass)) {
-					throw new Error('NOT_DESIGNATED_RESOLVER')
+					throw new PmError('NOT_DESIGNATED_RESOLVER')
 				}
 				const viaOverride = isDesignatedOverride(
 					market.designatedResolvers,
@@ -1459,7 +1400,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				return { marketId: market.id, status: finalStatus, resolvedOutcomeId }
 			})
 		} catch (error) {
-			if (!isExpectedResolverError(error)) {
+			if (!isExpectedError(error)) {
 				captureException(error as Error, {
 					tags: { durableObject: 'PredictionMarketsDO', method: 'approveResolution' },
 				})
@@ -1476,7 +1417,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		bypassDesignated?: boolean
 		adminOverride?: boolean
 	}): Promise<void> {
-		if (!input.reason.trim()) throw new Error('VOID_REASON_REQUIRED')
+		if (!input.reason.trim()) throw new PmError('VOID_REASON_REQUIRED')
 		try {
 			await this.db.transaction(async (tx) => {
 				const [market] = await tx
@@ -1484,8 +1425,8 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					.from(pmMarkets)
 					.where(eq(pmMarkets.id, input.marketId))
 					.for('update')
-				if (!market) throw new Error('MARKET_NOT_FOUND')
-				if (isTerminal(market.status)) throw new Error('MARKET_TERMINAL')
+				if (!market) throw new PmError('MARKET_NOT_FOUND')
+				if (isTerminal(market.status)) throw new PmError('MARKET_TERMINAL')
 
 				const bypass = input.bypassDesignated ?? false
 				// A site admin (adminOverride) may void ANY market unconditionally. A void refunds every
@@ -1500,12 +1441,12 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					// Voiding is a terminal settlement, so it carries the same conflict-of-interest guards as
 					// resolve/approve: a creator can't void their own market, and a resolver holding a
 					// position can't void one they have a stake in.
-					if (market.createdBy === input.actorUserId) throw new Error('CREATOR_CANNOT_RESOLVE')
+					if (market.createdBy === input.actorUserId) throw new PmError('CREATOR_CANNOT_RESOLVE')
 					if (await this.hasPosition(tx, input.marketId, input.actorUserId)) {
-						throw new Error('RESOLVER_HAS_POSITION')
+						throw new PmError('RESOLVER_HAS_POSITION')
 					}
 					if (!canResolveDesignated(market.designatedResolvers, input.actorUserId, bypass)) {
-						throw new Error('NOT_DESIGNATED_RESOLVER')
+						throw new PmError('NOT_DESIGNATED_RESOLVER')
 					}
 
 					// Contested markets (bets on 2+ outcomes) require a distinct second approver.
@@ -1515,7 +1456,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						.where(and(eq(pmBets.marketId, input.marketId), eq(pmBets.status, 'active')))
 					const contested = (distinctRow?.n ?? 0) >= 2
 					if (contested && (!input.approverId || input.approverId === input.actorUserId)) {
-						throw new Error('CONTESTED_VOID_REQUIRES_APPROVER')
+						throw new PmError('CONTESTED_VOID_REQUIRES_APPROVER')
 					}
 					// On a designated market, the contested-void second approver must ALSO be a designated
 					// member (unless overriding). NOTE: the DO cannot verify approverId's resolver TIER —
@@ -1525,7 +1466,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 					// the initiating actor.
 					if (contested && input.approverId && !bypass) {
 						if (!canResolveDesignated(market.designatedResolvers, input.approverId, false)) {
-							throw new Error('NOT_DESIGNATED_RESOLVER')
+							throw new PmError('NOT_DESIGNATED_RESOLVER')
 						}
 					}
 				}
@@ -1545,7 +1486,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 				)
 			})
 		} catch (error) {
-			if (!isExpectedResolverError(error)) {
+			if (!isExpectedError(error)) {
 				captureException(error as Error, {
 					tags: { durableObject: 'PredictionMarketsDO', method: 'voidMarket' },
 				})
@@ -1885,7 +1826,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 	 */
 	private async computeThresholdImpact(candidate: string | null): Promise<ThresholdImpact> {
 		if (candidate !== null && !isPositiveIntegerString(candidate))
-			throw new Error('INVALID_THRESHOLD')
+			throw new PmError('INVALID_THRESHOLD')
 		const cfg = await this.readActiveConfig()
 		const rows = await this.db
 			.select({
@@ -1919,11 +1860,11 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			input.defaultRakeBps < 0 ||
 			input.defaultRakeBps > 2000
 		) {
-			throw new Error('INVALID_RAKE')
+			throw new PmError('INVALID_RAKE')
 		}
-		if (!isPositiveIntegerString(input.defaultMinStake)) throw new Error('INVALID_MIN_STAKE')
+		if (!isPositiveIntegerString(input.defaultMinStake)) throw new PmError('INVALID_MIN_STAKE')
 		if (input.twoOfNThreshold !== null && !isPositiveIntegerString(input.twoOfNThreshold)) {
-			throw new Error('INVALID_THRESHOLD')
+			throw new PmError('INVALID_THRESHOLD')
 		}
 		// Creator rake-reward band: both bounds whole bps in [0, 10000] (fraction of the rake) and
 		// min ≤ max. Both 0 disables the feature. Enforced here (route also validates) so the stored
@@ -1937,11 +1878,11 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 			input.creatorRewardMaxBps > 10_000 ||
 			input.creatorRewardMinBps > input.creatorRewardMaxBps
 		) {
-			throw new Error('INVALID_CREATOR_REWARD')
+			throw new PmError('INVALID_CREATOR_REWARD')
 		}
 		// DO owns the invariant (the route caps at 500 too). Bound the free-text note defensively.
 		if (input.changeNote != null && input.changeNote.length > 500) {
-			throw new Error('INVALID_CHANGE_NOTE')
+			throw new PmError('INVALID_CHANGE_NOTE')
 		}
 
 		try {
@@ -1982,7 +1923,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 						.from(pmMarkets)
 						.where(inArray(pmMarkets.status, ['open', 'closed']))
 					const impact = bucketThresholdImpact(marketRows, curThreshold, input.twoOfNThreshold)
-					if (impact.strandedCandidates.length > 0) throw new Error('THRESHOLD_WOULD_STRAND')
+					if (impact.strandedCandidates.length > 0) throw new PmError('THRESHOLD_WOULD_STRAND')
 				}
 				await tx
 					.update(pmConfig)
@@ -2012,7 +1953,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		} catch (error) {
 			// THRESHOLD_WOULD_STRAND is an expected governance rejection (thrown in-tx) — surface it
 			// without paging; everything else is an infra failure worth capturing.
-			if (!(error instanceof Error && error.message === 'THRESHOLD_WOULD_STRAND')) {
+			if (!isExpectedError(error)) {
 				captureException(error as Error, {
 					tags: { durableObject: 'PredictionMarketsDO', method: 'updateConfig' },
 				})

--- a/apps/prediction-markets/src/lib/__tests__/errors.test.ts
+++ b/apps/prediction-markets/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { isExpectedError, PmError } from '../errors'
+import { assertTransition } from '../state-machine'
+
+describe('PmError', () => {
+	it('sets message === code so RPC-boundary string matching keeps working', () => {
+		const err = new PmError('MARKET_NOT_FOUND')
+		expect(err).toBeInstanceOf(Error)
+		expect(err.message).toBe('MARKET_NOT_FOUND')
+		expect(err.code).toBe('MARKET_NOT_FOUND')
+		expect(err.name).toBe('PmError')
+	})
+
+	it('defaults to expected=true (a normal user-facing rejection)', () => {
+		expect(new PmError('INSUFFICIENT_FUNDS').expected).toBe(true)
+	})
+
+	it('honors expected=false for internal invariants', () => {
+		expect(new PmError('MARKET_CREATE_FAILED', { expected: false }).expected).toBe(false)
+	})
+
+	it('appends a detail suffix to the message (e.g. RATE_LIMITED:1234) while keeping the bare code', () => {
+		const err = new PmError('RATE_LIMITED', { detail: 1234 })
+		expect(err.message).toBe('RATE_LIMITED:1234')
+		expect(err.code).toBe('RATE_LIMITED')
+		// Core parses the retry-after off the message prefix.
+		expect(err.message.startsWith('RATE_LIMITED')).toBe(true)
+	})
+})
+
+describe('isExpectedError', () => {
+	it('returns the PmError verdict (expected rejections are not paged)', () => {
+		expect(isExpectedError(new PmError('MARKET_CLOSED'))).toBe(true)
+		expect(isExpectedError(new PmError('RATE_LIMITED', { detail: 5 }))).toBe(true)
+		expect(isExpectedError(new PmError('MARKET_CREATE_FAILED', { expected: false }))).toBe(false)
+	})
+
+	it('treats the state-machine assertTransition throw as expected (matched by message prefix)', () => {
+		let thrown: unknown
+		try {
+			assertTransition('resolved', 'open') // terminal -> illegal
+		} catch (e) {
+			thrown = e
+		}
+		expect(thrown).toBeInstanceOf(Error)
+		expect(isExpectedError(thrown)).toBe(true)
+	})
+
+	it('treats an arbitrary infra error (or non-error) as unexpected (pages)', () => {
+		expect(isExpectedError(new Error('Failed query: relation "pm_bets" does not exist'))).toBe(
+			false
+		)
+		expect(isExpectedError('boom')).toBe(false)
+		expect(isExpectedError(undefined)).toBe(false)
+	})
+})

--- a/apps/prediction-markets/src/lib/__tests__/money.test.ts
+++ b/apps/prediction-markets/src/lib/__tests__/money.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	formatAmount,
+	isNonNegativeIntegerString,
+	isPositiveIntegerString,
+	negateAmount,
+	parseAmount,
+} from '../money'
+
+describe('parseAmount', () => {
+	it('parses plain integer strings to BigInt', () => {
+		expect(parseAmount('0')).toBe(0n)
+		expect(parseAmount('1')).toBe(1n)
+		expect(parseAmount('100')).toBe(100n)
+	})
+
+	it('treats null / undefined / empty string as zero', () => {
+		expect(parseAmount(null)).toBe(0n)
+		expect(parseAmount(undefined)).toBe(0n)
+		expect(parseAmount('')).toBe(0n)
+	})
+
+	it('truncates any fractional component toward the integer part', () => {
+		// The DB stores integer points, but a bare `numeric` column (or a SUM) could yield a decimal
+		// suffix; parseAmount floors it by splitting on '.' rather than rejecting. Documented behavior.
+		expect(parseAmount('100.00')).toBe(100n)
+		expect(parseAmount('100.99')).toBe(100n)
+		expect(parseAmount('5.5')).toBe(5n)
+	})
+
+	it('preserves values beyond Number.MAX_SAFE_INTEGER exactly (the reason for BigInt)', () => {
+		// 2^53 + 1 — not representable as a JS number, so a float-based parse would corrupt it.
+		expect(parseAmount('9007199254740993')).toBe(9007199254740993n)
+		expect(parseAmount('999999999999999999999')).toBe(999999999999999999999n)
+	})
+
+	it('tolerates a negative integer string (callers gate positivity separately)', () => {
+		expect(parseAmount('-100')).toBe(-100n)
+	})
+})
+
+describe('formatAmount', () => {
+	it('renders a BigInt as its decimal string', () => {
+		expect(formatAmount(0n)).toBe('0')
+		expect(formatAmount(100n)).toBe('100')
+		expect(formatAmount(-100n)).toBe('-100')
+	})
+
+	it('round-trips with parseAmount for integer strings', () => {
+		for (const s of ['0', '1', '42', '1000000', '9007199254740993']) {
+			expect(formatAmount(parseAmount(s))).toBe(s)
+		}
+	})
+})
+
+describe('negateAmount', () => {
+	it('flips the sign of a decimal-string amount', () => {
+		expect(negateAmount('100')).toBe('-100')
+		expect(negateAmount('-100')).toBe('100')
+		expect(negateAmount('1')).toBe('-1')
+	})
+
+	it('keeps zero as an unsigned "0"', () => {
+		expect(negateAmount('0')).toBe('0')
+	})
+
+	it('is its own inverse', () => {
+		expect(negateAmount(negateAmount('250'))).toBe('250')
+	})
+})
+
+describe('isPositiveIntegerString', () => {
+	it('accepts strictly-positive integers', () => {
+		expect(isPositiveIntegerString('1')).toBe(true)
+		expect(isPositiveIntegerString('100')).toBe(true)
+		// Leading zeros are permitted (regex is digit-only, not canonical-form).
+		expect(isPositiveIntegerString('007')).toBe(true)
+	})
+
+	it('rejects zero, negatives, decimals, blanks and non-digits', () => {
+		expect(isPositiveIntegerString('0')).toBe(false)
+		expect(isPositiveIntegerString('')).toBe(false)
+		expect(isPositiveIntegerString('-5')).toBe(false)
+		expect(isPositiveIntegerString('1.5')).toBe(false)
+		expect(isPositiveIntegerString(' 5')).toBe(false)
+		expect(isPositiveIntegerString('5 ')).toBe(false)
+		expect(isPositiveIntegerString('abc')).toBe(false)
+	})
+})
+
+describe('isNonNegativeIntegerString', () => {
+	it('accepts zero and positive integers (incl. leading zeros)', () => {
+		expect(isNonNegativeIntegerString('0')).toBe(true)
+		expect(isNonNegativeIntegerString('1')).toBe(true)
+		expect(isNonNegativeIntegerString('100')).toBe(true)
+		expect(isNonNegativeIntegerString('007')).toBe(true)
+	})
+
+	it('rejects the empty string, negatives, decimals and non-digits', () => {
+		// \d+ requires at least one digit, so '' does NOT match.
+		expect(isNonNegativeIntegerString('')).toBe(false)
+		expect(isNonNegativeIntegerString('-1')).toBe(false)
+		expect(isNonNegativeIntegerString('1.0')).toBe(false)
+		expect(isNonNegativeIntegerString('abc')).toBe(false)
+	})
+})

--- a/apps/prediction-markets/src/lib/errors.ts
+++ b/apps/prediction-markets/src/lib/errors.ts
@@ -1,0 +1,92 @@
+/**
+ * Typed domain errors for the prediction-markets DO.
+ *
+ * Every user-facing rejection is a `PmError` whose `code` is one of `PmErrorCode` — so a typo is a
+ * compile error rather than a silently-unhandled string — and whose `message` IS that code. Only
+ * `.message` survives the Durable Object RPC boundary, and core/discord consumers string-match on it
+ * (e.g. `msg === 'MARKET_NOT_FOUND'`, `msg.startsWith('RATE_LIMITED')`), so the message contract is
+ * preserved exactly.
+ *
+ * The `expected` flag never crosses RPC; it drives the DO's OWN Sentry-paging decision. Declaring it
+ * at each throw (default: expected) replaces the three hand-maintained EXPECTED_* sets + parallel
+ * `isExpected*` helpers with a single source of truth per error.
+ */
+
+export type PmErrorCode =
+	| 'APPROVER_MUST_DIFFER'
+	| 'AT_LEAST_TWO_OUTCOMES'
+	| 'CLOSES_AT_NOT_EDITABLE'
+	| 'CONTESTED_VOID_REQUIRES_APPROVER'
+	| 'CREATOR_CANNOT_RESOLVE'
+	| 'CREATOR_IS_RESOLVER'
+	| 'DESIGNATED_RESOLVER_CANNOT_BET'
+	| 'DESIGNATED_RESOLVERS_INSUFFICIENT_FOR_TWO_OF_N'
+	| 'DUPLICATE_OUTCOMES'
+	| 'IDEMPOTENCY_KEY_CONFLICT'
+	| 'INSUFFICIENT_FUNDS'
+	| 'INVALID_AMOUNT'
+	| 'INVALID_CHANGE_NOTE'
+	| 'INVALID_CLOSES_AT'
+	| 'INVALID_CREATOR_REWARD'
+	| 'INVALID_MAX_STAKE'
+	| 'INVALID_MIN_STAKE'
+	| 'INVALID_PER_USER_CAP'
+	| 'INVALID_RAKE'
+	| 'INVALID_RESOLVES_ON'
+	| 'INVALID_THRESHOLD'
+	| 'MARKET_CLOSED'
+	| 'MARKET_CREATE_FAILED'
+	| 'MARKET_NOT_CLOSED'
+	| 'MARKET_NOT_EDITABLE'
+	| 'MARKET_NOT_FOUND'
+	| 'MARKET_NOT_OPEN'
+	| 'MARKET_NOT_RESOLVING'
+	| 'MARKET_TERMINAL'
+	| 'NOT_DESIGNATED_RESOLVER'
+	| 'OUTCOME_NOT_FOUND'
+	| 'PER_USER_CAP_EXCEEDED'
+	| 'PROPOSAL_NOT_FOUND'
+	| 'PROPOSAL_NOT_PENDING'
+	| 'QUESTION_REQUIRED'
+	| 'RATE_LIMITED'
+	| 'REASON_REQUIRED'
+	| 'RESOLVER_HAS_POSITION'
+	| 'RESOLVES_ON_BEFORE_CLOSE'
+	| 'SELF_TARGET_FORBIDDEN'
+	| 'STAKE_ABOVE_MAX'
+	| 'STAKE_BELOW_MIN'
+	| 'SYSTEM_TARGET_FORBIDDEN'
+	| 'THRESHOLD_WOULD_STRAND'
+	| 'TOO_MANY_OUTCOMES'
+	| 'VOID_REASON_REQUIRED'
+
+export class PmError extends Error {
+	readonly code: PmErrorCode
+	/** True for normal user-facing rejections (surfaced but NOT paged); false for internal invariants. */
+	readonly expected: boolean
+
+	constructor(code: PmErrorCode, opts?: { expected?: boolean; detail?: string | number }) {
+		// message === code (optionally `code:detail`, e.g. `RATE_LIMITED:1234`) so the existing
+		// string-matching consumers across the RPC boundary keep working — the class and its extra
+		// properties do NOT survive RPC serialization, only `.message` does.
+		super(opts?.detail != null ? `${code}:${opts.detail}` : code)
+		this.name = 'PmError'
+		this.code = code
+		this.expected = opts?.expected ?? true
+	}
+}
+
+/** Prefix of the raw Error thrown by the state-machine's `assertTransition` (a stale-state guard). */
+const TRANSITION_ERROR_PREFIX = 'prediction-markets: invalid market transition'
+
+/**
+ * True for expected (user-facing) rejections the DO should surface to the caller WITHOUT paging Sentry.
+ * Replaces the former `isExpectedBetError` / `isExpectedResolverError` / `EXPECTED_MARKET_EDIT_ERRORS`
+ * trio: a `PmError` carries its own verdict, and the one non-`PmError` expected throw — the
+ * state-machine's `assertTransition` — is matched by its stable message prefix.
+ */
+export function isExpectedError(error: unknown): boolean {
+	if (error instanceof PmError) return error.expected
+	const msg = error instanceof Error ? error.message : String(error)
+	return msg.startsWith(TRANSITION_ERROR_PREFIX)
+}

--- a/apps/ui/src/client/features/prediction-markets/types.ts
+++ b/apps/ui/src/client/features/prediction-markets/types.ts
@@ -7,15 +7,20 @@
  */
 
 import type {
+	CreateMarketInput,
 	GlobalLedgerRow,
+	GrantPointsInput,
 	LedgerType,
 	MarketDetail,
 	MarketHistoryRow,
 	MarketStatus,
 	MarketSummary,
+	Paged,
 	PmConfigView,
 	StrandedMarket,
 	ThresholdImpact,
+	UpdateConfigInput,
+	UpdateMarketInput,
 	WalletRow,
 } from '@repo/prediction-markets'
 
@@ -26,16 +31,12 @@ export type {
 	MarketHistoryRow,
 	MarketStatus,
 	MarketSummary,
+	// Re-exported from the DO contract so the L1 list endpoints share one paged envelope.
+	Paged,
 	PmConfigView,
 	StrandedMarket,
 	ThresholdImpact,
 	WalletRow,
-}
-
-/** Generic paged envelope returned by every L1 list endpoint. */
-export interface Paged<T> {
-	rows: T[]
-	total: number
 }
 
 /** Enriched display identity attached to wallet/ledger rows by the core route. */
@@ -93,13 +94,11 @@ export interface MarketHistoryFilters {
 
 // --- deposit mutation ------------------------------------------------------
 
-export interface DepositRequest {
-	targetUserId: string
-	/** Integer string (numeric). DISPLAY ONLY — never Number() arithmetic. */
-	amount: string
-	reason: string
-	idempotencyKey?: string
-}
+/**
+ * Deposit (grant) wire body. Derived from the DO contract minus the server-injected `actorUserId`
+ * (the core route fills it from the session), so it can never drift from GrantPointsInput.
+ */
+export type DepositRequest = Omit<GrantPointsInput, 'actorUserId'>
 
 export interface DepositResponse {
 	/** Resulting wallet balance, integer string. */
@@ -109,27 +108,12 @@ export interface DepositResponse {
 
 // --- markets ---------------------------------------------------------------
 
-export interface CreateMarketRequest {
-	question: string
-	description?: string
-	outcomes: string[]
-	/** ISO-8601 timestamp when betting closes. */
-	closesAt: string
-	/** ISO-8601 expected resolution date. Required; must be at or after closesAt. */
-	resolvesOn: string
-	rakeBps?: number
-	/** Integer strings (numeric). DISPLAY ONLY — never Number() arithmetic. */
-	minStake?: string
-	maxStake?: string
-	perUserCap?: string
-	twoOfN?: boolean
-	/**
-	 * Optional core user ids to designate as this market's resolver(s). Admin surface only; the server
-	 * validates each holds the resolver tier and rejects designating the creator. Omit/empty => the
-	 * market uses global resolver authority.
-	 */
-	designatedResolverIds?: string[]
-}
+/**
+ * Market-create wire body. Derived from the DO contract minus the fields the server injects
+ * (`createdBy` from the session, `enforceRateLimit` as a server-set policy flag), so the admin and
+ * member create forms stay in lockstep with CreateMarketInput.
+ */
+export type CreateMarketRequest = Omit<CreateMarketInput, 'createdBy' | 'enforceRateLimit'>
 
 export interface CreateMarketResponse {
 	market: MarketDetail
@@ -139,13 +123,8 @@ export interface CreateMarketResponse {
 	postError: string | null
 }
 
-/** Partial admin edit of a market's safe fields. At least one must be present. */
-export interface UpdateMarketRequest {
-	/** ISO-8601; must be in the future. */
-	closesAt?: string
-	question?: string
-	description?: string | null
-}
+/** Partial admin edit of a market's safe fields (at least one present). Identical to the DO contract. */
+export type UpdateMarketRequest = UpdateMarketInput
 
 export interface UpdateMarketResponse {
 	market: MarketDetail
@@ -164,13 +143,9 @@ export interface MarketsResponse {
 
 // --- config ----------------------------------------------------------------
 
-/** Full-replace config write. Monetary fields are integer strings; threshold null = disable two-of-N. */
-export interface UpdateConfigRequest {
-	defaultRakeBps: number
-	defaultMinStake: string
-	twoOfNThreshold: string | null
-	/** Creator rake-reward band as a fraction of the rake in bps (0–10000). Both 0 disables it. */
-	creatorRewardMinBps: number
-	creatorRewardMaxBps: number
-	changeNote?: string
-}
+/**
+ * Full-replace config write. Derived from the DO contract minus the server-injected `actorUserId`.
+ * (Previously re-declared here with `changeNote: string`, which had drifted from the contract's
+ * `changeNote?: string | null` — deriving keeps the wire type and the DO input in lockstep.)
+ */
+export type UpdateConfigRequest = Omit<UpdateConfigInput, 'actorUserId'>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Replaces the prediction-markets Durable Object's three hand-maintained `EXPECTED_*` error-name sets (plus their parallel `isExpected*` helpers) with a single `PmError` class over a typed `PmErrorCode` union and one `isExpectedError()` check. This makes each throw self-declare whether it's an expected user-facing rejection or an internal invariant that should page Sentry, and turns unknown/typo'd error codes into compile errors instead of silently falling through the old string sets.

## Changes
- Added `apps/prediction-markets/src/lib/errors.ts` with the `PmErrorCode` union (all domain error strings), the `PmError` class (`code`, `expected` flag defaulting to `true`, `message === code` with an optional `:detail` suffix for `RATE_LIMITED`), and `isExpectedError()`.
- `isExpectedError()` treats a `PmError` by its own `expected` flag, and falls back to matching the state machine's raw `assertTransition` throw by its stable message prefix.
- Replaced the `throw new Error(...)` call sites in `durable-object.ts` (grantPoints, createMarket, updateMarket, placeBet, closeMarket, proposeResolution, approveResolution, voidMarket, updateConfig, etc.) with `throw new PmError(...)`.
- `MARKET_CREATE_FAILED` is now explicitly marked `expected: false` (the sole internal invariant that pages Sentry); `RATE_LIMITED` uses the new `detail` option instead of manual template-string interpolation.
- Removed `EXPECTED_BET_ERRORS`, `EXPECTED_RESOLVER_ERRORS`, `EXPECTED_MARKET_EDIT_ERRORS`, `isExpectedBetError`, and `isExpectedResolverError`, replacing their call sites with `isExpectedError()`.
- Added `apps/prediction-markets/src/lib/__tests__/errors.test.ts` covering `PmError` construction/defaults, the `RATE_LIMITED:<detail>` message suffix, and `isExpectedError()` behavior for `PmError`, the `assertTransition` prefix match, and arbitrary/non-Error values.

Behavior-preserving: `message` still equals the bare code (with the `RATE_LIMITED:<ms>` suffix intact) so existing string-matching consumers across the RPC boundary (core/discord) are unaffected, and every catch block's Sentry-paging decision is unchanged.

## Testing
- Added unit tests in `errors.test.ts` (commit message notes 74 unit tests passing).
<!-- claude:end -->