### PR TITLE
feat(prediction-markets): let site admins always resolve a market (adminOverride)

### DIFF
--- a/apps/core/src/services/__tests__/discord-components.resolve.test.ts
+++ b/apps/core/src/services/__tests__/discord-components.resolve.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { executeDiscordModalSubmit } from '../discord-components.service'
+
+// Verifies Core threads the site-admin `adminOverride` capability into proposeResolution: a plain
+// resolver and a (non-admin) manager pass adminOverride:false — they stay bound by the resolve
+// conflict-of-interest guards (creator ≠ resolver, no-position) AND the two-of-N second-signer rule —
+// while an is_admin resolver passes adminOverride:true, letting them settle ANY market in one step
+// (including one they created or bet on). bypassDesignated (admin OR manager) is threaded independently.
+
+const hoisted = vi.hoisted(() => ({
+	predictionBinding: {} as DurableObjectNamespace,
+	prediction: {
+		// A market with two outcomes so handleResolveModal reaches proposeResolution.
+		getMarket: vi.fn().mockResolvedValue({
+			id: 'm1',
+			outcomes: [
+				{ id: 'o1', label: 'A' },
+				{ id: 'o2', label: 'B' },
+			],
+		}),
+		// 'resolving' (non-terminal) ⇒ announceSettlement is skipped.
+		proposeResolution: vi
+			.fn()
+			.mockResolvedValue({ marketId: 'm1', status: 'resolving', resolvedOutcomeId: null }),
+	},
+	hasMarketPermission: vi.fn(),
+	findFirst: vi.fn(),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn((binding: DurableObjectNamespace) =>
+		binding === hoisted.predictionBinding ? hoisted.prediction : {}
+	),
+}))
+vi.mock('../../lib/market-permissions', () => ({
+	hasMarketPermission: hoisted.hasMarketPermission,
+}))
+vi.mock('../../lib/market-custom-id', () => ({
+	customIdAction: () => 'resolvemodal',
+	decodeSingleMarketId: () => 'm1',
+	RESOLVE_OUTCOME_INPUT_ID: 'outcome',
+}))
+// Downstream post/notify services aren't meaningfully reached; mock them so the module under test
+// loads without pulling their transitive deps. updateMarketPostFromDetail → { success: false } so the
+// refreshPost path never calls applyMarketPostStatus.
+vi.mock('../discord-market-post.service', () => ({
+	updateMarketPostFromDetail: vi.fn().mockResolvedValue({ success: false }),
+	applyMarketPostStatus: vi.fn(),
+	announceBetPlaced: vi.fn(),
+}))
+vi.mock('../discord-market-notify.service', () => ({
+	announceMarketClosed: vi.fn(),
+	announceMarketResolved: vi.fn(),
+	dmWagerResults: vi.fn(),
+}))
+
+const db = { query: { users: { findFirst: hoisted.findFirst } } } as any
+const env = {
+	PREDICTION_MARKETS: hoisted.predictionBinding,
+	DISCORD: {},
+	GROUPS: {},
+	PM_FORUM_GUILD_ID: 'g1',
+} as any
+const input = {
+	customId: 'resolvemodal:m1',
+	discordUserId: 'd1',
+	fields: { outcome: '1' },
+	interactionId: 'i1',
+} as any
+
+function mockTiers(isAdmin: boolean, manager: boolean) {
+	hoisted.findFirst.mockResolvedValue({ id: 'u1', is_admin: isAdmin })
+	// requireResolver checks 'resolver'; canBypassDesignated checks 'manager'.
+	hoisted.hasMarketPermission.mockImplementation((_e: unknown, _u: unknown, tier: string) =>
+		Promise.resolve(tier === 'manager' ? manager : true)
+	)
+}
+
+describe('executeDiscordModalSubmit — adminOverride threading (resolve)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		hoisted.prediction.getMarket.mockResolvedValue({
+			id: 'm1',
+			outcomes: [
+				{ id: 'o1', label: 'A' },
+				{ id: 'o2', label: 'B' },
+			],
+		})
+		hoisted.prediction.proposeResolution.mockResolvedValue({
+			marketId: 'm1',
+			status: 'resolving',
+			resolvedOutcomeId: null,
+		})
+	})
+
+	it('a plain resolver passes adminOverride:false and bypassDesignated:false', async () => {
+		mockTiers(false, false)
+		await executeDiscordModalSubmit(db, env, input)
+		expect(hoisted.prediction.proposeResolution).toHaveBeenCalledWith(
+			expect.objectContaining({
+				resolverId: 'u1',
+				marketId: 'm1',
+				outcomeId: 'o1',
+				bypassDesignated: false,
+				adminOverride: false,
+			})
+		)
+	})
+
+	it('a non-admin manager passes adminOverride:false but bypassDesignated:true', async () => {
+		mockTiers(false, true)
+		await executeDiscordModalSubmit(db, env, input)
+		expect(hoisted.prediction.proposeResolution).toHaveBeenCalledWith(
+			expect.objectContaining({ bypassDesignated: true, adminOverride: false })
+		)
+	})
+
+	it('an admin passes adminOverride:true (and bypassDesignated:true)', async () => {
+		mockTiers(true, false)
+		await executeDiscordModalSubmit(db, env, input)
+		expect(hoisted.prediction.proposeResolution).toHaveBeenCalledWith(
+			expect.objectContaining({ bypassDesignated: true, adminOverride: true })
+		)
+	})
+})

--- a/apps/core/src/services/__tests__/discord-components.service.test.ts
+++ b/apps/core/src/services/__tests__/discord-components.service.test.ts
@@ -2,9 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { executeDiscordComponent } from '../discord-components.service'
 
-// Verifies Core threads the admin/manager `bypassDesignated` capability into the settlement RPC:
-// a plain urn:markets:resolver passes false (narrowed to the market's designated set); an is_admin
-// or urn:markets:manager holder passes true (retains "resolve any market").
+// Verifies Core threads the admin/manager `bypassDesignated` capability AND the is_admin-only
+// `adminOverride` capability into the approveResolution RPC. bypassDesignated: a plain
+// urn:markets:resolver passes false (narrowed to the market's designated set); an is_admin or
+// urn:markets:manager holder passes true (retains "resolve any market"). adminOverride: only an
+// is_admin passes true (may single-sign any pending proposal); resolvers and non-admin managers pass
+// false (stay bound by every conflict-of-interest guard).
 
 const hoisted = vi.hoisted(() => ({
 	predictionBinding: {} as DurableObjectNamespace,
@@ -59,7 +62,7 @@ function mockTiers(isAdmin: boolean, manager: boolean) {
 	)
 }
 
-describe('executeDiscordComponent — bypassDesignated threading (approve)', () => {
+describe('executeDiscordComponent — bypassDesignated + adminOverride threading (approve)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		hoisted.prediction.getMarket.mockResolvedValue(null)
@@ -71,27 +74,32 @@ describe('executeDiscordComponent — bypassDesignated threading (approve)', () 
 		})
 	})
 
-	it('a plain resolver passes bypassDesignated: false', async () => {
+	it('a plain resolver passes bypassDesignated: false and adminOverride: false', async () => {
 		mockTiers(false, false)
 		await executeDiscordComponent(db, env, input)
 		expect(hoisted.prediction.approveResolution).toHaveBeenCalledWith(
-			expect.objectContaining({ resolverId: 'u1', proposalId: 'p1', bypassDesignated: false })
+			expect.objectContaining({
+				resolverId: 'u1',
+				proposalId: 'p1',
+				bypassDesignated: false,
+				adminOverride: false,
+			})
 		)
 	})
 
-	it('a manager passes bypassDesignated: true', async () => {
+	it('a non-admin manager passes bypassDesignated: true but adminOverride: false', async () => {
 		mockTiers(false, true)
 		await executeDiscordComponent(db, env, input)
 		expect(hoisted.prediction.approveResolution).toHaveBeenCalledWith(
-			expect.objectContaining({ bypassDesignated: true })
+			expect.objectContaining({ bypassDesignated: true, adminOverride: false })
 		)
 	})
 
-	it('an admin passes bypassDesignated: true', async () => {
+	it('an admin passes bypassDesignated: true and adminOverride: true', async () => {
 		mockTiers(true, false)
 		await executeDiscordComponent(db, env, input)
 		expect(hoisted.prediction.approveResolution).toHaveBeenCalledWith(
-			expect.objectContaining({ bypassDesignated: true })
+			expect.objectContaining({ bypassDesignated: true, adminOverride: true })
 		)
 	})
 })

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -343,6 +343,10 @@ export async function executeDiscordComponent(
 			marketId: decoded.marketId,
 			proposalId: proposal.id,
 			bypassDesignated: await canBypassDesignated(env, user),
+			// A site admin may finalize ANY pending proposal (even single-signing a two-of-N), matching
+			// their unconditional resolve/void authority. is_admin-only — managers keep the guards. The
+			// DO trusts this flag unverified, so it MUST come straight from is_admin.
+			adminOverride: user.is_admin,
 		})
 		await refreshPost(db, env, prediction, decoded.marketId)
 		let background: (() => Promise<void>) | undefined
@@ -495,6 +499,11 @@ async function handleResolveModal(
 			marketId,
 			outcomeId: outcome.id,
 			bypassDesignated: await canBypassDesignated(env, user),
+			// A site admin may resolve ANY market unconditionally — skipping the creator/position/
+			// designated guards AND the two-of-N second-signer rule (a lone admin settles in one step).
+			// Unlike a void this pays out the chosen outcome, so it's recorded in the audit history.
+			// is_admin-only; the DO trusts this flag unverified, so it MUST come straight from is_admin.
+			adminOverride: user.is_admin,
 		})
 		await refreshPost(db, env, prediction, marketId)
 		let background: (() => Promise<void>) | undefined

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -200,6 +200,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		marketId: string
 		outcomeId: string
 		bypassDesignated?: boolean
+		adminOverride?: boolean
 	}): Promise<ResolveResult> {
 		return settlement.proposeResolution(this.deps, input)
 	}
@@ -209,6 +210,7 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		marketId: string
 		proposalId: string
 		bypassDesignated?: boolean
+		adminOverride?: boolean
 	}): Promise<ResolveResult> {
 		return settlement.approveResolution(this.deps, input)
 	}

--- a/apps/prediction-markets/src/services/market-service.ts
+++ b/apps/prediction-markets/src/services/market-service.ts
@@ -86,8 +86,10 @@ export async function createMarket(deps: PmDeps, input: CreateMarketInput): Prom
 		// CREATE-TIME ONLY. If a size-1 designated market is created while NO threshold is active and
 		// an admin LATER activates/lowers `pmConfig.twoOfNThreshold` such that the pool crosses it,
 		// requiresTwoOfN() flips true at settle and the sole designated resolver can't self-complete
-		// (no distinct second signer). That market is then settleable only via admin/manager bypass
-		// (bypassDesignated) or the resolving->voided path — never permanently stuck. We deliberately
+		// (no distinct second signer). It is still never permanently stuck: a DISTINCT urn:markets:manager
+		// can supply the second signature (bypassDesignated waives the designated-membership check), a
+		// site admin can adminOverride to collapse two-of-N and resolve/void in one step, or it can simply
+		// be voided. We deliberately
 		// do NOT weaken requiresTwoOfN for small designated sets, so the two-of-N safeguard on large
 		// pools is never silently skipped by designating a single resolver.
 		if (designatedResolvers.length < 2) {

--- a/apps/prediction-markets/src/services/settlement-service.ts
+++ b/apps/prediction-markets/src/services/settlement-service.ts
@@ -21,6 +21,7 @@ export async function proposeResolution(
 		marketId: string
 		outcomeId: string
 		bypassDesignated?: boolean
+		adminOverride?: boolean
 	}
 ): Promise<ResolveResult> {
 	try {
@@ -45,23 +46,36 @@ export async function proposeResolution(
 				.limit(1)
 			if (!outcome) throw new PmError('OUTCOME_NOT_FOUND')
 
-			if (market.createdBy === input.resolverId) throw new PmError('CREATOR_CANNOT_RESOLVE')
-			if (await hasPosition(tx, input.marketId, input.resolverId)) {
-				throw new PmError('RESOLVER_HAS_POSITION')
-			}
+			// A site admin (adminOverride) may resolve ANY market unconditionally: skip every
+			// conflict-of-interest guard (creator ≠ resolver, no-position, designated membership) AND
+			// collapse the two-of-N second-signer requirement, so a lone admin settles in one step. This
+			// mirrors voidMarket's admin escape hatch, but demands sharper trust: unlike a void (which only
+			// refunds at stake), picking a winning outcome PAYS positions on it, so an admin who holds a
+			// stake could self-deal — the override is recorded in the resolution's audit history for
+			// accountability. adminOverride is is_admin-only, a trusted, DO-unverifiable capability Core
+			// derives solely from is_admin (never a client literal). Every non-admin actor stays fully
+			// bound by the guards below.
+			const adminOverride = input.adminOverride ?? false
 			const bypass = input.bypassDesignated ?? false
-			if (!canResolveDesignated(market.designatedResolvers, input.resolverId, bypass)) {
-				throw new PmError('NOT_DESIGNATED_RESOLVER')
+			if (!adminOverride) {
+				if (market.createdBy === input.resolverId) throw new PmError('CREATOR_CANNOT_RESOLVE')
+				if (await hasPosition(tx, input.marketId, input.resolverId)) {
+					throw new PmError('RESOLVER_HAS_POSITION')
+				}
+				if (!canResolveDesignated(market.designatedResolvers, input.resolverId, bypass)) {
+					throw new PmError('NOT_DESIGNATED_RESOLVER')
+				}
 			}
 			const viaOverride = isDesignatedOverride(market.designatedResolvers, input.resolverId, bypass)
 
-			if (!(await requiresTwoOfN(tx, market))) {
+			if (adminOverride || !(await requiresTwoOfN(tx, market))) {
 				const finalStatus = await executeResolution(
 					tx,
 					market,
 					input.outcomeId,
 					input.resolverId,
-					viaOverride
+					viaOverride,
+					adminOverride
 				)
 				return {
 					marketId: market.id,
@@ -120,6 +134,7 @@ export async function approveResolution(
 		marketId: string
 		proposalId: string
 		bypassDesignated?: boolean
+		adminOverride?: boolean
 	}
 ): Promise<ResolveResult> {
 	try {
@@ -142,17 +157,23 @@ export async function approveResolution(
 			}
 			if (proposal.status !== 'pending') throw new PmError('PROPOSAL_NOT_PENDING')
 
-			// Two distinct resolvers, neither the creator, neither holding a position, and — when the
-			// market is designated — both the proposer (checked in proposeResolution) and this approver
-			// must be designated members (or hold the admin/manager override).
-			if (proposal.proposedBy === input.resolverId) throw new PmError('APPROVER_MUST_DIFFER')
-			if (market.createdBy === input.resolverId) throw new PmError('CREATOR_CANNOT_RESOLVE')
-			if (await hasPosition(tx, input.marketId, input.resolverId)) {
-				throw new PmError('RESOLVER_HAS_POSITION')
-			}
+			// A site admin (adminOverride) may finalize ANY pending proposal unconditionally — the same
+			// escape hatch, trust model, and self-dealing caveat as proposeResolution above (an admin can
+			// even single-sign a two-of-N proposal). For every non-admin approver the two-of-N contract
+			// holds: two distinct resolvers, neither the creator, neither holding a position, and — when
+			// the market is designated — both the proposer (checked in proposeResolution) and this
+			// approver must be designated members (or hold the admin/manager designated bypass).
+			const adminOverride = input.adminOverride ?? false
 			const bypass = input.bypassDesignated ?? false
-			if (!canResolveDesignated(market.designatedResolvers, input.resolverId, bypass)) {
-				throw new PmError('NOT_DESIGNATED_RESOLVER')
+			if (!adminOverride) {
+				if (proposal.proposedBy === input.resolverId) throw new PmError('APPROVER_MUST_DIFFER')
+				if (market.createdBy === input.resolverId) throw new PmError('CREATOR_CANNOT_RESOLVE')
+				if (await hasPosition(tx, input.marketId, input.resolverId)) {
+					throw new PmError('RESOLVER_HAS_POSITION')
+				}
+				if (!canResolveDesignated(market.designatedResolvers, input.resolverId, bypass)) {
+					throw new PmError('NOT_DESIGNATED_RESOLVER')
+				}
 			}
 			const viaOverride = isDesignatedOverride(market.designatedResolvers, input.resolverId, bypass)
 
@@ -164,7 +185,8 @@ export async function approveResolution(
 					market,
 					input.resolverId,
 					'resolution voided by approval',
-					viaOverride
+					viaOverride,
+					adminOverride
 				)
 				finalStatus = 'voided'
 			} else {
@@ -173,7 +195,8 @@ export async function approveResolution(
 					market,
 					proposal.outcomeId,
 					input.resolverId,
-					viaOverride
+					viaOverride,
+					adminOverride
 				)
 				resolvedOutcomeId = finalStatus === 'resolved' ? proposal.outcomeId : null
 			}
@@ -320,13 +343,14 @@ export async function executeResolution(
 	market: PmMarket,
 	winningOutcomeId: string,
 	resolverId: string,
-	viaOverride = false
+	viaOverride = false,
+	adminOverride = false
 ): Promise<MarketStatus> {
 	const totalPool = await sumStakes(tx, market.id)
 	const poolW = await sumStakes(tx, market.id, winningOutcomeId)
 
 	if (poolW === 0n) {
-		await executeVoidRefund(tx, market, resolverId, 'no winning bets', viaOverride)
+		await executeVoidRefund(tx, market, resolverId, 'no winning bets', viaOverride, adminOverride)
 		return 'voided'
 	}
 
@@ -466,6 +490,7 @@ export async function executeResolution(
 			houseRake: formatAmount(houseRake),
 			dust: formatAmount(dust),
 			...(viaOverride ? { viaOverride: true } : {}),
+			...(adminOverride ? { adminOverride: true } : {}),
 		},
 	})
 	return 'resolved'

--- a/apps/prediction-markets/src/test/integration/money-flow.int.test.ts
+++ b/apps/prediction-markets/src/test/integration/money-flow.int.test.ts
@@ -22,7 +22,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { and, desc, eq, inArray, sql } from '@repo/db-utils'
 
 import { schema } from '../../db'
-import { pmBets, pmLedger, pmWallets } from '../../db/schema'
+import { pmBets, pmLedger, pmMarketHistory, pmWallets } from '../../db/schema'
 import * as betting from '../../services/betting-service'
 import * as governance from '../../services/governance-service'
 import * as market from '../../services/market-service'
@@ -282,5 +282,189 @@ suite('bet idempotency', () => {
 		expect(second.deduped).toBe(true)
 		expect(second.id).toBe(first.id)
 		expect(await balance(u1)).toBe('400') // debited once, not twice
+	})
+})
+
+// ---------------------------------------------------------------------------
+// D) admin override resolve — a site admin can ALWAYS resolve a market
+// ---------------------------------------------------------------------------
+suite('admin override resolve', () => {
+	it('lets a site admin resolve a market they created AND bet on, collapsing two-of-N in one step', async () => {
+		const [adminCreator, u1, u2] = [1, 3, 4].map(uuid)
+		// twoOfNThreshold '0' ⇒ requiresTwoOfN is true for EVERY market (pool ≥ 0), so a normal resolve
+		// would only PROPOSE and await a second distinct signer. rake 0 + reward band 0 keeps the payout
+		// arithmetic exact and self-contained.
+		await governance.updateConfig(deps, {
+			actorUserId: ADMIN,
+			defaultRakeBps: 0,
+			defaultMinStake: '1',
+			twoOfNThreshold: '0',
+			creatorRewardMinBps: 0,
+			creatorRewardMaxBps: 0,
+		})
+		for (const u of [adminCreator, u1, u2]) await grant(u, '1000') // supply 3000
+
+		const m = await market.createMarket(deps, {
+			createdBy: adminCreator,
+			question: 'admin resolves own?',
+			outcomes: ['A', 'B'],
+			closesAt: hoursFromNow(1),
+			resolvesOn: hoursFromNow(2),
+			rakeBps: 0,
+		})
+		const A = m.outcomes.find((o) => o.label === 'A')!.id
+
+		// The admin creator ALSO bets on A — normally BOTH CREATOR_CANNOT_RESOLVE and
+		// RESOLVER_HAS_POSITION would block them from resolving.
+		await betting.placeBet(deps, {
+			userId: adminCreator,
+			marketId: m.id,
+			outcomeId: A,
+			amount: '100',
+			idempotencyKey: 'ao-admin',
+		})
+		await betting.placeBet(deps, {
+			userId: u1,
+			marketId: m.id,
+			outcomeId: A,
+			amount: '100',
+			idempotencyKey: 'ao-u1',
+		})
+		await betting.placeBet(deps, {
+			userId: u2,
+			marketId: m.id,
+			outcomeId: m.outcomes.find((o) => o.label === 'B')!.id,
+			amount: '100',
+			idempotencyKey: 'ao-u2',
+		})
+
+		await market.closeMarket(deps, { actorUserId: adminCreator, marketId: m.id })
+
+		// Without adminOverride the creator-and-positioned resolver is blocked outright. The creator
+		// guard fires first (PmError.message IS the code across the RPC boundary).
+		await expect(
+			settlement.proposeResolution(deps, { resolverId: adminCreator, marketId: m.id, outcomeId: A })
+		).rejects.toThrow('CREATOR_CANNOT_RESOLVE')
+		// Market is untouched by the rejected attempt — still closed, not resolving.
+		expect((await reads.getMarket(deps, m.id))?.status).toBe('closed')
+
+		// adminOverride skips every conflict-of-interest guard AND the two-of-N second-signer rule ⇒
+		// resolves directly in a single step (never 'resolving').
+		const res = await settlement.proposeResolution(deps, {
+			resolverId: adminCreator,
+			marketId: m.id,
+			outcomeId: A,
+			adminOverride: true,
+		})
+		expect(res.status).toBe('resolved')
+		expect(res.resolvedOutcomeId).toBe(A)
+
+		// rake 0 ⇒ each A-bettor gets stake back + a pro-rata share of the 100-point losing pool:
+		// payout = 100 + floor(100 · 100 / 200) = 150. The admin self-dealt a win — now permitted.
+		expect(await balance(adminCreator)).toBe('1050')
+		expect(await balance(u1)).toBe('1050')
+		expect(await balance(u2)).toBe('900') // lost their stake
+		await assertConservation(3000n)
+
+		// Audit trail: the resolution records the admin override for accountability.
+		const [row] = await deps.db
+			.select({ metadata: pmMarketHistory.metadata })
+			.from(pmMarketHistory)
+			.where(and(eq(pmMarketHistory.marketId, m.id), eq(pmMarketHistory.action, 'resolved')))
+			.limit(1)
+		expect((row?.metadata as { adminOverride?: boolean }).adminOverride).toBe(true)
+	})
+
+	it('lets a site admin single-sign a pending two-of-N proposal they created AND bet on', async () => {
+		// Covers approveResolution's OWN adminOverride guard-skip branch (independent of proposeResolution's):
+		// a non-admin proposer opens a two-of-N proposal, then an admin who is the creator and holds a
+		// position — normally doubly blocked — finalizes it alone via adminOverride.
+		const [adminCreator, proposer, u1, u2] = [1, 2, 3, 4].map(uuid)
+		await governance.updateConfig(deps, {
+			actorUserId: ADMIN,
+			defaultRakeBps: 0,
+			defaultMinStake: '1',
+			twoOfNThreshold: '0', // every market is two-of-N ⇒ a normal resolve only PROPOSES
+			creatorRewardMinBps: 0,
+			creatorRewardMaxBps: 0,
+		})
+		for (const u of [adminCreator, u1, u2]) await grant(u, '1000') // supply 3000
+
+		const m = await market.createMarket(deps, {
+			createdBy: adminCreator,
+			question: 'admin approves own?',
+			outcomes: ['A', 'B'],
+			closesAt: hoursFromNow(1),
+			resolvesOn: hoursFromNow(2),
+			rakeBps: 0,
+		})
+		const A = m.outcomes.find((o) => o.label === 'A')!.id
+		const B = m.outcomes.find((o) => o.label === 'B')!.id
+
+		await betting.placeBet(deps, {
+			userId: adminCreator,
+			marketId: m.id,
+			outcomeId: A,
+			amount: '100',
+			idempotencyKey: 'ap-admin',
+		})
+		await betting.placeBet(deps, {
+			userId: u1,
+			marketId: m.id,
+			outcomeId: A,
+			amount: '100',
+			idempotencyKey: 'ap-u1',
+		})
+		await betting.placeBet(deps, {
+			userId: u2,
+			marketId: m.id,
+			outcomeId: B,
+			amount: '100',
+			idempotencyKey: 'ap-u2',
+		})
+
+		await market.closeMarket(deps, { actorUserId: adminCreator, marketId: m.id })
+
+		// A distinct non-creator, position-free resolver proposes ⇒ two-of-N ⇒ market enters 'resolving'
+		// with a pending proposal awaiting a second signer.
+		const proposed = await settlement.proposeResolution(deps, {
+			resolverId: proposer,
+			marketId: m.id,
+			outcomeId: A,
+		})
+		expect(proposed.status).toBe('resolving')
+		const proposalId = proposed.proposalId!
+
+		// The admin creator (also positioned) cannot approve normally — CREATOR_CANNOT_RESOLVE fires
+		// (RESOLVER_HAS_POSITION would too). The rejected attempt leaves the proposal pending.
+		await expect(
+			settlement.approveResolution(deps, { resolverId: adminCreator, marketId: m.id, proposalId })
+		).rejects.toThrow('CREATOR_CANNOT_RESOLVE')
+		expect((await reads.getMarket(deps, m.id))?.status).toBe('resolving')
+
+		// adminOverride lets them single-sign the pending proposal ⇒ resolved (self-dealt win — permitted).
+		const res = await settlement.approveResolution(deps, {
+			resolverId: adminCreator,
+			marketId: m.id,
+			proposalId,
+			adminOverride: true,
+		})
+		expect(res.status).toBe('resolved')
+		expect(res.resolvedOutcomeId).toBe(A)
+
+		// Same parimutuel arithmetic as the direct-resolve case: each A-bettor gets 100 + 50 = 150.
+		expect(await balance(adminCreator)).toBe('1050')
+		expect(await balance(u1)).toBe('1050')
+		expect(await balance(u2)).toBe('900')
+		await assertConservation(3000n)
+
+		// The 'resolved' audit row records the override; proposer earns nothing (never bet).
+		const [row] = await deps.db
+			.select({ metadata: pmMarketHistory.metadata })
+			.from(pmMarketHistory)
+			.where(and(eq(pmMarketHistory.marketId, m.id), eq(pmMarketHistory.action, 'resolved')))
+			.limit(1)
+		expect((row?.metadata as { adminOverride?: boolean }).adminOverride).toBe(true)
+		expect(await balance(proposer)).toBe('0')
 	})
 })

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -508,6 +508,15 @@ export interface PredictionMarkets {
 		 * from a tier check, never a literal.
 		 */
 		bypassDesignated?: boolean
+		/**
+		 * When true, resolve this market UNCONDITIONALLY — skip every conflict-of-interest guard (creator
+		 * ≠ resolver, no-position, designated membership) AND collapse the two-of-N second-signer rule so
+		 * a lone admin settles in one step. This is the site-admin escape hatch to settle ANY market;
+		 * unlike a void it PAYS positions on the chosen outcome, so it is recorded in the audit history.
+		 * Like voidMarket.adminOverride it is is_admin-only (managers keep the guards). Core sets it solely
+		 * from is_admin — a trusted, DO-unverifiable capability, never a client literal.
+		 */
+		adminOverride?: boolean
 	}): Promise<ResolveResult>
 	approveResolution(input: {
 		resolverId: string
@@ -515,6 +524,8 @@ export interface PredictionMarkets {
 		proposalId: string
 		/** See proposeResolution.bypassDesignated. */
 		bypassDesignated?: boolean
+		/** See proposeResolution.adminOverride. Lets an admin single-sign a pending two-of-N proposal. */
+		adminOverride?: boolean
 	}): Promise<ResolveResult>
 	/** The single pending resolution proposal for a market (for two-of-N approve), or null. */
 	getPendingProposal(marketId: string): Promise<PendingProposalView | null>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Extends the site-admin `adminOverride` escape hatch (already available for `voidMarket`) to the market resolution path, so an `is_admin` user can always resolve a prediction market — even one they created or hold a position in — and can single-sign a pending two-of-N proposal instead of needing a distinct second signer.

## Changes
- `proposeResolution` / `approveResolution` (in `settlement-service.ts`) accept an optional `adminOverride` flag that, when true, skips the `CREATOR_CANNOT_RESOLVE`, `RESOLVER_HAS_POSITION`, and designated-membership guards, and collapses the two-of-N requirement so a lone admin resolves in one step.
- `executeResolution` threads `adminOverride` through and stamps `adminOverride: true` in the resolution's audit history metadata (mirroring the existing void behavior).
- Threaded the new flag through the `PredictionMarketsDO` RPC facade and the `@repo/prediction-markets` shared interface (`packages/prediction-markets/src/index.ts`).
- `apps/core`'s Discord handlers (`discord-components.service.ts`) now derive `adminOverride` solely from the user's `is_admin` flag (never a client-supplied literal) when calling `proposeResolution`/`approveResolution`.
- Updated the comment in `market-service.ts` describing how a stuck size-1 designated market can now also be resolved via admin `adminOverride`, in addition to manager bypass or voiding.

## Testing
- New unit tests in `apps/core` (`discord-components.resolve.test.ts`, updates to `discord-components.service.test.ts`) verify `adminOverride` is threaded as `true` only for `is_admin` users, and `false` for plain resolvers and non-admin managers.
- New integration tests in `apps/prediction-markets` (`money-flow.int.test.ts`) cover an admin resolving a market they created and bet on (collapsing two-of-N in one step) and an admin single-signing a pending two-of-N proposal, including verifying the audit trail records `adminOverride: true`.
<!-- claude:end -->