### PR TITLE
disable the discord gateway

### DIFF
--- a/apps/discord/src/context.ts
+++ b/apps/discord/src/context.ts
@@ -21,6 +21,7 @@ export type Env = SharedHonoEnv & {
 	DATABASE_URL: string
 	DISCORD: DurableObjectNamespace
 	DISCORD_GATEWAY: DurableObjectNamespace
+	DISCORD_GATEWAY_ENABLED: string
 	DISCORD_RATE_LIMITS: KVNamespace
 	DISCORD_AUTHORIZE_URL: string
 	DISCORD_TOKEN_URL: string

--- a/apps/discord/src/durable-object.ts
+++ b/apps/discord/src/durable-object.ts
@@ -2327,6 +2327,10 @@ export class DiscordGatewayDO extends DurableObject<Env> implements DiscordGatew
 		await this.gateway.alarm()
 	}
 
+	async shutdown(): Promise<void> {
+		await this.gateway.shutdown()
+	}
+
 	async reserveJoinSuppressions(input: {
 		discordUserId: string
 		guildIds: string[]

--- a/apps/discord/src/gateway/client.ts
+++ b/apps/discord/src/gateway/client.ts
@@ -33,6 +33,7 @@ export class DiscordGatewayClient implements DiscordGateway {
 	private readonly router = new DiscordGatewayEventRouter(
 		createDiscordGatewayEventRegistry(defaultDiscordGatewayHandlers)
 	)
+	private readonly gatewayEnabled: boolean
 	private websocket: WebSocket | null = null
 	private connectPromise: Promise<DiscordGatewayBootstrapResult> | null = null
 	private heartbeatTimer: ReturnType<typeof setInterval> | null = null
@@ -54,6 +55,8 @@ export class DiscordGatewayClient implements DiscordGateway {
 		private readonly state: DurableObjectState,
 		private readonly env: Env
 	) {
+		this.gatewayEnabled = env.DISCORD_GATEWAY_ENABLED === 'true'
+
 		state.blockConcurrencyWhile(async () => {
 			const persisted = await state.storage.get<Partial<DiscordGatewayStatus>>('gateway-state')
 			if (!persisted) {
@@ -70,6 +73,11 @@ export class DiscordGatewayClient implements DiscordGateway {
 			this.lastEventAt = persisted.lastEventAt ?? null
 			this.lastError = persisted.lastError ?? null
 			this.connectionState = persisted.connectionState ?? 'idle'
+
+			if (!this.gatewayEnabled) {
+				this.connectionState = 'disabled'
+				this.lastError = 'Discord gateway is disabled by configuration'
+			}
 		})
 	}
 
@@ -356,6 +364,10 @@ export class DiscordGatewayClient implements DiscordGateway {
 	}
 
 	private scheduleReconnect(reason: string): void {
+		if (!this.gatewayEnabled) {
+			return
+		}
+
 		this.clearReconnectTimer()
 		this.clearHeartbeatTimer()
 
@@ -382,6 +394,16 @@ export class DiscordGatewayClient implements DiscordGateway {
 	}
 
 	private async connect(resume = true): Promise<DiscordGatewayBootstrapResult> {
+		if (!this.gatewayEnabled) {
+			this.closeWebSocket(1000, 'gateway-disabled', true)
+			this.clearReconnectTimer()
+			this.clearHeartbeatTimer()
+			this.connectionState = 'disabled'
+			this.lastError = 'Discord gateway is disabled by configuration'
+			await this.persistStatus()
+			return { status: 'disabled' as const, reason: 'Discord gateway is disabled' }
+		}
+
 		if (this.websocket && this.websocket.readyState === WebSocket.OPEN) {
 			return { status: 'already-running' }
 		}
@@ -520,12 +542,34 @@ export class DiscordGatewayClient implements DiscordGateway {
 	}
 
 	async alarm(): Promise<void> {
+		if (!this.gatewayEnabled) {
+			await this.shutdown()
+			return
+		}
+
 		const status = this.getStatus()
 		logger.info('[DiscordGateway] Alarm triggered', {
 			connectionState: status.connectionState,
 			connected: status.connected,
 		})
 		await this.connect(true)
+	}
+
+	async shutdown(): Promise<void> {
+		this.clearReconnectTimer()
+		this.clearHeartbeatTimer()
+		this.closeWebSocket(1000, 'gateway-disabled', true)
+		this.gatewayUrl = null
+		this.resumeGatewayUrl = null
+		this.sessionId = null
+		this.sequence = null
+		this.heartbeatIntervalMs = null
+		this.lastHelloAt = null
+		this.lastHeartbeatAckAt = null
+		this.lastEventAt = null
+		this.lastError = 'Discord gateway is disabled by configuration'
+		this.connectionState = 'disabled'
+		await this.persistStatus()
 	}
 
 	async reserveJoinSuppressions(input: {

--- a/apps/discord/src/gateway/types.ts
+++ b/apps/discord/src/gateway/types.ts
@@ -61,7 +61,7 @@ export interface DiscordGatewayEventHandler<T = unknown> {
 
 export interface DiscordGatewayStatus {
 	connected: boolean
-	connectionState: 'idle' | 'connecting' | 'open' | 'resuming' | 'disconnected'
+	connectionState: 'idle' | 'connecting' | 'open' | 'resuming' | 'disconnected' | 'disabled'
 	gatewayUrl: string | null
 	resumeGatewayUrl: string | null
 	sessionId: string | null
@@ -74,7 +74,7 @@ export interface DiscordGatewayStatus {
 }
 
 export interface DiscordGatewayBootstrapResult {
-	status: 'started' | 'already-running' | 'connecting' | 'failed'
+	status: 'started' | 'already-running' | 'connecting' | 'disabled' | 'failed'
 	reason?: string
 }
 
@@ -94,6 +94,7 @@ export interface DiscordGateway {
 	ensureConnected(): Promise<DiscordGatewayBootstrapResult>
 	getGatewayStatus(): Promise<DiscordGatewayStatus>
 	alarm(): Promise<void>
+	shutdown(): Promise<void>
 	reserveJoinSuppressions(input: {
 		discordUserId: string
 		guildIds: string[]

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -7,7 +7,6 @@ import { z } from 'zod'
 import { logger, withNotFound, withOnError, withSentry } from '@repo/hono-helpers'
 
 import { DiscordDO, DiscordGatewayDO } from './durable-object'
-import type { DiscordGateway } from './gateway/types'
 import * as discordService from './services/discord.service'
 import { resolveDeferralMode, resolveSubcommandKey } from './utils/interaction-routing'
 
@@ -730,23 +729,14 @@ const app = new Hono<App>()
 const sentryApp = withSentry(app)
 
 async function scheduled(event: ScheduledEvent, env: App['Bindings'], _ctx: ExecutionContext): Promise<void> {
-	try {
-		const gatewayStub = getStub<DiscordGateway>(env.DISCORD_GATEWAY, 'gateway')
-		const result = await gatewayStub.ensureConnected()
-
-		logger.info('[DiscordScheduled] Gateway bootstrap checked', {
-			cron: event.cron,
-			scheduledTime: new Date(event.scheduledTime).toISOString(),
-			status: result.status,
-			reason: result.reason ?? null,
-		})
-	} catch (error) {
-		logger.error('[DiscordScheduled] Gateway bootstrap failed', {
-			cron: event.cron,
-			scheduledTime: new Date(event.scheduledTime).toISOString(),
-			error: error instanceof Error ? error.message : String(error),
-		})
-	}
+	// Intentionally stubbed: the Discord gateway listener has been disabled because
+	// the always-on websocket bootstrap caused unacceptable hosting cost inflation.
+	// We keep the scheduled entrypoint and gateway DO stub in place so the feature can
+	// be reintroduced later without changing the worker shape again.
+	logger.info('[DiscordScheduled] Discord gateway bootstrap is disabled; skipping', {
+		cron: event.cron,
+		scheduledTime: new Date(event.scheduledTime).toISOString(),
+	})
 }
 
 // Export Hono app wrapped with Sentry for automatic error tracking

--- a/apps/discord/wrangler.jsonc
+++ b/apps/discord/wrangler.jsonc
@@ -7,9 +7,6 @@
 	"workers_dev": false,
 	"routes": ["pleaseignore.app/api/discord/interactions"],
 	"logpush": false,
-	"triggers": {
-		"crons": ["*/5 * * * *"]
-	},
 	"kv_namespaces": [
 		{
 			"binding": "DISCORD_RATE_LIMITS",
@@ -20,6 +17,9 @@
 		"enabled": true,
 		"head_sampling_rate": 1
 	},
+	// The Discord gateway websocket listener is intentionally disabled. It caused
+	// sustained Cloudflare cost inflation and is kept only as a dormant stub for
+	// future experimentation if we find a lower-cost design.
 	"vars": {
 		"NAME": "discord",
 		"ENVIRONMENT": "production",
@@ -30,6 +30,7 @@
 		"DISCORD_TOKEN_REVOKE_URL": "https://discord.com/api/oauth2/token/revoke",
 		"DISCORD_USER_INFO_URL": "https://discord.com/api/users/@me",
 		"DISCORD_CALLBACK_URL": "https://pleaseignore.app/api/discord/callback",
+		"DISCORD_GATEWAY_ENABLED": "false",
 		"DISCORD_ROLE_ADD_ONLY_MODE": "true",
 		"SENTRY_DSN": "https://c06f13e3a5604fcaacc1d897752246a2@app.glitchtip.com/13710"
 	},

--- a/apps/discord/wrangler.test.jsonc
+++ b/apps/discord/wrangler.test.jsonc
@@ -20,6 +20,7 @@
 		"DISCORD_TOKEN_REVOKE_URL": "https://discord.com/api/oauth2/token/revoke",
 		"DISCORD_USER_INFO_URL": "https://discord.com/api/users/@me",
 		"DISCORD_CALLBACK_URL": "https://pleaseignore.app/api/discord/callback",
+		"DISCORD_GATEWAY_ENABLED": "false",
 		"DISCORD_ROLE_ADD_ONLY_MODE": "true"
 	},
 	"durable_objects": {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Disables the Discord gateway websocket listener because its always-on connection was driving up Cloudflare hosting costs. The gateway code and cron entrypoint are kept in place as a dormant stub so the feature can be re-enabled later without reshaping the worker.

## Changes
- Add a `DISCORD_GATEWAY_ENABLED` env var (set to `"false"` in `wrangler.jsonc` and `wrangler.test.jsonc`) that gates the gateway client.
- `DiscordGatewayClient` checks `gatewayEnabled` on init, `connect()`, `scheduleReconnect()`, and `alarm()` — when disabled it marks the connection state as `disabled`, records a "disabled by configuration" error, and skips connecting/reconnecting.
- Add a new `shutdown()` method to `DiscordGatewayClient` (and expose it via `DiscordGatewayDO` and the `DiscordGateway` interface) that tears down any active websocket/timers and persists the disabled status; `alarm()` calls `shutdown()` when the gateway is disabled.
- Extend `DiscordGatewayStatus.connectionState` and `DiscordGatewayBootstrapResult.status` types with a `disabled` variant.
- Remove the `*/5 * * * *` cron trigger from `apps/discord/wrangler.jsonc` and stub out the `scheduled()` handler in `apps/discord/index.ts` to just log that gateway bootstrap is disabled, instead of calling `ensureConnected()` on the gateway DO.
<!-- claude:end -->