### PR TITLE
actually fix sov hubs

### DIFF
--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -46,6 +46,8 @@ import type {
 } from '@repo/eve-corporation-data'
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
 
+const SOVEREIGNTY_HUB_TYPE_ID = '35835'
+
 // ========================================================================
 // PUBLIC DATA FETCHING
 // ========================================================================
@@ -346,8 +348,7 @@ export async function fetchSovereigntySystems(
 export async function fetchSovereigntyHubs(
 	tokenStore: EveTokenStore,
 	corporationId: string,
-	characterId: string,
-	knownStructures: Array<Pick<EsiCorporationStructure, 'structure_id' | 'type_id'>> = []
+	characterId: string
 ): Promise<EsiSovereigntyHub[]> {
 	type RawSovereigntyHubsListing = {
 		sovereignty_hubs: Array<{
@@ -447,10 +448,6 @@ export async function fetchSovereigntyHubs(
 		return []
 	}
 
-	const knownStructureById = new Map(
-		knownStructures.map((structure) => [structure.structure_id, structure])
-	)
-
 	const details: Array<EsiSovereigntyHub | null> = await Promise.all(
 		sovereigntyHubs.map(async (hub) => {
 			try {
@@ -460,24 +457,13 @@ export async function fetchSovereigntyHubs(
 					{ cacheMode: 'no-store' }
 				)
 				const detail = detailResult.data
-				const hubId = String(hub.id)
-				const knownStructure = knownStructureById.get(hubId) ?? null
-
-				const typeId = knownStructure?.type_id ?? null
-				if (!typeId) {
-					logger.warn('[ESI Fetch] Skipping sovereignty hub without type metadata', {
-						corporationId,
-						structureId: hubId,
-					})
-					return null
-				}
 
 				return {
 					structure_id: String(detail.id),
 					corporation_id: corporationId,
 					system_id: String(detail.solar_system_id),
 					name: null,
-					type_id: typeId,
+					type_id: SOVEREIGNTY_HUB_TYPE_ID,
 					fuel_access_list_id:
 						detail.fuel_access_list_id !== undefined && detail.fuel_access_list_id !== null
 							? String(detail.fuel_access_list_id)

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -237,13 +237,7 @@ describe('esi structure enrichment ownership handling', () => {
 		const hubs = await fetchSovereigntyHubs(
 			tokenStore as never,
 			'98000001',
-			'211',
-			[
-				{
-					structure_id: '81001',
-					type_id: '35835',
-				},
-			]
+			'211'
 		)
 
 		expect(tokenStore.fetchEsi).toHaveBeenCalledTimes(2)

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -1,37 +1,47 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const fetchSovereigntyHubsMock = vi.fn()
-const readSharedSovereigntySystemsByIdsMock = vi.fn()
-const resolveSolarSystemsByIdsMock = vi.fn()
-const getStubMock = vi.fn(() => ({
-	resolveSolarSystemsByIds: resolveSolarSystemsByIdsMock,
-}))
-const createTokenStoreMock = vi.fn()
+const mocks = vi.hoisted(() => {
+	const fetchSovereigntyHubsMock = vi.fn()
+	const readSharedSovereigntySystemsByIdsMock = vi.fn()
+	const resolveSolarSystemsByIdsMock = vi.fn()
+	const getStubMock = vi.fn(() => ({
+		resolveSolarSystemsByIds: resolveSolarSystemsByIdsMock,
+	}))
+	const createTokenStoreMock = vi.fn()
+
+	return {
+		fetchSovereigntyHubsMock,
+		readSharedSovereigntySystemsByIdsMock,
+		resolveSolarSystemsByIdsMock,
+		getStubMock,
+		createTokenStoreMock,
+	}
+})
 
 vi.mock('@repo/do-utils', () => ({
-	getStub: getStubMock,
+	getStub: mocks.getStubMock,
 }))
 
 vi.mock('../../../services/esi-fetch', () => ({
-	fetchSovereigntyHubs: (...args: unknown[]) => fetchSovereigntyHubsMock(...args),
+	fetchSovereigntyHubs: (...args: unknown[]) => mocks.fetchSovereigntyHubsMock(...args),
 }))
 
 vi.mock('../../../workflows/utils/services', () => ({
-	createTokenStore: (...args: unknown[]) => createTokenStoreMock(...args),
+	createTokenStore: (...args: unknown[]) => mocks.createTokenStoreMock(...args),
 	getCorporationDataStub: vi.fn(),
 }))
 
 vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
 	readSharedSovereigntySystemsByIds: (...args: unknown[]) =>
-		readSharedSovereigntySystemsByIdsMock(...args),
+		mocks.readSharedSovereigntySystemsByIdsMock(...args),
 }))
 
 import { fetchSovereigntyEnrichment } from '../../../workflows/steps/structures'
 
 describe('fetchSovereigntyEnrichment', () => {
 	it('enriches sovereignty hub names from resolved solar systems before persistence', async () => {
-		createTokenStoreMock.mockReturnValue({})
-		fetchSovereigntyHubsMock.mockResolvedValue([
+		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.fetchSovereigntyHubsMock.mockResolvedValue([
 			{
 				structure_id: 'hub-1',
 				corporation_id: 'corp-1',
@@ -58,8 +68,8 @@ describe('fetchSovereigntyEnrichment', () => {
 				raw: { detail: { id: 1 } },
 			},
 		])
-		readSharedSovereigntySystemsByIdsMock.mockResolvedValue([])
-		resolveSolarSystemsByIdsMock.mockResolvedValue({
+		mocks.readSharedSovereigntySystemsByIdsMock.mockResolvedValue([])
+		mocks.resolveSolarSystemsByIdsMock.mockResolvedValue({
 			'30000142': {
 				solarSystemName: 'Jita',
 			},
@@ -70,13 +80,12 @@ describe('fetchSovereigntyEnrichment', () => {
 				UNIVERSE: {} as never,
 			} as never,
 			'corp-1',
-			'character-1',
-			[]
+			'character-1'
 		)
 
-		expect(fetchSovereigntyHubsMock).toHaveBeenCalledWith({}, 'corp-1', 'character-1', [])
-		expect(getStubMock).toHaveBeenCalledWith({}, 'default')
-		expect(resolveSolarSystemsByIdsMock).toHaveBeenCalledWith(['30000142'])
+		expect(mocks.fetchSovereigntyHubsMock).toHaveBeenCalledWith({}, 'corp-1', 'character-1')
+		expect(mocks.getStubMock).toHaveBeenCalledWith({}, 'default')
+		expect(mocks.resolveSolarSystemsByIdsMock).toHaveBeenCalledWith(['30000142'])
 		expect(result?.sovereigntyHubs[0]).toMatchObject({
 			name: 'Jita',
 			system_name: 'Jita',

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -59,8 +59,7 @@ export async function storeStructures(
 export async function fetchSovereigntyEnrichment(
 	env: Env,
 	corporationId: string,
-	directorCharacterId: string,
-	structures: StructuresData
+	directorCharacterId: string
 ): Promise<SovereigntyEnrichmentData | null> {
 	const tokenStore = createTokenStore(env)
 
@@ -68,8 +67,7 @@ export async function fetchSovereigntyEnrichment(
 		const sovereigntyHubs = await esiFetch.fetchSovereigntyHubs(
 			tokenStore,
 			corporationId,
-			directorCharacterId,
-			structures
+			directorCharacterId
 		)
 		const universe = getStub<Universe>(env.UNIVERSE, 'default')
 		const systemGeography =

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -723,12 +723,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 								timeout: '5 minutes',
 								requiredRoles: ['Station_Manager'],
 								run: (directorCharacterId) =>
-									fetchSovereigntyEnrichment(
-										this.env,
-										corporationId,
-										directorCharacterId,
-										structures
-									),
+									fetchSovereigntyEnrichment(this.env, corporationId, directorCharacterId),
 							})
 						: null
 					const skyhookEnrichment = structureEnrichmentEnabled


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes sovereignty structure hub (TCU) enrichment in `eve-corporation-data`, which was previously silently dropping any hub not already present in the corporation's known structures list.

## Changes
- `fetchSovereigntyHubs` no longer takes a `knownStructures` parameter; it now hardcodes `type_id` to a new `SOVEREIGNTY_HUB_TYPE_ID` ('35835') constant instead of looking it up from previously-fetched structures.
- Removed the logic that skipped/warned on sovereignty hubs lacking matching known-structure type metadata.
- Dropped the now-unused `structures` argument from `fetchSovereigntyEnrichment` (`workflows/steps/structures/index.ts`) and its call site in `sync-workflow.ts`.
- Updated unit tests to match the simplified function signatures, and refactored `structure-enrichment.test.ts` mocks to use `vi.hoisted` for cleaner hoisting.

## Testing
- Existing unit tests in `esi-fetch.structure-enrichment.test.ts` and `workflows/structure-enrichment.test.ts` were updated to reflect the new signatures and assertions.
<!-- claude:end -->