### PR TITLE
feat(do-utils): fluent type-safe DO accessor (forDO)

### DIFF
--- a/packages/do-utils/package.json
+++ b/packages/do-utils/package.json
@@ -7,7 +7,8 @@
 	"main": "src/index.ts",
 	"scripts": {
 		"check:lint": "run-eslint",
-		"check:types": "run-tsc"
+		"check:types": "run-tsc",
+		"test": "run-vitest"
 	},
 	"dependencies": {
 		"drizzle-orm": "0.44.7"
@@ -15,6 +16,7 @@
 	"devDependencies": {
 		"@repo/eslint-config": "workspace:*",
 		"@repo/tools": "workspace:*",
-		"@repo/typescript-config": "workspace:*"
+		"@repo/typescript-config": "workspace:*",
+		"vitest": "3.2.4"
 	}
 }

--- a/packages/do-utils/src/for-do.test.ts
+++ b/packages/do-utils/src/for-do.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+
+import { forDO, shardIndex, shardName } from './for-do'
+
+// ---------------------------------------------------------------------------
+// shardIndex — the FNV-1a-64 -> Lamping-Veach jump-consistent-hash core.
+//
+// GOLDEN VECTORS: exact `shardIndex(key, N)` outputs captured from this module.
+// They are a CHANGE DETECTOR for the FROZEN routing contract — the FNV/LCG
+// constants and the two-byte UTF-16 hashing. If any of them change, these break
+// in CI *before* the change can silently re-route production keys onto empty,
+// un-backfilled shards. Do NOT "fix" a failure by updating the numbers unless
+// you have consciously reshuffled every key and planned a full backfill.
+// ---------------------------------------------------------------------------
+const GOLDEN: Record<string, number> = {
+	'default|1': 0,
+	'default|2': 0,
+	'default|4': 0,
+	'default|8': 7,
+	'default|16': 11,
+	'default|64': 29,
+	'gateway|2': 1,
+	'gateway|16': 15,
+	'90000001|8': 1,
+	'90000001|64': 40,
+	'fleet-12345|16': 0,
+	'fleet-12345|64': 47,
+	'region-10000002|8': 4,
+	'region-10000002|16': 8,
+	'corp:98000001|4': 3,
+	'corp:98000001|16': 15,
+	// Non-ASCII: exercises the two-byte-per-code-unit hashing path.
+	'キャラクター|4': 3,
+	'キャラクター|8': 5,
+	'キャラクター|16': 14,
+	'キャラクター|64': 47,
+	// Empty string is a valid key (digest = FNV offset basis).
+	'|2': 1,
+	'|16': 13,
+}
+
+describe('shardIndex — golden vectors (frozen routing contract)', () => {
+	for (const [spec, expected] of Object.entries(GOLDEN)) {
+		const sep = spec.lastIndexOf('|')
+		const key = spec.slice(0, sep)
+		const shards = Number(spec.slice(sep + 1))
+		it(`${JSON.stringify(key)} @ ${shards} shards -> ${expected}`, () => {
+			expect(shardIndex(key, shards)).toBe(expected)
+		})
+	}
+})
+
+describe('shardIndex — invariants', () => {
+	const keys = ['default', 'gateway', 'a', '90000001', 'fleet-12345', 'キャラクター', '', 'x'.repeat(256)]
+
+	it('is deterministic — same (key, N) always maps to the same shard', () => {
+		for (const key of keys) {
+			for (const n of [1, 3, 7, 16, 100]) {
+				expect(shardIndex(key, n)).toBe(shardIndex(key, n))
+			}
+		}
+	})
+
+	it('always returns an integer in [0, N)', () => {
+		for (const key of keys) {
+			for (const n of [1, 2, 5, 16, 97, 1000]) {
+				const idx = shardIndex(key, n)
+				expect(Number.isInteger(idx)).toBe(true)
+				expect(idx).toBeGreaterThanOrEqual(0)
+				expect(idx).toBeLessThan(n)
+			}
+		}
+	})
+
+	it('maps every key to shard 0 when N === 1', () => {
+		for (const key of keys) {
+			expect(shardIndex(key, 1)).toBe(0)
+		}
+	})
+
+	it('is grow-only: N -> N+1 either keeps a key or moves it onto the new top shard (never reshuffles between existing shards)', () => {
+		// The defining property of jump consistent hash. This is what makes growing
+		// the shard count cheap (~1/(N+1) of keys move) and safe.
+		for (const key of keys) {
+			for (let n = 1; n < 128; n++) {
+				const before = shardIndex(key, n)
+				const after = shardIndex(key, n + 1)
+				// after is either unchanged, or exactly the newly added shard index (n).
+				expect(after === before || after === n).toBe(true)
+			}
+		}
+	})
+
+	it('distributes a large key population roughly uniformly', () => {
+		const shards = 16
+		const counts = new Array<number>(shards).fill(0)
+		const total = 20_000
+		for (let i = 0; i < total; i++) {
+			counts[shardIndex(`entity-${i}`, shards)]++
+		}
+		const expectedPerShard = total / shards
+		// Every shard should be within 25% of the mean — loose enough to never flake,
+		// tight enough to catch a badly skewed or constant hash.
+		for (const c of counts) {
+			expect(c).toBeGreaterThan(expectedPerShard * 0.75)
+			expect(c).toBeLessThan(expectedPerShard * 1.25)
+		}
+	})
+
+	it('rejects invalid shard counts', () => {
+		for (const bad of [0, -1, 1.5, NaN, Infinity]) {
+			expect(() => shardIndex('k', bad)).toThrow(RangeError)
+		}
+	})
+})
+
+describe('shardName', () => {
+	it('formats as `${prefix}:${index}` with the default prefix', () => {
+		expect(shardName('fleet-12345', 16)).toBe('shard:0')
+		expect(shardName('default', 16)).toBe('shard:11')
+	})
+
+	it('honors a custom prefix', () => {
+		expect(shardName('x', 8, 'replica')).toBe(`replica:${shardIndex('x', 8)}`)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// forDO routing — verify each mode targets the expected DO instance NAME.
+// A minimal fake namespace records the name each mode resolves to (getByName),
+// so we assert routing without a live Durable Object runtime.
+// ---------------------------------------------------------------------------
+interface RoutedStub {
+	__name?: string
+	__id?: unknown
+}
+
+function fakeNamespace(): {
+	ns: {
+		get(id: unknown): RoutedStub
+		getByName(name: string): RoutedStub
+		jurisdiction(j: string): unknown
+	}
+	byNameCalls: string[]
+	jurisdictions: string[]
+} {
+	const byNameCalls: string[] = []
+	const jurisdictions: string[] = []
+	const ns = {
+		get(id: unknown): RoutedStub {
+			return { __id: id }
+		},
+		getByName(name: string): RoutedStub {
+			byNameCalls.push(name)
+			return { __name: name }
+		},
+		jurisdiction(j: string) {
+			jurisdictions.push(j)
+			return ns
+		},
+	}
+	return { ns, byNameCalls, jurisdictions }
+}
+
+describe('forDO — mode routing', () => {
+	// The fake satisfies the structural AnyDoNamespace shape; cast through unknown
+	// since it is not a real branded DurableObjectNamespace.
+	const wrap = (f: ReturnType<typeof fakeNamespace>) =>
+		forDO<RoutedStub>(f.ns as unknown as Parameters<typeof forDO<RoutedStub>>[0])
+
+	it('singleton() routes to getByName("default")', () => {
+		const f = fakeNamespace()
+		wrap(f).singleton()
+		expect(f.byNameCalls).toEqual(['default'])
+	})
+
+	it('byName(name) routes to getByName(name)', () => {
+		const f = fakeNamespace()
+		wrap(f).byName('corp:98000001')
+		expect(f.byNameCalls).toEqual(['corp:98000001'])
+	})
+
+	it('sharded().forKey(key) routes to the key\'s owning shard name', () => {
+		const f = fakeNamespace()
+		const shards = 16
+		wrap(f).sharded({ shards }).forKey('fleet-12345')
+		expect(f.byNameCalls).toEqual([shardName('fleet-12345', shards)])
+	})
+
+	it('sharded().shard(i) routes by index and range-checks', () => {
+		const f = fakeNamespace()
+		const client = wrap(f).sharded({ shards: 8 })
+		client.shard(3)
+		expect(f.byNameCalls).toEqual(['shard:3'])
+		expect(() => client.shard(8)).toThrow(RangeError)
+		expect(() => client.shard(-1)).toThrow(RangeError)
+	})
+
+	it('sharded().all() returns one stub per shard, in index order', () => {
+		const f = fakeNamespace()
+		const stubs = wrap(f).sharded({ shards: 4 }).all()
+		expect(stubs.map((s) => s.__name)).toEqual(['shard:0', 'shard:1', 'shard:2', 'shard:3'])
+	})
+
+	it('sharded().map(fn) fans out across all shards and collects in order', async () => {
+		const f = fakeNamespace()
+		const names = await wrap(f)
+			.sharded({ shards: 4 })
+			.map((s) => s.__name)
+		expect(names).toEqual(['shard:0', 'shard:1', 'shard:2', 'shard:3'])
+	})
+
+	it('sharded honors a custom prefix so shard names cannot collide with entity keys', () => {
+		const f = fakeNamespace()
+		wrap(f).sharded({ shards: 4, prefix: 'replica' }).forKey('k')
+		expect(f.byNameCalls[0]).toBe(shardName('k', 4, 'replica'))
+	})
+
+	it('jurisdiction(j) transforms the namespace before deriving names', () => {
+		const f = fakeNamespace()
+		wrap(f).jurisdiction('eu' as unknown as DurableObjectJurisdiction).singleton()
+		expect(f.jurisdictions).toEqual(['eu'])
+		expect(f.byNameCalls).toEqual(['default'])
+	})
+
+	it('byId(id) routes through get(id), not getByName', () => {
+		const f = fakeNamespace()
+		const id = { toString: () => 'abc' }
+		const stub = wrap(f).byId(id as unknown as DurableObjectId)
+		expect(f.byNameCalls).toEqual([])
+		expect(stub.__id).toBe(id)
+	})
+})

--- a/packages/do-utils/src/for-do.ts
+++ b/packages/do-utils/src/for-do.ts
@@ -1,0 +1,284 @@
+// ============================================================================
+// @repo/do-utils — fluent, type-safe Durable Object namespace accessor.
+//
+// One entry point wraps a DO binding and exposes all three access modes:
+//
+//   forDO(env.FLEETS).singleton()                 -> the one global instance
+//   forDO(env.EVE_CORPORATION_DATA).byName(corpId) -> one instance per entity
+//   forDO(env.EVE_TOKEN_STORE).sharded({ shards: 16 }).forKey(characterId)
+//
+// TYPING is resolved ONCE, at the wrap site, and flows to every mode:
+//   * Same-worker bindings are DurableObjectNamespace<FooDO> (branded): the stub
+//     type is INFERRED as DurableObjectStub<FooDO> with zero generics.
+//   * Cross-worker service bindings are DurableObjectNamespace<undefined>: the
+//     runtime cannot see the class, so supply the shared RPC interface once, e.g.
+//         forDO<EveTokenStore>(env.EVE_TOKEN_STORE).byName(characterId)
+//   * Unbranded binding wrapped WITHOUT an interface -> ExplicitInterfaceRequired,
+//     whose only member is a guidance string, so every method call fails to
+//     compile with a readable "pass the interface" message.
+//
+// DISPOSAL is deliberately nothing-to-do for plain DO stubs. A DO stub is never
+// itself an RpcTarget in this repo; the one place an RpcTarget appears is a
+// second-hop method return (EveCharacterDataInstance from getInstance()), which
+// the Cloudflare runtime already types Disposable — so `using x = await
+// forDO(ns).byName(id).getInstance(id)` just works and this accessor attaches no
+// Symbol.dispose to anything, and never disposes a stub on the caller's behalf.
+//
+// CLAUDE.md rule: idFromName / getByName / jurisdiction are called ONLY inside
+// this module (in `route`), never at a call site — including the sharded paths.
+//
+// DurableObjectNamespace, DurableObjectStub, DurableObjectId,
+// DurableObjectLocationHint, DurableObjectJurisdiction and the `Rpc` namespace
+// are ambient globals from worker-configuration.d.ts, referenced without imports
+// (same convention as the rest of this package). No `any` in the public surface.
+// ============================================================================
+
+/** Placement option forwarded to the runtime on first instantiation only. */
+export interface StubOptions {
+	/**
+	 * Best-effort first-placement hint. Honored ONLY on the object's first
+	 * creation (DOs never relocate); never a guarantee — use `.jurisdiction()`
+	 * for a hard compliance boundary.
+	 */
+	locationHint?: DurableObjectLocationHint
+}
+
+/**
+ * Structural, brand-erased upper bound for any DO namespace.
+ *
+ * `DurableObjectNamespace<T>` is *invariant* in `T`, so no single instantiation
+ * is assignable from both branded (same-worker) and unbranded (cross-worker)
+ * bindings. This structural shape is satisfied by every `DurableObjectNamespace`
+ * regardless of its brand, yet still rejects non-DO bindings (KV/R2/fetchers) —
+ * a real bound without resorting to `any`, and one that lets this module
+ * type-check in isolation.
+ */
+export interface AnyDoNamespace {
+	get(id: DurableObjectId, options?: StubOptions): unknown
+	getByName(name: string, options?: StubOptions): unknown
+	jurisdiction(jurisdiction: DurableObjectJurisdiction): AnyDoNamespace
+}
+
+/**
+ * Compile-time nudge produced when a cross-worker (unbranded) namespace is
+ * wrapped without an explicit RPC interface. Every client method returns this
+ * type, so any call fails to type-check with the guidance below.
+ */
+export interface ExplicitInterfaceRequired {
+	readonly __doUtils: 'This binding is a cross-worker DurableObjectNamespace<undefined>; its stub type cannot be inferred. Pass the RPC interface explicitly, e.g. forDO<MyDoInterface>(env.BINDING).'
+}
+
+/**
+ * Resolve the stub surface for a namespace:
+ *  - explicit `T` (cross-worker): use the caller-supplied RPC interface verbatim
+ *    (these @repo interfaces are already Promise-typed and may be Pick<>-narrowed
+ *    structural subsets, so they are not re-wrapped in DurableObjectStub).
+ *  - no `T`, branded namespace (same-worker): infer `DurableObjectStub<I>`.
+ *  - no `T`, unbranded namespace: `ExplicitInterfaceRequired`.
+ *
+ * `[T] extends [never]` uses the tuple guard so the check never distributes.
+ */
+export type ResolveStub<NS extends AnyDoNamespace, T> = [T] extends [never]
+	? NS extends DurableObjectNamespace<infer I>
+		? I extends Rpc.DurableObjectBranded
+			? DurableObjectStub<I>
+			: ExplicitInterfaceRequired
+		: ExplicitInterfaceRequired
+	: T
+
+/** Config for a fixed-N sharded view. `shards` MUST be a stable, grow-only constant. */
+export interface ShardOptions {
+	/** Number of sibling shard instances. Treat as immutable; only ever increase it. */
+	shards: number
+	/**
+	 * Reserved name prefix for shard instances (default `'shard'`), producing DO
+	 * names `${prefix}:0 … ${prefix}:N-1`. Pass a distinct prefix for a binding
+	 * that is BOTH per-name and sharded so shard names cannot collide with an
+	 * entity key. Changing the prefix re-routes every key — treat as frozen.
+	 */
+	prefix?: string
+}
+
+/**
+ * Fixed-N sharded view over a namespace. Key -> shard routing is stable and
+ * dependency-free (FNV-1a-64 digest -> Lamping-Veach jump consistent hash).
+ */
+export interface ShardedClient<Stub> {
+	/** The immutable shard count this view was created with. */
+	readonly shards: number
+	/** Route one key to its owning shard and return that shard's stub. */
+	forKey(key: string, options?: StubOptions): Stub
+	/** Address a specific shard by index (range-checked) — for backfill/maintenance. */
+	shard(index: number, options?: StubOptions): Stub
+	/** Stubs for every shard, in index order — the scatter half of scatter/gather. */
+	all(options?: StubOptions): Stub[]
+	/**
+	 * Fan `fn` out across all shards concurrently and collect results in shard
+	 * order. Cost is O(N) billed RPC sessions — keep N modest and fan-out
+	 * infrequent. NOTE: `fn` should return serializable data. If a shard method
+	 * returns an RpcTarget, the CALLER owns each returned value and must dispose
+	 * it (`using`) — map() does not, and must not, dispose the shard sessions
+	 * out from under those results.
+	 */
+	map<R>(fn: (stub: Stub, shardIndex: number) => Promise<R> | R): Promise<R[]>
+}
+
+/** Fluent client wrapping a single DO namespace and exposing all three modes. */
+export interface DoClient<Stub> {
+	/**
+	 * The one global-singleton instance. Always resolves to `getByName('default')`
+	 * — the same id as `idFromName('default')`, so existing populated state is
+	 * preserved. A DO historically keyed on a different literal ('gateway',
+	 * 'global', 'universe') is honestly a fixed-name entity: use `.byName(key)`.
+	 */
+	singleton(options?: StubOptions): Stub
+	/** Entity-scoped access by name (e.g. characterId, `fleet-${id}`, `region-${id}`). */
+	byName(name: string, options?: StubOptions): Stub
+	/** Access by a pre-resolved / persisted DurableObjectId (e.g. rehydrated newUniqueId). */
+	byId(id: DurableObjectId, options?: StubOptions): Stub
+	/** Create a fixed-N sharded view; construct once and reuse so N stays constant. */
+	sharded(options: ShardOptions): ShardedClient<Stub>
+	/** Re-scope to a compliance jurisdiction. Changes the derived id (in-region identity). */
+	jurisdiction(jurisdiction: DurableObjectJurisdiction): DoClient<Stub>
+}
+
+const DEFAULT_SINGLETON_KEY = 'default'
+const DEFAULT_SHARD_PREFIX = 'shard'
+
+// --- Jump consistent hash (Lamping & Veach, 2014) over an FNV-1a-64 digest. ---
+// Dependency-free, allocation-free, uniformly balanced. Growing N -> N+1 remaps
+// only ~1/(N+1) of keys (all onto the new highest shard, none shuffled between
+// existing shards). DO storage never migrates, so `shards` is GROW-ONLY and the
+// constants + naming below are a FROZEN contract: changing any of them re-routes
+// every key and orphans per-instance storage.
+const U64_MASK = (1n << 64n) - 1n
+const FNV_OFFSET = 14695981039346656037n
+const FNV_PRIME = 1099511628211n
+const LCG_MULT = 2862933555777941757n
+
+function assertShardCount(shards: number): void {
+	if (!Number.isInteger(shards) || shards < 1) {
+		throw new RangeError(`@repo/do-utils: shards must be a positive integer, received ${String(shards)}`)
+	}
+}
+
+/** FNV-1a 64-bit digest of a string key, hashing BOTH bytes of each UTF-16 code
+ *  unit so non-ASCII keys distribute cleanly while staying deterministic. */
+function hashKeyToU64(key: string): bigint {
+	let h = FNV_OFFSET
+	for (let i = 0; i < key.length; i++) {
+		const c = key.charCodeAt(i)
+		h ^= BigInt(c & 0xff)
+		h = (h * FNV_PRIME) & U64_MASK
+		h ^= BigInt((c >> 8) & 0xff)
+		h = (h * FNV_PRIME) & U64_MASK
+	}
+	return h
+}
+
+/**
+ * Map a string key to a shard index in `[0, shards)` via jump consistent hash.
+ * Exported for unit tests and for aggregation/backfill jobs that need a key's
+ * home shard without materialising a stub.
+ */
+export function shardIndex(key: string, shards: number): number {
+	assertShardCount(shards)
+	if (shards === 1) return 0
+	let k = hashKeyToU64(key)
+	let b = -1n
+	let j = 0n
+	const n = BigInt(shards)
+	while (j < n) {
+		b = j
+		k = (k * LCG_MULT + 1n) & U64_MASK // 64-bit LCG step
+		j = ((b + 1n) * (1n << 31n)) / ((k >> 33n) + 1n) // floor((b+1) * 2^31 / ((k>>33)+1))
+	}
+	return Number(b)
+}
+
+/** Deterministic shard instance name: `${prefix}:${shardIndex(key, shards)}`. */
+export function shardName(key: string, shards: number, prefix: string = DEFAULT_SHARD_PREFIX): string {
+	return `${prefix}:${shardIndex(key, shards)}`
+}
+
+class ShardedClientImpl<Stub> implements ShardedClient<Stub> {
+	constructor(
+		private readonly ns: AnyDoNamespace,
+		public readonly shards: number,
+		private readonly prefix: string
+	) {
+		assertShardCount(shards)
+	}
+
+	forKey(key: string, options?: StubOptions): Stub {
+		return this.ns.getByName(`${this.prefix}:${shardIndex(key, this.shards)}`, options) as unknown as Stub
+	}
+
+	shard(index: number, options?: StubOptions): Stub {
+		if (!Number.isInteger(index) || index < 0 || index >= this.shards) {
+			throw new RangeError(`@repo/do-utils: shard index ${index} out of range [0, ${this.shards})`)
+		}
+		return this.ns.getByName(`${this.prefix}:${index}`, options) as unknown as Stub
+	}
+
+	all(options?: StubOptions): Stub[] {
+		const out: Stub[] = []
+		for (let i = 0; i < this.shards; i++) {
+			out.push(this.ns.getByName(`${this.prefix}:${i}`, options) as unknown as Stub)
+		}
+		return out
+	}
+
+	async map<R>(fn: (stub: Stub, shardIndex: number) => Promise<R> | R): Promise<R[]> {
+		const stubs = this.all()
+		return Promise.all(stubs.map((stub, i) => Promise.resolve(fn(stub, i))))
+	}
+}
+
+class DoClientImpl<Stub> implements DoClient<Stub> {
+	constructor(private readonly ns: AnyDoNamespace) {}
+
+	// The ONLY place get/getByName is invoked for name-derived modes.
+	private route(name: string, options?: StubOptions): Stub {
+		return this.ns.getByName(name, options) as unknown as Stub
+	}
+
+	singleton(options?: StubOptions): Stub {
+		return this.route(DEFAULT_SINGLETON_KEY, options)
+	}
+
+	byName(name: string, options?: StubOptions): Stub {
+		return this.route(name, options)
+	}
+
+	byId(id: DurableObjectId, options?: StubOptions): Stub {
+		return this.ns.get(id, options) as unknown as Stub
+	}
+
+	sharded(options: ShardOptions): ShardedClient<Stub> {
+		return new ShardedClientImpl<Stub>(this.ns, options.shards, options.prefix ?? DEFAULT_SHARD_PREFIX)
+	}
+
+	jurisdiction(jurisdiction: DurableObjectJurisdiction): DoClient<Stub> {
+		// jurisdiction is baked into id derivation, so transform the namespace
+		// once, up front — every subsequent name/shard is derived in-region.
+		return new DoClientImpl<Stub>(this.ns.jurisdiction(jurisdiction))
+	}
+}
+
+/**
+ * Wrap a Durable Object namespace in a fluent, type-safe client covering the
+ * global-singleton, per-name, and sharded (+ fan-out) access modes.
+ *
+ * Same-worker (branded) bindings infer their stub type — no generic needed:
+ *   const fleets = forDO(env.FLEETS)              // DoClient<DurableObjectStub<FleetsDO>>
+ *
+ * Cross-worker service bindings are `DurableObjectNamespace<undefined>`; supply
+ * the shared RPC interface once and every mode is typed from it:
+ *   const tokens = forDO<EveTokenStore>(env.EVE_TOKEN_STORE)
+ */
+export function forDO<T = never, NS extends AnyDoNamespace = AnyDoNamespace>(
+	namespace: NS
+): DoClient<ResolveStub<NS, T>> {
+	return new DoClientImpl<ResolveStub<NS, T>>(namespace)
+}

--- a/packages/do-utils/src/index.ts
+++ b/packages/do-utils/src/index.ts
@@ -4,6 +4,18 @@ import { DurableObject } from 'cloudflare:workers'
 export { createSqliteDbClient, migrateSqlite } from './sqlite-client'
 export type { DrizzleSqliteDODatabase, SqliteMigrationConfig } from './sqlite-client'
 
+// Fluent, type-safe DO namespace accessor: singleton / per-name / sharded (+ fan-out)
+export { forDO, shardIndex, shardName } from './for-do'
+export type {
+	AnyDoNamespace,
+	DoClient,
+	ExplicitInterfaceRequired,
+	ResolveStub,
+	ShardOptions,
+	ShardedClient,
+	StubOptions,
+} from './for-do'
+
 /**
  * Get a typed Durable Object stub with automatic resource management
  *

--- a/packages/do-utils/vitest.config.ts
+++ b/packages/do-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		globals: true,
+	},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3017,6 +3017,9 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@24.10.1)(@vitest/browser@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/doctrines:
     dependencies:


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds `forDO(namespace)`, a single fluent, type-safe entry point in `@repo/do-utils` for accessing Durable Objects, unifying the existing singleton/per-name access pattern with a new sharded/fan-out mode, and backs it with a full vitest test suite. This is additive — the existing `getStub` helper and all other exports are untouched.

## Changes
- New `packages/do-utils/src/for-do.ts`:
  - `forDO(env.BINDING)` returns a `DoClient` with `.singleton()`, `.byName(name)`, `.byId(id)`, `.sharded({ shards })`, and `.jurisdiction(...)` methods.
  - `.sharded({ shards, prefix? })` returns a `ShardedClient` with `.forKey(key)`, `.shard(index)`, `.all()`, and `.map(fn)` for scatter/gather across shards.
  - Type resolution happens at the wrap site via `ResolveStub`: same-worker branded bindings infer `DurableObjectStub<FooDO>` automatically; cross-worker (unbranded) service bindings require an explicit interface (`forDO<EveTokenStore>(env.X)`); an unbranded binding used without one resolves to `ExplicitInterfaceRequired`, causing every method call on it to fail to compile with a guidance message.
  - Shard routing uses a dependency-free FNV-1a-64 hash combined with a Lamping-Veach jump consistent hash, so shard counts are grow-only with minimal remap (~1/(N+1) of keys move when growing). `shardIndex` and `shardName` are exported for backfill/aggregation jobs.
  - `idFromName`/`getByName`/`jurisdiction` calls are centralized inside this module, in the `route` method, never at call sites.
- `packages/do-utils/src/index.ts`: re-exports `forDO`, `shardIndex`, `shardName`, and the associated types (`AnyDoNamespace`, `DoClient`, `ExplicitInterfaceRequired`, `ResolveStub`, `ShardOptions`, `ShardedClient`, `StubOptions`).
- New `packages/do-utils/src/for-do.test.ts`: 39 tests covering
  - Golden vectors freezing exact `shardIndex(key, N)` outputs, as a change detector for the FNV/jump-hash constants and UTF-16 hashing.
  - Invariants: determinism, index always in `[0, N)`, `N === 1` always maps to shard 0, the grow-only remap property, roughly uniform distribution over 20k keys, and `RangeError` on invalid shard counts.
  - `forDO` mode routing against a fake namespace: `singleton`, `byName`, `sharded().forKey/shard/all/map`, custom shard prefix, `jurisdiction`, and `byId`.
- `packages/do-utils/package.json`: adds a `test` script (`run-vitest`) and a `vitest` devDependency.
- New `packages/do-utils/vitest.config.ts`: minimal config enabling test globals.
- `pnpm-lock.yaml`: updated for the new `vitest` dependency.

## Testing
- Verified via the new `for-do.test.ts` suite (golden-vector, invariant, and routing tests), runnable with `pnpm -F @repo/do-utils test`.
<!-- claude:end -->