### PR TITLE
use affiliation endpoint for corp freshness in getCharacterInfo

### DIFF
--- a/apps/core/src/__tests__/core-do.user-corp-resolution.test.ts
+++ b/apps/core/src/__tests__/core-do.user-corp-resolution.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getEsiInstance, getEsiInstanceForCorporation } from '@repo/esi'
+import {
+	getEsiInstance,
+	getEsiInstanceForCharacter,
+	getEsiInstanceForCorporation,
+} from '@repo/esi'
 
 import { CoreDO } from '../durable-object'
 
@@ -23,10 +27,30 @@ function createDbMock() {
 	}
 }
 
+function buildPublicInfo(overrides: Partial<Record<string, unknown>>) {
+	return {
+		birthday: '2025-05-28T14:55:26Z',
+		bloodline_id: '7',
+		corporation_id: '1001',
+		description: null,
+		faction_id: null,
+		gender: 'male',
+		name: 'Alt Alpha',
+		race_id: '8',
+		security_status: '1.1',
+		title: null,
+		...overrides,
+	}
+}
+
 describe('CoreDO user corporation and alliance resolution', () => {
 	let core: CoreDO
 	let dbMock: ReturnType<typeof createDbMock>
 
+	const characterStub = {
+		fetchCharacterPublicInfo: vi.fn(),
+		fetchCharacterAffiliation: vi.fn(),
+	}
 	const corpStub = {
 		fetchCorporationPublicInfo: vi.fn(),
 	}
@@ -41,43 +65,66 @@ describe('CoreDO user corporation and alliance resolution', () => {
 		core = Object.create(CoreDO.prototype) as CoreDO
 		;(core as any).env = { ESI: {} }
 		;(core as any).getDb = vi.fn().mockReturnValue(dbMock)
-		;(core as any).getCharacterInfo = vi.fn()
 
+		vi.mocked(getEsiInstanceForCharacter).mockReturnValue(characterStub as any)
 		vi.mocked(getEsiInstanceForCorporation).mockReturnValue(corpStub as any)
 		vi.mocked(getEsiInstance).mockReturnValue(allianceStub as any)
 	})
 
-	it('resolves corporation names from corporation data rather than character names', async () => {
+	it('merges affiliation ids over stale public character info', async () => {
+		characterStub.fetchCharacterPublicInfo.mockResolvedValue(
+			buildPublicInfo({
+				corporation_id: '1001',
+				alliance_id: '9001',
+				name: 'Lorenzini',
+			})
+		)
+		characterStub.fetchCharacterAffiliation.mockResolvedValue([
+			{ character_id: 'char-1', corporation_id: '2002', alliance_id: '9002' },
+		])
+
+		const result = await (core as any).getCharacterInfo('char-1')
+
+		expect(result).toMatchObject({
+			corporation_id: '2002',
+			alliance_id: '9002',
+			name: 'Lorenzini',
+		})
+		expect(characterStub.fetchCharacterAffiliation).toHaveBeenCalledWith('char-1', ['char-1'])
+	})
+
+	it('resolves corporation names from merged character data rather than stale public info', async () => {
 		dbMock.query.users.findFirst.mockResolvedValue({ id: 'user-1' })
 		dbMock.query.userCharacters.findMany.mockResolvedValue([
 			{ characterId: 'char-1' },
 			{ characterId: 'char-2' },
-			{ characterId: 'char-3' },
 		])
 
-		;(core as any).getCharacterInfo
-			.mockResolvedValueOnce({
+		characterStub.fetchCharacterPublicInfo.mockImplementation(async (characterId: string) => {
+			if (characterId === 'char-1') {
+				return buildPublicInfo({ corporation_id: '1001', alliance_id: '9001', name: 'Alt Alpha' })
+			}
+
+			return buildPublicInfo({
 				corporation_id: '1001',
-				alliance_id: '9001',
-				name: 'Alt Alpha',
-			})
-			.mockResolvedValueOnce({
-				corporation_id: '1001',
-				alliance_id: '9001',
+				alliance_id: null,
 				name: 'Alt Beta',
 			})
-			.mockResolvedValueOnce({
-				corporation_id: '2002',
-				alliance_id: null,
-				name: 'Alt Gamma',
-			})
+		})
+		characterStub.fetchCharacterAffiliation.mockImplementation(async (characterId: string) => {
+			if (characterId === 'char-1') {
+				return [{ character_id: 'char-1', corporation_id: '2002', alliance_id: '9002' }]
+			}
+
+			return [{ character_id: 'char-2', corporation_id: '3003' }]
+		})
 
 		corpStub.fetchCorporationPublicInfo.mockImplementation(async (corporationId: string) => {
-			if (corporationId === '1001') {
-				return { name: 'Alpha Corp' }
-			}
 			if (corporationId === '2002') {
 				return { name: 'Beta Corp' }
+			}
+			if (corporationId === '3003') {
+				return { name: 'Gamma Corp' }
 			}
 			return null
 		})
@@ -85,36 +132,43 @@ describe('CoreDO user corporation and alliance resolution', () => {
 		const result = await core.getUserCorporations('user-1')
 
 		expect(result).toEqual([
-			{ corporationId: '1001', corporationName: 'Alpha Corp' },
 			{ corporationId: '2002', corporationName: 'Beta Corp' },
+			{ corporationId: '3003', corporationName: 'Gamma Corp' },
 		])
-		expect(result.some((corp) => corp.corporationName.startsWith('Alt'))).toBe(false)
+		expect(characterStub.fetchCharacterAffiliation).toHaveBeenCalledTimes(2)
 	})
 
-	it('resolves alliance names from alliance data rather than corporation names', async () => {
+	it('resolves alliance names from merged character data rather than stale public info', async () => {
 		dbMock.query.users.findFirst.mockResolvedValue({ id: 'user-1' })
 		dbMock.query.userCharacters.findMany.mockResolvedValue([
 			{ characterId: 'char-1' },
 			{ characterId: 'char-2' },
 		])
 
-		;(core as any).getCharacterInfo
-			.mockResolvedValueOnce({
-				corporation_id: '1001',
-				alliance_id: '9001',
-				name: 'Alt Alpha',
-			})
-			.mockResolvedValueOnce({
+		characterStub.fetchCharacterPublicInfo.mockImplementation(async (characterId: string) => {
+			if (characterId === 'char-1') {
+				return buildPublicInfo({ corporation_id: '1001', alliance_id: '9001', name: 'Alt Alpha' })
+			}
+
+			return buildPublicInfo({
 				corporation_id: '2002',
-				alliance_id: '9002',
+				alliance_id: null,
 				name: 'Alt Beta',
 			})
+		})
+		characterStub.fetchCharacterAffiliation.mockImplementation(async (characterId: string) => {
+			if (characterId === 'char-1') {
+				return [{ character_id: 'char-1', corporation_id: '2002', alliance_id: '9002' }]
+			}
+
+			return [{ character_id: 'char-2', corporation_id: '3003', alliance_id: '9003' }]
+		})
 
 		allianceStub.fetchAlliancePublicInfo.mockImplementation(async (allianceId: string) => {
-			if (allianceId === '9001') {
+			if (allianceId === '9002') {
 				return { name: 'First Alliance' }
 			}
-			if (allianceId === '9002') {
+			if (allianceId === '9003') {
 				return { name: 'Second Alliance' }
 			}
 			return null
@@ -123,13 +177,13 @@ describe('CoreDO user corporation and alliance resolution', () => {
 		const result = await core.getUserAlliances('user-1')
 
 		expect(result).toEqual([
-			{ allianceId: '9001', allianceName: 'First Alliance' },
-			{ allianceId: '9002', allianceName: 'Second Alliance' },
+			{ allianceId: '9002', allianceName: 'First Alliance' },
+			{ allianceId: '9003', allianceName: 'Second Alliance' },
 		])
-		expect(result.some((alliance) => alliance.allianceName.startsWith('Alt'))).toBe(false)
+		expect(characterStub.fetchCharacterAffiliation).toHaveBeenCalledTimes(2)
 	})
 
-	it('resolves batch corporation names from corporation data for each user', async () => {
+	it('resolves batch corporation names from merged character data for each user', async () => {
 		dbMock.query.users.findFirst.mockResolvedValue({ id: 'user-1' })
 		dbMock.query.userCharacters.findMany.mockResolvedValue([
 			{ userId: 'user-1', characterId: 'char-1' },
@@ -137,29 +191,40 @@ describe('CoreDO user corporation and alliance resolution', () => {
 			{ userId: 'user-2', characterId: 'char-3' },
 		])
 
-		;(core as any).getCharacterInfo
-			.mockResolvedValueOnce({
-				corporation_id: '1001',
-				alliance_id: '9001',
-				name: 'Alt Alpha',
-			})
-			.mockResolvedValueOnce({
+		characterStub.fetchCharacterPublicInfo.mockImplementation(async (characterId: string) => {
+			if (characterId === 'char-1') {
+				return buildPublicInfo({ corporation_id: '1001', alliance_id: '9001', name: 'Alt Alpha' })
+			}
+			if (characterId === 'char-2') {
+				return buildPublicInfo({
+					corporation_id: '1001',
+					alliance_id: null,
+					name: 'Alt Beta',
+				})
+			}
+
+			return buildPublicInfo({
 				corporation_id: '2002',
-				alliance_id: null,
-				name: 'Alt Beta',
-			})
-			.mockResolvedValueOnce({
-				corporation_id: '2002',
-				alliance_id: null,
+				alliance_id: '9003',
 				name: 'Alt Gamma',
 			})
+		})
+		characterStub.fetchCharacterAffiliation.mockImplementation(async (characterId: string) => {
+			if (characterId === 'char-1') {
+				return [{ character_id: 'char-1', corporation_id: '2002', alliance_id: '9002' }]
+			}
+			if (characterId === 'char-2') {
+				return [{ character_id: 'char-2', corporation_id: '2002' }]
+			}
+			return [{ character_id: 'char-3', corporation_id: '3003', alliance_id: '9003' }]
+		})
 
 		corpStub.fetchCorporationPublicInfo.mockImplementation(async (corporationId: string) => {
-			if (corporationId === '1001') {
-				return { name: 'Alpha Corp' }
-			}
 			if (corporationId === '2002') {
 				return { name: 'Beta Corp' }
+			}
+			if (corporationId === '3003') {
+				return { name: 'Gamma Corp' }
 			}
 			return null
 		})
@@ -167,9 +232,9 @@ describe('CoreDO user corporation and alliance resolution', () => {
 		const result = await core.getUserCorporationsBatch(['user-1', 'user-2'])
 
 		expect(result.get('user-1')).toEqual([
-			{ corporationId: '1001', corporationName: 'Alpha Corp' },
 			{ corporationId: '2002', corporationName: 'Beta Corp' },
 		])
-		expect(result.get('user-2')).toEqual([{ corporationId: '2002', corporationName: 'Beta Corp' }])
+		expect(result.get('user-2')).toEqual([{ corporationId: '3003', corporationName: 'Gamma Corp' }])
+		expect(characterStub.fetchCharacterAffiliation).toHaveBeenCalledTimes(3)
 	})
 })

--- a/apps/core/src/durable-object.ts
+++ b/apps/core/src/durable-object.ts
@@ -35,7 +35,7 @@ import { updateCharacterPublicInfo } from './workflows/steps/update-character'
 
 import type { Core } from '@repo/core'
 import type { Discord } from '@repo/discord'
-import type { CharacterPublicInfo } from '@repo/esi'
+import type { CharacterAffiliation, CharacterPublicInfo } from '@repo/esi'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { CreateRoleRequest, Groups } from '@repo/groups'
 import type { BlacklistTargetCheckItem, BlacklistTargetType, Hr } from '@repo/hr'
@@ -289,8 +289,32 @@ export class CoreDO extends DurableObject<Env> implements Core {
 
 	private async getCharacterInfo(characterId: string): Promise<CharacterPublicInfo | null> {
 		const instance = getEsiInstanceForCharacter(this.env.ESI, characterId)
-		const characterInfo = await instance.fetchCharacterPublicInfo(characterId)
-		return characterInfo
+		const [publicInfoResult, affiliationResult] = await Promise.allSettled([
+			instance.fetchCharacterPublicInfo(characterId),
+			instance.fetchCharacterAffiliation(characterId, [characterId]),
+		])
+
+		if (publicInfoResult.status === 'rejected') {
+			throw publicInfoResult.reason
+		}
+
+		const publicInfo = publicInfoResult.value
+		const affiliation =
+			affiliationResult.status === 'fulfilled'
+				? affiliationResult.value.find(
+						(entry: CharacterAffiliation) => String(entry.character_id) === characterId
+					)
+				: null
+
+		if (!affiliation) {
+			return publicInfo
+		}
+
+		return {
+			...publicInfo,
+			corporation_id: affiliation.corporation_id ?? publicInfo.corporation_id,
+			alliance_id: affiliation.alliance_id ?? publicInfo.alliance_id,
+		}
 	}
 
 	private async getCorporationName(corporationId: string): Promise<string | null> {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
`CoreDO.getCharacterInfo` previously relied solely on ESI's public character info endpoint, which can return a stale `corporation_id`/`alliance_id` due to caching. This PR augments it with the character affiliation endpoint, which is refreshed more frequently, so corporation and alliance resolution reflects the character's current affiliation.

## Changes
- `getCharacterInfo` now fetches both `fetchCharacterPublicInfo` and `fetchCharacterAffiliation` (via `Promise.allSettled`) for a character.
- If the affiliation lookup succeeds and returns a matching entry, its `corporation_id`/`alliance_id` override the (potentially stale) values from public info; falls back to public info if the affiliation call fails or returns no match.
- Public info fetch failures still throw, preserving prior error behavior.
- Updated `core-do.user-corp-resolution.test.ts` to mock `getEsiInstanceForCharacter`/`fetchCharacterAffiliation` directly (instead of stubbing `getCharacterInfo`) and assert that merged affiliation data—not stale public info—drives corporation/alliance name resolution.

## Testing
- Existing unit tests in `apps/core/src/__tests__/core-do.user-corp-resolution.test.ts` were updated to cover the new merge behavior, including verifying `fetchCharacterAffiliation` is called with the expected arguments and call counts.
<!-- claude:end -->