### PR TITLE
add ticker configs to corp discord attachments and fix woopsie

### DIFF
--- a/apps/core/.migrations/0042_even_blazing_skull.sql
+++ b/apps/core/.migrations/0042_even_blazing_skull.sql
@@ -1,0 +1,40 @@
+CREATE TABLE "corporation_discord_server_nickname_configs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"corporation_discord_server_id" uuid NOT NULL,
+	"bucket" text NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"source" text DEFAULT 'corp' NOT NULL,
+	"custom_ticker" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_corp_discord_server_nickname_config" UNIQUE("corporation_discord_server_id","bucket")
+);
+--> statement-breakpoint
+CREATE TABLE "corporation_discord_server_scenario_roles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"corporation_discord_server_id" uuid NOT NULL,
+	"bucket" text NOT NULL,
+	"discord_role_id" uuid,
+	"auto_apply" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_corp_discord_server_scenario_role" UNIQUE("corporation_discord_server_id","bucket")
+);
+--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP CONSTRAINT "corporation_discord_servers_corp_member_role_id_discord_roles_id_fk";
+--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP CONSTRAINT "corporation_discord_servers_alliance_guest_role_id_discord_roles_id_fk";
+--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP CONSTRAINT "corporation_discord_servers_non_alliance_guest_role_id_discord_roles_id_fk";
+--> statement-breakpoint
+ALTER TABLE "corporation_discord_server_nickname_configs" ADD CONSTRAINT "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk" FOREIGN KEY ("corporation_discord_server_id") REFERENCES "public"."corporation_discord_servers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "corporation_discord_server_scenario_roles" ADD CONSTRAINT "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk" FOREIGN KEY ("corporation_discord_server_id") REFERENCES "public"."corporation_discord_servers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "corporation_discord_server_scenario_roles" ADD CONSTRAINT "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk" FOREIGN KEY ("discord_role_id") REFERENCES "public"."discord_roles"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "corp_discord_server_nickname_configs_attachment_idx" ON "corporation_discord_server_nickname_configs" USING btree ("corporation_discord_server_id");--> statement-breakpoint
+CREATE INDEX "corp_discord_server_scenario_roles_attachment_idx" ON "corporation_discord_server_scenario_roles" USING btree ("corporation_discord_server_id");--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP COLUMN "corp_member_role_id";--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP COLUMN "corp_member_auto_apply";--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP COLUMN "alliance_guest_role_id";--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP COLUMN "alliance_guest_auto_apply";--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP COLUMN "non_alliance_guest_role_id";--> statement-breakpoint
+ALTER TABLE "corporation_discord_servers" DROP COLUMN "non_alliance_guest_auto_apply";

--- a/apps/core/.migrations/meta/0042_snapshot.json
+++ b/apps/core/.migrations/meta/0042_snapshot.json
@@ -1,0 +1,4970 @@
+{
+  "id": "c9dc70f2-8f3e-4cb2-823c-2942631853f3",
+  "prevId": "b27e190d-f5e3-41bb-be06-b5b66ca402d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_destinations": {
+      "name": "alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_destinations_scope_idx": {
+          "name": "alert_destinations_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_alert_type_idx": {
+          "name": "alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_type_idx": {
+          "name": "alert_destinations_type_idx",
+          "columns": [
+            {
+              "expression": "destination_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_enabled_idx": {
+          "name": "alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_core_user_id_users_id_fk": {
+          "name": "alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_created_by_users_id_fk": {
+          "name": "alert_destinations_created_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_updated_by_users_id_fk": {
+          "name": "alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_configs": {
+      "name": "corporation_alert_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_ids": {
+          "name": "destination_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_alert_configs_corp_idx": {
+          "name": "corporation_alert_configs_corp_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_alert_type_idx": {
+          "name": "corporation_alert_configs_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_enabled_idx": {
+          "name": "corporation_alert_configs_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_corp_alert_type_idx": {
+          "name": "corporation_alert_configs_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_configs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_alert_configs_corp_alert_type_unique": {
+          "name": "corporation_alert_configs_corp_alert_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "alert_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_destinations": {
+      "name": "corporation_alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_alert_destinations_corp_id_idx": {
+          "name": "corp_alert_destinations_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_alert_type_idx": {
+          "name": "corp_alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_enabled_idx": {
+          "name": "corp_alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_corp_alert_type_idx": {
+          "name": "corp_alert_destinations_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_core_user_id_users_id_fk": {
+          "name": "corporation_alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_created_by_users_id_fk": {
+          "name": "corporation_alert_destinations_created_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_updated_by_users_id_fk": {
+          "name": "corporation_alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_invites": {
+      "name": "corporation_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_discord_invites_corp_id_idx": {
+          "name": "corporation_discord_invites_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_user_id_idx": {
+          "name": "corporation_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_server_id_idx": {
+          "name": "corporation_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_created_at_idx": {
+          "name": "corporation_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_user_id_users_id_fk": {
+          "name": "corporation_discord_invites_user_id_users_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_nickname_configs": {
+      "name": "corporation_discord_server_nickname_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'corp'"
+        },
+        "custom_ticker": {
+          "name": "custom_ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_nickname_configs_attachment_idx": {
+          "name": "corp_discord_server_nickname_configs_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_nickname_configs",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_nickname_config": {
+          "name": "unique_corp_discord_server_nickname_config",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_roles": {
+      "name": "corporation_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_roles_attachment_idx": {
+          "name": "corp_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_role": {
+          "name": "unique_corp_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_scenario_roles": {
+      "name": "corporation_discord_server_scenario_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_scenario_roles_attachment_idx": {
+          "name": "corp_discord_server_scenario_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_scenario_role": {
+          "name": "unique_corp_discord_server_scenario_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_servers": {
+      "name": "corporation_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_servers_corp_id_idx": {
+          "name": "corp_discord_servers_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_id_idx": {
+          "name": "corp_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_auto_assign_idx": {
+          "name": "corp_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"corporation_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_discord_servers_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server": {
+          "name": "unique_corp_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_categories": {
+      "name": "discord_command_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_categories_sort_order_idx": {
+          "name": "discord_command_categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_categories_name_unique": {
+          "name": "discord_command_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_permissions": {
+      "name": "discord_command_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_permissions_command_id_idx": {
+          "name": "discord_command_permissions_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_command_permissions_permission_id_idx": {
+          "name": "discord_command_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_command_permissions_command_id_discord_commands_id_fk": {
+          "name": "discord_command_permissions_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_command_permissions",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_permissions_command_permission_unique": {
+          "name": "discord_command_permissions_command_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_commands": {
+      "name": "discord_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static_response'"
+        },
+        "response_template": {
+          "name": "response_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_commands_name_idx": {
+          "name": "discord_commands_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_type_idx": {
+          "name": "discord_commands_type_idx",
+          "columns": [
+            {
+              "expression": "command_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_is_active_idx": {
+          "name": "discord_commands_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_category_id_idx": {
+          "name": "discord_commands_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_commands_category_id_discord_command_categories_id_fk": {
+          "name": "discord_commands_category_id_discord_command_categories_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "discord_command_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discord_commands_created_by_users_id_fk": {
+          "name": "discord_commands_created_by_users_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_commands_name_unique": {
+          "name": "discord_commands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_rows": {
+      "name": "discord_member_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discriminator": {
+          "name": "discriminator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_ids": {
+          "name": "role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "linked": {
+          "name": "linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_rows_run_linked_user_idx": {
+          "name": "discord_member_audit_rows_run_linked_user_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk": {
+          "name": "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "discord_member_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_rows_core_user_id_users_id_fk": {
+          "name": "discord_member_audit_rows_core_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_rows_run_discord_user_unique": {
+          "name": "discord_member_audit_rows_run_discord_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_runs": {
+      "name": "discord_member_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_count": {
+          "name": "linked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unlinked_count": {
+          "name": "unlinked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_runs_server_started_idx": {
+          "name": "discord_member_audit_runs_server_started_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_member_audit_runs_status_idx": {
+          "name": "discord_member_audit_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_runs_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_member_audit_runs_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "discord_member_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_runs_workflow_instance_id_unique": {
+          "name": "discord_member_audit_runs_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_roles": {
+      "name": "discord_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_roles_server_id_idx": {
+          "name": "discord_roles_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_roles_server_auto_apply_active_idx": {
+          "name": "discord_roles_server_auto_apply_active_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_apply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_roles\".\"auto_apply\" = true AND \"discord_roles\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_roles_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_roles_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_roles",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_discord_server_role": {
+          "name": "unique_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_server_commands": {
+      "name": "discord_server_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_command_id": {
+          "name": "discord_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_server_commands_server_id_idx": {
+          "name": "discord_server_commands_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_server_commands_command_id_idx": {
+          "name": "discord_server_commands_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_server_commands_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_server_commands_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_command_id_discord_commands_id_fk": {
+          "name": "discord_server_commands_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_created_by_users_id_fk": {
+          "name": "discord_server_commands_created_by_users_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_server_commands_server_command_unique": {
+          "name": "discord_server_commands_server_command_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "command_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_servers": {
+      "name": "discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "manage_nicknames": {
+          "name": "manage_nicknames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_servers_guild_id_idx": {
+          "name": "discord_servers_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_servers_active_idx": {
+          "name": "discord_servers_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_servers\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_servers_created_by_users_id_fk": {
+          "name": "discord_servers_created_by_users_id_fk",
+          "tableFrom": "discord_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_servers_guild_id_unique": {
+          "name": "discord_servers_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guild_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_decay_config": {
+      "name": "dkp_decay_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_decay_config_active_idx": {
+          "name": "dkp_decay_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dkp_decay_config\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_decay_config_effective_from_idx": {
+          "name": "dkp_decay_config_effective_from_idx",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_decay_config_created_by_users_id_fk": {
+          "name": "dkp_decay_config_created_by_users_id_fk",
+          "tableFrom": "dkp_decay_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_transactions": {
+      "name": "dkp_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_reason": {
+          "name": "award_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_transactions_user_earned_idx": {
+          "name": "dkp_transactions_user_earned_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_user_source_idx": {
+          "name": "dkp_transactions_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_character_earned_idx": {
+          "name": "dkp_transactions_character_earned_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_corp_earned_idx": {
+          "name": "dkp_transactions_corp_earned_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_earned_at_idx": {
+          "name": "dkp_transactions_earned_at_idx",
+          "columns": [
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_type_idx": {
+          "name": "dkp_transactions_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_id_idx": {
+          "name": "dkp_transactions_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_awarded_by_idx": {
+          "name": "dkp_transactions_awarded_by_idx",
+          "columns": [
+            {
+              "expression": "awarded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_transactions_user_id_users_id_fk": {
+          "name": "dkp_transactions_user_id_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "dkp_transactions_awarded_by_users_id_fk": {
+          "name": "dkp_transactions_awarded_by_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "awarded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_corporations": {
+      "name": "managed_corporations",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_character_id": {
+          "name": "assigned_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_character_name": {
+          "name": "assigned_character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "healthy_director_count": {
+          "name": "healthy_director_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_member_corporation": {
+          "name": "is_member_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_alt_corp": {
+          "name": "is_alt_corp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_special_purpose": {
+          "name": "is_special_purpose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recruiting": {
+          "name": "is_recruiting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_corporations_name_idx": {
+          "name": "managed_corporations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_ticker_idx": {
+          "name": "managed_corporations_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_assigned_character_id_idx": {
+          "name": "managed_corporations_assigned_character_id_idx",
+          "columns": [
+            {
+              "expression": "assigned_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_is_active_idx": {
+          "name": "managed_corporations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_background_refresh_idx": {
+          "name": "managed_corporations_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_structure_asset_sync_idx": {
+          "name": "managed_corporations_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_member_idx": {
+          "name": "managed_corporations_corporation_id_is_member_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_member_corporation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_alt_idx": {
+          "name": "managed_corporations_corporation_id_is_alt_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_alt_corp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_special_purpose_idx": {
+          "name": "managed_corporations_corporation_id_is_special_purpose_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_special_purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_corporations_configured_by_users_id_fk": {
+          "name": "managed_corporations_configured_by_users_id_fk",
+          "tableFrom": "managed_corporations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_credential_handoffs": {
+      "name": "mumble_tempop_credential_handoffs",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mumble_tempop_credential_handoffs_expires_at_idx": {
+          "name": "mumble_tempop_credential_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_credential_handoffs",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_guests": {
+      "name": "mumble_tempop_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corp_ticker": {
+          "name": "corp_ticker",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_name": {
+          "name": "login_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mumble_tempop_guests_tempop_id_idx": {
+          "name": "mumble_tempop_guests_tempop_id_idx",
+          "columns": [
+            {
+              "expression": "tempop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_guests",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempop_guests_subject_id_unique": {
+          "name": "mumble_tempop_guests_subject_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id"
+          ]
+        },
+        "mumble_tempop_guests_tempop_character_uq": {
+          "name": "mumble_tempop_guests_tempop_character_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tempop_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempops": {
+      "name": "mumble_tempops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mumble_tempops_status_expires_at_idx": {
+          "name": "mumble_tempops_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mumble_tempops_creator_user_id_idx": {
+          "name": "mumble_tempops_creator_user_id_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempops_creator_user_id_users_id_fk": {
+          "name": "mumble_tempops_creator_user_id_users_id_fk",
+          "tableFrom": "mumble_tempops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempops_short_code_unique": {
+          "name": "mumble_tempops_short_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_code"
+          ]
+        },
+        "mumble_tempops_key_hash_unique": {
+          "name": "mumble_tempops_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_type": {
+          "name": "flow_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_forum_config": {
+      "name": "pm_forum_config",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forum_channel_id": {
+          "name": "forum_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_open_id": {
+          "name": "tag_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_closed_id": {
+          "name": "tag_closed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_resolved_id": {
+          "name": "tag_resolved_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_voided_id": {
+          "name": "tag_voided_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_services": {
+      "name": "core_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_services_enabled_idx": {
+          "name": "core_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_name_idx": {
+          "name": "core_services_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_slug_idx": {
+          "name": "core_services_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_external_links": {
+      "name": "sidebar_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidebar_external_links_sort_order_idx": {
+          "name": "sidebar_external_links_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_log": {
+      "name": "user_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_activity_log_user_id_idx": {
+          "name": "user_activity_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_action_idx": {
+          "name": "user_activity_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_timestamp_idx": {
+          "name": "user_activity_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_log_user_id_users_id_fk": {
+          "name": "user_activity_log_user_id_users_id_fk",
+          "tableFrom": "user_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_characters": {
+      "name": "user_characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_owner_hash": {
+          "name": "character_owner_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_character_refresh": {
+          "name": "last_character_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_characters_user_id_idx": {
+          "name": "user_characters_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_character_id_idx": {
+          "name": "user_characters_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_is_primary_idx": {
+          "name": "user_characters_is_primary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_status_idx": {
+          "name": "user_characters_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_deleted_idx": {
+          "name": "user_characters_deleted_idx",
+          "columns": [
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_id_idx": {
+          "name": "user_characters_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_id_idx": {
+          "name": "user_characters_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_name_idx": {
+          "name": "user_characters_corporation_name_idx",
+          "columns": [
+            {
+              "expression": "corporation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_name_idx": {
+          "name": "user_characters_alliance_name_idx",
+          "columns": [
+            {
+              "expression": "alliance_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_characters_user_id_users_id_fk": {
+          "name": "user_characters_user_id_users_id_fk",
+          "tableFrom": "user_characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_characters_character_id_unique": {
+          "name": "user_characters_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fingerprints": {
+      "name": "user_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_fingerprints_user_id_idx": {
+          "name": "user_fingerprints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_fingerprint_idx": {
+          "name": "user_fingerprints_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_user_id_fingerprint_idx": {
+          "name": "user_fingerprints_user_id_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fingerprints_user_id_users_id_fk": {
+          "name": "user_fingerprints_user_id_users_id_fk",
+          "tableFrom": "user_fingerprints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ip_addresses": {
+      "name": "user_ip_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addr": {
+          "name": "addr",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address_hash": {
+          "name": "ip_address_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_ip_addresses_user_id_idx": {
+          "name": "user_ip_addresses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_ip_addresses_ip_address_idx": {
+          "name": "user_ip_addresses_ip_address_idx",
+          "columns": [
+            {
+              "expression": "addr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ip_addresses_user_id_users_id_fk": {
+          "name": "user_ip_addresses_user_id_users_id_fk",
+          "tableFrom": "user_ip_addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_ip_addresses_user_ip_unique": {
+          "name": "user_ip_addresses_user_ip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "addr"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_user_services": {
+      "name": "core_user_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_user_services_user_id_idx": {
+          "name": "core_user_services_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_service_id_idx": {
+          "name": "core_user_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_user_id_service_id_idx": {
+          "name": "core_user_services_user_id_service_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_enabled_idx": {
+          "name": "core_user_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "core_user_services_user_id_users_id_fk": {
+          "name": "core_user_services_user_id_users_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "core_user_services_service_id_core_services_id_fk": {
+          "name": "core_user_services_service_id_core_services_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "core_services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_user_services_user_id_service_id_unique": {
+          "name": "core_user_services_user_id_service_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "service_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_session_token_idx": {
+          "name": "user_sessions_session_token_idx",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sessions_session_token_unique": {
+          "name": "user_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "immunitas": {
+          "name": "immunitas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_discord_refresh": {
+          "name": "last_discord_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "legacy_auth_user_id": {
+          "name": "legacy_auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_username": {
+          "name": "legacy_auth_user_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_email_hash": {
+          "name": "legacy_auth_user_email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow": {
+          "name": "last_refresh_workflow",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow_attempt": {
+          "name": "last_refresh_workflow_attempt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_main_character_id_idx": {
+          "name": "users_main_character_id_idx",
+          "columns": [
+            {
+              "expression": "main_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_discord_user_id_idx": {
+          "name": "users_discord_user_id_idx",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_discord_refresh_idx": {
+          "name": "users_last_discord_refresh_idx",
+          "columns": [
+            {
+              "expression": "last_discord_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_id_idx": {
+          "name": "users_legacy_auth_user_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_username_idx": {
+          "name": "users_legacy_auth_user_username_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_email_hash_idx": {
+          "name": "users_legacy_auth_user_email_hash_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_idx": {
+          "name": "users_last_refresh_workflow_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_attempt_idx": {
+          "name": "users_last_refresh_workflow_attempt_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow_attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_main_character_id_unique": {
+          "name": "users_main_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "main_character_id"
+          ]
+        },
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_user_id"
+          ]
+        },
+        "users_legacy_auth_user_id_unique": {
+          "name": "users_legacy_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_id"
+          ]
+        },
+        "users_legacy_auth_user_username_unique": {
+          "name": "users_legacy_auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_username"
+          ]
+        },
+        "users_legacy_auth_user_email_hash_unique": {
+          "name": "users_legacy_auth_user_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/.migrations/meta/_journal.json
+++ b/apps/core/.migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1783503885537,
       "tag": "0041_motionless_emma_frost",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1783567591406,
+      "tag": "0042_even_blazing_skull",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/db/schema.ts
+++ b/apps/core/src/db/schema.ts
@@ -601,25 +601,6 @@ export const corporationDiscordServers = pgTable(
 		autoInvite: boolean('auto_invite').default(false).notNull(),
 		/** Whether to automatically assign roles on invite */
 		autoAssignRoles: boolean('auto_assign_roles').default(false).notNull(),
-		/** Scenario role for corp members */
-		corpMemberRoleId: uuid('corp_member_role_id').references(() => discordRoles.id, {
-			onDelete: 'set null',
-		}),
-		/** Whether to auto-apply the corp member scenario role */
-		corpMemberAutoApply: boolean('corp_member_auto_apply').default(false).notNull(),
-		/** Scenario role for alliance guests */
-		allianceGuestRoleId: uuid('alliance_guest_role_id').references(() => discordRoles.id, {
-			onDelete: 'set null',
-		}),
-		/** Whether to auto-apply the alliance guest scenario role */
-		allianceGuestAutoApply: boolean('alliance_guest_auto_apply').default(false).notNull(),
-		/** Scenario role for non-alliance guests */
-		nonAllianceGuestRoleId: uuid('non_alliance_guest_role_id').references(
-			() => discordRoles.id,
-			{ onDelete: 'set null' }
-		),
-		/** Whether to auto-apply the non-alliance guest scenario role */
-		nonAllianceGuestAutoApply: boolean('non_alliance_guest_auto_apply').default(false).notNull(),
 		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
@@ -630,6 +611,73 @@ export const corporationDiscordServers = pgTable(
 			.on(table.discordServerId, table.autoAssignRoles)
 			.where(sql`${table.autoAssignRoles} = true`),
 		unique('unique_corp_discord_server').on(table.corporationId, table.discordServerId),
+	]
+)
+
+/**
+ * Corporation Discord Server Scenario Roles
+ *
+ * Stores one row per bucket for corp member, alliance guest, and non-alliance guest role sync.
+ */
+export const corporationDiscordServerScenarioRoles = pgTable(
+	'corporation_discord_server_scenario_roles',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		corporationDiscordServerId: uuid('corporation_discord_server_id')
+			.notNull()
+			.references(() => corporationDiscordServers.id, { onDelete: 'cascade' }),
+		bucket: text('bucket', {
+			enum: ['alliance_guest', 'non_alliance_guest'],
+		}).notNull(),
+		discordRoleId: uuid('discord_role_id').references(() => discordRoles.id, {
+			onDelete: 'set null',
+		}),
+		autoApply: boolean('auto_apply').default(false).notNull(),
+		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+	},
+	(table) => [
+		index('corp_discord_server_scenario_roles_attachment_idx').on(table.corporationDiscordServerId),
+		unique('unique_corp_discord_server_scenario_role').on(
+			table.corporationDiscordServerId,
+			table.bucket
+		),
+	]
+)
+
+/**
+ * Corporation Discord Server Nickname Configs
+ *
+ * Stores one row per nickname bucket, including All Members and the three member/guest buckets.
+ */
+export const corporationDiscordServerNicknameConfigs = pgTable(
+	'corporation_discord_server_nickname_configs',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		corporationDiscordServerId: uuid('corporation_discord_server_id')
+			.notNull()
+			.references(() => corporationDiscordServers.id, { onDelete: 'cascade' }),
+		bucket: text('bucket', {
+			enum: ['corp_member', 'alliance_guest', 'non_alliance_guest'],
+		}).notNull(),
+		enabled: boolean('enabled').default(false).notNull(),
+		source: text('source', {
+			enum: ['corp', 'alliance', 'custom'],
+		})
+			.default('corp')
+			.notNull(),
+		customTicker: text('custom_ticker'),
+		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+	},
+	(table) => [
+		index('corp_discord_server_nickname_configs_attachment_idx').on(
+			table.corporationDiscordServerId
+		),
+		unique('unique_corp_discord_server_nickname_config').on(
+			table.corporationDiscordServerId,
+			table.bucket
+		),
 	]
 )
 
@@ -1092,8 +1140,34 @@ export const corporationDiscordServersRelations = relations(
 			fields: [corporationDiscordServers.discordServerId],
 			references: [discordServers.id],
 		}),
+		scenarioRoles: many(corporationDiscordServerScenarioRoles),
+		nicknameConfigs: many(corporationDiscordServerNicknameConfigs),
 		roles: many(corporationDiscordServerRoles),
 		invites: many(corporationDiscordInvites),
+	})
+)
+
+export const corporationDiscordServerScenarioRolesRelations = relations(
+	corporationDiscordServerScenarioRoles,
+	({ one }) => ({
+		corporationDiscordServer: one(corporationDiscordServers, {
+			fields: [corporationDiscordServerScenarioRoles.corporationDiscordServerId],
+			references: [corporationDiscordServers.id],
+		}),
+		discordRole: one(discordRoles, {
+			fields: [corporationDiscordServerScenarioRoles.discordRoleId],
+			references: [discordRoles.id],
+		}),
+	})
+)
+
+export const corporationDiscordServerNicknameConfigsRelations = relations(
+	corporationDiscordServerNicknameConfigs,
+	({ one }) => ({
+		corporationDiscordServer: one(corporationDiscordServers, {
+			fields: [corporationDiscordServerNicknameConfigs.corporationDiscordServerId],
+			references: [corporationDiscordServers.id],
+		}),
 	})
 )
 
@@ -1310,6 +1384,8 @@ export const schema = {
 	discordCommandPermissions,
 	discordServerCommands,
 	corporationDiscordServers,
+	corporationDiscordServerScenarioRoles,
+	corporationDiscordServerNicknameConfigs,
 	corporationDiscordServerRoles,
 	corporationDiscordInvites,
 	alertDestinations,
@@ -1335,6 +1411,8 @@ export const schema = {
 	discordCommandPermissionsRelations,
 	discordServerCommandsRelations,
 	corporationDiscordServersRelations,
+	corporationDiscordServerScenarioRolesRelations,
+	corporationDiscordServerNicknameConfigsRelations,
 	corporationDiscordServerRolesRelations,
 	corporationDiscordInvitesRelations,
 	corporationAlertDestinationsRelations,

--- a/apps/core/src/routes/corporations/discord-routes.ts
+++ b/apps/core/src/routes/corporations/discord-routes.ts
@@ -6,6 +6,8 @@ import { logger } from '@repo/hono-helpers'
 
 import {
 	corporationDiscordServerRoles,
+	corporationDiscordServerNicknameConfigs,
+	corporationDiscordServerScenarioRoles,
 	corporationDiscordServers,
 	discordRoles,
 	discordServers,
@@ -17,6 +19,227 @@ import type { Core } from '@repo/core'
 import type { App } from '../../context'
 
 const app = new Hono<App>()
+
+type NicknameTickerSource = 'corp' | 'alliance' | 'custom'
+type ScenarioRoleBucket = 'alliance_guest' | 'non_alliance_guest'
+type NicknameBucket = 'corp_member' | 'alliance_guest' | 'non_alliance_guest'
+
+const NICKNAME_SOURCE_VALUES: NicknameTickerSource[] = ['corp', 'alliance', 'custom']
+
+const scenarioRoleBucketFields = [
+	{
+		bucket: 'alliance_guest' as const,
+		roleField: 'allianceGuestRoleId',
+		autoApplyField: 'allianceGuestAutoApply',
+	},
+	{
+		bucket: 'non_alliance_guest' as const,
+		roleField: 'nonAllianceGuestRoleId',
+		autoApplyField: 'nonAllianceGuestAutoApply',
+	},
+] as const
+
+const nicknameBucketFields = [
+	{
+		bucket: 'corp_member' as const,
+		enabledField: 'corpMemberNicknameEnabled',
+		sourceField: 'corpMemberNicknameSource',
+		customField: 'corpMemberNicknameCustomTicker',
+	},
+	{
+		bucket: 'alliance_guest' as const,
+		enabledField: 'allianceGuestNicknameEnabled',
+		sourceField: 'allianceGuestNicknameSource',
+		customField: 'allianceGuestNicknameCustomTicker',
+	},
+	{
+		bucket: 'non_alliance_guest' as const,
+		enabledField: 'nonAllianceGuestNicknameEnabled',
+		sourceField: 'nonAllianceGuestNicknameSource',
+		customField: 'nonAllianceGuestNicknameCustomTicker',
+	},
+] as const
+
+function normalizeTickerInput(value: unknown): string | null {
+	if (typeof value !== 'string') {
+		return null
+	}
+
+	const normalized = value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 5)
+	return normalized || null
+}
+
+function parseNicknameSource(value: unknown): NicknameTickerSource | null {
+	if (typeof value !== 'string') {
+		return null
+	}
+
+	return NICKNAME_SOURCE_VALUES.includes(value as NicknameTickerSource)
+		? (value as NicknameTickerSource)
+		: null
+}
+
+function getBucketFieldValue(body: Record<string, unknown>, field: string): unknown {
+	return Object.prototype.hasOwnProperty.call(body, field) ? body[field] : undefined
+}
+
+function buildScenarioRoleUpdateValues(
+	body: Record<string, unknown>,
+	existing?: Record<string, unknown>
+): Record<string, unknown> {
+	const values: Record<string, unknown> = {}
+
+	for (const bucket of scenarioRoleBucketFields) {
+		const roleValue = getBucketFieldValue(body, bucket.roleField)
+		if (roleValue !== undefined) {
+			values[bucket.roleField] = roleValue === null ? null : (roleValue as string)
+		} else if (existing) {
+			values[bucket.roleField] =
+				(existing[bucket.roleField] as string | null | undefined) ?? null
+		} else {
+			values[bucket.roleField] = null
+		}
+
+		const autoApplyValue = getBucketFieldValue(body, bucket.autoApplyField)
+		if (autoApplyValue !== undefined) {
+			values[bucket.autoApplyField] = Boolean(autoApplyValue)
+		} else if (existing) {
+			values[bucket.autoApplyField] = Boolean(existing[bucket.autoApplyField])
+		} else {
+			values[bucket.autoApplyField] = false
+		}
+	}
+
+	return values
+}
+
+function buildNicknameUpdateValues(
+	body: Record<string, unknown>,
+	existing?: Record<string, unknown>
+): Record<string, unknown> {
+	const values: Record<string, unknown> = {}
+
+	for (const bucket of nicknameBucketFields) {
+		const enabledValue = getBucketFieldValue(body, bucket.enabledField)
+		if (enabledValue !== undefined) {
+			values[bucket.enabledField] = Boolean(enabledValue)
+		} else if (existing) {
+			values[bucket.enabledField] = Boolean(existing[bucket.enabledField])
+		} else {
+			values[bucket.enabledField] = false
+		}
+
+		const sourceValue = getBucketFieldValue(body, bucket.sourceField)
+		if (sourceValue !== undefined) {
+			const source = parseNicknameSource(sourceValue)
+			if (!source) {
+				throw new Error(`Invalid ${bucket.bucket} nickname source`)
+			}
+			values[bucket.sourceField] = source
+		} else if (existing) {
+			values[bucket.sourceField] =
+				(existing[bucket.sourceField] as NicknameTickerSource | undefined) ?? 'corp'
+		} else {
+			values[bucket.sourceField] = 'corp'
+		}
+
+		const customTickerValue = getBucketFieldValue(body, bucket.customField)
+		if (customTickerValue !== undefined) {
+			values[bucket.customField] = normalizeTickerInput(customTickerValue)
+		} else if (existing) {
+			values[bucket.customField] =
+				(existing[bucket.customField] as string | null | undefined) ?? null
+		} else {
+			values[bucket.customField] = null
+		}
+	}
+
+	return values
+}
+
+function flattenCorporationDiscordAttachment(attachment: any) {
+	const scenarioRolesByBucket = new Map<ScenarioRoleBucket, any>(
+		(attachment.scenarioRoles ?? []).map((row: any) => [row.bucket as ScenarioRoleBucket, row])
+	)
+	const nicknameConfigsByBucket = new Map<NicknameBucket, any>(
+		(attachment.nicknameConfigs ?? []).map((row: any) => [row.bucket as NicknameBucket, row])
+	)
+
+	return {
+		...attachment,
+		allianceGuestRoleId: scenarioRolesByBucket.get('alliance_guest')?.discordRoleId ?? null,
+		allianceGuestAutoApply: scenarioRolesByBucket.get('alliance_guest')?.autoApply ?? false,
+		nonAllianceGuestRoleId:
+			scenarioRolesByBucket.get('non_alliance_guest')?.discordRoleId ?? null,
+		nonAllianceGuestAutoApply:
+			scenarioRolesByBucket.get('non_alliance_guest')?.autoApply ?? false,
+		corpMemberNicknameEnabled: nicknameConfigsByBucket.get('corp_member')?.enabled ?? false,
+		corpMemberNicknameSource:
+			nicknameConfigsByBucket.get('corp_member')?.source ?? 'corp',
+		corpMemberNicknameCustomTicker:
+			nicknameConfigsByBucket.get('corp_member')?.customTicker ?? null,
+		allianceGuestNicknameEnabled:
+			nicknameConfigsByBucket.get('alliance_guest')?.enabled ?? false,
+		allianceGuestNicknameSource:
+			nicknameConfigsByBucket.get('alliance_guest')?.source ?? 'corp',
+		allianceGuestNicknameCustomTicker:
+			nicknameConfigsByBucket.get('alliance_guest')?.customTicker ?? null,
+		nonAllianceGuestNicknameEnabled:
+			nicknameConfigsByBucket.get('non_alliance_guest')?.enabled ?? false,
+		nonAllianceGuestNicknameSource:
+			nicknameConfigsByBucket.get('non_alliance_guest')?.source ?? 'corp',
+		nonAllianceGuestNicknameCustomTicker:
+			nicknameConfigsByBucket.get('non_alliance_guest')?.customTicker ?? null,
+	}
+}
+
+async function fetchCorporationDiscordAttachments(db: any, corporationId: string) {
+	const attachments = await db.query.corporationDiscordServers.findMany({
+		where: eq(corporationDiscordServers.corporationId, corporationId),
+		with: {
+			discordServer: {
+				with: {
+					roles: true,
+				},
+			},
+			roles: {
+				with: {
+					discordRole: true,
+				},
+			},
+			scenarioRoles: true,
+			nicknameConfigs: true,
+		},
+		orderBy: desc(corporationDiscordServers.createdAt),
+	})
+
+	return attachments.map(flattenCorporationDiscordAttachment)
+}
+
+async function fetchCorporationDiscordAttachment(db: any, corporationId: string, attachmentId: string) {
+	const attachment = await db.query.corporationDiscordServers.findFirst({
+		where: and(
+			eq(corporationDiscordServers.id, attachmentId),
+			eq(corporationDiscordServers.corporationId, corporationId)
+		),
+		with: {
+			discordServer: {
+				with: {
+					roles: true,
+				},
+			},
+			roles: {
+				with: {
+					discordRole: true,
+				},
+			},
+			scenarioRoles: true,
+			nicknameConfigs: true,
+		},
+	})
+
+	return attachment ? flattenCorporationDiscordAttachment(attachment) : null
+}
 
 async function validateScenarioRoleSelections(
 	db: any,
@@ -57,23 +280,7 @@ app.get('/:corporationId/discord-servers', requireAuth(), requireAdmin(), async 
 	}
 
 	try {
-		const attachments = await db.query.corporationDiscordServers.findMany({
-			where: eq(corporationDiscordServers.corporationId, corporationId),
-			with: {
-				discordServer: {
-					with: {
-						roles: true,
-					},
-				},
-				roles: {
-					with: {
-						discordRole: true,
-					},
-				},
-			},
-			orderBy: desc(corporationDiscordServers.createdAt),
-		})
-
+		const attachments = await fetchCorporationDiscordAttachments(db, corporationId)
 		return c.json(attachments)
 	} catch (error) {
 		logger.error('Error fetching corporation Discord servers:', error)
@@ -99,7 +306,6 @@ app.post('/:corporationId/discord-servers', requireAuth(), requireAdmin(), async
 		const autoInvite = body.autoInvite as boolean | undefined
 		const autoAssignRoles = body.autoAssignRoles as boolean | undefined
 		const scenarioRoleIds = [
-			body.corpMemberRoleId as string | null | undefined,
 			body.allianceGuestRoleId as string | null | undefined,
 			body.nonAllianceGuestRoleId as string | null | undefined,
 		]
@@ -128,6 +334,8 @@ app.post('/:corporationId/discord-servers', requireAuth(), requireAdmin(), async
 		}
 
 		await validateScenarioRoleSelections(db, server.id, scenarioRoleIds)
+		const scenarioValues = buildScenarioRoleUpdateValues(body)
+		const nicknameValues = buildNicknameUpdateValues(body)
 
 		const [attachment] = await db
 			.insert(corporationDiscordServers)
@@ -136,23 +344,54 @@ app.post('/:corporationId/discord-servers', requireAuth(), requireAdmin(), async
 				discordServerId,
 				autoInvite: autoInvite ?? false,
 				autoAssignRoles: autoAssignRoles ?? false,
-				corpMemberRoleId: body.corpMemberRoleId as string | null | undefined,
-				corpMemberAutoApply: (body.corpMemberAutoApply as boolean | undefined) ?? false,
-				allianceGuestRoleId: body.allianceGuestRoleId as string | null | undefined,
-				allianceGuestAutoApply: (body.allianceGuestAutoApply as boolean | undefined) ?? false,
-				nonAllianceGuestRoleId: body.nonAllianceGuestRoleId as string | null | undefined,
-				nonAllianceGuestAutoApply:
-					(body.nonAllianceGuestAutoApply as boolean | undefined) ?? false,
 			})
 			.returning()
 
+		await db.insert(corporationDiscordServerScenarioRoles).values([
+			{
+				corporationDiscordServerId: attachment.id,
+				bucket: 'alliance_guest',
+				discordRoleId:
+					(scenarioValues.allianceGuestRoleId as string | null | undefined) ?? null,
+				autoApply: (scenarioValues.allianceGuestAutoApply as boolean | undefined) ?? false,
+			},
+			{
+				corporationDiscordServerId: attachment.id,
+				bucket: 'non_alliance_guest',
+				discordRoleId:
+					(scenarioValues.nonAllianceGuestRoleId as string | null | undefined) ?? null,
+				autoApply: (scenarioValues.nonAllianceGuestAutoApply as boolean | undefined) ?? false,
+			},
+		])
+
+		await db.insert(corporationDiscordServerNicknameConfigs).values(
+			nicknameBucketFields.map((bucket) => ({
+				corporationDiscordServerId: attachment.id,
+				bucket: bucket.bucket,
+				enabled: (nicknameValues[bucket.enabledField] as boolean | undefined) ?? false,
+				source:
+					(nicknameValues[bucket.sourceField] as NicknameTickerSource | undefined) ?? 'corp',
+				customTicker:
+					(nicknameValues[bucket.customField] as string | null | undefined) ?? null,
+			}))
+		)
+
+		const hydratedAttachment = await fetchCorporationDiscordAttachment(
+			db,
+			corporationId,
+			attachment.id
+		)
 		logger.info(`Discord server ${server.guildName} attached to corporation ${corporationId}`)
 
-		return c.json(attachment, 201)
+		return c.json(hydratedAttachment ?? attachment, 201)
 	} catch (error) {
 		logger.error('Error attaching Discord server to corporation:', error)
 		const message = error instanceof Error ? error.message : ''
-		if (message.startsWith('Role ')) {
+		if (
+			message.startsWith('Role ') ||
+			message.startsWith('Invalid ') ||
+			message.startsWith('Custom ticker is required')
+		) {
 			return c.json({ error: message }, 400)
 		}
 		return c.json({ error: 'Failed to attach Discord server' }, 500)
@@ -177,21 +416,7 @@ app.get(
 		}
 
 		try {
-			const attachment = await db.query.corporationDiscordServers.findFirst({
-				where: eq(corporationDiscordServers.id, attachmentId),
-				with: {
-					discordServer: {
-						with: {
-							roles: true,
-						},
-					},
-					roles: {
-						with: {
-							discordRole: true,
-						},
-					},
-				},
-			})
+			const attachment = await fetchCorporationDiscordAttachment(db, corporationId, attachmentId)
 
 			if (!attachment) {
 				return c.json({ error: 'Discord server attachment not found' }, 404)
@@ -227,59 +452,48 @@ app.put(
 			const autoInvite = body.autoInvite as boolean | undefined
 			const autoAssignRoles = body.autoAssignRoles as boolean | undefined
 			const scenarioRoleIds = [
-				body.corpMemberRoleId as string | null | undefined,
 				body.allianceGuestRoleId as string | null | undefined,
 				body.nonAllianceGuestRoleId as string | null | undefined,
 			]
 
-			const existing = await db.query.corporationDiscordServers.findFirst({
-				where: eq(corporationDiscordServers.id, attachmentId),
-				with: {
-					discordServer: {
-						columns: { id: true },
-					},
-				},
-			})
+			const existing = await fetchCorporationDiscordAttachment(db, corporationId, attachmentId)
 
 			if (!existing) {
 				return c.json({ error: 'Discord server attachment not found' }, 404)
 			}
 
-			await validateScenarioRoleSelections(
-				db,
-				existing.discordServer.id,
-				scenarioRoleIds
-			)
+			await validateScenarioRoleSelections(db, existing.discordServer.id, scenarioRoleIds)
 
 			const [updated] = await db
 				.update(corporationDiscordServers)
 				.set({
 					...(autoInvite !== undefined && { autoInvite }),
 					...(autoAssignRoles !== undefined && { autoAssignRoles }),
-					...(body.corpMemberRoleId !== undefined && {
-						corpMemberRoleId: body.corpMemberRoleId as string | null,
-					}),
-					...(body.corpMemberAutoApply !== undefined && {
-						corpMemberAutoApply: body.corpMemberAutoApply as boolean,
-					}),
-					...(body.allianceGuestRoleId !== undefined && {
-						allianceGuestRoleId: body.allianceGuestRoleId as string | null,
-					}),
-					...(body.allianceGuestAutoApply !== undefined && {
-						allianceGuestAutoApply: body.allianceGuestAutoApply as boolean,
-					}),
-					...(body.nonAllianceGuestRoleId !== undefined && {
-						nonAllianceGuestRoleId: body.nonAllianceGuestRoleId as string | null,
-					}),
-					...(body.nonAllianceGuestAutoApply !== undefined && {
-						nonAllianceGuestAutoApply: body.nonAllianceGuestAutoApply as boolean,
-					}),
 					updatedAt: new Date(),
 				})
 				.where(eq(corporationDiscordServers.id, attachmentId))
 				.returning()
 
-			return c.json(updated)
+			const scenarioValues = buildScenarioRoleUpdateValues(body, existing as Record<string, unknown>)
+			await db
+				.delete(corporationDiscordServerScenarioRoles)
+				.where(eq(corporationDiscordServerScenarioRoles.corporationDiscordServerId, attachmentId))
+			await db.insert(corporationDiscordServerScenarioRoles).values(
+				scenarioRoleBucketFields.map((bucket) => ({
+					corporationDiscordServerId: attachmentId,
+					bucket: bucket.bucket,
+					discordRoleId:
+						(scenarioValues[bucket.roleField] as string | null | undefined) ?? null,
+					autoApply: (scenarioValues[bucket.autoApplyField] as boolean | undefined) ?? false,
+				}))
+			)
+
+			const hydratedAttachment = await fetchCorporationDiscordAttachment(
+				db,
+				corporationId,
+				attachmentId
+			)
+			return c.json(hydratedAttachment ?? updated)
 		} catch (error) {
 			logger.error('Error updating Discord server attachment:', error)
 			const message = error instanceof Error ? error.message : ''
@@ -287,6 +501,72 @@ app.put(
 				return c.json({ error: message }, 400)
 			}
 			return c.json({ error: 'Failed to update Discord server attachment' }, 500)
+		}
+	}
+)
+
+/**
+ * PUT /corporations/:corporationId/discord-servers/:attachmentId/nickname-config
+ * Update nickname ticker settings for a corporation Discord server attachment
+ */
+app.put(
+	'/:corporationId/discord-servers/:attachmentId/nickname-config',
+	requireAuth(),
+	requireAdmin(),
+	async (c) => {
+		const corporationId = c.req.param('corporationId')
+		const attachmentId = c.req.param('attachmentId')
+		const db = c.get('db')
+
+		if (!db) {
+			return c.json({ error: 'Database not available' }, 500)
+		}
+
+			try {
+				const body = (await c.req.json()) as Record<string, unknown>
+				const existing = await fetchCorporationDiscordAttachment(db, corporationId, attachmentId)
+
+				if (!existing) {
+					return c.json({ error: 'Discord server attachment not found' }, 404)
+				}
+
+			const nicknameValues = buildNicknameUpdateValues(body, existing as Record<string, unknown>)
+
+			const [updated] = await db
+				.update(corporationDiscordServers)
+				.set({
+					updatedAt: new Date(),
+				})
+				.where(eq(corporationDiscordServers.id, attachmentId))
+				.returning()
+
+			await db
+				.delete(corporationDiscordServerNicknameConfigs)
+				.where(eq(corporationDiscordServerNicknameConfigs.corporationDiscordServerId, attachmentId))
+			await db.insert(corporationDiscordServerNicknameConfigs).values(
+				nicknameBucketFields.map((bucket) => ({
+					corporationDiscordServerId: attachmentId,
+					bucket: bucket.bucket,
+					enabled: (nicknameValues[bucket.enabledField] as boolean | undefined) ?? false,
+					source: (nicknameValues[bucket.sourceField] as NicknameTickerSource | undefined) ?? 'corp',
+					customTicker:
+						(nicknameValues[bucket.customField] as string | null | undefined) ?? null,
+				}))
+			)
+
+			const hydratedAttachment = await fetchCorporationDiscordAttachment(
+				db,
+				corporationId,
+				attachmentId
+			)
+			return c.json(hydratedAttachment ?? updated)
+		} catch (error) {
+			logger.error('Error updating Discord server nickname config:', error)
+			const message = error instanceof Error ? error.message : ''
+			if (message.startsWith('Invalid ') || message.startsWith('Custom ticker is required')) {
+				return c.json({ error: message }, 400)
+			}
+			return c.json({ error: 'Failed to update Discord server nickname config' }, 500)
 		}
 	}
 )

--- a/apps/core/src/services/__tests__/discord-role-sync.test.ts
+++ b/apps/core/src/services/__tests__/discord-role-sync.test.ts
@@ -56,6 +56,11 @@ const hrStubMethods = {
 
 const eveCorpStubMethods = {
 	getCorporationIdsByCharacterIds: vi.fn(),
+	getCorporationInfo: vi.fn(),
+}
+
+const tokenStoreStubMethods = {
+	getAllianceById: vi.fn(),
 }
 
 // DB query mock — every table.findMany / table.findFirst is wired per-test
@@ -124,6 +129,7 @@ const mockedGetStub = vi.mocked(getStub)
 const GROUPS_NS = Symbol('GROUPS')
 const HR_NS = Symbol('HR')
 const EVE_CORP_NS = Symbol('EVE_CORPORATION_DATA')
+const EVE_TOKEN_STORE_NS = Symbol('EVE_TOKEN_STORE')
 const DISCORD_NS = Symbol('DISCORD')
 
 const mockEnv = {
@@ -131,6 +137,7 @@ const mockEnv = {
 	GROUPS: GROUPS_NS,
 	HR: HR_NS,
 	EVE_CORPORATION_DATA: EVE_CORP_NS,
+	EVE_TOKEN_STORE: EVE_TOKEN_STORE_NS,
 	DISCORD: DISCORD_NS,
 	DISCORD_ROLE_ADD_ONLY_MODE: false,
 } as any
@@ -140,6 +147,7 @@ function setupGetStubRouting() {
 		if (namespace === GROUPS_NS) return groupsStubMethods as any
 		if (namespace === HR_NS) return hrStubMethods as any
 		if (namespace === EVE_CORP_NS) return eveCorpStubMethods as any
+		if (namespace === EVE_TOKEN_STORE_NS) return tokenStoreStubMethods as any
 		return {} as any
 	})
 }
@@ -202,12 +210,19 @@ function makeCorpAttachment(
 		guildName?: string
 		corpName?: string
 		isMemberCorporation?: boolean
-		corpMemberRoleId?: string | null
-		corpMemberAutoApply?: boolean
+		corpMemberNicknameEnabled?: boolean
+		corpMemberNicknameSource?: 'corp' | 'alliance' | 'custom'
+		corpMemberNicknameCustomTicker?: string | null
 		allianceGuestRoleId?: string | null
 		allianceGuestAutoApply?: boolean
+		allianceGuestNicknameEnabled?: boolean
+		allianceGuestNicknameSource?: 'corp' | 'alliance' | 'custom'
+		allianceGuestNicknameCustomTicker?: string | null
 		nonAllianceGuestRoleId?: string | null
 		nonAllianceGuestAutoApply?: boolean
+		nonAllianceGuestNicknameEnabled?: boolean
+		nonAllianceGuestNicknameSource?: 'corp' | 'alliance' | 'custom'
+		nonAllianceGuestNicknameCustomTicker?: string | null
 		roleIds?: string[]
 	} = {}
 ) {
@@ -218,18 +233,57 @@ function makeCorpAttachment(
 	const roleData = (overrides.roleIds ?? []).map((roleId) => ({
 		discordRole: { roleId, isActive: true },
 	}))
+	const scenarioRoles = [
+		{
+			bucket: 'alliance_guest' as const,
+			discordRoleId: overrides.allianceGuestRoleId ?? null,
+			autoApply: overrides.allianceGuestAutoApply ?? false,
+		},
+		{
+			bucket: 'non_alliance_guest' as const,
+			discordRoleId: overrides.nonAllianceGuestRoleId ?? null,
+			autoApply: overrides.nonAllianceGuestAutoApply ?? false,
+		},
+	]
+	const nicknameConfigs = [
+		{
+			bucket: 'corp_member' as const,
+			enabled: overrides.corpMemberNicknameEnabled ?? false,
+			source: overrides.corpMemberNicknameSource ?? 'corp',
+			customTicker: overrides.corpMemberNicknameCustomTicker ?? null,
+		},
+		{
+			bucket: 'alliance_guest' as const,
+			enabled: overrides.allianceGuestNicknameEnabled ?? false,
+			source: overrides.allianceGuestNicknameSource ?? 'corp',
+			customTicker: overrides.allianceGuestNicknameCustomTicker ?? null,
+		},
+		{
+			bucket: 'non_alliance_guest' as const,
+			enabled: overrides.nonAllianceGuestNicknameEnabled ?? false,
+			source: overrides.nonAllianceGuestNicknameSource ?? 'corp',
+			customTicker: overrides.nonAllianceGuestNicknameCustomTicker ?? null,
+		},
+	]
 	return {
 		id: `cds-${corpId}-${dsId}`,
 		corporationId: corpId,
 		discordServerId: dsId,
 		autoInvite: overrides.autoInvite ?? true,
 		autoAssignRoles: overrides.autoAssignRoles ?? true,
-		corpMemberRoleId: overrides.corpMemberRoleId ?? null,
-		corpMemberAutoApply: overrides.corpMemberAutoApply ?? false,
+		corpMemberNicknameEnabled: overrides.corpMemberNicknameEnabled ?? false,
+		corpMemberNicknameSource: overrides.corpMemberNicknameSource ?? 'corp',
+		corpMemberNicknameCustomTicker: overrides.corpMemberNicknameCustomTicker ?? null,
 		allianceGuestRoleId: overrides.allianceGuestRoleId ?? null,
 		allianceGuestAutoApply: overrides.allianceGuestAutoApply ?? false,
+		allianceGuestNicknameEnabled: overrides.allianceGuestNicknameEnabled ?? false,
+		allianceGuestNicknameSource: overrides.allianceGuestNicknameSource ?? 'corp',
+		allianceGuestNicknameCustomTicker: overrides.allianceGuestNicknameCustomTicker ?? null,
 		nonAllianceGuestRoleId: overrides.nonAllianceGuestRoleId ?? null,
 		nonAllianceGuestAutoApply: overrides.nonAllianceGuestAutoApply ?? false,
+		nonAllianceGuestNicknameEnabled: overrides.nonAllianceGuestNicknameEnabled ?? false,
+		nonAllianceGuestNicknameSource: overrides.nonAllianceGuestNicknameSource ?? 'corp',
+		nonAllianceGuestNicknameCustomTicker: overrides.nonAllianceGuestNicknameCustomTicker ?? null,
 		corporation: {
 			id: corpId,
 			name: overrides.corpName ?? 'Test Corp',
@@ -237,6 +291,8 @@ function makeCorpAttachment(
 		},
 		discordServer: { id: dsId, guildId, guildName, isActive: true },
 		roles: roleData,
+		scenarioRoles,
+		nicknameConfigs,
 	}
 }
 
@@ -278,6 +334,7 @@ beforeEach(() => {
 		groupsStubMethods,
 		hrStubMethods,
 		eveCorpStubMethods,
+		tokenStoreStubMethods,
 	]) {
 		for (const value of Object.values(stub)) {
 			value.mockReset()
@@ -299,6 +356,17 @@ beforeEach(() => {
 	hrStubMethods.isUserBlacklisted.mockResolvedValue(false)
 	// Default: character→corp mapping
 	eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({ 'char-1': 'corp-1' })
+	eveCorpStubMethods.getCorporationInfo.mockResolvedValue({
+		corporationId: 'corp-1',
+		name: 'Test Corp',
+		ticker: 'TEST',
+		allianceId: null,
+	} as any)
+	tokenStoreStubMethods.getAllianceById.mockResolvedValue({
+		allianceId: 'alliance-1',
+		name: 'Test Alliance',
+		ticker: 'ALLY',
+	} as any)
 	// Default: empty groups
 	groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
 	groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
@@ -750,8 +818,93 @@ describe('updateUserDiscordRoles', () => {
 			expect(scopedGuildIds).toEqual(['guild-1', 'guild-2'])
 			expect(discordStubMethods.updateUserNickname).toHaveBeenCalledWith(
 				'user-1',
-				['guild-1', 'guild-2'],
+				['guild-1'],
 				'Test Pilot'
+			)
+		})
+
+		it('should append the configured alliance ticker for corp members when that bucket is enabled', async () => {
+			dbQueryMocks.users.findFirst.mockResolvedValue(makeUser())
+			dbQueryMocks.userCharacters.findMany.mockResolvedValue([makeCharacter()])
+			dbQueryMocks.discordServers.findMany.mockResolvedValue([
+				makeDiscordServer({
+					id: 'ds-1',
+					guildId: 'guild-1',
+					guildName: 'Nick Server',
+					manageNicknames: true,
+				}),
+			])
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+					isMemberCorporation: true,
+					corpMemberNicknameEnabled: true,
+					corpMemberNicknameSource: 'alliance',
+					corpMemberNicknameCustomTicker: null,
+				}),
+			])
+			dbQueryMocks.managedCorporations.findMany.mockResolvedValue([
+				{ corporationId: 'corp-1', ticker: 'CORP' } as any,
+			])
+			eveCorpStubMethods.getCorporationInfo.mockResolvedValue({
+				corporationId: 'corp-1',
+				name: 'Test Corp',
+				allianceId: 'alliance-1',
+			} as any)
+			tokenStoreStubMethods.getAllianceById.mockResolvedValue({
+				allianceId: 'alliance-1',
+				name: 'Test Alliance',
+				ticker: 'ALLY',
+			} as any)
+			discordStubMethods.checkGuildMembershipWithBot.mockResolvedValue(['guild-1'])
+
+			await updateUserDiscordNickname(mockEnv, 'user-1', ['guild-1'])
+
+			expect(discordStubMethods.updateUserNickname).toHaveBeenCalledWith(
+				'user-1',
+				['guild-1'],
+				'[ALLY] Test Pilot'
+			)
+		})
+
+		it('should use the custom ticker configured for the all-members bucket', async () => {
+			dbQueryMocks.users.findFirst.mockResolvedValue(makeUser())
+			dbQueryMocks.userCharacters.findMany.mockResolvedValue([makeCharacter()])
+			dbQueryMocks.discordServers.findMany.mockResolvedValue([
+				makeDiscordServer({
+					id: 'ds-1',
+					guildId: 'guild-1',
+					guildName: 'Nick Server',
+					manageNicknames: true,
+				}),
+			])
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+					isMemberCorporation: true,
+					corpMemberNicknameEnabled: true,
+					corpMemberNicknameSource: 'custom',
+					corpMemberNicknameCustomTicker: 'corpx',
+				}),
+			])
+			dbQueryMocks.managedCorporations.findMany.mockResolvedValue([])
+			eveCorpStubMethods.getCorporationInfo.mockResolvedValue({
+				corporationId: 'corp-1',
+				name: 'Test Corp',
+				allianceId: null,
+			} as any)
+			discordStubMethods.checkGuildMembershipWithBot.mockResolvedValue(['guild-1'])
+
+			await updateUserDiscordNickname(mockEnv, 'user-1', ['guild-1'])
+
+			expect(discordStubMethods.updateUserNickname).toHaveBeenCalledWith(
+				'user-1',
+				['guild-1'],
+				'[CORPX] Test Pilot'
 			)
 		})
 	})
@@ -1450,6 +1603,34 @@ describe('inviteUserToDiscordServers', () => {
 			expect(guildIds).toContain('guild-2')
 			expect(result.totalInvited).toBeGreaterThanOrEqual(0) // depends on mock return
 		})
+
+		it('should not invite user when they are only a group owner/admin', async () => {
+			eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({})
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([])
+
+			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
+				makeGroupWithDiscord({
+					groupId: 'group-1',
+					discordServers: [
+						{
+							discordServerId: 'ds-2',
+							autoInvite: true,
+							autoAssignRoles: true,
+							roleIds: ['dr-role'],
+						},
+					],
+				}),
+			])
+			groupsStubMethods.getGroupMemberUserIds.mockResolvedValue([])
+			groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue(['user-1'])
+			dbQueryMocks.discordRoles.findMany.mockResolvedValue([])
+
+			const result = await inviteUserToDiscordServers(mockEnv, 'user-1')
+
+			expect(discordStubMethods.joinUserToServers).not.toHaveBeenCalled()
+			expect(result.totalInvited).toBe(0)
+			expect(result.results).toHaveLength(0)
+		})
 	})
 
 	describe('Corp with auto-invite', () => {
@@ -1478,6 +1659,31 @@ describe('inviteUserToDiscordServers', () => {
 			expect(discordStubMethods.joinUserToServers).toHaveBeenCalled()
 			const guildIds = discordStubMethods.joinUserToServers.mock.calls[0][1]
 			expect(guildIds).toContain('guild-1')
+		})
+
+		it('should not invite a non-member user even when guest buckets are configured', async () => {
+			eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({})
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					guildId: 'guild-1',
+					autoInvite: true,
+					autoAssignRoles: true,
+					allianceGuestRoleId: 'alliance-guest-role-db',
+					allianceGuestAutoApply: true,
+					nonAllianceGuestRoleId: 'non-alliance-guest-role-db',
+					nonAllianceGuestAutoApply: true,
+				}),
+			])
+
+			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
+			dbQueryMocks.discordRoles.findMany.mockResolvedValue([])
+
+			const result = await inviteUserToDiscordServers(mockEnv, 'user-1')
+
+			expect(discordStubMethods.joinUserToServers).not.toHaveBeenCalled()
+			expect(result.totalInvited).toBe(0)
+			expect(result.results).toHaveLength(0)
 		})
 	})
 
@@ -1605,6 +1811,55 @@ describe('inviteUserToDiscordServers', () => {
 			const uniqueGuildIds = [...new Set(guildIds)]
 			expect(uniqueGuildIds).toEqual(guildIds)
 		})
+
+		it('should only invite via the group path when a shared guild also has a corp attachment but the user lacks corp entitlement', async () => {
+			eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({})
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					guildId: 'guild-1',
+					autoInvite: true,
+					autoAssignRoles: true,
+					roleIds: ['corp-role-db'],
+				}),
+			])
+
+			groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
+				makeGroupWithDiscord({
+					groupId: 'group-1',
+					discordServers: [
+						{
+							discordServerId: 'ds-1',
+							autoInvite: true,
+							autoAssignRoles: true,
+							roleIds: ['group-role-db'],
+						},
+					],
+				}),
+			])
+			groupsStubMethods.getGroupMemberUserIds.mockResolvedValue(['user-1'])
+			dbQueryMocks.discordServers.findFirst.mockResolvedValue(
+				makeDiscordServer({ id: 'ds-1', guildId: 'guild-1', guildName: 'Shared Guild' })
+			)
+			dbQueryMocks.discordRoles.findMany
+				.mockResolvedValueOnce([{ id: 'group-role-db', roleId: 'group-role', isActive: true } as any])
+				.mockResolvedValueOnce([] as any)
+			discordStubMethods.joinUserToServers.mockResolvedValue([
+				{ guildId: 'guild-1', success: true, alreadyMember: false },
+			])
+			groupsStubMethods.insertDiscordInviteAuditRecords.mockResolvedValue(undefined)
+
+			const result = await inviteUserToDiscordServers(mockEnv, 'user-1')
+
+			expect(discordStubMethods.joinUserToServers).toHaveBeenCalledTimes(1)
+			expect(discordStubMethods.joinUserToServers.mock.calls[0][1]).toEqual(['guild-1'])
+			expect(result.results).toHaveLength(1)
+			expect(result.results[0].type).toBe('group')
+			expect(discordStubMethods.updateUserRoles).toHaveBeenCalledTimes(1)
+			expect(discordStubMethods.updateUserRoles.mock.calls[0][1][0].roleIds).toEqual([
+				'group-role',
+			])
+		})
 	})
 })
 
@@ -1634,6 +1889,49 @@ describe('syncUserDiscordAccess', () => {
 		expect(result.totalUpdated).toBe(2)
 		expect(result.totalFailed).toBe(0)
 		expect(result.results.map((r) => r.operation)).toEqual(['revoke-ban', 'revoke-ban'])
+	})
+
+	it('should not auto-invite on refresh when only exclusive corp buckets or group owner/admin access exist', async () => {
+		eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({})
+		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					guildId: 'guild-1',
+					autoInvite: true,
+					autoAssignRoles: true,
+					allianceGuestRoleId: 'alliance-guest-role-db',
+					allianceGuestAutoApply: true,
+					nonAllianceGuestRoleId: 'non-alliance-guest-role-db',
+				nonAllianceGuestAutoApply: true,
+			}),
+		])
+
+		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
+			makeGroupWithDiscord({
+				groupId: 'group-1',
+				discordServers: [
+					{
+						discordServerId: 'ds-2',
+						autoInvite: true,
+						autoAssignRoles: true,
+						roleIds: ['dr-role'],
+					},
+				],
+			}),
+		])
+		groupsStubMethods.getGroupMemberUserIds.mockResolvedValue([])
+		groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue(['user-1'])
+		dbQueryMocks.discordServers.findFirst.mockResolvedValue(
+			makeDiscordServer({ id: 'ds-2', guildId: 'guild-2', guildName: 'Group Guild' })
+		)
+		dbQueryMocks.discordRoles.findMany.mockResolvedValue([])
+		groupsStubMethods.insertDiscordInviteAuditRecords.mockResolvedValue(undefined)
+
+		const result = await syncUserDiscordAccess(mockEnv, 'user-1')
+
+		expect(discordStubMethods.joinUserToServers).not.toHaveBeenCalled()
+		expect(result.totalInvited).toBe(0)
+		expect(result.results.filter((r) => r.operation === 'invite')).toHaveLength(0)
 	})
 
 	it('should run invite then role sync and pass allowRemoval through to role updates', async () => {
@@ -1715,6 +2013,52 @@ describe('syncUserDiscordAccess', () => {
 		expect(result.totalUpdated).toBe(1)
 		expect(result.totalFailed).toBe(0)
 		expect(result.results.map((r) => r.operation)).toEqual(['invite', 'update'])
+	})
+})
+
+describe('updateUserDiscordRoles matrix', () => {
+	it('should still assign corp roles when autoInvite is disabled', async () => {
+		discordStubMethods.checkGuildMembershipWithBot.mockResolvedValue(['guild-1'])
+		dbQueryMocks.discordServers.findMany.mockResolvedValue([makeDiscordServer({ guildId: 'guild-1' })])
+		dbQueryMocks.corporationDiscordServers.findMany
+			.mockResolvedValueOnce([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					guildId: 'guild-1',
+					autoInvite: false,
+					autoAssignRoles: true,
+					roleIds: ['corp-role-db'],
+				}),
+			])
+			.mockResolvedValueOnce([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+				}),
+			])
+		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
+		groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
+		dbQueryMocks.discordRoles.findMany.mockImplementation(async (query: any) => {
+			if (query?.with?.discordServer) {
+				return []
+			}
+			if (query?.columns?.roleName) {
+				return []
+			}
+			return [{ id: 'corp-role-db', roleId: 'corp-role', isActive: true }]
+		})
+		discordStubMethods.updateUserRoles.mockResolvedValue([
+			{ guildId: 'guild-1', success: true, rolesAdded: ['corp-role'], rolesRemoved: [] },
+		])
+
+		const result = await updateUserDiscordRoles(mockEnv, 'user-1')
+
+		expect(discordStubMethods.updateUserRoles).toHaveBeenCalledTimes(1)
+		expect(discordStubMethods.updateUserRoles.mock.calls[0][1][0].roleIds).toEqual([
+			'corp-role-db',
+		])
+		expect(result.totalUpdated).toBe(1)
 	})
 })
 
@@ -2027,55 +2371,10 @@ describe('getExpectedManagedRoleIdsByGuild', () => {
 		)
 	})
 
-	it('should prefer corp-member scenarios over alliance guest scenarios', async () => {
-		dbQueryMocks.discordServers.findMany.mockResolvedValue([
-			makeDiscordServer({ id: 'ds-1', guildId: 'guild-1', guildName: 'Guild One' }),
-		])
-		dbQueryMocks.userCharacters.findMany.mockResolvedValue([
-			{
-				userId: 'user-1',
-				characterId: 'char-1',
-			},
-		] as any)
-		eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({
-			'char-1': 'corp-target',
-		})
-		dbQueryMocks.managedCorporations.findMany.mockResolvedValue([
-			{ corporationId: 'corp-target' },
-		] as any)
-		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
-			makeCorpAttachment({
-				corporationId: 'corp-target',
-				discordServerId: 'ds-1',
-				guildId: 'guild-1',
-				isMemberCorporation: true,
-				corpMemberRoleId: 'corp-role-db',
-				corpMemberAutoApply: true,
-				allianceGuestRoleId: 'alliance-role-db',
-				allianceGuestAutoApply: true,
-				nonAllianceGuestRoleId: 'guest-role-db',
-				nonAllianceGuestAutoApply: true,
-			}),
-		])
-		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
-		groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
-		dbQueryMocks.discordRoles.findMany
-			.mockResolvedValueOnce([
-				{ id: 'corp-role-db', roleId: 'corp-role', isActive: true },
-				{ id: 'alliance-role-db', roleId: 'alliance-role', isActive: true },
-				{ id: 'guest-role-db', roleId: 'guest-role', isActive: true },
-			] as any)
-			.mockResolvedValueOnce([] as any)
-
-		const result = await getExpectedManagedRoleIdsByGuild(mockEnv, 'user-1')
-
-		expect(Array.from(result.get('guild-1') ?? [])).toEqual(['corp-role'])
-	})
-
-	it('should use alliance guest scenarios for linked users affiliated through member corps', async () => {
-		dbQueryMocks.discordServers.findMany.mockResolvedValue([
-			makeDiscordServer({ id: 'ds-1', guildId: 'guild-1', guildName: 'Guild One' }),
-		])
+		it('should use alliance guest scenarios for linked users affiliated through member corps', async () => {
+			dbQueryMocks.discordServers.findMany.mockResolvedValue([
+				makeDiscordServer({ id: 'ds-1', guildId: 'guild-1', guildName: 'Guild One' }),
+			])
 		dbQueryMocks.userCharacters.findMany.mockResolvedValue([
 			{
 				userId: 'user-1',
@@ -2085,23 +2384,21 @@ describe('getExpectedManagedRoleIdsByGuild', () => {
 		eveCorpStubMethods.getCorporationIdsByCharacterIds.mockResolvedValue({
 			'char-1': 'corp-affiliated',
 		})
-		dbQueryMocks.managedCorporations.findMany.mockResolvedValue([
-			{ corporationId: 'corp-affiliated' },
-		] as any)
-		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
-			makeCorpAttachment({
-				corporationId: 'corp-target',
-				discordServerId: 'ds-1',
-				guildId: 'guild-1',
-				isMemberCorporation: true,
-				corpMemberRoleId: 'corp-role-db',
-				corpMemberAutoApply: false,
-				allianceGuestRoleId: 'alliance-role-db',
-				allianceGuestAutoApply: true,
-				nonAllianceGuestRoleId: 'guest-role-db',
-				nonAllianceGuestAutoApply: true,
-			}),
-		])
+			dbQueryMocks.managedCorporations.findMany.mockResolvedValue([
+				{ corporationId: 'corp-affiliated' },
+			] as any)
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-target',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+					isMemberCorporation: true,
+					allianceGuestRoleId: 'alliance-role-db',
+					allianceGuestAutoApply: true,
+					nonAllianceGuestRoleId: 'guest-role-db',
+					nonAllianceGuestAutoApply: true,
+				}),
+			])
 		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
 		groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([])
 		dbQueryMocks.discordRoles.findMany
@@ -2116,7 +2413,7 @@ describe('getExpectedManagedRoleIdsByGuild', () => {
 		expect(Array.from(result.get('guild-1') ?? [])).toEqual(['alliance-role'])
 	})
 
-	it('should include corp roles and both group membership buckets when building expected managed roles', async () => {
+	it('should include corp-managed roles when building expected managed roles', async () => {
 		dbQueryMocks.discordServers.findMany.mockReset()
 		dbQueryMocks.userCharacters.findMany.mockReset()
 		dbQueryMocks.corporationDiscordServers.findMany.mockReset()
@@ -2144,49 +2441,20 @@ describe('getExpectedManagedRoleIdsByGuild', () => {
 				discordServerId: 'ds-1',
 				guildId: 'guild-1',
 				autoAssignRoles: true,
-				corpMemberRoleId: 'corp-member-db',
-				corpMemberAutoApply: true,
 				roleIds: ['corp-managed-role-db'],
 			}),
 		])
-		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([
-			makeGroupWithDiscord({
-				groupId: 'group-1',
-				discordServers: [
-					{
-						discordServerId: 'ds-1',
-						autoInvite: true,
-						autoAssignRoles: true,
-						memberRoleIds: ['group-member-db'],
-						ownerAdminRoleIds: ['group-owner-db'],
-					},
-				],
-			}),
-		])
-		groupsStubMethods.getGroupMemberUserIds.mockResolvedValue(['user-1'])
-		groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue(['user-1'])
-		dbQueryMocks.discordRoles.findMany
-			.mockResolvedValueOnce([
-				{ id: 'corp-member-db', roleId: 'corp-member-role', isActive: true },
-				{ id: 'corp-managed-role-db', roleId: 'corp-managed-role', isActive: true },
-			] as any)
-			.mockResolvedValueOnce([
-				{ id: 'group-member-db', roleId: 'group-member-role', isActive: true },
-				{ id: 'group-owner-db', roleId: 'group-owner-role', isActive: true },
-			] as any)
-			.mockResolvedValueOnce([] as any)
+		groupsStubMethods.getGroupsWithDiscordAutoInvite.mockResolvedValue([])
+		groupsStubMethods.getGroupMemberUserIds.mockResolvedValue([])
+		groupsStubMethods.getGroupOwnerAndAdminUserIds.mockResolvedValue([])
+		dbQueryMocks.discordRoles.findMany.mockResolvedValueOnce([
+			{ id: 'corp-managed-role-db', roleId: 'corp-managed-role', isActive: true },
+		] as any)
 		discordStubMethods.getGuildRoles.mockResolvedValue([{ id: 'some-other-role' }])
 
 		const result = await getExpectedManagedRoleIdsByGuild(mockEnv, 'user-1')
 
-		expect(Array.from(result.get('guild-1') ?? [])).toEqual(
-			expect.arrayContaining([
-				'corp-member-role',
-				'corp-managed-role-db',
-				'group-member-role',
-				'group-owner-role',
-			])
-		)
+		expect(Array.from(result.get('guild-1') ?? [])).toEqual(['corp-managed-role-db'])
 	})
 })
 
@@ -2234,17 +2502,15 @@ describe('refreshServerMembers', () => {
 			'char-1': 'corp-1',
 		})
 		dbQueryMocks.managedCorporations.findMany.mockResolvedValue([])
-		dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
-			makeCorpAttachment({
-				corporationId: 'corp-1',
-				discordServerId: 'ds-1',
-				guildId: 'guild-1',
-				autoAssignRoles: true,
-				corpMemberRoleId: 'corp-member-role',
-				corpMemberAutoApply: true,
-				roleIds: ['corp-managed-role'],
-			}),
-		])
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+					autoAssignRoles: true,
+					roleIds: ['corp-managed-role'],
+				}),
+			])
 		groupsStubMethods.getGroupsByDiscordServer.mockResolvedValue([
 			{
 				groupId: 'group-1',
@@ -2263,17 +2529,11 @@ describe('refreshServerMembers', () => {
 		})
 		dbQueryMocks.discordRoles.findMany
 			.mockResolvedValueOnce([
-				{ id: 'corp-member-role', roleId: 'corp-member-role', isActive: true },
-			] as any)
-			.mockResolvedValueOnce([
 				{ id: 'group-member-role', roleId: 'group-member-role', isActive: true },
 				{ id: 'group-owner-role', roleId: 'group-owner-role', isActive: true },
 			] as any)
 			.mockResolvedValueOnce([] as any)
 			.mockResolvedValueOnce([] as any)
-			.mockResolvedValueOnce([
-				{ id: 'corp-member-role', roleId: 'corp-member-role', isActive: true },
-			] as any)
 			.mockResolvedValueOnce([
 				{ id: 'group-member-role', roleId: 'group-member-role', isActive: true },
 				{ id: 'group-owner-role', roleId: 'group-owner-role', isActive: true },
@@ -2283,28 +2543,23 @@ describe('refreshServerMembers', () => {
 			{ guildId: 'guild-1', success: true, rolesAdded: [], rolesRemoved: [] },
 		])
 		discordStubMethods.getDiscordUserStatus.mockResolvedValue(null)
-		discordStubMethods.updateUserRoles.mockResolvedValue([
-			{
-				guildId: 'guild-1',
-				success: true,
-				rolesAdded: ['corp-member-role', 'corp-managed-role', 'group-member-role', 'group-owner-role'],
-				rolesRemoved: [],
-			},
-		])
+			discordStubMethods.updateUserRoles.mockResolvedValue([
+				{
+					guildId: 'guild-1',
+					success: true,
+					rolesAdded: ['corp-managed-role', 'group-member-role', 'group-owner-role'],
+					rolesRemoved: [],
+				},
+			])
 
 		const result = await refreshServerMembers(mockEnv, 'ds-1', ['user-1'])
 
 		expect(result.successCount).toBe(1)
 		expect(result.failCount).toBe(0)
 		expect(discordStubMethods.updateUserRoles).toHaveBeenCalledTimes(1)
-		const requests = discordStubMethods.updateUserRoles.mock.calls[0][1]
-		expect(requests[0].roleIds).toEqual(
-			expect.arrayContaining([
-				'corp-member-role',
-				'corp-managed-role',
-				'group-member-role',
-				'group-owner-role',
-			])
-		)
+			const requests = discordStubMethods.updateUserRoles.mock.calls[0][1]
+			expect(requests[0].roleIds).toEqual(
+				expect.arrayContaining(['corp-managed-role', 'group-member-role', 'group-owner-role'])
+			)
 	})
 })

--- a/apps/core/src/services/discord.service.ts
+++ b/apps/core/src/services/discord.service.ts
@@ -9,6 +9,8 @@ import { logger } from '@repo/hono-helpers'
 import { createDb } from '../db'
 import {
 	corporationDiscordServers,
+	corporationDiscordServerNicknameConfigs,
+	corporationDiscordServerScenarioRoles,
 	discordRoles,
 	discordServers,
 	managedCorporations,
@@ -19,6 +21,7 @@ import {
 
 import type { Discord, DiscordProfile, JoinServerResult } from '@repo/discord'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Groups } from '@repo/groups'
 import type { Hr } from '@repo/hr'
 import type { Env } from '../context'
@@ -402,16 +405,7 @@ async function getAllManagedRolesForGuild(
 	// Query 2: Corporation-managed roles and scenario roles
 	const corpAttachments = await db.query.corporationDiscordServers.findMany({
 		where: eq(corporationDiscordServers.discordServerId, discordServerId),
-		columns: {
-			id: true,
-			autoAssignRoles: true,
-			corpMemberRoleId: true,
-			corpMemberAutoApply: true,
-			allianceGuestRoleId: true,
-			allianceGuestAutoApply: true,
-			nonAllianceGuestRoleId: true,
-			nonAllianceGuestAutoApply: true,
-		},
+		columns: { autoAssignRoles: true },
 		with: {
 			roles: {
 				with: {
@@ -419,6 +413,9 @@ async function getAllManagedRolesForGuild(
 						columns: { roleId: true, isActive: true },
 					},
 				},
+			},
+			scenarioRoles: {
+				columns: { bucket: true, discordRoleId: true, autoApply: true },
 			},
 		},
 	})
@@ -575,26 +572,214 @@ async function getUserCorporationIds(env: Env, characterIds: string[]): Promise<
 }
 
 type CorpAttachmentScenarioKey = 'corp-member' | 'alliance-guest' | 'non-alliance-guest'
+type CorporationDiscordScenarioRoleBucket = 'alliance_guest' | 'non_alliance_guest'
+type CorporationDiscordNicknameBucket =
+	| 'corp_member'
+	| 'alliance_guest'
+	| 'non_alliance_guest'
 
 type CorporationDiscordAttachmentScenarioFields = {
 	corporationId: string
-	corpMemberRoleId: string | null
-	corpMemberAutoApply: boolean
-	allianceGuestRoleId: string | null
-	allianceGuestAutoApply: boolean
-	nonAllianceGuestRoleId: string | null
-	nonAllianceGuestAutoApply: boolean
+	corporation: {
+		isMemberCorporation: boolean
+	}
+	scenarioRoles?: Array<{
+		bucket: CorporationDiscordScenarioRoleBucket
+		discordRoleId: string | null
+		autoApply: boolean
+	}>
 }
 
-type CorporationDiscordScenarioRoleFields = Pick<
-	CorporationDiscordAttachmentScenarioFields,
-	| 'corpMemberRoleId'
-	| 'corpMemberAutoApply'
-	| 'allianceGuestRoleId'
-	| 'allianceGuestAutoApply'
-	| 'nonAllianceGuestRoleId'
-	| 'nonAllianceGuestAutoApply'
->
+type CorporationDiscordScenarioRoleFields = {
+	scenarioRoles?: Array<{
+		bucket: CorporationDiscordScenarioRoleBucket
+		discordRoleId: string | null
+		autoApply: boolean
+	}>
+}
+
+type DiscordNicknameSource = 'corp' | 'alliance' | 'custom'
+
+type CorporationDiscordNicknameFields = {
+	corporationId: string
+	nicknameConfigs?: Array<{
+		bucket: CorporationDiscordNicknameBucket
+		enabled: boolean
+		source: DiscordNicknameSource
+		customTicker: string | null
+	}>
+	corporation: {
+		isMemberCorporation: boolean
+	}
+}
+
+type CorporationTickerSources = {
+	corpTicker: string | null
+	allianceTicker: string | null
+}
+
+function normalizeDiscordTicker(ticker?: string | null): string | null {
+	const normalized = ticker?.trim().toUpperCase().replace(/[^A-Z0-9]/g, '')
+	if (!normalized) {
+		return null
+	}
+
+	return normalized.slice(0, 5)
+}
+
+function buildDiscordNicknameWithTickers(baseName: string, suffixes: string[]): string {
+	if (suffixes.length === 0) {
+		return baseName
+	}
+
+	return `${suffixes.map((suffix) => `[${suffix}]`).join(' ')} ${baseName}`
+}
+
+function getScenarioRoleRecord(
+	attachment: CorporationDiscordScenarioRoleFields,
+	bucket: CorporationDiscordScenarioRoleBucket
+): { discordRoleId: string | null; autoApply: boolean } {
+	const row = attachment.scenarioRoles?.find((candidate) => candidate.bucket === bucket)
+	return row ?? { discordRoleId: null, autoApply: false }
+}
+
+function getNicknameConfigRecord(
+	attachment: CorporationDiscordNicknameFields,
+	bucket: CorporationDiscordNicknameBucket
+): {
+	enabled: boolean
+	source: DiscordNicknameSource
+	customTicker: string | null
+} {
+	const row = attachment.nicknameConfigs?.find((candidate) => candidate.bucket === bucket)
+	return row ?? { enabled: false, source: 'corp', customTicker: null }
+}
+
+function resolveTickerPreference(
+	source: DiscordNicknameSource,
+	tickerSources: CorporationTickerSources,
+	customTicker: string | null
+): string | null {
+	if (source === 'custom') {
+		return normalizeDiscordTicker(customTicker)
+	}
+
+	const corpTicker = normalizeDiscordTicker(tickerSources.corpTicker)
+	const allianceTicker = normalizeDiscordTicker(tickerSources.allianceTicker)
+
+	if (source === 'alliance') {
+		return allianceTicker ?? corpTicker
+	}
+
+	return corpTicker ?? allianceTicker
+}
+
+function resolveAttachmentNicknameSuffix(
+	attachment: CorporationDiscordNicknameFields,
+	isCorpMember: boolean,
+	isAllianceMember: boolean,
+	tickerSources: CorporationTickerSources
+): string | null {
+	const bucketConfigs = [
+		{
+			matches: isCorpMember,
+			...getNicknameConfigRecord(attachment, 'corp_member'),
+		},
+		{
+			matches: !isCorpMember && attachment.corporation.isMemberCorporation && isAllianceMember,
+			...getNicknameConfigRecord(attachment, 'alliance_guest'),
+		},
+		{
+			matches: !isCorpMember,
+			...getNicknameConfigRecord(attachment, 'non_alliance_guest'),
+		},
+	] as const
+
+	for (const bucket of bucketConfigs) {
+		if (!bucket.matches || !bucket.enabled) {
+			continue
+		}
+
+		const suffix = resolveTickerPreference(bucket.source, tickerSources, bucket.customTicker)
+		if (suffix) {
+			return suffix
+		}
+	}
+
+	return null
+}
+
+async function getCorporationTickerSources(
+	db: ReturnType<typeof createDb>,
+	env: Env,
+	corporationIds: string[]
+): Promise<Map<string, CorporationTickerSources>> {
+	if (corporationIds.length === 0) {
+		return new Map()
+	}
+
+	const uniqueCorporationIds = Array.from(new Set(corporationIds))
+	const corpRows = await db.query.managedCorporations.findMany({
+		where: inArray(managedCorporations.corporationId, uniqueCorporationIds),
+		columns: {
+			corporationId: true,
+			ticker: true,
+		},
+	})
+	const corpTickerById = new Map(corpRows.map((row) => [row.corporationId, row.ticker]))
+
+	const corpStub = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, 'default')
+	const tokenStoreStub = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
+	const corpInfoEntries = await Promise.all(
+		uniqueCorporationIds.map(async (corporationId) => {
+			try {
+				return [corporationId, await corpStub.getCorporationInfo(corporationId)] as const
+			} catch (error) {
+				logger.warn('[Discord] Failed to resolve corporation info for nickname routing', {
+					corporationId,
+					error: String(error),
+				})
+				return [corporationId, null] as const
+			}
+		})
+	)
+
+	const allianceIds = Array.from(
+		new Set(
+			corpInfoEntries
+				.map(([, corpInfo]) => corpInfo?.allianceId ?? null)
+				.filter((allianceId): allianceId is string => !!allianceId)
+		)
+	)
+
+	const allianceTickerById = new Map<string, string>()
+	await Promise.all(
+		allianceIds.map(async (allianceId) => {
+			try {
+				const allianceInfo = await tokenStoreStub.getAllianceById(allianceId)
+				if (allianceInfo?.ticker) {
+					allianceTickerById.set(allianceId, allianceInfo.ticker)
+				}
+			} catch (error) {
+				logger.warn('[Discord] Failed to resolve alliance info for nickname routing', {
+					allianceId,
+					error: String(error),
+				})
+			}
+		})
+	)
+
+	const result = new Map<string, CorporationTickerSources>()
+	for (const [corporationId, corpInfo] of corpInfoEntries) {
+		result.set(corporationId, {
+			corpTicker: corpTickerById.get(corporationId) ?? corpInfo?.ticker ?? null,
+			allianceTicker:
+				corpInfo?.allianceId ? allianceTickerById.get(corpInfo.allianceId) ?? null : null,
+		})
+	}
+
+	return result
+}
 
 async function getUserAllianceMemberCorporationIds(
 	db: ReturnType<typeof createDb>,
@@ -623,27 +808,22 @@ function resolveScenarioRoleId(
 	attachmentIsMemberCorp: boolean,
 	activeRoleIdByDbId: Map<string, string>
 ): { roleId: string | null; scenario: CorpAttachmentScenarioKey | null } {
-	if (isCorpMember && attachment.corpMemberAutoApply && attachment.corpMemberRoleId) {
-		const roleId = activeRoleIdByDbId.get(attachment.corpMemberRoleId) ?? null
-		if (roleId) {
-			return { roleId, scenario: 'corp-member' }
-		}
-	}
-
+	const allianceGuestRole = getScenarioRoleRecord(attachment, 'alliance_guest')
 	if (
 		attachmentIsMemberCorp &&
 		isAllianceMember &&
-		attachment.allianceGuestAutoApply &&
-		attachment.allianceGuestRoleId
+		allianceGuestRole.autoApply &&
+		allianceGuestRole.discordRoleId
 	) {
-		const roleId = activeRoleIdByDbId.get(attachment.allianceGuestRoleId) ?? null
+		const roleId = activeRoleIdByDbId.get(allianceGuestRole.discordRoleId) ?? null
 		if (roleId) {
 			return { roleId, scenario: 'alliance-guest' }
 		}
 	}
 
-	if (attachment.nonAllianceGuestAutoApply && attachment.nonAllianceGuestRoleId) {
-		const roleId = activeRoleIdByDbId.get(attachment.nonAllianceGuestRoleId) ?? null
+	const nonAllianceGuestRole = getScenarioRoleRecord(attachment, 'non_alliance_guest')
+	if (nonAllianceGuestRole.autoApply && nonAllianceGuestRole.discordRoleId) {
+		const roleId = activeRoleIdByDbId.get(nonAllianceGuestRole.discordRoleId) ?? null
 		if (roleId) {
 			return { roleId, scenario: 'non-alliance-guest' }
 		}
@@ -654,9 +834,12 @@ function resolveScenarioRoleId(
 
 function getScenarioManagedRoleDbIds(attachment: CorporationDiscordScenarioRoleFields): string[] {
 	const roleIds = [
-		attachment.corpMemberAutoApply ? attachment.corpMemberRoleId : null,
-		attachment.allianceGuestAutoApply ? attachment.allianceGuestRoleId : null,
-		attachment.nonAllianceGuestAutoApply ? attachment.nonAllianceGuestRoleId : null,
+		getScenarioRoleRecord(attachment, 'alliance_guest').autoApply
+			? getScenarioRoleRecord(attachment, 'alliance_guest').discordRoleId
+			: null,
+		getScenarioRoleRecord(attachment, 'non_alliance_guest').autoApply
+			? getScenarioRoleRecord(attachment, 'non_alliance_guest').discordRoleId
+			: null,
 	].filter((roleId): roleId is string => !!roleId)
 
 	return roleIds
@@ -760,16 +943,7 @@ export async function getExpectedManagedRoleIdsByGuild(
 		knownServerDbIds.length > 0
 			? await db.query.corporationDiscordServers.findMany({
 					where: inArray(corporationDiscordServers.discordServerId, knownServerDbIds),
-					columns: {
-						corporationId: true,
-						autoAssignRoles: true,
-						corpMemberRoleId: true,
-						corpMemberAutoApply: true,
-						allianceGuestRoleId: true,
-						allianceGuestAutoApply: true,
-						nonAllianceGuestRoleId: true,
-						nonAllianceGuestAutoApply: true,
-					},
+					columns: { corporationId: true, autoAssignRoles: true },
 					with: {
 						corporation: {
 							columns: { isMemberCorporation: true },
@@ -781,6 +955,9 @@ export async function getExpectedManagedRoleIdsByGuild(
 									columns: { id: true, roleId: true, isActive: true },
 								},
 							},
+						},
+						scenarioRoles: {
+							columns: { bucket: true, discordRoleId: true, autoApply: true },
 						},
 					},
 				})
@@ -1083,17 +1260,7 @@ export async function inviteUserToDiscordServers(
 	// Fetch all corporation attachments that may apply to this user via corp, alliance, or guest fallback.
 	const corpAttachments = await db.query.corporationDiscordServers.findMany({
 		where: eq(corporationDiscordServers.autoInvite, true),
-		columns: {
-			corporationId: true,
-			discordServerId: true,
-			autoAssignRoles: true,
-			corpMemberRoleId: true,
-			corpMemberAutoApply: true,
-			allianceGuestRoleId: true,
-			allianceGuestAutoApply: true,
-			nonAllianceGuestRoleId: true,
-			nonAllianceGuestAutoApply: true,
-		},
+		columns: { corporationId: true, discordServerId: true, autoAssignRoles: true },
 		with: {
 			corporation: {
 				columns: { name: true, isMemberCorporation: true },
@@ -1105,6 +1272,9 @@ export async function inviteUserToDiscordServers(
 						columns: { id: true, roleId: true, isActive: true },
 					},
 				},
+			},
+			scenarioRoles: {
+				columns: { bucket: true, discordRoleId: true, autoApply: true },
 			},
 		},
 	})
@@ -1186,7 +1356,10 @@ export async function inviteUserToDiscordServers(
 			roleIds.push(scenarioRoleId)
 		}
 
-		const shouldInvite = isCorpMember || scenarioRoleId !== null
+		// Auto-invite is intentionally reserved for actual corporation members.
+		// Guest buckets may still resolve a role for existing members, but they
+		// must not be used as a reason to join an unaffiliated user to the guild.
+		const shouldInvite = isCorpMember
 		if (!shouldInvite) {
 			logger.debug('[Discord] inviteUserToDiscordServers: Skipping corporation attachment', {
 				userId,
@@ -1249,7 +1422,10 @@ export async function inviteUserToDiscordServers(
 					isOwnerAdmin: membership.isOwnerAdmin,
 				})
 
-				if (membership.isMember || membership.isOwnerAdmin) {
+				// Auto-invite is reserved for actual group members.
+				// Owner/admin status can still matter for role assignment on existing members,
+				// but it must not cause a join for someone who is not a member.
+				if (membership.isMember) {
 					for (const discordServer of group.discordServers) {
 						// ONLY process servers with autoInvite=true
 						if (!discordServer.autoInvite) {
@@ -1272,15 +1448,9 @@ export async function inviteUserToDiscordServers(
 						})
 
 						if (serverInfo) {
-							const memberRoleDbIds =
-								discordServer.autoAssignRoles && membership.isMember
-									? getGroupMemberRoleDbIds(discordServer)
-									: []
-							const ownerAdminRoleDbIds =
-								discordServer.autoAssignRoles && membership.isOwnerAdmin
-									? getGroupOwnerAdminRoleDbIds(discordServer)
-									: []
-							const roleDbIds = [...new Set([...memberRoleDbIds, ...ownerAdminRoleDbIds])]
+							const roleDbIds = discordServer.autoAssignRoles
+								? getGroupMemberRoleDbIds(discordServer)
+								: []
 							const actualRoleIds: string[] = []
 							if (roleDbIds.length > 0) {
 								const roleRecords = await db.query.discordRoles.findMany({
@@ -1533,14 +1703,14 @@ export async function inviteUserToDiscordServers(
 		manageNicknamesByGuildId: Object.fromEntries(manageNicknamesByGuildId),
 	})
 
-	if (guildsForNicknameUpdate.length > 0 && primaryCharacterName) {
-		logger.info('[Discord] inviteUserToDiscordServers: Updating nicknames', {
-			userId,
-			guilds: guildsForNicknameUpdate,
-			nickname: primaryCharacterName,
-		})
-		await discordStub.updateUserNickname(userId, guildsForNicknameUpdate, primaryCharacterName)
-	}
+		if (guildsForNicknameUpdate.length > 0) {
+			logger.info('[Discord] inviteUserToDiscordServers: Updating nicknames', {
+				userId,
+				guilds: guildsForNicknameUpdate,
+				primaryCharacterName,
+			})
+			await updateUserDiscordNickname(env, userId, guildsForNicknameUpdate)
+		}
 
 	// === UPDATE ROLES (only for successful joins) ===
 
@@ -1752,16 +1922,7 @@ export async function updateUserDiscordRoles(
 			targetServerDbIds.length > 0
 				? await db.query.corporationDiscordServers.findMany({
 						where: inArray(corporationDiscordServers.discordServerId, targetServerDbIds),
-						columns: {
-							corporationId: true,
-							autoAssignRoles: true,
-							corpMemberRoleId: true,
-							corpMemberAutoApply: true,
-							allianceGuestRoleId: true,
-							allianceGuestAutoApply: true,
-							nonAllianceGuestRoleId: true,
-							nonAllianceGuestAutoApply: true,
-						},
+						columns: { corporationId: true, autoAssignRoles: true },
 						with: {
 							corporation: {
 								columns: { name: true, isMemberCorporation: true },
@@ -1773,6 +1934,9 @@ export async function updateUserDiscordRoles(
 										columns: { id: true, roleId: true, isActive: true },
 									},
 								},
+							},
+							scenarioRoles: {
+								columns: { bucket: true, discordRoleId: true, autoApply: true },
 							},
 						},
 					})
@@ -2004,14 +2168,16 @@ export async function updateUserDiscordRoles(
 	const updateResults = await discordStub.updateUserRoles(userId, updateRequests, allowRemoval)
 
 	// Best-effort nickname sync for servers that opt into nickname management.
-	// This is scoped to the servers included in this role refresh.
-	try {
-		await updateUserDiscordNickname(env, userId, serversToUpdate)
-	} catch (error) {
-		logger.error('[Discord] updateUserDiscordRoles: Nickname update failed', {
-			userId,
-			error: error instanceof Error ? error.message : String(error),
-		})
+	// Skip when Discord authorization has been revoked so we avoid extra user lookups.
+	if (!isAuthorizationRevoked) {
+		try {
+			await updateUserDiscordNickname(env, userId, serversToUpdate)
+		} catch (error) {
+			logger.error('[Discord] updateUserDiscordRoles: Nickname update failed', {
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
 	}
 
 	// Resolve role names for display/debug output.
@@ -2541,16 +2707,30 @@ export async function updateUserDiscordNickname(
 		return // User doesn't have Discord linked
 	}
 
-	// Get primary character
-	const primaryChar = await db.query.userCharacters.findFirst({
-		where: and(eq(userCharacters.userId, userId), eq(userCharacters.is_primary, true)),
+	// Get all linked characters so nickname suffixes can reflect corp attachment buckets.
+	const userChars = await db.query.userCharacters.findMany({
+		where: eq(userCharacters.userId, userId),
+		columns: {
+			characterId: true,
+			characterName: true,
+			is_primary: true,
+		},
 	})
 
-	if (!primaryChar) {
+	const primaryChar = userChars.find((char) => char.is_primary)
+	const primaryCharacterName = primaryChar?.characterName
+
+	if (!primaryCharacterName) {
 		return // No primary character set
 	}
 
-	const nickname = primaryChar.characterName
+	const characterIds = userChars.map((char) => char.characterId)
+	const userCorporationIds = await getUserCorporationIds(env, characterIds)
+	const userAllianceMemberCorporationIds = await getUserAllianceMemberCorporationIds(
+		db,
+		userCorporationIds
+	)
+	const isAllianceMember = userAllianceMemberCorporationIds.size > 0
 
 	// Get all servers with nickname management enabled.
 	// When guildIds are provided, only inspect that subset.
@@ -2562,8 +2742,8 @@ export async function updateUserDiscordNickname(
 						eq(discordServers.isActive, true),
 						inArray(discordServers.guildId, guildIds)
 					)
-				: and(eq(discordServers.manageNicknames, true), eq(discordServers.isActive, true)),
-		columns: { guildId: true },
+					: and(eq(discordServers.manageNicknames, true), eq(discordServers.isActive, true)),
+		columns: { id: true, guildId: true },
 	})
 
 	if (serverSettings.length === 0) {
@@ -2580,13 +2760,77 @@ export async function updateUserDiscordNickname(
 		return // User is not in any Discord servers with nickname management
 	}
 
-	// Update nickname on each server
-	await discordStub.updateUserNickname(userId, userGuildIds, nickname)
+	const activeServerSettings = serverSettings.filter((server) => userGuildIds.includes(server.guildId))
+	if (activeServerSettings.length === 0) {
+		return
+	}
+
+	const corpAttachments = await db.query.corporationDiscordServers.findMany({
+		where: inArray(
+			corporationDiscordServers.discordServerId,
+			activeServerSettings.map((server) => server.id)
+		),
+		columns: { corporationId: true, discordServerId: true },
+		with: {
+			corporation: {
+				columns: { isMemberCorporation: true },
+			},
+			nicknameConfigs: {
+				columns: { bucket: true, enabled: true, source: true, customTicker: true },
+			},
+		},
+	})
+
+	const tickerSourcesByCorporationId = await getCorporationTickerSources(
+		db,
+		env,
+		corpAttachments.map((attachment) => attachment.corporationId)
+	)
+
+	const nicknameToGuildIds = new Map<string, string[]>()
+	for (const server of activeServerSettings) {
+		const suffixes = new Set<string>()
+		const attachmentsForServer = corpAttachments.filter(
+			(attachment) => attachment.discordServerId === server.id
+		)
+
+		for (const attachment of attachmentsForServer) {
+			const suffix = resolveAttachmentNicknameSuffix(
+				attachment as CorporationDiscordNicknameFields,
+				userCorporationIds.has(attachment.corporationId),
+				isAllianceMember,
+				tickerSourcesByCorporationId.get(attachment.corporationId) ?? {
+					corpTicker: null,
+					allianceTicker: null,
+				}
+			)
+
+			if (suffix) {
+				suffixes.add(suffix)
+			}
+		}
+
+		const nickname = buildDiscordNicknameWithTickers(
+			primaryCharacterName,
+			Array.from(suffixes)
+		)
+		const existingGuildIds = nicknameToGuildIds.get(nickname) ?? []
+		existingGuildIds.push(server.guildId)
+		nicknameToGuildIds.set(nickname, existingGuildIds)
+	}
+
+	// Update nickname on each guild, grouping guilds that share the same resolved nickname.
+	for (const [nickname, guildIdGroup] of nicknameToGuildIds.entries()) {
+		await discordStub.updateUserNickname(userId, guildIdGroup, nickname)
+	}
 
 	logger.info('[Discord] Updated user nickname', {
 		userId,
 		discordUserId: user.discordUserId,
-		nickname,
+		nicknameGroups: Array.from(nicknameToGuildIds.entries()).map(([resolvedNickname, guildIdGroup]) => ({
+			nickname: resolvedNickname,
+			guildIds: guildIdGroup,
+		})),
 		serverCount: serverSettings.length,
 	})
 }
@@ -2640,16 +2884,7 @@ async function calculateUserRolesForServer(
 	// === CORPORATION ROLES ===
 	const corpAttachments = await db.query.corporationDiscordServers.findMany({
 		where: eq(corporationDiscordServers.discordServerId, serverId),
-		columns: {
-			corporationId: true,
-			autoAssignRoles: true,
-			corpMemberRoleId: true,
-			corpMemberAutoApply: true,
-			allianceGuestRoleId: true,
-			allianceGuestAutoApply: true,
-			nonAllianceGuestRoleId: true,
-			nonAllianceGuestAutoApply: true,
-		},
+		columns: { corporationId: true, autoAssignRoles: true },
 		with: {
 			corporation: {
 				columns: { isMemberCorporation: true },
@@ -2658,6 +2893,9 @@ async function calculateUserRolesForServer(
 				with: {
 					discordRole: true,
 				},
+			},
+			scenarioRoles: {
+				columns: { bucket: true, discordRoleId: true, autoApply: true },
 			},
 		},
 	})
@@ -2854,7 +3092,7 @@ export async function refreshServerMembers(
 					nickname,
 					guildId: server.guildId,
 				})
-				await discordStub.updateUserNickname(userId, [server.guildId], nickname)
+				await updateUserDiscordNickname(env, userId, [server.guildId])
 			}
 
 			// 3. SET ROLES (after nickname)

--- a/apps/ui/src/client/components/admin/corporation-alerts-card.tsx
+++ b/apps/ui/src/client/components/admin/corporation-alerts-card.tsx
@@ -229,7 +229,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 
 	if (isLoading) {
 		return (
-			<Card>
+			<Card className="border-border/80 bg-card/95 shadow-elevated">
 				<CardHeader>
 					<CardTitle>Alert Destinations</CardTitle>
 					<CardDescription>Loading configured alert destinations...</CardDescription>
@@ -239,7 +239,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 	}
 
 	return (
-		<Card>
+	<Card className="border-border/80 bg-card/95 shadow-elevated">
 			<CardHeader>
 				<div className="flex items-center justify-between gap-4">
 					<div>
@@ -260,8 +260,11 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 								alertDestinations.filter((destination) => destination.alertType === section.type)
 							const draftRowsForType = newRows.filter((row) => row.alertType === section.type)
 
-							return (
-								<div key={section.type} className="space-y-4 rounded-lg border p-4">
+								return (
+									<div
+										key={section.type}
+										className="space-y-4 rounded-xl border border-border/80 bg-background/75 p-4 shadow-sm"
+									>
 									<div className="flex flex-wrap items-start justify-between gap-3">
 										<div className="space-y-1">
 											<h3 className="text-sm font-semibold">{section.title}</h3>
@@ -301,7 +304,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 													isExisting
 													saveButtonVariant="primary"
 													removeButtonVariant="destructive"
-													className="rounded-md border border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
+														className="rounded-xl border border-border/90 bg-card/95 p-4 shadow-md ring-1 ring-border/60"
 												/>
 											)
 										})}
@@ -318,7 +321,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 												onRemove={() => handleClearNew(row.id)}
 												isSaving={createDestination.isPending}
 												removeButtonVariant="cancel"
-												className="rounded-md border border-dashed border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
+													className="rounded-xl border border-dashed border-border/90 bg-card/90 p-4 shadow-md ring-1 ring-border/60"
 											/>
 										))}
 									</div>
@@ -330,8 +333,11 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 							const destinationsForType = rowsByType.get(definition.type) ?? []
 							const draftRowsForType = newRowsByType.get(definition.type) ?? []
 
-							return (
-							<div key={definition.type} className="space-y-4 rounded-lg border p-4">
+								return (
+									<div
+										key={definition.type}
+										className="space-y-4 rounded-xl border border-border/80 bg-background/75 p-4 shadow-sm"
+									>
 								<div className="flex flex-wrap items-start justify-between gap-3">
 									<div className="space-y-1">
 										<h3 className="text-sm font-semibold">{definition.label}</h3>
@@ -371,7 +377,7 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 												isExisting
 												saveButtonVariant="primary"
 												removeButtonVariant="destructive"
-												className="rounded-md border border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
+													className="rounded-xl border border-border/90 bg-card/95 p-4 shadow-md ring-1 ring-border/60"
 											/>
 										)
 									})}
@@ -388,13 +394,13 @@ export function CorporationAlertsCard({ corporationId }: { corporationId: string
 											onRemove={() => handleClearNew(row.id)}
 											isSaving={createDestination.isPending}
 											removeButtonVariant="cancel"
-											className="rounded-md border border-dashed border-border/90 bg-card p-3 shadow-md ring-1 ring-border/50"
-										/>
-									))}
-								</div>
-								</div>
-							)
-						})}
+												className="rounded-xl border border-dashed border-border/90 bg-card/90 p-4 shadow-md ring-1 ring-border/60"
+											/>
+										))}
+									</div>
+									</div>
+								)
+							})}
 					</>
 				)}
 			</CardContent>

--- a/apps/ui/src/client/hooks/useDiscord.ts
+++ b/apps/ui/src/client/hooks/useDiscord.ts
@@ -7,8 +7,10 @@ import type {
 	AttachDiscordServerRequest,
 	CreateDiscordRoleRequest,
 	CreateDiscordServerRequest,
+	CorporationDiscordServer,
 	UpdateDiscordRoleRequest,
 	UpdateDiscordServerAttachmentRequest,
+	UpdateDiscordServerNicknameConfigRequest,
 	UpdateDiscordServerRequest,
 } from '@/lib/api'
 
@@ -90,6 +92,20 @@ export const discordKeys = {
 		[...discordKeys.all, 'audit', serverId, tab, page, pageSize] as const,
 	corporationServers: (corporationId: string) =>
 		['admin', 'corporations', corporationId, 'discord-servers'] as const,
+}
+
+function patchCorporationServerCache(
+	queryClient: ReturnType<typeof useQueryClient>,
+	corporationId: string,
+	updatedAttachment: CorporationDiscordServer
+): void {
+	queryClient.setQueryData<CorporationDiscordServer[]>(
+		discordKeys.corporationServers(corporationId),
+		(current) =>
+			current?.map((attachment) =>
+				attachment.id === updatedAttachment.id ? updatedAttachment : attachment
+			) ?? current
+	)
 }
 
 /**
@@ -281,11 +297,31 @@ export function useUpdateCorporationDiscordServer() {
 			attachmentId: string
 			data: UpdateDiscordServerAttachmentRequest
 		}) => apiClient.updateCorporationDiscordServer(corporationId, attachmentId, data),
-		onSuccess: (_, { corporationId }) => {
-			void queryClient.invalidateQueries({
-				queryKey: discordKeys.corporationServers(corporationId),
-				refetchType: 'active',
-			})
+		onSuccess: (updatedAttachment, { corporationId }) => {
+			patchCorporationServerCache(queryClient, corporationId, updatedAttachment)
+		},
+	})
+}
+
+/**
+ * Update nickname ticker settings for a corporation Discord server attachment
+ */
+export function useUpdateCorporationDiscordServerNicknameConfig() {
+	const queryClient = useQueryClient()
+
+	return useMutation({
+		mutationFn: ({
+			corporationId,
+			attachmentId,
+			data,
+		}: {
+			corporationId: string
+			attachmentId: string
+			data: UpdateDiscordServerNicknameConfigRequest
+		}) =>
+			apiClient.updateCorporationDiscordServerNicknameConfig(corporationId, attachmentId, data),
+		onSuccess: (updatedAttachment, { corporationId }) => {
+			patchCorporationServerCache(queryClient, corporationId, updatedAttachment)
 		},
 	})
 }

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -641,12 +641,19 @@ export interface CorporationDiscordServer {
 	discordServerId: string
 	autoInvite: boolean
 	autoAssignRoles: boolean
-	corpMemberRoleId: string | null
-	corpMemberAutoApply: boolean
+	corpMemberNicknameEnabled: boolean
+	corpMemberNicknameSource: 'corp' | 'alliance' | 'custom'
+	corpMemberNicknameCustomTicker: string | null
 	allianceGuestRoleId: string | null
 	allianceGuestAutoApply: boolean
+	allianceGuestNicknameEnabled: boolean
+	allianceGuestNicknameSource: 'corp' | 'alliance' | 'custom'
+	allianceGuestNicknameCustomTicker: string | null
 	nonAllianceGuestRoleId: string | null
 	nonAllianceGuestAutoApply: boolean
+	nonAllianceGuestNicknameEnabled: boolean
+	nonAllianceGuestNicknameSource: 'corp' | 'alliance' | 'custom'
+	nonAllianceGuestNicknameCustomTicker: string | null
 	createdAt: string
 	updatedAt: string
 	discordServer?: DiscordServerWithRoles
@@ -1133,23 +1140,40 @@ export interface AttachDiscordServerRequest {
 	discordServerId: string
 	autoInvite?: boolean
 	autoAssignRoles?: boolean
-	corpMemberRoleId?: string | null
-	corpMemberAutoApply?: boolean
+	corpMemberNicknameEnabled?: boolean
+	corpMemberNicknameSource?: 'corp' | 'alliance' | 'custom'
+	corpMemberNicknameCustomTicker?: string | null
+	allianceGuestRoleId?: string | null
+	allianceGuestAutoApply?: boolean
+	allianceGuestNicknameEnabled?: boolean
+	allianceGuestNicknameSource?: 'corp' | 'alliance' | 'custom'
+	allianceGuestNicknameCustomTicker?: string | null
+	nonAllianceGuestRoleId?: string | null
+	nonAllianceGuestAutoApply?: boolean
+	nonAllianceGuestNicknameEnabled?: boolean
+	nonAllianceGuestNicknameSource?: 'corp' | 'alliance' | 'custom'
+	nonAllianceGuestNicknameCustomTicker?: string | null
+}
+
+export interface UpdateDiscordServerAttachmentRequest {
+	autoInvite?: boolean
+	autoAssignRoles?: boolean
 	allianceGuestRoleId?: string | null
 	allianceGuestAutoApply?: boolean
 	nonAllianceGuestRoleId?: string | null
 	nonAllianceGuestAutoApply?: boolean
 }
 
-export interface UpdateDiscordServerAttachmentRequest {
-	autoInvite?: boolean
-	autoAssignRoles?: boolean
-	corpMemberRoleId?: string | null
-	corpMemberAutoApply?: boolean
-	allianceGuestRoleId?: string | null
-	allianceGuestAutoApply?: boolean
-	nonAllianceGuestRoleId?: string | null
-	nonAllianceGuestAutoApply?: boolean
+export interface UpdateDiscordServerNicknameConfigRequest {
+	corpMemberNicknameEnabled?: boolean
+	corpMemberNicknameSource?: 'corp' | 'alliance' | 'custom'
+	corpMemberNicknameCustomTicker?: string | null
+	allianceGuestNicknameEnabled?: boolean
+	allianceGuestNicknameSource?: 'corp' | 'alliance' | 'custom'
+	allianceGuestNicknameCustomTicker?: string | null
+	nonAllianceGuestNicknameEnabled?: boolean
+	nonAllianceGuestNicknameSource?: 'corp' | 'alliance' | 'custom'
+	nonAllianceGuestNicknameCustomTicker?: string | null
 }
 
 export interface AssignRoleRequest {
@@ -3650,6 +3674,17 @@ export class ApiClient {
 		data: UpdateDiscordServerAttachmentRequest
 	): Promise<CorporationDiscordServer> {
 		return this.put(`/corporations/${corporationId}/discord-servers/${attachmentId}`, data)
+	}
+
+	async updateCorporationDiscordServerNicknameConfig(
+		corporationId: string,
+		attachmentId: string,
+		data: UpdateDiscordServerNicknameConfigRequest
+	): Promise<CorporationDiscordServer> {
+		return this.put(
+			`/corporations/${corporationId}/discord-servers/${attachmentId}/nickname-config`,
+			data
+		)
 	}
 
 	async detachDiscordServerFromCorporation(

--- a/apps/ui/src/client/routes/admin/corporation-detail.tsx
+++ b/apps/ui/src/client/routes/admin/corporation-detail.tsx
@@ -69,6 +69,7 @@ import {
 	useDiscordServers,
 	useUnassignRoleFromCorporationServer,
 	useUpdateCorporationDiscordServer,
+	useUpdateCorporationDiscordServerNicknameConfig,
 } from '@/hooks/useDiscord'
 import { useConfirmationDialog } from '@/hooks/useConfirmationDialog'
 import { useMessage } from '@/hooks/useMessage'
@@ -98,6 +99,60 @@ type AttachmentSettingsState = {
 	autoAssignRoles: boolean
 }
 
+type NicknameBucketSource = 'corp' | 'alliance' | 'custom'
+
+type NicknameBucketKey = 'corpMember' | 'allianceGuest' | 'nonAllianceGuest'
+
+type NicknameBucketDraft = {
+	enabled: boolean
+	source: NicknameBucketSource
+	customTicker: string
+}
+
+const NICKNAME_SOURCE_OPTIONS: Array<{ value: NicknameBucketSource; label: string }> = [
+	{ value: 'corp', label: 'Corp ticker' },
+	{ value: 'alliance', label: 'Alliance ticker' },
+	{ value: 'custom', label: 'Custom ticker' },
+]
+
+function sanitizeNicknameTickerInput(value: string): string {
+	return value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 5)
+}
+
+const NICKNAME_BUCKET_CONFIGS: Array<{
+	key: NicknameBucketKey
+	label: string
+	description: string
+	enabledField: 'corpMemberNicknameEnabled' | 'allianceGuestNicknameEnabled' | 'nonAllianceGuestNicknameEnabled'
+	sourceField: 'corpMemberNicknameSource' | 'allianceGuestNicknameSource' | 'nonAllianceGuestNicknameSource'
+	customField: 'corpMemberNicknameCustomTicker' | 'allianceGuestNicknameCustomTicker' | 'nonAllianceGuestNicknameCustomTicker'
+}> = [
+	{
+		key: 'corpMember',
+		label: 'Corp Members',
+		description: 'Multi-select roles and ticker settings for members of this corporation.',
+		enabledField: 'corpMemberNicknameEnabled',
+		sourceField: 'corpMemberNicknameSource',
+		customField: 'corpMemberNicknameCustomTicker',
+	},
+	{
+		key: 'allianceGuest',
+		label: 'Alliance Guest',
+		description: 'Guest access for users affiliated with member corporations.',
+		enabledField: 'allianceGuestNicknameEnabled',
+		sourceField: 'allianceGuestNicknameSource',
+		customField: 'allianceGuestNicknameCustomTicker',
+	},
+	{
+		key: 'nonAllianceGuest',
+		label: 'Non-Alliance Guest',
+		description: 'Guest access for linked users outside the alliance.',
+		enabledField: 'nonAllianceGuestNicknameEnabled',
+		sourceField: 'nonAllianceGuestNicknameSource',
+		customField: 'nonAllianceGuestNicknameCustomTicker',
+	},
+] as const
+
 export default function CorporationDetailPage() {
 	const { corporationId } = useParams<{ corporationId: string }>()
 	const corpId = corporationId || ''
@@ -118,6 +173,7 @@ export default function CorporationDetailPage() {
 	const attachServer = useAttachDiscordServer()
 	const detachServer = useDetachDiscordServer()
 	const updateAttachment = useUpdateCorporationDiscordServer()
+	const updateNicknameConfig = useUpdateCorporationDiscordServerNicknameConfig()
 	const assignRole = useAssignRoleToCorporationServer()
 	const unassignRole = useUnassignRoleFromCorporationServer()
 
@@ -164,6 +220,9 @@ export default function CorporationDetailPage() {
 	const [showAddServerDialog, setShowAddServerDialog] = useState(false)
 	const [selectedServerId, setSelectedServerId] = useState('')
 	const [pendingRoleSelections, setPendingRoleSelections] = useState<Record<string, string>>({})
+	const [nicknameConfigDrafts, setNicknameConfigDrafts] = useState<
+		Record<string, Record<NicknameBucketKey, NicknameBucketDraft>>
+	>({})
 	const [attachmentSettings, setAttachmentSettings] = useState<AttachmentSettingsState>({
 		...DEFAULT_ATTACHMENT_SETTINGS,
 	})
@@ -177,7 +236,34 @@ export default function CorporationDetailPage() {
 		setAttachmentSettings({ ...DEFAULT_ATTACHMENT_SETTINGS })
 	}, [selectedServerId])
 
-	const updateDiscordAttachment = async (
+	useEffect(() => {
+		setNicknameConfigDrafts(
+			Object.fromEntries(
+				corporationDiscordServers.map((attachment) => [
+					attachment.id,
+					{
+						corpMember: {
+							enabled: attachment.corpMemberNicknameEnabled,
+							source: attachment.corpMemberNicknameSource,
+							customTicker: attachment.corpMemberNicknameCustomTicker ?? '',
+						},
+						allianceGuest: {
+							enabled: attachment.allianceGuestNicknameEnabled,
+							source: attachment.allianceGuestNicknameSource,
+							customTicker: attachment.allianceGuestNicknameCustomTicker ?? '',
+						},
+						nonAllianceGuest: {
+							enabled: attachment.nonAllianceGuestNicknameEnabled,
+							source: attachment.nonAllianceGuestNicknameSource,
+							customTicker: attachment.nonAllianceGuestNicknameCustomTicker ?? '',
+						},
+					},
+				])
+			)
+		)
+	}, [corporationDiscordServers])
+
+	const updateRoleAttachment = async (
 		attachmentId: string,
 		data: Parameters<typeof updateAttachment.mutateAsync>[0]['data'],
 		successMessage: string,
@@ -185,6 +271,24 @@ export default function CorporationDetailPage() {
 	) => {
 		try {
 			await updateAttachment.mutateAsync({
+				corporationId: corpId,
+				attachmentId,
+				data,
+			})
+			showSuccess(successMessage)
+		} catch (error) {
+			showError(error instanceof Error ? error.message : errorMessage)
+		}
+	}
+
+	const updateNicknameAttachment = async (
+		attachmentId: string,
+		data: Parameters<typeof updateNicknameConfig.mutateAsync>[0]['data'],
+		successMessage: string,
+		errorMessage: string
+	) => {
+		try {
+			await updateNicknameConfig.mutateAsync({
 				corporationId: corpId,
 				attachmentId,
 				data,
@@ -236,7 +340,7 @@ export default function CorporationDetailPage() {
 	}
 
 	const handleToggleAutoInvite = async (attachmentId: string, currentValue: boolean) => {
-		await updateDiscordAttachment(
+		await updateRoleAttachment(
 			attachmentId,
 			{ autoInvite: !currentValue },
 			'Auto-invite setting updated!',
@@ -245,7 +349,7 @@ export default function CorporationDetailPage() {
 	}
 
 	const handleToggleAutoAssignRoles = async (attachmentId: string, currentValue: boolean) => {
-		await updateDiscordAttachment(
+		await updateRoleAttachment(
 			attachmentId,
 			{ autoAssignRoles: !currentValue },
 			'Auto-assign roles setting updated!',
@@ -268,10 +372,10 @@ export default function CorporationDetailPage() {
 
 	const handleScenarioRoleChange = async (
 		attachmentId: string,
-		field: 'corpMemberRoleId' | 'allianceGuestRoleId' | 'nonAllianceGuestRoleId',
+		field: 'allianceGuestRoleId' | 'nonAllianceGuestRoleId',
 		nextValue: string
 	) => {
-		await updateDiscordAttachment(
+		await updateRoleAttachment(
 			attachmentId,
 			{
 				[field]: nextValue === noneScenarioRoleValue ? null : nextValue,
@@ -283,16 +387,67 @@ export default function CorporationDetailPage() {
 
 	const handleScenarioAutoApplyToggle = async (
 		attachmentId: string,
-		field: 'corpMemberAutoApply' | 'allianceGuestAutoApply' | 'nonAllianceGuestAutoApply',
+		field: 'allianceGuestAutoApply' | 'nonAllianceGuestAutoApply',
 		currentValue: boolean
 	) => {
-		await updateDiscordAttachment(
+		await updateRoleAttachment(
 			attachmentId,
 			{
 				[field]: !currentValue,
 			} as Parameters<typeof updateAttachment.mutateAsync>[0]['data'],
 			'Scenario auto-apply updated!',
 			'Failed to update scenario auto-apply'
+		)
+	}
+
+	const updateNicknameBucketDraft = (
+		attachmentId: string,
+		bucket: NicknameBucketKey,
+		patch: Partial<NicknameBucketDraft>
+	) => {
+		setNicknameConfigDrafts((current) => ({
+			...current,
+			[attachmentId]: {
+				...(current[attachmentId] ?? {
+					corpMember: { enabled: false, source: 'corp', customTicker: '' },
+					allianceGuest: { enabled: false, source: 'corp', customTicker: '' },
+					nonAllianceGuest: { enabled: false, source: 'corp', customTicker: '' },
+				}),
+				[bucket]: {
+					...(current[attachmentId]?.[bucket] ?? {
+						enabled: false,
+						source: 'corp',
+						customTicker: '',
+					}),
+					...patch,
+				},
+			},
+		}))
+	}
+
+	const saveNicknameBucketDraft = async (attachmentId: string, bucket: NicknameBucketKey) => {
+		const attachmentDraft = nicknameConfigDrafts[attachmentId]?.[bucket]
+		if (!attachmentDraft) {
+			return
+		}
+
+		const bucketConfig = NICKNAME_BUCKET_CONFIGS.find((config) => config.key === bucket)
+		if (!bucketConfig) {
+			return
+		}
+
+		await updateNicknameAttachment(
+			attachmentId,
+			{
+				[bucketConfig.enabledField]: attachmentDraft.enabled,
+				[bucketConfig.sourceField]: attachmentDraft.source,
+				[bucketConfig.customField]:
+					attachmentDraft.source === 'custom'
+						? sanitizeNicknameTickerInput(attachmentDraft.customTicker) || null
+						: null,
+			} as Parameters<typeof updateNicknameConfig.mutateAsync>[0]['data'],
+			'Nickname config updated!',
+			'Failed to update nickname config'
 		)
 	}
 
@@ -447,18 +602,14 @@ export default function CorporationDetailPage() {
 
 	const scenarioRoleConfigs = [
 		{
-			label: 'Corp Member',
-			description: 'Members of this corporation',
-			roleIdKey: 'corpMemberRoleId' as const,
-			autoApplyKey: 'corpMemberAutoApply' as const,
-		},
-		{
+			key: 'allianceGuest',
 			label: 'Alliance Guest',
 			description: 'Guest access for users affiliated with member corporations',
 			roleIdKey: 'allianceGuestRoleId' as const,
 			autoApplyKey: 'allianceGuestAutoApply' as const,
 		},
 		{
+			key: 'nonAllianceGuest',
 			label: 'Non-Alliance Guest',
 			description: 'Guest access for linked users outside the alliance',
 			roleIdKey: 'nonAllianceGuestRoleId' as const,
@@ -471,7 +622,6 @@ export default function CorporationDetailPage() {
 		for (const roleAssignment of attachment.roles ?? []) {
 			roleIds.add(roleAssignment.discordRole.id)
 		}
-		if (attachment.corpMemberRoleId) roleIds.add(attachment.corpMemberRoleId)
 		if (attachment.allianceGuestRoleId) roleIds.add(attachment.allianceGuestRoleId)
 		if (attachment.nonAllianceGuestRoleId) roleIds.add(attachment.nonAllianceGuestRoleId)
 		return roleIds
@@ -921,11 +1071,33 @@ export default function CorporationDetailPage() {
 									type="multiple"
 									defaultValue={[]}
 									className="space-y-4"
-								>
-									{corporationDiscordServers.map((attachment) => (
-										<AccordionItem
-											key={attachment.id}
-											value={attachment.id}
+									>
+										{corporationDiscordServers.map((attachment) => {
+											const nicknameManagementEnabled =
+												attachment.discordServer?.manageNicknames ?? false
+											const nicknameControlsDisabled = !nicknameManagementEnabled
+												const attachmentNicknameDrafts = nicknameConfigDrafts[attachment.id] ?? {
+													corpMember: {
+														enabled: attachment.corpMemberNicknameEnabled,
+														source: attachment.corpMemberNicknameSource,
+													customTicker: attachment.corpMemberNicknameCustomTicker ?? '',
+												},
+												allianceGuest: {
+													enabled: attachment.allianceGuestNicknameEnabled,
+													source: attachment.allianceGuestNicknameSource,
+													customTicker: attachment.allianceGuestNicknameCustomTicker ?? '',
+												},
+												nonAllianceGuest: {
+													enabled: attachment.nonAllianceGuestNicknameEnabled,
+													source: attachment.nonAllianceGuestNicknameSource,
+													customTicker: attachment.nonAllianceGuestNicknameCustomTicker ?? '',
+												},
+											}
+
+											return (
+											<AccordionItem
+												key={attachment.id}
+												value={attachment.id}
 											className="overflow-hidden rounded-lg border border-border/90 bg-card shadow-md ring-1 ring-border/50"
 										>
 											<AccordionTrigger className="px-4 py-4 text-left hover:bg-muted/40">
@@ -941,7 +1113,7 @@ export default function CorporationDetailPage() {
 													)}
 												</div>
 											</AccordionTrigger>
-											<AccordionContent className="px-4">
+											<AccordionContent className="px-4 pb-4">
 												<div className="space-y-4">
 													<div className="flex justify-end">
 														<Button
@@ -953,182 +1125,354 @@ export default function CorporationDetailPage() {
 														</Button>
 													</div>
 
-													<div className="flex gap-4">
-														<div className="flex items-center space-x-2">
-															<Switch
-																id={`auto-invite-${attachment.id}`}
-																checked={attachment.autoInvite}
-																onCheckedChange={() =>
-																	handleToggleAutoInvite(
-																		attachment.id,
-																		attachment.autoInvite
-																	)
-																}
-															/>
-															<Label
-																htmlFor={`auto-invite-${attachment.id}`}
-																className="cursor-pointer"
-															>
-																Auto-Invite
-															</Label>
+													<div className="grid gap-4 md:grid-cols-2">
+														<div className="rounded-xl border border-border/80 bg-background/75 p-4 shadow-sm">
+															<div className="flex items-start justify-between gap-3">
+																<div>
+																	<p className="text-sm font-medium">Auto-Invite</p>
+																	<p className="text-xs text-muted-foreground">
+																		Invite matching members automatically.
+																	</p>
+																</div>
+																<Switch
+																	id={`auto-invite-${attachment.id}`}
+																	checked={attachment.autoInvite}
+																	onCheckedChange={() =>
+																		handleToggleAutoInvite(
+																			attachment.id,
+																			attachment.autoInvite
+																		)
+																	}
+																/>
+															</div>
 														</div>
 
-														<div className="flex items-center space-x-2">
-															<Switch
-																id={`auto-assign-${attachment.id}`}
-																checked={attachment.autoAssignRoles}
-																onCheckedChange={() =>
-																	handleToggleAutoAssignRoles(
-																		attachment.id,
-																		attachment.autoAssignRoles
-																	)
-																}
-															/>
-															<Label
-																htmlFor={`auto-assign-${attachment.id}`}
-																className="cursor-pointer"
-															>
-																Auto-Assign Roles
-															</Label>
+														<div className="rounded-xl border border-border/80 bg-background/75 p-4 shadow-sm">
+															<div className="flex items-start justify-between gap-3">
+																<div>
+																	<p className="text-sm font-medium">Role Sync</p>
+																	<p className="text-xs text-muted-foreground">
+																		When off, the role buckets below are ignored. Nickname tickers still
+																		apply if the server is configured to manage nicknames.
+																	</p>
+																</div>
+																<Switch
+																	id={`auto-assign-${attachment.id}`}
+																	checked={attachment.autoAssignRoles}
+																	onCheckedChange={() =>
+																		handleToggleAutoAssignRoles(
+																			attachment.id,
+																			attachment.autoAssignRoles
+																		)
+																	}
+																/>
+															</div>
 														</div>
 													</div>
 
-													<div className="space-y-4">
-														<div className="space-y-2 rounded-md border border-dashed p-3">
-															<p className="text-sm font-medium">All Members</p>
-															<div className="flex flex-wrap gap-2">
-																{attachment.roles?.map((roleAssignment) => (
-																	<div
-																		key={roleAssignment.id}
-																		className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-sm"
-																	>
-																		<span>{roleAssignment.discordRole.roleName}</span>
-																		<button
-																			onClick={() =>
-																				handleUnassignRole(attachment.id, roleAssignment.id)
-																			}
-																			className="ml-1 hover:text-destructive"
-																		>
-																			<X className="h-3 w-3" />
-																		</button>
-																	</div>
-																))}
-															</div>
-															{(attachment.discordServer?.roles ?? []).filter(
-																(role) =>
-																	!getAttachmentUsedRoleIds(attachment).has(role.roleId)
-															).length > 0 && (
-																<div className="flex items-center gap-2">
-																	<Select
-																		value=""
-																		onValueChange={(nextValue) => {
-																			if (!nextValue) {
-																				return
-																			}
-																			void handleAssignRole(attachment.id, nextValue).finally(() => {
-																				setPendingRoleSelections((prev) => {
-																					const { [attachment.id]: _, ...rest } = prev
-																					return rest
-																				})
-																			})
-																		}}
-																		query={pendingRoleSelections[attachment.id] ?? ''}
-																		onQueryChange={(value) =>
-																			setPendingRoleSelections((prev) => ({
-																				...prev,
-																				[attachment.id]: value,
-																			}))
-																		}
-																		searchable
-																		options={buildRoleOptions(attachment).filter(
-																			(option) => option.value !== noneScenarioRoleValue
-																		)}
-																		placeholder="Add role..."
-																		emptyText="No matching roles found"
-																		className="w-full"
-																		contentClassName="w-[min(90vw,36rem)]"
-																		inputClassName="h-9"
-																	/>
+													<div className="rounded-xl border border-border/90 bg-card/90 p-4 shadow-md ring-1 ring-border/60">
+														<div className="grid gap-6 xl:grid-cols-2">
+														<div className="space-y-3">
+															<div className="flex items-start justify-between gap-3">
+																<div>
+																	<p className="text-sm font-medium">Corp Members</p>
+																	<p className="text-xs text-muted-foreground">
+																		Multi-select roles that apply to every linked user. This bucket
+																		is the fallback ticker choice for corporation members.
+																	</p>
 																</div>
-															)}
+															</div>
+																{attachment.roles?.length ? (
+																	<div className="flex flex-wrap gap-2">
+																		{attachment.roles.map((roleAssignment) => (
+																			<div
+																				key={roleAssignment.id}
+																				className="inline-flex items-center gap-1 rounded-md border border-primary/50 bg-primary/10 px-2 py-1 text-sm text-primary"
+																			>
+																				<span>{roleAssignment.discordRole.roleName}</span>
+																				<button
+																					onClick={() =>
+																						handleUnassignRole(
+																							attachment.id,
+																							roleAssignment.id
+																						)
+																					}
+																					className="ml-1 hover:text-destructive"
+																				>
+																					<X className="h-3 w-3" />
+																				</button>
+																			</div>
+																		))}
+																	</div>
+																) : (
+																	<p className="text-xs text-muted-foreground">
+																		No Corp Members roles assigned yet.
+																	</p>
+																)}
+																{(attachment.discordServer?.roles ?? []).filter(
+																	(role) => !getAttachmentUsedRoleIds(attachment).has(role.roleId)
+																).length > 0 && (
+																	<div className="flex items-center gap-2">
+																		<Select
+																			value=""
+																			onValueChange={(nextValue) => {
+																				if (!nextValue) {
+																					return
+																				}
+																				void handleAssignRole(attachment.id, nextValue).finally(() => {
+																					setPendingRoleSelections((prev) => {
+																						const { [attachment.id]: _, ...rest } = prev
+																						return rest
+																					})
+																				})
+																			}}
+																			query={pendingRoleSelections[attachment.id] ?? ''}
+																			onQueryChange={(value) =>
+																				setPendingRoleSelections((prev) => ({
+																					...prev,
+																					[attachment.id]: value,
+																				}))
+																			}
+																			searchable
+																			options={buildRoleOptions(attachment).filter(
+																				(option) => option.value !== noneScenarioRoleValue
+																			)}
+																			placeholder="Add role..."
+																			emptyText="No matching roles found"
+																			className="w-full"
+																			contentClassName="w-[min(90vw,36rem)]"
+																			inputClassName="h-9"
+																		/>
+																	</div>
+																)}
+															</div>
+
+															<div className="space-y-3 border-border/60 xl:border-l xl:pl-6">
+																<div className="flex items-start justify-between gap-3">
+																	<div>
+																		<p className="text-sm font-medium">Nickname Ticker</p>
+																		<p className="text-xs text-muted-foreground">
+																			Only applies when the server manages nicknames. Specific
+																			member-level buckets override Corp Members.
+																		</p>
+																		{!nicknameManagementEnabled && (
+																			<p className="mt-1 text-xs text-muted-foreground">
+																				Enable nickname management on the Discord server to edit ticker settings.
+																			</p>
+																		)}
+																	</div>
+																	<div className="flex items-center gap-2">
+																		<Switch
+																			id={`corp-members-nickname-enabled-${attachment.id}`}
+																			aria-label="Enable Corp Members ticker"
+																			checked={attachmentNicknameDrafts.corpMember.enabled}
+																			disabled={nicknameControlsDisabled}
+																			onCheckedChange={() =>
+																				updateNicknameBucketDraft(attachment.id, 'corpMember', {
+																					enabled: !attachmentNicknameDrafts.corpMember.enabled,
+																				})
+																			}
+																		/>
+																		<Button
+																			variant="confirm"
+																			size="sm"
+																			showIcon={false}
+																			disabled={nicknameControlsDisabled || updateNicknameConfig.isPending}
+																			onClick={() => void saveNicknameBucketDraft(attachment.id, 'corpMember')}
+																		>
+																			Save
+																		</Button>
+																	</div>
+																</div>
+																<div className="grid gap-3 sm:grid-cols-2">
+																	<Select
+																		value={attachmentNicknameDrafts.corpMember.source}
+																		disabled={
+																			nicknameControlsDisabled ||
+																			!attachmentNicknameDrafts.corpMember.enabled
+																		}
+																		onValueChange={(nextValue) =>
+																			updateNicknameBucketDraft(attachment.id, 'corpMember', {
+																				source: nextValue as NicknameBucketSource,
+																			})
+																		}
+																		options={NICKNAME_SOURCE_OPTIONS}
+																		className="w-full"
+																		contentClassName="w-[min(90vw,24rem)]"
+																	/>
+																	<div className="space-y-1">
+																		<Input
+																			value={attachmentNicknameDrafts.corpMember.customTicker}
+																			disabled={
+																				nicknameControlsDisabled ||
+																				!attachmentNicknameDrafts.corpMember.enabled ||
+																				attachmentNicknameDrafts.corpMember.source !== 'custom'
+																			}
+																			onChange={(event) =>
+																				updateNicknameBucketDraft(attachment.id, 'corpMember', {
+																					customTicker: sanitizeNicknameTickerInput(event.target.value),
+																				})
+																			}
+																			placeholder="Custom ticker"
+																			maxLength={5}
+																		/>
+																			<p className="text-xs text-muted-foreground">
+																				Max 5 characters.
+																			</p>
+																	</div>
+																</div>
+															</div>
 														</div>
+													</div>
 
-														{scenarioRoleConfigs.map((config) => {
-															const currentRoleId = attachment[config.roleIdKey]
-															const currentRoleLabel =
-																attachment.discordServer?.roles?.find(
-																	(role) => role.id === currentRoleId
-																)?.roleName ?? 'None'
-															const currentValue = currentRoleId ?? noneScenarioRoleValue
+													{scenarioRoleConfigs.map((config) => {
+														const currentRoleId = attachment[config.roleIdKey]
+													const currentRoleLabel =
+														attachment.discordServer?.roles?.find(
+															(role) => role.id === currentRoleId
+														)?.roleName ?? 'None'
+													const currentValue = currentRoleId ?? noneScenarioRoleValue
+													const nicknameDraft = attachmentNicknameDrafts[config.key]
 
-															return (
-																<div
-																	key={`${attachment.id}-${config.roleIdKey}`}
-																	className="space-y-2 rounded-md border border-dashed p-3"
-																>
+													return (
+															<div
+																key={`${attachment.id}-${config.roleIdKey}`}
+																className="rounded-xl border border-border/90 bg-card/90 p-4 shadow-md ring-1 ring-border/60"
+															>
+																<div className="grid gap-6 xl:grid-cols-2">
+																	<div className="space-y-3">
 																	<div className="flex items-start justify-between gap-3">
 																		<div>
-																			<p className="text-sm font-medium">
-																				{config.label}
-																			</p>
+																			<p className="text-sm font-medium">{config.label}</p>
 																			<p className="text-xs text-muted-foreground">
 																				{config.description}
 																			</p>
 																		</div>
-																		<div className="flex items-center space-x-2">
+																		<div className="flex items-center gap-2">
 																			<Switch
 																				id={`${config.autoApplyKey}-${attachment.id}`}
 																				checked={attachment[config.autoApplyKey]}
 																				onCheckedChange={() =>
 																					handleScenarioAutoApplyToggle(
+																							attachment.id,
+																							config.autoApplyKey,
+																							attachment[config.autoApplyKey]
+																						)
+																					}
+																				/>
+																				<Label
+																					htmlFor={`${config.autoApplyKey}-${attachment.id}`}
+																					className="cursor-pointer"
+																				>
+																					Auto-apply
+																				</Label>
+																			</div>
+																		</div>
+																		<div className="space-y-1">
+																			<Select
+																				value={currentValue}
+																				onValueChange={(nextValue) =>
+																					void handleScenarioRoleChange(
 																						attachment.id,
-																						config.autoApplyKey,
-																						attachment[config.autoApplyKey]
+																						config.roleIdKey,
+																						nextValue
 																					)
 																				}
+																				searchable
+																				options={buildRoleOptions(
+																					attachment,
+																					currentRoleId
+																				)}
+																				placeholder="Select a role..."
+																				emptyText="No roles available"
+																				className="w-full"
+																				contentClassName="w-[min(90vw,36rem)]"
+																				inputClassName="h-9"
 																			/>
-																			<Label
-																				htmlFor={`${config.autoApplyKey}-${attachment.id}`}
-																				className="cursor-pointer"
-																			>
-																				Auto-apply
-																			</Label>
+																			<p className="text-xs text-muted-foreground">
+																				Currently {currentRoleLabel}
+																			</p>
 																		</div>
 																	</div>
-																	<div className="space-y-1">
-																		<Select
-																			value={currentValue}
-																			onValueChange={(nextValue) =>
-																				void handleScenarioRoleChange(
-																					attachment.id,
-																					config.roleIdKey,
-																					nextValue
-																				)
-																			}
-																			searchable
-																			options={buildRoleOptions(
-																				attachment,
-																				currentRoleId
-																			)}
-																			placeholder="Select a role..."
-																			emptyText="No roles available"
-																			className="w-full"
-																			contentClassName="w-[min(90vw,36rem)]"
-																			inputClassName="h-9"
-																		/>
-																		<p className="text-xs text-muted-foreground">
-																			Currently {currentRoleLabel}
-																		</p>
+
+																		<div className="space-y-3 border-border/60 xl:border-l xl:pl-6">
+																			<div className="flex items-start justify-between gap-3">
+																				<div>
+																					<p className="text-sm font-medium">Nickname Ticker</p>
+																					<p className="text-xs text-muted-foreground">
+																						Choose which ticker is prefixed before the nickname.
+																						More specific member buckets override All Members.
+																					</p>
+																				</div>
+																				<div className="flex items-center gap-2">
+																					<Switch
+																						id={`${attachment.id}-${config.key}-nickname-enabled`}
+																						checked={nicknameDraft.enabled}
+																						disabled={nicknameControlsDisabled}
+																						onCheckedChange={() =>
+																							updateNicknameBucketDraft(attachment.id, config.key, {
+																								enabled: !nicknameDraft.enabled,
+																							})
+																						}
+																					/>
+																					<Button
+																					variant="confirm"
+																					size="sm"
+																					showIcon={false}
+																					disabled={nicknameControlsDisabled || updateNicknameConfig.isPending}
+																					onClick={() =>
+																						void saveNicknameBucketDraft(attachment.id, config.key)
+																					}
+																					>
+																						Save
+																					</Button>
+																				</div>
+																			</div>
+																			<div className="grid gap-3 sm:grid-cols-2">
+																				<Select
+																					value={nicknameDraft.source}
+																					disabled={nicknameControlsDisabled || !nicknameDraft.enabled}
+																					onValueChange={(nextValue) =>
+																						updateNicknameBucketDraft(attachment.id, config.key, {
+																							source: nextValue as NicknameBucketSource,
+																						})
+																					}
+																					options={NICKNAME_SOURCE_OPTIONS}
+																					className="w-full"
+																					contentClassName="w-[min(90vw,24rem)]"
+																				/>
+																				<div className="space-y-1">
+																					<Input
+																						value={nicknameDraft.customTicker}
+																						disabled={
+																							nicknameControlsDisabled ||
+																							!nicknameDraft.enabled ||
+																							nicknameDraft.source !== 'custom'
+																						}
+																						onChange={(event) =>
+																							updateNicknameBucketDraft(attachment.id, config.key, {
+																								customTicker: sanitizeNicknameTickerInput(event.target.value),
+																							})
+																						}
+																						placeholder="Custom ticker"
+																						maxLength={5}
+																					/>
+																					<p className="text-xs text-muted-foreground">
+																						Max 5 characters.
+																					</p>
+																			</div>
+																		</div>
 																	</div>
 																</div>
-															)
-														})}
-													</div>
+															</div>
+														)
+													})}
 												</div>
 											</AccordionContent>
 										</AccordionItem>
-									))}
-								</Accordion>
+										)
+										})}
+									</Accordion>
 							)}
 
 							{/* Add Server Dialog */}

--- a/apps/ui/src/client/routes/admin/group-detail.tsx
+++ b/apps/ui/src/client/routes/admin/group-detail.tsx
@@ -1009,7 +1009,7 @@ export default function GroupDetailPage() {
 												}
 
 												return (
-													<div className="space-y-4">
+													<div className="rounded-xl border border-border/90 bg-card/90 p-4 shadow-md ring-1 ring-border/60 space-y-4">
 														<p className="text-xs text-muted-foreground">
 															{groupDiscordRoleAssignmentSummary}
 														</p>
@@ -1028,7 +1028,7 @@ export default function GroupDetailPage() {
 															return (
 																<div
 																	key={`${attachment.id}-${section.membershipType}`}
-																	className="space-y-3 rounded-md border border-dashed border-border/70 p-3"
+																	className="space-y-3 rounded-lg border border-border/80 bg-background/75 p-4 shadow-sm"
 																>
 																	<div className="flex items-start justify-between gap-3">
 																		<div>
@@ -1051,7 +1051,7 @@ export default function GroupDetailPage() {
 																			sectionAssignments.map((roleAssignment) => (
 																				<div
 																					key={roleAssignment.id}
-																					className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-sm"
+																					className="inline-flex items-center gap-1 rounded-md border border-primary/50 bg-primary/10 px-2 py-1 text-sm text-primary"
 																				>
 																					<span>{roleAssignment.discordRole.roleName}</span>
 																					<button

--- a/apps/ui/src/client/routes/admin/groups.tsx
+++ b/apps/ui/src/client/routes/admin/groups.tsx
@@ -151,6 +151,7 @@ export default function GroupsPage() {
 								onValueChange={(value) =>
 									updateFilter('categoryId', value === 'all' ? undefined : value)
 								}
+								searchable
 								options={[
 									{ value: 'all', label: 'All categories' },
 									...(categories?.map((category) => ({ value: category.id,
@@ -169,6 +170,7 @@ export default function GroupsPage() {
 								onValueChange={(value) =>
 									updateFilter('visibility', value === 'all' ? undefined : value)
 								}
+								searchable
 								options={[
 									{ value: 'all', label: 'All visibilities' },
 									{ value: 'public', label: 'Public' },
@@ -187,6 +189,7 @@ export default function GroupsPage() {
 								onValueChange={(value) =>
 									updateFilter('joinMode', value === 'all' ? undefined : value)
 								}
+								searchable
 								options={[
 									{ value: 'all', label: 'All modes' },
 									{ value: 'open', label: 'Open' },


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Reworks corp Discord scenario-role storage into per-bucket tables and adds per-bucket nickname ticker configuration (corp/alliance/custom ticker), while fixing an auto-invite bug where guests or owner/admins could be joined to a Discord server despite not actually being a member.

## Changes
- **DB migration (`0042`)**: adds `corporation_discord_server_scenario_roles` (one row per `alliance_guest`/`non_alliance_guest` bucket) and `corporation_discord_server_nickname_configs` (one row per `corp_member`/`alliance_guest`/`non_alliance_guest` bucket, with `enabled`, `source`, `custom_ticker`), and drops the now-redundant flat scenario-role columns (including `corp_member_role_id`/`corp_member_auto_apply`, which is removed entirely) from `corporation_discord_servers`.
- **`discord-routes.ts`**: attach/update endpoints now read and write the new per-bucket tables and flatten them back into the existing API shape; adds a new `PUT /corporations/:corporationId/discord-servers/:attachmentId/nickname-config` endpoint so nickname ticker settings can be updated independently of scenario roles.
- **`discord.service.ts`**: nickname sync now resolves a ticker suffix (corp, alliance, or custom) per membership bucket via a new `getCorporationTickerSources` helper (EVE corp data + token store lookups), and groups guilds that resolve to the same nickname before calling `updateUserNickname`.
- **Auto-invite fix**: corporation and group auto-invite eligibility now requires actual membership (`isCorpMember` / `membership.isMember`) — a resolved guest scenario role or owner/admin status alone no longer triggers joining a user to a guild they aren't a member of.
- **UI** (`corporation-detail.tsx`, `corporation-alerts-card.tsx`, `useDiscord.ts`, `api.ts`): adds nickname ticker config controls and a dedicated mutation/cache-patch hook (`useUpdateCorporationDiscordServerNicknameConfig`) instead of invalidating the whole list on every update.

## Testing
- Updated `discord-role-sync.test.ts` mocks/fixtures (scenario-role and nickname-config table shape, new EVE token store stub) to match the reworked data model.
<!-- claude:end -->