### PR TITLE
Feat/split structure tabs

### DIFF
--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -299,6 +299,14 @@ app.get('/mining', async (c) => {
 	return handleMiningStructuresRequest(c)
 })
 
+app.get('/moon-drills', async (c) => {
+	return handleMiningStructuresRequest(c)
+})
+
+app.get('/mining-citadels', async (c) => {
+	return handleMiningCitadelsStructuresRequest(c)
+})
+
 app.get('/overview', async (c) => {
 	return handleStructureOverviewRequest(c)
 })
@@ -518,6 +526,39 @@ async function handleMiningStructuresRequest(c: Context<App>): Promise<Response>
 	}
 
 	try {
+	const query = miningStructureListQuerySchema.parse({
+		page: c.req.query('page'),
+			pageSize: c.req.query('pageSize'),
+			sortBy: c.req.query('sortBy') || undefined,
+			sortDirection: c.req.query('sortDirection') || undefined,
+			corporationId: c.req.query('corporationId') || undefined,
+			assignedGroupId: c.req.query('assignedGroupId') || undefined,
+			lowPower: c.req.query('lowPower') || undefined,
+			lowPowerAllowed: c.req.query('lowPowerAllowed') || undefined,
+			regionId: c.req.query('regionId') || undefined,
+			systemId: c.req.query('systemId') || undefined,
+			state: c.req.query('state') || undefined,
+			typeId: c.req.query('typeId') || undefined,
+		planetId: c.req.query('planetId') || undefined,
+	}) satisfies StructureMiningListQuery
+		return c.json(await c.env.STRUCTURES.listMoonDrillStructures(await getStructureActor(c), query))
+	} catch (error) {
+		return c.json(
+			{
+				error: error instanceof Error ? error.message : 'Failed to list structures',
+			},
+			error instanceof z.ZodError ? 400 : 500
+		)
+	}
+}
+
+async function handleMiningCitadelsStructuresRequest(c: Context<App>): Promise<Response> {
+	const user = c.get('user')
+	if (!user) {
+		return c.json({ error: 'Unauthorized' }, 401)
+	}
+
+	try {
 		const query = miningStructureListQuerySchema.parse({
 			page: c.req.query('page'),
 			pageSize: c.req.query('pageSize'),
@@ -533,7 +574,7 @@ async function handleMiningStructuresRequest(c: Context<App>): Promise<Response>
 			typeId: c.req.query('typeId') || undefined,
 			planetId: c.req.query('planetId') || undefined,
 		}) satisfies StructureMiningListQuery
-		return c.json(await c.env.STRUCTURES.listMiningStructures(await getStructureActor(c), query))
+		return c.json(await c.env.STRUCTURES.listMiningCitadelStructures(await getStructureActor(c), query))
 	} catch (error) {
 		return c.json(
 			{

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -2085,6 +2085,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			await this.getDb()
 				.delete(corporationStructures)
 				.where(eq(corporationStructures.corporationId, corporationId))
+			await this.getDb()
+				.delete(structureSkyhookStates)
+				.where(eq(structureSkyhookStates.corporationId, corporationId))
+			await this.getDb()
+				.delete(structureMiningStates)
+				.where(eq(structureMiningStates.corporationId, corporationId))
 			return
 		}
 		const BATCH_SIZE = 10
@@ -2131,6 +2137,22 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				and(
 					eq(corporationStructures.corporationId, corporationId),
 					notInArray(corporationStructures.structureId, structureIds)
+				)
+			)
+		await this.getDb()
+			.delete(structureSkyhookStates)
+			.where(
+				and(
+					eq(structureSkyhookStates.corporationId, corporationId),
+					notInArray(structureSkyhookStates.structureId, structureIds)
+				)
+			)
+		await this.getDb()
+			.delete(structureMiningStates)
+			.where(
+				and(
+					eq(structureMiningStates.corporationId, corporationId),
+					notInArray(structureMiningStates.structureId, structureIds)
 				)
 			)
 	}

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -2626,25 +2626,17 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 */
 	async storeSovereigntyHubs(corporationId: string, hubs: EsiSovereigntyHub[]): Promise<void> {
 		const now = new Date()
-		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const existingRows = await this.getDb().query.structureSovereigntyHubs.findMany({
 			where: eq(structureSovereigntyHubs.corporationId, corporationId),
 		})
 		const existingByStructureId = new Map(existingRows.map((row) => [row.structureId, row]))
-		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
-			hubs.length > 0
-				? await universe.resolveSolarSystemsByIds([...new Set(hubs.map((hub) => hub.system_id))])
-				: {}
 		const values = hubs.map((hub) => {
 			const existing = existingByStructureId.get(hub.structure_id) ?? null
-			const resolvedSystemName =
-				systemGeography[hub.system_id]?.solarSystemName ?? hub.system_name ?? null
-
 			return {
 				structureId: hub.structure_id,
 				corporationId,
 				systemId: hub.system_id,
-				systemName: resolvedSystemName ?? existing?.systemName ?? null,
+				systemName: hub.system_name ?? existing?.systemName ?? null,
 				name: hub.name ?? existing?.name ?? null,
 				typeId: hub.type_id,
 				fuelAccessListId: hub.fuel_access_list_id ?? null,

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -46,50 +46,6 @@ import type {
 } from '@repo/eve-corporation-data'
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
 
-type RawUniverseStructureInfo = {
-	name: string | null
-	owner_id: number
-	position: {
-		x: number
-		y: number
-		z: number
-	}
-	solar_system_id: number
-	type_id: number
-}
-
-function getUniverseStructureCorporationId(universe: RawUniverseStructureInfo): string {
-	return String(universe.owner_id)
-}
-
-async function fetchUniverseStructureMetadata(
-	tokenStore: EveTokenStore,
-	structureId: string,
-	characterId: string,
-	context: 'sovereignty hub' | 'skyhook'
-): Promise<RawUniverseStructureInfo | null> {
-	try {
-		const result = await tokenStore.fetchEsi<RawUniverseStructureInfo>(
-			`/universe/structures/${structureId}`,
-			characterId,
-			{ cacheMode: 'no-store' }
-		)
-		return result.data
-	} catch (error) {
-		const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
-		if (message.includes('403') || message.includes('404')) {
-			logger.warn(`[ESI Fetch] Skipping ${context} enrichment for inaccessible universe metadata`, {
-				structureId,
-				characterId,
-				error: error instanceof Error ? error.message : String(error),
-			})
-			return null
-		}
-
-		throw error
-	}
-}
-
 // ========================================================================
 // PUBLIC DATA FETCHING
 // ========================================================================
@@ -390,7 +346,8 @@ export async function fetchSovereigntySystems(
 export async function fetchSovereigntyHubs(
 	tokenStore: EveTokenStore,
 	corporationId: string,
-	characterId: string
+	characterId: string,
+	knownStructures: Array<Pick<EsiCorporationStructure, 'structure_id' | 'type_id'>> = []
 ): Promise<EsiSovereigntyHub[]> {
 	type RawSovereigntyHubsListing = {
 		sovereignty_hubs: Array<{
@@ -490,70 +447,72 @@ export async function fetchSovereigntyHubs(
 		return []
 	}
 
+	const knownStructureById = new Map(
+		knownStructures.map((structure) => [structure.structure_id, structure])
+	)
+
 	const details: Array<EsiSovereigntyHub | null> = await Promise.all(
 		sovereigntyHubs.map(async (hub) => {
-			const universe = await fetchUniverseStructureMetadata(
-				tokenStore,
-				String(hub.id),
-				characterId,
-				'sovereignty hub'
-			)
-			if (!universe) {
-				return null
-			}
-			const universeCorporationId = getUniverseStructureCorporationId(universe)
+			try {
+				const detailResult = await tokenStore.fetchEsi<RawSovereigntyHubDetail>(
+					`/corporations/${corporationId}/structures/sovereignty-hubs/${hub.id}`,
+					characterId,
+					{ cacheMode: 'no-store' }
+				)
+				const detail = detailResult.data
+				const hubId = String(hub.id)
+				const knownStructure = knownStructureById.get(hubId) ?? null
 
-			if (universeCorporationId !== corporationId) {
-				logger.warn('[ESI Fetch] Skipping sovereignty hub enrichment for mismatched owner', {
+				const typeId = knownStructure?.type_id ?? null
+				if (!typeId) {
+					logger.warn('[ESI Fetch] Skipping sovereignty hub without type metadata', {
+						corporationId,
+						structureId: hubId,
+					})
+					return null
+				}
+
+				return {
+					structure_id: String(detail.id),
+					corporation_id: corporationId,
+					system_id: String(detail.solar_system_id),
+					name: null,
+					type_id: typeId,
+					fuel_access_list_id:
+						detail.fuel_access_list_id !== undefined && detail.fuel_access_list_id !== null
+							? String(detail.fuel_access_list_id)
+							: null,
+					reagent_bay: {
+						last_updated: detail.reagent_bay.last_updated,
+						reagents: detail.reagent_bay.reagents.map((reagent) => ({
+							type_id: String(reagent.type_id),
+							secured_stock: reagent.secured_stock,
+							unsecured_stock: reagent.unsecured_stock,
+							last_cycle: reagent.last_cycle,
+						})),
+					},
+					resources: detail.resources,
+					upgrades: detail.upgrades.map((upgrade) => ({
+						type_id: String(upgrade.type_id),
+						power_state: upgrade.power_state,
+					})),
+					vulnerability_window: detail.vulnerability_window ?? null,
+					workforce_transport: {
+						configuration: detail.workforce_transport.configuration,
+						state: detail.workforce_transport.state,
+					},
+					raw: {
+						detail,
+					},
+				} as EsiSovereigntyHub
+			} catch (error) {
+				logger.warn('[ESI Fetch] Failed to enrich sovereignty hub', {
 					corporationId,
 					structureId: String(hub.id),
-					universeCorporationId,
+					error: error instanceof Error ? error.message : String(error),
 				})
 				return null
 			}
-
-			const detailResult = await tokenStore.fetchEsi<RawSovereigntyHubDetail>(
-				`/corporations/${corporationId}/structures/sovereignty-hubs/${hub.id}`,
-				characterId,
-				{ cacheMode: 'no-store' }
-			)
-
-			const detail = detailResult.data
-
-			return {
-				structure_id: String(detail.id),
-				corporation_id: universeCorporationId,
-				system_id: String(detail.solar_system_id),
-				name: universe.name ?? null,
-				type_id: String(universe.type_id),
-				fuel_access_list_id:
-					detail.fuel_access_list_id !== undefined && detail.fuel_access_list_id !== null
-						? String(detail.fuel_access_list_id)
-						: null,
-				reagent_bay: {
-					last_updated: detail.reagent_bay.last_updated,
-					reagents: detail.reagent_bay.reagents.map((reagent) => ({
-						type_id: String(reagent.type_id),
-						secured_stock: reagent.secured_stock,
-						unsecured_stock: reagent.unsecured_stock,
-						last_cycle: reagent.last_cycle,
-					})),
-				},
-				resources: detail.resources,
-				upgrades: detail.upgrades.map((upgrade) => ({
-					type_id: String(upgrade.type_id),
-					power_state: upgrade.power_state,
-				})),
-				vulnerability_window: detail.vulnerability_window ?? null,
-				workforce_transport: {
-					configuration: detail.workforce_transport.configuration,
-					state: detail.workforce_transport.state,
-				},
-				raw: {
-					detail,
-					universe,
-				},
-			} as EsiSovereigntyHub
 		})
 	)
 

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -201,7 +201,7 @@ describe('esi structure enrichment ownership handling', () => {
 		expect(base?.stateTimerEnd?.toISOString()).toBe('2026-06-27T12:30:00.000Z')
 	})
 
-	it('skips sovereignty hub detail fetch when the authenticated universe owner does not match', async () => {
+	it('keeps sovereignty hub details when the base structure metadata is available', async () => {
 		const tokenStore = {
 			fetchEsi: vi
 				.fn()
@@ -213,33 +213,59 @@ describe('esi structure enrichment ownership handling', () => {
 				})
 				.mockResolvedValueOnce({
 					data: {
-						name: 'Wrong Corp Hub',
-						owner_id: 98000002,
-						position: { x: 0, y: 0, z: 0 },
+						id: 81001,
 						solar_system_id: 30000142,
-						type_id: 35835,
+						fuel_access_list_id: null,
+						reagent_bay: {
+							last_updated: '2026-07-12T19:36:46.834Z',
+							reagents: [],
+						},
+						resources: {
+							power: { allocated: 0, available: 0 },
+							workforce: { allocated: 0, available: 0 },
+						},
+						upgrades: [],
+						vulnerability_window: null,
+						workforce_transport: {
+							configuration: { transit: true },
+							state: { transit: true },
+						},
 					},
 				}),
 		}
 
-		const hubs = await fetchSovereigntyHubs(tokenStore as never, '98000001', '211')
+		const hubs = await fetchSovereigntyHubs(
+			tokenStore as never,
+			'98000001',
+			'211',
+			[
+				{
+					structure_id: '81001',
+					type_id: '35835',
+				},
+			]
+		)
 
 		expect(tokenStore.fetchEsi).toHaveBeenCalledTimes(2)
-		expect(tokenStore.fetchEsi).toHaveBeenCalledWith(
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			1,
 			'/corporations/98000001/structures/sovereignty-hubs?page=1',
 			'211',
 			{ cacheMode: 'no-store' }
 		)
-		expect(tokenStore.fetchEsi).toHaveBeenCalledWith(
-			'/universe/structures/81001',
-			'211',
-			{ cacheMode: 'no-store' }
-		)
-		expect(tokenStore.fetchEsi).not.toHaveBeenCalledWith(
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			2,
 			'/corporations/98000001/structures/sovereignty-hubs/81001',
 			'211',
 			{ cacheMode: 'no-store' }
 		)
-		expect(hubs).toEqual([])
+		expect(hubs).toHaveLength(1)
+		expect(hubs[0]).toMatchObject({
+			structure_id: '81001',
+			corporation_id: '98000001',
+			system_id: '30000142',
+			type_id: '35835',
+			name: null,
+		})
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { EveCorporationDataDO } from '../../../durable-object'
+import { corporationStructures, structureMiningStates, structureSkyhookStates } from '../../../db/schema'
+
+function makeDb() {
+	const where = vi.fn().mockResolvedValue(undefined)
+	const deleteMock = vi.fn(() => ({ where }))
+	const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
+	const values = vi.fn(() => ({ onConflictDoUpdate }))
+	const insert = vi.fn(() => ({ values }))
+
+	return {
+		delete: deleteMock,
+		insert,
+		_where: where,
+	}
+}
+
+function createDoInstance(db: ReturnType<typeof makeDb>) {
+	const instance = new EveCorporationDataDO(
+		{} as DurableObjectState,
+		{
+			DATABASE_URL: 'postgres://example',
+			UNIVERSE: {} as never,
+			EVE_TOKEN_STORE: {} as never,
+		} as never
+	)
+
+	;(instance as any).getDb = () => db
+
+	return instance
+}
+
+describe('structure prune cleanup', () => {
+	it('prunes stale skyhook and mining snapshots when structures disappear from a successful sync', async () => {
+		const db = makeDb()
+		const instance = createDoInstance(db)
+
+		;(instance as any).hydrateStructureRows = vi.fn().mockResolvedValue([
+			{
+				corporationId: 'corp-1',
+				structureId: 'structure-1',
+				name: 'Structure One',
+				typeId: '35832',
+				typeName: 'Astrahus',
+				systemId: '30000142',
+				systemName: 'Jita',
+				regionId: '10000002',
+				regionName: 'The Forge',
+				profileId: 'profile-1',
+				fuelExpires: null,
+				fuelAmount: null,
+				nextReinforceApply: null,
+				nextReinforceHour: null,
+				reinforceHour: null,
+				state: 'online',
+				stateTimerEnd: null,
+				stateTimerStart: null,
+				unanchorsAt: null,
+				lowPower: false,
+				syncStatus: 'ok',
+				syncFailureReason: null,
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				services: null,
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		])
+
+		await instance.storeStructures('corp-1', [
+			{
+				structure_id: 'structure-1',
+				type_id: '35832',
+				system_id: '30000142',
+				profile_id: 'profile-1',
+				state: 'online',
+			},
+		])
+
+		expect(db.delete).toHaveBeenCalledTimes(3)
+		expect(db.delete).toHaveBeenNthCalledWith(1, corporationStructures)
+		expect(db.delete).toHaveBeenNthCalledWith(2, structureSkyhookStates)
+		expect(db.delete).toHaveBeenNthCalledWith(3, structureMiningStates)
+		expect(db._where).toHaveBeenCalledTimes(3)
+	})
+
+	it('clears all structure-side rows when the successful sync returns no structures', async () => {
+		const db = makeDb()
+		const instance = createDoInstance(db)
+
+		;(instance as any).hydrateStructureRows = vi.fn().mockResolvedValue([])
+
+		await instance.storeStructures('corp-1', [])
+
+		expect(db.delete).toHaveBeenCalledTimes(3)
+		expect(db.delete).toHaveBeenNthCalledWith(1, corporationStructures)
+		expect(db.delete).toHaveBeenNthCalledWith(2, structureSkyhookStates)
+		expect(db.delete).toHaveBeenNthCalledWith(3, structureMiningStates)
+		expect(db._where).toHaveBeenCalledTimes(3)
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -1,19 +1,57 @@
 import { describe, expect, it, vi } from 'vitest'
 
+const mocks = vi.hoisted(() => {
+	const findMany = vi.fn()
+	const onConflictDoUpdate = vi.fn()
+	const values = vi.fn(() => ({ onConflictDoUpdate }))
+	const insert = vi.fn(() => ({ values }))
+	const deleteMock = vi.fn()
+	const resolveSolarSystemsByIds = vi.fn()
+	const getStub = vi.fn(() => ({
+		resolveSolarSystemsByIds,
+	}))
+
+	return {
+		findMany,
+		onConflictDoUpdate,
+		values,
+		insert,
+		deleteMock,
+		resolveSolarSystemsByIds,
+		getStub,
+	}
+})
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: mocks.getStub,
+}))
+
 import { EveCorporationDataDO } from '../../../durable-object'
-import { corporationStructures, structureMiningStates, structureSkyhookStates } from '../../../db/schema'
+import {
+	corporationStructures,
+	structureMiningStates,
+	structureSkyhookStates,
+	structureSovereigntyHubs,
+} from '../../../db/schema'
 
 function makeDb() {
 	const where = vi.fn().mockResolvedValue(undefined)
 	const deleteMock = vi.fn(() => ({ where }))
 	const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
-	const values = vi.fn(() => ({ onConflictDoUpdate }))
+	const values = vi.fn((rows) => ({ onConflictDoUpdate, rows }))
 	const insert = vi.fn(() => ({ values }))
+	const findMany = vi.fn().mockResolvedValue([])
 
 	return {
+		query: {
+			structureSovereigntyHubs: {
+				findMany,
+			},
+		},
 		delete: deleteMock,
 		insert,
 		_where: where,
+		_values: values,
 	}
 }
 
@@ -97,5 +135,45 @@ describe('structure prune cleanup', () => {
 		expect(db.delete).toHaveBeenNthCalledWith(2, structureSkyhookStates)
 		expect(db.delete).toHaveBeenNthCalledWith(3, structureMiningStates)
 		expect(db._where).toHaveBeenCalledTimes(3)
+	})
+
+	it('stores sovereignty hub names using resolved solar system names', async () => {
+		const db = makeDb()
+		const instance = createDoInstance(db)
+
+		await instance.storeSovereigntyHubs('corp-1', [
+			{
+				structure_id: 'hub-1',
+				corporation_id: 'corp-1',
+				system_id: '30000142',
+				system_name: 'Jita',
+				type_id: '35835',
+				name: 'Jita',
+				fuel_access_list_id: null,
+				controller_alliance_id: null,
+				reagent_bay: {
+					last_updated: '2026-07-12T19:36:46.834Z',
+					reagents: [],
+				},
+				resources: {
+					power: { allocated: 0, available: 0 },
+					workforce: { allocated: 0, available: 0 },
+				},
+				upgrades: [],
+				vulnerability_window: null,
+				workforce_transport: {
+					configuration: { transit: true },
+					state: { transit: true },
+				},
+				raw: { detail: { id: 1 } },
+			} as never,
+		])
+
+		expect(db._values).toHaveBeenCalled()
+		expect(db._values.mock.calls[0][0][0]).toMatchObject({
+			systemName: 'Jita',
+			name: 'Jita',
+		})
+		expect(db.delete).toHaveBeenCalledWith(structureSovereigntyHubs)
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const fetchSovereigntyHubsMock = vi.fn()
+const readSharedSovereigntySystemsByIdsMock = vi.fn()
+const resolveSolarSystemsByIdsMock = vi.fn()
+const getStubMock = vi.fn(() => ({
+	resolveSolarSystemsByIds: resolveSolarSystemsByIdsMock,
+}))
+const createTokenStoreMock = vi.fn()
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: getStubMock,
+}))
+
+vi.mock('../../../services/esi-fetch', () => ({
+	fetchSovereigntyHubs: (...args: unknown[]) => fetchSovereigntyHubsMock(...args),
+}))
+
+vi.mock('../../../workflows/utils/services', () => ({
+	createTokenStore: (...args: unknown[]) => createTokenStoreMock(...args),
+	getCorporationDataStub: vi.fn(),
+}))
+
+vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
+	readSharedSovereigntySystemsByIds: (...args: unknown[]) =>
+		readSharedSovereigntySystemsByIdsMock(...args),
+}))
+
+import { fetchSovereigntyEnrichment } from '../../../workflows/steps/structures'
+
+describe('fetchSovereigntyEnrichment', () => {
+	it('enriches sovereignty hub names from resolved solar systems before persistence', async () => {
+		createTokenStoreMock.mockReturnValue({})
+		fetchSovereigntyHubsMock.mockResolvedValue([
+			{
+				structure_id: 'hub-1',
+				corporation_id: 'corp-1',
+				system_id: '30000142',
+				system_name: null,
+				name: null,
+				type_id: '35835',
+				controller_alliance_id: null,
+				fuel_access_list_id: null,
+				reagent_bay: {
+					last_updated: '2026-07-12T19:36:46.834Z',
+					reagents: [],
+				},
+				resources: {
+					power: { allocated: 0, available: 0 },
+					workforce: { allocated: 0, available: 0 },
+				},
+				upgrades: [],
+				vulnerability_window: null,
+				workforce_transport: {
+					configuration: { transit: true },
+					state: { transit: true },
+				},
+				raw: { detail: { id: 1 } },
+			},
+		])
+		readSharedSovereigntySystemsByIdsMock.mockResolvedValue([])
+		resolveSolarSystemsByIdsMock.mockResolvedValue({
+			'30000142': {
+				solarSystemName: 'Jita',
+			},
+		})
+
+		const result = await fetchSovereigntyEnrichment(
+			{
+				UNIVERSE: {} as never,
+			} as never,
+			'corp-1',
+			'character-1',
+			[]
+		)
+
+		expect(fetchSovereigntyHubsMock).toHaveBeenCalledWith({}, 'corp-1', 'character-1', [])
+		expect(getStubMock).toHaveBeenCalledWith({}, 'default')
+		expect(resolveSolarSystemsByIdsMock).toHaveBeenCalledWith(['30000142'])
+		expect(result?.sovereigntyHubs[0]).toMatchObject({
+			name: 'Jita',
+			system_name: 'Jita',
+		})
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -216,6 +216,78 @@ describe('EveCorporationSyncWorkflow', () => {
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
 	})
 
+	it('passes the current corporation structure listing through to storage so stale rows can be pruned', async () => {
+		vi.clearAllMocks()
+		const { env, updateCorporationAuthHealth } = createWorkflowEnv()
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockResolvedValue([
+			{
+				structure_id: 'structure-1',
+				type_id: '35832',
+			},
+		])
+		storeStructuresMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures', 'assets'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-1b',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(storeStructuresMock).toHaveBeenCalledTimes(1)
+		expect(storeStructuresMock).toHaveBeenCalledWith(env, '693378155', [
+			{
+				structure_id: 'structure-1',
+				type_id: '35832',
+			},
+		])
+		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001', ['structure-1'])
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
+	})
+
 	it('skips mining enrichment for moon-drills and still continues to asset sync', async () => {
 		vi.clearAllMocks()
 		const { env, updateCorporationAuthHealth } = createWorkflowEnv()

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -7,6 +7,13 @@ import type { WorkflowStep } from 'cloudflare:workers'
 const getStubMock = vi.fn()
 const syncAssetsMock = vi.fn()
 const fetchStructuresMock = vi.fn()
+const fetchSovereigntyEnrichmentMock = vi.fn()
+const fetchSkyhookEnrichmentMock = vi.fn()
+const fetchMiningEnrichmentMock = vi.fn()
+const storeStructuresMock = vi.fn()
+const storeSovereigntyEnrichmentMock = vi.fn()
+const storeSkyhookEnrichmentMock = vi.fn()
+const storeMiningEnrichmentMock = vi.fn()
 const selectDirectorMock = vi.fn()
 const verifyAllDirectorsHealthMock = vi.fn()
 const reconcileDirectorsFromCorporationRolesMock = vi.fn()
@@ -78,6 +85,13 @@ vi.mock('../../../workflows/steps/directors', () => ({
 
 vi.mock('../../../workflows/steps/structures', () => ({
 	fetchStructures: (...args: unknown[]) => fetchStructuresMock(...args),
+	fetchSovereigntyEnrichment: (...args: unknown[]) => fetchSovereigntyEnrichmentMock(...args),
+	fetchSkyhookEnrichment: (...args: unknown[]) => fetchSkyhookEnrichmentMock(...args),
+	fetchMiningEnrichment: (...args: unknown[]) => fetchMiningEnrichmentMock(...args),
+	storeStructures: (...args: unknown[]) => storeStructuresMock(...args),
+	storeSovereigntyEnrichment: (...args: unknown[]) => storeSovereigntyEnrichmentMock(...args),
+	storeSkyhookEnrichment: (...args: unknown[]) => storeSkyhookEnrichmentMock(...args),
+	storeMiningEnrichment: (...args: unknown[]) => storeMiningEnrichmentMock(...args),
 }))
 
 function createStep() {
@@ -200,5 +214,164 @@ describe('EveCorporationSyncWorkflow', () => {
 		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets'])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
+	})
+
+	it('skips mining enrichment for moon-drills and still continues to asset sync', async () => {
+		vi.clearAllMocks()
+		const { env, updateCorporationAuthHealth } = createWorkflowEnv()
+		const workflowEnv = env as any
+		workflowEnv.STRUCTURE_ENRICHMENT_ENABLED = true
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockResolvedValue([
+			{
+				structure_id: '1000001',
+				type_id: '81826',
+			},
+		])
+		fetchSovereigntyEnrichmentMock.mockResolvedValue(null)
+		fetchSkyhookEnrichmentMock.mockResolvedValue(null)
+		fetchMiningEnrichmentMock.mockResolvedValue([
+			{
+				structure_id: '1000001',
+			},
+			{
+				structure_id: '1000002',
+			},
+		])
+		storeStructuresMock.mockResolvedValue(undefined)
+		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
+		storeSkyhookEnrichmentMock.mockResolvedValue(undefined)
+		storeMiningEnrichmentMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, workflowEnv)
+		const { step, executedStepNames } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures', 'assets'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-2',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(fetchMiningEnrichmentMock).not.toHaveBeenCalled()
+		expect(storeMiningEnrichmentMock).not.toHaveBeenCalled()
+		expect(executedStepNames).toContain('sync-assets')
+		expect(syncAssetsMock).toHaveBeenCalledWith(workflowEnv, '693378155', '900000001', ['1000001'])
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
+	})
+
+	it('keeps asset sync running when mining enrichment fails for a mining citadel run', async () => {
+		vi.clearAllMocks()
+		const { env, updateCorporationAuthHealth } = createWorkflowEnv()
+		const workflowEnv = env as any
+		workflowEnv.STRUCTURE_ENRICHMENT_ENABLED = true
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockResolvedValue([
+			{
+				structure_id: '2000001',
+				type_id: '35833',
+			},
+		])
+		fetchSovereigntyEnrichmentMock.mockResolvedValue(null)
+		fetchSkyhookEnrichmentMock.mockResolvedValue(null)
+		fetchMiningEnrichmentMock.mockRejectedValue(new Error('boom'))
+		storeStructuresMock.mockResolvedValue(undefined)
+		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
+		storeSkyhookEnrichmentMock.mockResolvedValue(undefined)
+		storeMiningEnrichmentMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, workflowEnv)
+		const { step, executedStepNames } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures', 'assets'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-3',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(fetchMiningEnrichmentMock).toHaveBeenCalledTimes(1)
+		expect(storeMiningEnrichmentMock).not.toHaveBeenCalled()
+		expect(executedStepNames).toContain('sync-assets')
+		expect(syncAssetsMock).toHaveBeenCalledWith(workflowEnv, '693378155', '900000001', ['2000001'])
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -1,9 +1,11 @@
 import { logger } from '@repo/hono-helpers'
+import { getStub } from '@repo/do-utils'
 
 import * as esiFetch from '../../../services/esi-fetch'
 import { shouldSuppressDirectorUnhealthyOnStructureEnrichmentAuthFailure } from '../../utils/structure-enrichment-auth'
 import { createTokenStore, getCorporationDataStub } from '../../utils/services'
 import { readSharedSovereigntySystemsByIds } from '../../utils/sovereignty-systems-cache'
+import type { Universe } from '@repo/universe'
 
 import type { Env } from '../../../context'
 
@@ -57,7 +59,8 @@ export async function storeStructures(
 export async function fetchSovereigntyEnrichment(
 	env: Env,
 	corporationId: string,
-	directorCharacterId: string
+	directorCharacterId: string,
+	structures: StructuresData
 ): Promise<SovereigntyEnrichmentData | null> {
 	const tokenStore = createTokenStore(env)
 
@@ -65,8 +68,16 @@ export async function fetchSovereigntyEnrichment(
 		const sovereigntyHubs = await esiFetch.fetchSovereigntyHubs(
 			tokenStore,
 			corporationId,
-			directorCharacterId
+			directorCharacterId,
+			structures
 		)
+		const universe = getStub<Universe>(env.UNIVERSE, 'default')
+		const systemGeography =
+			sovereigntyHubs.length > 0
+				? await universe.resolveSolarSystemsByIds(
+						[...new Set(sovereigntyHubs.map((hub) => hub.system_id))]
+					)
+				: {}
 		const sovereigntySystems = await readSharedSovereigntySystemsByIds(
 			env,
 			sovereigntyHubs.map((hub) => hub.system_id)
@@ -85,6 +96,8 @@ export async function fetchSovereigntyEnrichment(
 		)
 		const enrichedSovereigntyHubs = sovereigntyHubs.map((hub) => ({
 			...hub,
+			name: systemGeography[hub.system_id]?.solarSystemName ?? hub.name ?? null,
+			system_name: systemGeography[hub.system_id]?.solarSystemName ?? hub.system_name ?? null,
 			controller_alliance_id: allianceBySystemId.get(hub.system_id) ?? null,
 		}))
 

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -723,7 +723,12 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 								timeout: '5 minutes',
 								requiredRoles: ['Station_Manager'],
 								run: (directorCharacterId) =>
-									fetchSovereigntyEnrichment(this.env, corporationId, directorCharacterId),
+									fetchSovereigntyEnrichment(
+										this.env,
+										corporationId,
+										directorCharacterId,
+										structures
+									),
 							})
 						: null
 					const skyhookEnrichment = structureEnrichmentEnabled

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -58,6 +58,7 @@ import type {
 	CorporationRole,
 	EveCorporationData,
 	EveCorporationSyncDataType,
+	EsiCorporationStructure,
 } from '@repo/eve-corporation-data'
 import type { Env } from '../context'
 import type {
@@ -68,6 +69,11 @@ import type {
 } from './types'
 
 const STEP_RETRY_OPTIONS = esiRetryOptions
+const MINING_CITADEL_STRUCTURE_TYPE_IDS = new Set(['35833', '35834'])
+
+function isMiningCitadelStructure(structure: Pick<EsiCorporationStructure, 'type_id'>): boolean {
+	return MINING_CITADEL_STRUCTURE_TYPE_IDS.has(structure.type_id)
+}
 
 function readEnvFlag(value: boolean | string | undefined, defaultValue: boolean): boolean {
 	if (typeof value === 'boolean') return value
@@ -705,6 +711,12 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						await storeStructures(this.env, corporationId, structures)
 					})
 
+					const miningCitadelStructureIds = new Set(
+						structures
+							.filter((structure) => isMiningCitadelStructure(structure))
+							.map((structure) => String(structure.structure_id))
+					)
+
 					const sovereigntyEnrichment = structureEnrichmentEnabled
 						? await runDirectorStepWithFailover({
 								stepName: 'fetch-structure-sovereignty-enrichment',
@@ -723,15 +735,35 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 									fetchSkyhookEnrichment(this.env, corporationId, directorCharacterId),
 							})
 						: null
-					const miningExtractions = structureEnrichmentEnabled
-						? await runDirectorStepWithFailover({
+					let miningExtractions: Awaited<ReturnType<typeof fetchMiningEnrichment>> | null = null
+					if (structureEnrichmentEnabled && miningCitadelStructureIds.size > 0) {
+						try {
+							const fetchedMiningExtractions = await runDirectorStepWithFailover({
 								stepName: 'fetch-structure-mining-enrichment',
 								timeout: '5 minutes',
 								requiredRoles: ['Station_Manager'],
 								run: (directorCharacterId) =>
 									fetchMiningEnrichment(this.env, corporationId, directorCharacterId),
 							})
-						: null
+							miningExtractions = fetchedMiningExtractions.filter((extraction) =>
+								miningCitadelStructureIds.has(String(extraction.structure_id))
+							)
+
+							if (miningExtractions.length > 0) {
+								await step.do('store-structure-mining-enrichment', {}, async () => {
+									await storeMiningEnrichment(this.env, corporationId, miningExtractions!)
+								})
+							}
+						} catch (error) {
+							logger.warn(
+								'[EveCorporationSyncWorkflow] Mining enrichment failed; continuing without it',
+								{
+									corporationId,
+									error: error instanceof Error ? error.message : String(error),
+								}
+							)
+						}
+					}
 
 					if (sovereigntyEnrichment) {
 						await step.do('store-structure-sovereignty-enrichment', {}, async () => {
@@ -741,11 +773,6 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 					if (skyhookEnrichment) {
 						await step.do('store-structure-skyhook-enrichment', {}, async () => {
 							await storeSkyhookEnrichment(this.env, corporationId, skyhookEnrichment)
-						})
-					}
-					if (miningExtractions) {
-						await step.do('store-structure-mining-enrichment', {}, async () => {
-							await storeMiningEnrichment(this.env, corporationId, miningExtractions)
 						})
 					}
 

--- a/apps/structures/src/index.ts
+++ b/apps/structures/src/index.ts
@@ -8,6 +8,7 @@ import {
 	updateAlertDestination,
 } from './services/alert-destinations.service'
 import {
+	listMiningCitadelStructures,
 	deleteStructureGroupAlertConfig,
 	deleteStructureGroupSetting,
 	getStructureModuleConfig,
@@ -15,6 +16,7 @@ import {
 	getVisibleStructureDetail,
 	listCitadelStructures,
 	listMiningStructures,
+	listMoonDrillStructures,
 	listNavigationStructures,
 	listSkyhookStructures,
 	listSovereigntyStructures,
@@ -89,6 +91,17 @@ export class StructuresWorkerEntrypoint extends WorkerEntrypoint<Env> implements
 
 	async listMiningStructures(actor: StructureActor, query: StructureMiningListQuery = {}): Promise<unknown> {
 		return listMiningStructures(this.getDb(), actor, query)
+	}
+
+	async listMoonDrillStructures(actor: StructureActor, query: StructureMiningListQuery = {}): Promise<unknown> {
+		return listMoonDrillStructures(this.getDb(), actor, query)
+	}
+
+	async listMiningCitadelStructures(
+		actor: StructureActor,
+		query: StructureMiningListQuery = {}
+	): Promise<unknown> {
+		return listMiningCitadelStructures(this.getDb(), actor, query)
 	}
 
 	async getStructureOverviewMetrics(actor: StructureActor): Promise<StructureOverviewMetrics> {

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -109,13 +109,18 @@ export interface StructureListResponse<TItem = StructureListItem> {
 	summary: StructureListSummary
 }
 
-interface StructureAccessScope {
+interface StructurePermissionAccessTarget {
 	viewAll: boolean
 	sensitiveAll: boolean
 	managerAll: boolean
 	viewCorporationIds: Set<string>
 	sensitiveCorporationIds: Set<string>
 	managerCorporationIds: Set<string>
+}
+
+interface StructureAccessScope {
+	all: StructurePermissionAccessTarget
+	tabs: Record<StructureTab, StructurePermissionAccessTarget>
 }
 
 export interface StructureListItem {
@@ -383,78 +388,206 @@ export interface UpsertStructureGroupAlertConfigInput {
 	isEnabled: boolean
 }
 
-function computeStructureAccess(roles: string[], isAdmin: boolean): StructureAccessScope {
-	if (isAdmin) {
-		return {
-			viewAll: true,
-			sensitiveAll: true,
-			managerAll: true,
-			viewCorporationIds: new Set<string>(),
-			sensitiveCorporationIds: new Set<string>(),
-			managerCorporationIds: new Set<string>(),
+const STRUCTURE_ACCESS_TABS: StructureTab[] = [
+	'citadels',
+	'navigation',
+	'sovereignty',
+	'skyhooks',
+	'moon-drills',
+	'mining-citadels',
+]
+
+function createStructurePermissionAccessTarget(): StructurePermissionAccessTarget {
+	return {
+		viewAll: false,
+		sensitiveAll: false,
+		managerAll: false,
+		viewCorporationIds: new Set<string>(),
+		sensitiveCorporationIds: new Set<string>(),
+		managerCorporationIds: new Set<string>(),
+	}
+}
+
+function addParsedStructurePermissionToTarget(
+	target: StructurePermissionAccessTarget,
+	parsed: NonNullable<ReturnType<typeof parseStructurePermissionUrn>>
+): void {
+	if (parsed.scope === STRUCTURE_PERMISSION_SCOPE_ALL) {
+		target.viewAll = true
+		if (parsed.role === 'manager' || parsed.role === 'sensitive') {
+			target.sensitiveAll = true
+		}
+		if (parsed.role === 'manager') {
+			target.managerAll = true
+		}
+		return
+	}
+
+	if (!parsed.corporationId) {
+		return
+	}
+
+	target.viewCorporationIds.add(parsed.corporationId)
+	if (parsed.role === 'manager' || parsed.role === 'sensitive') {
+		target.sensitiveCorporationIds.add(parsed.corporationId)
+	}
+	if (parsed.role === 'manager') {
+		target.managerCorporationIds.add(parsed.corporationId)
+	}
+}
+
+function buildStructureAccessTargetSummary(
+	access: StructurePermissionAccessTarget,
+	corporationId: string
+): {
+	canView: boolean
+	canViewSensitive: boolean
+	canEdit: boolean
+} {
+	const canView =
+		access.viewAll ||
+		access.sensitiveAll ||
+		access.managerAll ||
+		access.viewCorporationIds.has(corporationId) ||
+		access.sensitiveCorporationIds.has(corporationId) ||
+		access.managerCorporationIds.has(corporationId)
+	const canViewSensitive =
+		access.sensitiveAll ||
+		access.managerAll ||
+		access.sensitiveCorporationIds.has(corporationId) ||
+		access.managerCorporationIds.has(corporationId)
+	const canEdit = access.managerAll || access.managerCorporationIds.has(corporationId)
+
+	return {
+		canView,
+		canViewSensitive,
+		canEdit,
+	}
+}
+
+function getStructureAccessTarget(access: StructureAccessScope, tab: StructureTab): StructurePermissionAccessTarget {
+	return {
+		viewAll: access.all.viewAll || access.tabs[tab].viewAll,
+		sensitiveAll: access.all.sensitiveAll || access.tabs[tab].sensitiveAll,
+		managerAll: access.all.managerAll || access.tabs[tab].managerAll,
+		viewCorporationIds: new Set([
+			...access.all.viewCorporationIds,
+			...access.tabs[tab].viewCorporationIds,
+		]),
+		sensitiveCorporationIds: new Set([
+			...access.all.sensitiveCorporationIds,
+			...access.tabs[tab].sensitiveCorporationIds,
+		]),
+		managerCorporationIds: new Set([
+			...access.all.managerCorporationIds,
+			...access.tabs[tab].managerCorporationIds,
+		]),
+	}
+}
+
+function hasAnyStructureAccess(target: StructurePermissionAccessTarget): boolean {
+	return (
+		target.viewAll ||
+		target.sensitiveAll ||
+		target.managerAll ||
+		target.viewCorporationIds.size > 0 ||
+		target.sensitiveCorporationIds.size > 0 ||
+		target.managerCorporationIds.size > 0
+	)
+}
+
+function hasStructureAccessForTab(access: StructureAccessScope, corporationId: string, tab: StructureTab): boolean {
+	const target = getStructureAccessTarget(access, tab)
+	return buildStructureAccessTargetSummary(target, corporationId).canView
+}
+
+function canViewSensitiveStructure(access: StructureAccessScope, corporationId: string, tab: StructureTab): boolean {
+	const target = getStructureAccessTarget(access, tab)
+	return buildStructureAccessTargetSummary(target, corporationId).canViewSensitive
+}
+
+function canEditStructure(access: StructureAccessScope, corporationId: string, tab: StructureTab): boolean {
+	const target = getStructureAccessTarget(access, tab)
+	return buildStructureAccessTargetSummary(target, corporationId).canEdit
+}
+
+function getAccessibleCorporationIds(
+	access: StructureAccessScope,
+	tab?: StructureTab
+): { hasGlobalAccess: boolean; corporationIds: Set<string> } {
+	const targets = tab ? [access.all, access.tabs[tab]] : [access.all, ...STRUCTURE_ACCESS_TABS.map((entry) => access.tabs[entry])]
+	const corporationIds = new Set<string>()
+	let hasGlobalAccess = false
+
+	for (const target of targets) {
+		if (target.viewAll) {
+			hasGlobalAccess = true
+		}
+		for (const corporationId of target.viewCorporationIds) {
+			corporationIds.add(corporationId)
+		}
+		for (const corporationId of target.sensitiveCorporationIds) {
+			corporationIds.add(corporationId)
+		}
+		for (const corporationId of target.managerCorporationIds) {
+			corporationIds.add(corporationId)
 		}
 	}
 
-	const viewCorporationIds = new Set<string>()
-	const sensitiveCorporationIds = new Set<string>()
-	const managerCorporationIds = new Set<string>()
-	let viewAll = false
-	let sensitiveAll = false
-	let managerAll = false
+	return { hasGlobalAccess, corporationIds }
+}
+
+function computeStructureAccess(roles: string[], isAdmin: boolean): StructureAccessScope {
+	if (isAdmin) {
+		return {
+			all: {
+				viewAll: true,
+				sensitiveAll: true,
+				managerAll: true,
+				viewCorporationIds: new Set<string>(),
+				sensitiveCorporationIds: new Set<string>(),
+				managerCorporationIds: new Set<string>(),
+			},
+			tabs: Object.fromEntries(
+				STRUCTURE_ACCESS_TABS.map((tab) => [
+					tab,
+					{
+						viewAll: true,
+						sensitiveAll: true,
+						managerAll: true,
+						viewCorporationIds: new Set<string>(),
+						sensitiveCorporationIds: new Set<string>(),
+						managerCorporationIds: new Set<string>(),
+					},
+				])
+			) as Record<StructureTab, StructurePermissionAccessTarget>,
+		}
+	}
+
+	const all = createStructurePermissionAccessTarget()
+	const tabs = Object.fromEntries(
+		STRUCTURE_ACCESS_TABS.map((tab) => [tab, createStructurePermissionAccessTarget()])
+	) as Record<StructureTab, StructurePermissionAccessTarget>
 
 	for (const roleUrn of roles) {
 		const parsed = parseStructurePermissionUrn(roleUrn)
 		if (!parsed) continue
-		if (parsed.scope === STRUCTURE_PERMISSION_SCOPE_ALL) {
-			viewAll = true
-			if (parsed.role === 'manager' || parsed.role === 'sensitive') {
-				sensitiveAll = true
-			}
-			if (parsed.role === 'manager') {
-				managerAll = true
-			}
-			continue
-		}
-
-		if (parsed.corporationId) {
-			if (STRUCTURE_PERMISSION_ROLES.includes(parsed.role)) {
-				viewCorporationIds.add(parsed.corporationId)
-			}
-			if (parsed.role === 'manager' || parsed.role === 'sensitive') {
-				sensitiveCorporationIds.add(parsed.corporationId)
-			}
-			if (parsed.role === 'manager') {
-				managerCorporationIds.add(parsed.corporationId)
-			}
+		if (parsed.tab === 'all') {
+			addParsedStructurePermissionToTarget(all, parsed)
+		} else {
+			addParsedStructurePermissionToTarget(tabs[parsed.tab], parsed)
 		}
 	}
 
 	return {
-		viewAll,
-		sensitiveAll,
-		managerAll,
-		viewCorporationIds,
-		sensitiveCorporationIds,
-		managerCorporationIds,
+		all,
+		tabs,
 	}
 }
 
 export function canManageStructureModule(user: SessionUser): boolean {
 	const access = computeStructureAccess(user.roles, user.is_admin)
-	return user.is_admin || access.managerAll
-}
-
-function canViewSensitiveStructure(access: StructureAccessScope, corporationId: string): boolean {
-	return (
-		access.sensitiveAll ||
-		access.managerAll ||
-		access.sensitiveCorporationIds.has(corporationId) ||
-		access.managerCorporationIds.has(corporationId)
-	)
-}
-
-function canEditStructure(access: StructureAccessScope, corporationId: string): boolean {
-	return access.managerAll || access.managerCorporationIds.has(corporationId)
+	return user.is_admin || access.all.managerAll
 }
 
 function toIso(value: Date | null | undefined): string | null {
@@ -709,7 +842,7 @@ async function loadStructureTabDetailData(
 		}
 	}
 
-	if (tab === 'mining') {
+	if (tab === 'mining-citadels') {
 		const miningRow = await db.query.structureMiningStates.findFirst({
 			where: eq(structureMiningStates.structureId, structure.structureId),
 		})
@@ -1097,11 +1230,11 @@ const EMPTY_STRUCTURE_FUEL_USAGE_HISTORY: StructureFuelUsageHistory = {
 	sampleCount: 0,
 }
 
-export function getStructureTab(structure: Pick<StructureListItem, 'typeId'>): StructureTab {
-	return getStructureTabForTypeId(structure.typeId)
+export function getStructureTab(structure: Pick<StructureListItem, 'typeId' | 'typeName'>): StructureTab {
+	return getStructureTabForTypeId(structure.typeId, structure.typeName)
 }
 
-function matchesStructureTab(structure: Pick<StructureListItem, 'typeId'>, tab: StructureTab): boolean {
+function matchesStructureTab(structure: Pick<StructureListItem, 'typeId' | 'typeName'>, tab: StructureTab): boolean {
 	return getStructureTab(structure) === tab
 }
 
@@ -1144,14 +1277,15 @@ async function getVisibleStructureContext(
 	structureId: string
 ): Promise<VisibleStructureContext | null> {
 	const access = computeStructureAccess(user.roles, user.is_admin)
+	const accessibleCorporations = getAccessibleCorporationIds(access)
 	const structure = await db.query.corporationStructures.findFirst({
 		where: (() => {
 			const conditions = [eq(corporationStructures.structureId, structureId)]
-			if (!access.viewAll) {
-				if (access.viewCorporationIds.size === 0) {
+			if (!accessibleCorporations.hasGlobalAccess) {
+				if (accessibleCorporations.corporationIds.size === 0) {
 					return and(...conditions, eq(corporationStructures.corporationId, '__no_access__'))
 				}
-				conditions.push(inArray(corporationStructures.corporationId, [...access.viewCorporationIds]))
+				conditions.push(inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds]))
 			}
 			return and(...conditions)
 		})(),
@@ -1172,8 +1306,13 @@ async function getVisibleStructureContext(
 			includeInStructureAssetSync: true,
 		},
 	})
-	const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, structure.corporationId)
-	const canEdit = user.is_admin || canEditStructure(access, structure.corporationId)
+	const structureTab = getStructureTab(structure)
+	if (!hasStructureAccessForTab(access, structure.corporationId, structureTab)) {
+		return null
+	}
+
+	const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
+	const canEdit = user.is_admin || canEditStructure(access, structure.corporationId, structureTab)
 	if (config?.hidden && !canViewSensitive) {
 		return null
 	}
@@ -1477,8 +1616,9 @@ async function loadVisibleStructureContexts(
 }> {
 	const moduleConfig = await getStructureModuleConfig(db)
 	const access = computeStructureAccess(user.roles, user.is_admin)
+	const accessibleCorporations = getAccessibleCorporationIds(access)
 
-	if (!access.viewAll && access.viewCorporationIds.size === 0) {
+	if (!accessibleCorporations.hasGlobalAccess && accessibleCorporations.corporationIds.size === 0) {
 		return {
 			moduleConfig,
 			access,
@@ -1490,8 +1630,12 @@ async function loadVisibleStructureContexts(
 		const conditions: StructureWhereCondition[] = []
 		if (query.corporationId) {
 			conditions.push(eq(corporationStructures.corporationId, query.corporationId))
-		} else if (!access.viewAll && access.viewCorporationIds.size > 0) {
-			conditions.push(inArray(corporationStructures.corporationId, [...access.viewCorporationIds]))
+		}
+		if (!accessibleCorporations.hasGlobalAccess) {
+			if (accessibleCorporations.corporationIds.size === 0) {
+				return combineWhereConditions([eq(corporationStructures.corporationId, '__no_access__')])
+			}
+			conditions.push(inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds]))
 		}
 		if (query.lowPower === 'true') {
 			conditions.push(eq(corporationStructures.lowPower, true))
@@ -1543,8 +1687,9 @@ async function loadVisibleStructureContexts(
 		contexts: corpStructures
 			.map<VisibleStructureContext | null>((structure) => {
 				const config = configsByStructureId.get(structure.structureId) ?? null
-				const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, structure.corporationId)
-				const canEdit = user.is_admin || canEditStructure(access, structure.corporationId)
+				const structureTab = getStructureTab(structure)
+				const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
+				const canEdit = user.is_admin || canEditStructure(access, structure.corporationId, structureTab)
 				if (config?.hidden && !canViewSensitive) {
 					return null
 				}
@@ -1590,7 +1735,8 @@ async function listVisibleOperationalStructures(
 	activeTab: StructureTab
 ): Promise<StructureListResponse> {
 	const { moduleConfig, access, contexts } = await loadVisibleStructureContexts(db, user, query)
-	if (contexts.length === 0 && !access.viewAll && access.viewCorporationIds.size === 0) {
+	const tabAccess = getStructureAccessTarget(access, activeTab)
+	if (!hasAnyStructureAccess(tabAccess)) {
 		return {
 			items: [],
 			pagination: {
@@ -1614,6 +1760,7 @@ async function listVisibleOperationalStructures(
 	const baseItems = contexts
 		.map((context) => buildStructureListItem(context))
 		.filter((item) => matchesStructureTab(item, activeTab))
+		.filter((item) => hasStructureAccessForTab(access, item.corporationId, activeTab))
 	const filterOptions = buildStructureFilterOptions(baseItems)
 	const filteredItems = baseItems
 	const sortBy = query.sortBy ?? 'fuel'
@@ -1648,15 +1795,18 @@ export async function getStructureOverviewMetrics(
 	user: SessionUser
 ): Promise<StructureOverviewMetrics> {
 	const { moduleConfig, access, contexts } = await loadVisibleStructureContexts(db, user, {})
-	if (contexts.length === 0 && !access.viewAll && access.viewCorporationIds.size === 0) {
+	const visibleContexts = contexts.filter((context) =>
+		hasStructureAccessForTab(access, context.structure.corporationId, getStructureTab(context.structure))
+	)
+	if (visibleContexts.length === 0) {
 		return emptyStructureOverviewMetrics()
 	}
 
-	const items = contexts.map((context) => buildStructureListItem(context))
+	const items = visibleContexts.map((context) => buildStructureListItem(context))
 	const summary = buildStructureSummary(items, moduleConfig)
 	const fuelHistorySamplesByStructure = await loadFuelHistorySamplesByStructure(
 		db,
-		contexts.map((context) => context.structure.structureId)
+		visibleContexts.map((context) => context.structure.structureId)
 	)
 	const burnRate = aggregateFuelBurnRatePerHour(fuelHistorySamplesByStructure)
 
@@ -1688,6 +1838,14 @@ export async function listNavigationStructures(
 	query: StructureNavigationListQuery = {}
 ): Promise<StructureListResponse> {
 	return listVisibleOperationalStructures(db, user, query as StructureListQuery, 'navigation')
+}
+
+export async function listMoonDrillStructures(
+	db: DbClient<DbSchema>,
+	user: SessionUser,
+	query: StructureMiningListQuery = {}
+): Promise<StructureListResponse> {
+	return listVisibleOperationalStructures(db, user, query as StructureListQuery, 'moon-drills')
 }
 
 function getSnapshotSyncStatus(lastSyncedAt: Date | null | undefined): 'ok' | 'warning' | 'error' {
@@ -1867,7 +2025,8 @@ export async function listSovereigntyStructures(
 		typeId: query.typeId,
 	})
 
-	if (!access.viewAll && access.viewCorporationIds.size === 0) {
+	const accessForTab = getStructureAccessTarget(access, 'sovereignty')
+	if (!hasAnyStructureAccess(accessForTab)) {
 		return {
 			items: [],
 			pagination: {
@@ -1990,7 +2149,8 @@ export async function listSkyhookStructures(
 		typeId: query.typeId,
 	})
 
-	if (!access.viewAll && access.viewCorporationIds.size === 0) {
+	const accessForTab = getStructureAccessTarget(access, 'skyhooks')
+	if (!hasAnyStructureAccess(accessForTab)) {
 		return {
 			items: [],
 			pagination: {
@@ -2093,10 +2253,11 @@ export async function listSkyhookStructures(
 	}
 }
 
-export async function listMiningStructures(
+async function listStructuresWithMiningSnapshot(
 	db: DbClient<DbSchema>,
 	user: SessionUser,
-	query: StructureMiningListQuery = {}
+	query: StructureMiningListQuery,
+	tab: Extract<StructureTab, 'moon-drills' | 'mining-citadels'>
 ): Promise<StructureListResponse<StructureMiningListItem>> {
 	const { moduleConfig, contexts, access } = await loadVisibleStructureContexts(db, user, {
 		corporationId: query.corporationId,
@@ -2109,7 +2270,8 @@ export async function listMiningStructures(
 		typeId: query.typeId,
 	})
 
-	if (!access.viewAll && access.viewCorporationIds.size === 0) {
+	const accessForTab = getStructureAccessTarget(access, tab)
+	if (!hasAnyStructureAccess(accessForTab)) {
 		return {
 			items: [],
 			pagination: {
@@ -2130,8 +2292,8 @@ export async function listMiningStructures(
 		}
 	}
 
-	const miningContexts = contexts.filter((context) => getStructureTab(context.structure) === 'mining')
-	const structureIds = miningContexts.map((context) => context.structure.structureId)
+	const matchingContexts = contexts.filter((context) => getStructureTab(context.structure) === tab)
+	const structureIds = matchingContexts.map((context) => context.structure.structureId)
 
 	if (structureIds.length === 0) {
 		return {
@@ -2170,7 +2332,7 @@ export async function listMiningStructures(
 		orderBy: desc(structureMiningStates.updatedAt),
 	})
 	const miningByStructureId = new Map(miningRows.map((row) => [row.structureId, row]))
-	const items = miningContexts.map((context) =>
+	const items = matchingContexts.map((context) =>
 		buildMiningListItem({
 			context,
 			miningRow: miningByStructureId.get(context.structure.structureId) ?? null,
@@ -2202,6 +2364,22 @@ export async function listMiningStructures(
 	}
 }
 
+export async function listMiningStructures(
+	db: DbClient<DbSchema>,
+	user: SessionUser,
+	query: StructureMiningListQuery = {}
+): Promise<StructureListResponse> {
+	return await listMoonDrillStructures(db, user, query)
+}
+
+export async function listMiningCitadelStructures(
+	db: DbClient<DbSchema>,
+	user: SessionUser,
+	query: StructureMiningListQuery = {}
+): Promise<StructureListResponse<StructureMiningListItem>> {
+	return await listStructuresWithMiningSnapshot(db, user, query, 'mining-citadels')
+}
+
 export async function getVisibleStructureDetail(
 	env: Env,
 	db: DbClient<DbSchema>,
@@ -2231,10 +2409,8 @@ export async function updateStructureConfig(
 	}
 
 	const access = computeStructureAccess(user.roles, user.is_admin)
-	const canEdit =
-		user.is_admin ||
-		access.managerAll ||
-		access.managerCorporationIds.has(context.structure.corporationId)
+	const structureTab = getStructureTab(context.structure)
+	const canEdit = user.is_admin || canEditStructure(access, context.structure.corporationId, structureTab)
 	if (!canEdit) {
 		return null
 	}

--- a/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
+++ b/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
@@ -13,7 +13,11 @@ vi.mock('@repo/hono-helpers', () => ({
 	},
 }))
 
-import { listVisibleStructures } from '../../../services/structures.service'
+import {
+	listMiningCitadelStructures,
+	listMoonDrillStructures,
+	listVisibleStructures,
+} from '../../../services/structures.service'
 
 type FakeDb = Parameters<typeof listVisibleStructures>[0]
 
@@ -40,6 +44,20 @@ function makeDb(
 			lowPower: boolean
 			syncStatus: 'ok'
 			syncFailureReason: null
+			lastSyncedAt: Date
+			updatedAt: Date
+		}>
+		miningStates?: Array<{
+			structureId: string
+			moonId: string
+			moonName: string | null
+			planetId: string | null
+			planetName: string | null
+			systemId: string | null
+			systemName: string | null
+			extractionStartTime: Date | null
+			chunkArrivalTime: Date | null
+			naturalDecayTime: Date | null
 			lastSyncedAt: Date
 			updatedAt: Date
 		}>
@@ -115,6 +133,10 @@ function makeDb(
 		structureFuelLog: {
 			findMany: vi.fn().mockResolvedValue([]),
 		},
+		structureMiningStates: {
+			findFirst: vi.fn().mockResolvedValue(null),
+			findMany: vi.fn().mockResolvedValue(options.miningStates ?? []),
+		},
 	}
 
 	return { query } as unknown as FakeDb
@@ -152,6 +174,213 @@ describe('structure permission gating', () => {
 		expect(db.query.corporationStructures.findMany).toHaveBeenCalledTimes(1)
 		expect(result.items).toHaveLength(1)
 		expect(result.items[0]?.corporationId).toBe('corp-1')
+	})
+
+	it('does not leak citadels to a tab-scoped moon-drills permission', async () => {
+		const db = makeDb()
+
+		const result = await listVisibleStructures(db as never, {
+			id: 'user-3',
+			is_admin: false,
+			roles: ['urn:structures:moon-drills:all:viewer'],
+		})
+
+		expect(db.query.corporationStructures.findMany).toHaveBeenCalledTimes(1)
+		expect(result.items).toHaveLength(0)
+	})
+
+	it('returns moon-drill structures for a moon-drills tab permission', async () => {
+		const db = makeDb({
+			structures: [
+				{
+					structureId: 'structure-moon-drill',
+					corporationId: 'corp-1',
+					name: 'Moon Drill',
+					typeId: '81826',
+					typeName: 'Metenox Moon Drill',
+					systemId: '30000142',
+					systemName: 'Jita',
+					regionId: '10000002',
+					regionName: 'The Forge',
+					profileId: 'profile-1',
+					state: 'online',
+					nextReinforceApply: null,
+					stateTimerEnd: null,
+					unanchorsAt: null,
+					fuelExpires: null,
+					fuelAmount: 2000,
+					lowPower: false,
+					syncStatus: 'ok',
+					syncFailureReason: null,
+					lastSyncedAt: new Date('2026-01-01T00:00:00Z'),
+					updatedAt: new Date('2026-01-01T00:00:00Z'),
+				},
+			],
+		})
+
+		const result = await listMoonDrillStructures(db as never, {
+			id: 'user-4',
+			is_admin: false,
+			roles: ['urn:structures:moon-drills:all:viewer'],
+		})
+
+		expect(db.query.corporationStructures.findMany).toHaveBeenCalledTimes(1)
+		expect(result.items).toHaveLength(1)
+		expect(result.items[0]?.structureId).toBe('structure-moon-drill')
+	})
+
+	it('returns mining citadel structures for a mining-citadels tab permission', async () => {
+		const db = makeDb({
+			structures: [
+				{
+					structureId: 'structure-mining-citadel',
+					corporationId: 'corp-1',
+					name: 'Mining Citadel',
+					typeId: '35833',
+					typeName: 'Athanor',
+					systemId: '30000142',
+					systemName: 'Jita',
+					regionId: '10000002',
+					regionName: 'The Forge',
+					profileId: 'profile-1',
+					state: 'online',
+					nextReinforceApply: null,
+					stateTimerEnd: null,
+					unanchorsAt: null,
+					fuelExpires: null,
+					fuelAmount: 2000,
+					lowPower: false,
+					syncStatus: 'ok',
+					syncFailureReason: null,
+					lastSyncedAt: new Date('2026-01-01T00:00:00Z'),
+					updatedAt: new Date('2026-01-01T00:00:00Z'),
+				},
+			],
+		})
+
+		const result = await listMiningCitadelStructures(db as never, {
+			id: 'user-4b',
+			is_admin: false,
+			roles: ['urn:structures:mining-citadels:all:viewer'],
+		})
+
+		expect(db.query.corporationStructures.findMany).toHaveBeenCalledTimes(1)
+		expect(result.items).toHaveLength(1)
+		expect(result.items[0]?.structureId).toBe('structure-mining-citadel')
+	})
+
+	it('applies tab-scoped sensitive and manager access to hidden moon-drills', async () => {
+		const db = makeDb({
+			hidden: true,
+			structures: [
+				{
+					structureId: 'structure-moon-drill',
+					corporationId: 'corp-1',
+					name: 'Moon Drill',
+					typeId: '81826',
+					typeName: 'Metenox Moon Drill',
+					systemId: '30000142',
+					systemName: 'Jita',
+					regionId: '10000002',
+					regionName: 'The Forge',
+					profileId: 'profile-1',
+					state: 'online',
+					nextReinforceApply: null,
+					stateTimerEnd: null,
+					unanchorsAt: null,
+					fuelExpires: null,
+					fuelAmount: 2000,
+					lowPower: false,
+					syncStatus: 'ok',
+					syncFailureReason: null,
+					lastSyncedAt: new Date('2026-01-01T00:00:00Z'),
+					updatedAt: new Date('2026-01-01T00:00:00Z'),
+				},
+			],
+		})
+
+		const sensitiveResult = await listMoonDrillStructures(db as never, {
+			id: 'user-4c',
+			is_admin: false,
+			roles: ['urn:structures:moon-drills:corp-1:sensitive'],
+		})
+
+		expect(sensitiveResult.items).toHaveLength(1)
+		expect(sensitiveResult.items[0]?.canEdit).toBe(false)
+
+		const managerResult = await listMoonDrillStructures(db as never, {
+			id: 'user-4d',
+			is_admin: false,
+			roles: ['urn:structures:moon-drills:corp-1:manager'],
+		})
+
+		expect(managerResult.items).toHaveLength(1)
+		expect(managerResult.items[0]?.canEdit).toBe(true)
+	})
+
+	it('returns mining snapshot data for mining citadels when permissioned', async () => {
+		const db = makeDb({
+			structures: [
+				{
+					structureId: 'structure-mining-citadel',
+					corporationId: 'corp-1',
+					name: 'Mining Citadel',
+					typeId: '35833',
+					typeName: 'Athanor',
+					systemId: '30000142',
+					systemName: 'Jita',
+					regionId: '10000002',
+					regionName: 'The Forge',
+					profileId: 'profile-1',
+					state: 'online',
+					nextReinforceApply: null,
+					stateTimerEnd: null,
+					unanchorsAt: null,
+					fuelExpires: null,
+					fuelAmount: 2000,
+					lowPower: false,
+					syncStatus: 'ok',
+					syncFailureReason: null,
+					lastSyncedAt: new Date('2026-01-01T00:00:00Z'),
+					updatedAt: new Date('2026-01-01T00:00:00Z'),
+				},
+			],
+			miningStates: [
+				{
+					structureId: 'structure-mining-citadel',
+					moonId: '40200001',
+					moonName: 'Jita IV - Moon 4',
+					planetId: '40000042',
+					planetName: 'Jita IV',
+					systemId: '30000142',
+					systemName: 'Jita',
+					extractionStartTime: new Date('2026-01-01T01:00:00Z'),
+					chunkArrivalTime: new Date('2026-01-02T01:00:00Z'),
+					naturalDecayTime: new Date('2026-01-03T01:00:00Z'),
+					lastSyncedAt: new Date('2026-01-01T02:00:00Z'),
+					updatedAt: new Date('2026-01-01T02:00:00Z'),
+				},
+			],
+		})
+
+		const result = await listMiningCitadelStructures(db as never, {
+			id: 'user-4e',
+			is_admin: false,
+			roles: ['urn:structures:mining-citadels:all:viewer'],
+		})
+
+		expect(db.query.structureMiningStates.findMany).toHaveBeenCalledTimes(1)
+		expect(result.items).toHaveLength(1)
+		expect(result.items[0]?.structureId).toBe('structure-mining-citadel')
+		expect(result.items[0]?.moonId).toBe('40200001')
+		expect(result.items[0]?.moonName).toBe('Jita IV - Moon 4')
+		expect(result.items[0]?.planetId).toBe('40000042')
+		expect(result.items[0]?.planetName).toBe('Jita IV')
+		expect(result.items[0]?.systemId).toBe('30000142')
+		expect(result.items[0]?.systemName).toBe('Jita')
+		expect(result.items[0]?.extractionStartTime).toBe('2026-01-01T01:00:00.000Z')
+		expect(result.items[0]?.chunkArrivalTime).toBe('2026-01-02T01:00:00.000Z')
+		expect(result.items[0]?.naturalDecayTime).toBe('2026-01-03T01:00:00.000Z')
 	})
 
 	it('unions multiple corp-scoped permissions across corporations', async () => {

--- a/apps/ui/src/client/features/structures/hooks.ts
+++ b/apps/ui/src/client/features/structures/hooks.ts
@@ -88,12 +88,25 @@ export function useSkyhookStructures(
 	)
 }
 
-export function useMiningStructures(
+export function useMiningCitadelStructures(
 	query: StructureMiningListQuery,
 	options: Pick<UseQueryOptions<StructureMiningListResponse>, 'enabled'> = {}
 ) {
 	return useQuery<StructureMiningListResponse>(
-		createStructureListQueryOptions(structureKeys.mining(query), () => api.getMiningStructures(query), options)
+		createStructureListQueryOptions(
+			structureKeys.miningCitadels(query),
+			() => api.getMiningCitadelStructures(query),
+			options
+		)
+	)
+}
+
+export function useMoonDrillStructures(
+	query: StructureMiningListQuery,
+	options: Pick<UseQueryOptions<StructureMiningListResponse>, 'enabled'> = {}
+) {
+	return useQuery<StructureMiningListResponse>(
+		createStructureListQueryOptions(structureKeys.moonDrills(query), () => api.getMoonDrillStructures(query), options)
 	)
 }
 
@@ -133,8 +146,10 @@ export function useStructuresForTab(
 				return structureKeys.sovereignty(query)
 			case 'skyhooks':
 				return structureKeys.skyhooks(query)
-			case 'mining':
-				return structureKeys.mining(query)
+			case 'mining-citadels':
+				return structureKeys.miningCitadels(query)
+			case 'moon-drills':
+				return structureKeys.moonDrills(query)
 		}
 		throw new Error(`Unknown structures tab: ${tab}`)
 	})()
@@ -153,8 +168,10 @@ export function useStructuresForTab(
 					return api.getSovereigntyStructures(query)
 				case 'skyhooks':
 					return api.getSkyhookStructures(query)
-				case 'mining':
-					return api.getMiningStructures(query)
+				case 'mining-citadels':
+					return api.getMiningCitadelStructures(query)
+				case 'moon-drills':
+					return api.getMoonDrillStructures(query)
 			}
 			throw new Error(`Unknown structures tab: ${tab}`)
 		},

--- a/apps/ui/src/client/features/structures/query-keys.ts
+++ b/apps/ui/src/client/features/structures/query-keys.ts
@@ -20,7 +20,8 @@ export const structureKeys = {
 	navigation: (query: StructureTabQuery) => [...structureKeys.all, 'navigation', query] as const,
 	sovereignty: (query: StructureTabQuery) => [...structureKeys.all, 'sovereignty', query] as const,
 	skyhooks: (query: StructureTabQuery) => [...structureKeys.all, 'skyhooks', query] as const,
-	mining: (query: StructureTabQuery) => [...structureKeys.all, 'mining', query] as const,
+	miningCitadels: (query: StructureTabQuery) => [...structureKeys.all, 'mining-citadels', query] as const,
+	moonDrills: (query: StructureTabQuery) => [...structureKeys.all, 'moon-drills', query] as const,
 	detail: (structureId: string) => [...structureKeys.all, 'detail', structureId] as const,
 	config: () => [...structureKeys.all, 'config'] as const,
 }

--- a/apps/ui/src/client/features/structures/state/structure-table-store.ts
+++ b/apps/ui/src/client/features/structures/state/structure-table-store.ts
@@ -76,15 +76,19 @@ const TAB_FILTER_FIELDS: Record<StructureTab, Array<keyof StructureTableFilters>
 	navigation: [...COMMON_TAB_FILTER_FIELDS],
 	sovereignty: [...COMMON_TAB_FILTER_FIELDS.filter((field) => field !== 'typeId'), 'allianceId'],
 	skyhooks: [...SKYHOOK_TAB_FILTER_FIELDS, 'isRaidable'],
-	mining: [...COMMON_TAB_FILTER_FIELDS],
+	'mining-citadels': [...COMMON_TAB_FILTER_FIELDS],
+	'moon-drills': [...COMMON_TAB_FILTER_FIELDS],
 }
 
 function normalizeTab(tab: unknown): StructureTab {
 	return tab === 'sovereignty' ||
 		tab === 'skyhooks' ||
 		tab === 'navigation' ||
-		tab === 'mining'
+		tab === 'mining-citadels' ||
+		tab === 'moon-drills'
 		? tab
+		: tab === 'mining'
+			? 'moon-drills'
 		: 'citadels'
 }
 

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -3433,7 +3433,7 @@ export class ApiClient {
 		return this.get(`/structures/skyhooks${queryString ? `?${queryString}` : ''}`)
 	}
 
-	async getMiningStructures(query: StructureMiningListQuery = {}): Promise<StructureMiningListResponse> {
+	async getMoonDrillStructures(query: StructureMiningListQuery = {}): Promise<StructureMiningListResponse> {
 		const params = new URLSearchParams()
 		if (query.page) params.set('page', String(query.page))
 		if (query.pageSize) params.set('pageSize', String(query.pageSize))
@@ -3444,7 +3444,27 @@ export class ApiClient {
 		if (query.planetId) params.set('planetId', query.planetId)
 		if (query.typeId) params.set('typeId', query.typeId)
 		const queryString = params.toString()
-		return this.get(`/structures/mining${queryString ? `?${queryString}` : ''}`)
+		return this.get(`/structures/moon-drills${queryString ? `?${queryString}` : ''}`)
+	}
+
+	async getMiningCitadelStructures(
+		query: StructureMiningListQuery = {}
+	): Promise<StructureMiningListResponse> {
+		const params = new URLSearchParams()
+		if (query.page) params.set('page', String(query.page))
+		if (query.pageSize) params.set('pageSize', String(query.pageSize))
+		if (query.sortBy) params.set('sortBy', query.sortBy)
+		if (query.sortDirection) params.set('sortDirection', query.sortDirection)
+		if (query.corporationId) params.set('corporationId', query.corporationId)
+		if (query.systemId) params.set('systemId', query.systemId)
+		if (query.planetId) params.set('planetId', query.planetId)
+		if (query.typeId) params.set('typeId', query.typeId)
+		const queryString = params.toString()
+		return this.get(`/structures/mining-citadels${queryString ? `?${queryString}` : ''}`)
+	}
+
+	async getMiningStructures(query: StructureMiningListQuery = {}): Promise<StructureMiningListResponse> {
+		return this.getMoonDrillStructures(query)
 	}
 
 	async getStructureOverviewMetrics(): Promise<StructureOverviewMetrics> {

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -298,10 +298,10 @@ export default function StructuresDetailPage() {
 		structure.syncFailureReason,
 		structure.lastSyncedAt
 	)
-	const structureFamily = getStructureTabForTypeId(structure.typeId)
+	const structureFamily = getStructureTabForTypeId(structure.typeId, structure.typeName)
 	const hasSovereigntySummary = structureFamily === 'sovereignty' && structure.sovereignty
 	const hasSkyhookSummary = structureFamily === 'skyhooks' && structure.skyhook
-	const hasMiningSummary = structureFamily === 'mining'
+	const hasMiningSummary = structureFamily === 'mining-citadels'
 
 	const handleSave = async () => {
 		await updateMutation.mutateAsync({

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -10,7 +10,11 @@ import {
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
 
-import { hasAllStructureManagerPermission, hasAnyStructurePermission } from '@repo/groups'
+import {
+	hasAllStructureManagerPermission,
+	hasAnyStructurePermission,
+	hasStructureTabPermission,
+} from '@repo/groups'
 import { STRUCTURE_TABS, type StructureTab } from '@repo/structures'
 
 import { TableRefreshFrame } from '@/components/table-refresh-frame'
@@ -135,6 +139,16 @@ export default function StructuresPage() {
 	const canManageStructures =
 		user?.is_admin === true || hasAllStructureManagerPermission(permissions)
 	const tableState = useStructureTableUiState((state) => state)
+	const visibleTabs = useMemo(
+		() =>
+			user?.is_admin === true
+				? STRUCTURE_TABS
+				: STRUCTURE_TABS.filter((tab) => hasStructureTabPermission(permissions, tab.tab)),
+		[user, permissions]
+	)
+	const activeTab = visibleTabs.some((tab) => tab.tab === tableState.tab)
+		? tableState.tab
+		: visibleTabs[0]?.tab ?? tableState.tab
 	const [nowMs, setNowMs] = useState(() => Date.now())
 	const { data: moduleConfig } = useStructureModuleConfig()
 	const {
@@ -163,7 +177,7 @@ export default function StructuresPage() {
 			typeId: tableState.filters.typeId,
 		}
 
-		switch (tableState.tab) {
+		switch (activeTab) {
 			case 'citadels':
 				return {
 					...base,
@@ -187,15 +201,20 @@ export default function StructuresPage() {
 					planetId: tableState.filters.planetId,
 					isRaidable: tableState.filters.isRaidable,
 				}
-			case 'mining':
+			case 'mining-citadels':
 				return {
 					...base,
 					...common,
 					planetId: tableState.filters.planetId,
 				}
+			case 'moon-drills':
+				return {
+					...base,
+					...common,
+				}
 		}
-		throw new Error(`Unknown structures tab: ${tableState.tab}`)
-	}, [tableState])
+		throw new Error(`Unknown structures tab: ${activeTab}`)
+	}, [activeTab, tableState])
 
 	const {
 		data: structuresResponse,
@@ -203,7 +222,7 @@ export default function StructuresPage() {
 		error,
 		refetch,
 		isFetching,
-	} = useStructuresForTab(tableState.tab, query, {
+	} = useStructuresForTab(activeTab, query, {
 		enabled: !authLoading && !permissionsLoading && canViewStructures,
 	})
 
@@ -222,6 +241,16 @@ export default function StructuresPage() {
 		}, 60_000)
 		return () => window.clearInterval(timer)
 	}, [])
+
+	useEffect(() => {
+		if (visibleTabs.length === 0) {
+			return
+		}
+
+		if (!visibleTabs.some((tab) => tab.tab === tableState.tab)) {
+			setStructureTableTab(visibleTabs[0]?.tab ?? 'citadels')
+		}
+	}, [tableState.tab, visibleTabs])
 
 	const corporationOptions = useMemo<SelectOption[]>(
 		() =>
@@ -319,7 +348,7 @@ export default function StructuresPage() {
 		[filterOptions]
 	)
 	const structuresContentKey = [
-		tableState.tab,
+		activeTab,
 		tableState.page,
 		tableState.pageSize,
 		tableState.sortBy,
@@ -401,18 +430,19 @@ export default function StructuresPage() {
 		</TableHead>
 	)
 
-	const isSovereigntyTab = tableState.tab === 'sovereignty'
-	const isSkyhooksTab = tableState.tab === 'skyhooks'
-	const isMiningTab = tableState.tab === 'mining'
+	const isSovereigntyTab = activeTab === 'sovereignty'
+	const isSkyhooksTab = activeTab === 'skyhooks'
+	const isMiningCitadelTab = activeTab === 'mining-citadels'
 	const primaryFilterSlot: PrimaryStructureFilterSlot = (() => {
-		switch (tableState.tab) {
+		switch (activeTab) {
 			case 'sovereignty':
 				return 'alliance'
 			case 'skyhooks':
 				return 'raidable'
 			case 'citadels':
 			case 'navigation':
-			case 'mining':
+			case 'mining-citadels':
+			case 'moon-drills':
 				return 'type'
 		}
 	})()
@@ -648,11 +678,11 @@ export default function StructuresPage() {
 				</CardHeader>
 				<CardContent className="space-y-4">
 					<Tabs
-						value={tableState.tab}
+						value={activeTab}
 						onValueChange={(value) => setStructureTableTab(value as StructureTab)}
 					>
 						<TabsList className="flex w-full flex-wrap gap-1 border-b-0">
-							{STRUCTURE_TABS.map((tab) => (
+							{visibleTabs.map((tab) => (
 								<TabsTrigger key={tab.tab} value={tab.tab}>
 									{tab.label}
 								</TabsTrigger>
@@ -723,14 +753,14 @@ export default function StructuresPage() {
 									No structures were returned for the selected filters.
 								</div>
 							) : (
-								<Table
-									className={cn(
-										'min-w-[118rem]',
-										isSovereigntyTab && 'min-w-[128rem]',
-										isSkyhooksTab && 'min-w-[126rem]',
-										isMiningTab && 'min-w-[124rem]'
-									)}
-								>
+						<Table
+							className={cn(
+								'min-w-[118rem]',
+								isSovereigntyTab && 'min-w-[128rem]',
+								isSkyhooksTab && 'min-w-[126rem]',
+								isMiningCitadelTab && 'min-w-[124rem]'
+							)}
+						>
 									<TableHeader>
 										<TableRow>
 											<SortableHead field="region" label="Region" />
@@ -758,7 +788,7 @@ export default function StructuresPage() {
 													<TableHead>Raidable</TableHead>
 													<TableHead>Vulnerable</TableHead>
 												</>
-											) : isMiningTab ? (
+											) : isMiningCitadelTab ? (
 												<>
 													<TableHead>Moon</TableHead>
 													<TableHead>Planet</TableHead>
@@ -893,10 +923,10 @@ export default function StructuresPage() {
 																{skyhookStructure.theftVulnerabilityStart &&
 																skyhookStructure.theftVulnerabilityEnd
 																	? `${formatDateTimeLong(skyhookStructure.theftVulnerabilityStart)} - ${formatDateTimeLong(skyhookStructure.theftVulnerabilityEnd)}`
-																	: formatNullableDateTime(skyhookStructure.vulnerableAt)}
+																: formatNullableDateTime(skyhookStructure.vulnerableAt)}
 															</TableCell>
 														</>
-													) : isMiningTab ? (
+													) : isMiningCitadelTab ? (
 														<>
 															<TableCell>
 																{(miningStructure.moonName ?? miningStructure.moonId) || '-'}

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -196,8 +196,8 @@ export interface EsiSovereigntySystem {
 }
 
 /**
- * ESI sovereignty hub details enriched with universe metadata.
- * GET /corporations/{corporation_id}/structures/sovereignty-hubs/{sovereignty_hub_id}
+ * ESI sovereignty hub details from the corporation sovereignty hub endpoint.
+ * Solar-system display metadata is resolved during persistence.
  */
 export interface EsiSovereigntyHub {
 	structure_id: string

--- a/packages/groups/src/permissions.ts
+++ b/packages/groups/src/permissions.ts
@@ -223,6 +223,17 @@ export interface GetMultiGroupMemberPermissionsResponse {
 export const STRUCTURE_PERMISSION_ROLES = ['viewer', 'manager', 'sensitive'] as const
 export type StructurePermissionRole = (typeof STRUCTURE_PERMISSION_ROLES)[number]
 
+export const STRUCTURE_PERMISSION_TABS = [
+	'all',
+	'citadels',
+	'navigation',
+	'sovereignty',
+	'skyhooks',
+	'moon-drills',
+	'mining-citadels',
+] as const
+export type StructurePermissionTab = (typeof STRUCTURE_PERMISSION_TABS)[number]
+
 export const STRUCTURE_PERMISSION_SCOPE_ALL = 'all' as const
 export type StructurePermissionScope = string
 
@@ -231,6 +242,7 @@ export interface PermissionLike {
 }
 
 export interface ParsedStructurePermissionUrn {
+	tab: StructurePermissionTab
 	scope: 'all' | 'corp'
 	corporationId: string | null
 	role: StructurePermissionRole
@@ -245,6 +257,14 @@ export function buildStructurePermissionUrn(
 	return `${STRUCTURE_PERMISSION_URN_PREFIX}${scope}:${role}`
 }
 
+export function buildStructureTabPermissionUrn(
+	tab: Exclude<StructurePermissionTab, 'all'>,
+	scope: StructurePermissionScope | typeof STRUCTURE_PERMISSION_SCOPE_ALL,
+	role: StructurePermissionRole
+): string {
+	return `${STRUCTURE_PERMISSION_URN_PREFIX}${tab}:${scope}:${role}`
+}
+
 export function isStructurePermissionUrn(value: string): boolean {
 	return value.startsWith(STRUCTURE_PERMISSION_URN_PREFIX)
 }
@@ -255,29 +275,78 @@ export function parseStructurePermissionUrn(value: string): ParsedStructurePermi
 	}
 
 	const remainder = value.slice(STRUCTURE_PERMISSION_URN_PREFIX.length)
-	const [scope, role] = remainder.split(':')
-	if (!scope || !role) return null
-	if (!STRUCTURE_PERMISSION_ROLES.includes(role as StructurePermissionRole)) {
-		return null
-	}
+	const parts = remainder.split(':')
 
-	if (scope === STRUCTURE_PERMISSION_SCOPE_ALL) {
+	if (parts.length === 2) {
+		const [scope, role] = parts
+		if (!scope || !role) return null
+		if (!STRUCTURE_PERMISSION_ROLES.includes(role as StructurePermissionRole)) {
+			return null
+		}
+
+		if (scope === STRUCTURE_PERMISSION_SCOPE_ALL) {
+			return {
+				tab: 'all',
+				scope: 'all',
+				corporationId: null,
+				role: role as StructurePermissionRole,
+			}
+		}
+
 		return {
-			scope: 'all',
-			corporationId: null,
+			tab: 'all',
+			scope: 'corp',
+			corporationId: scope,
 			role: role as StructurePermissionRole,
 		}
 	}
 
-	return {
-		scope: 'corp',
-		corporationId: scope,
-		role: role as StructurePermissionRole,
+	if (parts.length === 3) {
+		const [tab, scope, role] = parts
+		if (!tab || !scope || !role) return null
+		if (!STRUCTURE_PERMISSION_TABS.includes(tab as StructurePermissionTab)) {
+			return null
+		}
+		if (!STRUCTURE_PERMISSION_ROLES.includes(role as StructurePermissionRole)) {
+			return null
+		}
+
+		if (scope === STRUCTURE_PERMISSION_SCOPE_ALL) {
+			return {
+				tab: tab as Exclude<StructurePermissionTab, 'all'>,
+				scope: 'all',
+				corporationId: null,
+				role: role as StructurePermissionRole,
+			}
+		}
+
+		return {
+			tab: tab as Exclude<StructurePermissionTab, 'all'>,
+			scope: 'corp',
+			corporationId: scope,
+			role: role as StructurePermissionRole,
+		}
 	}
+
+	return null
 }
 
 export function hasAnyStructurePermission(permissions: Array<PermissionLike>): boolean {
 	return permissions.some((permission) => parseStructurePermissionUrn(permission.urn) !== null)
+}
+
+export function hasStructureTabPermission(
+	permissions: Array<PermissionLike>,
+	tab: Exclude<StructurePermissionTab, 'all'>
+): boolean {
+	return permissions.some((permission) => {
+		const parsed = parseStructurePermissionUrn(permission.urn)
+		if (!parsed) {
+			return false
+		}
+
+		return parsed.tab === 'all' || parsed.tab === tab
+	})
 }
 
 export function hasStructureManagerPermission(permissions: Array<PermissionLike>): boolean {

--- a/packages/groups/src/test/unit/permissions.test.ts
+++ b/packages/groups/src/test/unit/permissions.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	buildStructurePermissionUrn,
+	buildStructureTabPermissionUrn,
 	hasAllStructureManagerPermission,
 	hasAllStructureSensitivePermission,
 	hasAnyStructurePermission,
 	hasStructureManagerPermission,
 	hasStructureSensitivePermission,
+	hasStructureTabPermission,
 	isStructurePermissionUrn,
 	parseStructurePermissionUrn,
 } from '../../permissions'
@@ -18,6 +20,7 @@ describe('structure permission utilities', () => {
 		expect(urn).toBe('urn:structures:all:viewer')
 		expect(isStructurePermissionUrn(urn)).toBe(true)
 		expect(parseStructurePermissionUrn(urn)).toEqual({
+			tab: 'all',
 			scope: 'all',
 			corporationId: null,
 			role: 'viewer',
@@ -30,6 +33,7 @@ describe('structure permission utilities', () => {
 		expect(urn).toBe('urn:structures:1234567890:manager')
 		expect(isStructurePermissionUrn(urn)).toBe(true)
 		expect(parseStructurePermissionUrn(urn)).toEqual({
+			tab: 'all',
 			scope: 'corp',
 			corporationId: '1234567890',
 			role: 'manager',
@@ -42,16 +46,83 @@ describe('structure permission utilities', () => {
 		expect(urn).toBe('urn:structures:1234567890:sensitive')
 		expect(isStructurePermissionUrn(urn)).toBe(true)
 		expect(parseStructurePermissionUrn(urn)).toEqual({
+			tab: 'all',
 			scope: 'corp',
 			corporationId: '1234567890',
 			role: 'sensitive',
 		})
 	})
 
+	it('builds and parses tab-scoped viewer URNs', () => {
+		const urn = buildStructureTabPermissionUrn('moon-drills', 'all', 'viewer')
+
+		expect(urn).toBe('urn:structures:moon-drills:all:viewer')
+		expect(isStructurePermissionUrn(urn)).toBe(true)
+		expect(parseStructurePermissionUrn(urn)).toEqual({
+			tab: 'moon-drills',
+			scope: 'all',
+			corporationId: null,
+			role: 'viewer',
+		})
+	})
+
+	it('builds and parses corp-scoped tab URNs', () => {
+		const urn = buildStructureTabPermissionUrn('citadels', '1234567890', 'manager')
+
+		expect(urn).toBe('urn:structures:citadels:1234567890:manager')
+		expect(parseStructurePermissionUrn(urn)).toEqual({
+			tab: 'citadels',
+			scope: 'corp',
+			corporationId: '1234567890',
+			role: 'manager',
+		})
+	})
+
+	it.each([
+		'citadels',
+		'navigation',
+		'sovereignty',
+		'skyhooks',
+		'moon-drills',
+		'mining-citadels',
+	] as const)('builds and parses every valid tab scope: %s', (tab) => {
+		const viewerUrn = buildStructureTabPermissionUrn(tab, 'all', 'viewer')
+		const corpUrn = buildStructureTabPermissionUrn(tab, '1234567890', 'manager')
+
+		expect(parseStructurePermissionUrn(viewerUrn)).toEqual({
+			tab,
+			scope: 'all',
+			corporationId: null,
+			role: 'viewer',
+		})
+		expect(parseStructurePermissionUrn(corpUrn)).toEqual({
+			tab,
+			scope: 'corp',
+			corporationId: '1234567890',
+			role: 'manager',
+		})
+		expect(hasStructureTabPermission([{ urn: viewerUrn }], tab)).toBe(true)
+		expect(hasStructureTabPermission([{ urn: corpUrn }], tab)).toBe(true)
+	})
+
+	it.each([
+		'citadels',
+		'navigation',
+		'sovereignty',
+		'skyhooks',
+		'moon-drills',
+		'mining-citadels',
+	] as const)('treats legacy all-scope permissions as access to every tab: %s', (tab) => {
+		expect(hasStructureTabPermission([{ urn: 'urn:structures:all:viewer' }], tab)).toBe(true)
+		expect(hasStructureTabPermission([{ urn: 'urn:structures:all:manager' }], tab)).toBe(true)
+	})
+
 	it('rejects malformed or non-structure URNs', () => {
 		expect(isStructurePermissionUrn('urn:srp:reviewer')).toBe(false)
 		expect(parseStructurePermissionUrn('urn:srp:reviewer')).toBeNull()
 		expect(parseStructurePermissionUrn('urn:structures:all:not-a-role')).toBeNull()
+		expect(parseStructurePermissionUrn('urn:structures:not-a-tab:all:viewer')).toBeNull()
+		expect(parseStructurePermissionUrn('urn:structures:moon-drills:all:not-a-role')).toBeNull()
 		expect(parseStructurePermissionUrn('urn:structures:')).toBeNull()
 	})
 
@@ -61,10 +132,17 @@ describe('structure permission utilities', () => {
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:all:view' }])).toBe(false)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:all:manager' }])).toBe(true)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:1001:sensitive' }])).toBe(true)
+		expect(hasAnyStructurePermission([{ urn: 'urn:structures:moon-drills:all:viewer' }])).toBe(true)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:all:not-a-role' }])).toBe(false)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:' }])).toBe(false)
 		expect(hasAnyStructurePermission([{ urn: 'urn:srp:reviewer' }])).toBe(false)
 		expect(hasAnyStructurePermission([])).toBe(false)
+	})
+
+	it('treats tab-scoped structure URNs as access only for that tab', () => {
+		expect(hasStructureTabPermission([{ urn: 'urn:structures:moon-drills:all:viewer' }], 'moon-drills')).toBe(true)
+		expect(hasStructureTabPermission([{ urn: 'urn:structures:moon-drills:all:viewer' }], 'citadels')).toBe(false)
+		expect(hasStructureTabPermission([{ urn: 'urn:structures:all:viewer' }], 'citadels')).toBe(true)
 	})
 
 	it('only treats manager structure URNs as manager access', () => {

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -1,6 +1,12 @@
 export type StructurePermissionRole = 'viewer' | 'manager' | 'sensitive'
 export type CorporationAlertDestinationType = 'discord_channel' | 'discord_user' | 'discord_webhook' | 'group'
-export type StructureTab = 'citadels' | 'sovereignty' | 'skyhooks' | 'navigation' | 'mining'
+export type StructureTab =
+	| 'citadels'
+	| 'sovereignty'
+	| 'skyhooks'
+	| 'navigation'
+	| 'mining-citadels'
+	| 'moon-drills'
 export type StructureListSortBy =
 	| 'updatedAt'
 	| 'nextStateAt'
@@ -24,6 +30,8 @@ export const ANSIBLEX_JUMP_GATE_TYPE_ID = '35841'
 export const TENEBREX_CYNO_JAMMER_TYPE_ID = '37534'
 export const PHAROLUX_CYNO_BEACON_TYPE_ID = '35840'
 export const METENOX_MOON_DRILL_TYPE_ID = '81826'
+export const METENOX_MOON_DRILL_TYPE_NAME = 'Metenox Moon Drill'
+export const MINING_CITADEL_TYPE_NAMES = new Set(['Athanor', 'Tatara'])
 
 export const SOVEREIGNTY_STRUCTURE_TYPE_IDS = new Set([SOVEREIGNTY_HUB_TYPE_ID])
 export const SKYHOOK_STRUCTURE_TYPE_IDS = new Set([ORBITAL_SKYHOOK_TYPE_ID])
@@ -47,18 +55,27 @@ export const STRUCTURE_TABS: StructureTabDefinition[] = [
 	{ tab: 'sovereignty', label: 'Sovereignty' },
 	{ tab: 'skyhooks', label: 'Skyhooks' },
 	{ tab: 'navigation', label: 'Navigation' },
-	{ tab: 'mining', label: 'Mining' },
+	{ tab: 'mining-citadels', label: 'Mining Citadels' },
+	{ tab: 'moon-drills', label: 'Moon Drills' },
 ]
 
 function normalizeStructureTypeId(value: string | null | undefined): string {
 	return (value ?? '').trim()
 }
 
-export function getStructureTabForTypeId(typeId: string | null | undefined): StructureTab {
+export function getStructureTabForTypeId(
+	typeId: string | null | undefined,
+	typeName?: string | null | undefined
+): StructureTab {
 	const normalized = normalizeStructureTypeId(typeId)
+	const normalizedName = (typeName ?? '').trim()
 
-	if (MINING_STRUCTURE_TYPE_IDS.has(normalized)) {
-		return 'mining'
+	if (normalizedName === METENOX_MOON_DRILL_TYPE_NAME || MINING_STRUCTURE_TYPE_IDS.has(normalized)) {
+		return 'moon-drills'
+	}
+
+	if (MINING_CITADEL_TYPE_NAMES.has(normalizedName)) {
+		return 'mining-citadels'
 	}
 	if (SOVEREIGNTY_STRUCTURE_TYPE_IDS.has(normalized)) {
 		return 'sovereignty'
@@ -220,6 +237,8 @@ export interface StructuresWorker {
 	listSovereigntyStructures(actor: StructureActor, query?: StructureSovereigntyListQuery): Promise<unknown>
 	listSkyhookStructures(actor: StructureActor, query?: StructureSkyhookListQuery): Promise<unknown>
 	listMiningStructures(actor: StructureActor, query?: StructureMiningListQuery): Promise<unknown>
+	listMoonDrillStructures(actor: StructureActor, query?: StructureMiningListQuery): Promise<unknown>
+	listMiningCitadelStructures(actor: StructureActor, query?: StructureMiningListQuery): Promise<unknown>
 	getStructureOverviewMetrics(actor: StructureActor): Promise<StructureOverviewMetrics>
 	getVisibleStructureDetail(actor: StructureActor, structureId: string): Promise<unknown>
 	updateStructureConfig(


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Splits the structures "Mining" tab into two distinct tabs — Moon Drills (Metenoxes) and Mining Citadels (Athanor/Tatara) — and introduces per-tab structure permissions so viewer/manager/sensitive access can be granted per tab instead of only across all structure types. Also hardens corporation structure sync: stale skyhook/mining snapshot rows are pruned alongside structures, mining enrichment is skipped/fault-tolerant when no mining citadels exist, and sovereignty hub enrichment no longer depends on the unreliable ESI universe-structure lookup.

## Changes
- **Split Mining tab into Moon Drills and Mining Citadels**: new `StructureTab` values (`moon-drills`, `mining-citadels`), new `/structures/moon-drills` and `/structures/mining-citadels` routes/RPC methods/service functions, and `getStructureTabForTypeId` now also considers `typeName` (Metenox → moon-drills, Athanor/Tatara → mining-citadels) rather than type ID alone.
- **Tab-scoped structure permissions**: extended the `urn:structures:...` permission scheme to support an optional tab segment (`urn:structures:<tab>:<scope>:<role>`), added `StructurePermissionTab`, `buildStructureTabPermissionUrn`, and `hasStructureTabPermission`; legacy all-tab URNs still grant access to every tab. `computeStructureAccess`/`getStructureAccessTarget` in `structures.service.ts` now gate view/sensitive/edit access per tab, and the UI structures page only shows tabs the user has permission for and auto-switches off an inaccessible tab.
- **Structure/enrichment pruning**: when a corporation's structure sync succeeds, stale `structureSkyhookStates` and `structureMiningStates` rows for structures that disappeared (or when there are no structures at all) are now deleted alongside `corporationStructures`.
- **Mining enrichment resilience**: the sync workflow only fetches mining enrichment when at least one mining-citadel-type structure is present, and a mining enrichment fetch failure is now caught/logged so it no longer blocks asset sync or the rest of the workflow.
- **Sovereignty hub fix**: removed the `/universe/structures/{id}` lookup used to verify hub ownership/enrich name/type, which was unreliable; `fetchSovereigntyHubs` now takes the already-known structures list (for `type_id`) and hub/system names are resolved afterwards via the Universe DO during the `fetchSovereigntyEnrichment` workflow step instead.

## Testing
- Added/updated unit tests: `packages/groups` permission parsing/tab-gating tests, `apps/structures` permission-gating tests for moon-drills/mining-citadels tabs, `apps/eve-corporation-data` structure prune-cleanup tests, sovereignty-hub enrichment tests, and sync-workflow tests covering skipped/failed mining enrichment.
<!-- claude:end -->