### PR TITLE
fix revokation state for invite codes

### DIFF
--- a/apps/groups/src/test/integration/api.test.ts
+++ b/apps/groups/src/test/integration/api.test.ts
@@ -739,6 +739,11 @@ describe('Groups Durable Object - Invite Codes', () => {
 
 		await stub.revokeInviteCode(code.id, USER_1_ID)
 
+		const codes = await stub.listInviteCodes(group.id, USER_1_ID)
+		const revokedCode = codes.find((inviteCode) => inviteCode.id === code.id)
+		expect(revokedCode).toBeDefined()
+		expect(revokedCode?.revokedAt).not.toBeNull()
+
 		await expect(stub.redeemInviteCode(code.code, USER_2_ID)).rejects.toThrow('revoked')
 	})
 })

--- a/apps/ui/src/client/hooks/useInviteCodes.ts
+++ b/apps/ui/src/client/hooks/useInviteCodes.ts
@@ -57,6 +57,26 @@ export function useRevokeInviteCode() {
 	return useMutation({
 		mutationFn: ({ codeId, groupId }: { codeId: string; groupId: string }) =>
 			apiClient.revokeGroupInviteCode(codeId),
+		onMutate: async ({ codeId, groupId }) => {
+			await queryClient.cancelQueries({ queryKey: inviteCodeKeys.group(groupId) })
+			const previousInviteCodes = queryClient.getQueryData<GroupInviteCode[]>(
+				inviteCodeKeys.group(groupId)
+			)
+			queryClient.setQueryData<GroupInviteCode[]>(
+				inviteCodeKeys.group(groupId),
+				(current = []) =>
+					current.map((inviteCode) =>
+						inviteCode.id === codeId
+							? { ...inviteCode, revokedAt: new Date().toISOString() }
+							: inviteCode
+					)
+			)
+			return { previousInviteCodes, groupId }
+		},
+		onError: (_error, _variables, context) => {
+			if (!context) return
+			queryClient.setQueryData(inviteCodeKeys.group(context.groupId), context.previousInviteCodes)
+		},
 		onSuccess: (_, { groupId }) => {
 			void queryClient.invalidateQueries({
 				queryKey: inviteCodeKeys.group(groupId),

--- a/apps/ui/src/client/routes/admin/group-detail.tsx
+++ b/apps/ui/src/client/routes/admin/group-detail.tsx
@@ -717,26 +717,36 @@ export default function GroupDetailPage() {
 					</div>
 				</CardHeader>
 				<CardContent>
-					{inviteCodes.length === 0 ? (
-						<div className="text-center py-8">
-							<Ticket className="mx-auto h-12 w-12 text-muted-foreground" />
-							<h3 className="mt-4 text-sm font-medium">No active invite codes</h3>
-							<p className="text-sm text-muted-foreground mt-2">
-								Create an invite code to allow users to join this group
-							</p>
-						</div>
+							{inviteCodes.length === 0 ? (
+								<div className="text-center py-8">
+									<Ticket className="mx-auto h-12 w-12 text-muted-foreground" />
+									<h3 className="mt-4 text-sm font-medium">No invite codes</h3>
+									<p className="text-sm text-muted-foreground mt-2">
+										Create an invite code to allow users to join this group
+									</p>
+								</div>
 					) : (
 						<div className="space-y-3">
 							{inviteCodes.map((inviteCode) => {
+								const isRevoked = inviteCode.revokedAt !== null
 								const isExpired = new Date(inviteCode.expiresAt) < new Date()
 								const isMaxedOut =
+									!isRevoked &&
+									!isExpired &&
 									inviteCode.maxUses !== null && inviteCode.currentUses >= inviteCode.maxUses
+								const statusLabel = isRevoked
+									? 'Revoked'
+									: isExpired
+										? 'Expired'
+										: isMaxedOut
+											? 'Max uses reached'
+											: null
 								const inviteUrl = `${window.location.origin}/invite/${inviteCode.code}`
 
 								return (
 									<div
 										key={inviteCode.id}
-										className={`rounded-lg border p-4 ${isExpired || isMaxedOut ? 'opacity-50' : ''}`}
+										className={`rounded-lg border p-4 ${statusLabel ? 'opacity-50' : ''}`}
 									>
 										<div className="flex items-start justify-between">
 											<div className="flex-1 space-y-2">
@@ -757,9 +767,9 @@ export default function GroupDetailPage() {
 															<Copy className="h-4 w-4" />
 														)}
 													</Button>
-													{(isExpired || isMaxedOut) && (
+													{statusLabel && (
 														<span className="text-xs text-destructive font-medium">
-															{isExpired ? 'Expired' : 'Max uses reached'}
+															{statusLabel}
 														</span>
 													)}
 												</div>

--- a/apps/ui/src/client/routes/group-detail.tsx
+++ b/apps/ui/src/client/routes/group-detail.tsx
@@ -253,30 +253,40 @@ export default function GroupDetailPage() {
 							</div>
 						</CardHeader>
 						<CardContent>
-							{inviteCodes.length === 0 ? (
-								<div className="text-center py-8">
-									<Ticket className="mx-auto h-12 w-12 text-muted-foreground" />
-									<h3 className="mt-4 text-sm font-medium">No active invite codes</h3>
-									<p className="text-sm text-muted-foreground mt-2">
-										Create an invite code to allow users to join this group
-									</p>
-								</div>
+					{inviteCodes.length === 0 ? (
+						<div className="text-center py-8">
+							<Ticket className="mx-auto h-12 w-12 text-muted-foreground" />
+							<h3 className="mt-4 text-sm font-medium">No invite codes</h3>
+							<p className="text-sm text-muted-foreground mt-2">
+								Create an invite code to allow users to join this group
+							</p>
+						</div>
 							) : (
-								<div className="space-y-3">
-									{inviteCodes.map((inviteCode) => {
-										const isExpired = new Date(inviteCode.expiresAt) < new Date()
-										const isMaxedOut =
-											inviteCode.maxUses !== null && inviteCode.currentUses >= inviteCode.maxUses
-										const inviteUrl = `${window.location.origin}/invite/${inviteCode.code}`
+						<div className="space-y-3">
+							{inviteCodes.map((inviteCode) => {
+								const isRevoked = inviteCode.revokedAt !== null
+								const isExpired = new Date(inviteCode.expiresAt) < new Date()
+								const isMaxedOut =
+									!isRevoked &&
+									!isExpired &&
+									inviteCode.maxUses !== null && inviteCode.currentUses >= inviteCode.maxUses
+								const statusLabel = isRevoked
+									? 'Revoked'
+									: isExpired
+										? 'Expired'
+										: isMaxedOut
+											? 'Max uses reached'
+											: null
+								const inviteUrl = `${window.location.origin}/invite/${inviteCode.code}`
 
-										return (
-											<div
-												key={inviteCode.id}
-												className={`rounded-lg border p-4 ${isExpired || isMaxedOut ? 'opacity-50' : ''}`}
-											>
-												<div className="flex items-start justify-between">
-													<div className="flex-1 space-y-2">
-														<div className="flex items-center gap-2">
+								return (
+									<div
+										key={inviteCode.id}
+										className={`rounded-lg border p-4 ${statusLabel ? 'opacity-50' : ''}`}
+									>
+										<div className="flex items-start justify-between">
+											<div className="flex-1 space-y-2">
+												<div className="flex items-center gap-2">
 															<code className="text-sm font-mono bg-muted px-2 py-1 rounded">
 																{inviteCode.code}
 															</code>
@@ -287,18 +297,18 @@ export default function GroupDetailPage() {
 																className="h-7 px-2"
 																title="Copy code"
 															>
-																{copiedCode === inviteCode.code ? (
-																	<Check className="h-4 w-4 text-green-500" />
-																) : (
-																	<Copy className="h-4 w-4" />
-																)}
-															</Button>
-															{(isExpired || isMaxedOut) && (
-																<span className="text-xs text-destructive font-medium">
-																	{isExpired ? 'Expired' : 'Max uses reached'}
-																</span>
-															)}
-														</div>
+														{copiedCode === inviteCode.code ? (
+															<Check className="h-4 w-4 text-green-500" />
+														) : (
+															<Copy className="h-4 w-4" />
+														)}
+													</Button>
+													{statusLabel && (
+														<span className="text-xs text-destructive font-medium">
+															{statusLabel}
+														</span>
+													)}
+												</div>
 														<div className="flex items-center gap-2 text-xs">
 															<code className="bg-muted/50 px-2 py-1 rounded text-muted-foreground truncate max-w-md">
 																{inviteUrl}


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the invite code list UI so revoked invite codes are shown with a "Revoked" status instead of disappearing or being mislabeled, and adds a regression test confirming `revokeInviteCode` persists `revokedAt`.

## Changes
- Added an integration test asserting that after `revokeInviteCode`, the code returned by `listInviteCodes` has a non-null `revokedAt`.
- `useRevokeInviteCode` now does an optimistic update: on mutate it sets `revokedAt` locally for the revoked code (rolling back on error), so the UI reflects the revocation immediately instead of waiting on refetch.
- Both the admin and member group-detail pages now compute a `statusLabel` ("Revoked" / "Expired" / "Max uses reached") that treats revoked codes as revoked first, and no longer count a revoked/expired code as "maxed out".
- Updated the empty-state copy from "No active invite codes" to "No invite codes" since the list can now include revoked codes.

## Testing
- Added/extended integration test in `apps/groups/src/test/integration/api.test.ts` covering revoked invite code state via `listInviteCodes`.
<!-- claude:end -->