### PR TITLE
disable invocation event logging

### DIFF
--- a/apps/admin/wrangler.jsonc
+++ b/apps/admin/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"logpush": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"workers_dev": false,
 	"vars": {

--- a/apps/beancounter/wrangler.jsonc
+++ b/apps/beancounter/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"rules": [

--- a/apps/bills/wrangler.jsonc
+++ b/apps/bills/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"triggers": {
 		"crons": ["*/30 * * * *"]

--- a/apps/broadcasts/wrangler.jsonc
+++ b/apps/broadcasts/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -15,7 +15,11 @@
 	"logpush": true,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"workers_dev": false,
 	"triggers": {

--- a/apps/core/wrangler.test.jsonc
+++ b/apps/core/wrangler.test.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"durable_objects": {
 		"bindings": [

--- a/apps/corporation-tax/wrangler.jsonc
+++ b/apps/corporation-tax/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"ESS_ALERT_THRESHOLD_ISK": "1000000000"

--- a/apps/corporation-tax/wrangler.test.jsonc
+++ b/apps/corporation-tax/wrangler.test.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"ESS_ALERT_THRESHOLD_ISK": "1000000000"

--- a/apps/discord/wrangler.jsonc
+++ b/apps/discord/wrangler.jsonc
@@ -15,7 +15,11 @@
 	],
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	// The Discord gateway websocket listener is intentionally disabled. It caused
 	// sustained Cloudflare cost inflation and is kept only as a dormant stub for

--- a/apps/discord/wrangler.test.jsonc
+++ b/apps/discord/wrangler.test.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"NAME": "discord",

--- a/apps/doctrines/wrangler.jsonc
+++ b/apps/doctrines/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/donations/wrangler.jsonc
+++ b/apps/donations/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/esi/wrangler.jsonc
+++ b/apps/esi/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"rules": [

--- a/apps/eve-character-data/wrangler.jsonc
+++ b/apps/eve-character-data/wrangler.jsonc
@@ -9,7 +9,11 @@
 	"logpush": true,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"triggers": {
 		"crons": ["0 */6 * * *"]

--- a/apps/eve-character-data/wrangler.test.jsonc
+++ b/apps/eve-character-data/wrangler.test.jsonc
@@ -8,7 +8,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"NAME": "eve-character-data"

--- a/apps/eve-corporation-data/wrangler.jsonc
+++ b/apps/eve-corporation-data/wrangler.jsonc
@@ -11,7 +11,11 @@
 		"crons": ["*/5 * * * *"]
 	},
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"ASSETS_SYNC_ENABLED": true,

--- a/apps/eve-token-store/wrangler.jsonc
+++ b/apps/eve-token-store/wrangler.jsonc
@@ -9,7 +9,11 @@
 	"logpush": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"kv_namespaces": [

--- a/apps/features/wrangler.jsonc
+++ b/apps/features/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/fleets/wrangler.jsonc
+++ b/apps/fleets/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": true,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"kv_namespaces": [

--- a/apps/freight/wrangler.jsonc
+++ b/apps/freight/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/fulcrum/wrangler.jsonc
+++ b/apps/fulcrum/wrangler.jsonc
@@ -9,7 +9,11 @@
 	// "routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"APP_BASE_URL": "https://pleaseignore.app"

--- a/apps/groups/wrangler.jsonc
+++ b/apps/groups/wrangler.jsonc
@@ -9,7 +9,11 @@
 	"logpush": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"SENTRY_DSN": "https://88d010dc5ed04607aaf6452c456c7a00@app.glitchtip.com/13712"

--- a/apps/hr/wrangler.jsonc
+++ b/apps/hr/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"queues": {
 		"consumers": [{ "queue": "hr-member-departed", "max_batch_size": 100, "max_batch_timeout": 5 }]

--- a/apps/hr/wrangler.test.jsonc
+++ b/apps/hr/wrangler.test.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"durable_objects": {
 		"bindings": [

--- a/apps/industry/wrangler.jsonc
+++ b/apps/industry/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/legacy/wrangler.jsonc
+++ b/apps/legacy/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"NAME": "legacy",

--- a/apps/mailroom/wrangler.jsonc
+++ b/apps/mailroom/wrangler.jsonc
@@ -11,7 +11,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	// Cross-worker bindings to shared Durable Objects (both workers must be deployed in the same
 	// account). DISCORD (apps/discord) powers the markeedragon@ → Discord post; PREDICTION_MARKETS

--- a/apps/markets/wrangler.jsonc
+++ b/apps/markets/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"routes": ["api.pleaseignore.app/v1/markets/*"],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"triggers": {
 		"crons": ["0 * * * *"]

--- a/apps/moon-scan/wrangler.jsonc
+++ b/apps/moon-scan/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"ENVIRONMENT": "production"

--- a/apps/mumble/wrangler.jsonc
+++ b/apps/mumble/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"NAME": "mumble",

--- a/apps/mumble/wrangler.test.jsonc
+++ b/apps/mumble/wrangler.test.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"NAME": "mumble",

--- a/apps/paste/wrangler.jsonc
+++ b/apps/paste/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"logpush": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"workers_dev": false,
 	"triggers": {

--- a/apps/postman/wrangler.jsonc
+++ b/apps/postman/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/prediction-markets/wrangler.jsonc
+++ b/apps/prediction-markets/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"durable_objects": {
 		"bindings": [

--- a/apps/skills/wrangler.jsonc
+++ b/apps/skills/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/apps/srp/wrangler.jsonc
+++ b/apps/srp/wrangler.jsonc
@@ -9,7 +9,11 @@
 	"workers_dev": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"triggers": {
 		"crons": ["15,45 * * * *"]

--- a/apps/structures/wrangler.jsonc
+++ b/apps/structures/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"logpush": false,
 	"workers_dev": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"NAME": "structures",

--- a/apps/third-party-apps/wrangler.jsonc
+++ b/apps/third-party-apps/wrangler.jsonc
@@ -14,7 +14,11 @@
 	],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {
 		"NAME": "third-party-apps",

--- a/apps/ui/wrangler.jsonc
+++ b/apps/ui/wrangler.jsonc
@@ -9,7 +9,11 @@
 	"logpush": false,
 	"observability": {
 		"enabled": true,
-		"head_sampling_rate": 1
+		"head_sampling_rate": 1,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"assets": {
 		"binding": "ASSETS",

--- a/apps/universe/wrangler.jsonc
+++ b/apps/universe/wrangler.jsonc
@@ -8,7 +8,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"kv_namespaces": [

--- a/turbo/generators/templates/durable-object-worker/wrangler.jsonc
+++ b/turbo/generators/templates/durable-object-worker/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {},
 	"durable_objects": {

--- a/turbo/generators/templates/worker/wrangler.jsonc
+++ b/turbo/generators/templates/worker/wrangler.jsonc
@@ -7,7 +7,11 @@
 	"routes": [],
 	"logpush": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"invocation_logs": false
+		}
 	},
 	"vars": {}
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Disables Cloudflare Workers invocation event logging across every worker in the monorepo, while keeping regular observability logs enabled.

## Changes
- Added `"logs": { "enabled": true, "invocation_logs": false }` under `observability` in every app's `wrangler.jsonc` (and `wrangler.test.jsonc` where present), covering all `apps/*` workers.
- Applied the same change to the `durable-object-worker` and `worker` generator templates under `turbo/generators/templates/` so newly generated workers default to invocation logging disabled.

## Testing
Config-only change to `wrangler.jsonc`/`wrangler.test.jsonc` files; no code paths affected.
<!-- claude:end -->