### PR TITLE
feat(mailroom): post markeedragon@ inbound email to a Discord channel

### DIFF
--- a/apps/mailroom/README.md
+++ b/apps/mailroom/README.md
@@ -1,9 +1,9 @@
 # mailroom
 
 Inbound-email worker for **pleaseignore.app**. Receives mail via Cloudflare Email
-Routing and processes it through a small, modular routing framework. This is the initial
-setup: the worker, the framework, and example routes — no persistence, outbound sending,
-or replies yet (all easy to add; see [Extending](#extending)).
+Routing and processes it through a small, modular routing framework. Its first feature
+posts mail sent to `markeedragon@` into a Discord channel. Outbound sending, replies, and
+persistence are deferred by design (all easy to add; see [Extending](#extending)).
 
 ## How inbound email reaches this worker
 
@@ -55,6 +55,17 @@ Dispositions (`src/email/dispositions.ts`):
 | `consume`        | Accept and intentionally discard (the only sanctioned no-op).     |
 | `next`           | Not terminal — continue to the next route.                        |
 
+### Current routes (`src/routes.ts`)
+
+1. **log-inbound** — structured-logs every message (`sideEffect`, non-terminal).
+2. **markeedragon-to-discord** — mail to `markeedragon@` is posted to a Discord channel via
+   the shared Discord Durable Object (`@repo/discord`, reached with `forDO`), then
+   `consume`d. The Discord send is awaited inline, so a failure surfaces (Sentry +
+   forward-to-fallback) instead of the notification being silently lost. See
+   `src/notify-discord.ts`.
+3. **forward-team** — example alias forward, active only when `FORWARD_TEAM_TO` is set.
+4. **otherwise** — unknown recipients get a permanent reject.
+
 ### Safety: no silent drops
 
 Dropping mail is the cardinal sin of an email worker, and `setReject` is **always a
@@ -71,14 +82,22 @@ platform behaviour:
 
 ## Configuration (`wrangler.jsonc` vars)
 
-| Var                                     | Required | Purpose                                                  |
-| --------------------------------------- | -------- | -------------------------------------------------------- |
-| `NAME`, `ENVIRONMENT`, `SENTRY_RELEASE` | yes      | Standard worker vars.                                    |
-| `FALLBACK_FORWARD_ADDRESS`              | no       | Verified mailbox that receives mail on internal failure. |
-| `FORWARD_TEAM_TO`                       | no       | Example: destination for the `team@` alias route.        |
+| Var                                     | Required    | Purpose                                                  |
+| --------------------------------------- | ----------- | -------------------------------------------------------- |
+| `NAME`, `ENVIRONMENT`, `SENTRY_RELEASE` | yes         | Standard worker vars.                                    |
+| `FALLBACK_FORWARD_ADDRESS`              | no          | Verified mailbox that receives mail on internal failure. |
+| `FORWARD_TEAM_TO`                       | no          | Example: destination for the `team@` alias route.        |
+| `DISCORD_GUILD_ID`                      | for Discord | Guild the bot posts to for the `markeedragon@` route.    |
+| `MARKEE_DISCORD_CHANNEL_ID`             | for Discord | Channel that receives mail sent to `markeedragon@`.      |
 
 Set forwarding targets to **verified Email Routing destination addresses** — an unverified
 address makes `forward()` fail (which then hits the fallback path).
+
+The `markeedragon@` → Discord route also needs the `DISCORD` binding (a cross-worker binding
+to `apps/discord`, already in `wrangler.jsonc`), the `discord` worker deployed in the same
+account, and the Discord **bot** to be a member of the guild with permission to post in the
+channel. Until `DISCORD_GUILD_ID` + `MARKEE_DISCORD_CHANNEL_ID` are set, mail to
+`markeedragon@` errors to the fallback/last-resort path rather than posting.
 
 ## Extending
 

--- a/apps/mailroom/package.json
+++ b/apps/mailroom/package.json
@@ -16,6 +16,8 @@
 		"test": "run-vitest"
 	},
 	"dependencies": {
+		"@repo/discord": "workspace:*",
+		"@repo/do-utils": "workspace:*",
 		"@repo/hono-helpers": "workspace:*",
 		"@repo/worker-utils": "workspace:*",
 		"hono": "4.10.6",

--- a/apps/mailroom/src/context.ts
+++ b/apps/mailroom/src/context.ts
@@ -12,6 +12,13 @@ export type Env = SharedHonoEnv & {
 	 * falls through to the no-match policy (nothing is forwarded).
 	 */
 	FORWARD_TEAM_TO?: string
+
+	/** Cross-worker binding to the shared Discord Durable Object (`apps/discord`). */
+	DISCORD: DurableObjectNamespace
+	/** Discord guild/server ID the bot posts to (required for the markeedragon→Discord route). */
+	DISCORD_GUILD_ID?: string
+	/** Discord channel ID that receives mail sent to `markeedragon@`. */
+	MARKEE_DISCORD_CHANNEL_ID?: string
 }
 
 /** Variables can be extended per-request as needed. */

--- a/apps/mailroom/src/notify-discord.ts
+++ b/apps/mailroom/src/notify-discord.ts
@@ -1,0 +1,84 @@
+import { forDO } from '@repo/do-utils'
+import { parseDateOrNull } from '@repo/worker-utils'
+
+import { consume } from './email'
+
+import type { Discord, DiscordEmbed, MessageContent } from '@repo/discord'
+import type { Env } from './context'
+import type { EmailHandler } from './email'
+
+/** Discord "blurple". */
+const EMBED_COLOR = 0x5865f2
+/** Discord embed field limits (characters). */
+const LIMIT = { title: 256, description: 4000, fieldValue: 1024 }
+
+/**
+ * Route handler: post an inbound email to a Discord channel via the shared Discord
+ * Durable Object (`@repo/discord`), reached with `forDO`.
+ *
+ * On success the email is `consume`d — its purpose is fulfilled by the Discord post, so it
+ * is accepted and discarded. Any failure (missing config, or the send failing) throws, so
+ * the framework's error fallback preserves the mail (forward-to-fallback) and Sentry
+ * captures it rather than the notification being silently lost.
+ */
+export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
+	const guildId = ctx.env.DISCORD_GUILD_ID
+	const channelId = ctx.env.MARKEE_DISCORD_CHANNEL_ID
+	if (!guildId || !channelId) {
+		throw new Error(
+			'Discord notify is not configured: set DISCORD_GUILD_ID and MARKEE_DISCORD_CHANNEL_ID'
+		)
+	}
+
+	const parsed = await ctx.parsed()
+	const body = (parsed.text ?? htmlToText(parsed.html) ?? '').trim()
+	const timestamp = parseDateOrNull(parsed.date)?.toISOString()
+
+	const embed: DiscordEmbed = {
+		title: truncate(parsed.subject ?? '(no subject)', LIMIT.title),
+		description: body ? truncate(body, LIMIT.description) : '_(empty body)_',
+		color: EMBED_COLOR,
+		fields: [
+			{ name: 'From', value: truncate(ctx.sender, LIMIT.fieldValue), inline: true },
+			{ name: 'To', value: truncate(ctx.recipient, LIMIT.fieldValue), inline: true },
+		],
+		...(timestamp ? { timestamp } : {}),
+	}
+
+	const message: MessageContent = {
+		content: `📧 New email to **${ctx.recipient}**`,
+		embeds: [embed],
+		allowEveryone: false,
+	}
+
+	const discord = forDO<Discord>(ctx.env.DISCORD).singleton()
+	const result = await discord.sendMessage(guildId, channelId, message)
+	if (!result.success) {
+		throw new Error(`Discord sendMessage failed: ${result.error ?? 'unknown error'}`)
+	}
+
+	ctx.log.info('email posted to Discord', {
+		from: ctx.sender,
+		to: ctx.recipient,
+		channelId,
+		messageId: result.messageId,
+	})
+
+	// The email's purpose is fulfilled by the Discord post — accept and discard.
+	return consume
+}
+
+function truncate(value: string, max: number): string {
+	return value.length > max ? `${value.slice(0, max - 1)}…` : value
+}
+
+/** Rough HTML→text fallback for emails that carry only an HTML body. */
+function htmlToText(html: string | null): string | null {
+	if (!html) return null
+	return html
+		.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+		.replace(/<[^>]+>/g, ' ')
+		.replace(/&nbsp;/gi, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+}

--- a/apps/mailroom/src/routes.ts
+++ b/apps/mailroom/src/routes.ts
@@ -7,6 +7,7 @@ import {
 	reject,
 	sideEffect,
 } from './email'
+import { notifyDiscord } from './notify-discord'
 
 import type { Env } from './context'
 
@@ -33,6 +34,11 @@ export const emailRouter = new EmailRouter<Env>()
 		}),
 		'log-inbound'
 	)
+
+	// markeedragon@ → post the email to a Discord channel (via the shared Discord DO), then
+	// consume it. Envelope-only match, so the body is parsed only when it's actually for
+	// this address. Sends inline so a Discord failure surfaces (Sentry + forward-to-fallback).
+	.on(recipientLocalPartIs('markeedragon'), notifyDiscord, 'markeedragon-to-discord')
 
 	// Example alias: forward "team@…" to a configured, verified destination. The match is
 	// envelope-only; the handler forwards only when FORWARD_TEAM_TO is set, otherwise it

--- a/apps/mailroom/src/test/notify-discord.test.ts
+++ b/apps/mailroom/src/test/notify-discord.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createEmailContext } from '../email'
+import { notifyDiscord } from '../notify-discord'
+import { emailRouter } from '../routes'
+import { fakeExecutionCtx, makeMessage } from './make-message'
+
+import type { Env } from '../context'
+import type { EmailLogger } from '../email'
+
+const log: EmailLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+/** Build an Env whose DISCORD binding resolves to a stub with the given `sendMessage` mock. */
+function envWith(sendMessage: ReturnType<typeof vi.fn>, overrides: Partial<Env> = {}): Env {
+	return {
+		DISCORD_GUILD_ID: 'guild-1',
+		MARKEE_DISCORD_CHANNEL_ID: 'chan-1',
+		DISCORD: { getByName: () => ({ sendMessage }) },
+		...overrides,
+	} as unknown as Env
+}
+
+function ctxFor(env: Env, mime?: string) {
+	const message = makeMessage({
+		to: 'markeedragon@pleaseignore.app',
+		from: 'sender@example.com',
+		mime,
+	})
+	return createEmailContext(message, env, fakeExecutionCtx(), log)
+}
+
+describe('notifyDiscord', () => {
+	it('posts the email to the configured Discord channel and consumes it', async () => {
+		const sendMessage = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
+		const mime =
+			'From: sender@example.com\r\nTo: markeedragon@pleaseignore.app\r\nSubject: Hello Markee\r\n\r\nThe body text.'
+		const disposition = await notifyDiscord(ctxFor(envWith(sendMessage), mime))
+
+		expect(sendMessage).toHaveBeenCalledTimes(1)
+		const [guildId, channelId, message] = sendMessage.mock.calls[0]
+		expect(guildId).toBe('guild-1')
+		expect(channelId).toBe('chan-1')
+		expect(message.content).toContain('markeedragon@pleaseignore.app')
+		expect(message.embeds[0].title).toBe('Hello Markee')
+		expect(message.embeds[0].description).toContain('The body text.')
+		expect(message.embeds[0].fields).toEqual([
+			{ name: 'From', value: 'sender@example.com', inline: true },
+			{ name: 'To', value: 'markeedragon@pleaseignore.app', inline: true },
+		])
+		expect(disposition).toEqual({ type: 'consume' })
+	})
+
+	it('throws when guild/channel are not configured', async () => {
+		const sendMessage = vi.fn()
+		const env = envWith(sendMessage, {
+			DISCORD_GUILD_ID: undefined,
+			MARKEE_DISCORD_CHANNEL_ID: undefined,
+		})
+		await expect(notifyDiscord(ctxFor(env))).rejects.toThrow(/not configured/)
+		expect(sendMessage).not.toHaveBeenCalled()
+	})
+
+	it('throws when the Discord send fails (so the framework preserves the mail)', async () => {
+		const sendMessage = vi.fn().mockResolvedValue({ success: false, error: 'missing permissions' })
+		await expect(notifyDiscord(ctxFor(envWith(sendMessage)))).rejects.toThrow(/missing permissions/)
+	})
+
+	it('is wired into the email router for markeedragon@', async () => {
+		const sendMessage = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
+		const disposition = await emailRouter.route(ctxFor(envWith(sendMessage)))
+		expect(sendMessage).toHaveBeenCalledTimes(1)
+		expect(disposition).toEqual({ type: 'consume' })
+	})
+})

--- a/apps/mailroom/vitest.config.ts
+++ b/apps/mailroom/vitest.config.ts
@@ -10,6 +10,23 @@ export default defineWorkersProject({
 					bindings: {
 						ENVIRONMENT: 'VITEST',
 					},
+					// The DISCORD binding targets the cross-worker `discord` Durable Object. Provide a
+					// stub `discord` worker exposing a `Discord` DO so the pool can resolve the binding
+					// at startup. Mailroom's tests never call the real DO — Discord is faked in the
+					// notify-discord unit tests — this only satisfies the runtime.
+					workers: [
+						{
+							name: 'discord',
+							modules: true,
+							script: [
+								'export class Discord {',
+								'  async sendMessage() { return { success: false, error: "stub discord worker" } }',
+								'}',
+								'export default { fetch() { return new Response("stub") } }',
+							].join('\n'),
+							durableObjects: { Discord: 'Discord' },
+						},
+					],
 				},
 			},
 		},

--- a/apps/mailroom/wrangler.jsonc
+++ b/apps/mailroom/wrangler.jsonc
@@ -13,10 +13,26 @@
 	"observability": {
 		"enabled": true
 	},
+	// Cross-worker binding to the shared Discord Durable Object (apps/discord). Used by the
+	// markeedragon@ → Discord route. The `discord` worker must be deployed in the same account.
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "DISCORD",
+				"class_name": "Discord",
+				"script_name": "discord"
+			}
+		]
+	},
 	"vars": {
 		"NAME": "mailroom",
 		"ENVIRONMENT": "production",
-		"SENTRY_RELEASE": "unknown"
+		"SENTRY_RELEASE": "unknown",
+		// markeedragon@ → Discord: set to the target guild + channel IDs (the Discord bot must be
+		// in that guild and able to post in the channel). Until both are set, mail to markeedragon@
+		// errors out to the fallback/last-resort path rather than posting.
+		"DISCORD_GUILD_ID": "",
+		"MARKEE_DISCORD_CHANNEL_ID": ""
 		// Optional framework config (set to VERIFIED Email Routing destinations before relying on them):
 		//   "FALLBACK_FORWARD_ADDRESS": "ops@pleaseignore.app"  // receives mail when inbound processing fails
 		//   "FORWARD_TEAM_TO": "team-inbox@pleaseignore.app"     // destination for the example "team@" alias

--- a/apps/mailroom/wrangler.jsonc
+++ b/apps/mailroom/wrangler.jsonc
@@ -31,8 +31,8 @@
 		// markeedragon@ → Discord: set to the target guild + channel IDs (the Discord bot must be
 		// in that guild and able to post in the channel). Until both are set, mail to markeedragon@
 		// errors out to the fallback/last-resort path rather than posting.
-		"DISCORD_GUILD_ID": "",
-		"MARKEE_DISCORD_CHANNEL_ID": ""
+		"DISCORD_GUILD_ID": "356398105404375041",
+		"MARKEE_DISCORD_CHANNEL_ID": "730208741181358100"
 		// Optional framework config (set to VERIFIED Email Routing destinations before relying on them):
 		//   "FALLBACK_FORWARD_ADDRESS": "ops@pleaseignore.app"  // receives mail when inbound processing fails
 		//   "FORWARD_TEAM_TO": "team-inbox@pleaseignore.app"     // destination for the example "team@" alias

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1822,6 +1822,12 @@ importers:
 
   apps/mailroom:
     dependencies:
+      '@repo/discord':
+        specifier: workspace:*
+        version: link:../../packages/discord
+      '@repo/do-utils':
+        specifier: workspace:*
+        version: link:../../packages/do-utils
       '@repo/hono-helpers':
         specifier: workspace:*
         version: link:../../packages/hono-helpers


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds the mailroom worker's first concrete route: inbound email sent to `markeedragon@pleaseignore.app` is posted as a Discord embed to a channel via the shared Discord Durable Object, then consumed.

## Changes
- `src/notify-discord.ts`: new `notifyDiscord` handler that builds a Discord embed (subject, body, from, to) from the parsed email and sends it via `forDO<Discord>(env.DISCORD).singleton().sendMessage(...)`; throws on missing config or a failed send so the framework's fallback/forward path preserves the mail and Sentry captures the failure, otherwise `consume`s the message.
- `src/routes.ts`: wires `notifyDiscord` into the router for envelope matches on `markeedragon`.
- `wrangler.jsonc`: adds the cross-worker `DISCORD` Durable Object binding (targeting the `discord` worker) plus the `DISCORD_GUILD_ID` / `MARKEE_DISCORD_CHANNEL_ID` vars, set to the target guild/channel IDs.
- `src/context.ts`: adds `DISCORD`, `DISCORD_GUILD_ID`, `MARKEE_DISCORD_CHANNEL_ID` to `Env`.
- `package.json`: adds `@repo/discord` and `@repo/do-utils` workspace dependencies.
- `vitest.config.ts`: registers a stub `discord` worker so the test pool can resolve the cross-worker DO binding at startup.
- `README.md`: documents the new route, its required config, and the Discord bot/binding prerequisites.

## Testing
- New unit tests in `src/test/notify-discord.test.ts` cover: successful post + consume, missing guild/channel config throwing, a failed Discord send throwing, and the route being reachable through `emailRouter`.
- Per the commit message: 42 tests, typecheck, and build all green.
<!-- claude:end -->