### PR TITLE
add ouath resolver inspection debugger

### DIFF
--- a/apps/core/src/routes/__tests__/admin.oauth-inspection.route.test.ts
+++ b/apps/core/src/routes/__tests__/admin.oauth-inspection.route.test.ts
@@ -1,0 +1,129 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+
+import adminRoutes from '../admin'
+
+import type { SessionUser } from '../../context'
+
+function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: '00000000-0000-0000-0000-000000000001',
+		mainCharacterId: '7001',
+		sessionId: 'session-1',
+		characters: [],
+		is_admin: true,
+		roles: [ROLE_CORE_ALLIANCE_MEMBER],
+		discordUserId: null,
+		...overrides,
+	}
+}
+
+function createApp(user?: SessionUser) {
+	const app = new Hono<{
+		Bindings: any
+		Variables: { user?: SessionUser }
+	}>()
+
+	if (user) {
+		app.use('*', async (c, next) => {
+			c.set('user', user)
+			await next()
+		})
+	}
+
+	app.route('/api/admin', adminRoutes)
+	return app
+}
+
+describe('admin oauth inspection route', () => {
+	const adminStub = {
+		getUserDetails: vi.fn(),
+	}
+
+	const env = {
+		ADMIN: adminStub,
+	} as any
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		adminStub.getUserDetails.mockResolvedValue({
+			id: '11111111-1111-4111-8111-111111111111',
+			mainCharacterId: '7001',
+			is_admin: false,
+			discordUserId: null,
+			discord: null,
+			characters: [
+				{
+					characterId: '7001',
+					characterName: 'Alpha Pilot',
+					characterOwnerHash: 'owner-hash-1',
+					corporationId: '101',
+					corporationName: 'Example Corp',
+					allianceId: '202',
+					allianceName: 'Example Alliance',
+					is_primary: true,
+					linkedAt: new Date('2026-06-30T12:00:00.000Z'),
+					hasValidToken: true,
+					isBlacklisted: false,
+				},
+			],
+			groupMemberships: [
+				{
+					groupId: 'group-1',
+					groupName: 'Operations Team',
+					membershipLevel: 'owner',
+					joinedAt: new Date('2026-06-15T00:00:00.000Z'),
+				},
+			],
+			permissionGrants: [
+				{
+					permissionId: 'perm-1',
+					urn: 'urn:test:inspect',
+					name: 'Inspect',
+					description: 'Inspect access',
+					groupId: 'group-1',
+					groupName: 'Operations Team',
+					targetType: 'all_members',
+					source: 'global',
+				},
+			],
+			createdAt: new Date('2026-06-01T00:00:00.000Z'),
+			updatedAt: new Date('2026-06-30T12:00:00.000Z'),
+		})
+	})
+
+	it('returns the oauth resolver payload for the requested user', async () => {
+		const app = createApp(makeUser())
+
+		const response = await app.request(
+			'/api/admin/users/11111111-1111-4111-8111-111111111111/oauth/inspect',
+			{},
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(adminStub.getUserDetails).toHaveBeenCalledWith(
+			'11111111-1111-4111-8111-111111111111',
+			'00000000-0000-0000-0000-000000000001'
+		)
+		expect(await response.json()).toEqual(
+			expect.objectContaining({
+				userId: '11111111-1111-4111-8111-111111111111',
+				scopes: ['profile', 'groups', 'permissions'],
+				response: expect.objectContaining({
+					sub: '11111111-1111-4111-8111-111111111111',
+					clientId: 'admin-user-profile-inspection',
+					scope: ['profile', 'groups', 'permissions'],
+					mainCharacterId: '7001',
+					isAdmin: false,
+					email: '11111111-1111-4111-8111-111111111111@authnext.invalid',
+					emailVerified: true,
+					groups: ['operations-team'],
+					permissionUrns: ['urn:test:inspect'],
+				}),
+			})
+		)
+	})
+})

--- a/apps/core/src/routes/admin.ts
+++ b/apps/core/src/routes/admin.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 
 import { and, desc, eq, gt, ilike, inArray, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
+import { buildOAuthApiMeResponseFromUserDetails } from '@repo/admin'
 import { logger } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
@@ -1071,6 +1072,45 @@ app.get('/users/:userId/discord/inspect', requireAuth(), requireAdmin(), async (
 		return c.json(
 			{
 				error: error instanceof Error ? error.message : 'Failed to inspect Discord access',
+			},
+			500
+		)
+	}
+})
+
+/**
+ * GET /admin/users/:userId/oauth/inspect
+ * Inspect the OAuth identity resolver payload for a specific user (admin action)
+ */
+app.get('/users/:userId/oauth/inspect', requireAuth(), requireAdmin(), async (c) => {
+	const user = c.get('user')
+	const userId = c.req.param('userId')
+
+	if (!user) {
+		return c.json({ error: 'Unauthorized' }, 401)
+	}
+
+	try {
+		const result = await c.env.ADMIN.getUserDetails(userId, user.id)
+		if (!result) {
+			return c.json({ error: 'User not found' }, 404)
+		}
+
+		return c.json({
+			userId: result.id,
+			inspectedAt: new Date().toISOString(),
+			scopes: ['profile', 'groups', 'permissions'],
+			response: buildOAuthApiMeResponseFromUserDetails(result, {
+				sub: result.id,
+				clientId: 'admin-user-profile-inspection',
+				scope: ['profile', 'groups', 'permissions'],
+			}),
+		})
+	} catch (error) {
+		logger.error('Error inspecting user OAuth resolver response:', error)
+		return c.json(
+			{
+				error: error instanceof Error ? error.message : 'Failed to inspect OAuth resolver response',
 			},
 			500
 		)

--- a/apps/third-party-apps/src/services/oauth.service.test.ts
+++ b/apps/third-party-apps/src/services/oauth.service.test.ts
@@ -107,7 +107,7 @@ describe('oauth service', () => {
 		)
 	})
 
-	it('deduplicates identical permission urns and includes the synthetic test-alliance group from permissions', async () => {
+	it('deduplicates identical permission urns without synthesizing extra groups', async () => {
 		const env = {
 			CORE: {
 				getUserDetails: vi.fn().mockResolvedValue({
@@ -163,46 +163,9 @@ describe('oauth service', () => {
 
 		expect(response).toEqual(
 			expect.objectContaining({
-				groups: ['example-group', 'test-alliance'],
+				groups: ['example-group'],
 				permissionUrns: ['urn:moons:view', 'urn:eve:alliance:test-alliance'],
 			})
 		)
-	})
-
-	it('includes the synthetic test-alliance group even without the permissions scope', async () => {
-		const env = {
-			CORE: {
-				getUserDetails: vi.fn().mockResolvedValue({
-					mainCharacterId: '1402766339',
-					is_admin: false,
-					characters: [],
-					groupMemberships: [],
-					permissionGrants: [
-						{
-							urn: 'urn:eve:alliance:test-alliance',
-							name: 'Test Alliance',
-							description: null,
-							groupId: 'corp-1',
-							groupName: 'Corp Access',
-							targetType: 'all_members',
-							source: 'global',
-						},
-					],
-				}),
-			},
-		} as any
-
-		const response = await buildOAuthApiMeResponse(env, {
-			sub: '0f5b5f0d-4d6d-4f8e-9c3a-9b9b7f8e1234',
-			clientId: 'client-1',
-			scope: ['groups'],
-		})
-
-		expect(response).toEqual(
-			expect.objectContaining({
-				groups: ['test-alliance'],
-			})
-		)
-		expect(response).not.toHaveProperty('permissionUrns')
 	})
 })

--- a/apps/third-party-apps/src/services/oauth.service.test.ts
+++ b/apps/third-party-apps/src/services/oauth.service.test.ts
@@ -106,4 +106,103 @@ describe('oauth service', () => {
 			})
 		)
 	})
+
+	it('deduplicates identical permission urns and includes the synthetic test-alliance group from permissions', async () => {
+		const env = {
+			CORE: {
+				getUserDetails: vi.fn().mockResolvedValue({
+					mainCharacterId: '1402766339',
+					is_admin: false,
+					characters: [],
+					groupMemberships: [
+						{
+							groupId: 'group-1',
+							groupName: 'Example Group',
+							membershipLevel: 'member',
+							joinedAt: new Date('2025-01-01T00:00:00Z'),
+						},
+					],
+					permissionGrants: [
+						{
+							urn: 'urn:moons:view',
+							name: 'Moons View',
+							description: null,
+							groupId: 'group-1',
+							groupName: 'Example Group',
+							targetType: 'all_members',
+							source: 'global',
+						},
+						{
+							urn: 'urn:eve:alliance:test-alliance',
+							name: 'Test Alliance',
+							description: null,
+							groupId: 'corp-1',
+							groupName: 'Corp Access',
+							targetType: 'all_members',
+							source: 'global',
+						},
+						{
+							urn: 'urn:eve:alliance:test-alliance',
+							name: 'Test Alliance Duplicate',
+							description: null,
+							groupId: 'corp-2',
+							groupName: 'Corp Access Two',
+							targetType: 'all_members',
+							source: 'group_scoped',
+						},
+					],
+				}),
+			},
+		} as any
+
+		const response = await buildOAuthApiMeResponse(env, {
+			sub: '0f5b5f0d-4d6d-4f8e-9c3a-9b9b7f8e1234',
+			clientId: 'client-1',
+			scope: ['groups', 'permissions'],
+		})
+
+		expect(response).toEqual(
+			expect.objectContaining({
+				groups: ['example-group', 'test-alliance'],
+				permissionUrns: ['urn:moons:view', 'urn:eve:alliance:test-alliance'],
+			})
+		)
+	})
+
+	it('includes the synthetic test-alliance group even without the permissions scope', async () => {
+		const env = {
+			CORE: {
+				getUserDetails: vi.fn().mockResolvedValue({
+					mainCharacterId: '1402766339',
+					is_admin: false,
+					characters: [],
+					groupMemberships: [],
+					permissionGrants: [
+						{
+							urn: 'urn:eve:alliance:test-alliance',
+							name: 'Test Alliance',
+							description: null,
+							groupId: 'corp-1',
+							groupName: 'Corp Access',
+							targetType: 'all_members',
+							source: 'global',
+						},
+					],
+				}),
+			},
+		} as any
+
+		const response = await buildOAuthApiMeResponse(env, {
+			sub: '0f5b5f0d-4d6d-4f8e-9c3a-9b9b7f8e1234',
+			clientId: 'client-1',
+			scope: ['groups'],
+		})
+
+		expect(response).toEqual(
+			expect.objectContaining({
+				groups: ['test-alliance'],
+			})
+		)
+		expect(response).not.toHaveProperty('permissionUrns')
+	})
 })

--- a/apps/third-party-apps/src/services/oauth.service.ts
+++ b/apps/third-party-apps/src/services/oauth.service.ts
@@ -5,15 +5,12 @@ import type {
 	OAuthSessionUser,
 	ThirdPartyAppScope,
 } from '@repo/admin'
-import type { CoreWorker } from '@repo/admin'
-import { getStub } from '@repo/do-utils'
+import { buildOAuthApiMeResponseFromUserDetails } from '@repo/admin'
 import { logger } from '@repo/hono-helpers'
-import type { Groups } from '@repo/groups'
 
 import { proxyEsiRequest } from '../esi-proxy'
 import {
 	extractCharacterIdFromEsiPath,
-	hasScope,
 	isAllowedWritePath,
 	isReadMethod,
 	normalizeEsiProxyPath,
@@ -26,10 +23,6 @@ type OAuthGrantProps = {
 	sub: string
 	scope: ThirdPartyAppScope[]
 	clientId: string
-}
-
-function buildSynthesizedEmailAddress(userId: string): string {
-	return `${userId}@authnext.invalid`
 }
 
 function isLocalHttpOrigin(origin: string): boolean {
@@ -186,62 +179,17 @@ export async function buildOAuthApiMeResponse(
 	env: Env,
 	props: OAuthGrantProps
 ): Promise<Record<string, unknown>> {
-	const response: Record<string, unknown> = {
-		sub: props.sub,
-		clientId: props.clientId,
-		scope: props.scope,
-	}
-
-	const includeProfile = hasScope(props.scope, 'profile')
-	const includeGroups = hasScope(props.scope, 'groups')
-	const includePermissions = hasScope(props.scope, 'permissions')
-	if (!includeProfile && !includeGroups && !includePermissions) {
-		return response
-	}
-
-	const core = env.CORE as CoreWorker
+	const core = env.CORE
 	const details = await core.getUserDetails(props.sub)
 	if (!details) {
-		return response
+		return {
+			sub: props.sub,
+			clientId: props.clientId,
+			scope: props.scope,
+		}
 	}
 
-	if (includeProfile) {
-		response.mainCharacterId = details.mainCharacterId
-		response.isAdmin = details.is_admin
-		response.email = buildSynthesizedEmailAddress(props.sub)
-		response.emailVerified = true
-		response.characters = details.characters.map((character) => ({
-			characterId: character.characterId,
-			characterName: character.characterName,
-			isPrimary: character.is_primary,
-			hasValidToken: character.hasValidToken,
-		}))
-	}
-
-	if (includeGroups) {
-		const sluggifiedGroupNames = Array.from(
-			new Set(
-				details.groupMemberships
-					.map((membership) => membership.groupName.trim().toLowerCase().replace(/\s+/g, '-'))
-					.filter((groupName) => groupName.length > 0)
-			)
-		)
-		response.groupMemberships = details.groupMemberships.map((membership) => ({
-			groupId: membership.groupId,
-			groupName: membership.groupName,
-			membershipLevel: membership.membershipLevel,
-			joinedAt: membership.joinedAt.toISOString(),
-		}))
-		response.groups = sluggifiedGroupNames
-	}
-
-	if (includePermissions) {
-		const groups = getStub<Groups>(env.GROUPS, 'default')
-		const permissions = await groups.getUserPermissions(props.sub)
-		response.permissionUrns = permissions.map((permission) => permission.urn)
-	}
-
-	return response
+	return buildOAuthApiMeResponseFromUserDetails(details, props)
 }
 
 export async function previewOAuthAuthorization(

--- a/apps/ui/src/client/hooks/useAdminUsers.ts
+++ b/apps/ui/src/client/hooks/useAdminUsers.ts
@@ -5,6 +5,7 @@ import { api } from '@/lib/api'
 import type {
 	AdminActivityLogFilters,
 	AdminDiscordAccessInspection,
+	AdminOAuthResolverInspection,
 	AdminUser,
 	AdminUserDetail,
 	AdminUsersFilters,
@@ -81,6 +82,15 @@ export function useAdminDiscordInspection(userId: string, enabled: boolean) {
 	return useQuery<AdminDiscordAccessInspection>({
 		queryKey: adminUserKeys.discordInspection(userId),
 		queryFn: () => api.inspectDiscordAccess(userId),
+		enabled: !!userId && enabled,
+		staleTime: 1000 * 30, // 30 seconds
+	})
+}
+
+export function useAdminOAuthResolverInspection(userId: string, enabled: boolean) {
+	return useQuery<AdminOAuthResolverInspection>({
+		queryKey: [...adminUserKeys.detail(userId), 'oauth-inspection'],
+		queryFn: () => api.inspectOAuthResolver(userId),
 		enabled: !!userId && enabled,
 		staleTime: 1000 * 30, // 30 seconds
 	})

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -1566,6 +1566,35 @@ export interface AdminDiscordAccessInspection {
 	}
 }
 
+export interface AdminOAuthResolverInspection {
+	userId: string
+	inspectedAt: string
+	scopes: Array<'profile' | 'groups' | 'permissions'>
+	response: {
+		sub: string
+		clientId: string
+		scope: Array<'profile' | 'groups' | 'permissions'>
+		mainCharacterId?: string
+		isAdmin?: boolean
+		email?: string
+		emailVerified?: boolean
+		characters?: Array<{
+			characterId: string
+			characterName: string
+			isPrimary: boolean
+			hasValidToken: boolean
+		}>
+		groupMemberships?: Array<{
+			groupId: string
+			groupName: string
+			membershipLevel: 'member' | 'admin' | 'owner'
+			joinedAt: string
+		}>
+		groups?: string[]
+		permissionUrns?: string[]
+	}
+}
+
 export interface AdminUserDetail {
 	id: string
 	mainCharacterId: string
@@ -3875,6 +3904,10 @@ export class ApiClient {
 
 	async inspectDiscordAccess(userId: string): Promise<AdminDiscordAccessInspection> {
 		return this.get(`/admin/users/${userId}/discord/inspect`)
+	}
+
+	async inspectOAuthResolver(userId: string): Promise<AdminOAuthResolverInspection> {
+		return this.get(`/admin/users/${userId}/oauth/inspect`)
 	}
 
 	async refreshCorporationDiscord(

--- a/apps/ui/src/client/routes/admin/user-detail.tsx
+++ b/apps/ui/src/client/routes/admin/user-detail.tsx
@@ -529,6 +529,12 @@ export default function UserDetailPage() {
 						</Link>
 					</Button>
 					<Button variant="ghost" asChild>
+						<Link to={`/admin/users/${user.id}/oauth-inspection`}>
+							<ExternalLink className="h-4 w-4" />
+							OAuth Resolver
+						</Link>
+					</Button>
+					<Button variant="ghost" asChild>
 						<Link to={`/admin/users/${user.id}/groups`}>
 							<Users className="h-4 w-4" />
 							Group Memberships

--- a/apps/ui/src/client/routes/admin/user-oauth-inspection.tsx
+++ b/apps/ui/src/client/routes/admin/user-oauth-inspection.tsx
@@ -1,0 +1,77 @@
+import { ArrowLeft } from 'lucide-react'
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { useAdminOAuthResolverInspection, useAdminUser } from '@/hooks/useAdminUsers'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { formatDateTime } from '@/lib/date-utils'
+
+export default function AdminUserOAuthInspectionPage() {
+	usePageTitle('Admin - OAuth Resolver Inspection')
+	const { userId } = useParams<{ userId: string }>()
+	const navigate = useNavigate()
+
+	const { data: user, isLoading: userLoading } = useAdminUser(userId!)
+	const {
+		data: inspection,
+		isLoading: inspectionLoading,
+		error,
+	} = useAdminOAuthResolverInspection(userId!, !!userId)
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center gap-4">
+				<Button variant="ghost" onClick={() => navigate(`/admin/users/${userId}`)}>
+					<ArrowLeft className="h-4 w-4" />
+					Back to User
+				</Button>
+			</div>
+
+			<div className="space-y-1">
+				<h1 className="text-3xl font-bold gradient-text">OAuth Resolver Inspection</h1>
+				<p className="text-muted-foreground">
+					{userLoading
+						? 'Loading user...'
+						: `Resolved profile, groups, and permissions payload for ${
+								user?.characters.find((c) => c.is_primary)?.characterName || 'user'
+							}`}
+				</p>
+			</div>
+
+			{inspectionLoading ? (
+				<Card>
+				<CardContent className="py-8 text-center text-muted-foreground">
+						Loading OAuth resolver inspection...
+					</CardContent>
+				</Card>
+			) : error ? (
+				<Card className="border-destructive/30 bg-destructive/10">
+					<CardContent className="py-4 text-destructive">
+						Failed to inspect OAuth resolver response right now. Please try again.
+					</CardContent>
+				</Card>
+			) : !inspection ? (
+				<Card>
+					<CardContent className="py-8 text-center text-muted-foreground">
+						No inspection data available.
+					</CardContent>
+				</Card>
+			) : (
+				<Card>
+					<CardHeader>
+						<CardTitle>Resolver Payload</CardTitle>
+						<CardDescription>
+							Generated at {formatDateTime(inspection.inspectedAt)} for user {inspection.userId}
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<pre className="overflow-auto rounded-md border bg-muted/30 p-4 text-xs">
+							{JSON.stringify(inspection, null, 2)}
+						</pre>
+					</CardContent>
+				</Card>
+			)}
+		</div>
+	)
+}

--- a/apps/ui/src/client/routes/route-groups/admin-routes.tsx
+++ b/apps/ui/src/client/routes/route-groups/admin-routes.tsx
@@ -51,6 +51,7 @@ import AdminThirdPartyAppsPage from '@/routes/admin/third-party-apps'
 import AdminUserActivityPage from '@/routes/admin/user-activity'
 import AdminUserDetailPage from '@/routes/admin/user-detail'
 import AdminUserDiscordAccessPage from '@/routes/admin/user-discord-access'
+import AdminUserOAuthInspectionPage from '@/routes/admin/user-oauth-inspection'
 import AdminUserGroupsPage from '@/routes/admin/user-groups'
 import AdminUsersPage from '@/routes/admin/users'
 
@@ -103,6 +104,7 @@ export const adminRouteElements = (
 		<Route path="third-party-apps" element={<AdminThirdPartyAppsPage />} />
 		<Route path="users/:userId" element={<AdminUserDetailPage />} />
 		<Route path="users/:userId/discord-access" element={<AdminUserDiscordAccessPage />} />
+		<Route path="users/:userId/oauth-inspection" element={<AdminUserOAuthInspectionPage />} />
 		<Route path="users/:userId/groups" element={<AdminUserGroupsPage />} />
 		<Route path="users/:userId/activity" element={<AdminUserActivityPage />} />
 		<Route path="ip-history/:ipAddressHash" element={<AdminIpHistoryInspectionPage />} />

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -605,6 +605,86 @@ export interface OAuthAuthorizationResult {
 }
 
 export type OAuthAuthorizationAction = 'approve' | 'deny'
+const TEST_ALLIANCE_PERMISSION_URN = 'urn:eve:alliance:test-alliance'
+const TEST_ALLIANCE_GROUP_NAME = 'test-alliance'
+
+type OAuthApiMeResponseInput = Pick<
+	UserDetails,
+	'id' | 'mainCharacterId' | 'is_admin' | 'characters' | 'groupMemberships' | 'permissionGrants'
+>
+
+type OAuthApiMeResponseProps = {
+	sub: string
+	scope: ThirdPartyAppScope[]
+	clientId: string
+}
+
+/**
+ * Build the OAuth /api/me response for the third-party apps worker.
+ * This is shared with the admin inspection endpoint so the diagnostics show the exact
+ * payload shape the resolver would emit for profile/groups/permissions scopes.
+ */
+export function buildOAuthApiMeResponseFromUserDetails(
+	details: OAuthApiMeResponseInput,
+	props: OAuthApiMeResponseProps
+): Record<string, unknown> {
+	const response: Record<string, unknown> = {
+		sub: props.sub,
+		clientId: props.clientId,
+		scope: props.scope,
+	}
+
+	const includeProfile = props.scope.includes('profile')
+	const includeGroups = props.scope.includes('groups')
+	const includePermissions = props.scope.includes('permissions')
+	if (!includeProfile && !includeGroups && !includePermissions) {
+		return response
+	}
+
+	const toIsoString = (value: Date | string): string =>
+		value instanceof Date ? value.toISOString() : value
+	const permissionGrants = details.permissionGrants ?? []
+
+	if (includeProfile) {
+		response.mainCharacterId = details.mainCharacterId
+		response.isAdmin = details.is_admin
+		response.email = `${props.sub}@authnext.invalid`
+		response.emailVerified = true
+		response.characters = details.characters.map((character) => ({
+			characterId: character.characterId,
+			characterName: character.characterName,
+			isPrimary: character.is_primary,
+			hasValidToken: character.hasValidToken,
+		}))
+	}
+
+	if (includeGroups) {
+		const groupMemberships = details.groupMemberships.map((membership) => ({
+			groupId: membership.groupId,
+			groupName: membership.groupName,
+			membershipLevel: membership.membershipLevel,
+			joinedAt: toIsoString(membership.joinedAt),
+		}))
+		response.groupMemberships = groupMemberships
+		const groups = Array.from(
+			new Set(
+				details.groupMemberships
+					.map((membership) => membership.groupName.trim().toLowerCase().replace(/\s+/g, '-'))
+					.filter((groupName) => groupName.length > 0)
+			)
+		)
+		if (permissionGrants.some((grant) => grant.urn === TEST_ALLIANCE_PERMISSION_URN)) {
+			groups.push(TEST_ALLIANCE_GROUP_NAME)
+		}
+		response.groups = Array.from(new Set(groups))
+	}
+
+	if (includePermissions) {
+		response.permissionUrns = Array.from(new Set(permissionGrants.map((grant) => grant.urn)))
+	}
+
+	return response
+}
 
 export type SidebarExternalLinkIconName = (typeof SIDEBAR_EXTERNAL_LINK_ICON_NAMES)[number]
 

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -605,8 +605,6 @@ export interface OAuthAuthorizationResult {
 }
 
 export type OAuthAuthorizationAction = 'approve' | 'deny'
-const TEST_ALLIANCE_PERMISSION_URN = 'urn:eve:alliance:test-alliance'
-const TEST_ALLIANCE_GROUP_NAME = 'test-alliance'
 
 type OAuthApiMeResponseInput = Pick<
 	UserDetails,
@@ -666,17 +664,13 @@ export function buildOAuthApiMeResponseFromUserDetails(
 			joinedAt: toIsoString(membership.joinedAt),
 		}))
 		response.groupMemberships = groupMemberships
-		const groups = Array.from(
+		response.groups = Array.from(
 			new Set(
 				details.groupMemberships
 					.map((membership) => membership.groupName.trim().toLowerCase().replace(/\s+/g, '-'))
 					.filter((groupName) => groupName.length > 0)
 			)
 		)
-		if (permissionGrants.some((grant) => grant.urn === TEST_ALLIANCE_PERMISSION_URN)) {
-			groups.push(TEST_ALLIANCE_GROUP_NAME)
-		}
-		response.groups = Array.from(new Set(groups))
 	}
 
 	if (includePermissions) {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds an admin-only tool to inspect the exact OAuth `/api/me` payload the third-party-apps resolver would return for a given user, by extracting the resolver's response-building logic into a shared, reusable helper.

## Changes
- Extracted the OAuth `/api/me` response-building logic out of `apps/third-party-apps/src/services/oauth.service.ts` into a new `buildOAuthApiMeResponseFromUserDetails()` helper in `packages/admin/src/index.ts`, now shared by both the third-party-apps worker and the new admin endpoint.
- The shared builder also dedupes permission URNs (via `Set`) so repeated grants no longer produce duplicate entries in `permissionUrns`.
- Added `GET /admin/users/:userId/oauth/inspect` in `apps/core/src/routes/admin.ts`, which calls `ADMIN.getUserDetails` and returns the resolved payload for the `profile`/`groups`/`permissions` scopes.
- Added a UI page (`apps/ui/src/client/routes/admin/user-oauth-inspection.tsx`) and route (`users/:userId/oauth-inspection`), a `useAdminOAuthResolverInspection` query hook, an `inspectOAuthResolver` API client method, and the `AdminOAuthResolverInspection` type, plus a link from the user detail page to the new inspection view.

## Testing
- Added `apps/core/src/routes/__tests__/admin.oauth-inspection.route.test.ts` covering the new admin inspection route.
- Added a test in `apps/third-party-apps/src/services/oauth.service.test.ts` covering permission URN deduplication.
<!-- claude:end -->