### PR TITLE
feat(mailroom): award a random prediction-market wallet a house-funded bonus on markeedragon@ email

### DIFF
--- a/apps/mailroom/package.json
+++ b/apps/mailroom/package.json
@@ -19,6 +19,7 @@
 		"@repo/discord": "workspace:*",
 		"@repo/do-utils": "workspace:*",
 		"@repo/hono-helpers": "workspace:*",
+		"@repo/prediction-markets": "workspace:*",
 		"@repo/worker-utils": "workspace:*",
 		"hono": "4.10.6",
 		"postal-mime": "2.7.5",

--- a/apps/mailroom/package.json
+++ b/apps/mailroom/package.json
@@ -20,7 +20,6 @@
 		"@repo/do-utils": "workspace:*",
 		"@repo/hono-helpers": "workspace:*",
 		"@repo/prediction-markets": "workspace:*",
-		"@repo/worker-utils": "workspace:*",
 		"hono": "4.10.6",
 		"postal-mime": "2.7.5",
 		"workers-tagged-logger": "0.13.7"

--- a/apps/mailroom/src/context.ts
+++ b/apps/mailroom/src/context.ts
@@ -19,6 +19,14 @@ export type Env = SharedHonoEnv & {
 	DISCORD_GUILD_ID?: string
 	/** Discord channel ID that receives mail sent to `markeedragon@`. */
 	MARKEE_DISCORD_CHANNEL_ID?: string
+
+	/** Cross-worker binding to the Prediction Markets Durable Object (`apps/prediction-markets`). */
+	PREDICTION_MARKETS: DurableObjectNamespace
+	/**
+	 * Points awarded to a random prediction-market wallet on a markeedragon@ email (paid from the
+	 * house wallet). Optional — defaults to a small fixed amount when unset. Must be a positive integer.
+	 */
+	MARKEE_BONUS_AMOUNT?: string
 }
 
 /** Variables can be extended per-request as needed. */

--- a/apps/mailroom/src/markee-bonus.ts
+++ b/apps/mailroom/src/markee-bonus.ts
@@ -34,10 +34,8 @@ export const BONUS_MESSAGES: readonly string[] = [
  * rules as {@link BONUS_MESSAGES} — unicode emoji and custom `<:name:id>` emotes both render.
  */
 export const BONUS_HEADINGS: readonly string[] = [
-	'Someone just used our referral code to buy ETCs from Markee Dragon!' +
-		'\n' +
-		'Get your own at https://etc.pleaseignore.com, use code tapi for a discount' +
-		'Additionally',
+	'📣 Someone just used our referral code to buy ETCs from **Markee Dragon**!\n' +
+		'Get your own at <https://etc.pleaseignore.com> — use code **tapi** for a discount.\n',
 ]
 
 /** Pick a random predefined opener. */

--- a/apps/mailroom/src/markee-bonus.ts
+++ b/apps/mailroom/src/markee-bonus.ts
@@ -12,19 +12,22 @@ const DEFAULT_BONUS_AMOUNT = '5'
 
 /**
  * Predefined celebratory openers for the bonus announcement. One is chosen at random and the winner's
- * display name is appended (see {@link awardAndAnnounce}). These are sent as Discord message *content*,
- * so both unicode emoji AND custom guild emotes render — drop `<:name:id>` / `<a:name:id>` syntax in
- * here (using the real emote id from this guild) and it comes across as a live emote.
+ * display name is appended (see {@link awardAndAnnounce}). Each states WHY the bonus is being paid — a
+ * Markee Dragon referral/affiliate sale generated a commission, so the house shares points with a
+ * random member — so the announcement is self-explanatory even when no {@link BONUS_HEADINGS} is set.
+ * These are sent as Discord message *content*, so both unicode emoji AND custom guild emotes render —
+ * drop `<:name:id>` / `<a:name:id>` syntax in here (using the real emote id from this guild) and it
+ * comes across as a live emote.
  */
 export const BONUS_MESSAGES: readonly string[] = [
-	'🎉 Jackpot! Bonus points just landed for',
-	'💰 Ka-ching! The house is feeling generous toward',
-	'✨ A wild bonus appears for',
-	'🍀 Fortune smiles upon',
-	'🎁 Surprise! A little something from the vault for',
-	'🚀 Points incoming — congrats to',
-	'🏆 Winner winner! Bonus points go to',
-	'📬 The mail carrier brought a gift for',
+	'🎉 A Markee Dragon referral sale just landed, so bonus points go to',
+	'💰 Our referral link earned a commission — sharing the winnings with',
+	'✨ Someone bought game codes through our code, so a bonus flies to',
+	'🍀 A Markee Dragon affiliate sale means free points for',
+	'🎁 Thanks to a referral purchase, the house is gifting points to',
+	'🚀 Referral commission in the bank — bonus points launched to',
+	'🏆 A Markee Dragon sale just paid out, and the lucky winner is',
+	'📬 A referral order came through, so points are headed to',
 ]
 
 /**

--- a/apps/mailroom/src/markee-bonus.ts
+++ b/apps/mailroom/src/markee-bonus.ts
@@ -1,0 +1,129 @@
+import { forDO, getStub } from '@repo/do-utils'
+
+import { errorMessage } from './email'
+
+import type { Discord } from '@repo/discord'
+import type { PredictionMarkets } from '@repo/prediction-markets'
+import type { Env } from './context'
+import type { EmailContext } from './email'
+
+/** Fallback bonus (points) used when `MARKEE_BONUS_AMOUNT` is unset. Small by design. */
+const DEFAULT_BONUS_AMOUNT = '5'
+
+/**
+ * Predefined celebratory openers for the bonus announcement. One is chosen at random and the winner's
+ * display name is appended (see {@link awardAndAnnounce}). These are sent as Discord message *content*,
+ * so both unicode emoji AND custom guild emotes render — drop `<:name:id>` / `<a:name:id>` syntax in
+ * here (using the real emote id from this guild) and it comes across as a live emote.
+ */
+export const BONUS_MESSAGES: readonly string[] = [
+	'🎉 Jackpot! Bonus points just landed for',
+	'💰 Ka-ching! The house is feeling generous toward',
+	'✨ A wild bonus appears for',
+	'🍀 Fortune smiles upon',
+	'🎁 Surprise! A little something from the vault for',
+	'🚀 Points incoming — congrats to',
+	'🏆 Winner winner! Bonus points go to',
+	'📬 The mail carrier brought a gift for',
+]
+
+/**
+ * Optional heading lines for the bonus announcement. When non-empty, one is chosen at random and
+ * rendered on its OWN line above the opener+winner line (see {@link awardAndAnnounce}); while empty
+ * (the default) the announcement is just the opener + winner, exactly as before. Same content-rendering
+ * rules as {@link BONUS_MESSAGES} — unicode emoji and custom `<:name:id>` emotes both render.
+ */
+export const BONUS_HEADINGS: readonly string[] = [
+	'Someone just used our referral code to buy ETCs from Markee Dragon!' +
+		'\n' +
+		'Get your own at https://etc.pleaseignore.com, use code tapi for a discount' +
+		'Additionally',
+]
+
+/** Pick a random predefined opener. */
+function pickBonusMessage(): string {
+	return BONUS_MESSAGES[Math.floor(Math.random() * BONUS_MESSAGES.length)]
+}
+
+/** Pick a random heading, or `null` when none are configured (so no heading line is rendered). */
+function pickBonusHeading(): string | null {
+	if (BONUS_HEADINGS.length === 0) return null
+	return BONUS_HEADINGS[Math.floor(Math.random() * BONUS_HEADINGS.length)]
+}
+
+/**
+ * Award a random prediction-market wallet a small bonus (paid from the house wallet, atomically inside
+ * the PM Durable Object) and return a Discord announcement naming the winner — or `null` when no one
+ * was bonused (no eligible wallet / empty house / a failure).
+ *
+ * The announcement is `<random opener> <display name>`, where the display name is a Discord *mention*
+ * of the winner (`<@discordUserId>`) — which renders as their current display name and pings them —
+ * resolved from their core user id via the Discord DO. It falls back to a generic label if the winner
+ * has no linked Discord account. When {@link BONUS_HEADINGS} is non-empty, a random heading is
+ * prepended on its own line (`<heading>\n<opener> <display name>`).
+ *
+ * Best-effort by contract: every failure (a misconfigured binding, either DO being down, an invalid
+ * amount) is swallowed and logged and yields `null`, so this can NEVER bounce, delay past a single RPC,
+ * or misroute the mail. The caller uses the returned string as the post's content when present.
+ */
+export async function awardAndAnnounce(ctx: EmailContext<Env>): Promise<string | null> {
+	const winnerUserId = await awardBonus(ctx)
+	if (!winnerUserId) return null
+	const displayName = await resolveWinnerName(ctx, winnerUserId)
+	const body = `${pickBonusMessage()} ${displayName}`
+	const heading = pickBonusHeading()
+	return heading ? `${heading}\n${body}` : body
+}
+
+/**
+ * Award the bonus and return the winning core user id, or `null` if nothing was awarded. Never throws.
+ */
+async function awardBonus(ctx: EmailContext<Env>): Promise<string | null> {
+	try {
+		// Coerce + read INSIDE the try: wrangler `vars` are untyped JSON, so a mis-set numeric
+		// `MARKEE_BONUS_AMOUNT` (e.g. `5` not `"5"`) would make a bare `.trim()` throw. `String(...)`
+		// normalizes it, and being inside the try means any bad config is swallowed like every other
+		// failure — preserving the never-throws contract. A non-integer string reaches the DO, which
+		// rejects it (INVALID_AMOUNT), and that rejection is caught here too.
+		const amount = String(ctx.env.MARKEE_BONUS_AMOUNT ?? DEFAULT_BONUS_AMOUNT).trim()
+		const prediction = getStub<PredictionMarkets>(ctx.env.PREDICTION_MARKETS, 'default')
+		const result = await prediction.awardRandomBonus({
+			amount,
+			reason: `markeedragon@ inbound email from ${ctx.sender}`,
+		})
+		if (result.awarded) {
+			ctx.log.info('markee bonus awarded to a random wallet', {
+				userId: result.userId,
+				amount: result.amount,
+				balanceAfter: result.balanceAfter,
+			})
+			return result.userId
+		}
+		// Expected no-ops (no wallets yet, or an empty house wallet) — informational, not an error.
+		ctx.log.info('markee bonus skipped', { reason: result.reason, amount })
+		return null
+	} catch (error) {
+		ctx.log.error('markee bonus award failed (continuing)', { error: errorMessage(error) })
+		return null
+	}
+}
+
+/**
+ * Resolve a winner's core user id to a display name for the announcement. Returns a Discord mention
+ * (`<@discordUserId>`, which renders as the user's display name and pings them) when the account is
+ * linked, else a generic label. Never throws.
+ */
+async function resolveWinnerName(ctx: EmailContext<Env>, coreUserId: string): Promise<string> {
+	try {
+		const discord = forDO<Discord>(ctx.env.DISCORD).singleton()
+		const profile = await discord.getProfileByCoreUserId(coreUserId)
+		if (profile?.userId) return `<@${profile.userId}>`
+		ctx.log.info('markee bonus winner has no linked Discord profile', { coreUserId })
+	} catch (error) {
+		ctx.log.error('resolving markee bonus winner name failed (continuing)', {
+			error: errorMessage(error),
+			coreUserId,
+		})
+	}
+	return 'a lucky member'
+}

--- a/apps/mailroom/src/notify-discord.ts
+++ b/apps/mailroom/src/notify-discord.ts
@@ -2,6 +2,7 @@ import { forDO } from '@repo/do-utils'
 import { parseDateOrNull } from '@repo/worker-utils'
 
 import { consume } from './email'
+import { awardAndAnnounce } from './markee-bonus'
 
 import type { Discord, DiscordEmbed, MessageContent } from '@repo/discord'
 import type { Env } from './context'
@@ -34,6 +35,14 @@ export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 	const body = (parsed.text ?? htmlToText(parsed.html) ?? '').trim()
 	const timestamp = parseDateOrNull(parsed.date)?.toISOString()
 
+	// Side perk of a markeedragon@ email: award a random prediction-market wallet a small bonus from
+	// the house wallet, and get back a celebratory announcement naming the winner. Runs BEFORE the post
+	// because the post announces the winner; it is fully self-contained (never throws) and returns null
+	// when no one was bonused (empty house / no wallets / a failure), in which case the post keeps its
+	// plain "new email" line. As Discord message content, the announcement renders emoji AND custom
+	// emotes, and the winner mention resolves to their display name.
+	const announcement = await awardAndAnnounce(ctx)
+
 	const embed: DiscordEmbed = {
 		title: truncate(parsed.subject ?? '(no subject)', LIMIT.title),
 		description: body ? truncate(body, LIMIT.description) : '_(empty body)_',
@@ -46,7 +55,7 @@ export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 	}
 
 	const message: MessageContent = {
-		content: `📧 New email to **${ctx.recipient}**`,
+		content: announcement ?? `📧 New email to **${ctx.recipient}**`,
 		embeds: [embed],
 		allowEveryone: false,
 	}
@@ -62,6 +71,7 @@ export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 		to: ctx.recipient,
 		channelId,
 		messageId: result.messageId,
+		announced: announcement !== null,
 	})
 
 	// The email's purpose is fulfilled by the Discord post — accept and discard.

--- a/apps/mailroom/src/notify-discord.ts
+++ b/apps/mailroom/src/notify-discord.ts
@@ -1,26 +1,22 @@
 import { forDO } from '@repo/do-utils'
-import { parseDateOrNull } from '@repo/worker-utils'
 
 import { consume } from './email'
 import { awardAndAnnounce } from './markee-bonus'
 
-import type { Discord, DiscordEmbed, MessageContent } from '@repo/discord'
+import type { Discord, MessageContent } from '@repo/discord'
 import type { Env } from './context'
 import type { EmailHandler } from './email'
 
-/** Discord "blurple". */
-const EMBED_COLOR = 0x5865f2
-/** Discord embed field limits (characters). */
-const LIMIT = { title: 256, description: 4000, fieldValue: 1024 }
-
 /**
- * Route handler: post an inbound email to a Discord channel via the shared Discord
- * Durable Object (`@repo/discord`), reached with `forDO`.
+ * Route handler for markeedragon@ inbound mail. The message is a Markee Dragon affiliate-sale
+ * notification; its only job here is to trigger a reward. So on each one we award a random
+ * prediction-market wallet a small house-funded bonus and post a celebratory announcement naming the
+ * winner to a Discord channel, via the shared Discord Durable Object (`@repo/discord`, reached with
+ * `forDO`). The email body itself is not posted (it was only ever shown while debugging).
  *
- * On success the email is `consume`d — its purpose is fulfilled by the Discord post, so it
- * is accepted and discarded. Any failure (missing config, or the send failing) throws, so
- * the framework's error fallback preserves the mail (forward-to-fallback) and Sentry
- * captures it rather than the notification being silently lost.
+ * Once the post succeeds the mail is `consume`d (accepted and discarded). The award is best-effort and
+ * never throws; only a missing config or the Discord send failing throws, so the framework's error
+ * fallback preserves the mail (forward-to-fallback) and Sentry captures it.
  */
 export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 	const guildId = ctx.env.DISCORD_GUILD_ID
@@ -31,32 +27,14 @@ export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 		)
 	}
 
-	const parsed = await ctx.parsed()
-	const body = (parsed.text ?? htmlToText(parsed.html) ?? '').trim()
-	const timestamp = parseDateOrNull(parsed.date)?.toISOString()
-
-	// Side perk of a markeedragon@ email: award a random prediction-market wallet a small bonus from
-	// the house wallet, and get back a celebratory announcement naming the winner. Runs BEFORE the post
-	// because the post announces the winner; it is fully self-contained (never throws) and returns null
-	// when no one was bonused (empty house / no wallets / a failure), in which case the post keeps its
-	// plain "new email" line. As Discord message content, the announcement renders emoji AND custom
-	// emotes, and the winner mention resolves to their display name.
+	// Award a random prediction-market wallet a house-funded bonus and build the announcement naming
+	// the winner. Best-effort (never throws); returns null when no one was bonused (empty house / no
+	// wallets / a failure), in which case we post a plain sale notice. As Discord message content, the
+	// announcement renders emoji + custom emotes and the winner mention resolves to their display name.
 	const announcement = await awardAndAnnounce(ctx)
 
-	const embed: DiscordEmbed = {
-		title: truncate(parsed.subject ?? '(no subject)', LIMIT.title),
-		description: body ? truncate(body, LIMIT.description) : '_(empty body)_',
-		color: EMBED_COLOR,
-		fields: [
-			{ name: 'From', value: truncate(ctx.sender, LIMIT.fieldValue), inline: true },
-			{ name: 'To', value: truncate(ctx.recipient, LIMIT.fieldValue), inline: true },
-		],
-		...(timestamp ? { timestamp } : {}),
-	}
-
 	const message: MessageContent = {
-		content: announcement ?? `📧 New email to **${ctx.recipient}**`,
-		embeds: [embed],
+		content: announcement ?? '📣 A Markee Dragon referral sale just came in!',
 		allowEveryone: false,
 	}
 
@@ -66,7 +44,7 @@ export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 		throw new Error(`Discord sendMessage failed: ${result.error ?? 'unknown error'}`)
 	}
 
-	ctx.log.info('email posted to Discord', {
+	ctx.log.info('markee bonus announcement posted to Discord', {
 		from: ctx.sender,
 		to: ctx.recipient,
 		channelId,
@@ -74,21 +52,6 @@ export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 		announced: announcement !== null,
 	})
 
-	// The email's purpose is fulfilled by the Discord post — accept and discard.
+	// The email's purpose (trigger the bonus + announce it) is fulfilled — accept and discard.
 	return consume
-}
-
-function truncate(value: string, max: number): string {
-	return value.length > max ? `${value.slice(0, max - 1)}…` : value
-}
-
-/** Rough HTML→text fallback for emails that carry only an HTML body. */
-function htmlToText(html: string | null): string | null {
-	if (!html) return null
-	return html
-		.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ')
-		.replace(/<[^>]+>/g, ' ')
-		.replace(/&nbsp;/gi, ' ')
-		.replace(/\s+/g, ' ')
-		.trim()
 }

--- a/apps/mailroom/src/test/markee-bonus.test.ts
+++ b/apps/mailroom/src/test/markee-bonus.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createEmailContext } from '../email'
+import { awardAndAnnounce, BONUS_HEADINGS, BONUS_MESSAGES } from '../markee-bonus'
+import { fakeExecutionCtx, makeMessage } from './make-message'
+
+import type { Env } from '../context'
+import type { EmailLogger } from '../email'
+import type { DiscordProfile } from '@repo/discord'
+import type { AwardBonusResult } from '@repo/prediction-markets'
+
+type AwardMock = ReturnType<typeof vi.fn<() => Promise<AwardBonusResult>>>
+type ProfileMock = ReturnType<typeof vi.fn<() => Promise<DiscordProfile | null>>>
+
+/**
+ * Build an Env whose PREDICTION_MARKETS binding resolves (via getStub's idFromName + get) to a stub
+ * with the given `awardRandomBonus`, and whose DISCORD binding resolves (via forDO().singleton() →
+ * getByName) to a stub with the given `getProfileByCoreUserId`.
+ */
+function envWith(
+	awardRandomBonus: AwardMock,
+	getProfileByCoreUserId: ProfileMock,
+	overrides: Partial<Env> = {}
+): Env {
+	return {
+		PREDICTION_MARKETS: { idFromName: (name: string) => name, get: () => ({ awardRandomBonus }) },
+		DISCORD: { getByName: () => ({ getProfileByCoreUserId }) },
+		...overrides,
+	} as unknown as Env
+}
+
+function ctxFor(env: Env, log: EmailLogger) {
+	const message = makeMessage({ to: 'markeedragon@pleaseignore.app', from: 'sender@example.com' })
+	return createEmailContext(message, env, fakeExecutionCtx(), log)
+}
+
+const makeLog = (): EmailLogger => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+const profile = (userId: string): DiscordProfile => ({
+	userId,
+	username: 'winner',
+	discriminator: '0',
+	scopes: [],
+})
+
+/**
+ * True when `content`'s body line is one of the predefined openers followed by `name`. The body is
+ * the last line — an optional heading (from BONUS_HEADINGS) precedes it on its own line when configured.
+ */
+function isAnnouncementFor(content: string | null, name: string): boolean {
+	if (content === null) return false
+	const body = content.slice(content.lastIndexOf('\n') + 1)
+	return BONUS_MESSAGES.some((m) => body === `${m} ${name}`)
+}
+
+const awardOk = (over: Partial<Extract<AwardBonusResult, { awarded: true }>> = {}): AwardMock =>
+	vi.fn<() => Promise<AwardBonusResult>>().mockResolvedValue({
+		awarded: true,
+		userId: 'core-1',
+		amount: '7',
+		balanceAfter: '107',
+		...over,
+	})
+
+describe('awardAndAnnounce', () => {
+	it('announces a random opener followed by the winner mention (their display name)', async () => {
+		const award = awardOk()
+		const getProfile = vi
+			.fn<() => Promise<DiscordProfile | null>>()
+			.mockResolvedValue(profile('999'))
+		const log = makeLog()
+
+		const content = await awardAndAnnounce(
+			ctxFor(envWith(award, getProfile, { MARKEE_BONUS_AMOUNT: '7' }), log)
+		)
+
+		expect(isAnnouncementFor(content, '<@999>')).toBe(true) // <opener> <@discordId> (mention + ping)
+		// Heading: none while BONUS_HEADINGS is empty (single-line body); once configured, a random one
+		// (which may itself span multiple lines) is prepended above the body as `<heading>\n<body>`.
+		if (BONUS_HEADINGS.length === 0) {
+			expect(content).not.toContain('\n')
+		} else {
+			expect(BONUS_HEADINGS.some((h) => (content ?? '').startsWith(`${h}\n`))).toBe(true)
+		}
+		expect(award).toHaveBeenCalledWith({
+			amount: '7',
+			reason: 'markeedragon@ inbound email from sender@example.com',
+		})
+		expect(getProfile).toHaveBeenCalledWith('core-1') // resolved by the winner's core user id
+		expect(log.error).not.toHaveBeenCalled()
+	})
+
+	it('falls back to a generic label when the winner has no linked Discord profile', async () => {
+		const getProfile = vi.fn<() => Promise<DiscordProfile | null>>().mockResolvedValue(null)
+		const content = await awardAndAnnounce(ctxFor(envWith(awardOk(), getProfile), makeLog()))
+		expect(isAnnouncementFor(content, 'a lucky member')).toBe(true)
+	})
+
+	it('still announces (generic label) when resolving the display name throws', async () => {
+		const getProfile = vi
+			.fn<() => Promise<DiscordProfile | null>>()
+			.mockRejectedValue(new Error('discord down'))
+		const log = makeLog()
+		const content = await awardAndAnnounce(ctxFor(envWith(awardOk(), getProfile), log))
+		expect(isAnnouncementFor(content, 'a lucky member')).toBe(true)
+		expect(log.error).toHaveBeenCalledWith(
+			'resolving markee bonus winner name failed (continuing)',
+			expect.objectContaining({ coreUserId: 'core-1' })
+		)
+	})
+
+	it('returns null (and never resolves a name) when no one was bonused', async () => {
+		const award = vi
+			.fn<() => Promise<AwardBonusResult>>()
+			.mockResolvedValue({ awarded: false, reason: 'INSUFFICIENT_HOUSE_FUNDS' })
+		const getProfile = vi.fn<() => Promise<DiscordProfile | null>>()
+		const content = await awardAndAnnounce(ctxFor(envWith(award, getProfile), makeLog()))
+		expect(content).toBeNull()
+		expect(getProfile).not.toHaveBeenCalled()
+	})
+
+	it('returns null and never throws when the award DO call fails', async () => {
+		const award = vi.fn<() => Promise<AwardBonusResult>>().mockRejectedValue(new Error('DO down'))
+		const getProfile = vi.fn<() => Promise<DiscordProfile | null>>()
+		const log = makeLog()
+		await expect(awardAndAnnounce(ctxFor(envWith(award, getProfile), log))).resolves.toBeNull()
+		expect(getProfile).not.toHaveBeenCalled()
+		expect(log.error).toHaveBeenCalledWith(
+			'markee bonus award failed (continuing)',
+			expect.objectContaining({ error: 'DO down' })
+		)
+	})
+
+	it('falls back to the default amount when MARKEE_BONUS_AMOUNT is unset', async () => {
+		const award = vi
+			.fn<() => Promise<AwardBonusResult>>()
+			.mockResolvedValue({ awarded: false, reason: 'NO_ELIGIBLE_WALLETS' })
+		await awardAndAnnounce(ctxFor(envWith(award, vi.fn()), makeLog()))
+		expect(award).toHaveBeenCalledWith(expect.objectContaining({ amount: '5' }))
+	})
+})

--- a/apps/mailroom/src/test/notify-discord.test.ts
+++ b/apps/mailroom/src/test/notify-discord.test.ts
@@ -10,12 +10,30 @@ import type { EmailLogger } from '../email'
 
 const log: EmailLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 
-/** Build an Env whose DISCORD binding resolves to a stub with the given `sendMessage` mock. */
-function envWith(sendMessage: ReturnType<typeof vi.fn>, overrides: Partial<Env> = {}): Env {
+const MIME_WITH_BODY =
+	'From: sender@example.com\r\nTo: markeedragon@pleaseignore.app\r\nSubject: Hello Markee\r\n\r\nThe body text.'
+
+/** A skipped-award mock (no one bonused) — the default so the post keeps its plain "new email" line. */
+const skippedAward = () =>
+	vi.fn().mockResolvedValue({ awarded: false, reason: 'NO_ELIGIBLE_WALLETS' })
+
+/**
+ * Build an Env whose DISCORD binding resolves (via forDO().singleton() → getByName) to a stub with the
+ * given `sendMessage` + `getProfileByCoreUserId`, and whose PREDICTION_MARKETS binding resolves (via
+ * getStub) to a stub with the given `awardRandomBonus`. The award/profile mocks are passed in so a test
+ * can hold references and assert the wiring; the helper's own behaviour lives in markee-bonus.test.ts.
+ */
+function envWith(
+	sendMessage: ReturnType<typeof vi.fn>,
+	overrides: Partial<Env> = {},
+	award: ReturnType<typeof vi.fn> = skippedAward(),
+	getProfile: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(null)
+): Env {
 	return {
 		DISCORD_GUILD_ID: 'guild-1',
 		MARKEE_DISCORD_CHANNEL_ID: 'chan-1',
-		DISCORD: { getByName: () => ({ sendMessage }) },
+		DISCORD: { getByName: () => ({ sendMessage, getProfileByCoreUserId: getProfile }) },
+		PREDICTION_MARKETS: { idFromName: (name: string) => name, get: () => ({ awardRandomBonus: award }) },
 		...overrides,
 	} as unknown as Env
 }
@@ -30,16 +48,16 @@ function ctxFor(env: Env, mime?: string) {
 }
 
 describe('notifyDiscord', () => {
-	it('posts the email to the configured Discord channel and consumes it', async () => {
+	it('posts the email (default line when no one is bonused), invokes the award, and consumes', async () => {
 		const sendMessage = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
-		const mime =
-			'From: sender@example.com\r\nTo: markeedragon@pleaseignore.app\r\nSubject: Hello Markee\r\n\r\nThe body text.'
-		const disposition = await notifyDiscord(ctxFor(envWith(sendMessage), mime))
+		const award = skippedAward()
+		const disposition = await notifyDiscord(ctxFor(envWith(sendMessage, {}, award), MIME_WITH_BODY))
 
 		expect(sendMessage).toHaveBeenCalledTimes(1)
 		const [guildId, channelId, message] = sendMessage.mock.calls[0]
 		expect(guildId).toBe('guild-1')
 		expect(channelId).toBe('chan-1')
+		// No bonus ⇒ content falls back to the plain "new email" line; the email embed is attached.
 		expect(message.content).toContain('markeedragon@pleaseignore.app')
 		expect(message.embeds[0].title).toBe('Hello Markee')
 		expect(message.embeds[0].description).toContain('The body text.')
@@ -47,22 +65,53 @@ describe('notifyDiscord', () => {
 			{ name: 'From', value: 'sender@example.com', inline: true },
 			{ name: 'To', value: 'markeedragon@pleaseignore.app', inline: true },
 		])
+		// The award is actually wired in (guards against silently disconnecting the feature).
+		expect(award).toHaveBeenCalledTimes(1)
+		expect(award).toHaveBeenCalledWith({
+			amount: '5',
+			reason: 'markeedragon@ inbound email from sender@example.com',
+		})
 		expect(disposition).toEqual({ type: 'consume' })
 	})
 
-	it('throws when guild/channel are not configured', async () => {
+	it('posts a random bonus announcement naming the winner when a bonus is awarded', async () => {
+		const sendMessage = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
+		const award = vi
+			.fn()
+			.mockResolvedValue({ awarded: true, userId: 'core-1', amount: '5', balanceAfter: '5' })
+		const getProfile = vi
+			.fn()
+			.mockResolvedValue({ userId: '999', username: 'w', discriminator: '0', scopes: [] })
+
+		const disposition = await notifyDiscord(
+			ctxFor(envWith(sendMessage, {}, award, getProfile), MIME_WITH_BODY)
+		)
+
+		const [, , message] = sendMessage.mock.calls[0]
+		expect(message.content).toContain('<@999>') // winner mention → renders as their display name + pings
+		expect(message.content).not.toContain('New email to') // announcement replaced the default line
+		expect(message.embeds[0].title).toBe('Hello Markee') // email embed still attached for context
+		expect(getProfile).toHaveBeenCalledWith('core-1') // resolved by the winner's core user id
+		expect(disposition).toEqual({ type: 'consume' })
+	})
+
+	it('throws when guild/channel are not configured (before any award)', async () => {
 		const sendMessage = vi.fn()
-		const env = envWith(sendMessage, {
-			DISCORD_GUILD_ID: undefined,
-			MARKEE_DISCORD_CHANNEL_ID: undefined,
-		})
+		const award = skippedAward()
+		const env = envWith(sendMessage, { DISCORD_GUILD_ID: undefined, MARKEE_DISCORD_CHANNEL_ID: undefined }, award)
 		await expect(notifyDiscord(ctxFor(env))).rejects.toThrow(/not configured/)
 		expect(sendMessage).not.toHaveBeenCalled()
+		expect(award).not.toHaveBeenCalled()
 	})
 
 	it('throws when the Discord send fails (so the framework preserves the mail)', async () => {
 		const sendMessage = vi.fn().mockResolvedValue({ success: false, error: 'missing permissions' })
-		await expect(notifyDiscord(ctxFor(envWith(sendMessage)))).rejects.toThrow(/missing permissions/)
+		const award = skippedAward()
+		await expect(notifyDiscord(ctxFor(envWith(sendMessage, {}, award)))).rejects.toThrow(
+			/missing permissions/
+		)
+		// The award runs BEFORE the post (the post announces the winner), so it is attempted regardless.
+		expect(award).toHaveBeenCalledTimes(1)
 	})
 
 	it('is wired into the email router for markeedragon@', async () => {

--- a/apps/mailroom/src/test/notify-discord.test.ts
+++ b/apps/mailroom/src/test/notify-discord.test.ts
@@ -10,10 +10,7 @@ import type { EmailLogger } from '../email'
 
 const log: EmailLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 
-const MIME_WITH_BODY =
-	'From: sender@example.com\r\nTo: markeedragon@pleaseignore.app\r\nSubject: Hello Markee\r\n\r\nThe body text.'
-
-/** A skipped-award mock (no one bonused) — the default so the post keeps its plain "new email" line. */
+/** A skipped-award mock (no one bonused) — the default so the post falls back to the plain sale notice. */
 const skippedAward = () =>
 	vi.fn().mockResolvedValue({ awarded: false, reason: 'NO_ELIGIBLE_WALLETS' })
 
@@ -38,33 +35,23 @@ function envWith(
 	} as unknown as Env
 }
 
-function ctxFor(env: Env, mime?: string) {
-	const message = makeMessage({
-		to: 'markeedragon@pleaseignore.app',
-		from: 'sender@example.com',
-		mime,
-	})
+function ctxFor(env: Env) {
+	const message = makeMessage({ to: 'markeedragon@pleaseignore.app', from: 'sender@example.com' })
 	return createEmailContext(message, env, fakeExecutionCtx(), log)
 }
 
 describe('notifyDiscord', () => {
-	it('posts the email (default line when no one is bonused), invokes the award, and consumes', async () => {
+	it('posts a plain sale notice (no embed) when no one is bonused, invokes the award, and consumes', async () => {
 		const sendMessage = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
 		const award = skippedAward()
-		const disposition = await notifyDiscord(ctxFor(envWith(sendMessage, {}, award), MIME_WITH_BODY))
+		const disposition = await notifyDiscord(ctxFor(envWith(sendMessage, {}, award)))
 
 		expect(sendMessage).toHaveBeenCalledTimes(1)
 		const [guildId, channelId, message] = sendMessage.mock.calls[0]
 		expect(guildId).toBe('guild-1')
 		expect(channelId).toBe('chan-1')
-		// No bonus ⇒ content falls back to the plain "new email" line; the email embed is attached.
-		expect(message.content).toContain('markeedragon@pleaseignore.app')
-		expect(message.embeds[0].title).toBe('Hello Markee')
-		expect(message.embeds[0].description).toContain('The body text.')
-		expect(message.embeds[0].fields).toEqual([
-			{ name: 'From', value: 'sender@example.com', inline: true },
-			{ name: 'To', value: 'markeedragon@pleaseignore.app', inline: true },
-		])
+		expect(message.content).toBe('📣 A Markee Dragon referral sale just came in!')
+		expect(message.embeds).toBeUndefined() // the email body/embed was debug-only and is gone
 		// The award is actually wired in (guards against silently disconnecting the feature).
 		expect(award).toHaveBeenCalledTimes(1)
 		expect(award).toHaveBeenCalledWith({
@@ -83,49 +70,14 @@ describe('notifyDiscord', () => {
 			.fn()
 			.mockResolvedValue({ userId: '999', username: 'w', discriminator: '0', scopes: [] })
 
-		const disposition = await notifyDiscord(
-			ctxFor(envWith(sendMessage, {}, award, getProfile), MIME_WITH_BODY)
-		)
+		const disposition = await notifyDiscord(ctxFor(envWith(sendMessage, {}, award, getProfile)))
 
 		const [, , message] = sendMessage.mock.calls[0]
 		expect(message.content).toContain('<@999>') // winner mention → renders as their display name + pings
-		expect(message.content).not.toContain('New email to') // announcement replaced the default line
-		expect(message.embeds[0].title).toBe('Hello Markee') // email embed still attached for context
+		expect(message.content).not.toContain('sale just came in') // the announcement, not the fallback notice
+		expect(message.embeds).toBeUndefined() // no email embed
 		expect(getProfile).toHaveBeenCalledWith('core-1') // resolved by the winner's core user id
 		expect(disposition).toEqual({ type: 'consume' })
-	})
-
-	it('reproduces a real Markee Dragon affiliate email body in the Discord embed', async () => {
-		const sendMessage = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
-		const from = 'test.high.command+caf_=markeedragon=pleaseignore.app@gmail.com'
-		// The actual affiliate-notification body Markee Dragon sends (whitespace-collapsed to one run,
-		// exactly as it reaches Discord).
-		const body =
-			'Your link to Markee Dragon Game Codes has generated a sale! Customer Service: ' +
-			'support@markeedragon.com | Phone: (512) 666-7740 | Postal: PO Box # 106 ,Hereford, USA 85615 ' +
-			'Your link to Markee Dragon Game Codes generated a sale on 2026-07-10 19:30:43 Order ID: 914805, ' +
-			'Your commission: $6.06 Total owed to you: $15.31 Thank you for your help! You can log in to ' +
-			'check how much you have earned at: https://store.markeedragon.com/affiliate/login.php ' +
-			'Markee Dragon Game Codes'
-		const mime =
-			`From: ${from}\r\nTo: markeedragon@pleaseignore.app\r\n` +
-			`Subject: Markee Dragon Game Codes affiliate notification\r\n\r\n${body}`
-		const message = makeMessage({ to: 'markeedragon@pleaseignore.app', from, mime })
-		const ctx = createEmailContext(message, envWith(sendMessage), fakeExecutionCtx(), log)
-
-		await notifyDiscord(ctx)
-		const [, , sent] = sendMessage.mock.calls[0]
-		const embed = sent.embeds[0]
-		expect(embed.title).toBe('Markee Dragon Game Codes affiliate notification')
-		expect(embed.description).toContain('has generated a sale')
-		expect(embed.description).toContain('Order ID: 914805')
-		expect(embed.description).toContain('Your commission: $6.06')
-		expect(embed.description).toContain('Total owed to you: $15.31')
-		expect(embed.description).toContain('https://store.markeedragon.com/affiliate/login.php')
-		expect(embed.fields).toEqual([
-			{ name: 'From', value: from, inline: true },
-			{ name: 'To', value: 'markeedragon@pleaseignore.app', inline: true },
-		])
 	})
 
 	it('throws when guild/channel are not configured (before any award)', async () => {

--- a/apps/mailroom/src/test/notify-discord.test.ts
+++ b/apps/mailroom/src/test/notify-discord.test.ts
@@ -95,6 +95,39 @@ describe('notifyDiscord', () => {
 		expect(disposition).toEqual({ type: 'consume' })
 	})
 
+	it('reproduces a real Markee Dragon affiliate email body in the Discord embed', async () => {
+		const sendMessage = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
+		const from = 'test.high.command+caf_=markeedragon=pleaseignore.app@gmail.com'
+		// The actual affiliate-notification body Markee Dragon sends (whitespace-collapsed to one run,
+		// exactly as it reaches Discord).
+		const body =
+			'Your link to Markee Dragon Game Codes has generated a sale! Customer Service: ' +
+			'support@markeedragon.com | Phone: (512) 666-7740 | Postal: PO Box # 106 ,Hereford, USA 85615 ' +
+			'Your link to Markee Dragon Game Codes generated a sale on 2026-07-10 19:30:43 Order ID: 914805, ' +
+			'Your commission: $6.06 Total owed to you: $15.31 Thank you for your help! You can log in to ' +
+			'check how much you have earned at: https://store.markeedragon.com/affiliate/login.php ' +
+			'Markee Dragon Game Codes'
+		const mime =
+			`From: ${from}\r\nTo: markeedragon@pleaseignore.app\r\n` +
+			`Subject: Markee Dragon Game Codes affiliate notification\r\n\r\n${body}`
+		const message = makeMessage({ to: 'markeedragon@pleaseignore.app', from, mime })
+		const ctx = createEmailContext(message, envWith(sendMessage), fakeExecutionCtx(), log)
+
+		await notifyDiscord(ctx)
+		const [, , sent] = sendMessage.mock.calls[0]
+		const embed = sent.embeds[0]
+		expect(embed.title).toBe('Markee Dragon Game Codes affiliate notification')
+		expect(embed.description).toContain('has generated a sale')
+		expect(embed.description).toContain('Order ID: 914805')
+		expect(embed.description).toContain('Your commission: $6.06')
+		expect(embed.description).toContain('Total owed to you: $15.31')
+		expect(embed.description).toContain('https://store.markeedragon.com/affiliate/login.php')
+		expect(embed.fields).toEqual([
+			{ name: 'From', value: from, inline: true },
+			{ name: 'To', value: 'markeedragon@pleaseignore.app', inline: true },
+		])
+	})
+
 	it('throws when guild/channel are not configured (before any award)', async () => {
 		const sendMessage = vi.fn()
 		const award = skippedAward()

--- a/apps/mailroom/vitest.config.ts
+++ b/apps/mailroom/vitest.config.ts
@@ -10,10 +10,10 @@ export default defineWorkersProject({
 					bindings: {
 						ENVIRONMENT: 'VITEST',
 					},
-					// The DISCORD binding targets the cross-worker `discord` Durable Object. Provide a
-					// stub `discord` worker exposing a `Discord` DO so the pool can resolve the binding
-					// at startup. Mailroom's tests never call the real DO — Discord is faked in the
-					// notify-discord unit tests — this only satisfies the runtime.
+					// The DISCORD and PREDICTION_MARKETS bindings target cross-worker Durable Objects
+					// (`discord` / `prediction-markets`). Provide stub workers exposing those DO classes so
+					// the pool can resolve the bindings at startup. Mailroom's tests never call the real DOs
+					// — both are faked in the unit tests (envWith) — these only satisfy the runtime.
 					workers: [
 						{
 							name: 'discord',
@@ -21,10 +21,22 @@ export default defineWorkersProject({
 							script: [
 								'export class Discord {',
 								'  async sendMessage() { return { success: false, error: "stub discord worker" } }',
+								'  async getProfileByCoreUserId() { return null }',
 								'}',
 								'export default { fetch() { return new Response("stub") } }',
 							].join('\n'),
 							durableObjects: { Discord: 'Discord' },
+						},
+						{
+							name: 'prediction-markets',
+							modules: true,
+							script: [
+								'export class PredictionMarkets {',
+								'  async awardRandomBonus() { return { awarded: false, reason: "NO_ELIGIBLE_WALLETS" } }',
+								'}',
+								'export default { fetch() { return new Response("stub") } }',
+							].join('\n'),
+							durableObjects: { PredictionMarkets: 'PredictionMarkets' },
 						},
 					],
 				},

--- a/apps/mailroom/wrangler.jsonc
+++ b/apps/mailroom/wrangler.jsonc
@@ -38,7 +38,7 @@
 		// in that guild and able to post in the channel). Until both are set, mail to markeedragon@
 		// errors out to the fallback/last-resort path rather than posting.
 		"DISCORD_GUILD_ID": "356398105404375041",
-		"MARKEE_DISCORD_CHANNEL_ID": "730208741181358100",
+		"MARKEE_DISCORD_CHANNEL_ID": "362144221148479489",
 		// Points awarded to a random prediction-market wallet on each markeedragon@ email, paid from
 		// the house wallet. Tune without a code change; the award silently no-ops if the house can't fund it.
 		"MARKEE_BONUS_AMOUNT": "5"

--- a/apps/mailroom/wrangler.jsonc
+++ b/apps/mailroom/wrangler.jsonc
@@ -13,14 +13,20 @@
 	"observability": {
 		"enabled": true
 	},
-	// Cross-worker binding to the shared Discord Durable Object (apps/discord). Used by the
-	// markeedragon@ → Discord route. The `discord` worker must be deployed in the same account.
+	// Cross-worker bindings to shared Durable Objects (both workers must be deployed in the same
+	// account). DISCORD (apps/discord) powers the markeedragon@ → Discord post; PREDICTION_MARKETS
+	// (apps/prediction-markets) lets that same route award a random wallet a small house-funded bonus.
 	"durable_objects": {
 		"bindings": [
 			{
 				"name": "DISCORD",
 				"class_name": "Discord",
 				"script_name": "discord"
+			},
+			{
+				"name": "PREDICTION_MARKETS",
+				"class_name": "PredictionMarkets",
+				"script_name": "prediction-markets"
 			}
 		]
 	},
@@ -32,7 +38,10 @@
 		// in that guild and able to post in the channel). Until both are set, mail to markeedragon@
 		// errors out to the fallback/last-resort path rather than posting.
 		"DISCORD_GUILD_ID": "356398105404375041",
-		"MARKEE_DISCORD_CHANNEL_ID": "730208741181358100"
+		"MARKEE_DISCORD_CHANNEL_ID": "730208741181358100",
+		// Points awarded to a random prediction-market wallet on each markeedragon@ email, paid from
+		// the house wallet. Tune without a code change; the award silently no-ops if the house can't fund it.
+		"MARKEE_BONUS_AMOUNT": "5"
 		// Optional framework config (set to VERIFIED Email Routing destinations before relying on them):
 		//   "FALLBACK_FORWARD_ADDRESS": "ops@pleaseignore.app"  // receives mail when inbound processing fails
 		//   "FORWARD_TEAM_TO": "team-inbox@pleaseignore.app"     // destination for the example "team@" alias

--- a/apps/prediction-markets/src/durable-object.ts
+++ b/apps/prediction-markets/src/durable-object.ts
@@ -9,6 +9,8 @@ import * as settlement from './services/settlement-service'
 import * as wallet from './services/wallet-service'
 
 import type {
+	AwardBonusInput,
+	AwardBonusResult,
 	BetResult,
 	BetView,
 	CreateMarketInput,
@@ -141,6 +143,10 @@ export class PredictionMarketsDO extends DurableObject<Env> implements Predictio
 		userId: string
 	): Promise<{ balance: string; granted: string; alreadyOnboarded: boolean }> {
 		return wallet.onboardUser(this.deps, userId)
+	}
+
+	async awardRandomBonus(input: AwardBonusInput): Promise<AwardBonusResult> {
+		return wallet.awardRandomBonus(this.deps, input)
 	}
 
 	async createMarket(input: CreateMarketInput): Promise<MarketDetail> {

--- a/apps/prediction-markets/src/services/wallet-service.ts
+++ b/apps/prediction-markets/src/services/wallet-service.ts
@@ -1,15 +1,15 @@
-import { eq } from '@repo/db-utils'
+import { and, eq, ne, sql } from '@repo/db-utils'
 import { captureException } from '@repo/hono-helpers'
 import { SYSTEM_WALLET_USER_ID } from '@repo/prediction-markets'
 
 import { pmLedger, pmWallets } from '../db/schema'
 import { isExpectedError, PmError } from '../lib/errors'
-import { isPositiveIntegerString, parseAmount } from '../lib/money'
+import { formatAmount, isPositiveIntegerString, parseAmount } from '../lib/money'
 import { ONBOARDING_GRANT, ONBOARDING_REASON, SYSTEM_ACTOR } from './context'
 import { getWalletBalance } from './read-service'
 import { creditWallet } from './shared'
 
-import type { GrantPointsInput } from '@repo/prediction-markets'
+import type { AwardBonusInput, AwardBonusResult, GrantPointsInput } from '@repo/prediction-markets'
 import type { PmDeps } from './context'
 
 export async function grantPoints(
@@ -120,6 +120,104 @@ export async function onboardUser(
 		if (error instanceof Error && error.message === 'IDEMPOTENCY_KEY_CONFLICT') {
 			const { balance } = await getWalletBalance(deps, userId)
 			return { balance, granted: '0', alreadyOnboarded: true }
+		}
+		throw error
+	}
+}
+
+/**
+ * Award a small bonus to a random existing (non-system) wallet, paid FROM the house/system wallet.
+ *
+ * A pure, points-conserving transfer done atomically in one transaction: pick a random real wallet,
+ * debit the house wallet overdraft-safe, then credit the winner — booked as two `adjustment` ledger
+ * lines tagged `source: 'bonus'` (the recipient credit routes through the shared `creditWallet`
+ * primitive; the house debit is its signed mirror). Reusing `adjustment` (rather than a new ledger
+ * enum value) keeps this migration-free — it is the type reserved for exactly these out-of-band
+ * balance movements, and it already renders/filters in the admin audit UI.
+ *
+ * Best-effort by contract: it no-ops (`{ awarded: false }`) when there is no eligible wallet or the
+ * house lacks the funds, so a caller (e.g. the mailroom Easter-egg) can fire it without special-
+ * casing an empty house. It throws only on a genuinely invalid request or an infra failure.
+ */
+export async function awardRandomBonus(
+	deps: PmDeps,
+	input: AwardBonusInput
+): Promise<AwardBonusResult> {
+	if (!isPositiveIntegerString(input.amount)) {
+		throw new PmError('INVALID_AMOUNT')
+	}
+	if (!input.reason?.trim()) {
+		throw new PmError('REASON_REQUIRED')
+	}
+	const amount = parseAmount(input.amount)
+	const formatted = formatAmount(amount)
+	try {
+		return await deps.db.transaction(async (tx) => {
+			// Pick a random real recipient and lock its wallet row. The house/system wallet is an
+			// internal accumulator, never a prize target, so exclude it. `FOR UPDATE` here is NOT for
+			// credit correctness (the credit below is an atomic increment) — it enforces a consistent
+			// lock ORDER: every money op must take member-wallet locks BEFORE the SYSTEM-wallet lock.
+			// executeResolution locks winners then SYSTEM (rake/dust); locking the winner here first
+			// keeps this in the same order and avoids a deadlock cycle with a concurrent resolution.
+			const [winner] = await tx
+				.select({ userId: pmWallets.userId })
+				.from(pmWallets)
+				.where(ne(pmWallets.userId, SYSTEM_WALLET_USER_ID))
+				.orderBy(sql`random()`)
+				.limit(1)
+				.for('update')
+			if (!winner) return { awarded: false, reason: 'NO_ELIGIBLE_WALLETS' }
+
+			// Debit the house wallet, overdraft-safe (mirrors placeBet's guarded debit): the balance
+			// guard makes 0 affected rows mean "house can't fund this" — skip without moving money. This
+			// also handles a house wallet that has never been created (no row ⇒ 0 rows ⇒ skip).
+			const debited = await tx
+				.update(pmWallets)
+				.set({
+					balance: sql`${pmWallets.balance} - ${formatted}::numeric`,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(pmWallets.userId, SYSTEM_WALLET_USER_ID),
+						sql`${pmWallets.balance} >= ${formatted}::numeric`
+					)
+				)
+				.returning({ balance: pmWallets.balance })
+			if (debited.length === 0) {
+				return { awarded: false, reason: 'INSUFFICIENT_HOUSE_FUNDS' }
+			}
+
+			// Record the house debit as a signed (negative) adjustment line carrying its running balance.
+			await tx.insert(pmLedger).values({
+				userId: SYSTEM_WALLET_USER_ID,
+				amount: formatAmount(-amount),
+				type: 'adjustment',
+				balanceAfter: debited[0].balance,
+				metadata: { source: 'bonus', reason: input.reason, counterpartyUserId: winner.userId },
+			})
+
+			// Credit the winner. Their wallet exists (we just selected it), so skip the lazy upsert.
+			const { balanceAfter } = await creditWallet(tx, {
+				userId: winner.userId,
+				amount,
+				type: 'adjustment',
+				metadata: { source: 'bonus', reason: input.reason },
+				ensureWallet: false,
+			})
+
+			return {
+				awarded: true,
+				userId: winner.userId,
+				amount: formatted,
+				balanceAfter: balanceAfter ?? '0',
+			}
+		})
+	} catch (error) {
+		if (!isExpectedError(error)) {
+			captureException(error as Error, {
+				tags: { durableObject: 'PredictionMarketsDO', method: 'awardRandomBonus' },
+			})
 		}
 		throw error
 	}

--- a/apps/prediction-markets/src/test/integration/money-flow.int.test.ts
+++ b/apps/prediction-markets/src/test/integration/money-flow.int.test.ts
@@ -468,3 +468,136 @@ suite('admin override resolve', () => {
 		expect(await balance(proposer)).toBe('0')
 	})
 })
+
+// ---------------------------------------------------------------------------
+// E) award random bonus — a house-funded transfer to a random member
+// ---------------------------------------------------------------------------
+suite('award random bonus', () => {
+	/** Resolve a raked market so the house/system wallet accrues a real, conserved balance. */
+	async function fundHouseViaResolve(): Promise<{ house: bigint; u1: string; u2: string }> {
+		const [creator, resolver, u1, u2] = [1, 2, 3, 4].map(uuid)
+		// rake 10%, no creator reward ⇒ all the rake lands in the house wallet (nothing to the creator,
+		// whose wallet therefore never gets created), keeping the eligible set exactly {u1, u2}.
+		await governance.updateConfig(deps, {
+			actorUserId: ADMIN,
+			defaultRakeBps: 0,
+			defaultMinStake: '1',
+			twoOfNThreshold: null,
+			creatorRewardMinBps: 0,
+			creatorRewardMaxBps: 0,
+		})
+		for (const u of [u1, u2]) await grant(u, '1000') // supply 2000
+		const m = await market.createMarket(deps, {
+			createdBy: creator,
+			question: 'fund the house',
+			outcomes: ['A', 'B'],
+			closesAt: hoursFromNow(1),
+			resolvesOn: hoursFromNow(2),
+			rakeBps: 1000,
+		})
+		const A = m.outcomes.find((o) => o.label === 'A')!.id
+		const B = m.outcomes.find((o) => o.label === 'B')!.id
+		await betting.placeBet(deps, {
+			userId: u1,
+			marketId: m.id,
+			outcomeId: A,
+			amount: '100',
+			idempotencyKey: 'ab-u1',
+		})
+		await betting.placeBet(deps, {
+			userId: u2,
+			marketId: m.id,
+			outcomeId: B,
+			amount: '100',
+			idempotencyKey: 'ab-u2',
+		})
+		await market.closeMarket(deps, { actorUserId: resolver, marketId: m.id })
+		const res = await settlement.proposeResolution(deps, {
+			resolverId: resolver,
+			marketId: m.id,
+			outcomeId: A,
+		})
+		expect(res.status).toBe('resolved')
+		const house = BigInt(await balance(SYSTEM))
+		expect(house).toBeGreaterThan(0n)
+		await assertConservation(2000n) // a resolve is a pure redistribution
+		return { house, u1, u2 }
+	}
+
+	it('moves the bonus from the house wallet to a random member and conserves supply', async () => {
+		const { house, u1, u2 } = await fundHouseViaResolve()
+		const before1 = BigInt(await balance(u1))
+		const before2 = BigInt(await balance(u2))
+
+		const result = await wallet.awardRandomBonus(deps, { amount: '3', reason: 'markee bonus' })
+		expect(result.awarded).toBe(true)
+		if (!result.awarded) throw new Error('expected an award')
+		// The winner is a real member (never the house), drawn from the only eligible wallets.
+		expect(result.userId).not.toBe(SYSTEM)
+		expect([u1, u2]).toContain(result.userId)
+		expect(result.amount).toBe('3')
+
+		// House down by exactly 3; exactly one member up by exactly 3; nothing created or destroyed.
+		expect(BigInt(await balance(SYSTEM))).toBe(house - 3n)
+		const d1 = BigInt(await balance(u1)) - before1
+		const d2 = BigInt(await balance(u2)) - before2
+		expect(d1 + d2).toBe(3n)
+		expect([d1, d2]).toContain(3n)
+		expect(BigInt(await balance(result.userId))).toBe(
+			result.userId === u1 ? before1 + 3n : before2 + 3n
+		)
+		await assertConservation(2000n)
+
+		// Booked as two `adjustment` lines (house −3, member +3) that net to zero, tagged source:'bonus'.
+		const adj = await deps.db
+			.select({ userId: pmLedger.userId, amount: pmLedger.amount, metadata: pmLedger.metadata })
+			.from(pmLedger)
+			.where(eq(pmLedger.type, 'adjustment'))
+		expect(adj).toHaveLength(2)
+		expect(adj.reduce((s, r) => s + BigInt(r.amount), 0n)).toBe(0n)
+		const houseLine = adj.find((r) => r.userId === SYSTEM)!
+		const memberLine = adj.find((r) => r.userId === result.userId)!
+		expect(BigInt(houseLine.amount)).toBe(-3n)
+		expect(BigInt(memberLine.amount)).toBe(3n)
+		// Audit payload (not just the tag): the reason is stamped on BOTH lines, and the house debit
+		// carries counterpartyUserId linking it to the winner — the adjustment lines have no
+		// marketId/betId, so this is the only ledger link pairing the two halves of the transfer.
+		const meta = (r: (typeof adj)[number]) =>
+			r.metadata as { source?: string; reason?: string; counterpartyUserId?: string }
+		expect(meta(houseLine)).toMatchObject({ source: 'bonus', reason: 'markee bonus' })
+		expect(meta(memberLine)).toMatchObject({ source: 'bonus', reason: 'markee bonus' })
+		expect(meta(houseLine).counterpartyUserId).toBe(result.userId)
+	})
+
+	it('skips cleanly when there are no eligible wallets', async () => {
+		// Fresh truncated state ⇒ pm_wallets is empty (not even a house wallet exists).
+		const result = await wallet.awardRandomBonus(deps, { amount: '5', reason: 'x' })
+		expect(result).toEqual({ awarded: false, reason: 'NO_ELIGIBLE_WALLETS' })
+	})
+
+	it('skips (and moves no money) when the house wallet cannot fund the bonus', async () => {
+		await grant(uuid(3), '10') // creates only the member's wallet; the house wallet stays absent
+		const result = await wallet.awardRandomBonus(deps, { amount: '5', reason: 'x' })
+		expect(result).toEqual({ awarded: false, reason: 'INSUFFICIENT_HOUSE_FUNDS' })
+		expect(await balance(uuid(3))).toBe('10') // untouched
+		const [{ n }] = await deps.db
+			.select({ n: sql<number>`count(*)::int` })
+			.from(pmLedger)
+			.where(eq(pmLedger.type, 'adjustment'))
+		expect(n).toBe(0) // no ledger lines written on a skip
+		await assertConservation(10n)
+	})
+
+	it('rejects an invalid request (non-positive amount / missing reason)', async () => {
+		await grant(uuid(3), '10')
+		await expect(wallet.awardRandomBonus(deps, { amount: '0', reason: 'x' })).rejects.toThrow(
+			'INVALID_AMOUNT'
+		)
+		await expect(wallet.awardRandomBonus(deps, { amount: 'abc', reason: 'x' })).rejects.toThrow(
+			'INVALID_AMOUNT'
+		)
+		await expect(wallet.awardRandomBonus(deps, { amount: '5', reason: '  ' })).rejects.toThrow(
+			'REASON_REQUIRED'
+		)
+	})
+})

--- a/packages/prediction-markets/src/index.ts
+++ b/packages/prediction-markets/src/index.ts
@@ -46,6 +46,25 @@ export interface GrantPointsInput {
 	idempotencyKey?: string
 }
 
+export interface AwardBonusInput {
+	/** Positive integer amount as a decimal string, paid FROM the house/system wallet. */
+	amount: string
+	/** Audit reason recorded on both ledger lines (the house debit and the recipient credit). */
+	reason: string
+}
+
+/**
+ * Outcome of {@link PredictionMarkets.awardRandomBonus}. A discriminated union so callers must
+ * handle the no-op cases explicitly rather than assuming a payout always happened.
+ * - `awarded: true`  — `amount` moved from the house wallet to `userId`; `balanceAfter` is their
+ *   resulting balance.
+ * - `awarded: false` — nothing moved: either no eligible wallet existed, or the house wallet lacked
+ *   the funds to cover the bonus.
+ */
+export type AwardBonusResult =
+	| { awarded: true; userId: string; amount: string; balanceAfter: string }
+	| { awarded: false; reason: 'NO_ELIGIBLE_WALLETS' | 'INSUFFICIENT_HOUSE_FUNDS' }
+
 export interface CreateMarketInput {
 	createdBy: string
 	question: string
@@ -464,6 +483,16 @@ export interface PredictionMarkets {
 	onboardUser(
 		userId: string
 	): Promise<{ balance: string; granted: string; alreadyOnboarded: boolean }>
+	/**
+	 * Award a small bonus to a RANDOM existing (non-system) wallet, paid FROM the house/system
+	 * wallet. This is a pure transfer — the house is debited and the recipient credited by the same
+	 * amount in one atomic transaction, so the total points supply is conserved — booked as two
+	 * `adjustment` ledger lines (metadata `source: 'bonus'`). It is a best-effort perk, so it cleanly
+	 * no-ops (`{ awarded: false }`) when there is no eligible wallet or the house can't fund it,
+	 * rather than throwing. Throws only on a genuinely invalid request (non-positive amount, missing
+	 * reason) or an infra failure.
+	 */
+	awardRandomBonus(input: AwardBonusInput): Promise<AwardBonusResult>
 	createMarket(input: CreateMarketInput): Promise<MarketDetail>
 	/**
 	 * Edit a non-terminal market's safe fields (closing time / question / description). `closesAt` is

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1834,9 +1834,6 @@ importers:
       '@repo/prediction-markets':
         specifier: workspace:*
         version: link:../../packages/prediction-markets
-      '@repo/worker-utils':
-        specifier: workspace:*
-        version: link:../../packages/worker-utils
       hono:
         specifier: 4.10.6
         version: 4.10.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1831,6 +1831,9 @@ importers:
       '@repo/hono-helpers':
         specifier: workspace:*
         version: link:../../packages/hono-helpers
+      '@repo/prediction-markets':
+        specifier: workspace:*
+        version: link:../../packages/prediction-markets
       '@repo/worker-utils':
         specifier: workspace:*
         version: link:../../packages/worker-utils


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

On each inbound `markeedragon@` affiliate-sale email, mailroom now awards a small house-funded bonus to a random prediction-markets wallet and announces the winner in Discord, instead of just posting the raw email content.

## Changes

- **`apps/prediction-markets`**: adds an `awardRandomBonus` RPC (`wallet-service.ts` + DO + package types) that atomically transfers points from the house/system wallet to a random non-system wallet in one DB transaction — an overdraft-safe house debit paired with a credit to the winner, booked as two `adjustment` ledger lines tagged `source: 'bonus'`. No-ops (`{ awarded: false }`) when there's no eligible wallet or the house can't cover the amount, and locks the winner's wallet before the system wallet to preserve the existing lock order and avoid deadlocking with resolution.
- **`apps/mailroom`**: adds a `PREDICTION_MARKETS` DO binding and an optional `MARKEE_BONUS_AMOUNT` var (defaults to `5`). New `markee-bonus.ts` calls the award, resolves the winner's Discord display name via the Discord DO, and composes an announcement from a random referral-themed opener (`BONUS_MESSAGES`) plus an optional heading (`BONUS_HEADINGS`).
- `notify-discord.ts` now awards/announces before posting: the announcement becomes the Discord message content, falling back to a plain "referral sale just came in" notice if nothing was awarded. The award is best-effort — any failure is swallowed and logged so mail is never bounced or delayed.
- Removes the debug embed that showed the raw email (subject/body/from/to), which was only added to confirm the real Markee Dragon email format, along with the now-dead MIME/HTML parsing and the `@repo/worker-utils` dependency.
- Points `MARKEE_DISCORD_CHANNEL_ID` at the intended target Discord channel.
- `wrangler.jsonc` / `vitest.config.ts` updated with the new binding and a stub `prediction-markets` worker for tests.

## Testing

- `apps/mailroom/src/test/markee-bonus.test.ts` covers award/announcement composition, fallback when no Discord profile is linked, and best-effort no-throw behavior on award/lookup failures.
- `apps/mailroom/src/test/notify-discord.test.ts` covers both the no-bonus and bonus-announced paths, confirms the award is wired in before the Discord post, and that the debug embed is gone.
- `apps/prediction-markets/src/test/integration/money-flow.int.test.ts` adds integration coverage verifying the transfer conserves total supply, skips cleanly with no eligible wallets or an underfunded house, and rejects invalid input.
<!-- claude:end -->