### PR TITLE
feat: add csv data export for moons and srp

### DIFF
--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -8,6 +8,7 @@ import type { StructuresWorker } from '@repo/structures'
 import type { Skills } from '@repo/skills'
 import type { PasteWorker } from '@repo/paste'
 import type { createDb } from './db'
+import type { CsvExportWorkflowParams } from './workflows/csv-export.workflow'
 import type { UserDiscordRefreshWorkflowParams } from './workflows/user-discord-refresh.workflow'
 import type { UserMumbleRefreshWorkflowParams } from './workflows/user-mumble-refresh.workflow'
 import type { DiscordMemberAuditWorkflowParams } from './workflows/discord-member-audit.workflow'
@@ -69,6 +70,8 @@ export type Env = SharedHonoEnv & {
 	DISCORD_MEMBER_AUDIT_WORKFLOW: Workflow<DiscordMemberAuditWorkflowParams>
 	/** User Mumble Refresh Workflow binding */
 	USER_MUMBLE_REFRESH_WORKFLOW: Workflow<UserMumbleRefreshWorkflowParams>
+	/** CSV Export Workflow binding */
+	EXPORT_WORKFLOW: Workflow<CsvExportWorkflowParams>
 	/** ESI Type Resolver Durable Object binding */
 	ESI_TYPE_RESOLVER: DurableObjectNamespace
 	/** Industry Durable Object binding */
@@ -85,6 +88,10 @@ export type Env = SharedHonoEnv & {
 	PASTE: PasteWorker
 	/** Moon Scan Durable Object binding */
 	MOON_SCAN: DurableObjectNamespace
+	/** Moon Scan export artifact bucket */
+	MOON_SCAN_EXPORTS: R2Bucket
+	/** SRP export artifact bucket */
+	SRP_EXPORTS: R2Bucket
 	/** Markets Durable Object binding */
 	MARKETS: DurableObjectNamespace
 	/** Mumble Durable Object binding */

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -209,7 +209,7 @@ export default {
 							console.log('[Core:Scheduled] Prediction-market reconcile', r)
 						}
 					})
-					.catch((error) => captureException(error as Error, { tags: { job: 'pm-reconcile' } }))
+				.catch((error) => captureException(error as Error, { tags: { job: 'pm-reconcile' } }))
 			)
 		}
 
@@ -1163,3 +1163,4 @@ export { UserRefreshWorkflow } from './workflows/user-refresh.workflow'
 export { UserDiscordRefreshWorkflow } from './workflows/user-discord-refresh.workflow'
 export { DiscordMemberAuditWorkflow } from './workflows/discord-member-audit.workflow'
 export { UserMumbleRefreshWorkflow } from './workflows/user-mumble-refresh.workflow'
+export { CsvExportWorkflow } from './workflows/csv-export.workflow'

--- a/apps/core/src/lib/__tests__/user-corporation-affiliations.test.ts
+++ b/apps/core/src/lib/__tests__/user-corporation-affiliations.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+	getUserCorporationAffiliationIds,
+	hasUserCorporationAffiliation,
+} from '../user-corporation-affiliations'
+
+describe('user corporation affiliations helper', () => {
+	it('returns distinct active corporation affiliations for a user', async () => {
+		const db = {
+			query: {
+				userCharacters: {
+					findMany: vi.fn().mockResolvedValue([
+						{ corporationId: '1001' },
+						{ corporationId: '1001' },
+						{ corporationId: '2001' },
+						{ corporationId: null },
+						{ corporationId: '' },
+					]),
+				},
+			},
+		} as any
+
+		await expect(getUserCorporationAffiliationIds(db, 'user-1')).resolves.toEqual(['1001', '2001'])
+		expect(db.query.userCharacters.findMany).toHaveBeenCalledTimes(1)
+	})
+
+	it('detects whether a user is affiliated with a specific corporation', async () => {
+		const db = {
+			query: {
+				userCharacters: {
+					findMany: vi.fn().mockResolvedValue([{ corporationId: '1001' }]),
+				},
+			},
+		} as any
+
+		await expect(hasUserCorporationAffiliation(db, 'user-1', '1001')).resolves.toBe(true)
+		await expect(hasUserCorporationAffiliation(db, 'user-1', '2001')).resolves.toBe(false)
+	})
+})

--- a/apps/core/src/lib/export-retention.ts
+++ b/apps/core/src/lib/export-retention.ts
@@ -1,0 +1,57 @@
+import { parseDateOrNull, runExpirySweep } from '@repo/worker-utils'
+
+export const EXPORT_ARTIFACT_TTL_MS = 60 * 1000
+export const EXPORT_ARTIFACT_METADATA_EXPIRY_KEY = 'expiresAt'
+
+export function getExportArtifactExpiresAt(now = new Date()): Date {
+	return new Date(now.getTime() + EXPORT_ARTIFACT_TTL_MS)
+}
+
+export function getExportArtifactExpiresAtIso(now = new Date()): string {
+	return getExportArtifactExpiresAt(now).toISOString()
+}
+
+export function isExportArtifactExpired(
+	expiresAtRaw: string | null | undefined,
+	now = new Date()
+): boolean {
+	const expiresAt = parseDateOrNull(expiresAtRaw ?? undefined)
+	return expiresAt !== null && expiresAt <= now
+}
+
+export async function cleanupExpiredExportArtifacts(
+	bucket: R2Bucket,
+	prefix: string,
+	now = new Date()
+): Promise<{ scanned: number; purged: number; failed: number }> {
+	let cursor: string | undefined
+	let scanned = 0
+	let purged = 0
+	let failed = 0
+
+	do {
+		const listed = await bucket.list({
+			prefix,
+			cursor,
+			limit: 1000,
+		})
+
+		const result = await runExpirySweep({
+			items: listed.objects.map((object) => ({
+				id: object.key,
+				expiresAt: parseDateOrNull(object.customMetadata?.[EXPORT_ARTIFACT_METADATA_EXPIRY_KEY]),
+			})),
+			now,
+			onHardDelete: async (item) => {
+				await bucket.delete(item.id)
+			},
+		})
+
+		scanned += result.scanned
+		purged += result.purged
+		failed += result.failed
+		cursor = listed.truncated ? listed.cursor : undefined
+	} while (cursor)
+
+	return { scanned, purged, failed }
+}

--- a/apps/core/src/lib/user-corporation-affiliations.ts
+++ b/apps/core/src/lib/user-corporation-affiliations.ts
@@ -1,0 +1,35 @@
+import { and, eq } from '@repo/db-utils'
+
+import { userCharacters } from '../db/schema'
+
+import type { DbClient, schema } from '../db'
+
+/**
+ * Resolve all corporation IDs the user is affiliated with through linked characters.
+ * This is intentionally HR-agnostic and only reflects persisted character affiliation.
+ */
+export async function getUserCorporationAffiliationIds(
+	db: DbClient<typeof schema>,
+	userId: string
+): Promise<string[]> {
+	const rows = await db.query.userCharacters.findMany({
+		where: and(eq(userCharacters.userId, userId), eq(userCharacters.isDeleted, false)),
+		columns: {
+			corporationId: true,
+		},
+	})
+
+	return [...new Set(rows.map((row) => row.corporationId).filter(Boolean))] as string[]
+}
+
+/**
+ * Check whether the user is affiliated with a specific corporation through any linked character.
+ */
+export async function hasUserCorporationAffiliation(
+	db: DbClient<typeof schema>,
+	userId: string,
+	corporationId: string
+): Promise<boolean> {
+	const corporationIds = await getUserCorporationAffiliationIds(db, userId)
+	return corporationIds.includes(corporationId)
+}

--- a/apps/core/src/lib/workflow-status.ts
+++ b/apps/core/src/lib/workflow-status.ts
@@ -1,0 +1,25 @@
+export type NormalizedWorkflowStatus = 'queued' | 'running' | 'completed' | 'failed' | 'unknown'
+
+export function normalizeWorkflowStatus(
+	rawStatus: string | undefined,
+	outputStatus?: string | undefined
+): NormalizedWorkflowStatus {
+	if (outputStatus === 'completed') return 'completed'
+	if (outputStatus === 'failed') return 'failed'
+
+	switch (rawStatus) {
+		case 'queued':
+		case 'waiting':
+			return 'queued'
+		case 'running':
+			return 'running'
+		case 'complete':
+		case 'completed':
+			return 'completed'
+		case 'errored':
+		case 'failed':
+			return 'failed'
+		default:
+			return 'unknown'
+	}
+}

--- a/apps/core/src/routes/__tests__/hr.access-matrix.route.test.ts
+++ b/apps/core/src/routes/__tests__/hr.access-matrix.route.test.ts
@@ -78,6 +78,31 @@ function makeHrStub() {
 			createdAt: new Date().toISOString(),
 			updatedAt: new Date().toISOString(),
 		}),
+		listCorpApplicationsForRecommendation: vi.fn().mockResolvedValue([]),
+		getApplicationForRecommender: vi.fn().mockResolvedValue({
+			id: 'app-1',
+			corporationId: '1001',
+			characterId: '2001',
+			characterName: 'Target Pilot',
+			applicationText: 'Test application',
+			status: 'pending',
+			createdAt: new Date().toISOString(),
+			recommendations: [],
+			recommendationCount: 0,
+			userRecommendation: null,
+		}),
+		addRecommendation: vi.fn().mockResolvedValue({
+			id: 'rec-1',
+			applicationId: 'app-1',
+			userId: 'user-1',
+			characterId: '1001',
+			characterName: 'Main Pilot',
+			recommendationText: 'Looks good to me',
+			sentiment: 'positive',
+			isPublic: false,
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		}),
 		listMessages: vi.fn().mockResolvedValue([]),
 		getMessageCount: vi.fn().mockResolvedValue(0),
 		listApplicationStaffNotes: vi.fn().mockResolvedValue([
@@ -663,6 +688,175 @@ describe('hr route access matrix', () => {
 			isAdmin: false,
 			isAuditor: true,
 		})
+	})
+
+	it('allows attached corp members to discover, view, and submit recommendations for member corporations', async () => {
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{
+				corporationId: '1001',
+			},
+		] as any)
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+
+		const pendingRes = await app.request('/api/hr/recommendations/pending', {}, env)
+		expect(pendingRes.status).toBe(200)
+		expect(hrStub.listCorpApplicationsForRecommendation).toHaveBeenCalledWith(['1001'], 'user-1')
+
+		const detailRes = await app.request('/api/hr/recommendations/applications/app-1', {}, env)
+		expect(detailRes.status).toBe(200)
+		expect(hrStub.getApplicationForRecommender).toHaveBeenCalledWith(
+			'app-1',
+			'user-1',
+			['1001'],
+			{ isAdmin: false, isAuditor: false }
+		)
+
+		const submitRes = await app.request(
+			'/api/hr/applications/app-1/recommendations',
+			{
+				method: 'POST',
+				body: JSON.stringify({
+					characterId: '1001',
+					recommendationText: 'Looks good to me',
+					sentiment: 'positive',
+					isPublic: false,
+				}),
+				headers: { 'content-type': 'application/json' },
+			},
+			env
+		)
+
+		expect(submitRes.status).toBe(201)
+		expect(hrStub.addRecommendation).toHaveBeenCalledWith(
+			'app-1',
+			'user-1',
+			'1001',
+			'Main Pilot',
+			'Looks good to me',
+			'positive',
+			false
+		)
+	})
+
+	it('denies recommendation access when the user is not attached to the target corporation', async () => {
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{
+				corporationId: '2001',
+			},
+		] as any)
+		dbStub.query.managedCorporations.findMany.mockResolvedValue([])
+		hrStub.getApplicationForRecommender.mockResolvedValue({
+			id: 'app-2',
+			corporationId: '2001',
+			characterId: '2002',
+			characterName: 'Target Pilot',
+			applicationText: 'Test application',
+			status: 'pending',
+			createdAt: new Date().toISOString(),
+			recommendations: [],
+			recommendationCount: 0,
+			userRecommendation: null,
+		})
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+
+		const pendingRes = await app.request('/api/hr/recommendations/pending', {}, env)
+		expect(pendingRes.status).toBe(200)
+		expect(await pendingRes.json()).toEqual([])
+
+		const detailRes = await app.request('/api/hr/recommendations/applications/app-2', {}, env)
+		expect(detailRes.status).toBe(403)
+		expect(await detailRes.json()).toEqual({
+			error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+		})
+
+		const submitRes = await app.request(
+			'/api/hr/applications/app-2/recommendations',
+			{
+				method: 'POST',
+				body: JSON.stringify({
+					characterId: '1001',
+					recommendationText: 'Looks good to me',
+					sentiment: 'positive',
+					isPublic: false,
+				}),
+				headers: { 'content-type': 'application/json' },
+			},
+			env
+		)
+
+		expect(submitRes.status).toBe(403)
+		expect(await submitRes.json()).toEqual({
+			error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+		})
+		expect(hrStub.addRecommendation).not.toHaveBeenCalled()
+	})
+
+	it('allows an HR auditor to recommend against a member corporation without a corp attachment', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([
+			{
+				permissionId: 'perm-auditor',
+				urn: 'urn:hr:auditor',
+				name: 'HR Auditor',
+				description: null,
+				category: null,
+				groupId: 'g-1',
+				groupName: 'HR',
+				targetType: 'all_members',
+				source: 'global',
+			},
+		] as any)
+		dbStub.query.userCharacters.findMany.mockResolvedValue([] as any)
+		hrStub.getApplicationForRecommender.mockResolvedValue({
+			id: 'app-1',
+			corporationId: '1001',
+			characterId: '2001',
+			characterName: 'Target Pilot',
+			applicationText: 'Test application',
+			status: 'pending',
+			createdAt: new Date().toISOString(),
+			recommendations: [],
+			recommendationCount: 0,
+			userRecommendation: null,
+		})
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+
+		const detailRes = await app.request('/api/hr/recommendations/applications/app-1', {}, env)
+		expect(detailRes.status).toBe(200)
+		expect(hrStub.getApplicationForRecommender).toHaveBeenCalledWith(
+			'app-1',
+			'user-1',
+			[],
+			{ isAdmin: false, isAuditor: true }
+		)
+
+		const submitRes = await app.request(
+			'/api/hr/applications/app-1/recommendations',
+			{
+				method: 'POST',
+				body: JSON.stringify({
+					characterId: '1001',
+					recommendationText: 'Looks good to me',
+					sentiment: 'positive',
+					isPublic: false,
+				}),
+				headers: { 'content-type': 'application/json' },
+			},
+			env
+		)
+
+		expect(submitRes.status).toBe(201)
+		expect(hrStub.addRecommendation).toHaveBeenCalledWith(
+			'app-1',
+			'user-1',
+			'1001',
+			'Main Pilot',
+			'Looks good to me',
+			'positive',
+			false
+		)
 	})
 
 	it('denies /applications/:id read for non-member corporations', async () => {

--- a/apps/core/src/routes/__tests__/moon-scan.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/moon-scan.access.route.test.ts
@@ -86,6 +86,7 @@ describe('moon-scan access matrix', () => {
 	const env = {
 		MOON_SCAN: { name: 'MOON_SCAN' },
 		UNIVERSE: { name: 'UNIVERSE' },
+		EXPORT_WORKFLOW: { create: vi.fn(), get: vi.fn() },
 	} as any
 
 	let moonScanStub: Record<string, ReturnType<typeof vi.fn>>
@@ -144,6 +145,26 @@ describe('moon-scan access matrix', () => {
 
 		expect(res.status).toBe(403)
 		expect(await res.json()).toEqual({ error: 'Forbidden' })
+	})
+
+	it('denies submitters from exporting verified moons', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:moons:scan:submit' }] as any)
+
+		const app = createApp(makeUser({ id: 'submit-export' }))
+		const res = await app.request('/api/moon-scan/moons/verified/export', { method: 'POST' }, env)
+
+		expect(res.status).toBe(403)
+		expect(await res.json()).toEqual({ error: 'Forbidden' })
+	})
+
+	it('requires a region selection before exporting verified moons', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:moons:view' }] as any)
+
+		const app = createApp(makeUser({ id: 'view-export' }))
+		const res = await app.request('/api/moon-scan/moons/verified/export', { method: 'POST' }, env)
+
+		expect(res.status).toBe(400)
+		expect(await res.json()).toEqual({ error: 'regionId is required for moon export' })
 	})
 
 	it('allows submitters to read the leaderboard', async () => {

--- a/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
+++ b/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
@@ -69,13 +69,23 @@ function createApp(user: SessionUser) {
 describe('moon-scan profitability and batching behavior', () => {
 	const env = {
 		MOON_SCAN: { name: 'MOON_SCAN' },
+		MOON_SCAN_EXPORTS: { name: 'MOON_SCAN_EXPORTS' },
 		UNIVERSE: { name: 'UNIVERSE' },
 		MARKETS: { name: 'MARKETS' },
+		EXPORT_WORKFLOW: { create: vi.fn(), get: vi.fn() },
 	} as any
 
 	let moonScanStub: Record<string, ReturnType<typeof vi.fn>>
 	let universeStub: Record<string, ReturnType<typeof vi.fn>>
 	let marketsStub: Record<string, ReturnType<typeof vi.fn>>
+	let exportWorkflowStub: {
+		create: ReturnType<typeof vi.fn>
+		get: ReturnType<typeof vi.fn>
+	}
+	let exportBucketStub: {
+		get: ReturnType<typeof vi.fn>
+		delete: ReturnType<typeof vi.fn>
+	}
 
 	beforeEach(() => {
 		vi.clearAllMocks()
@@ -149,6 +159,34 @@ describe('moon-scan profitability and batching behavior', () => {
 		marketsStub = {
 			getBatchMarketDataAtTime: vi.fn().mockResolvedValue({ prices: [] }),
 		}
+		const storedExports = new Map<string, { text: string; fileName: string }>()
+		exportWorkflowStub = {
+			create: vi.fn().mockResolvedValue({ id: 'workflow-1' }),
+			get: vi.fn().mockResolvedValue({
+				status: vi.fn().mockResolvedValue({
+					status: 'queued',
+					output: null,
+				}),
+			}),
+		}
+		exportBucketStub = {
+			get: vi.fn(async (key: string) => {
+				const stored = storedExports.get(key)
+				if (!stored) return null
+				const response = new Response(stored.text, {
+					headers: { 'content-type': 'text/csv; charset=utf-8' },
+				}) as Response & {
+					customMetadata?: { fileName?: string }
+					httpMetadata?: { contentType?: string }
+				}
+				response.customMetadata = { fileName: stored.fileName }
+				response.httpMetadata = { contentType: 'text/csv; charset=utf-8' }
+				return response
+			}),
+			delete: vi.fn().mockResolvedValue(undefined),
+		}
+		env.MOON_SCAN_EXPORTS = exportBucketStub as any
+		env.EXPORT_WORKFLOW = exportWorkflowStub as any
 
 		getStubMock.mockImplementation((binding: unknown) => {
 			if (binding === env.MOON_SCAN) return moonScanStub as any
@@ -455,5 +493,111 @@ describe('moon-scan profitability and batching behavior', () => {
 			const summaries = call[0] as Array<{ moonId: string }>
 			expect(summaries.length).toBeLessThanOrEqual(250)
 		}
+	})
+
+	it('starts a chunked export workflow and ignores sort params', async () => {
+		const app = createApp(makeUser())
+		const response = await app.request(
+			'/api/moon-scan/moons/verified/export?regionId=region-1&sortBy=moonName&sortDir=asc',
+			{ method: 'POST' },
+			env
+		)
+		expect(response.status).toBe(202)
+		const payload = await response.json() as { exportId: string; fileName: string; workflowInstanceId: string }
+		expect(payload.fileName).toMatch(/^scanned-moons-export-/)
+		const workflowInput = exportWorkflowStub.create.mock.calls[0]?.[0] as {
+			params?: { query?: Record<string, unknown> }
+		}
+		expect(workflowInput.params?.query).toMatchObject({ regionId: 'region-1' })
+		expect(workflowInput.params?.query).not.toHaveProperty('sortBy')
+		expect(workflowInput.params?.query).not.toHaveProperty('sortDir')
+
+		const key = `moon-scan/verified-moons-exports/${payload.exportId}.csv`
+		const csv = 'regionId,regionName,solarSystemId,solarSystemName,moonId,moonName\nmoon-1'
+		const responseBody = new Response(csv, {
+			headers: { 'content-type': 'text/csv; charset=utf-8' },
+		}) as Response & {
+			customMetadata?: { fileName?: string }
+			httpMetadata?: { contentType?: string }
+		}
+		responseBody.customMetadata = { fileName: payload.fileName }
+		responseBody.httpMetadata = { contentType: 'text/csv; charset=utf-8' }
+		const storedExports = new Map<string, Response>()
+		storedExports.set(key, responseBody)
+		exportBucketStub.get.mockImplementation(async (requestKey: string) => storedExports.get(requestKey) ?? null)
+
+		const exportResponse = await app.request(
+			`/api/moon-scan/moons/verified/export/${payload.exportId}/download`,
+			{},
+			env
+		)
+		expect(exportResponse.status).toBe(200)
+		expect(exportResponse.headers.get('content-type')).toContain('text/csv')
+		expect(exportResponse.headers.get('content-disposition')).toContain(payload.fileName)
+		expect(await exportResponse.text()).toContain('moon-1')
+		expect(exportBucketStub.delete).toHaveBeenCalledWith(key)
+	})
+
+	it('allows constellation-scoped exports without a region', async () => {
+		const app = createApp(makeUser())
+		const response = await app.request(
+			'/api/moon-scan/moons/verified/export?constellationId=const-1&sortBy=moonName&sortDir=asc',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(response.status).toBe(202)
+		const workflowInput = exportWorkflowStub.create.mock.calls[0]?.[0] as {
+			params?: { query?: Record<string, unknown> }
+		}
+		expect(workflowInput.params?.query).toMatchObject({ constellationId: 'const-1' })
+		expect(workflowInput.params?.query?.regionId).toBeUndefined()
+	})
+
+	it('returns workflow status for an export', async () => {
+		exportWorkflowStub.get.mockResolvedValue({
+			status: vi.fn().mockResolvedValue({
+				status: 'complete',
+				output: {
+					status: 'completed',
+					rowCount: 1,
+					fileName: 'scanned-moons-export-12345678.csv',
+				},
+			}),
+		})
+
+		const app = createApp(makeUser())
+		const response = await app.request('/api/moon-scan/moons/verified/export/workflow-1', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toMatchObject({
+			workflowInstanceId: 'workflow-1',
+			status: 'completed',
+		})
+	})
+
+	it('ignores profit sort params when starting the export workflow', async () => {
+		moonScanStub.getScanSummary.mockResolvedValue({
+			scannedMoonIds: ['moon-1', 'moon-2'],
+			verifiedMoonIds: ['moon-1', 'moon-2'],
+		})
+		const app = createApp(makeUser())
+		const response = await app.request(
+			'/api/moon-scan/moons/verified/export?regionId=region-1&sortBy=metenoxProfit&sortDir=desc',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(response.status).toBe(202)
+		expect(await response.json()).toMatchObject({
+			exportId: 'workflow-1',
+			workflowInstanceId: 'workflow-1',
+		})
+		const workflowInput = exportWorkflowStub.create.mock.calls[0]?.[0] as {
+			params?: { query?: Record<string, unknown> }
+		}
+		expect(workflowInput.params?.query).toMatchObject({ regionId: 'region-1' })
+		expect(workflowInput.params?.query).not.toHaveProperty('sortBy')
+		expect(workflowInput.params?.query).not.toHaveProperty('sortDir')
 	})
 })

--- a/apps/core/src/routes/__tests__/srp.route.test.ts
+++ b/apps/core/src/routes/__tests__/srp.route.test.ts
@@ -37,10 +37,15 @@ const env = {
 		idFromName: vi.fn(),
 		get: vi.fn(),
 	},
+	SRP_EXPORTS: {
+		name: 'SRP_EXPORTS',
+	},
 	EVE_TOKEN_STORE: { name: 'EVE_TOKEN_STORE' },
 	DOCTRINES: { name: 'DOCTRINES' },
 	UNIVERSE: { name: 'UNIVERSE' },
+	ESI_TYPE_RESOLVER: { name: 'ESI_TYPE_RESOLVER' },
 	GROUPS: { name: 'GROUPS' },
+	EXPORT_WORKFLOW: { create: vi.fn(), get: vi.fn() },
 	DATABASE_URL: 'postgres://test',
 } as any
 
@@ -66,15 +71,18 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 	}
 }
 
-function createApp(user?: SessionUser) {
+function createApp(user?: SessionUser, db?: any) {
 	const app = new Hono<{
 		Bindings: any
-		Variables: { user?: SessionUser }
+		Variables: { user?: SessionUser; db?: any }
 	}>()
 
 	if (user) {
 		app.use('*', async (c, next) => {
 			c.set('user', user)
+			if (db) {
+				c.set('db', db)
+			}
 			await next()
 		})
 	}
@@ -160,6 +168,15 @@ describe('srp routes - permissions', () => {
 		resolveTypeNamesByIds: ReturnType<typeof vi.fn>
 		resolveSolarSystemsByIds: ReturnType<typeof vi.fn>
 	}
+	let resolverStub: { resolveIds: ReturnType<typeof vi.fn> }
+	let exportWorkflowStub: {
+		create: ReturnType<typeof vi.fn>
+		get: ReturnType<typeof vi.fn>
+	}
+	let exportBucketStub: {
+		get: ReturnType<typeof vi.fn>
+		delete: ReturnType<typeof vi.fn>
+	}
 
 	beforeEach(() => {
 		vi.clearAllMocks()
@@ -180,6 +197,23 @@ describe('srp routes - permissions', () => {
 			resolveTypeNamesByIds: vi.fn().mockResolvedValue({}),
 			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({}),
 		}
+		resolverStub = {
+			resolveIds: vi.fn().mockResolvedValue({}),
+		}
+		exportWorkflowStub = {
+			create: vi.fn().mockResolvedValue({ id: 'workflow-1' }),
+			get: vi.fn().mockResolvedValue({
+				status: vi.fn().mockResolvedValue({
+					status: 'queued',
+					output: null,
+				}),
+			}),
+		}
+		exportBucketStub = {
+			get: vi.fn(),
+			delete: vi.fn().mockResolvedValue(undefined),
+		}
+		env.SRP_EXPORTS = exportBucketStub as any
 
 		getStubMock.mockImplementation((binding: any) => {
 			if (binding === env.SRP) return srpStub as any
@@ -187,11 +221,178 @@ describe('srp routes - permissions', () => {
 			if (binding === env.EVE_TOKEN_STORE) return tokenStoreStub as any
 			if (binding === env.DOCTRINES) return doctrinesStub as any
 			if (binding === env.UNIVERSE) return universeStub as any
+			if (binding === env.ESI_TYPE_RESOLVER) return resolverStub as any
 			throw new Error('Unexpected binding')
 		})
+		env.EXPORT_WORKFLOW = exportWorkflowStub as any
 
-		getCachedUserPermissionsMock.mockResolvedValue([])
-		mockDbPrimaryCharacterRows([])
+	getCachedUserPermissionsMock.mockResolvedValue([])
+	mockDbPrimaryCharacterRows([])
+	})
+
+	it('requires a selected entry date range for wallet history CSV export', async () => {
+		const app = createApp(makeUser({ is_admin: true }))
+
+		const response = await app.request('/api/srp/payments/wallet-history/export', { method: 'POST' }, env)
+
+		expect(response.status).toBe(400)
+		expect(await response.json()).toEqual({
+			error: 'dateFrom and dateTo must be selected for CSV export',
+		})
+	})
+
+	it('rejects wallet history CSV exports that exceed one year', async () => {
+		const app = createApp(makeUser({ is_admin: true }))
+		srpStub.getConfig.mockResolvedValue({ paymentProcessorCorporationId: '9000' })
+
+		const response = await app.request(
+			'/api/srp/payments/wallet-history/export?dateFrom=2025-01-01&dateTo=2026-02-01',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(response.status).toBe(400)
+		expect(await response.json()).toEqual({
+			error: 'CSV export date range cannot exceed 1 year',
+		})
+	})
+
+	it('exports wallet history as CSV with alerts and resolved recipient names', async () => {
+		const app = createApp(makeUser({ id: 'wallet-export-user', is_admin: true }))
+		const response = await app.request(
+			'/api/srp/payments/wallet-history/export?dateFrom=2026-07-01&dateTo=2026-07-31&alertsOnly=true',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(response.status).toBe(202)
+		expect(await response.json()).toMatchObject({
+			workflowInstanceId: 'workflow-1',
+			fileName: 'srp-wallet-history-2026-07-01-2026-07-31.csv',
+		})
+		expect(exportWorkflowStub.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				params: expect.objectContaining({
+					kind: 'srp-wallet-history',
+					dateFrom: '2026-07-01',
+					dateTo: '2026-07-31',
+					alertsOnly: true,
+				}),
+			})
+		)
+	})
+
+	it('exports paid SRP requests as CSV for reviewer users', async () => {
+		const app = createApp(makeUser({ id: 'paid-export-user' }))
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:srp:reviewer' }] as any)
+
+		const response = await app.request(
+			'/api/srp/requests/paid/export?characterName=Losing&shipTypeName=Rifter&solarSystemName=Jita&dateFrom=2026-07-01&dateTo=2026-07-31',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(response.status).toBe(202)
+		expect(await response.json()).toMatchObject({
+			workflowInstanceId: 'workflow-1',
+			fileName: 'srp-paid-requests-2026-07-01-2026-07-31.csv',
+		})
+		expect(exportWorkflowStub.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				params: expect.objectContaining({
+					kind: 'srp-paid-requests',
+					characterName: 'Losing',
+					shipTypeName: 'Rifter',
+					solarSystemName: 'Jita',
+					dateFrom: '2026-07-01',
+					dateTo: '2026-07-31',
+				}),
+			})
+		)
+	})
+
+	it('deletes paid SRP exports after download', async () => {
+		const app = createApp(makeUser({ id: 'paid-export-user' }))
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:srp:reviewer' }] as any)
+
+		const storedResponse = new Response('userId,losingCharacterId\n1,2', {
+			headers: { 'content-type': 'text/csv; charset=utf-8' },
+		}) as Response & {
+			customMetadata?: { fileName?: string; expiresAt?: string }
+			httpMetadata?: { contentType?: string }
+		}
+		storedResponse.customMetadata = {
+			fileName: 'srp-paid-requests-2026-07-01-2026-07-31.csv',
+			expiresAt: new Date(Date.now() + 60_000).toISOString(),
+		}
+		storedResponse.httpMetadata = { contentType: 'text/csv; charset=utf-8' }
+		exportBucketStub.get.mockResolvedValue(storedResponse)
+
+		const response = await app.request(
+			'/api/srp/requests/paid/export/workflow-1/download',
+			{},
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toContain('userId,losingCharacterId')
+		expect(exportBucketStub.delete).toHaveBeenCalledWith('srp-exports/paid-requests/workflow-1.csv')
+	})
+
+	it('deletes wallet history exports after download', async () => {
+		const app = createApp(makeUser({ id: 'wallet-export-user', is_admin: true }))
+		srpStub.getConfig.mockResolvedValue({ paymentProcessorCorporationId: '9000' })
+
+		const storedResponse = new Response('date,reason\n2026-07-01,refund', {
+			headers: { 'content-type': 'text/csv; charset=utf-8' },
+		}) as Response & {
+			customMetadata?: { fileName?: string; expiresAt?: string }
+			httpMetadata?: { contentType?: string }
+		}
+		storedResponse.customMetadata = {
+			fileName: 'srp-wallet-history-2026-07-01-2026-07-31.csv',
+			expiresAt: new Date(Date.now() + 60_000).toISOString(),
+		}
+		storedResponse.httpMetadata = { contentType: 'text/csv; charset=utf-8' }
+		exportBucketStub.get.mockResolvedValue(storedResponse)
+
+		const response = await app.request(
+			'/api/srp/payments/wallet-history/export/workflow-1/download',
+			{},
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toContain('date,reason')
+		expect(exportBucketStub.delete).toHaveBeenCalledWith('srp-exports/wallet-history/workflow-1.csv')
+	})
+
+	it('requires a selected entry date range for paid SRP CSV export', async () => {
+		const app = createApp(makeUser({ id: 'paid-export-user' }))
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:srp:reviewer' }] as any)
+
+		const response = await app.request('/api/srp/requests/paid/export', { method: 'POST' }, env)
+
+		expect(response.status).toBe(400)
+		expect(await response.json()).toEqual({
+			error: 'dateFrom and dateTo must be selected for CSV export',
+		})
+	})
+
+	it('rejects paid SRP CSV exports that exceed one year', async () => {
+		const app = createApp(makeUser({ id: 'paid-export-user' }))
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:srp:reviewer' }] as any)
+
+		const response = await app.request(
+			'/api/srp/requests/paid/export?dateFrom=2025-01-01&dateTo=2026-02-01',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(response.status).toBe(400)
+		expect(await response.json()).toEqual({
+			error: 'CSV export date range cannot exceed 1 year',
+		})
 	})
 
 	it('lists requests for the authenticated user only', async () => {

--- a/apps/core/src/routes/corporation-tax/index.ts
+++ b/apps/core/src/routes/corporation-tax/index.ts
@@ -30,6 +30,7 @@ import {
 	TAX_RULE_PRIORITY_MAX,
 	TAX_RULE_PRIORITY_MIN,
 } from './shared'
+import { buildCsvLine } from '@repo/worker-utils'
 
 import type { CorporationTax } from '@repo/corporation-tax'
 import type { EveCharacterData } from '@repo/eve-character-data'
@@ -267,6 +268,28 @@ async function getMemberCharacterIdsInCorporation(
 		)
 
 		return memberships.filter((characterId): characterId is string => characterId !== null)
+	})
+}
+
+async function getCorporationMemberCharacterIds(
+	c: { env: App['Bindings'] },
+	corporationId: string
+): Promise<string[]> {
+	const cacheKey = `corp:${corporationId}:member-character-ids`
+	return corpMembershipCache.getOrSet(cacheKey, async () => {
+		try {
+			const corporationStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, 'default')
+			const members = await corporationStub.getMembers(corporationId)
+			return members
+				.map((member) => member.characterId)
+				.filter((characterId): characterId is string => Boolean(characterId))
+		} catch (error) {
+			logger.warn('[CorporationTax] Failed corporation membership lookup for member summary', {
+				corporationId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return []
+		}
 	})
 }
 
@@ -2167,6 +2190,98 @@ app.post('/corporations/:corporationId/bills/sync', requireAuth(), async (c) => 
 	}
 })
 
+async function resolveMemberSummaryTargets(input: {
+	c: any
+	user: SessionUser
+	corporationId: string
+	characterQuery?: string
+}): Promise<
+	| { targetCharacterIds: string[] | undefined }
+	| { response: Response }
+> {
+	const { c, user, corporationId, characterQuery } = input
+	const canReadWithTaxScopes = await canReadTaxFeature(c.env, user, corporationId)
+	const memberCharacterIds = await getMemberCharacterIdsInCorporation(c, user, corporationId)
+	const corporationMemberIds = canReadWithTaxScopes
+		? await getCorporationMemberCharacterIds(c, corporationId)
+		: []
+	const allowedCharacterIds = [...new Set([...memberCharacterIds, ...corporationMemberIds])]
+	const hasMemberReadAccess = memberCharacterIds.length > 0
+
+	if (!canReadWithTaxScopes && !hasMemberReadAccess) {
+		return { response: c.json({ error: 'Forbidden' }, 403) }
+	}
+
+	if (characterQuery) {
+		const numericOnly = /^\d+$/.test(characterQuery)
+		if (numericOnly) {
+			const targetCharacterIds = allowedCharacterIds.includes(characterQuery) ? [characterQuery] : []
+			if (!canReadWithTaxScopes && targetCharacterIds.length === 0) {
+				return { response: c.json({ error: 'Forbidden' }, 403) }
+			}
+			return { targetCharacterIds }
+		}
+
+		const scopedCharacterIds = [...allowedCharacterIds]
+		if (scopedCharacterIds.length === 0) {
+			return { targetCharacterIds: [] }
+		}
+
+		const matchedCharacterIds = new Set<string>()
+
+		try {
+			const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
+			try {
+				const searchResultIds = await tokenStoreStub.searchCharacter(characterQuery, false)
+				for (const characterId of searchResultIds) {
+					if (scopedCharacterIds.includes(characterId)) {
+						matchedCharacterIds.add(characterId)
+					}
+				}
+			} finally {
+				disposeRpcStub(tokenStoreStub)
+			}
+		} catch (error) {
+			logger.warn('[CorporationTax] Failed ESI character search for member summary', {
+				corporationId,
+				characterQuery,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+
+		const db = c.get('db')
+		if (db) {
+			const rows = await db
+				.select({
+					characterId: userCharacters.characterId,
+				})
+				.from(userCharacters)
+				.where(
+					and(
+						inArray(userCharacters.characterId, scopedCharacterIds),
+						ilike(userCharacters.characterName, `${characterQuery}%`)
+					)
+				)
+				.limit(100)
+			for (const row of rows) {
+				matchedCharacterIds.add(row.characterId)
+			}
+		}
+
+		const targetCharacterIds = Array.from(matchedCharacterIds)
+		if (!canReadWithTaxScopes && targetCharacterIds.length === 0) {
+			return { response: c.json({ error: 'Forbidden' }, 403) }
+		}
+		return { targetCharacterIds }
+	}
+
+	if (!canReadWithTaxScopes) {
+		return { targetCharacterIds: memberCharacterIds }
+	}
+
+	return { targetCharacterIds: undefined }
+}
+
 /**
  * GET /corporation-tax/corporations/:corporationId/member-summary
  * Member-level tax summary. Without characterId, returns caller-owned member character summaries only.
@@ -2210,95 +2325,22 @@ app.get('/corporations/:corporationId/member-summary', requireAuth(), async (c) 
 		return c.json({ error: 'sortDir must be "asc" or "desc"' }, 400)
 	}
 
-	const canReadWithTaxScopes = await canReadTaxFeature(c.env, user, corporationId)
-	const memberCharacterIds = await getMemberCharacterIdsInCorporation(c, user, corporationId)
-	const hasMemberReadAccess = memberCharacterIds.length > 0
-
-	if (!canReadWithTaxScopes && !hasMemberReadAccess) {
-		return c.json({ error: 'Forbidden' }, 403)
-	}
-
 	try {
 		const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
-		let scopedCharacterIds: string[] = memberCharacterIds
-		if (canReadWithTaxScopes) {
-			const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
-			try {
-				const members = await corpStub.getMembers(corporationId)
-				scopedCharacterIds = members.map((member) => member.characterId)
-			} finally {
-				disposeRpcStub(corpStub)
-			}
-		}
-		const scopedCharacterIdSet = new Set(scopedCharacterIds)
-
-		let targetCharacterIds: string[] | undefined
-		if (characterQuery) {
-			const numericOnly = /^\d+$/.test(characterQuery)
-			if (numericOnly) {
-				targetCharacterIds = scopedCharacterIdSet.has(characterQuery) ? [characterQuery] : []
-			} else if (scopedCharacterIds.length > 0) {
-				const matchedCharacterIds = new Set<string>()
-
-				// Resolve name matches via ESI search and then scope to corporation members.
-				// This includes members that are not linked site users.
-				try {
-					const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
-					try {
-						const searchResultIds = await tokenStoreStub.searchCharacter(characterQuery, false)
-						for (const characterId of searchResultIds) {
-							if (scopedCharacterIdSet.has(characterId)) {
-								matchedCharacterIds.add(characterId)
-							}
-						}
-					} finally {
-						disposeRpcStub(tokenStoreStub)
-					}
-				} catch (error) {
-					logger.warn('[CorporationTax] Failed ESI character search for member summary', {
-						corporationId,
-						characterQuery,
-						error: error instanceof Error ? error.message : String(error),
-					})
-				}
-
-				// Keep local fallback for linked-user rows so name-prefix search still works
-				// when ESI search is unavailable in development/test paths.
-				const db = c.get('db')
-				if (db) {
-					const rows = await db
-						.select({
-							characterId: userCharacters.characterId,
-						})
-						.from(userCharacters)
-						.where(
-							and(
-								inArray(userCharacters.characterId, scopedCharacterIds),
-								ilike(userCharacters.characterName, `${characterQuery}%`)
-							)
-						)
-						.limit(100)
-					for (const row of rows) {
-						matchedCharacterIds.add(row.characterId)
-					}
-				}
-
-				targetCharacterIds = Array.from(matchedCharacterIds)
-			} else {
-				targetCharacterIds = []
-			}
-
-			if (!canReadWithTaxScopes && targetCharacterIds.length === 0) {
-				return c.json({ error: 'Forbidden' }, 403)
-			}
-		} else if (!canReadWithTaxScopes) {
-			targetCharacterIds = memberCharacterIds
+		const resolvedTargets = await resolveMemberSummaryTargets({
+			c,
+			user,
+			corporationId,
+			characterQuery,
+		})
+		if ('response' in resolvedTargets) {
+			return resolvedTargets.response
 		}
 
 		try {
 			const result = await stub.getMemberSummaryReport({
 				corporationId,
-				characterIds: targetCharacterIds,
+				characterIds: resolvedTargets.targetCharacterIds,
 				fromDate: fromDate ?? undefined,
 				toDate: toDate ?? undefined,
 				topRefTypesLimit: topRefTypesLimit ?? undefined,
@@ -2326,6 +2368,7 @@ app.get('/corporations/:corporationId/member-summary', requireAuth(), async (c) 
 		return c.json({ error: 'Failed to fetch member summary' }, 500)
 	}
 })
+
 registerCorporationTaxReportsRoutes(app)
 registerCorporationTaxAlertsRoutes(app, { validateDiscordDestinationInput })
 

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -8,6 +8,7 @@ import { managedCorporations, userCharacters, users } from '../../db/schema'
 import { isNpcCorporationId } from '../../lib/corporation-id'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 import { requireAdmin, requireAuth } from '../../middleware/session'
+import { buildCsvLine } from '@repo/worker-utils'
 import corporationsAlertsRoutes from './alerts-routes'
 import corporationsDirectorsRoutes from './directors-routes'
 import corporationsDiscordRoutes from './discord-routes'
@@ -642,16 +643,6 @@ function filterSortMembers(members: CorporationMemberListItem[], query: MembersQ
 	})
 
 	return filtered
-}
-
-function escapeCsvValue(value: string | number | boolean | null | undefined): string {
-	if (value === null || value === undefined) return ''
-	const text = String(value)
-	return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
-}
-
-function buildCsvLine(values: Array<string | number | boolean | null | undefined>): string {
-	return values.map((value) => escapeCsvValue(value)).join(',')
 }
 
 function getEsiStatusLabel(member: Pick<CorporationMemberListItem, 'hasAuthAccount' | 'hasValidToken'>) {

--- a/apps/core/src/routes/hr.ts
+++ b/apps/core/src/routes/hr.ts
@@ -16,6 +16,7 @@ import { waitUntilWithTelemetry } from '../lib/background-task'
 import { getIpHashMatches, getUserIpHistory } from '../lib/ip-history'
 import { dispatchCorporationAlert } from '../services/corporation-alerts.service'
 import { validatePagination } from '../lib/validation'
+import { getUserCorporationAffiliationIds } from '../lib/user-corporation-affiliations'
 import { requireAdmin, requireAuth } from '../middleware/session'
 
 import type { Context } from 'hono'
@@ -88,6 +89,40 @@ function getLegacyStub(c: Context<App>): Legacy {
 function getCharacterName(user: Context<App>['var']['user'], characterId: string): string {
 	const character = user?.characters.find((c) => c.characterId === characterId)
 	return character?.characterName || 'Unknown'
+}
+
+async function getActiveMemberCorporationIds(c: Context<App>): Promise<string[]> {
+	const db = c.get('db')
+	if (!db) {
+		throw new Error('Database not available')
+	}
+
+	const memberCorporations = await db.query.managedCorporations.findMany({
+		where: and(eq(managedCorporations.isActive, true), eq(managedCorporations.isMemberCorporation, true)),
+		columns: { corporationId: true },
+	})
+
+	return memberCorporations.map((corp) => corp.corporationId)
+}
+
+async function getAccessibleRecommendationCorporationIds(c: Context<App>): Promise<string[]> {
+	const user = c.get('user')!
+	const db = c.get('db')
+	if (!db) {
+		throw new Error('Database not available')
+	}
+
+	const memberCorporationIds = await getActiveMemberCorporationIds(c)
+	if (user.is_admin) {
+		return memberCorporationIds
+	}
+
+	if (await hasHrAuditorPermissionForUser({ env: c.env, userId: user.id })) {
+		return memberCorporationIds
+	}
+
+	const userCorporationIds = await getUserCorporationAffiliationIds(db, user.id)
+	return memberCorporationIds.filter((corporationId) => userCorporationIds.includes(corporationId))
 }
 
 /**
@@ -895,41 +930,14 @@ app.delete('/applications/:id', requireAdmin(), async (c) => {
  */
 app.get('/recommendations/pending', requireAuth(), async (c) => {
 	const user = c.get('user')!
-	const db = c.get('db')!
-	const isAdmin = user.is_admin
-	const isAuditor = await hasHrAuditorPermission(c)
+	const accessibleCorporationIds = await getAccessibleRecommendationCorporationIds(c)
 
-	// Resolve corporation IDs from the database (session user doesn't carry corporationId)
-	const userChars = await db.query.userCharacters.findMany({
-		where: and(eq(userCharacters.userId, user.id), eq(userCharacters.isDeleted, false)),
-	})
-	const corporationIds = [
-		...new Set(userChars.map((ch) => ch.corporationId).filter(Boolean)),
-	] as string[]
-
-	if (corporationIds.length === 0) {
+	if (accessibleCorporationIds.length === 0) {
 		return c.json([])
 	}
 
 	try {
 		const hr = getHrStub(c)
-		const accessibleCorporationIds = isAdmin || isAuditor
-			? corporationIds
-			: (
-				await db.query.managedCorporations.findMany({
-					where: and(
-						eq(managedCorporations.isActive, true),
-						eq(managedCorporations.isMemberCorporation, true),
-						inArray(managedCorporations.corporationId, corporationIds)
-					),
-					columns: { corporationId: true },
-				})
-			).map((corp) => corp.corporationId)
-
-		if (accessibleCorporationIds.length === 0) {
-			return c.json([])
-		}
-
 		const applications = await hr.listCorpApplicationsForRecommendation(accessibleCorporationIds, user.id)
 		return c.json(applications)
 	} catch (error) {
@@ -948,28 +956,27 @@ app.get('/recommendations/pending', requireAuth(), async (c) => {
 app.get('/recommendations/applications/:id', requireAuth(), async (c) => {
 	const user = c.get('user')!
 	const applicationId = c.req.param('id')
-	const db = c.get('db')!
-	const isAdmin = user.is_admin
-	const isAuditor = await hasHrAuditorPermission(c)
-
-	// Resolve corporation IDs from the database (session user doesn't carry corporationId)
-	const userChars = await db.query.userCharacters.findMany({
-		where: and(eq(userCharacters.userId, user.id), eq(userCharacters.isDeleted, false)),
-	})
-	const corporationIds = [
-		...new Set(userChars.map((ch) => ch.corporationId).filter(Boolean)),
-	] as string[]
+	const isAuditor = await hasHrAuditorPermissionForUser({ env: c.env, userId: user.id })
+	const db = c.get('db')
+	if (!db) {
+		return c.json({ error: 'Database not available' }, 500)
+	}
+	const userCorporationIds = await getUserCorporationAffiliationIds(db, user.id)
+	const accessibleCorporationIds = await getAccessibleRecommendationCorporationIds(c)
 
 	try {
 		const hr = getHrStub(c)
 		const application = await hr.getApplicationForRecommender(
 			applicationId,
 			user.id,
-			corporationIds
+			userCorporationIds,
+			{ isAdmin: user.is_admin, isAuditor }
 		)
-		if (!isAdmin && !isAuditor && !(await canUseHrToolsForCorporation(c, application.corporationId))) {
+		if (!accessibleCorporationIds.includes(application.corporationId)) {
 			return c.json(
-				{ error: 'Access denied. HR tools are only available for member corporations.' },
+				{
+					error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+				},
 				403
 			)
 		}
@@ -990,6 +997,13 @@ app.post('/applications/:applicationId/recommendations', requireAuth(), async (c
 	const user = c.get('user')!
 	const applicationId = c.req.param('applicationId')
 	const { characterId, recommendationText, sentiment, isPublic } = await c.req.json()
+	const isAuditor = await hasHrAuditorPermissionForUser({ env: c.env, userId: user.id })
+	const db = c.get('db')
+	if (!db) {
+		return c.json({ error: 'Database not available' }, 500)
+	}
+	const userCorporationIds = await getUserCorporationAffiliationIds(db, user.id)
+	const accessibleCorporationIds = await getAccessibleRecommendationCorporationIds(c)
 
 	// Validate character ownership
 	const ownsCharacter = user.characters.some((char) => char.characterId === characterId)
@@ -1001,13 +1015,17 @@ app.post('/applications/:applicationId/recommendations', requireAuth(), async (c
 
 	try {
 		const hr = getHrStub(c)
-		const application = await hr.getApplication(applicationId, user.id, {
-			isAdmin: user.is_admin,
-			isAuditor: false,
-		})
-		if (!(await canUseHrToolsForCorporation(c, application.corporationId))) {
+		const application = await hr.getApplicationForRecommender(
+			applicationId,
+			user.id,
+			userCorporationIds,
+			{ isAdmin: user.is_admin, isAuditor }
+		)
+		if (!accessibleCorporationIds.includes(application.corporationId)) {
 			return c.json(
-				{ error: 'Access denied. HR tools are only available for member corporations.' },
+				{
+					error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+				},
 				403
 			)
 		}

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -23,8 +23,11 @@ import {
 	type StructureProfitability,
 	type VerifiedComposition,
 } from '@repo/moon-scan'
+import { buildCsvLine, createR2MultipartTextWriter } from '@repo/worker-utils'
 
 import { getCachedUserPermissions } from '../lib/groups-cache'
+import { isExportArtifactExpired } from '../lib/export-retention'
+import { normalizeWorkflowStatus } from '../lib/workflow-status'
 import { requireAllianceMember } from '../middleware/session'
 
 import { createEveRegionId, createEveTypeId } from '@repo/eve-types'
@@ -66,6 +69,13 @@ const MAX_SCAN_RAW_BYTES = 1_000_000
 
 const permissionCache = new TimeCache<boolean>(15_000)
 const VERIFIED_MOON_SUMMARY_BACKFILL_BATCH_SIZE = 250
+const VERIFIED_MOONS_EXPORT_PAGE_SIZE = 100
+const VERIFIED_MOONS_EXPORT_BUCKET_PREFIX = 'moon-scan/verified-moons-exports'
+
+export type VerifiedMoonsExportQuery = Pick<
+	z.infer<typeof VerifiedMoonsQuerySchema>,
+	'regionId' | 'constellationId' | 'rarity' | 'search'
+>
 
 // Minerals that Metenox does NOT output (only moon goo materials)
 const MINERAL_TYPE_IDS = new Set(['35', '36'])
@@ -155,6 +165,369 @@ function chunkArray<T>(items: readonly T[], size: number): T[][] {
 		chunks.push(items.slice(index, index + size) as T[])
 	}
 	return chunks
+}
+
+function getExecutionContextOrNull(c: { executionCtx?: ExecutionContext }): ExecutionContext | null {
+	try {
+		return c.executionCtx ?? null
+	} catch {
+		return null
+	}
+}
+
+export function getVerifiedMoonsExportBucket(env: App['Bindings']): R2Bucket {
+	return env.MOON_SCAN_EXPORTS
+}
+
+export function buildVerifiedMoonsExportKey(exportId: string): string {
+	return `${VERIFIED_MOONS_EXPORT_BUCKET_PREFIX}/${exportId}.csv`
+}
+
+export function buildVerifiedMoonsExportFileName(exportId: string): string {
+	return `scanned-moons-export-${exportId.slice(0, 8)}.csv`
+}
+
+export async function writeVerifiedMoonsExportToBucket(args: {
+	bucket: R2Bucket
+	exportKey: string
+	fileName: string
+	expiresAt: string
+	moonScan: MoonScanDO
+	universe: Universe
+	env: App['Bindings']
+	query: VerifiedMoonsExportQuery
+}): Promise<number> {
+	const writer = await createR2MultipartTextWriter(args.bucket, args.exportKey, {
+		httpMetadata: {
+			contentType: 'text/csv; charset=utf-8',
+		},
+		customMetadata: {
+			fileName: args.fileName,
+			expiresAt: args.expiresAt,
+		},
+	})
+
+	let rowCount = 0
+	try {
+		await writer.writeLine(
+			buildCsvLine([
+				'regionId',
+				'regionName',
+				'solarSystemId',
+				'solarSystemName',
+				'moonId',
+				'moonName',
+				'securityStatus',
+				'highestRarity',
+				'metenoxProfit',
+				'tataraProfit',
+				'oreTypeId',
+				'oreTypeName',
+				'oreRarity',
+				'oreCompositionPercent',
+				'oreTotalOreValue',
+			])
+		)
+
+		const firstPage = await args.moonScan.getVerifiedMoonPage({
+			page: 1,
+			pageSize: VERIFIED_MOONS_EXPORT_PAGE_SIZE,
+			regionId: args.query.regionId,
+			constellationId: args.query.constellationId,
+			rarity: args.query.rarity,
+			search: args.query.search,
+			sortBy: 'moonName',
+			sortDir: 'asc',
+		})
+		const totalPages = Math.max(1, Math.ceil(firstPage.total / VERIFIED_MOONS_EXPORT_PAGE_SIZE))
+		for (let page = 1; page <= totalPages; page += 1) {
+			const pageData =
+				page === 1
+					? firstPage
+					: await args.moonScan.getVerifiedMoonPage({
+						page,
+						pageSize: VERIFIED_MOONS_EXPORT_PAGE_SIZE,
+						regionId: args.query.regionId,
+						constellationId: args.query.constellationId,
+						rarity: args.query.rarity,
+						search: args.query.search,
+						sortBy: 'moonName',
+						sortDir: 'asc',
+					})
+			const pageEntries = await buildMoonExportEntriesForPage({
+				moonScan: args.moonScan,
+				universe: args.universe,
+				env: args.env,
+				summaries: pageData.items,
+			})
+			for (const entry of pageEntries) {
+				for (const row of buildMoonExportRows(entry)) {
+					await writer.writeLine(buildCsvLine(row))
+					rowCount += 1
+				}
+			}
+		}
+
+		await writer.close()
+		return rowCount
+	} catch (error) {
+		await writer.abort().catch(() => {})
+		throw error
+	}
+}
+
+type MoonPricingInputs = {
+	settings: Awaited<ReturnType<MoonScanDO['getExtractionSettings']>>
+	profiles: Awaited<ReturnType<MoonScanDO['getStructureProfiles']>>
+	typeMaterialsMap: Record<string, Array<{ materialTypeId: string; quantity: number }>>
+	priceMap: Record<string, number>
+	typeNamesMap: Record<string, { typeName: string } | null>
+}
+
+type MoonExportEntry = {
+	moon: {
+		moonId: string
+		moonName: string
+		solarSystemId: string
+		solarSystemName: string
+		regionId: string
+		regionName: string
+		constellationId: string
+		constellationName: string
+		securityStatus: string | null
+		highestRarity: string | null
+	}
+	profitability: MoonProfitability | null
+}
+
+function getMoonProfitabilityInputsFromComposition(
+	composition: VerifiedComposition,
+	inputs: MoonPricingInputs,
+): MoonProfitability | null {
+	try {
+		const reprocessingYield = parseFloat(inputs.settings.defaultReprocessingYield)
+		const cycleDays = inputs.settings.defaultCycleDays
+		const cycleHours = cycleDays * 24
+
+		function buildStructureOres(totalVolume: number, isPassive: boolean): OreWithProfitability[] {
+			return composition.ores
+				.map((ore) => {
+					const liveMaterials = inputs.typeMaterialsMap[ore.oreTypeId] ?? []
+					const fraction = parseFloat(ore.quantity)
+					const oreUnits = (totalVolume * fraction) / getOreVolume(ore.oreTypeId)
+
+					const refinesTo = liveMaterials
+						.filter((mat) => !(isPassive && MINERAL_TYPE_IDS.has(mat.materialTypeId)))
+						.map((mat) => {
+							const batchQty = mat.quantity
+							const units = Math.floor(Math.floor(oreUnits / 100) * batchQty * reprocessingYield)
+							const unitSellPrice = inputs.priceMap[mat.materialTypeId] ?? 0
+							return {
+								materialTypeId: mat.materialTypeId,
+								materialName: inputs.typeNamesMap[mat.materialTypeId]?.typeName ?? mat.materialTypeId,
+								quantity: units,
+								batchSize: 100,
+								batchQty,
+								unitSellPrice: String(unitSellPrice),
+								totalValue: String(units * unitSellPrice),
+								materialRarity: null,
+							}
+						})
+						.sort((a, b) =>
+							(RARITY_ORDER[ORE_TYPE_RARITY[b.materialTypeId] as OreRarity] ?? 0) -
+							(RARITY_ORDER[ORE_TYPE_RARITY[a.materialTypeId] as OreRarity] ?? 0)
+						)
+
+					const totalOreValue = refinesTo.reduce((sum, r) => sum + parseFloat(r.totalValue), 0)
+					return {
+						oreTypeId: ore.oreTypeId,
+						oreName: inputs.typeNamesMap[ore.oreTypeId]?.typeName ?? ore.oreTypeId,
+						quantity: ore.quantity,
+						rarity: ORE_TYPE_RARITY[ore.oreTypeId] ?? null,
+						refinesTo,
+						totalOreValue: String(totalOreValue),
+					}
+				})
+				.sort((a, b) =>
+					(RARITY_ORDER[ORE_TYPE_RARITY[b.oreTypeId] as OreRarity] ?? 0) -
+					(RARITY_ORDER[ORE_TYPE_RARITY[a.oreTypeId] as OreRarity] ?? 0)
+				)
+		}
+
+		const structures: StructureProfitability[] = []
+		for (const profile of inputs.profiles) {
+			const baseRate = parseFloat(profile.baseVolumePerHr) * (1 + parseFloat(profile.rigBonus))
+			const fuelPerHr = parseFloat(profile.fuelPerHr)
+			const magmaticGasPerHr = profile.magmaticGasPerHr ? parseFloat(profile.magmaticGasPerHr) : 0
+			const totalVolume = profile.isPassive
+				? baseRate * parseFloat(profile.nullsecModifier) * cycleHours
+				: baseRate * cycleHours
+			const fuelUnits = fuelPerHr * cycleHours
+			const magmaticGasUnits = profile.isPassive ? magmaticGasPerHr * cycleHours : 0
+
+			const ores = buildStructureOres(totalVolume, profile.isPassive)
+			const grossIsk = ores.reduce((sum, ore) => sum + parseFloat(ore.totalOreValue), 0)
+			const fuelCost = fuelUnits * resolveEffectivePrice(
+				inputs.settings.fuelBlockPriceOverride,
+				inputs.priceMap[FUEL_BLOCK_TYPE_ID] ?? 0
+			)
+			const magmaticGasCost = magmaticGasUnits * resolveEffectivePrice(
+				inputs.settings.magmaticGasPriceOverride,
+				inputs.priceMap[MAGMATIC_GAS_TYPE_ID] ?? 0
+			)
+
+			structures.push({
+				structureType: profile.id,
+				cycleDays,
+				grossIsk: String(Math.round(grossIsk)),
+				fuelCost: String(Math.round(fuelCost)),
+				magmaticGasCost: profile.isPassive ? String(Math.round(magmaticGasCost)) : null,
+				profit: String(Math.round(grossIsk - fuelCost - magmaticGasCost)),
+				ores,
+			})
+		}
+
+		const tataraProfile = inputs.profiles.find((profile) => profile.id === 'tatara')
+		const compositionOres = tataraProfile
+			? structures.find((structure) => structure.structureType === 'tatara')?.ores ?? []
+			: []
+
+		return {
+			ores: compositionOres,
+			structures,
+			updatedAt: new Date().toISOString(),
+		}
+	} catch (error) {
+		console.error('[moon-scan] failed to build profitability from cached inputs', { error })
+		return null
+	}
+}
+
+async function getMoonPricingInputs(
+	env: App['Bindings'],
+	universe: Universe,
+	moonScan: MoonScanDO,
+	compositions: VerifiedComposition[],
+): Promise<MoonPricingInputs> {
+	const oreTypeIds = [...new Set(compositions.flatMap((composition) => composition.ores.map((ore) => ore.oreTypeId)))]
+	const [settings, profiles, typeMaterialsMap] = await Promise.all([
+		moonScan.getExtractionSettings(),
+		moonScan.getStructureProfiles(),
+		universe.getTypeMaterials(oreTypeIds),
+	])
+
+	const materialTypeIds = [
+		...new Set(
+			Object.values(typeMaterialsMap).flatMap((materials) => materials.map((material) => material.materialTypeId))
+		),
+	]
+	const typeIdsForNames = [...new Set([...oreTypeIds, ...materialTypeIds])]
+	const markets = getMarketsStub(env)
+	const [priceResponse, typeNamesMap] = await Promise.all([
+		markets.getBatchMarketDataAtTime({
+			regionId: createEveRegionId('universe'),
+			typeIds: [...materialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID].map(createEveTypeId),
+			atTime: new Date(),
+		}),
+		typeIdsForNames.length > 0
+			? universe.resolveTypeNamesByIds(typeIdsForNames)
+			: Promise.resolve({} as Record<string, { typeName: string } | null>),
+	])
+
+	const priceMap: Record<string, number> = {}
+	for (const price of priceResponse.prices) {
+		if (price.bestSellPrice) priceMap[price.typeId] = parseFloat(price.bestSellPrice)
+	}
+
+	return {
+		settings,
+		profiles,
+		typeMaterialsMap,
+		priceMap,
+		typeNamesMap,
+	}
+}
+
+function buildMoonExportRows(entry: MoonExportEntry): Array<Array<string | number | boolean | null | undefined>> {
+	const rows: Array<Array<string | number | boolean | null | undefined>> = []
+	const ores = entry.profitability?.ores ?? []
+	const metenoxProfit = entry.profitability?.structures.find((structure) => structure.structureType === 'metenox')?.profit ?? null
+	const tataraProfit = entry.profitability?.structures.find((structure) => structure.structureType === 'tatara')?.profit ?? null
+
+	if (ores.length === 0) {
+		rows.push([
+			entry.moon.regionId,
+			entry.moon.regionName,
+			entry.moon.solarSystemId,
+			entry.moon.solarSystemName,
+			entry.moon.moonId,
+			entry.moon.moonName,
+			entry.moon.securityStatus ?? '',
+			entry.moon.highestRarity ?? '',
+			metenoxProfit ?? '',
+			tataraProfit ?? '',
+			'',
+			'',
+			'',
+			'',
+			'',
+		])
+		return rows
+	}
+
+	for (const ore of ores) {
+		rows.push([
+			entry.moon.regionId,
+			entry.moon.regionName,
+			entry.moon.solarSystemId,
+			entry.moon.solarSystemName,
+			entry.moon.moonId,
+			entry.moon.moonName,
+			entry.moon.securityStatus ?? '',
+			entry.moon.highestRarity ?? '',
+			metenoxProfit ?? '',
+			tataraProfit ?? '',
+			ore.oreTypeId,
+			ore.oreName,
+			ore.rarity ?? '',
+			`${(Number.parseFloat(ore.quantity) * 100).toFixed(2)}%`,
+			ore.totalOreValue,
+		])
+	}
+
+	return rows
+}
+
+async function buildMoonExportEntriesForPage(args: {
+	moonScan: MoonScanDO
+	universe: Universe
+	env: App['Bindings']
+	summaries: Array<{
+		moonId: string
+		moonName: string
+		solarSystemId: string
+		solarSystemName: string
+		regionId: string
+		regionName: string
+		constellationId: string
+		constellationName: string
+		securityStatus: string | null
+		highestRarity: string | null
+	}>
+}): Promise<MoonExportEntry[]> {
+	if (args.summaries.length === 0) return []
+
+	const compositions = await args.moonScan.getVerifiedCompositions(args.summaries.map((summary) => summary.moonId))
+	const compositionMap = new Map(compositions.map((composition) => [composition.moonId, composition]))
+	const inputs = await getMoonPricingInputs(args.env, args.universe, args.moonScan, compositions)
+
+	return args.summaries.map((summary) => {
+		const composition = compositionMap.get(summary.moonId)
+		return {
+			moon: summary,
+			profitability: composition ? getMoonProfitabilityInputsFromComposition(composition, inputs) : null,
+		}
+	})
 }
 
 // ─── Zod schemas ──────────────────────────────────────────────────────────────
@@ -836,11 +1209,121 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 	})
 })
 
+moonScanRoutes.post('/moons/verified/export', async (c) => {
+	const user = c.get('user')!
+	if (!await hasMoonPerm(c.env, user.id, MOON_URNS.view, user.is_admin)) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	const query = VerifiedMoonsQuerySchema.safeParse({
+		page: c.req.query('page'),
+		pageSize: c.req.query('pageSize'),
+		regionId: c.req.query('regionId'),
+		constellationId: c.req.query('constellationId'),
+		rarity: c.req.query('rarity'),
+		search: c.req.query('search'),
+		sortBy: c.req.query('sortBy'),
+		sortDir: c.req.query('sortDir'),
+	})
+	if (!query.success) {
+		return c.json({ error: 'Invalid query', issues: query.error.issues }, 400)
+	}
+	if (!query.data.regionId && !query.data.constellationId) {
+		return c.json({ error: 'regionId or constellationId is required for moon export' }, 400)
+	}
+	const { sortBy: _sortBy, sortDir: _sortDir, page: _page, pageSize: _pageSize, ...exportQuery } = query.data
+
+	const workflow = await c.env.EXPORT_WORKFLOW.create({
+		params: {
+			kind: 'moon-scan-verified',
+			userId: user.id,
+			query: exportQuery,
+		},
+	})
+
+	return c.json(
+		{
+			workflowInstanceId: workflow.id,
+			exportId: workflow.id,
+			fileName: buildVerifiedMoonsExportFileName(workflow.id),
+			status: 'queued',
+		},
+		202
+	)
+})
+
+moonScanRoutes.get('/moons/verified/export/:workflowInstanceId', async (c) => {
+	const user = c.get('user')!
+	if (!await hasMoonPerm(c.env, user.id, MOON_URNS.view, user.is_admin)) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const workflow = await c.env.EXPORT_WORKFLOW.get(workflowInstanceId)
+	const status = await workflow.status()
+	const outputStatus =
+		status.output && typeof status.output === 'object' && 'status' in status.output
+			? String((status.output as { status?: string }).status ?? '')
+			: undefined
+	return c.json({
+		workflowInstanceId,
+		status: normalizeWorkflowStatus(status.status, outputStatus),
+		rawStatus: status.status,
+		output: status.output ?? null,
+	})
+})
+
+moonScanRoutes.get('/moons/verified/export/:workflowInstanceId/download', async (c) => {
+	const user = c.get('user')!
+	if (!await hasMoonPerm(c.env, user.id, MOON_URNS.view, user.is_admin)) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const bucket = getVerifiedMoonsExportBucket(c.env)
+	const exportKey = buildVerifiedMoonsExportKey(workflowInstanceId)
+	const object = await bucket.get(exportKey)
+	if (!object) {
+		return c.json({ error: 'Export not found' }, 404)
+	}
+	if (isExportArtifactExpired(object.customMetadata?.expiresAt)) {
+		await bucket.delete(exportKey).catch(() => {})
+		return c.json({ error: 'Export expired' }, 404)
+	}
+
+	const fileName = object.customMetadata?.fileName ?? buildVerifiedMoonsExportFileName(workflowInstanceId)
+	const contentType = object.httpMetadata?.contentType ?? 'text/csv; charset=utf-8'
+	const response = new Response(object.body, {
+		status: 200,
+		headers: {
+			'Content-Type': contentType,
+			'Content-Disposition': `attachment; filename="${fileName}"`,
+			'Cache-Control': 'no-store',
+		},
+	})
+	const executionCtx = getExecutionContextOrNull(c)
+	const cleanup = bucket.delete(exportKey).catch(() => {})
+	if (executionCtx) {
+		executionCtx.waitUntil(cleanup)
+	} else {
+		void cleanup
+	}
+	return response
+})
+
 function getMarketsStub(env: App['Bindings']): Markets {
 	return getStub<Markets>(env.MARKETS, 'region-10000002')
 }
 
-async function buildVerifiedMoonSummaryRecords(
+export async function buildVerifiedMoonSummaryRecords(
 	compositions: VerifiedComposition[],
 	universe: Universe,
 ): Promise<VerifiedMoonSummaryRecord[]> {
@@ -914,133 +1397,9 @@ async function computeProfitability(
 	moonScan: MoonScanDO,
 ): Promise<MoonProfitability | null> {
 	try {
-		const oreTypeIds = composition.ores.map((o) => o.oreTypeId)
-
 		const universe = getUniverseStub(env)
-		const [settings, profiles, typeMaterialsMap] = await Promise.all([
-			moonScan.getExtractionSettings(),
-			moonScan.getStructureProfiles(),
-			universe.getTypeMaterials(oreTypeIds),
-		])
-
-		// Collect all unique material type IDs from the live data for pricing + name lookup
-		const liveMaterialTypeIds = [...new Set(
-			Object.values(typeMaterialsMap).flatMap((mats) => mats.map((m) => m.materialTypeId))
-		)]
-		const oreTypeIdsForNames = composition.ores.map((o) => o.oreTypeId)
-
-		const markets = getMarketsStub(env)
-		const [priceResponse, typeNamesMap] = await Promise.all([
-			markets.getBatchMarketDataAtTime({
-				regionId: createEveRegionId('universe'),
-				typeIds: [...liveMaterialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID].map(createEveTypeId),
-				atTime: new Date(),
-			}),
-			universe.resolveTypeNamesByIds([...liveMaterialTypeIds, ...oreTypeIdsForNames]),
-		])
-		const priceMap: Record<string, number> = {}
-		for (const p of priceResponse.prices) {
-			if (p.bestSellPrice) priceMap[p.typeId] = parseFloat(p.bestSellPrice)
-		}
-
-		const fuelBlockPrice = resolveEffectivePrice(
-			settings.fuelBlockPriceOverride,
-			priceMap[FUEL_BLOCK_TYPE_ID] ?? 0
-		)
-		const magmaticGasPrice = resolveEffectivePrice(
-			settings.magmaticGasPriceOverride,
-			priceMap[MAGMATIC_GAS_TYPE_ID] ?? 0
-		)
-		const reprocessingYield = parseFloat(settings.defaultReprocessingYield)
-		const cycleDays = settings.defaultCycleDays
-
-		const cycleHours = cycleDays * 24
-
-		function buildStructureOres(totalVolume: number, isPassive: boolean): OreWithProfitability[] {
-			return composition.ores
-				.map((ore) => {
-					const liveMaterials = typeMaterialsMap[ore.oreTypeId] ?? []
-					const fraction = parseFloat(ore.quantity)
-					const oreUnits = (totalVolume * fraction) / getOreVolume(ore.oreTypeId)
-
-					const refinesTo = liveMaterials
-						.filter((mat) => !(isPassive && MINERAL_TYPE_IDS.has(mat.materialTypeId)))
-						.map((mat) => {
-							const batchQty = mat.quantity
-							const units = Math.floor(Math.floor(oreUnits / 100) * batchQty * reprocessingYield)
-							const unitSellPrice = priceMap[mat.materialTypeId] ?? 0
-							return {
-								materialTypeId: mat.materialTypeId,
-								materialName: typeNamesMap[mat.materialTypeId]?.typeName ?? mat.materialTypeId,
-								quantity: units,
-								batchSize: 100,
-								batchQty,
-								unitSellPrice: String(unitSellPrice),
-								totalValue: String(units * unitSellPrice),
-								materialRarity: null,
-							}
-						})
-						.sort((a, b) =>
-							(RARITY_ORDER[ORE_TYPE_RARITY[b.materialTypeId] as OreRarity] ?? 0) -
-							(RARITY_ORDER[ORE_TYPE_RARITY[a.materialTypeId] as OreRarity] ?? 0)
-						)
-
-					const totalOreValue = refinesTo.reduce((sum, r) => sum + parseFloat(r.totalValue), 0)
-					return {
-						oreTypeId: ore.oreTypeId,
-						oreName: typeNamesMap[ore.oreTypeId]?.typeName ?? ore.oreTypeId,
-						quantity: ore.quantity,
-						rarity: null,
-						refinesTo,
-						totalOreValue: String(totalOreValue),
-					}
-				})
-				.sort((a, b) =>
-					(RARITY_ORDER[ORE_TYPE_RARITY[b.oreTypeId] as OreRarity] ?? 0) -
-					(RARITY_ORDER[ORE_TYPE_RARITY[a.oreTypeId] as OreRarity] ?? 0)
-				)
-		}
-
-		// Compute per-structure profitability, each with its own volume and ore rows
-		const tataraProfile = profiles.find((p) => p.id === 'tatara')
-		const structures: StructureProfitability[] = []
-		for (const profile of profiles) {
-			const baseRate = parseFloat(profile.baseVolumePerHr) * (1 + parseFloat(profile.rigBonus))
-			const fuelPerHr = parseFloat(profile.fuelPerHr)
-			const magmaticGasPerHr = profile.magmaticGasPerHr ? parseFloat(profile.magmaticGasPerHr) : 0
-
-			const totalVolume = profile.isPassive
-				? baseRate * parseFloat(profile.nullsecModifier) * cycleHours
-				: baseRate * cycleHours
-			const fuelUnits = fuelPerHr * cycleHours
-			const magmaticGasUnits = profile.isPassive ? magmaticGasPerHr * cycleHours : 0
-
-			const ores = buildStructureOres(totalVolume, profile.isPassive)
-			const grossIsk = ores.reduce((sum, ore) => sum + parseFloat(ore.totalOreValue), 0)
-			const fuelCost = fuelUnits * fuelBlockPrice
-			const magmaticGasCost = magmaticGasUnits * magmaticGasPrice
-
-			structures.push({
-				structureType: profile.id,
-				cycleDays,
-				grossIsk: String(Math.round(grossIsk)),
-				fuelCost: String(Math.round(fuelCost)),
-				magmaticGasCost: profile.isPassive ? String(Math.round(magmaticGasCost)) : null,
-				profit: String(Math.round(grossIsk - fuelCost - magmaticGasCost)),
-				ores,
-			})
-		}
-
-		// Tatara ores drive the composition table (shows all materials incl. minerals)
-		const compositionOres = tataraProfile
-			? structures.find((s) => s.structureType === 'tatara')?.ores ?? []
-			: []
-
-		return {
-			ores: compositionOres,
-			structures,
-			updatedAt: new Date().toISOString(),
-		}
+		const inputs = await getMoonPricingInputs(env, universe, moonScan, [composition])
+		return getMoonProfitabilityInputsFromComposition(composition, inputs)
 	} catch (err) {
 		console.error('[computeProfitability] failed:', err)
 		return null

--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -14,10 +14,13 @@ import {
 	UpdateSRPConfigSchema,
 	WithdrawSRPRequestSchema,
 } from '@repo/srp'
+import { buildCsvLine, createR2MultipartTextWriter, parseDateOrNull } from '@repo/worker-utils'
 
 import { createDb } from '../db'
 import { managedCorporations, userCharacters } from '../db/schema'
+import { isExportArtifactExpired } from '../lib/export-retention'
 import { getCachedUserPermissions } from '../lib/groups-cache'
+import { normalizeWorkflowStatus } from '../lib/workflow-status'
 import { requireAllianceMember } from '../middleware/session'
 
 import type { Doctrines, FittingWithItems } from '@repo/doctrines'
@@ -74,9 +77,62 @@ function getPrimaryCharacterName(user: any): string {
 
 const SRP_ROLE_URNS = ['urn:srp:reviewer', 'urn:srp:payer', 'urn:srp:manager']
 const SRP_REQUEST_ID_PATTERN = /^\d+$/
+const SRP_CSV_EXPORT_MAX_RANGE_YEARS = 1
+
+function getExecutionContextOrNull(c: { executionCtx?: ExecutionContext }): ExecutionContext | null {
+	try {
+		return c.executionCtx ?? null
+	} catch {
+		return null
+	}
+}
 
 function isValidSrpRequestId(requestId: string): boolean {
 	return SRP_REQUEST_ID_PATTERN.test(requestId)
+}
+
+function normalizeUtcStartOfDay(date: Date): Date {
+	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0))
+}
+
+function normalizeUtcEndOfDay(date: Date): Date {
+	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999))
+}
+
+export function parseSrpCsvExportDateRange(dateFromRaw: string | undefined, dateToRaw: string | undefined): {
+	dateFrom: string
+	dateTo: string
+	startDate: Date
+	endDate: Date
+} | { error: string } {
+	if (!dateFromRaw || !dateToRaw) {
+		return { error: 'dateFrom and dateTo must be selected for CSV export' }
+	}
+
+	const dateFrom = parseDateOrNull(dateFromRaw)
+	const dateTo = parseDateOrNull(dateToRaw)
+	if (!dateFrom || !dateTo) {
+		return { error: 'dateFrom and dateTo must be valid dates' }
+	}
+
+	const startDate = normalizeUtcStartOfDay(dateFrom)
+	const endDate = normalizeUtcEndOfDay(dateTo)
+	if (endDate < startDate) {
+		return { error: 'dateTo must be on or after dateFrom' }
+	}
+
+	const maxEndDate = normalizeUtcEndOfDay(new Date(startDate.getTime()))
+	maxEndDate.setUTCFullYear(maxEndDate.getUTCFullYear() + SRP_CSV_EXPORT_MAX_RANGE_YEARS)
+	if (endDate > maxEndDate) {
+		return { error: 'CSV export date range cannot exceed 1 year' }
+	}
+
+	return {
+		dateFrom: dateFromRaw,
+		dateTo: dateToRaw,
+		startDate,
+		endDate,
+	}
 }
 
 async function enrichRequestsWithSystemRegions<T extends SRPRequestResponse>(
@@ -1499,6 +1555,499 @@ srp.get('/payments/pending-total', async (c) => {
 	return c.json({ pendingPayoutTotal })
 })
 
+const SRP_EXPORT_BUCKET_PREFIX = 'srp-exports'
+
+export function getSrpExportBucket(env: App['Bindings']): R2Bucket {
+	return env.SRP_EXPORTS
+}
+
+export interface SrpCsvExportDateRange {
+	dateFrom: string
+	dateTo: string
+	startDate: Date
+	endDate: Date
+}
+
+export interface SrpPaidRequestsExportFilters {
+	characterName?: string
+	shipTypeName?: string
+	solarSystemName?: string
+	dateRange: SrpCsvExportDateRange
+}
+
+export interface SrpWalletHistoryExportFilters {
+	reason?: string
+	recipientId?: string
+	alertsOnly?: boolean
+	dateRange: SrpCsvExportDateRange
+}
+
+export function buildSrpPaidRequestsExportKey(exportId: string): string {
+	return `${SRP_EXPORT_BUCKET_PREFIX}/paid-requests/${exportId}.csv`
+}
+
+export function buildSrpPaidRequestsExportFileName(dateFrom: string, dateTo: string): string {
+	return `srp-paid-requests-${dateFrom.slice(0, 10)}-${dateTo.slice(0, 10)}.csv`
+}
+
+export function buildSrpWalletHistoryExportKey(exportId: string): string {
+	return `${SRP_EXPORT_BUCKET_PREFIX}/wallet-history/${exportId}.csv`
+}
+
+export function buildSrpWalletHistoryExportFileName(dateFrom: string, dateTo: string): string {
+	return `srp-wallet-history-${dateFrom.slice(0, 10)}-${dateTo.slice(0, 10)}.csv`
+}
+
+export async function writeSrpPaidRequestsExportToBucket(args: {
+	bucket: R2Bucket
+	exportKey: string
+	fileName: string
+	expiresAt: string
+	env: App['Bindings']
+	filters: SrpPaidRequestsExportFilters
+}): Promise<number> {
+	const writer = await createR2MultipartTextWriter(args.bucket, args.exportKey, {
+		httpMetadata: {
+			contentType: 'text/csv; charset=utf-8',
+		},
+		customMetadata: {
+			fileName: args.fileName,
+			expiresAt: args.expiresAt,
+		},
+	})
+
+	const srpStub = getStub<Srp>(args.env.SRP, 'default')
+	let rowCount = 0
+
+	try {
+		await writer.writeLine(
+			buildCsvLine([
+				'userId',
+				'losingCharacterId',
+				'losingCharacterName',
+				'shipTypeId',
+				'shipTypeName',
+				'srpCapType',
+				'payoutModifierType',
+				'fullValue',
+				'paidValue',
+			])
+		)
+
+		const pageSize = 200
+		let offset = 0
+		for (;;) {
+			const result = await srpStub.getRequestsByStatus('paid', {
+				limit: pageSize,
+				offset,
+				characterName: args.filters.characterName,
+				shipTypeName: args.filters.shipTypeName,
+				solarSystemName: args.filters.solarSystemName,
+				dateFrom: args.filters.dateRange.startDate.toISOString(),
+				dateTo: args.filters.dateRange.endDate.toISOString(),
+			})
+			for (const request of result.requests) {
+				await writer.writeLine(
+					buildCsvLine([
+						request.userId,
+						request.characterId,
+						request.characterName,
+						request.shipTypeId,
+						request.shipTypeName,
+						request.appliedCapPolicyName ?? 'None',
+						request.appliedModifierPolicyName ?? 'None',
+						request.shipValue,
+						request.approvedAmount ?? '',
+					])
+				)
+				rowCount += 1
+			}
+			if (result.requests.length < pageSize || rowCount >= result.total) {
+				break
+			}
+			offset += pageSize
+		}
+
+		await writer.close()
+		return rowCount
+	} catch (error) {
+		await writer.abort().catch(() => {})
+		throw error
+	}
+}
+
+export async function writeSrpWalletHistoryExportToBucket(args: {
+	bucket: R2Bucket
+	exportKey: string
+	fileName: string
+	expiresAt: string
+	env: App['Bindings']
+	filters: SrpWalletHistoryExportFilters
+}): Promise<number> {
+	const writer = await createR2MultipartTextWriter(args.bucket, args.exportKey, {
+		httpMetadata: {
+			contentType: 'text/csv; charset=utf-8',
+		},
+		customMetadata: {
+			fileName: args.fileName,
+			expiresAt: args.expiresAt,
+		},
+	})
+
+	const srpStub = getStub<Srp>(args.env.SRP, 'default')
+	const config = await srpStub.getConfig()
+	const processorCorporationId = config?.paymentProcessorCorporationId?.trim() ?? ''
+	if (!processorCorporationId) {
+		await writer.abort().catch(() => {})
+		throw new Error('SRP payment processor corporation is not configured')
+	}
+
+	const db = createDb(args.env.DATABASE_URL)
+	let rowCount = 0
+	const whereParts = [
+		sql`corporation_id = ${processorCorporationId}`,
+		sql`ref_type = 'corporation_account_withdrawal'`,
+		sql`exists (
+			select 1
+			from user_characters recipient_char
+			where recipient_char.character_id = second_party_id
+		)`,
+	]
+	if (args.filters.reason) whereParts.push(sql`reason ilike ${`%${args.filters.reason}%`}`)
+	if (args.filters.recipientId) whereParts.push(sql`second_party_id = ${args.filters.recipientId}`)
+	whereParts.push(
+		sql`date >= ${args.filters.dateRange.startDate}`,
+		sql`date <= ${args.filters.dateRange.endDate}`,
+	)
+	const whereClause = sql.join(whereParts, sql` and `)
+
+	const [rowsResult, matchingRequestsResult, paymentAlertsResult] = await Promise.all([
+		db.execute<{
+			journalId: string
+			refType: string | null
+			amount: string
+			reason: string | null
+			recipientId: string | null
+			entryDate: Date
+		}>(sql`select
+				journal_id::text as "journalId",
+				ref_type as "refType",
+				amount as "amount",
+				reason as "reason",
+				second_party_id as "recipientId",
+				date as "entryDate"
+			from corporation_wallet_journal
+			where ${whereClause}
+			order by date desc`),
+		db.execute<{ id: string; characterId: string }>(
+			sql`select id::text as "id", character_id as "characterId"
+				from srp_requests
+				where id in (
+					select distinct substring(coalesce(reason, '') from 'KM#([0-9]+)')::text
+					from corporation_wallet_journal
+					where ${whereClause}
+						and reason ~ 'KM#[0-9]+'
+				)`
+		).catch(() => ({ rows: [] as Array<{ id: string; characterId: string }> })),
+		db.execute<{
+			journalId: string
+			kind: string
+			state: string
+			expectedAmount: string | null
+			observedAmount: string | null
+			expectedRecipientCharacterId: string | null
+			expectedRecipientCharacterName: string | null
+			actualRecipientCharacterId: string | null
+			actualRecipientCharacterName: string | null
+		}>(sql`select
+				journal_id::text as "journalId",
+				kind,
+				state,
+				expected_amount as "expectedAmount",
+				observed_amount as "observedAmount",
+				expected_recipient_character_id as "expectedRecipientCharacterId",
+				expected_recipient_character_name as "expectedRecipientCharacterName",
+				actual_recipient_character_id as "actualRecipientCharacterId",
+				actual_recipient_character_name as "actualRecipientCharacterName"
+			from srp_payment_alerts
+			where journal_id in (
+				select journal_id
+				from corporation_wallet_journal
+				where ${whereClause}
+			)`).catch(() => ({
+			rows: [] as Array<{
+				journalId: string
+				kind: string
+				state: string
+				expectedAmount: string | null
+				observedAmount: string | null
+				expectedRecipientCharacterId: string | null
+				expectedRecipientCharacterName: string | null
+				actualRecipientCharacterId: string | null
+				actualRecipientCharacterName: string | null
+			}>,
+		})),
+	])
+
+	const requestById = new Map(
+		(matchingRequestsResult.rows ?? []).map((row) => [row.id, row.characterId])
+	)
+	const alertKindsByJournalId = new Map<string, string[]>()
+	const paymentAlertDetailByJournalId = new Map<
+		string,
+		{
+			expectedAmount: string | null
+			observedAmount: string | null
+			expectedRecipientCharacterId: string | null
+			expectedRecipientCharacterName: string | null
+			actualRecipientCharacterId: string | null
+			actualRecipientCharacterName: string | null
+		}
+	>()
+	for (const row of paymentAlertsResult.rows ?? []) {
+		const existing = alertKindsByJournalId.get(row.journalId) ?? []
+		if (row.state === 'open' && !existing.includes(row.kind)) {
+			existing.push(row.kind)
+			alertKindsByJournalId.set(row.journalId, existing)
+		}
+		if (row.state === 'open' && !paymentAlertDetailByJournalId.has(row.journalId)) {
+			paymentAlertDetailByJournalId.set(row.journalId, {
+				expectedAmount: row.expectedAmount,
+				observedAmount: row.observedAmount,
+				expectedRecipientCharacterId: row.expectedRecipientCharacterId,
+				expectedRecipientCharacterName: row.expectedRecipientCharacterName,
+				actualRecipientCharacterId: row.actualRecipientCharacterId,
+				actualRecipientCharacterName: row.actualRecipientCharacterName,
+			})
+		}
+	}
+
+	const requestCharacterIds = [...new Set((matchingRequestsResult.rows ?? []).map((row) => row.characterId))]
+	const idsToResolve = [
+		...new Set(
+			[...rowsResult.rows.map((row) => row.recipientId), ...requestCharacterIds].filter(
+				(id): id is string => Boolean(id)
+			)
+		),
+	]
+	const resolver = getStub<EsiTypeResolver>(args.env.ESI_TYPE_RESOLVER, 'global')
+	const resolvedNames: Record<string, string> =
+		idsToResolve.length > 0 ? await resolver.resolveIds(idsToResolve).catch(() => ({})) : {}
+
+	const computedItems = rowsResult.rows.map((row) => {
+		const requestIdFromReason = (() => {
+			const reasonText = row.reason ?? ''
+			const match = reasonText.match(SRP_REQUEST_ID_IN_REASON_REGEX)
+			return match?.[1] ?? null
+		})()
+		const expectedRequestCharacterId = requestIdFromReason
+			? (requestById.get(requestIdFromReason) ?? null)
+			: null
+		const hasRecipientMismatch = Boolean(
+			expectedRequestCharacterId && row.recipientId && row.recipientId !== expectedRequestCharacterId
+		)
+		const hasMissingReasonWarning = Boolean(
+			row.refType === 'corporation_account_withdrawal' &&
+				row.recipientId &&
+				(!row.reason || row.reason.trim().length === 0)
+		)
+
+		return {
+			hasRecipientMismatch,
+			hasMissingReasonWarning,
+			linkedRequestId: (() => {
+				if (!requestIdFromReason) return null
+				return requestById.has(requestIdFromReason) ? requestIdFromReason : null
+			})(),
+			journalId: row.journalId,
+			refType: row.refType,
+			amount: row.amount,
+			reason: row.reason,
+			recipientId: row.recipientId,
+			recipientName: row.recipientId ? (resolvedNames[row.recipientId] ?? null) : null,
+			entryDate:
+				row.entryDate instanceof Date
+					? row.entryDate.toISOString()
+					: new Date(String(row.entryDate)).toISOString(),
+			matchingAlertKinds: alertKindsByJournalId.get(row.journalId) ?? [],
+			alertDetail:
+				paymentAlertDetailByJournalId.get(row.journalId) ??
+				(hasRecipientMismatch
+					? {
+							expectedAmount: null,
+							observedAmount: row.amount,
+							expectedRecipientCharacterId: expectedRequestCharacterId,
+							expectedRecipientCharacterName: expectedRequestCharacterId
+								? (resolvedNames[expectedRequestCharacterId] ?? null)
+								: null,
+							actualRecipientCharacterId: row.recipientId,
+							actualRecipientCharacterName: row.recipientId
+								? (resolvedNames[row.recipientId] ?? null)
+								: null,
+					  }
+					: null),
+			hasOpenAlert:
+				(alertKindsByJournalId.get(row.journalId) ?? []).length > 0 ||
+				hasRecipientMismatch,
+		}
+	})
+
+	const filteredItems = args.filters.alertsOnly
+		? computedItems.filter((item) => item.hasOpenAlert || item.hasMissingReasonWarning)
+		: computedItems
+
+	try {
+		await writer.writeLine(
+			buildCsvLine([
+				'entryDate',
+				'reason',
+				'recipientId',
+				'recipientName',
+				'amount',
+				'journalId',
+				'refType',
+				'hasOpenAlert',
+				'hasMissingReasonWarning',
+				'linkedRequestId',
+				'alertKinds',
+				'alertDetail',
+			])
+		)
+
+		for (const item of filteredItems) {
+			await writer.writeLine(
+				buildCsvLine([
+					item.entryDate,
+					item.reason,
+					item.recipientId,
+					item.recipientName,
+					item.amount,
+					item.journalId,
+					item.refType,
+					item.hasOpenAlert,
+					item.hasMissingReasonWarning,
+					item.linkedRequestId,
+					(item.matchingAlertKinds ?? []).join('|'),
+					item.alertDetail ? JSON.stringify(item.alertDetail) : '',
+				])
+			)
+			rowCount += 1
+		}
+
+		await writer.close()
+		return rowCount
+	} catch (error) {
+		await writer.abort().catch(() => {})
+		throw error
+	}
+}
+
+/**
+ * Start a paid SRP requests export workflow.
+ * POST /api/srp/requests/paid/export?characterName=&shipTypeName=&solarSystemName=&dateFrom=&dateTo=
+ */
+srp.post('/requests/paid/export', async (c) => {
+	const user = c.get('user')!
+	const canReview = await hasSrpTierPermission(c.env, user.id, 'reviewer', user.is_admin)
+	if (!canReview) return c.json({ error: 'Requires SRP staff permissions' }, 403)
+
+	const characterName = c.req.query('characterName')?.trim() || undefined
+	const shipTypeName = c.req.query('shipTypeName')?.trim() || undefined
+	const solarSystemName = c.req.query('solarSystemName')?.trim() || undefined
+	const dateFrom = c.req.query('dateFrom')?.trim() || undefined
+	const dateTo = c.req.query('dateTo')?.trim() || undefined
+	const dateRange = parseSrpCsvExportDateRange(dateFrom, dateTo)
+	if ('error' in dateRange) {
+		return c.json({ error: dateRange.error }, 400)
+	}
+
+	const workflow = await c.env.EXPORT_WORKFLOW.create({
+		params: {
+			kind: 'srp-paid-requests',
+			userId: user.id,
+			characterName,
+			shipTypeName,
+			solarSystemName,
+			dateFrom: dateRange.dateFrom,
+			dateTo: dateRange.dateTo,
+		},
+	})
+
+	return c.json(
+		{
+			workflowInstanceId: workflow.id,
+			exportId: workflow.id,
+			fileName: buildSrpPaidRequestsExportFileName(dateRange.dateFrom, dateRange.dateTo),
+			status: 'queued',
+		},
+		202
+	)
+})
+
+srp.get('/requests/paid/export/:workflowInstanceId', async (c) => {
+	const user = c.get('user')!
+	const canReview = await hasSrpTierPermission(c.env, user.id, 'reviewer', user.is_admin)
+	if (!canReview) return c.json({ error: 'Requires SRP staff permissions' }, 403)
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const workflow = await c.env.EXPORT_WORKFLOW.get(workflowInstanceId)
+	const status = await workflow.status()
+	const outputStatus =
+		status.output && typeof status.output === 'object' && 'status' in status.output
+			? String((status.output as { status?: string }).status ?? '')
+			: undefined
+	return c.json({
+		workflowInstanceId,
+		status: normalizeWorkflowStatus(status.status, outputStatus),
+		rawStatus: status.status,
+		output: status.output ?? null,
+	})
+})
+
+srp.get('/requests/paid/export/:workflowInstanceId/download', async (c) => {
+	const user = c.get('user')!
+	const canReview = await hasSrpTierPermission(c.env, user.id, 'reviewer', user.is_admin)
+	if (!canReview) return c.json({ error: 'Requires SRP staff permissions' }, 403)
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const bucket = getSrpExportBucket(c.env)
+	const exportKey = buildSrpPaidRequestsExportKey(workflowInstanceId)
+	const object = await bucket.get(exportKey)
+	if (!object) {
+		return c.json({ error: 'Export not found' }, 404)
+	}
+	if (isExportArtifactExpired(object.customMetadata?.expiresAt)) {
+		await bucket.delete(exportKey).catch(() => {})
+		return c.json({ error: 'Export expired' }, 404)
+	}
+
+	const fileName = object.customMetadata?.fileName ?? `${workflowInstanceId}.csv`
+	const response = new Response(object.body, {
+		status: 200,
+		headers: {
+			'Content-Type': object.httpMetadata?.contentType ?? 'text/csv; charset=utf-8',
+			'Content-Disposition': `attachment; filename="${fileName}"`,
+			'Cache-Control': 'no-store',
+		},
+	})
+	const executionCtx = getExecutionContextOrNull(c)
+	const cleanup = bucket.delete(exportKey).catch(() => {})
+	if (executionCtx) {
+		executionCtx.waitUntil(cleanup)
+	} else {
+		void cleanup
+	}
+	return response
+})
+
 /**
  * Wallet history for configured SRP payment processor corporation
  * GET /api/srp/payments/wallet-history?reason=&recipientId=&alertsOnly=false&dateFrom=&dateTo=&limit=50&offset=0
@@ -1766,6 +2315,112 @@ srp.get('/payments/wallet-history', async (c) => {
 		limit,
 		offset,
 	})
+})
+
+/**
+ * Start an SRP wallet history export workflow.
+ * POST /api/srp/payments/wallet-history/export?reason=&recipientId=&alertsOnly=false&dateFrom=&dateTo=
+ */
+srp.post('/payments/wallet-history/export', async (c) => {
+	const user = c.get('user')!
+	const canPay = await hasSrpTierPermission(c.env, user.id, 'payer', user.is_admin)
+	if (!canPay) return c.json({ error: 'Requires payer-or-higher permissions' }, 403)
+
+	const reason = c.req.query('reason')?.trim()
+	const recipientId = c.req.query('recipientId')?.trim()
+	const alertsOnly = c.req.query('alertsOnly') === 'true'
+	const dateFrom = c.req.query('dateFrom')?.trim()
+	const dateTo = c.req.query('dateTo')?.trim()
+	const dateRange = parseSrpCsvExportDateRange(dateFrom, dateTo)
+	if ('error' in dateRange) {
+		return c.json({ error: dateRange.error }, 400)
+	}
+
+	const workflow = await c.env.EXPORT_WORKFLOW.create({
+		params: {
+			kind: 'srp-wallet-history',
+			userId: user.id,
+			reason,
+			recipientId,
+			alertsOnly,
+			dateFrom: dateRange.dateFrom,
+			dateTo: dateRange.dateTo,
+		},
+	})
+
+	return c.json(
+		{
+			workflowInstanceId: workflow.id,
+			exportId: workflow.id,
+			fileName: buildSrpWalletHistoryExportFileName(dateRange.dateFrom, dateRange.dateTo),
+			status: 'queued',
+		},
+		202
+	)
+})
+
+srp.get('/payments/wallet-history/export/:workflowInstanceId', async (c) => {
+	const user = c.get('user')!
+	const canPay = await hasSrpTierPermission(c.env, user.id, 'payer', user.is_admin)
+	if (!canPay) return c.json({ error: 'Requires payer-or-higher permissions' }, 403)
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const workflow = await c.env.EXPORT_WORKFLOW.get(workflowInstanceId)
+	const status = await workflow.status()
+	const outputStatus =
+		status.output && typeof status.output === 'object' && 'status' in status.output
+			? String((status.output as { status?: string }).status ?? '')
+			: undefined
+	return c.json({
+		workflowInstanceId,
+		status: normalizeWorkflowStatus(status.status, outputStatus),
+		rawStatus: status.status,
+		output: status.output ?? null,
+	})
+})
+
+srp.get('/payments/wallet-history/export/:workflowInstanceId/download', async (c) => {
+	const user = c.get('user')!
+	const canPay = await hasSrpTierPermission(c.env, user.id, 'payer', user.is_admin)
+	if (!canPay) return c.json({ error: 'Requires payer-or-higher permissions' }, 403)
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const bucket = getSrpExportBucket(c.env)
+	const exportKey = buildSrpWalletHistoryExportKey(workflowInstanceId)
+	const object = await bucket.get(exportKey)
+	if (!object) {
+		return c.json({ error: 'Export not found' }, 404)
+	}
+	if (isExportArtifactExpired(object.customMetadata?.expiresAt)) {
+		await bucket.delete(exportKey).catch(() => {})
+		return c.json({ error: 'Export expired' }, 404)
+	}
+
+	const fileName = object.customMetadata?.fileName ?? `${workflowInstanceId}.csv`
+	const response = new Response(object.body, {
+		status: 200,
+		headers: {
+			'Content-Type': object.httpMetadata?.contentType ?? 'text/csv; charset=utf-8',
+			'Content-Disposition': `attachment; filename="${fileName}"`,
+			'Cache-Control': 'no-store',
+		},
+	})
+	const executionCtx = getExecutionContextOrNull(c)
+	const cleanup = bucket.delete(exportKey).catch(() => {})
+	if (executionCtx) {
+		executionCtx.waitUntil(cleanup)
+	} else {
+		void cleanup
+	}
+	return response
 })
 
 /**

--- a/apps/core/src/workflows/csv-export.workflow.ts
+++ b/apps/core/src/workflows/csv-export.workflow.ts
@@ -1,0 +1,262 @@
+import { WorkflowEntrypoint } from 'cloudflare:workers'
+
+import { getStub } from '@repo/do-utils'
+
+import { getExportArtifactExpiresAtIso } from '../lib/export-retention'
+
+import {
+	buildVerifiedMoonsExportFileName,
+	buildVerifiedMoonsExportKey,
+	getVerifiedMoonsExportBucket,
+	buildVerifiedMoonSummaryRecords,
+	type VerifiedMoonsExportQuery,
+	writeVerifiedMoonsExportToBucket,
+} from '../routes/moon-scan'
+import {
+	buildSrpPaidRequestsExportFileName,
+	buildSrpPaidRequestsExportKey,
+	buildSrpWalletHistoryExportFileName,
+	buildSrpWalletHistoryExportKey,
+	getSrpExportBucket,
+	parseSrpCsvExportDateRange,
+	writeSrpPaidRequestsExportToBucket,
+	writeSrpWalletHistoryExportToBucket,
+} from '../routes/srp'
+
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import type { MoonScanDO } from '@repo/moon-scan'
+import type { Universe } from '@repo/universe'
+import type { Env } from '../context'
+
+export type CsvExportWorkflowParams =
+	| {
+			kind: 'moon-scan-verified'
+			userId: string
+			query: VerifiedMoonsExportQuery
+	  }
+	| {
+			kind: 'srp-paid-requests'
+			userId: string
+			characterName?: string
+			shipTypeName?: string
+			solarSystemName?: string
+			dateFrom: string
+			dateTo: string
+	  }
+	| {
+			kind: 'srp-wallet-history'
+			userId: string
+			reason?: string
+			recipientId?: string
+			alertsOnly?: boolean
+			dateFrom: string
+			dateTo: string
+	  }
+
+export type CsvExportWorkflowKind = CsvExportWorkflowParams['kind']
+
+type ExportWorkflowStatus = 'completed' | 'failed'
+
+export interface CsvExportWorkflowResult {
+	status: ExportWorkflowStatus
+	workflowInstanceId: string
+	kind: CsvExportWorkflowKind
+	exportId: string
+	fileName: string
+	expiresAt: string | null
+	rowCount: number
+	error?: {
+		message: string
+		stack?: string
+	}
+}
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+	const chunks: T[][] = []
+	for (let index = 0; index < items.length; index += size) {
+		chunks.push(items.slice(index, index + size) as T[])
+	}
+	return chunks
+}
+
+async function runMoonScanExport(
+	env: Env,
+	workflowInstanceId: string,
+	query: VerifiedMoonsExportQuery
+): Promise<{ fileName: string; expiresAt: string; rowCount: number }> {
+	const moonScan = getStub<MoonScanDO>(env.MOON_SCAN, 'default')
+	const universe = getStub<Universe>(env.UNIVERSE, 'default')
+	const expiresAt = getExportArtifactExpiresAtIso()
+
+	try {
+		const [scanSummary, summaryMoonIds] = await Promise.all([
+			moonScan.getScanSummary(),
+			moonScan.getVerifiedMoonSummaryIds(),
+		])
+		const summaryMoonIdSet = new Set(summaryMoonIds)
+		const missingMoonIds = scanSummary.verifiedMoonIds.filter((moonId) => !summaryMoonIdSet.has(moonId))
+		if (missingMoonIds.length > 0) {
+			for (const missingMoonIdChunk of chunkArray(missingMoonIds, 250)) {
+				const missingCompositions = await moonScan.getVerifiedCompositions(missingMoonIdChunk)
+				const summaryRecords = await buildVerifiedMoonSummaryRecords(missingCompositions, universe)
+				await moonScan.upsertVerifiedMoonSummaries(summaryRecords)
+			}
+		}
+	} catch (error) {
+		console.warn('Failed to backfill moon summary export read model', {
+			error,
+		})
+	}
+
+	const exportKey = buildVerifiedMoonsExportKey(workflowInstanceId)
+	const fileName = buildVerifiedMoonsExportFileName(workflowInstanceId)
+	const bucket = getVerifiedMoonsExportBucket(env)
+	return {
+		fileName,
+		expiresAt,
+		rowCount: await writeVerifiedMoonsExportToBucket({
+			bucket,
+			exportKey,
+			fileName,
+			expiresAt,
+			moonScan,
+			universe,
+			env,
+			query,
+		}),
+	}
+}
+
+async function runSrpPaidRequestsExport(
+	env: Env,
+	workflowInstanceId: string,
+	params: Extract<CsvExportWorkflowParams, { kind: 'srp-paid-requests' }>
+): Promise<{ fileName: string; expiresAt: string; rowCount: number }> {
+	const dateRange = parseSrpCsvExportDateRange(params.dateFrom, params.dateTo)
+	if ('error' in dateRange) {
+		throw new Error(dateRange.error)
+	}
+
+	const expiresAt = getExportArtifactExpiresAtIso()
+	const bucket = getSrpExportBucket(env)
+	const exportKey = buildSrpPaidRequestsExportKey(workflowInstanceId)
+	const fileName = buildSrpPaidRequestsExportFileName(params.dateFrom, params.dateTo)
+	return {
+		fileName,
+		expiresAt,
+		rowCount: await writeSrpPaidRequestsExportToBucket({
+			bucket,
+			exportKey,
+			fileName,
+			expiresAt,
+			env,
+			filters: {
+				dateRange,
+				characterName: params.characterName,
+				shipTypeName: params.shipTypeName,
+				solarSystemName: params.solarSystemName,
+			},
+		}),
+	}
+}
+
+async function runSrpWalletHistoryExport(
+	env: Env,
+	workflowInstanceId: string,
+	params: Extract<CsvExportWorkflowParams, { kind: 'srp-wallet-history' }>
+): Promise<{ fileName: string; expiresAt: string; rowCount: number }> {
+	const dateRange = parseSrpCsvExportDateRange(params.dateFrom, params.dateTo)
+	if ('error' in dateRange) {
+		throw new Error(dateRange.error)
+	}
+
+	const expiresAt = getExportArtifactExpiresAtIso()
+	const bucket = getSrpExportBucket(env)
+	const exportKey = buildSrpWalletHistoryExportKey(workflowInstanceId)
+	const fileName = buildSrpWalletHistoryExportFileName(params.dateFrom, params.dateTo)
+	return {
+		fileName,
+		expiresAt,
+		rowCount: await writeSrpWalletHistoryExportToBucket({
+			bucket,
+			exportKey,
+			fileName,
+			expiresAt,
+			env,
+			filters: {
+				dateRange,
+				reason: params.reason,
+				recipientId: params.recipientId,
+				alertsOnly: params.alertsOnly,
+			},
+		}),
+	}
+}
+
+export class CsvExportWorkflow extends WorkflowEntrypoint<Env, CsvExportWorkflowParams> {
+	async run(
+		event: WorkflowEvent<CsvExportWorkflowParams>,
+		step: WorkflowStep
+	): Promise<CsvExportWorkflowResult> {
+		const workflowInstanceId = event.instanceId
+		const payload = event.payload
+
+		await step.do('init-workflow', async () => ({
+			kind: payload.kind,
+			workflowInstanceId,
+			startedAt: new Date().toISOString(),
+		}))
+
+		try {
+			const result = await step.do(
+				'write-export-artifact',
+				{
+					retries: {
+						limit: 3,
+						delay: '5 seconds',
+						backoff: 'exponential',
+					},
+					timeout: '30 minutes',
+				},
+				async () => {
+					switch (payload.kind) {
+						case 'moon-scan-verified':
+							return await runMoonScanExport(
+								this.env,
+								workflowInstanceId,
+								payload.query
+							)
+						case 'srp-paid-requests':
+							return await runSrpPaidRequestsExport(this.env, workflowInstanceId, payload)
+						case 'srp-wallet-history':
+							return await runSrpWalletHistoryExport(this.env, workflowInstanceId, payload)
+					}
+				}
+			)
+
+			return {
+				status: 'completed',
+				workflowInstanceId,
+				kind: payload.kind,
+				exportId: workflowInstanceId,
+				fileName: result.fileName,
+				expiresAt: result.expiresAt,
+				rowCount: result.rowCount,
+			}
+		} catch (error) {
+			return {
+				status: 'failed',
+				workflowInstanceId,
+				kind: payload.kind,
+				exportId: workflowInstanceId,
+				fileName: workflowInstanceId,
+				expiresAt: null,
+				rowCount: 0,
+				error: {
+					message: error instanceof Error ? error.message : String(error),
+					stack: error instanceof Error ? error.stack : undefined,
+				},
+			}
+		}
+	}
+}

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -39,6 +39,16 @@
 		"PM_FORUM_GUILD_ID": "356398105404375041",
 		"PM_FORUM_CATEGORY_ID": "1524076742745260093"
 	},
+	"r2_buckets": [
+		{
+			"binding": "MOON_SCAN_EXPORTS",
+			"bucket_name": "moon-scan-exports"
+		},
+		{
+			"binding": "SRP_EXPORTS",
+			"bucket_name": "srp-exports"
+		}
+	],
 	"durable_objects": {
 		"bindings": [
 			{
@@ -206,6 +216,11 @@
 		}
 	],
 	"workflows": [
+		{
+			"name": "csv-export-workflow",
+			"binding": "EXPORT_WORKFLOW",
+			"class_name": "CsvExportWorkflow"
+		},
 		{
 			"name": "user-refresh-workflow",
 			"binding": "USER_REFRESH_WORKFLOW",

--- a/apps/hr/src/durable-object.ts
+++ b/apps/hr/src/durable-object.ts
@@ -300,12 +300,14 @@ export class HrDO extends DurableObject<Env> implements Hr {
 	async getApplicationForRecommender(
 		applicationId: string,
 		userId: string,
-		userCorporationIds: string[]
+		userCorporationIds: string[],
+		access?: { isAdmin: boolean; isAuditor: boolean }
 	): Promise<RecommenderApplicationDetail> {
 		return await this.applicationService.getApplicationForRecommender(
 			applicationId,
 			userId,
-			userCorporationIds
+			userCorporationIds,
+			access
 		)
 	}
 

--- a/apps/hr/src/services/application.service.ts
+++ b/apps/hr/src/services/application.service.ts
@@ -9,6 +9,7 @@ import type {
 	ApplicationFilters,
 	ApplicationListResult,
 	ApplicationStatus,
+	HrAccessContext,
 	RecommendableApplication,
 	RecommendationSentiment,
 	RecommenderApplicationDetail,
@@ -649,7 +650,8 @@ export class ApplicationService {
 	async getApplicationForRecommender(
 		applicationId: string,
 		userId: string,
-		userCorporationIds: string[]
+		userCorporationIds: string[],
+		access: HrAccessContext = { isAdmin: false, isAuditor: false }
 	): Promise<RecommenderApplicationDetail> {
 		const application = await this.ctx.db.query.applications.findFirst({
 			where: eq(applications.id, applicationId),
@@ -659,8 +661,12 @@ export class ApplicationService {
 			throw new Error('Application not found')
 		}
 
-		// Verify the user is in the same corporation
-		if (!userCorporationIds.includes(application.corporationId)) {
+		// Site admins and HR auditors can recommend against any member corporation target.
+		// All other users must be attached to the target corporation.
+		const hasCorporationAccess =
+			access.isAdmin || access.isAuditor || userCorporationIds.includes(application.corporationId)
+
+		if (!hasCorporationAccess) {
 			throw new Error('You do not have permission to view this application')
 		}
 

--- a/apps/ui/src/client/components/tax-member-summary/member-summary-grid-card.tsx
+++ b/apps/ui/src/client/components/tax-member-summary/member-summary-grid-card.tsx
@@ -14,6 +14,8 @@ type MemberSummaryStats = {
 
 type MemberSummaryGridCardProps = {
 	effectiveCorporationId?: string
+	isScopeLoading?: boolean
+	canViewSummary: boolean
 	canSearchCharacter: boolean
 	characterQuery: string
 	fromDateIso?: string
@@ -61,13 +63,16 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 					| 'assessmentCount'
 					| 'lastAssessmentAt') ?? 'contributionIncome',
 			sortDir: grid.sortDir,
-			enabled: Boolean(props.effectiveCorporationId),
+			enabled: Boolean(props.effectiveCorporationId) && props.canViewSummary,
 		}
 	)
 
 	useEffect(() => {
+		if (!props.effectiveCorporationId || !props.canViewSummary) {
+			return
+		}
 		void refetch()
-	}, [props.refreshToken, refetch])
+	}, [props.canViewSummary, props.effectiveCorporationId, props.refreshToken, refetch])
 
 	const rows = useMemo(() => data?.rows ?? [], [data?.rows])
 	const totalRows = data?.totalRows ?? 0
@@ -85,7 +90,7 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 	}, [rows])
 
 	const { data: entityNames = {} } = useEntityNames(entityIds, {
-		enabled: Boolean(props.effectiveCorporationId),
+		enabled: Boolean(props.effectiveCorporationId) && props.canViewSummary && entityIds.length > 0,
 	})
 
 	useEffect(() => {
@@ -111,16 +116,28 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 
 	return (
 		<Card>
-			<CardHeader>
-				<CardTitle>Member Contribution Summary</CardTitle>
-				<CardDescription>
-					Aggregated from corporation wallet entries attributed to members in the selected period.
-				</CardDescription>
+			<CardHeader className="space-y-3">
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+					<div className="space-y-1">
+						<CardTitle>Member Contribution Summary</CardTitle>
+						<CardDescription>
+							Aggregated from corporation wallet entries attributed to members in the selected period.
+						</CardDescription>
+					</div>
+				</div>
 			</CardHeader>
 			<CardContent>
-				{!props.effectiveCorporationId ? (
+				{props.isScopeLoading ? (
+					<div className="py-8 text-sm text-muted-foreground">
+						Resolving corporation access before loading member summaries.
+					</div>
+				) : !props.effectiveCorporationId ? (
 					<div className="py-8 text-sm text-muted-foreground">
 						Select a corporation to load member summaries.
+					</div>
+				) : !props.canViewSummary ? (
+					<div className="py-8 text-sm text-muted-foreground">
+						You do not have permission to view this member summary.
 					</div>
 				) : (
 					<MemberSummaryReportGrid

--- a/apps/ui/src/client/dev/tax-demo-mode.ts
+++ b/apps/ui/src/client/dev/tax-demo-mode.ts
@@ -1975,6 +1975,9 @@ export const taxDemoApi = {
 			sortDir?: 'asc' | 'desc'
 		}
 	) {
+		if (!corporationId?.trim()) {
+			throw new Error('Corporation id is required for member summary')
+		}
 		const query = filters?.characterQuery?.trim()
 		let rows = ensureDemoState().memberSummary.filter((row) => {
 			if (row.corporationId !== corporationId) return false

--- a/apps/ui/src/client/features/moon-scan/api.ts
+++ b/apps/ui/src/client/features/moon-scan/api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api'
+import { downloadTextFile } from '@/lib/csv-utils'
 
 import type {
 	AdminSettings,
@@ -42,6 +43,54 @@ export async function getScannedMoons(params: {
 	if (params.sortDir) qs.set('sortDir', params.sortDir)
 	const query = qs.toString()
 	return apiClient.get(`/moon-scan/moons/verified${query ? `?${query}` : ''}`)
+}
+
+export async function requestScannedMoonsExport(params: {
+	regionId?: string
+	constellationId?: string
+	rarities?: string[]
+	search?: string
+	sortBy?: string
+	sortDir?: 'asc' | 'desc'
+} = {}): Promise<{ workflowInstanceId: string; exportId: string; fileName: string; status: 'queued' }> {
+	const qs = new URLSearchParams()
+	if (params.regionId && params.regionId !== 'all') qs.set('regionId', params.regionId)
+	if (params.constellationId && params.constellationId !== 'all') qs.set('constellationId', params.constellationId)
+	if (params.rarities && params.rarities.length > 0) qs.set('rarity', params.rarities.join(','))
+	if (params.search?.trim()) qs.set('search', params.search.trim())
+	if (params.sortBy) qs.set('sortBy', params.sortBy)
+	if (params.sortDir) qs.set('sortDir', params.sortDir)
+
+	const query = qs.toString()
+	return apiClient.post(`/moon-scan/moons/verified/export${query ? `?${query}` : ''}`, {})
+}
+
+export async function getScannedMoonsExportStatus(workflowInstanceId: string): Promise<{
+	workflowInstanceId: string
+	status: 'queued' | 'running' | 'completed' | 'failed' | 'unknown'
+	rawStatus?: string
+	output: unknown | null
+}> {
+	return apiClient.get(`/moon-scan/moons/verified/export/${workflowInstanceId}`)
+}
+
+export async function downloadScannedMoonsExport(
+	workflowInstanceId: string,
+	fileName: string
+): Promise<void> {
+	const response = await fetch(`/api/moon-scan/moons/verified/export/${workflowInstanceId}/download`, {
+		credentials: 'include',
+		headers: {
+			'X-Requested-With': 'XMLHttpRequest',
+		},
+	})
+	if (!response.ok) {
+		const message = await response.text()
+		throw new Error(message || 'Failed to download scanned moons export')
+	}
+
+	const csv = await response.text()
+	downloadTextFile(fileName, 'text/csv; charset=utf-8', csv)
 }
 
 export async function getRegions(): Promise<RegionsResponse> {

--- a/apps/ui/src/client/features/moon-scan/export.ts
+++ b/apps/ui/src/client/features/moon-scan/export.ts
@@ -1,0 +1,74 @@
+import { buildCsv } from '@/lib/csv-utils'
+
+import type { MoonDetail, ScannedMoonEntry } from './types'
+
+export type MoonDetailById = Record<string, MoonDetail | null | undefined>
+
+export function buildScannedMoonsCsv(items: ScannedMoonEntry[], detailsByMoonId: MoonDetailById): string {
+	const headers = [
+		'regionId',
+		'regionName',
+		'solarSystemId',
+		'solarSystemName',
+		'moonId',
+		'moonName',
+		'securityStatus',
+		'highestRarity',
+		'metenoxProfit',
+		'tataraProfit',
+		'oreTypeId',
+		'oreTypeName',
+		'oreRarity',
+		'oreCompositionPercent',
+		'oreTotalOreValue',
+	]
+
+	const rows: Array<Array<string | number | boolean | null | undefined>> = []
+
+	for (const moon of items) {
+		const detail = detailsByMoonId[moon.moonId]
+		const ores = detail?.profitability?.ores ?? []
+		if (ores.length === 0) {
+			rows.push([
+				moon.regionId,
+				moon.regionName,
+				moon.solarSystemId,
+				moon.solarSystemName,
+				moon.moonId,
+				moon.moonName,
+				moon.securityStatus ?? '',
+				moon.highestRarity ?? '',
+				moon.metenoxProfit ?? '',
+				moon.tataraProfit ?? '',
+				'',
+				'',
+				'',
+				'',
+				'',
+			])
+			continue
+		}
+
+		for (const ore of ores) {
+			rows.push([
+				moon.regionId,
+				moon.regionName,
+				moon.solarSystemId,
+				moon.solarSystemName,
+				moon.moonId,
+				moon.moonName,
+				moon.securityStatus ?? '',
+				moon.highestRarity ?? '',
+				moon.metenoxProfit ?? '',
+				moon.tataraProfit ?? '',
+				ore.oreTypeId,
+				ore.oreName,
+				ore.rarity ?? '',
+				`${(Number.parseFloat(ore.quantity) * 100).toFixed(2)}%`,
+				ore.totalOreValue,
+			])
+		}
+	}
+
+	return buildCsv(headers, rows)
+}

--- a/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
@@ -1,10 +1,13 @@
-import { Fragment, useMemo, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ArrowDown, ArrowUp, ChevronDown, ChevronRight } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
+import { HoverPopover } from '@/components/ui/hover-popover'
 import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
 import { Select } from '@/components/ui/select'
@@ -20,8 +23,14 @@ import {
 import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { formatISK } from '@/lib/format-utils'
+import toast from '@/lib/toast'
 
 import { RARITY_COLORS } from '../ore-rarities'
+import {
+	downloadScannedMoonsExport,
+	getScannedMoonsExportStatus,
+	requestScannedMoonsExport,
+} from '../api'
 import { useScannedMoons, useMoonRegions } from '../hooks'
 import { useMoonScanPermissions } from '../permissions'
 import { parseSecurityStatus, securityStatusTextClass } from '../security-status'
@@ -107,6 +116,50 @@ export default function ScannedMoonsPage() {
 	const [sortDir, setSortDir] = useState<SortDir>('asc')
 	const [viewMode, setViewMode] = useState<ViewMode>('grouped')
 	const [collapsedConstellations, setCollapsedConstellations] = useState<Set<string>>(new Set())
+	const [pendingExport, setPendingExport] = useState<{ workflowInstanceId: string; fileName: string } | null>(null)
+	const [isExporting, setIsExporting] = useState(false)
+
+	const exportStatusQuery = useQuery({
+		queryKey: ['moon-scan', 'verified-moons', 'export-status', pendingExport?.workflowInstanceId ?? null],
+		queryFn: () => getScannedMoonsExportStatus(pendingExport!.workflowInstanceId),
+		enabled: Boolean(pendingExport?.workflowInstanceId),
+		refetchInterval: (query) => {
+			const status = query.state.data?.status
+			return status === 'queued' || status === 'running' ? 5000 : false
+		},
+		refetchOnWindowFocus: false,
+	})
+	const exportStatus = exportStatusQuery.data?.status
+	const isExportPolling =
+		Boolean(pendingExport) && (exportStatus === undefined || exportStatus === 'queued' || exportStatus === 'running')
+	const isExportBusy = isExporting || isExportPolling
+
+	useEffect(() => {
+		if (!pendingExport) return
+		if (!exportStatusQuery.data) return
+		if (exportStatusQuery.data.status === 'completed') {
+			void (async () => {
+				try {
+					await downloadScannedMoonsExport(pendingExport.workflowInstanceId, pendingExport.fileName)
+					toast.success('Scanned moons export ready')
+				} catch (error) {
+					const messageText =
+						error instanceof Error ? error.message : 'Failed to download scanned moons export'
+					toast.error(messageText)
+					console.error('[MoonScan] Failed to download scanned moons export', error)
+				} finally {
+					setPendingExport(null)
+					setIsExporting(false)
+				}
+			})()
+			return
+		}
+		if (exportStatusQuery.data.status === 'failed' || exportStatusQuery.data.status === 'unknown') {
+			toast.error('Scanned moons export failed')
+			setPendingExport(null)
+			setIsExporting(false)
+		}
+	}, [exportStatusQuery.data, pendingExport])
 
 	const toggleRarity = (rarity: OreRarity) => {
 		setSelectedRarities((prev) =>
@@ -177,6 +230,9 @@ export default function ScannedMoonsPage() {
 
 	const totalCount = data?.total ?? 0
 	const hasPagination = Math.ceil(totalCount / pageSize) > 1
+	const hasExportScope = regionFilter !== 'all' || constellationFilter !== 'all'
+	const canExportCsv = canView && hasExportScope
+	const exportHelpMessage = 'Select a region or constellation to export this scope.'
 	const toggleSort = (column: SortBy) => {
 		if (sortBy === column) {
 			setSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))
@@ -225,6 +281,41 @@ export default function ScannedMoonsPage() {
 			itemLabel="moons"
 		/>
 	)
+	const handleExport = useCallback(async () => {
+		if (!canExportCsv || isExporting) {
+			return
+		}
+
+		setIsExporting(true)
+		try {
+			const exportResult = await requestScannedMoonsExport({
+				regionId: regionFilter,
+				constellationId: constellationFilter,
+				rarities: selectedRarities,
+				search,
+				sortBy,
+				sortDir,
+			})
+			setPendingExport({
+				workflowInstanceId: exportResult.workflowInstanceId,
+				fileName: exportResult.fileName,
+			})
+		} catch (error) {
+			const messageText = error instanceof Error ? error.message : 'Failed to export scanned moons'
+			toast.error(messageText)
+			console.error('[MoonScan] Failed to export scanned moons', error)
+			setIsExporting(false)
+		}
+	}, [
+		canExportCsv,
+		constellationFilter,
+		isExporting,
+		regionFilter,
+		search,
+		selectedRarities,
+		sortBy,
+		sortDir,
+	])
 
 	if (!canView) {
 		return (
@@ -239,13 +330,50 @@ export default function ScannedMoonsPage() {
 			<PageHeader
 				title="Scanned Moons"
 				description="All verified moon compositions with profitability estimates"
+				action={
+					<div className="flex items-center gap-3">
+						{isExportPolling && (
+							<span className="text-xs text-muted-foreground">Waiting for export to generate...</span>
+						)}
+						{!canExportCsv && !isExportBusy ? (
+							<HoverPopover
+								align="end"
+								side="bottom"
+								className="w-72 border border-border bg-popover p-3 text-popover-foreground shadow-lg"
+								trigger={
+									<span className="inline-block cursor-help">
+										<Button type="button" variant="ghost" disabled>
+											Export CSV
+										</Button>
+									</span>
+								}
+							>
+								<div className="text-sm font-medium">Export scope required</div>
+								<div className="text-sm text-muted-foreground">{exportHelpMessage}</div>
+							</HoverPopover>
+						) : (
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={() => {
+									void handleExport()
+								}}
+								disabled={!canExportCsv || isExportBusy}
+								loading={isExportBusy}
+								loadingText={isExporting ? 'Exporting…' : 'Generating…'}
+							>
+								Export CSV
+							</Button>
+						)}
+					</div>
+				}
 			/>
 
 			{error && (
 				<div className="mt-4 rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-sm text-red-500">
 					Failed to load moon data
 				</div>
-			)}
+				)}
 
 			{/* Filters */}
 			<div className="mt-section flex flex-wrap items-center gap-3">
@@ -348,7 +476,7 @@ export default function ScannedMoonsPage() {
 				</div>
 
 				{!isLoading && data && (
-					<span className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+					<span className="flex items-center gap-2 text-xs text-muted-foreground">
 						{isFetching && (
 							<span
 								className="inline-block h-2 w-2 animate-pulse rounded-full bg-primary"

--- a/apps/ui/src/client/features/srp/routes/review.tsx
+++ b/apps/ui/src/client/features/srp/routes/review.tsx
@@ -1,6 +1,6 @@
 import { Loader2, RefreshCw } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
 
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
@@ -9,6 +9,7 @@ import { DateRangeInput } from '@/components/ui/date-range-input'
 import { Card, CardContent } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { EveTimeDisplay } from '@/components/ui/eve-time-display'
+import { HoverPopover } from '@/components/ui/hover-popover'
 import { PageHeader } from '@/components/ui/page-header'
 import { Select } from '@/components/ui/select'
 import {
@@ -38,7 +39,7 @@ import {
 	useReviewQueueUiState,
 	updateReviewQueueFilters,
 } from '../state/review-queue-snapshot-store'
-import { formatISKShort, formatRelativeTime, getRequestCharacterRole } from '../utils'
+import { formatISKShort, formatRelativeTime, getRequestCharacterRole, isDateRangeWithinOneYear } from '../utils'
 
 import type { RequestStatus, SRPRequestResponse } from '../types'
 
@@ -282,6 +283,85 @@ function ReviewTabContent({
 		gcTime: 1000 * 60 * 5,
 	})
 	const [showLoadWarning, setShowLoadWarning] = useState(false)
+	const [pendingExport, setPendingExport] = useState<{
+		workflowInstanceId: string
+		fileName: string
+	} | null>(null)
+	const [isExporting, setIsExporting] = useState(false)
+
+	const exportStatusQuery = useQuery({
+		queryKey: ['srp', 'requests', 'paid', 'export-status', pendingExport?.workflowInstanceId ?? null],
+		queryFn: () => api.getSrpPaidRequestsCsvExportStatus(pendingExport!.workflowInstanceId),
+		enabled: Boolean(pendingExport?.workflowInstanceId),
+		refetchInterval: (query) => {
+			const status = query.state.data?.status
+			return status === 'queued' || status === 'running' ? 5000 : false
+		},
+		refetchOnWindowFocus: false,
+	})
+	const exportStatus = exportStatusQuery.data?.status
+	const isExportPolling =
+		Boolean(pendingExport) && (exportStatus === undefined || exportStatus === 'queued' || exportStatus === 'running')
+	const isExportBusy = isExporting || isExportPolling
+
+	useEffect(() => {
+		if (!pendingExport) return
+		if (!exportStatusQuery.data) return
+		if (exportStatusQuery.data.status === 'completed') {
+			void (async () => {
+				try {
+					await api.downloadSrpPaidRequestsCsv(
+						pendingExport.workflowInstanceId,
+						pendingExport.fileName
+					)
+				} finally {
+					setPendingExport(null)
+					setIsExporting(false)
+				}
+			})()
+			return
+		}
+		if (exportStatusQuery.data.status === 'failed' || exportStatusQuery.data.status === 'unknown') {
+			setPendingExport(null)
+			setIsExporting(false)
+		}
+	}, [exportStatusQuery.data, pendingExport])
+
+	const handleExportPaidRequests = useCallback(async () => {
+		if (status !== 'paid' || isExporting) {
+			return
+		}
+		const dateFrom = filters.dateFrom
+		const dateTo = filters.dateTo
+		if (!dateFrom || !dateTo || !isDateRangeWithinOneYear(dateFrom, dateTo)) {
+			return
+		}
+
+		setIsExporting(true)
+		try {
+			const exportResult = await api.requestSrpPaidRequestsCsvExport({
+				characterName: filters.characterName?.trim() || undefined,
+				shipTypeName: filters.shipTypeName?.trim() || undefined,
+				solarSystemName: filters.solarSystemName?.trim() || undefined,
+				dateFrom,
+				dateTo,
+			})
+			setPendingExport({
+				workflowInstanceId: exportResult.workflowInstanceId,
+				fileName: exportResult.fileName,
+			})
+		} catch {
+			setIsExporting(false)
+		}
+	}, [
+		filters.characterName,
+		filters.dateFrom,
+		filters.dateTo,
+		filters.shipTypeName,
+		filters.solarSystemName,
+		isExporting,
+		status,
+	])
 
 	useEffect(() => {
 		if (!data) return
@@ -332,6 +412,62 @@ function ReviewTabContent({
 			<span className="ml-2">Refresh</span>
 		</Button>
 	)
+	const actionButtons =
+		status === 'paid' ? (
+			<div className="flex items-center gap-2">
+				{refreshButton}
+				<div className="flex items-center gap-3">
+					{isExportPolling && (
+						<span className="text-xs text-muted-foreground">Waiting for export to generate...</span>
+					)}
+					{!isExportBusy &&
+					(!filters.dateFrom ||
+						!filters.dateTo ||
+						!isDateRangeWithinOneYear(filters.dateFrom, filters.dateTo)) ? (
+						<HoverPopover
+							align="end"
+							side="bottom"
+							className="w-72 border border-border bg-popover p-3 text-popover-foreground shadow-lg"
+							trigger={
+								<span className="inline-block cursor-help">
+									<Button type="button" variant="secondary" size="sm" className="h-8" disabled>
+										Export CSV
+									</Button>
+								</span>
+							}
+						>
+							<div className="text-sm font-medium">Date range required</div>
+							<div className="text-sm text-muted-foreground">
+								Select a date range up to 1 year to export paid requests.
+							</div>
+						</HoverPopover>
+					) : (
+						<Button
+							type="button"
+							variant="secondary"
+							size="sm"
+							className="h-8"
+							onClick={() => {
+								void handleExportPaidRequests()
+							}}
+							disabled={
+								isFetching ||
+								isExportBusy ||
+								!filters.dateFrom ||
+								!filters.dateTo ||
+								!isDateRangeWithinOneYear(filters.dateFrom, filters.dateTo)
+							}
+							loading={isExportBusy}
+							loadingText={isExporting ? 'Exporting…' : 'Generating…'}
+						>
+							Export CSV
+						</Button>
+					)}
+				</div>
+			</div>
+		) : (
+			refreshButton
+		)
 
 	if (!effectiveData && (isLoading || isFetching)) {
 		if (showLoadWarning) {
@@ -399,146 +535,145 @@ function ReviewTabContent({
 						? 'No requests match the current filters'
 						: `No ${status.replace('_', ' ')} requests`}
 				</p>
-				<div className="mt-4 flex justify-center">{refreshButton}</div>
+				<div className="mt-4 flex justify-center">{actionButtons}</div>
 			</div>
 		)
 	}
 
-		return (
-			<div>
-				<TableRefreshFrame
-					isRefreshing={isSoftLoading}
-					refreshMessage="Refreshing recent losses..."
-					errorMessage={error && effectiveData ? (error instanceof Error ? error.message : 'Failed to refresh requests.') : null}
-					onRetry={error && effectiveData ? () => void refetch() : undefined}
-					retryDisabled={isFetching}
-				>
-					<div className="mb-3 rounded-md border p-3">
-						<UserSearchPaginationControls
-							totalCount={totalCount}
-							page={page}
-							pageSize={pageSize}
-							onPageChange={onPageChange}
-							onPageSizeChange={onPageSizeChange}
-							pageSizeOptions={[10, 25, 50, 100]}
-							itemLabel="requests"
-							nextButtonLoading={isFetching}
-							summaryAction={refreshButton}
-						/>
-					</div>
-					<div className="rounded-md border">
-						<Table>
-							<TableHeader>
-								<TableRow>
-									<TableHead className="w-14" />
-									<TableHead>Ship</TableHead>
-									<TableHead>Pilot</TableHead>
-									<TableHead className="text-right">Payout / Value</TableHead>
-									<TableHead>System</TableHead>
-									<TableHead>
-										<button
-											type="button"
-											className="inline-flex items-center gap-1 text-left hover:text-foreground"
-											onClick={() => toggleSort('loss')}
-										>
-											Lost
-											<span className="text-xs text-muted-foreground">{sortIndicator('loss')}</span>
-										</button>
-									</TableHead>
-									<TableHead>
-										<button
-											type="button"
-											className="inline-flex items-center gap-1 text-left hover:text-foreground"
-											onClick={() => toggleSort('submitted')}
-										>
-											Submitted
-											<span className="text-xs text-muted-foreground">
-												{sortIndicator('submitted')}
-											</span>
-										</button>
-									</TableHead>
-									<TableHead>Status</TableHead>
-									<TableHead className="text-right">Actions</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{visibleRequests.map((req) => (
-									<TableRow key={req.id}>
-										<TableCell className="py-2">
-											{req.shipTypeId && (
-												<div className="h-10 w-10 overflow-hidden rounded border border-border/50">
-													<img
-														src={typeIconUrl(req.shipTypeId, 32)}
-														alt={req.shipTypeName ?? ''}
-														className="h-full w-full object-contain"
-														loading="lazy"
-													/>
-												</div>
-											)}
-										</TableCell>
-										<TableCell className="font-semibold">
-											<Link
-												to={`/srp/review/${req.id}`}
-												className="underline-offset-4 hover:underline focus-visible:underline"
-											>
-												{req.shipTypeName ?? '—'}
-											</Link>
-										</TableCell>
-										<TableCell className="text-sm">
-											<div className="inline-flex items-center gap-2">
-												<span>{req.characterName}</span>
-												<CharacterRoleBadge
-													role={getRequestCharacterRole(req)}
-													mainCharacterName={req.mainCharacterName}
-													mainCharacterId={req.mainCharacterId}
+	return (
+		<div>
+			<TableRefreshFrame
+				isRefreshing={isSoftLoading}
+				refreshMessage="Refreshing recent losses..."
+				errorMessage={error && effectiveData ? (error instanceof Error ? error.message : 'Failed to refresh requests.') : null}
+				onRetry={error && effectiveData ? () => void refetch() : undefined}
+				retryDisabled={isFetching}
+			>
+				<div className="mb-3 rounded-md border p-3">
+					<UserSearchPaginationControls
+						totalCount={totalCount}
+						page={page}
+						pageSize={pageSize}
+						onPageChange={onPageChange}
+						onPageSizeChange={onPageSizeChange}
+						pageSizeOptions={[10, 25, 50, 100]}
+						itemLabel="requests"
+						nextButtonLoading={isFetching}
+						summaryAction={actionButtons}
+					/>
+				</div>
+				<div className="rounded-md border">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead className="w-14" />
+								<TableHead>Ship</TableHead>
+								<TableHead>Pilot</TableHead>
+								<TableHead className="text-right">Payout / Value</TableHead>
+								<TableHead>System</TableHead>
+								<TableHead>
+									<button
+										type="button"
+										className="inline-flex items-center gap-1 text-left hover:text-foreground"
+										onClick={() => toggleSort('loss')}
+									>
+										Lost
+										<span className="text-xs text-muted-foreground">{sortIndicator('loss')}</span>
+									</button>
+								</TableHead>
+								<TableHead>
+									<button
+										type="button"
+										className="inline-flex items-center gap-1 text-left hover:text-foreground"
+										onClick={() => toggleSort('submitted')}
+									>
+										Submitted
+										<span className="text-xs text-muted-foreground">
+											{sortIndicator('submitted')}
+										</span>
+									</button>
+								</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead className="text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{visibleRequests.map((req) => (
+								<TableRow key={req.id}>
+									<TableCell className="py-2">
+										{req.shipTypeId && (
+											<div className="h-10 w-10 overflow-hidden rounded border border-border/50">
+												<img
+													src={typeIconUrl(req.shipTypeId, 32)}
+													alt={req.shipTypeName ?? ''}
+													className="h-full w-full object-contain"
+													loading="lazy"
 												/>
 											</div>
-											{req.corporationName && req.corporationName !== 'Unknown' && (
-												<div className="text-xs text-muted-foreground">{req.corporationName}</div>
-											)}
-										</TableCell>
-										<TableCell className="text-right font-mono text-sm tabular-nums">
-											{formatISKShort(
-												req.approvedAmount ?? req.srpEquipmentValue ?? req.shipValue,
-												{ showDecimals: false }
-											)}
-										</TableCell>
-										<TableCell className="text-sm text-muted-foreground">
-											<div>{req.solarSystemName ?? '—'}</div>
-											{req.solarSystemRegionName ? (
-												<div className="text-xs text-muted-foreground/80">
-													{req.solarSystemRegionName}
-												</div>
-											) : null}
-										</TableCell>
-										<TableCell className="text-sm text-muted-foreground">
-											{req.lossDate ? (
-												<EveTimeDisplay
-													dateStr={req.lossDate}
-													format="compact"
-													className="whitespace-nowrap text-sm text-muted-foreground"
-												/>
-											) : (
-												'—'
-											)}
-										</TableCell>
-										<TableCell className="text-sm text-muted-foreground">
-											{formatRelativeTime(req.createdAt)}
-										</TableCell>
-										<TableCell>
-											<RequestStatusBadge status={req.requestStatus as any} />
-										</TableCell>
-										<TableCell className="text-right">
-											<Button size="sm" variant="secondary" asChild>
-												<Link to={`/srp/review/${req.id}`}>View</Link>
-											</Button>
-										</TableCell>
-									</TableRow>
-								))}
-							</TableBody>
-						</Table>
-					</div>
-				</TableRefreshFrame>
-			</div>
-		)
+										)}
+									</TableCell>
+									<TableCell className="font-semibold">
+										<Link
+											to={`/srp/review/${req.id}`}
+											className="underline-offset-4 hover:underline focus-visible:underline"
+										>
+											{req.shipTypeName ?? '—'}
+										</Link>
+									</TableCell>
+									<TableCell className="text-sm">
+										<div className="inline-flex items-center gap-2">
+											<span>{req.characterName}</span>
+											<CharacterRoleBadge
+												role={getRequestCharacterRole(req)}
+												mainCharacterName={req.mainCharacterName}
+												mainCharacterId={req.mainCharacterId}
+											/>
+										</div>
+										{req.corporationName && req.corporationName !== 'Unknown' && (
+											<div className="text-xs text-muted-foreground">{req.corporationName}</div>
+										)}
+									</TableCell>
+									<TableCell className="text-right font-mono text-sm tabular-nums">
+										{formatISKShort(req.approvedAmount ?? req.srpEquipmentValue ?? req.shipValue, {
+											showDecimals: false,
+										})}
+									</TableCell>
+									<TableCell className="text-sm text-muted-foreground">
+										<div>{req.solarSystemName ?? '—'}</div>
+										{req.solarSystemRegionName ? (
+											<div className="text-xs text-muted-foreground/80">
+												{req.solarSystemRegionName}
+											</div>
+										) : null}
+									</TableCell>
+									<TableCell className="text-sm text-muted-foreground">
+										{req.lossDate ? (
+											<EveTimeDisplay
+												dateStr={req.lossDate}
+												format="compact"
+												className="whitespace-nowrap text-sm text-muted-foreground"
+											/>
+										) : (
+											'—'
+										)}
+									</TableCell>
+									<TableCell className="text-sm text-muted-foreground">
+										{formatRelativeTime(req.createdAt)}
+									</TableCell>
+									<TableCell>
+										<RequestStatusBadge status={req.requestStatus as any} />
+									</TableCell>
+									<TableCell className="text-right">
+										<Button size="sm" variant="secondary" asChild>
+											<Link to={`/srp/review/${req.id}`}>View</Link>
+										</Button>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			</TableRefreshFrame>
+		</div>
+	)
 	}

--- a/apps/ui/src/client/features/srp/routes/wallet-history.tsx
+++ b/apps/ui/src/client/features/srp/routes/wallet-history.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useCallback, useEffect, useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
 
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
@@ -8,6 +9,7 @@ import { Container } from '@/components/ui/container'
 import { DateRangeInput } from '@/components/ui/date-range-input'
 import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { HoverPopover } from '@/components/ui/hover-popover'
+import { Button } from '@/components/ui/button'
 import { PageHeader } from '@/components/ui/page-header'
 import { Select } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
@@ -30,7 +32,7 @@ import {
 	useWalletHistoryUiState,
 	updateWalletHistoryFilters,
 } from '../state/wallet-history-store'
-import { formatISK } from '../utils'
+import { formatISK, isDateRangeWithinOneYear } from '../utils'
 
 export default function SRPWalletHistoryPage() {
 	usePageTitle('SRP - Wallet History')
@@ -38,6 +40,49 @@ export default function SRPWalletHistoryPage() {
 	const filters = useWalletHistoryUiState((state) => state.filters)
 	const page = useWalletHistoryUiState((state) => state.page)
 	const pageSize = useWalletHistoryUiState((state) => state.pageSize)
+	const [pendingExport, setPendingExport] = useState<{
+		workflowInstanceId: string
+		fileName: string
+	} | null>(null)
+	const [isExporting, setIsExporting] = useState(false)
+
+	const exportStatusQuery = useQuery({
+		queryKey: ['srp', 'payments', 'wallet-history', 'export-status', pendingExport?.workflowInstanceId ?? null],
+		queryFn: () => api.getSrpWalletHistoryCsvExportStatus(pendingExport!.workflowInstanceId),
+		enabled: Boolean(pendingExport?.workflowInstanceId),
+		refetchInterval: (query) => {
+			const status = query.state.data?.status
+			return status === 'queued' || status === 'running' ? 5000 : false
+		},
+		refetchOnWindowFocus: false,
+	})
+	const exportStatus = exportStatusQuery.data?.status
+	const isExportPolling =
+		Boolean(pendingExport) && (exportStatus === undefined || exportStatus === 'queued' || exportStatus === 'running')
+	const isExportBusy = isExporting || isExportPolling
+
+	useEffect(() => {
+		if (!pendingExport) return
+		if (!exportStatusQuery.data) return
+		if (exportStatusQuery.data.status === 'completed') {
+			void (async () => {
+				try {
+					await api.downloadSrpWalletHistoryCsv(
+						pendingExport.workflowInstanceId,
+						pendingExport.fileName
+					)
+				} finally {
+					setPendingExport(null)
+					setIsExporting(false)
+				}
+			})()
+			return
+		}
+		if (exportStatusQuery.data.status === 'failed' || exportStatusQuery.data.status === 'unknown') {
+			setPendingExport(null)
+			setIsExporting(false)
+		}
+	}, [exportStatusQuery.data, pendingExport])
 
 	const canAccess = hasAnyPermission('urn:srp:payer', 'urn:srp:manager')
 	if (!canAccess) return <Navigate to="/srp" replace />
@@ -59,6 +104,34 @@ export default function SRPWalletHistoryPage() {
 	const total = effectiveData?.total ?? 0
 	const hasPagination = Math.ceil(total / pageSize) > 1
 	const isSoftLoading = Boolean(effectiveData) && (isLoading || isFetching)
+	const canExportCsv = Boolean(
+		filters.dateFrom &&
+		filters.dateTo &&
+		isDateRangeWithinOneYear(filters.dateFrom, filters.dateTo)
+	)
+
+	const handleExport = useCallback(async () => {
+		if (!canExportCsv || isExporting) {
+			return
+		}
+
+		setIsExporting(true)
+		try {
+			const exportResult = await api.requestSrpWalletHistoryCsvExport({
+				reason: filters.reason,
+				recipientId: filters.recipientId,
+				alertsOnly: filters.alertsOnly,
+				dateFrom: filters.dateFrom,
+				dateTo: filters.dateTo,
+			})
+			setPendingExport({
+				workflowInstanceId: exportResult.workflowInstanceId,
+				fileName: exportResult.fileName,
+			})
+		} catch {
+			setIsExporting(false)
+		}
+	}, [canExportCsv, filters, isExporting])
 
 	const getAlertReasonLines = (item: (typeof items)[number]): string[] => {
 		const lines: string[] = []
@@ -171,6 +244,28 @@ export default function SRPWalletHistoryPage() {
 								}}
 							/>
 							<span className="text-sm text-muted-foreground">Alerts only</span>
+						</div>
+					</div>
+
+					<div className="flex items-center justify-end">
+						<div className="flex items-center gap-3">
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={() => {
+									void handleExport()
+								}}
+								disabled={!canExportCsv || isExportBusy}
+								loading={isExportBusy}
+								loadingText={isExporting ? 'Exporting…' : 'Generating…'}
+							>
+								Export CSV
+							</Button>
+							{isExportPolling && (
+								<span className="text-xs text-muted-foreground">
+									Waiting for export to generate...
+								</span>
+							)}
 						</div>
 					</div>
 

--- a/apps/ui/src/client/features/srp/utils.ts
+++ b/apps/ui/src/client/features/srp/utils.ts
@@ -154,3 +154,14 @@ export function getRequestCharacterRole(
 	}
 	return undefined
 }
+
+export function isDateRangeWithinOneYear(dateFrom?: string, dateTo?: string): boolean {
+	if (!dateFrom || !dateTo) return false
+	const from = new Date(dateFrom.includes('T') ? dateFrom : `${dateFrom}T00:00:00.000Z`)
+	const to = new Date(dateTo.includes('T') ? dateTo : `${dateTo}T23:59:59.999Z`)
+	if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return false
+	if (to < from) return false
+	const maxTo = new Date(from.getTime())
+	maxTo.setUTCFullYear(maxTo.getUTCFullYear() + 1)
+	return to <= maxTo
+}

--- a/apps/ui/src/client/hooks/corporation-tax/reports.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/reports.ts
@@ -124,7 +124,12 @@ export function useTaxMemberSummary(
 ) {
 	return useQuery({
 		queryKey: corporationTaxKeys.memberSummary(corporationId ?? 'none', filters),
-		queryFn: () => corporationTaxApi.getMemberSummary(corporationId!, filters),
+		queryFn: () => {
+			if (!corporationId) {
+				throw new Error('Corporation id is required for member summary')
+			}
+			return corporationTaxApi.getMemberSummary(corporationId, filters)
+		},
 		staleTime: 1000 * 60 * 10,
 		enabled: Boolean(corporationId) && (filters?.enabled ?? true),
 	})

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -19,6 +19,9 @@ import type {
 } from '@repo/admin'
 
 import type { TrackingSession } from '../features/fleet-tracking/types'
+import { isDateRangeWithinOneYear } from '../features/srp/utils'
+
+import { downloadTextFile } from './csv-utils'
 
 export const API_BASE_URL =
 	import.meta.env.VITE_API_BASE_URL || '/api'
@@ -4498,6 +4501,133 @@ export class ApiClient {
 			`/srp/payments/wallet-history/search-values?${searchParams.toString()}`
 		)
 		return result.values ?? []
+	}
+
+	async requestSrpWalletHistoryCsvExport(params?: {
+		reason?: string
+		recipientId?: string
+		alertsOnly?: boolean
+		dateFrom?: string
+		dateTo?: string
+	}): Promise<{ workflowInstanceId: string; exportId: string; fileName: string; status: 'queued' }> {
+		if (!params?.dateFrom || !params?.dateTo || !isDateRangeWithinOneYear(params.dateFrom, params.dateTo)) {
+			throw new Error('Entry date range is required for wallet history export and must not exceed 1 year')
+		}
+
+		const searchParams = new URLSearchParams()
+		if (params.reason) searchParams.set('reason', params.reason)
+		if (params.recipientId) searchParams.set('recipientId', params.recipientId)
+		if (params.alertsOnly) searchParams.set('alertsOnly', 'true')
+		searchParams.set('dateFrom', params.dateFrom)
+		searchParams.set('dateTo', params.dateTo)
+
+		const response = await fetch(`/api/srp/payments/wallet-history/export?${searchParams.toString()}`, {
+			method: 'POST',
+			credentials: 'include',
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest',
+			},
+		})
+		if (!response.ok) {
+			const message = await response.text()
+			throw new Error(message || 'Failed to request SRP wallet history export')
+		}
+
+		return (await response.json()) as {
+			workflowInstanceId: string
+			exportId: string
+			fileName: string
+			status: 'queued'
+		}
+	}
+
+	async getSrpWalletHistoryCsvExportStatus(workflowInstanceId: string): Promise<{
+		workflowInstanceId: string
+		status: 'queued' | 'running' | 'completed' | 'failed' | 'unknown'
+		rawStatus?: string
+		output: unknown | null
+	}> {
+		return this.get(`/srp/payments/wallet-history/export/${workflowInstanceId}`)
+	}
+
+	async downloadSrpWalletHistoryCsv(workflowInstanceId: string, fileName: string): Promise<void> {
+		const response = await fetch(`/api/srp/payments/wallet-history/export/${workflowInstanceId}/download`, {
+			credentials: 'include',
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest',
+			},
+		})
+		if (!response.ok) {
+			const message = await response.text()
+			throw new Error(message || 'Failed to export SRP wallet history')
+		}
+
+		const csv = await response.text()
+		downloadTextFile(fileName, 'text/csv; charset=utf-8', csv)
+	}
+
+	async requestSrpPaidRequestsCsvExport(params: {
+		characterName?: string
+		shipTypeName?: string
+		solarSystemName?: string
+		dateFrom: string
+		dateTo: string
+	}): Promise<{ workflowInstanceId: string; exportId: string; fileName: string; status: 'queued' }> {
+		if (!isDateRangeWithinOneYear(params.dateFrom, params.dateTo)) {
+			throw new Error('Paid SRP export requires a date range of no more than 1 year')
+		}
+
+		const searchParams = new URLSearchParams()
+		if (params.characterName) searchParams.set('characterName', params.characterName)
+		if (params.shipTypeName) searchParams.set('shipTypeName', params.shipTypeName)
+		if (params.solarSystemName) searchParams.set('solarSystemName', params.solarSystemName)
+		searchParams.set('dateFrom', params.dateFrom)
+		searchParams.set('dateTo', params.dateTo)
+
+		const query = searchParams.toString()
+		const response = await fetch(`/api/srp/requests/paid/export${query ? `?${query}` : ''}`, {
+			method: 'POST',
+			credentials: 'include',
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest',
+			},
+		})
+		if (!response.ok) {
+			const message = await response.text()
+			throw new Error(message || 'Failed to request paid SRP export')
+		}
+
+		return (await response.json()) as {
+			workflowInstanceId: string
+			exportId: string
+			fileName: string
+			status: 'queued'
+		}
+	}
+
+	async getSrpPaidRequestsCsvExportStatus(workflowInstanceId: string): Promise<{
+		workflowInstanceId: string
+		status: 'queued' | 'running' | 'completed' | 'failed' | 'unknown'
+		rawStatus?: string
+		output: unknown | null
+	}> {
+		return this.get(`/srp/requests/paid/export/${workflowInstanceId}`)
+	}
+
+	async downloadSrpPaidRequestsCsv(workflowInstanceId: string, fileName: string): Promise<void> {
+		const response = await fetch(`/api/srp/requests/paid/export/${workflowInstanceId}/download`, {
+			credentials: 'include',
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest',
+			},
+		})
+		if (!response.ok) {
+			const message = await response.text()
+			throw new Error(message || 'Failed to download paid SRP requests')
+		}
+
+		const csv = await response.text()
+		downloadTextFile(fileName, 'text/csv; charset=utf-8', csv)
 	}
 
 	async getSrpPaymentMismatchAlerts(params?: {

--- a/apps/ui/src/client/lib/csv-utils.ts
+++ b/apps/ui/src/client/lib/csv-utils.ts
@@ -1,0 +1,31 @@
+export function escapeCsvValue(value: string | number | boolean | null | undefined): string {
+	if (value === null || value === undefined) {
+		return ''
+	}
+	const raw = String(value)
+	if (!/[,"\n\r]/.test(raw)) {
+		return raw
+	}
+	return `"${raw.replace(/"/g, '""')}"`
+}
+
+export function buildCsvLine(values: Array<string | number | boolean | null | undefined>): string {
+	return values.map(escapeCsvValue).join(',')
+}
+
+export function buildCsv(
+	headers: Array<string>,
+	rows: Array<Array<string | number | boolean | null | undefined>>
+): string {
+	return [buildCsvLine(headers), ...rows.map((row) => buildCsvLine(row))].join('\n')
+}
+
+export function downloadTextFile(fileName: string, contentType: string, content: string): void {
+	const blob = new Blob([content], { type: contentType })
+	const url = URL.createObjectURL(blob)
+	const anchor = document.createElement('a')
+	anchor.href = url
+	anchor.download = fileName
+	anchor.click()
+	URL.revokeObjectURL(url)
+}

--- a/apps/ui/src/client/lib/tax-api.ts
+++ b/apps/ui/src/client/lib/tax-api.ts
@@ -796,6 +796,9 @@ export class CorporationTaxApiClient extends ApiClient {
 		corporationId: string,
 		filters?: TaxMemberSummaryFilters
 	): Promise<TaxPagedResult<TaxMemberSummary>> {
+		if (!corporationId?.trim()) {
+			throw new Error('Corporation id is required for member summary')
+		}
 		if (this.shouldUseDemo()) return taxDemoApi.getMemberSummary(corporationId, filters)
 		const params = new URLSearchParams()
 		if (filters?.characterQuery) params.set('character', filters.characterQuery)

--- a/apps/ui/src/client/routes/tax-member-summary.tsx
+++ b/apps/ui/src/client/routes/tax-member-summary.tsx
@@ -4,6 +4,7 @@ import { TaxCorporationScopeSelector } from '@/components/tax-corporation-scope-
 import { MemberSummaryGridCard } from '@/components/tax-member-summary/member-summary-grid-card'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
+import { Button } from '@/components/ui/button'
 import { DateRangeInput } from '@/components/ui/date-range-input'
 import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
@@ -18,33 +19,41 @@ import { useEntityNames } from '@/hooks/useEntityNames'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { getCurrentMonthDateRange } from '@/lib/tax-date'
 import { formatTaxIskCompact, formatTaxNumber } from '@/lib/tax-display'
-import { Button } from '@/components/ui/button'
 
 const DEFAULT_MONTH_RANGE = getCurrentMonthDateRange()
 export default function TaxMemberSummaryPage() {
 	usePageTitle('Tax Member Summary')
 
-	const { data: globalCapabilities } = useTaxCapabilities()
+	const { data: globalCapabilities, isLoading: globalCapabilitiesLoading } = useTaxCapabilities()
 	const canReadWithUrn = globalCapabilities?.global.canRead ?? false
-	const { data: corporationAccess } = useCorporationAccess()
+	const { data: corporationAccess, isLoading: corporationAccessLoading } = useCorporationAccess()
 
-	const { data: corporationSettings = [] } = useTaxCorporations({
+	const { data: corporationSettings = [], isLoading: corporationSettingsLoading } = useTaxCorporations({
 		limit: 1000,
 		enabled: canReadWithUrn,
 	})
+	const isCorporationScopeLoading =
+		globalCapabilitiesLoading || corporationAccessLoading || corporationSettingsLoading
+
 	const unresolvedCorporationIds = useMemo(() => {
+		if (isCorporationScopeLoading) {
+			return []
+		}
 		const accessIdSet = new Set(
 			(corporationAccess?.corporations ?? []).map((corp) => corp.corporationId)
 		)
 		return corporationSettings
 			.map((setting) => setting.corporationId)
 			.filter((corporationId) => !accessIdSet.has(corporationId))
-	}, [corporationAccess?.corporations, corporationSettings])
+	}, [isCorporationScopeLoading, corporationAccess?.corporations, corporationSettings])
 	const { data: resolvedCorporationNames = {} } = useEntityNames(unresolvedCorporationIds, {
-		enabled: unresolvedCorporationIds.length > 0,
+		enabled: !isCorporationScopeLoading && unresolvedCorporationIds.length > 0,
 	})
 
 	const corporationOptions = useMemo(() => {
+		if (isCorporationScopeLoading) {
+			return []
+		}
 		const map = new Map<string, string>()
 		for (const corp of corporationAccess?.corporations ?? []) {
 			map.set(corp.corporationId, corp.name)
@@ -58,7 +67,7 @@ export default function TaxMemberSummaryPage() {
 			}
 		}
 		return Array.from(map.entries()).map(([corporationId, name]) => ({ corporationId, name }))
-	}, [corporationAccess?.corporations, corporationSettings, resolvedCorporationNames])
+	}, [isCorporationScopeLoading, corporationAccess?.corporations, corporationSettings, resolvedCorporationNames])
 
 	const [selectedCorporationId, setSelectedCorporationId] = useState<string | undefined>(undefined)
 	const [characterQuery, setCharacterQuery] = useState('')
@@ -84,6 +93,9 @@ export default function TaxMemberSummaryPage() {
 	)
 
 	const effectiveCorporationId = useMemo(() => {
+		if (isCorporationScopeLoading) {
+			return undefined
+		}
 		if (selectedCorporationId) {
 			return selectedCorporationId
 		}
@@ -91,12 +103,18 @@ export default function TaxMemberSummaryPage() {
 			return corporationOptions[0]?.corporationId
 		}
 		return undefined
-	}, [selectedCorporationId, corporationOptions])
+	}, [isCorporationScopeLoading, selectedCorporationId, corporationOptions])
 
 	const { data: scopedCapabilities } = useTaxCapabilities(
 		effectiveCorporationId,
 		Boolean(effectiveCorporationId)
 	)
+	const canViewSummaryTotals =
+		(globalCapabilities?.global.canAudit ?? false) || (scopedCapabilities?.scoped.canAudit ?? false)
+	const canViewMemberSummary =
+		canReadWithUrn ||
+		(scopedCapabilities?.scoped.canRead ?? false) ||
+		(corporationAccess?.hasAccess ?? false)
 	const canSearchCharacter =
 		canReadWithUrn ||
 		(scopedCapabilities?.scoped.canRead ?? false) ||
@@ -113,7 +131,7 @@ export default function TaxMemberSummaryPage() {
 		corporationId: effectiveCorporationId,
 		fromDate: fromDateIso,
 		toDate: toDateIso,
-		enabled: Boolean(effectiveCorporationId),
+		enabled: Boolean(effectiveCorporationId) && !isCorporationScopeLoading && canViewSummaryTotals,
 	})
 
 	const isRefreshing = isSummaryReportFetching
@@ -126,7 +144,16 @@ export default function TaxMemberSummaryPage() {
 			/>
 
 			<Section>
-				{corporationOptions.length > 0 ? (
+				{isCorporationScopeLoading ? (
+					<Card>
+						<CardHeader>
+							<CardTitle>Loading Corporation Scope</CardTitle>
+							<CardDescription>
+								Resolving accessible corporations before loading member summaries.
+							</CardDescription>
+						</CardHeader>
+					</Card>
+				) : corporationOptions.length > 0 ? (
 					<TaxCorporationScopeSelector
 						corporations={corporationOptions}
 						effectiveCorporationId={effectiveCorporationId}
@@ -180,13 +207,14 @@ export default function TaxMemberSummaryPage() {
 										className="h-10"
 									/>
 								</div>
-								<Button variant="ghost"
+								<Button
 									type="button"
 									onClick={() => {
 										void refetchSummaryReport()
 										setRefreshToken((value) => value + 1)
 									}}
 									disabled={isRefreshing}
+									variant="ghost"
 									className="h-10"
 								>
 									{isRefreshing ? 'Refreshing…' : 'Refresh'}
@@ -221,18 +249,22 @@ export default function TaxMemberSummaryPage() {
 							{formatTaxIskCompact(memberStats.totalTaxableIncome)}
 						</CardContent>
 					</Card>
-					<Card>
-						<CardHeader className="pb-2">
-							<CardTitle className="text-sm">Taxes Paid</CardTitle>
-						</CardHeader>
-						<CardContent className="text-2xl font-semibold">
-							{formatTaxIskCompact(summaryReport?.taxPaid ?? '0')}
-						</CardContent>
-					</Card>
+					{canViewSummaryTotals ? (
+						<Card>
+							<CardHeader className="pb-2">
+								<CardTitle className="text-sm">Taxes Paid</CardTitle>
+							</CardHeader>
+							<CardContent className="text-2xl font-semibold">
+								{formatTaxIskCompact(summaryReport?.taxPaid ?? '0')}
+							</CardContent>
+						</Card>
+					) : null}
 				</div>
 
 				<MemberSummaryGridCard
 					effectiveCorporationId={effectiveCorporationId}
+					isScopeLoading={isCorporationScopeLoading}
+					canViewSummary={canViewMemberSummary}
 					canSearchCharacter={canSearchCharacter}
 					characterQuery={characterQuery}
 					fromDateIso={fromDateIso}

--- a/apps/ui/src/test/unit/corporation-tax-member-summary.test.ts
+++ b/apps/ui/src/test/unit/corporation-tax-member-summary.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { corporationTaxKeys, useTaxMemberSummary } from '../../client/hooks/corporation-tax'
+import { CorporationTaxApiClient } from '../../client/lib/tax-api'
+
+const { useQueryMock } = vi.hoisted(() => ({
+	useQueryMock: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+	useQuery: (...args: unknown[]) => useQueryMock(...args),
+}))
+
+describe('useTaxMemberSummary', () => {
+	beforeEach(() => {
+		useQueryMock.mockReset()
+		useQueryMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isFetching: false,
+			error: undefined,
+			refetch: vi.fn(),
+		})
+	})
+
+	it('keeps the query disabled until a corporation id is available', async () => {
+		const filters: NonNullable<Parameters<typeof useTaxMemberSummary>[1]> = {
+			characterQuery: 'Zen',
+			fromDate: '2026-07-01T00:00:00.000Z',
+			toDate: '2026-07-31T23:59:59.999Z',
+			limit: 25,
+			offset: 0,
+			sortBy: 'contributionIncome',
+			sortDir: 'desc',
+			enabled: true,
+		}
+
+		useTaxMemberSummary(undefined, filters)
+
+		expect(useQueryMock).toHaveBeenCalledTimes(1)
+		const options = useQueryMock.mock.calls[0][0] as {
+			enabled: boolean
+			queryKey: unknown
+			queryFn: () => Promise<unknown>
+		}
+		expect(options.enabled).toBe(false)
+		expect(options.queryKey).toEqual(corporationTaxKeys.memberSummary('none', filters))
+		expect(() => options.queryFn()).toThrow('Corporation id is required for member summary')
+	})
+})
+
+describe('CorporationTaxApiClient.getMemberSummary', () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('rejects missing corporation ids before issuing a request', async () => {
+		const fetchSpy = vi.fn()
+		vi.stubGlobal('fetch', fetchSpy)
+
+		const client = new CorporationTaxApiClient('/api')
+
+		await expect(client.getMemberSummary('' as unknown as string)).rejects.toThrow(
+			'Corporation id is required for member summary'
+		)
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+})

--- a/apps/ui/src/test/unit/features/moon-scan/export.unit.test.ts
+++ b/apps/ui/src/test/unit/features/moon-scan/export.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildScannedMoonsCsv } from '@/features/moon-scan/export'
+
+describe('moon-scan csv export', () => {
+	it('flattens moon and ore detail rows into CSV', () => {
+		const csv = buildScannedMoonsCsv(
+			[
+				{
+					moonId: 'moon-1',
+					moonName: 'Moon 1',
+					solarSystemId: 'sys-1',
+					solarSystemName: 'System 1',
+					regionId: 'reg-1',
+					regionName: 'Region 1',
+					constellationId: 'const-1',
+					constellationName: 'Constellation 1',
+					securityStatus: '0.5',
+					highestRarity: 'R64',
+					metenoxProfit: '12345',
+					tataraProfit: '67890',
+				},
+			],
+			{
+				'moon-1': {
+					moon: {
+						moonId: 'moon-1',
+						moonName: 'Moon 1',
+						solarSystemId: 'sys-1',
+						solarSystemName: 'System 1',
+					},
+					scans: [],
+					composition: null,
+					profitability: {
+						ores: [
+							{
+								oreTypeId: '45490',
+								oreName: 'Bitumens',
+								quantity: '0.25',
+								rarity: 'R64',
+								totalOreValue: '987654',
+								refinesTo: [],
+							},
+						],
+						structures: [],
+						updatedAt: '2026-07-01T00:00:00.000Z',
+					},
+				} as any,
+			}
+		)
+
+		expect(csv).toContain(
+			'regionId,regionName,solarSystemId,solarSystemName,moonId,moonName,securityStatus,highestRarity,metenoxProfit,tataraProfit,oreTypeId,oreTypeName,oreRarity,oreCompositionPercent,oreTotalOreValue'
+		)
+		expect(csv).toContain('reg-1')
+		expect(csv).toContain('sys-1')
+		expect(csv).toContain('moon-1')
+		expect(csv).toContain('45490')
+		expect(csv).toContain('Bitumens')
+		expect(csv).toContain('25.00%')
+		expect(csv).toContain('987654')
+	})
+})

--- a/apps/ui/src/test/unit/routes/tax-member-summary.route.test.tsx
+++ b/apps/ui/src/test/unit/routes/tax-member-summary.route.test.tsx
@@ -1,0 +1,208 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import TaxMemberSummaryPage from '@/routes/tax-member-summary'
+
+const {
+	useCorporationAccessMock,
+	useEntityNamesMock,
+	usePageTitleMock,
+	useTaxCapabilitiesMock,
+	useTaxCorporationsMock,
+	useTaxSummaryReportMock,
+} = vi.hoisted(() => ({
+	useCorporationAccessMock: vi.fn(),
+	useEntityNamesMock: vi.fn(),
+	usePageTitleMock: vi.fn(),
+	useTaxCapabilitiesMock: vi.fn(),
+	useTaxCorporationsMock: vi.fn(),
+	useTaxSummaryReportMock: vi.fn(),
+}))
+
+vi.mock('@/features/corporations', () => ({
+	useCorporationAccess: (...args: unknown[]) => useCorporationAccessMock(...args),
+}))
+
+vi.mock('@/hooks/useEntityNames', () => ({
+	useEntityNames: (...args: unknown[]) => useEntityNamesMock(...args),
+}))
+
+vi.mock('@/hooks/usePageTitle', () => ({
+	usePageTitle: (...args: unknown[]) => usePageTitleMock(...args),
+}))
+
+vi.mock('@/hooks/corporation-tax', () => ({
+	useTaxCapabilities: (...args: unknown[]) => useTaxCapabilitiesMock(...args),
+	useTaxCorporations: (...args: unknown[]) => useTaxCorporationsMock(...args),
+	useTaxSummaryReport: (...args: unknown[]) => useTaxSummaryReportMock(...args),
+}))
+
+vi.mock('@/components/tax-corporation-scope-selector', () => ({
+	TaxCorporationScopeSelector: () => <div data-testid="scope-selector">scope-selector</div>,
+}))
+
+vi.mock('@/components/tax-member-summary/member-summary-grid-card', () => ({
+	MemberSummaryGridCard: (props: {
+		effectiveCorporationId?: string
+		isScopeLoading?: boolean
+		canViewSummary?: boolean
+	}) => (
+		<div data-testid="member-summary-grid">
+			{props.isScopeLoading
+				? 'loading'
+				: `${props.effectiveCorporationId ?? 'none'}:${props.canViewSummary ? 'enabled' : 'disabled'}`}
+		</div>
+	),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+	Button: (props: { children?: ReactNode }) => <button>{props.children}</button>,
+}))
+
+vi.mock('@/components/ui/card', () => ({
+	Card: (props: { children?: ReactNode }) => <div>{props.children}</div>,
+	CardContent: (props: { children?: ReactNode }) => <div>{props.children}</div>,
+	CardDescription: (props: { children?: ReactNode }) => <div>{props.children}</div>,
+	CardHeader: (props: { children?: ReactNode }) => <div>{props.children}</div>,
+	CardTitle: (props: { children?: ReactNode }) => <div>{props.children}</div>,
+}))
+
+vi.mock('@/components/ui/container', () => ({
+	Container: (props: { children?: ReactNode }) => <div>{props.children}</div>,
+}))
+
+vi.mock('@/components/ui/date-range-input', () => ({
+	DateRangeInput: () => <div data-testid="date-range-input">date-range-input</div>,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+	Input: (props: { value?: string }) => <input value={props.value ?? ''} readOnly />,
+}))
+
+vi.mock('@/components/ui/page-header', () => ({
+	PageHeader: (props: { title?: string; description?: string }) => (
+		<div>
+			<div>{props.title}</div>
+			<div>{props.description}</div>
+		</div>
+	),
+}))
+
+vi.mock('@/components/ui/section', () => ({
+	Section: (props: { children?: ReactNode }) => <div>{props.children}</div>,
+}))
+
+describe('TaxMemberSummaryPage corporation scope gating', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('holds summary fetching until corporation scope resolution completes', () => {
+		usePageTitleMock.mockReturnValue(undefined)
+		useTaxCapabilitiesMock.mockImplementation((corporationId?: string) =>
+			corporationId
+				? {
+						data: {
+							corporationId,
+							global: { canRead: false, canAudit: false, canManage: false },
+							scoped: { canRead: false, canAudit: false, canManage: false },
+						},
+						isLoading: false,
+					}
+				: {
+						data: {
+							corporationId: null,
+							global: { canRead: true, canAudit: false, canManage: false },
+							scoped: { canRead: false, canAudit: false, canManage: false },
+						},
+						isLoading: false,
+					}
+		)
+		useCorporationAccessMock.mockReturnValue({
+			data: {
+				hasAccess: true,
+				corporations: [{ corporationId: 'corp-1', name: 'Alpha Corp' }],
+			},
+			isLoading: true,
+		})
+		useTaxCorporationsMock.mockReturnValue({
+			data: [{ corporationId: 'corp-1', name: 'Alpha Corp' }],
+			isLoading: true,
+		})
+		useEntityNamesMock.mockReturnValue({ data: {}, isLoading: false })
+		useTaxSummaryReportMock.mockReturnValue({
+			data: { taxPaid: '0' },
+			isFetching: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		})
+
+		const html = renderToStaticMarkup(<TaxMemberSummaryPage />)
+
+		expect(html).toContain('Loading Corporation Scope')
+		expect(html).toContain('Resolving accessible corporations before loading member summaries.')
+		expect(html).toContain('loading')
+		expect(html).not.toContain('Taxes Paid')
+
+		expect(useTaxSummaryReportMock).toHaveBeenCalledTimes(1)
+		expect(useTaxSummaryReportMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				corporationId: undefined,
+				enabled: false,
+			})
+		)
+	})
+
+	it('keeps the member summary grid available for read-only access while hiding audit totals', () => {
+		usePageTitleMock.mockReturnValue(undefined)
+		useTaxCapabilitiesMock.mockImplementation((corporationId?: string) =>
+			corporationId
+				? {
+						data: {
+							corporationId,
+							global: { canRead: true, canAudit: false, canManage: false },
+							scoped: { canRead: true, canAudit: false, canManage: false },
+						},
+						isLoading: false,
+					}
+				: {
+						data: {
+							corporationId: null,
+							global: { canRead: true, canAudit: false, canManage: false },
+							scoped: { canRead: false, canAudit: false, canManage: false },
+						},
+						isLoading: false,
+					}
+		)
+		useCorporationAccessMock.mockReturnValue({
+			data: {
+				hasAccess: true,
+				corporations: [{ corporationId: 'corp-1', name: 'Alpha Corp' }],
+			},
+			isLoading: false,
+		})
+		useTaxCorporationsMock.mockReturnValue({
+			data: [{ corporationId: 'corp-1', name: 'Alpha Corp' }],
+			isLoading: false,
+		})
+		useEntityNamesMock.mockReturnValue({ data: {}, isLoading: false })
+		useTaxSummaryReportMock.mockReturnValue({
+			data: { taxPaid: '0' },
+			isFetching: false,
+			isLoading: false,
+			refetch: vi.fn(),
+		})
+
+		const html = renderToStaticMarkup(<TaxMemberSummaryPage />)
+
+		expect(html).toContain('corp-1:enabled')
+		expect(html).not.toContain('Taxes Paid')
+		expect(useTaxSummaryReportMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				corporationId: 'corp-1',
+				enabled: false,
+			})
+		)
+	})
+})

--- a/packages/hr/src/index.ts
+++ b/packages/hr/src/index.ts
@@ -586,7 +586,8 @@ export interface Hr extends DurableObject {
 	getApplicationForRecommender(
 		applicationId: string,
 		userId: string,
-		userCorporationIds: string[]
+		userCorporationIds: string[],
+		access?: HrAccessContext
 	): Promise<RecommenderApplicationDetail>
 
 	/**

--- a/packages/worker-utils/src/csv.ts
+++ b/packages/worker-utils/src/csv.ts
@@ -1,0 +1,16 @@
+export function escapeCsvValue(value: string | number | boolean | null | undefined): string {
+	if (value === null || value === undefined) {
+		return ''
+	}
+
+	const raw = String(value)
+	if (!/[,"\n\r]/.test(raw)) {
+		return raw
+	}
+
+	return `"${raw.replace(/"/g, '""')}"`
+}
+
+export function buildCsvLine(values: Array<string | number | boolean | null | undefined>): string {
+	return values.map(escapeCsvValue).join(',')
+}

--- a/packages/worker-utils/src/index.ts
+++ b/packages/worker-utils/src/index.ts
@@ -1,6 +1,12 @@
 export { parseDateOrNull } from './date'
 export { formatISK, type FormatISKOptions } from './isk'
 export { parseJsonResponse, type ParseJsonResponseOptions } from './fetch'
+export { buildCsvLine, escapeCsvValue } from './csv'
+export {
+	createR2MultipartTextWriter,
+	type R2MultipartTextWriter,
+	type R2MultipartTextWriterOptions,
+} from './r2-export'
 export {
 	runExpirySweep,
 	type ExpirySweepItem,

--- a/packages/worker-utils/src/r2-export.test.ts
+++ b/packages/worker-utils/src/r2-export.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createR2MultipartTextWriter } from './r2-export'
+
+function makeBucketMock() {
+	const uploadedBodies: string[] = []
+	const abort = vi.fn(async () => {})
+	const uploadPart = vi.fn(async (partNumber: number, value: string | ArrayBuffer | ArrayBufferView | Blob | ReadableStream) => {
+		const body = typeof value === 'string' ? value : await new Response(value).text()
+		uploadedBodies[partNumber - 1] = body
+		return { partNumber, etag: `etag-${partNumber}` }
+	})
+	const complete = vi.fn(async (uploadedParts: Array<{ partNumber: number; etag: string }>) => ({
+		key: 'exports/test.csv',
+		version: '1',
+		size: uploadedBodies.join('').length,
+		etag: 'etag',
+		httpEtag: '"etag"',
+		checksums: {},
+		uploaded: new Date('2026-07-01T00:00:00.000Z'),
+		httpMetadata: { contentType: 'text/csv; charset=utf-8' },
+		customMetadata: { fileName: 'test.csv' },
+		storageClass: 'Standard',
+		writeHttpMetadata: vi.fn(),
+		uploadedParts,
+	} as any))
+
+	return {
+		uploadedBodies,
+		abort,
+		createMultipartUpload: vi.fn(async (key: string, options?: { httpMetadata?: R2HTTPMetadata; customMetadata?: Record<string, string> }) => ({
+			key,
+			uploadId: 'upload-1',
+			uploadPart,
+			abort,
+			complete,
+			options,
+		})),
+		uploadPart,
+		complete,
+	}
+}
+
+describe('createR2MultipartTextWriter', () => {
+	it('uploads chunked text as multipart parts', async () => {
+		const bucket = makeBucketMock()
+
+		const writer = await createR2MultipartTextWriter(bucket as any, 'exports/test.csv', {
+			httpMetadata: { contentType: 'text/csv; charset=utf-8' },
+			customMetadata: { fileName: 'test.csv' },
+			partSizeBytes: 4,
+		})
+
+		await writer.writeLine('abc')
+		await writer.writeLine('de')
+		const result = await writer.close()
+
+		expect(bucket.createMultipartUpload).toHaveBeenCalledWith(
+			'exports/test.csv',
+			expect.objectContaining({
+				httpMetadata: { contentType: 'text/csv; charset=utf-8' },
+				customMetadata: { fileName: 'test.csv' },
+			})
+		)
+		expect(bucket.uploadPart).toHaveBeenCalledTimes(2)
+		expect(bucket.complete).toHaveBeenCalledTimes(1)
+		expect(result.key).toBe('exports/test.csv')
+		expect(bucket.uploadedBodies).toEqual(['abc\n', 'de\n'])
+	})
+
+	it('aborts the multipart upload if completion fails', async () => {
+		const bucket = makeBucketMock()
+		bucket.complete.mockRejectedValueOnce(new Error('complete failed'))
+
+		const writer = await createR2MultipartTextWriter(bucket as any, 'exports/test.csv', {
+			httpMetadata: { contentType: 'text/csv; charset=utf-8' },
+			customMetadata: { fileName: 'test.csv' },
+			partSizeBytes: 4,
+		})
+
+		await writer.writeLine('abc')
+		await expect(writer.close()).rejects.toThrow('complete failed')
+		expect(bucket.abort).toHaveBeenCalledTimes(1)
+	})
+})

--- a/packages/worker-utils/src/r2-export.ts
+++ b/packages/worker-utils/src/r2-export.ts
@@ -1,0 +1,88 @@
+const DEFAULT_R2_MULTIPART_PART_SIZE_BYTES = 5 * 1024 * 1024
+
+export interface R2MultipartTextWriterOptions {
+	httpMetadata?: R2HTTPMetadata
+	customMetadata?: Record<string, string>
+	partSizeBytes?: number
+}
+
+export interface R2MultipartTextWriter {
+	readonly key: string
+	readonly uploadId: string
+	write(text: string): Promise<void>
+	writeLine(text: string): Promise<void>
+	close(): Promise<R2Object>
+	abort(): Promise<void>
+}
+
+export async function createR2MultipartTextWriter(
+	bucket: R2Bucket,
+	key: string,
+	options: R2MultipartTextWriterOptions = {},
+): Promise<R2MultipartTextWriter> {
+	const multipart = await bucket.createMultipartUpload(key, {
+		httpMetadata: options.httpMetadata,
+		customMetadata: options.customMetadata,
+	})
+
+	const partSizeBytes = options.partSizeBytes ?? DEFAULT_R2_MULTIPART_PART_SIZE_BYTES
+	const encoder = new TextEncoder()
+	const chunks: string[] = []
+	const uploadedParts: R2UploadedPart[] = []
+	let bufferedBytes = 0
+	let nextPartNumber = 1
+	let finalized = false
+
+	const flush = async (): Promise<void> => {
+		if (bufferedBytes === 0) return
+		const body = chunks.join('')
+		chunks.length = 0
+		bufferedBytes = 0
+		uploadedParts.push(await multipart.uploadPart(nextPartNumber++, body))
+	}
+
+	const append = async (text: string): Promise<void> => {
+		if (finalized) {
+			throw new Error('Cannot write to a closed R2 multipart text writer')
+		}
+		if (text.length === 0) return
+		chunks.push(text)
+		bufferedBytes += encoder.encode(text).byteLength
+		if (bufferedBytes >= partSizeBytes) {
+			await flush()
+		}
+	}
+
+	return {
+		key: multipart.key,
+		uploadId: multipart.uploadId,
+		async write(text: string): Promise<void> {
+			await append(text)
+		},
+		async writeLine(text: string): Promise<void> {
+			await append(`${text}\n`)
+		},
+		async close(): Promise<R2Object> {
+			if (finalized) {
+				throw new Error('Cannot close an R2 multipart text writer more than once')
+			}
+			await flush()
+			try {
+				const object = await multipart.complete(uploadedParts)
+				finalized = true
+				return object
+			} catch (error) {
+				await multipart.abort().catch(() => {})
+				finalized = true
+				throw error
+			}
+		},
+		async abort(): Promise<void> {
+			if (finalized) return
+			finalized = true
+			chunks.length = 0
+			bufferedBytes = 0
+			await multipart.abort()
+		},
+	}
+}


### PR DESCRIPTION
+ bugfix for recommendations submission
+ bugfix for member summary loading

<!-- claude:begin -->
## Summary
Adds asynchronous, R2-backed CSV export for verified scanned moons and SRP data (paid requests, wallet history), so large datasets can be exported without blocking a request or holding everything in memory. Also fixes two access-control/loading bugs: HR recommendation submission incorrectly denying admins/auditors, and the tax member summary page firing queries before corporation access had resolved.

## Changes
- **CSV export pipeline**: new `CsvExportWorkflow` (Cloudflare Workflow) drives moon-scan and SRP exports; writes CSV via a new streaming `createR2MultipartTextWriter` helper (`packages/worker-utils/src/r2-export.ts`) into new `MOON_SCAN_EXPORTS` / `SRP_EXPORTS` R2 buckets.
- **New export routes**: `POST .../export` to enqueue a workflow, `GET .../export/:id` to poll status (via new `normalizeWorkflowStatus` helper), and `GET .../export/:id/download` to stream the CSV and delete the R2 object after serving it.
- **Export artifact retention**: new `apps/core/src/lib/export-retention.ts` computes short-lived (60s) expiry timestamps and sweeps/purges expired R2 objects.
- **Shared CSV helpers**: `escapeCsvValue`/`buildCsvLine` moved from `apps/core/src/routes/corporations/index.ts` into `@repo/worker-utils` and reused across corporation-tax, moon-scan, and SRP export code.
- **UI**: moon-scan "scanned moons" and SRP "review"/"wallet history" pages get export-to-CSV actions that poll workflow status and trigger a browser download (`downloadTextFile` in `apps/ui/src/client/lib/csv-utils.ts`).
- **Bugfix — HR recommendations**: `getApplicationForRecommender` now accepts an `HrAccessContext` (`isAdmin`/`isAuditor`) so site admins and HR auditors can view/submit recommendations for any member corporation, not just ones they're personally affiliated with; corporation-affiliation lookup extracted into `apps/core/src/lib/user-corporation-affiliations.ts` and reused across the recommendation routes.
- **Bugfix — tax member summary**: the member summary page and grid card now track corporation-scope loading state (`isCorporationScopeLoading`/`isScopeLoading`) and gate queries/rendering on it plus a new `canViewSummary` permission check, preventing premature or unauthorized fetches while corporation access is still resolving.
- **Corporation-tax member summary**: member-target resolution (character search/filtering/permission checks) extracted into `resolveMemberSummaryTargets`, and corporation membership lookups are now cached via `getCorporationMemberCharacterIds`.
- `wrangler.jsonc` updated with the `EXPORT_WORKFLOW` workflow binding and the two new R2 bucket bindings.

## Testing
- New unit tests for `createR2MultipartTextWriter` (`packages/worker-utils/src/r2-export.test.ts`), moon-scan export CSV building (`apps/ui/src/test/unit/features/moon-scan/export.unit.test.ts`), and tax member summary loading/gating behavior (`apps/ui/src/test/unit/corporation-tax-member-summary.test.ts`, `apps/ui/src/test/unit/routes/tax-member-summary.route.test.tsx`).
- Updated/added route tests for HR access matrix and recommendation permissions, moon-scan access, moon-scan profitability/batching, and SRP routes.
<!-- claude:end -->
