### PR TITLE
add metanox inventory type to filter

### DIFF
--- a/apps/core/src/services/__tests__/discord-refresh-special-role.test.ts
+++ b/apps/core/src/services/__tests__/discord-refresh-special-role.test.ts
@@ -48,4 +48,16 @@ describe('augmentRequestedRoleIdsForRefresh', () => {
 		expect(result.newRoleIds).toContain('1431816436640256060')
 		expect(result.rolesRemoved).not.toContain('1431816436640256060')
 	})
+
+	it('preserves roles that are not managed by the resolver during removal-mode updates', () => {
+		const result = calculateRoleChanges({
+			currentRoleIds: ['manual-role', 'managed-role'],
+			requestedRoleIds: ['managed-role-2'],
+			managedRoleIds: ['managed-role', 'managed-role-2'],
+			isAddOnlyMode: false,
+		})
+
+		expect(result.newRoleIds).toEqual(['manual-role', 'managed-role-2'])
+		expect(result.rolesRemoved).toEqual(['managed-role'])
+	})
 })

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -2981,9 +2981,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 
 		if (values.length === 0) {
-			await this.getDb()
-				.delete(structureMiningStates)
-				.where(eq(structureMiningStates.corporationId, corporationId))
 			return
 		}
 
@@ -3013,15 +3010,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					},
 				})
 		}
-
-		await this.getDb()
-			.delete(structureMiningStates)
-			.where(
-				and(
-					eq(structureMiningStates.corporationId, corporationId),
-					notInArray(structureMiningStates.structureId, values.map((row) => row.structureId))
-				)
-			)
 	}
 
 	/**

--- a/apps/eve-corporation-data/src/services/structure-inventory.ts
+++ b/apps/eve-corporation-data/src/services/structure-inventory.ts
@@ -10,6 +10,7 @@ const STRUCTURE_INVENTORY_LOCATION_FLAG_PREFIXES = [
 	'DroneBay',
 	'FighterBay',
 	'FighterTube',
+	'MoonMaterialBay',
 ] as const
 
 export interface StructureInventoryRowInput {

--- a/apps/eve-corporation-data/src/test/unit/services/structure-inventory.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-inventory.test.ts
@@ -9,6 +9,7 @@ describe('structure inventory filtering', () => {
 	it('recognizes structure inventory bay and hold flags', () => {
 		expect(isStructureInventoryLocationFlag('SpecializedAmmoHold')).toBe(true)
 		expect(isStructureInventoryLocationFlag('FighterTube3')).toBe(true)
+		expect(isStructureInventoryLocationFlag('MoonMaterialBay')).toBe(true)
 		expect(isStructureInventoryLocationFlag('ServiceSlot0')).toBe(false)
 		expect(isStructureInventoryLocationFlag('RigSlot0')).toBe(false)
 	})
@@ -57,6 +58,15 @@ describe('structure inventory filtering', () => {
 				{
 					item_id: '5',
 					is_singleton: false,
+					location_flag: 'MoonMaterialBay',
+					location_id: '1002',
+					location_type: 'item',
+					quantity: 99,
+					type_id: '12345',
+				},
+				{
+					item_id: '6',
+					is_singleton: false,
 					location_flag: 'CorpSAG1',
 					location_id: '1002',
 					location_type: 'station',
@@ -86,6 +96,16 @@ describe('structure inventory filtering', () => {
 				locationType: 'item',
 				quantity: 12,
 				typeId: '404',
+			},
+			{
+				corporationId: '98000001',
+				structureId: '1002',
+				itemId: '5',
+				isSingleton: false,
+				locationFlag: 'MoonMaterialBay',
+				locationType: 'item',
+				quantity: 99,
+				typeId: '12345',
 			},
 		])
 	})

--- a/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+	const findMany = vi.fn()
+	const onConflictDoUpdate = vi.fn()
+	const values = vi.fn(() => ({ onConflictDoUpdate }))
+	const insert = vi.fn(() => ({ values }))
+	const deleteMock = vi.fn()
+	const resolveMoonGeographyByIds = vi.fn()
+	const getStub = vi.fn(() => ({
+		resolveMoonGeographyByIds,
+	}))
+
+	return {
+		findMany,
+		onConflictDoUpdate,
+		values,
+		insert,
+		deleteMock,
+		resolveMoonGeographyByIds,
+		getStub,
+	}
+})
+
+vi.mock('../../../db', () => ({
+	createDb: vi.fn(() => ({
+		query: {
+			structureMiningStates: {
+				findMany: mocks.findMany,
+			},
+		},
+		insert: mocks.insert,
+		delete: mocks.deleteMock,
+	})),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: mocks.getStub,
+}))
+
+import { EveCorporationDataDO } from '../../../durable-object'
+
+describe('storeMiningExtractions', () => {
+	it('preserves the last known mining snapshot when the extraction pull is empty', async () => {
+		mocks.findMany.mockResolvedValue([
+			{
+				structureId: 'structure-1',
+				corporationId: 'corp-1',
+				moonId: 'moon-1',
+				moonName: 'Old Moon',
+				planetId: 'planet-1',
+				planetName: 'Old Planet',
+				systemId: 'system-1',
+				systemName: 'Old System',
+				extractionStartTime: new Date('2026-07-01T00:00:00.000Z'),
+				chunkArrivalTime: new Date('2026-07-02T00:00:00.000Z'),
+				naturalDecayTime: new Date('2026-07-03T00:00:00.000Z'),
+				sourceSyncAt: new Date('2026-07-01T00:00:00.000Z'),
+				lastSyncedAt: new Date('2026-07-01T00:00:00.000Z'),
+				rawPayload: {},
+				updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+			},
+		])
+
+		const doInstance = new EveCorporationDataDO(
+			{} as DurableObjectState,
+			{
+				DATABASE_URL: 'postgres://example',
+				UNIVERSE: {} as never,
+			} as never
+		)
+
+		await doInstance.storeMiningExtractions('corp-1', [])
+
+		expect(mocks.resolveMoonGeographyByIds).not.toHaveBeenCalled()
+		expect(mocks.insert).not.toHaveBeenCalled()
+		expect(mocks.deleteMock).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds `MoonMaterialBay` (metanox) as a recognized structure inventory location flag, and fixes structure mining state storage to stop wiping out previously stored mining data when an ESI extraction pull comes back empty.

## Changes
- Add `MoonMaterialBay` to `STRUCTURE_INVENTORY_LOCATION_FLAG_PREFIXES` so metanox/moon material bay contents are captured by structure inventory sync (`apps/eve-corporation-data/src/services/structure-inventory.ts`).
- Remove the `structureMiningStates` delete calls in `EveCorporationDataDO` so an empty or partial extraction pull no longer deletes existing mining state rows for a corporation's structures — the last known snapshot is now preserved instead (`apps/eve-corporation-data/src/durable-object.ts`).
- Add unit test coverage for the new `MoonMaterialBay` flag and item filtering.
- Add a unit test verifying `storeMiningExtractions` preserves the last known mining snapshot and performs no delete/insert when the extraction pull is empty.
- Add a test case for `calculateRoleChanges` covering preservation of unmanaged roles during removal-mode Discord role refresh updates.

## Testing
- New/updated unit tests: `structure-inventory.test.ts`, `structure-mining-storage.test.ts`, `discord-refresh-special-role.test.ts`.
<!-- claude:end -->