### PR TITLE
URGENT fix(prediction-markets): PmError.name corrupts .message across Workers RPC — all coded errors broken

### DIFF
--- a/apps/prediction-markets/src/lib/__tests__/errors.test.ts
+++ b/apps/prediction-markets/src/lib/__tests__/errors.test.ts
@@ -9,7 +9,20 @@ describe('PmError', () => {
 		expect(err).toBeInstanceOf(Error)
 		expect(err.message).toBe('MARKET_NOT_FOUND')
 		expect(err.code).toBe('MARKET_NOT_FOUND')
-		expect(err.name).toBe('PmError')
+	})
+
+	it('keeps the inherited name "Error" — a custom name breaks Workers RPC message serialization', () => {
+		// Regression guard (incident 2026-07-09): Cloudflare Workers RPC only preserves `.message`
+		// verbatim for a thrown error whose `.name` is a recognized built-in. Setting
+		// `this.name = 'PmError'` here made the RPC-reconstructed error on the DO CALLER's side
+		// (apps/core, across getStub RPC) read `.message === 'PmError: <code>'` instead of the bare
+		// code — silently breaking every exact-string match (core's ERROR_MESSAGES lookup, admin-route
+		// `.message === 'CODE'` checks) across the whole feature. Confirmed via a live getStub RPC
+		// round-trip in the real workers-pool/workerd runtime — a direct in-process function call (as
+		// in money-flow.int.test.ts) or a plain `new PmError(...)` unit test does NOT reproduce this;
+		// only an actual DO RPC call does, which is why this class-level property is so easy to get
+		// wrong without a live round-trip check.
+		expect(new PmError('MARKET_NOT_FOUND').name).toBe('Error')
 	})
 
 	it('defaults to expected=true (a normal user-facing rejection)', () => {

--- a/apps/prediction-markets/src/lib/errors.ts
+++ b/apps/prediction-markets/src/lib/errors.ts
@@ -68,9 +68,16 @@ export class PmError extends Error {
 	constructor(code: PmErrorCode, opts?: { expected?: boolean; detail?: string | number }) {
 		// message === code (optionally `code:detail`, e.g. `RATE_LIMITED:1234`) so the existing
 		// string-matching consumers across the RPC boundary keep working — the class and its extra
-		// properties do NOT survive RPC serialization, only `.message` does.
+		// properties do NOT survive Workers RPC serialization, only `.message` does.
+		//
+		// CRITICAL: do NOT set `this.name` to anything but the inherited 'Error'. Cloudflare's Workers
+		// RPC only cleanly preserves `.message` for a thrown error whose `.name` is a recognized
+		// built-in (Error/TypeError/RangeError/...); an unrecognized name (e.g. 'PmError') makes the
+		// receiving side reconstruct a generic Error whose `.message` becomes `"<name>: <message>"` —
+		// silently breaking every exact-string match on the caller side (core's ERROR_MESSAGES lookup,
+		// admin route `.message === 'CODE'` checks, etc.). Verified via an actual DO RPC round-trip in
+		// the workers pool test runtime — a direct in-process function call does NOT reproduce this.
 		super(opts?.detail != null ? `${code}:${opts.detail}` : code)
-		this.name = 'PmError'
 		this.code = code
 		this.expected = opts?.expected ?? true
 	}


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a production incident where every coded `PmError` (e.g. `MARKET_NOT_FOUND`, `CREATOR_CANNOT_RESOLVE`) lost its specific message and fell back to a generic Discord error. The cause was `PmError` setting `this.name = 'PmError'`, which breaks Cloudflare Workers RPC message serialization across `getStub` calls.

## Changes
- `apps/prediction-markets/src/lib/errors.ts`: remove the `this.name = 'PmError'` assignment so `PmError` keeps the inherited `Error` name; add a comment explaining why a custom `.name` corrupts `.message` on the RPC caller side (apps/core).
- `apps/prediction-markets/src/lib/__tests__/errors.test.ts`: update the test to assert `name` is `'Error'` instead of `'PmError'`, and add a regression test/comment documenting the RPC serialization issue.

## Testing
Typecheck clean; 75 unit tests pass. Per the commit message, the root cause was confirmed via a live `getStub` RPC round-trip in the real workers-pool (workerd) runtime — a direct in-process call or a plain `new PmError(...)` unit test does not reproduce the bug.
<!-- claude:end -->
