### PR TITLE
more sov hub fixes

### DIFF
--- a/apps/eve-corporation-data/.migrations/0022_striped_tempest.sql
+++ b/apps/eve-corporation-data/.migrations/0022_striped_tempest.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "structure_sovereignty_hubs" DROP CONSTRAINT "structure_sovereignty_hubs_structure_id_corporation_structures_structure_id_fk";
+--> statement-breakpoint
+ALTER TABLE "structure_sovereignty_systems" DROP CONSTRAINT "structure_sovereignty_systems_sovereignty_hub_structure_id_corporation_structures_structure_id_fk";
+--> statement-breakpoint
+CREATE INDEX "structure_sovereignty_systems_sovereignty_hub_structure_id_idx" ON "structure_sovereignty_systems" USING btree ("sovereignty_hub_structure_id");--> statement-breakpoint
+ALTER TABLE "structure_mining_states" DROP COLUMN "raw_payload";--> statement-breakpoint
+ALTER TABLE "structure_skyhook_states" DROP COLUMN "owner_id";--> statement-breakpoint
+ALTER TABLE "structure_skyhook_states" DROP COLUMN "raw_payload";--> statement-breakpoint
+ALTER TABLE "structure_sovereignty_hubs" DROP COLUMN "owner_id";--> statement-breakpoint
+ALTER TABLE "structure_sovereignty_hubs" DROP COLUMN "raw_payload";--> statement-breakpoint
+ALTER TABLE "structure_sovereignty_systems" DROP COLUMN "raw_payload";

--- a/apps/eve-corporation-data/.migrations/meta/0022_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0022_snapshot.json
@@ -1,0 +1,3310 @@
+{
+  "id": "f723d659-d192-4b9f-947d-cd6bbd032b60",
+  "prevId": "1d264945-214e-468d-8011-e826df27bd97",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_corporation_roles": {
+      "name": "character_corporation_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_at_hq": {
+          "name": "roles_at_hq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_base": {
+          "name": "roles_at_base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_other": {
+          "name": "roles_at_other",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "character_corporation_roles",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_corporation_roles_corporation_id_character_id_unique": {
+          "name": "character_corporation_roles_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_assets": {
+      "name": "corporation_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_blueprint_copy": {
+          "name": "is_blueprint_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_assets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_assets_corporation_id_item_id_unique": {
+          "name": "corporation_assets_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_config": {
+      "name": "corporation_config",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "corporation_type": {
+          "name": "corporation_type",
+          "type": "corporation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "members_last_sync": {
+          "name": "members_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_tracking_last_sync": {
+          "name": "member_tracking_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets_last_sync": {
+          "name": "wallets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_journal_last_sync": {
+          "name": "wallet_journal_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_transactions_last_sync": {
+          "name": "wallet_transactions_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assets_last_sync": {
+          "name": "assets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structures_last_sync": {
+          "name": "structures_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_last_sync": {
+          "name": "orders_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contracts_last_sync": {
+          "name": "contracts_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_jobs_last_sync": {
+          "name": "industry_jobs_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killmails_last_sync": {
+          "name": "killmails_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_config_include_in_background_refresh_idx": {
+          "name": "corporation_config_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_include_in_structure_asset_sync_idx": {
+          "name": "corporation_config_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_corporation_type_idx": {
+          "name": "corporation_config_corporation_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_member_tracking_last_sync_idx": {
+          "name": "corporation_config_member_tracking_last_sync_idx",
+          "columns": [
+            {
+              "expression": "member_tracking_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallets_last_sync_idx": {
+          "name": "corporation_config_wallets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_assets_last_sync_idx": {
+          "name": "corporation_config_assets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "assets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_structures_last_sync_idx": {
+          "name": "corporation_config_structures_last_sync_idx",
+          "columns": [
+            {
+              "expression": "structures_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_orders_last_sync_idx": {
+          "name": "corporation_config_orders_last_sync_idx",
+          "columns": [
+            {
+              "expression": "orders_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_contracts_last_sync_idx": {
+          "name": "corporation_config_contracts_last_sync_idx",
+          "columns": [
+            {
+              "expression": "contracts_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_industry_jobs_last_sync_idx": {
+          "name": "corporation_config_industry_jobs_last_sync_idx",
+          "columns": [
+            {
+              "expression": "industry_jobs_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_killmails_last_sync_idx": {
+          "name": "corporation_config_killmails_last_sync_idx",
+          "columns": [
+            {
+              "expression": "killmails_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_members_last_sync_idx": {
+          "name": "corporation_config_members_last_sync_idx",
+          "columns": [
+            {
+              "expression": "members_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_transactions_last_sync_idx": {
+          "name": "corporation_config_wallet_transactions_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_transactions_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_journal_last_sync_idx": {
+          "name": "corporation_config_wallet_journal_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_journal_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_contracts": {
+      "name": "corporation_contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptor_id": {
+          "name": "acceptor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyout": {
+          "name": "buyout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collateral": {
+          "name": "collateral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_accepted": {
+          "name": "date_accepted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_expired": {
+          "name": "date_expired",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_to_complete": {
+          "name": "days_to_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_location_id": {
+          "name": "end_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_corporation": {
+          "name": "for_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_corporation_id": {
+          "name": "issuer_corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward": {
+          "name": "reward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_location_id": {
+          "name": "start_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_contracts_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_contracts_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_contracts",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_contracts_corporation_id_contract_id_unique": {
+          "name": "corporation_contracts_corporation_id_contract_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "contract_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_directors": {
+      "name": "corporation_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_healthy": {
+          "name": "is_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permanent_failure_at": {
+          "name": "permanent_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_directors_corp_healthy_idx": {
+          "name": "corporation_directors_corp_healthy_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_healthy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_next_retry_idx": {
+          "name": "corporation_directors_corp_next_retry_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_permanent_failure_idx": {
+          "name": "corporation_directors_corp_permanent_failure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permanent_failure_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_last_used_idx": {
+          "name": "corporation_directors_last_used_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_directors",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_directors_corporation_id_character_id_unique": {
+          "name": "corporation_directors_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_industry_jobs": {
+      "name": "corporation_industry_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_id": {
+          "name": "installer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_type_id": {
+          "name": "blueprint_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_location_id": {
+          "name": "blueprint_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_location_id": {
+          "name": "output_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs": {
+          "name": "runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_runs": {
+          "name": "licensed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_type_id": {
+          "name": "product_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_date": {
+          "name": "pause_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_character_id": {
+          "name": "completed_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successful_runs": {
+          "name": "successful_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_industry_jobs",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_industry_jobs_corporation_id_job_id_unique": {
+          "name": "corporation_industry_jobs_corporation_id_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_killmails": {
+      "name": "corporation_killmails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_id": {
+          "name": "killmail_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_hash": {
+          "name": "killmail_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_time": {
+          "name": "killmail_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_killmails",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_killmails_corporation_id_killmail_id_unique": {
+          "name": "corporation_killmails_corporation_id_killmail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "killmail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_member_tracking": {
+      "name": "corporation_member_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoff_date": {
+          "name": "logoff_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logon_date": {
+          "name": "logon_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_member_tracking",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_member_tracking_corporation_id_character_id_unique": {
+          "name": "corporation_member_tracking_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_members": {
+      "name": "corporation_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_members_character_id_idx": {
+          "name": "corporation_members_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_members",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_members_corporation_id_character_id_unique": {
+          "name": "corporation_members_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_orders": {
+      "name": "corporation_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escrow": {
+          "name": "escrow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_buy_order": {
+          "name": "is_buy_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issued": {
+          "name": "issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_volume": {
+          "name": "min_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_remain": {
+          "name": "volume_remain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_total": {
+          "name": "volume_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_division": {
+          "name": "wallet_division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_orders",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_orders_corporation_id_order_id_unique": {
+          "name": "corporation_orders_corporation_id_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_public_info": {
+      "name": "corporation_public_info",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ceo_id": {
+          "name": "ceo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_founded": {
+          "name": "date_founded",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_station_id": {
+          "name": "home_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "war_eligible": {
+          "name": "war_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory": {
+      "name": "corporation_structure_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_corp_structure_idx": {
+          "name": "corporation_structure_inventory_corp_structure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+          "name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structure_inventory_corporation_id_item_id_unique": {
+          "name": "corporation_structure_inventory_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structures": {
+      "name": "corporation_structures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_expires": {
+          "name": "fuel_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_amount": {
+          "name": "fuel_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refilled_at": {
+          "name": "last_refilled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_apply": {
+          "name": "next_reinforce_apply",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_hour": {
+          "name": "next_reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforce_hour": {
+          "name": "reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_timer_end": {
+          "name": "state_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_timer_start": {
+          "name": "state_timer_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unanchors_at": {
+          "name": "unanchors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_power": {
+          "name": "low_power",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structures",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structures_structure_id_unique": {
+          "name": "corporation_structures_structure_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "structure_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_journal": {
+      "name": "corporation_wallet_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id_type": {
+          "name": "context_id_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_receiver_id": {
+          "name": "tax_receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_journal",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+          "name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "journal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_transactions": {
+      "name": "corporation_wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy": {
+          "name": "is_buy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "journal_ref_id": {
+          "name": "journal_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_transactions",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+          "name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallets": {
+      "name": "corporation_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallets_corporation_id_division_unique": {
+          "name": "corporation_wallets_corporation_id_division_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_fuel_log": {
+      "name": "structure_fuel_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_block_units": {
+          "name": "fuel_block_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_fuel_log_corp_structure_observed_idx": {
+          "name": "structure_fuel_log_corp_structure_observed_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_mining_states": {
+      "name": "structure_mining_states",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_name": {
+          "name": "moon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_start_time": {
+          "name": "extraction_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_arrival_time": {
+          "name": "chunk_arrival_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "natural_decay_time": {
+          "name": "natural_decay_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_mining_states_corporation_id_idx": {
+          "name": "structure_mining_states_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_states_moon_id_idx": {
+          "name": "structure_mining_states_moon_id_idx",
+          "columns": [
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_states_planet_id_idx": {
+          "name": "structure_mining_states_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_states_system_id_idx": {
+          "name": "structure_mining_states_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_states_last_synced_at_idx": {
+          "name": "structure_mining_states_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_mining_states_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_mining_states_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_mining_states",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_mining_states_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_mining_states_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_mining_states",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhook_states": {
+      "name": "structure_skyhook_states",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "effective_workforce": {
+          "name": "effective_workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagents": {
+          "name": "reagents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reinforcement_timer_end": {
+          "name": "reinforcement_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_start": {
+          "name": "theft_vulnerability_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_end": {
+          "name": "theft_vulnerability_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_raidable": {
+          "name": "is_raidable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "becomes_raidable_at": {
+          "name": "becomes_raidable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerable_at": {
+          "name": "vulnerable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhook_states_corporation_id_idx": {
+          "name": "structure_skyhook_states_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhook_states_planet_id_idx": {
+          "name": "structure_skyhook_states_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhook_states_system_id_idx": {
+          "name": "structure_skyhook_states_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhook_states_type_id_idx": {
+          "name": "structure_skyhook_states_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhook_states_is_raidable_idx": {
+          "name": "structure_skyhook_states_is_raidable_idx",
+          "columns": [
+            {
+              "expression": "is_raidable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhook_states_last_synced_at_idx": {
+          "name": "structure_skyhook_states_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhook_states_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhook_states_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhook_states",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhook_states_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhook_states_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhook_states",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_hubs": {
+      "name": "structure_sovereignty_hubs",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_access_list_id": {
+          "name": "fuel_access_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_id": {
+          "name": "controller_alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay_last_updated": {
+          "name": "reagent_bay_last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay": {
+          "name": "reagent_bay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+        },
+        "upgrades": {
+          "name": "upgrades",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_transport": {
+          "name": "workforce_transport",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_hubs_corporation_id_idx": {
+          "name": "structure_sovereignty_hubs_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_system_id_idx": {
+          "name": "structure_sovereignty_hubs_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_type_id_idx": {
+          "name": "structure_sovereignty_hubs_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_last_synced_at_idx": {
+          "name": "structure_sovereignty_hubs_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_hubs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_systems": {
+      "name": "structure_sovereignty_systems",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_claimant_id": {
+          "name": "corporation_claimant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_since": {
+          "name": "claimed_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sovereignty_hub_structure_id": {
+          "name": "sovereignty_hub_structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capital_system": {
+          "name": "is_capital_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_defense_multiplier": {
+          "name": "activity_defense_multiplier",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "military_level": {
+          "name": "military_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industrial_level": {
+          "name": "industrial_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategic_level": {
+          "name": "strategic_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_systems_corporation_id_idx": {
+          "name": "structure_sovereignty_systems_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_alliance_id_idx": {
+          "name": "structure_sovereignty_systems_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+          "name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+          "columns": [
+            {
+              "expression": "sovereignty_hub_structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_last_synced_at_idx": {
+          "name": "structure_sovereignty_systems_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_systems",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.corporation_type": {
+      "name": "corporation_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "alt",
+        "special_purpose",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/eve-corporation-data/.migrations/meta/_journal.json
+++ b/apps/eve-corporation-data/.migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781634026073,
       "tag": "0021_dry_korg",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1783949372726,
+      "tag": "0022_striped_tempest",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -20,11 +20,11 @@ import {
 	corporationOrders,
 	corporationPublicInfo,
 	corporationStructureInventory,
-	structureFuelLog,
 	corporationStructures,
 	corporationWalletJournal,
 	corporationWallets,
 	corporationWalletTransactions,
+	structureFuelLog,
 	structureMiningStates,
 	structureSkyhookStates,
 	structureSovereigntyHubs,
@@ -33,9 +33,13 @@ import {
 import { syncAssetsPaged } from './services/assets-paging-sync'
 import { DirectorManager } from './services/director-manager'
 import * as esiFetch from './services/esi-fetch'
+import { preserveStructureHydrationFields } from './services/structure-hydration'
+import {
+	filterStructureInventoryAssets,
+	summarizeFuelBlockUnitsByStructure,
+} from './services/structure-inventory'
 
 import type { SQL } from 'drizzle-orm'
-import type { RawEsiAsset } from './services/assets-paging-sync'
 import type {
 	CharacterCorporationRolesData,
 	CorporationAccessVerification,
@@ -46,7 +50,6 @@ import type {
 	CorporationContractData,
 	CorporationContractSortBy,
 	CorporationContractsPageData,
-	CourierLeaderboard,
 	CorporationCoreData,
 	CorporationFinancialData,
 	CorporationIndustryJobData,
@@ -57,19 +60,20 @@ import type {
 	CorporationMemberTrackingData,
 	CorporationOrderData,
 	CorporationPublicData,
-	CorporationStructureInventoryData,
-	CorporationStructureQuery,
 	CorporationRole,
 	CorporationStructureData,
+	CorporationStructureInventoryData,
+	CorporationStructureQuery,
 	CorporationSyncHealth,
 	CorporationTaxMetadata,
 	CorporationType,
 	CorporationWalletData,
 	CorporationWalletJournalData,
 	CorporationWalletTransactionData,
+	CourierLeaderboard,
 	DirectorHealth,
-	EsiCorporationAsset,
 	EsiCharacterRoles,
+	EsiCorporationAsset,
 	EsiCorporationContract,
 	EsiCorporationIndustryJob,
 	EsiCorporationKillmail,
@@ -79,11 +83,11 @@ import type {
 	EsiCorporationOrder,
 	EsiCorporationSkyhook,
 	EsiCorporationStructure,
-	EsiSovereigntyHub,
-	EsiSovereigntySystem,
 	EsiCorporationWallet,
 	EsiCorporationWalletJournalEntry,
 	EsiCorporationWalletTransaction,
+	EsiSovereigntyHub,
+	EsiSovereigntySystem,
 	EveCorporationData,
 	SearchAssetsFilters,
 	WalletJournalWindowFilters,
@@ -91,14 +95,15 @@ import type {
 } from '@repo/eve-corporation-data'
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
 import type { EveCharacterId, EveStructureId } from '@repo/eve-types'
-import type { Universe, UniversePlanetGeography, UniverseRegion, UniverseSolarSystem } from '@repo/universe'
+import type {
+	Universe,
+	UniversePlanetGeography,
+	UniverseRegion,
+	UniverseSolarSystem,
+} from '@repo/universe'
 import type { Env } from './context'
-import {
-	filterStructureInventoryAssets,
-	summarizeFuelBlockUnitsByStructure,
-	type StructureInventoryRowInput,
-} from './services/structure-inventory'
-import { preserveStructureHydrationFields } from './services/structure-hydration'
+import type { RawEsiAsset } from './services/assets-paging-sync'
+import type { StructureInventoryRowInput } from './services/structure-inventory'
 
 type CorporationConfigRow = typeof corporationConfig.$inferSelect
 
@@ -117,6 +122,26 @@ const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY = 'shared:sovereignty-systems:ob
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX = 'shared:sovereignty-systems:row:'
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS = 300
 const ORBITAL_SKYHOOK_TYPE_ID = '81080'
+const STRUCTURE_SNAPSHOT_BATCH_SIZE = 10
+const STRUCTURE_CLEANUP_BATCH_SIZE = 250
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+	const chunks: T[][] = []
+	for (let index = 0; index < items.length; index += size) {
+		chunks.push(items.slice(index, index + size))
+	}
+	return chunks
+}
+
+async function deleteIdsInBatches(
+	ids: readonly string[],
+	batchSize: number,
+	deleteBatch: (batch: string[]) => Promise<void>
+): Promise<void> {
+	for (const batch of chunkArray(ids, batchSize)) {
+		await deleteBatch(batch)
+	}
+}
 
 function parseNumberOrNull(value: unknown): number | null {
 	if (value === null || value === undefined || value === '') {
@@ -158,7 +183,6 @@ type SkyhookStorageRow = {
 	lastObservedAt: Date
 	sourceSyncAt: Date
 	lastSyncedAt: Date
-	rawPayload: Record<string, unknown>
 }
 type SkyhookStorageInsertRow = SkyhookStorageRow & { updatedAt: Date }
 type SkyhookBaseStructureRow = {
@@ -189,7 +213,10 @@ type SkyhookBaseStructureRow = {
 	services: Array<{ name: string; state: string }> | null
 	updatedAt: Date
 }
-type SkyhookPlanetGeography = Pick<UniversePlanetGeography, 'planetId' | 'planetName' | 'solarSystemName'> | null
+type SkyhookPlanetGeography = Pick<
+	UniversePlanetGeography,
+	'planetId' | 'planetName' | 'solarSystemName'
+> | null
 
 export function buildSkyhookStorageRow(input: {
 	corporationId: string
@@ -209,7 +236,8 @@ export function buildSkyhookStorageRow(input: {
 	}
 
 	const resolvedPlanetName = planet?.planetName ?? existingRow?.planetName ?? null
-	const resolvedSystemName = planet?.solarSystemName ?? baseStructure.systemName ?? existingRow?.systemName ?? null
+	const resolvedSystemName =
+		planet?.solarSystemName ?? baseStructure.systemName ?? existingRow?.systemName ?? null
 
 	return {
 		structureId: skyhook.structure_id,
@@ -239,7 +267,6 @@ export function buildSkyhookStorageRow(input: {
 		lastObservedAt: observedAt,
 		sourceSyncAt: observedAt,
 		lastSyncedAt: observedAt,
-		rawPayload: skyhook.raw ?? { ...skyhook },
 	} satisfies SkyhookStorageRow
 }
 
@@ -349,7 +376,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		return right.contractId.localeCompare(left.contractId)
 	}
 
-	private mapAllianceCourierContract(row: typeof corporationContracts.$inferSelect): CorporationContractData {
+	private mapAllianceCourierContract(
+		row: typeof corporationContracts.$inferSelect
+	): CorporationContractData {
 		return {
 			id: row.id,
 			corporationId: row.corporationId,
@@ -436,12 +465,15 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		try {
 			await this.clearCharacterRolesSnapshot(characterId)
 		} catch (error) {
-			logger.warn('[EveCorporationData] Failed to clear stale director role cache after affiliation mismatch', {
-				characterId,
-				expectedCorporationId,
-				actualCorporationId,
-				error: error instanceof Error ? error.message : String(error),
-			})
+			logger.warn(
+				'[EveCorporationData] Failed to clear stale director role cache after affiliation mismatch',
+				{
+					characterId,
+					expectedCorporationId,
+					actualCorporationId,
+					error: error instanceof Error ? error.message : String(error),
+				}
+			)
 		}
 
 		try {
@@ -610,11 +642,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		try {
 			const response: EsiResponse<EsiCharacterRoles> = await retryWithBackoff(
 				() =>
-					this.getEveTokenStoreStub().fetchEsi(
-						`/characters/${characterId}/roles`,
-						characterId,
-						{ cacheMode: 'no-store' }
-					),
+					this.getEveTokenStoreStub().fetchEsi(`/characters/${characterId}/roles`, characterId, {
+						cacheMode: 'no-store',
+					}),
 				{
 					onRetry: (attempt, error, delayMs) => {
 						logger.warn('[EveCorporationData] Retrying role refresh after ESI throttling', {
@@ -969,7 +999,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const config = await this.getDb().query.corporationConfig.findFirst({
 			where: eq(corporationConfig.corporationId, corporationId),
 		})
-		const fallbackMissingRoles = ['Required corporation sync roles were not satisfied by any healthy director']
+		const fallbackMissingRoles = [
+			'Required corporation sync roles were not satisfied by any healthy director',
+		]
 
 		const extractMissingRoles = (failureReasons: Array<string | null | undefined>): string[] => {
 			const missingRoles = new Set<string>()
@@ -1044,11 +1076,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		const verifiedRoles = rolesData
 			? [
-				...(rolesData.roles || []),
-				...(rolesData.rolesAtHq || []),
-				...(rolesData.rolesAtBase || []),
-				...(rolesData.rolesAtOther || []),
-			]
+					...(rolesData.roles || []),
+					...(rolesData.rolesAtHq || []),
+					...(rolesData.rolesAtBase || []),
+					...(rolesData.rolesAtOther || []),
+				]
 			: []
 
 		const verification = {
@@ -1603,15 +1635,15 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			const existingRows =
 				batchJournalIds.length > 0
 					? await this.getDb().query.corporationWalletJournal.findMany({
-						where: and(
-							eq(corporationWalletJournal.corporationId, String(corporationId)),
-							eq(corporationWalletJournal.division, division),
-							inArray(corporationWalletJournal.journalId, batchJournalIds)
-						),
-						columns: {
-							journalId: true,
-						},
-					})
+							where: and(
+								eq(corporationWalletJournal.corporationId, String(corporationId)),
+								eq(corporationWalletJournal.division, division),
+								inArray(corporationWalletJournal.journalId, batchJournalIds)
+							),
+							columns: {
+								journalId: true,
+							},
+						})
 					: []
 			const existingJournalIds = new Set(existingRows.map((row) => row.journalId))
 			persistedNewRows += batchJournalIds.filter((id) => !existingJournalIds.has(id)).length
@@ -1680,15 +1712,15 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			const existingRows =
 				batchTransactionIds.length > 0
 					? await this.getDb().query.corporationWalletTransactions.findMany({
-						where: and(
-							eq(corporationWalletTransactions.corporationId, String(corporationId)),
-							eq(corporationWalletTransactions.division, division),
-							inArray(corporationWalletTransactions.transactionId, batchTransactionIds)
-						),
-						columns: {
-							transactionId: true,
-						},
-					})
+							where: and(
+								eq(corporationWalletTransactions.corporationId, String(corporationId)),
+								eq(corporationWalletTransactions.division, division),
+								inArray(corporationWalletTransactions.transactionId, batchTransactionIds)
+							),
+							columns: {
+								transactionId: true,
+							},
+						})
 					: []
 			const existingTransactionIds = new Set(existingRows.map((row) => row.transactionId))
 			persistedNewRows += batchTransactionIds.filter((id) => !existingTransactionIds.has(id)).length
@@ -1782,7 +1814,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): Promise<void> {
 		const observedAt = new Date()
 		const ownedStructureIds = await this.getOwnedStructureIds(corporationId)
-		const fuelBlockUnitsByStructure = summarizeFuelBlockUnitsByStructure(ownedStructureIds, inventory)
+		const fuelBlockUnitsByStructure = summarizeFuelBlockUnitsByStructure(
+			ownedStructureIds,
+			inventory
+		)
 		const previousFuelRows = ownedStructureIds.size
 			? await this.getDb().query.structureFuelLog.findMany({
 					where: and(
@@ -1875,14 +1910,15 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			.where(
 				and(
 					eq(structureFuelLog.corporationId, corporationId),
-					lte(structureFuelLog.observedAt, new Date(observedAt.getTime() - 30 * 24 * 60 * 60 * 1000))
+					lte(
+						structureFuelLog.observedAt,
+						new Date(observedAt.getTime() - 30 * 24 * 60 * 60 * 1000)
+					)
 				)
 			)
 	}
 
-	private async getStructureInventoryNextAllowedAt(
-		corporationId: string
-	): Promise<Date | null> {
+	private async getStructureInventoryNextAllowedAt(corporationId: string): Promise<Date | null> {
 		const config = await this.getDb().query.corporationConfig.findFirst({
 			where: eq(corporationConfig.corporationId, corporationId),
 		})
@@ -2081,29 +2117,47 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			structures as EsiCorporationStructure[]
 		)
 		const structureIds = hydratedStructures.map((structure) => structure.structureId)
-		if (structureIds.length === 0) {
-			await this.getDb()
-				.delete(corporationStructures)
-				.where(eq(corporationStructures.corporationId, corporationId))
-			await this.getDb()
-				.delete(structureSkyhookStates)
-				.where(eq(structureSkyhookStates.corporationId, corporationId))
-			await this.getDb()
-				.delete(structureMiningStates)
-				.where(eq(structureMiningStates.corporationId, corporationId))
-			return
-		}
-		const BATCH_SIZE = 10
+		const [existingStructureRows, existingSkyhookRows, existingMiningRows] = await Promise.all([
+			this.getDb().query.corporationStructures.findMany({
+				where: eq(corporationStructures.corporationId, corporationId),
+				columns: {
+					structureId: true,
+				},
+			}),
+			this.getDb().query.structureSkyhookStates.findMany({
+				where: eq(structureSkyhookStates.corporationId, corporationId),
+				columns: {
+					structureId: true,
+				},
+			}),
+			this.getDb().query.structureMiningStates.findMany({
+				where: eq(structureMiningStates.corporationId, corporationId),
+				columns: {
+					structureId: true,
+				},
+			}),
+		])
+		const currentStructureIds = new Set(structureIds)
+		const departedStructureIds = existingStructureRows
+			.map((row) => row.structureId)
+			.filter((structureId) => !currentStructureIds.has(structureId))
+		const departedSkyhookIds = existingSkyhookRows
+			.map((row) => row.structureId)
+			.filter((structureId) => !currentStructureIds.has(structureId))
+		const departedMiningIds = existingMiningRows
+			.map((row) => row.structureId)
+			.filter((structureId) => !currentStructureIds.has(structureId))
+		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 
 		for (let i = 0; i < hydratedStructures.length; i += BATCH_SIZE) {
 			const batch = hydratedStructures.slice(i, i + BATCH_SIZE)
 
-				await this.getDb()
-					.insert(corporationStructures)
-					.values(batch)
-					.onConflictDoUpdate({
-						target: corporationStructures.structureId,
-						set: {
+			await this.getDb()
+				.insert(corporationStructures)
+				.values(batch)
+				.onConflictDoUpdate({
+					target: corporationStructures.structureId,
+					set: {
 						name: sql`excluded.name`,
 						typeId: sql`excluded.type_id`,
 						typeName: sql`excluded.type_name`,
@@ -2131,30 +2185,36 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				})
 		}
 
-		await this.getDb()
-			.delete(corporationStructures)
-			.where(
-				and(
-					eq(corporationStructures.corporationId, corporationId),
-					notInArray(corporationStructures.structureId, structureIds)
+		await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+			await this.getDb()
+				.delete(corporationStructures)
+				.where(
+					and(
+						eq(corporationStructures.corporationId, corporationId),
+						inArray(corporationStructures.structureId, batch)
+					)
 				)
-			)
-		await this.getDb()
-			.delete(structureSkyhookStates)
-			.where(
-				and(
-					eq(structureSkyhookStates.corporationId, corporationId),
-					notInArray(structureSkyhookStates.structureId, structureIds)
+		})
+		await deleteIdsInBatches(departedSkyhookIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+			await this.getDb()
+				.delete(structureSkyhookStates)
+				.where(
+					and(
+						eq(structureSkyhookStates.corporationId, corporationId),
+						inArray(structureSkyhookStates.structureId, batch)
+					)
 				)
-			)
-		await this.getDb()
-			.delete(structureMiningStates)
-			.where(
-				and(
-					eq(structureMiningStates.corporationId, corporationId),
-					notInArray(structureMiningStates.structureId, structureIds)
+		})
+		await deleteIdsInBatches(departedMiningIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+			await this.getDb()
+				.delete(structureMiningStates)
+				.where(
+					and(
+						eq(structureMiningStates.corporationId, corporationId),
+						inArray(structureMiningStates.structureId, batch)
+					)
 				)
-			)
+		})
 	}
 
 	/**
@@ -2377,40 +2437,50 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				.where(eq(corporationMembers.corporationId, corporationId))
 			const characterIds = members.map((row) => row.characterId)
 
-				if (characterIds.length > 0) {
-					try {
-						const result = await this.env.CORE.addPendingDiscordRefreshesForCharacters(characterIds)
-						logger.info('[EveCorporationData] Queued Discord refresh after alliance affiliation change', {
+			if (characterIds.length > 0) {
+				try {
+					const result = await this.env.CORE.addPendingDiscordRefreshesForCharacters(characterIds)
+					logger.info(
+						'[EveCorporationData] Queued Discord refresh after alliance affiliation change',
+						{
 							corporationId,
-						previousAllianceId,
-						nextAllianceId,
-						charactersMatched: characterIds.length,
-						usersQueued: result.usersQueued,
+							previousAllianceId,
+							nextAllianceId,
+							charactersMatched: characterIds.length,
+							usersQueued: result.usersQueued,
 							pendingCount: result.pendingCount,
-						})
-					} catch (error) {
-						logger.error(
-							'[EveCorporationData] Failed to queue Discord refresh after alliance affiliation change',
-							{
-								corporationId,
-								previousAllianceId,
-								nextAllianceId,
-								error: error instanceof Error ? error.message : String(error),
-							}
-						)
-					}
+						}
+					)
+				} catch (error) {
+					logger.error(
+						'[EveCorporationData] Failed to queue Discord refresh after alliance affiliation change',
+						{
+							corporationId,
+							previousAllianceId,
+							nextAllianceId,
+							error: error instanceof Error ? error.message : String(error),
+						}
+					)
 				}
 			}
 		}
+	}
 
 	/**
 	 * Store sovereignty system snapshots (workflow-friendly)
 	 */
-	async storeSovereigntySystems(corporationId: string, systems: EsiSovereigntySystem[]): Promise<void> {
+	async storeSovereigntySystems(
+		corporationId: string,
+		systems: EsiSovereigntySystem[]
+	): Promise<void> {
 		const now = new Date()
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const existingRows = await this.getDb().query.structureSovereigntySystems.findMany({
 			where: eq(structureSovereigntySystems.corporationId, corporationId),
+			columns: {
+				systemId: true,
+				systemName: true,
+			},
 		})
 		const existingBySystemId = new Map(existingRows.map((row) => [row.systemId, row]))
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
@@ -2447,9 +2517,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				strategicLevel: system.strategic_level ?? null,
 				sourceSyncAt: now,
 				lastSyncedAt: now,
-				rawPayload: system.raw ?? {
-					...system,
-				},
 				updatedAt: now,
 			}
 		})
@@ -2461,7 +2528,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			return
 		}
 
-		const BATCH_SIZE = 25
+		const currentSystemIds = new Set(values.map((row) => row.systemId))
+		const departedSystemIds = existingRows
+			.map((row) => row.systemId)
+			.filter((systemId) => !currentSystemIds.has(systemId))
+		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < values.length; i += BATCH_SIZE) {
 			const batch = values.slice(i, i + BATCH_SIZE)
 			await this.getDb()
@@ -2487,23 +2558,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						strategicLevel: sql`excluded.strategic_level`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
-						rawPayload: sql`excluded.raw_payload`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})
 		}
 
-		await this.getDb()
-			.delete(structureSovereigntySystems)
-			.where(
-				and(
-					eq(structureSovereigntySystems.corporationId, corporationId),
-					notInArray(
-						structureSovereigntySystems.systemId,
-						values.map((row) => row.systemId)
+		await deleteIdsInBatches(departedSystemIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+			await this.getDb()
+				.delete(structureSovereigntySystems)
+				.where(
+					and(
+						eq(structureSovereigntySystems.corporationId, corporationId),
+						inArray(structureSovereigntySystems.systemId, batch)
 					)
 				)
-			)
+		})
 	}
 
 	/**
@@ -2512,7 +2581,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async storeSharedSovereigntySystems(systems: EsiSovereigntySystem[]): Promise<void> {
 		const observedAt = new Date().toISOString()
 		const rowEntries = Object.fromEntries(
-			systems.map((system) => [`${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX}${system.system_id}`, system])
+			systems.map((system) => [
+				`${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX}${system.system_id}`,
+				system,
+			])
 		)
 
 		await this.state.storage.transaction(async (txn) => {
@@ -2536,7 +2608,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		systemIds: string[],
 		maxAgeSeconds = SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS
 	): Promise<EsiSovereigntySystem[] | null> {
-		const observedAtRaw = await this.state.storage.get<string>(SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY)
+		const observedAtRaw = await this.state.storage.get<string>(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
+		)
 		if (!observedAtRaw) {
 			return null
 		}
@@ -2617,7 +2691,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			military_level: row.militaryLevel ?? null,
 			industrial_level: row.industrialLevel ?? null,
 			strategic_level: row.strategicLevel ?? null,
-			raw: row.rawPayload ?? {},
 		}))
 	}
 
@@ -2628,6 +2701,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const now = new Date()
 		const existingRows = await this.getDb().query.structureSovereigntyHubs.findMany({
 			where: eq(structureSovereigntyHubs.corporationId, corporationId),
+			columns: {
+				structureId: true,
+				systemName: true,
+				name: true,
+			},
 		})
 		const existingByStructureId = new Map(existingRows.map((row) => [row.structureId, row]))
 		const values = hubs.map((hub) => {
@@ -2661,7 +2739,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				workforceTransport: hub.workforce_transport,
 				sourceSyncAt: now,
 				lastSyncedAt: now,
-				rawPayload: hub.raw ?? { ...hub },
 				updatedAt: now,
 			}
 		})
@@ -2673,7 +2750,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			return
 		}
 
-		const BATCH_SIZE = 25
+		const currentStructureIds = new Set(values.map((row) => row.structureId))
+		const departedStructureIds = existingRows
+			.map((row) => row.structureId)
+			.filter((structureId) => !currentStructureIds.has(structureId))
+		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < values.length; i += BATCH_SIZE) {
 			const batch = values.slice(i, i + BATCH_SIZE)
 			await this.getDb()
@@ -2698,20 +2779,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						workforceTransport: sql`excluded.workforce_transport`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
-						rawPayload: sql`excluded.raw_payload`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})
 		}
 
-		await this.getDb()
-			.delete(structureSovereigntyHubs)
-			.where(
-				and(
-					eq(structureSovereigntyHubs.corporationId, corporationId),
-					notInArray(structureSovereigntyHubs.structureId, values.map((row) => row.structureId))
+		await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+			await this.getDb()
+				.delete(structureSovereigntyHubs)
+				.where(
+					and(
+						eq(structureSovereigntyHubs.corporationId, corporationId),
+						inArray(structureSovereigntyHubs.structureId, batch)
+					)
 				)
-			)
+		})
 	}
 
 	/**
@@ -2722,18 +2804,32 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const existingRows = await this.getDb().query.structureSkyhookStates.findMany({
 			where: eq(structureSkyhookStates.corporationId, corporationId),
+			columns: {
+				structureId: true,
+				planetName: true,
+				systemName: true,
+				name: true,
+			},
 		})
 		const existingByStructureId = new Map(existingRows.map((row) => [row.structureId, row]))
 		const structureIds = [...new Set(skyhooks.map((skyhook) => skyhook.structure_id))]
-		const existingBaseStructures =
-			structureIds.length > 0
-				? await this.getDb().query.corporationStructures.findMany({
-						where: and(
-							eq(corporationStructures.corporationId, corporationId),
-							inArray(corporationStructures.structureId, structureIds)
-						),
-					})
-				: []
+		const existingBaseStructures = await this.getDb().query.corporationStructures.findMany({
+			where: and(
+				eq(corporationStructures.corporationId, corporationId),
+				eq(corporationStructures.typeId, ORBITAL_SKYHOOK_TYPE_ID)
+			),
+			columns: {
+				structureId: true,
+				corporationId: true,
+				name: true,
+				typeId: true,
+				systemId: true,
+				systemName: true,
+				regionId: true,
+				regionName: true,
+				updatedAt: true,
+			},
+		})
 		const baseStructureById = new Map(existingBaseStructures.map((row) => [row.structureId, row]))
 		const planetGeography: Awaited<ReturnType<Universe['resolvePlanetGeographyByIds']>> =
 			skyhooks.length > 0
@@ -2764,10 +2860,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				const existing = existingByStructureId.get(skyhook.structure_id) ?? null
 				const resolvedPlanet = planetGeography[skyhook.planet_id] ?? null
 				const resolvedSystem = resolvedPlanet?.solarSystemId
-					? systemGeography[resolvedPlanet.solarSystemId] ?? null
+					? (systemGeography[resolvedPlanet.solarSystemId] ?? null)
 					: null
 				const resolvedRegion = resolvedSystem?.regionId
-					? regionGeography[resolvedSystem.regionId] ?? null
+					? (regionGeography[resolvedSystem.regionId] ?? null)
 					: null
 				const baseStructure = buildSkyhookBaseStructureRow({
 					corporationId,
@@ -2788,11 +2884,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					observedAt: now,
 				})
 				if (!baseStructure) {
-					logger.warn('[storeSkyhooks] Skipping skyhook without resolvable base structure geography', {
-						corporationId,
-						structureId: skyhook.structure_id,
-						planetId: skyhook.planet_id,
-					})
+					logger.warn(
+						'[storeSkyhooks] Skipping skyhook without resolvable base structure geography',
+						{
+							corporationId,
+							structureId: skyhook.structure_id,
+							planetId: skyhook.planet_id,
+						}
+					)
 					return null
 				}
 				const storageRow = buildSkyhookStorageRow({
@@ -2854,7 +2953,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const baseValues = synthesizedRows.map((row) => row.baseStructure)
 		const values = synthesizedRows.map((row) => row.storageRow)
 
-		const BASE_BATCH_SIZE = 25
+		const currentStructureIds = new Set(baseValues.map((row) => row.structureId))
+		const departedBaseStructureIds = existingBaseStructures
+			.map((row) => row.structureId)
+			.filter((structureId) => !currentStructureIds.has(structureId))
+		const departedStateIds = existingRows
+			.map((row) => row.structureId)
+			.filter((structureId) => !currentStructureIds.has(structureId))
+		const BASE_BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < baseValues.length; i += BASE_BATCH_SIZE) {
 			const batch = baseValues.slice(i, i + BASE_BATCH_SIZE)
 			await this.getDb()
@@ -2891,7 +2997,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					},
 				})
 		}
-		const STATE_BATCH_SIZE = 25
+		await deleteIdsInBatches(
+			departedBaseStructureIds,
+			STRUCTURE_CLEANUP_BATCH_SIZE,
+			async (batch) => {
+				await this.getDb()
+					.delete(corporationStructures)
+					.where(
+						and(
+							eq(corporationStructures.corporationId, corporationId),
+							inArray(corporationStructures.structureId, batch)
+						)
+					)
+			}
+		)
+		const STATE_BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < values.length; i += STATE_BATCH_SIZE) {
 			const batch = values.slice(i, i + STATE_BATCH_SIZE)
 			await this.getDb()
@@ -2920,33 +3040,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						lastObservedAt: sql`excluded.last_observed_at`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
-						rawPayload: sql`excluded.raw_payload`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})
 		}
 
-		await this.getDb()
-			.delete(corporationStructures)
-			.where(
-				and(
-					eq(corporationStructures.corporationId, corporationId),
-					eq(corporationStructures.typeId, ORBITAL_SKYHOOK_TYPE_ID),
-					notInArray(
-						corporationStructures.structureId,
-						baseValues.map((row) => row.structureId)
+		await deleteIdsInBatches(departedStateIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+			await this.getDb()
+				.delete(structureSkyhookStates)
+				.where(
+					and(
+						eq(structureSkyhookStates.corporationId, corporationId),
+						inArray(structureSkyhookStates.structureId, batch)
 					)
 				)
-			)
-
-		await this.getDb()
-			.delete(structureSkyhookStates)
-			.where(
-				and(
-					eq(structureSkyhookStates.corporationId, corporationId),
-					notInArray(structureSkyhookStates.structureId, values.map((row) => row.structureId))
-				)
-			)
+		})
 	}
 
 	/**
@@ -2960,6 +3068,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const existingRows = await this.getDb().query.structureMiningStates.findMany({
 			where: eq(structureMiningStates.corporationId, corporationId),
+			columns: {
+				structureId: true,
+				moonName: true,
+				planetId: true,
+				planetName: true,
+				systemId: true,
+				systemName: true,
+			},
 		})
 		const existingByStructureId = new Map(existingRows.map((row) => [row.structureId, row]))
 		const moonGeography: Awaited<ReturnType<Universe['resolveMoonGeographyByIds']>> =
@@ -2989,7 +3105,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				naturalDecayTime: parseDateOrNull(extraction.natural_decay_time) ?? null,
 				sourceSyncAt: now,
 				lastSyncedAt: now,
-				rawPayload: extraction.raw ?? { ...extraction },
 				updatedAt: now,
 			}
 		})
@@ -2998,7 +3113,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			return
 		}
 
-		const BATCH_SIZE = 25
+		const currentStructureIds = new Set(values.map((row) => row.structureId))
+		const departedStructureIds = existingRows
+			.map((row) => row.structureId)
+			.filter((structureId) => !currentStructureIds.has(structureId))
+		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < values.length; i += BATCH_SIZE) {
 			const batch = values.slice(i, i + BATCH_SIZE)
 			await this.getDb()
@@ -3019,11 +3138,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						naturalDecayTime: sql`excluded.natural_decay_time`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
-						rawPayload: sql`excluded.raw_payload`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})
 		}
+
+		await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+			await this.getDb()
+				.delete(structureMiningStates)
+				.where(
+					and(
+						eq(structureMiningStates.corporationId, corporationId),
+						inArray(structureMiningStates.structureId, batch)
+					)
+				)
+		})
 	}
 
 	/**
@@ -3596,9 +3725,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			fetchPage: (page) =>
 				tokenStore.fetchEsi(`${basePath}?page=${page}`, characterId, {
 					cacheMode: 'no-store',
-				}) as Promise<
-					EsiResponse<RawEsiAsset[]>
-				>,
+				}) as Promise<EsiResponse<RawEsiAsset[]>>,
 			storeAssets: (assets) => this.storeAssets(corporationId, assets),
 			onProgress: ({ page, totalPages, totalAssets }) => {
 				if (page % 10 === 0 || page === totalPages) {
@@ -3687,17 +3814,23 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				await this.fetchAndStoreStructures(corporationId, true)
 				ownedStructureIds = await this.getOwnedStructureIds(corporationId)
 			} catch (error) {
-				logger.warn('[EveCorporationData] Structures refresh fallback failed before inventory filtering', {
-					corporationId,
-					error: error instanceof Error ? error.message : String(error),
-				})
+				logger.warn(
+					'[EveCorporationData] Structures refresh fallback failed before inventory filtering',
+					{
+						corporationId,
+						error: error instanceof Error ? error.message : String(error),
+					}
+				)
 			}
 		}
 
 		if (ownedStructureIds.size === 0) {
-			logger.info('[EveCorporationData] No owned structures found; clearing structure inventory snapshot', {
-				corporationId,
-			})
+			logger.info(
+				'[EveCorporationData] No owned structures found; clearing structure inventory snapshot',
+				{
+					corporationId,
+				}
+			)
 			await this.storeStructureInventory(corporationId, [])
 			await this.updateCorporationSyncTimestamp(corporationId, 'assetsLastSync')
 			return 0
@@ -3707,10 +3840,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const basePath = `/corporations/${corporationId}/assets`
 		const inventoryRows: StructureInventoryRowInput[] = []
 		try {
-			logger.info('[EveCorporationData] fetchAndStoreStructureInventoryByCharacter: Fetching structure inventory', {
-				corporationId,
-				ownedStructureCount: ownedStructureIds.size,
-			})
+			logger.info(
+				'[EveCorporationData] fetchAndStoreStructureInventoryByCharacter: Fetching structure inventory',
+				{
+					corporationId,
+					ownedStructureCount: ownedStructureIds.size,
+				}
+			)
 			const result = await syncAssetsPaged({
 				fetchPage: (page) =>
 					tokenStore.fetchEsi(`${basePath}?page=${page}`, characterId, {
@@ -3790,7 +3926,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 */
 	private async fetchAndStoreOrders(corporationId: string, _forceRefresh = false): Promise<void> {
 		const { characterId } = await this.getConfiguredCharacter(corporationId)
-		await this.requireCorpRole(corporationId, characterId, ['Accountant', 'Junior_Accountant', 'Trader'])
+		await this.requireCorpRole(corporationId, characterId, [
+			'Accountant',
+			'Junior_Accountant',
+			'Trader',
+		])
 
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const orders: EsiCorporationOrder[] = await esiFetch.fetchOrders(
@@ -4643,14 +4783,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async getWallets(corporationId: string, division?: number): Promise<CorporationWalletData[]> {
 		const results = division
 			? await this.getDb().query.corporationWallets.findMany({
-				where: and(
-					eq(corporationWallets.corporationId, corporationId),
-					eq(corporationWallets.division, division)
-				),
-			})
+					where: and(
+						eq(corporationWallets.corporationId, corporationId),
+						eq(corporationWallets.division, division)
+					),
+				})
 			: await this.getDb().query.corporationWallets.findMany({
-				where: eq(corporationWallets.corporationId, corporationId),
-			})
+					where: eq(corporationWallets.corporationId, corporationId),
+				})
 
 		return results.map((r) => ({
 			id: r.id,
@@ -4671,18 +4811,18 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): Promise<CorporationWalletJournalData[]> {
 		const results = division
 			? await this.getDb().query.corporationWalletJournal.findMany({
-				where: and(
-					eq(corporationWalletJournal.corporationId, corporationId),
-					eq(corporationWalletJournal.division, division)
-				),
-				orderBy: desc(corporationWalletJournal.date),
-				limit,
-			})
+					where: and(
+						eq(corporationWalletJournal.corporationId, corporationId),
+						eq(corporationWalletJournal.division, division)
+					),
+					orderBy: desc(corporationWalletJournal.date),
+					limit,
+				})
 			: await this.getDb().query.corporationWalletJournal.findMany({
-				where: eq(corporationWalletJournal.corporationId, corporationId),
-				orderBy: desc(corporationWalletJournal.date),
-				limit,
-			})
+					where: eq(corporationWalletJournal.corporationId, corporationId),
+					orderBy: desc(corporationWalletJournal.date),
+					limit,
+				})
 
 		return results.map((r) => ({
 			id: r.id,
@@ -4715,18 +4855,18 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): Promise<CorporationWalletTransactionData[]> {
 		const results = division
 			? await this.getDb().query.corporationWalletTransactions.findMany({
-				where: and(
-					eq(corporationWalletTransactions.corporationId, corporationId),
-					eq(corporationWalletTransactions.division, division)
-				),
-				orderBy: desc(corporationWalletTransactions.date),
-				limit,
-			})
+					where: and(
+						eq(corporationWalletTransactions.corporationId, corporationId),
+						eq(corporationWalletTransactions.division, division)
+					),
+					orderBy: desc(corporationWalletTransactions.date),
+					limit,
+				})
 			: await this.getDb().query.corporationWalletTransactions.findMany({
-				where: eq(corporationWalletTransactions.corporationId, corporationId),
-				orderBy: desc(corporationWalletTransactions.date),
-				limit,
-			})
+					where: eq(corporationWalletTransactions.corporationId, corporationId),
+					orderBy: desc(corporationWalletTransactions.date),
+					limit,
+				})
 
 		return results.map((r) => ({
 			id: r.id,
@@ -5075,9 +5215,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): Promise<CorporationStructureInventoryData[]> {
 		const where = structureId
 			? and(
-				eq(corporationStructureInventory.corporationId, corporationId),
-				eq(corporationStructureInventory.structureId, structureId)
-			)
+					eq(corporationStructureInventory.corporationId, corporationId),
+					eq(corporationStructureInventory.structureId, structureId)
+				)
 			: eq(corporationStructureInventory.corporationId, corporationId)
 
 		const results = await this.getDb().query.corporationStructureInventory.findMany({
@@ -5264,14 +5404,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async getContracts(corporationId: string, status?: string): Promise<CorporationContractData[]> {
 		const results = status
 			? await this.getDb().query.corporationContracts.findMany({
-				where: and(
-					eq(corporationContracts.corporationId, corporationId),
-					eq(corporationContracts.status, status)
-				),
-			})
+					where: and(
+						eq(corporationContracts.corporationId, corporationId),
+						eq(corporationContracts.status, status)
+					),
+				})
 			: await this.getDb().query.corporationContracts.findMany({
-				where: eq(corporationContracts.corporationId, corporationId),
-			})
+					where: eq(corporationContracts.corporationId, corporationId),
+				})
 
 		return results.map((r) => ({
 			id: r.id,
@@ -5437,14 +5577,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): Promise<CorporationIndustryJobData[]> {
 		const results = status
 			? await this.getDb().query.corporationIndustryJobs.findMany({
-				where: and(
-					eq(corporationIndustryJobs.corporationId, corporationId),
-					eq(corporationIndustryJobs.status, status)
-				),
-			})
+					where: and(
+						eq(corporationIndustryJobs.corporationId, corporationId),
+						eq(corporationIndustryJobs.status, status)
+					),
+				})
 			: await this.getDb().query.corporationIndustryJobs.findMany({
-				where: eq(corporationIndustryJobs.corporationId, corporationId),
-			})
+					where: eq(corporationIndustryJobs.corporationId, corporationId),
+				})
 
 		return results.map((r) => ({
 			id: r.id,
@@ -5572,7 +5712,8 @@ export function buildSkyhookBaseStructureRow(input: {
 		return null
 	}
 
-	const resolvedSystemName = planet?.solarSystemName ?? system?.solarSystemName ?? existingRow?.systemName ?? null
+	const resolvedSystemName =
+		planet?.solarSystemName ?? system?.solarSystemName ?? existingRow?.systemName ?? null
 	const resolvedRegionId = system?.regionId ?? existingRow?.regionId ?? null
 	const resolvedRegionName = region?.regionName ?? existingRow?.regionName ?? null
 	const resolvedName = existingRow?.name ?? planet?.planetName ?? `Skyhook ${skyhook.structure_id}`
@@ -5595,7 +5736,9 @@ export function buildSkyhookBaseStructureRow(input: {
 		nextReinforceHour: null,
 		reinforceHour: null,
 		state: skyhook.state,
-		stateTimerEnd: skyhook.reinforcement_timer?.end ? new Date(skyhook.reinforcement_timer.end) : null,
+		stateTimerEnd: skyhook.reinforcement_timer?.end
+			? new Date(skyhook.reinforcement_timer.end)
+			: null,
 		stateTimerStart: null,
 		unanchorsAt: null,
 		lowPower: false,

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -46,7 +46,7 @@ import type {
 } from '@repo/eve-corporation-data'
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
 
-const SOVEREIGNTY_HUB_TYPE_ID = '35835'
+const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 
 // ========================================================================
 // PUBLIC DATA FETCHING

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../services/esi-fetch'
 
 const ORBITAL_SKYHOOK_TYPE_ID = '81080'
+const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 
 describe('esi structure enrichment ownership handling', () => {
 	it('maps the requested corporation id onto base structures', async () => {
@@ -258,7 +259,7 @@ describe('esi structure enrichment ownership handling', () => {
 			structure_id: '81001',
 			corporation_id: '98000001',
 			system_id: '30000142',
-			type_id: '35835',
+			type_id: SOVEREIGNTY_HUB_TYPE_ID,
 			name: null,
 		})
 	})

--- a/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
@@ -57,7 +57,6 @@ describe('storeMiningExtractions', () => {
 				naturalDecayTime: new Date('2026-07-03T00:00:00.000Z'),
 				sourceSyncAt: new Date('2026-07-01T00:00:00.000Z'),
 				lastSyncedAt: new Date('2026-07-01T00:00:00.000Z'),
-				rawPayload: {},
 				updatedAt: new Date('2026-07-01T00:00:00.000Z'),
 			},
 		])

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import {
+	corporationStructures,
+	structureMiningStates,
+	structureSkyhookStates,
+	structureSovereigntyHubs,
+} from '../../../db/schema'
+import { EveCorporationDataDO } from '../../../durable-object'
+
+const SOVEREIGNTY_HUB_TYPE_ID = '32458'
+
 const mocks = vi.hoisted(() => {
 	const findMany = vi.fn()
 	const onConflictDoUpdate = vi.fn()
@@ -26,26 +36,36 @@ vi.mock('@repo/do-utils', () => ({
 	getStub: mocks.getStub,
 }))
 
-import { EveCorporationDataDO } from '../../../durable-object'
-import {
-	corporationStructures,
-	structureMiningStates,
-	structureSkyhookStates,
-	structureSovereigntyHubs,
-} from '../../../db/schema'
-
 function makeDb() {
 	const where = vi.fn().mockResolvedValue(undefined)
 	const deleteMock = vi.fn(() => ({ where }))
 	const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
 	const values = vi.fn((rows) => ({ onConflictDoUpdate, rows }))
 	const insert = vi.fn(() => ({ values }))
-	const findMany = vi.fn().mockResolvedValue([])
+	const corporationStructuresFindMany = vi
+		.fn()
+		.mockResolvedValue([{ structureId: 'stale-structure' }])
+	const structureSkyhookStatesFindMany = vi
+		.fn()
+		.mockResolvedValue([{ structureId: 'stale-structure' }])
+	const structureMiningStatesFindMany = vi
+		.fn()
+		.mockResolvedValue([{ structureId: 'stale-structure' }])
+	const structureSovereigntyHubsFindMany = vi.fn().mockResolvedValue([])
 
 	return {
 		query: {
+			corporationStructures: {
+				findMany: corporationStructuresFindMany,
+			},
+			structureSkyhookStates: {
+				findMany: structureSkyhookStatesFindMany,
+			},
+			structureMiningStates: {
+				findMany: structureMiningStatesFindMany,
+			},
 			structureSovereigntyHubs: {
-				findMany,
+				findMany: structureSovereigntyHubsFindMany,
 			},
 		},
 		delete: deleteMock,
@@ -147,7 +167,7 @@ describe('structure prune cleanup', () => {
 				corporation_id: 'corp-1',
 				system_id: '30000142',
 				system_name: 'Jita',
-				type_id: '35835',
+				type_id: SOVEREIGNTY_HUB_TYPE_ID,
 				name: 'Jita',
 				fuel_access_list_id: null,
 				controller_alliance_id: null,
@@ -174,6 +194,6 @@ describe('structure prune cleanup', () => {
 			systemName: 'Jita',
 			name: 'Jita',
 		})
-		expect(db.delete).toHaveBeenCalledWith(structureSovereigntyHubs)
+		expect(db.delete).not.toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 
 const mocks = vi.hoisted(() => {
 	const fetchSovereigntyHubsMock = vi.fn()
@@ -48,7 +49,7 @@ describe('fetchSovereigntyEnrichment', () => {
 				system_id: '30000142',
 				system_name: null,
 				name: null,
-				type_id: '35835',
+				type_id: SOVEREIGNTY_HUB_TYPE_ID,
 				controller_alliance_id: null,
 				fuel_access_list_id: null,
 				reagent_bay: {

--- a/apps/structures/src/context.ts
+++ b/apps/structures/src/context.ts
@@ -5,6 +5,7 @@ export type SessionUser = StructureActor
 export type Env = {
 	DATABASE_URL: string
 	EVE_CORPORATION_DATA: DurableObjectNamespace
+	UNIVERSE: DurableObjectNamespace
 	NAME: string
 	ENVIRONMENT: string
 	SENTRY_RELEASE: string

--- a/apps/structures/src/index.ts
+++ b/apps/structures/src/index.ts
@@ -82,7 +82,7 @@ export class StructuresWorkerEntrypoint extends WorkerEntrypoint<Env> implements
 		actor: StructureActor,
 		query: StructureSovereigntyListQuery = {}
 	): Promise<unknown> {
-		return listSovereigntyStructures(this.getDb(), actor, query)
+		return listSovereigntyStructures(this.env, this.getDb(), actor, query)
 	}
 
 	async listSkyhookStructures(actor: StructureActor, query: StructureSkyhookListQuery = {}): Promise<unknown> {

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -230,6 +230,33 @@ export interface StructureSovereigntyHubSummary {
 	controllerAllianceId: string | null
 	reagentBayLastUpdated: string | null
 	reagentCount: number
+	reagentBay: {
+		lastUpdated: string
+		reagents: Array<{
+			typeId: string
+			securedStock: number
+			unsecuredStock: number
+			lastCycle: string
+		}>
+	}
+	resources: {
+		power: {
+			allocated: number
+			available: number
+		}
+		workforce: {
+			allocated: number
+			available: number
+		}
+	}
+	upgrades: Array<{
+		typeId: string
+		powerState: string
+	}>
+	workforceTransport: {
+		configuration: Record<string, unknown>
+		state: Record<string, unknown>
+	}
 	totalSecuredStock: number
 	totalUnsecuredStock: number
 	resourcePowerAllocated: number
@@ -628,6 +655,13 @@ function compareNullableNumbers(
 
 type StructureWhereCondition = NonNullable<Parameters<typeof and>[number]>
 
+type SovereigntyHubUniverseStub = {
+	resolveSolarSystemsByIds(systemIds: string[]): Promise<
+		Record<string, { solarSystemName: string; regionId: string } | null>
+	>
+	resolveRegionsByIds(regionIds: string[]): Promise<Record<string, { regionName: string } | null>>
+}
+
 function combineWhereConditions(
 	conditions: Array<StructureWhereCondition | undefined>
 ): any {
@@ -673,6 +707,10 @@ function summarizeStructureSovereigntyHub(
 		controllerAllianceId: hub.controllerAllianceId ?? null,
 		reagentBayLastUpdated: hub.reagentBayLastUpdated ? hub.reagentBayLastUpdated.toISOString() : null,
 		reagentCount: hub.reagentBay.reagents.length,
+		reagentBay: hub.reagentBay,
+		resources: hub.resources,
+		upgrades: hub.upgrades,
+		workforceTransport: hub.workforceTransport as StructureSovereigntyHubSummary['workforceTransport'],
 		totalSecuredStock: reagentTotals.secured,
 		totalUnsecuredStock: reagentTotals.unsecured,
 		resourcePowerAllocated: hub.resources.power.allocated,
@@ -807,6 +845,81 @@ function buildStructureListItem(context: VisibleStructureContext): StructureList
 		canViewSensitive,
 		canEdit,
 	}
+}
+
+interface SovereigntyHubGeography {
+	solarSystemName: string
+	regionId: string
+	regionName: string
+}
+
+async function resolveSovereigntyHubGeographies(
+	env: Env,
+	systemIds: string[]
+): Promise<Record<string, SovereigntyHubGeography | null>> {
+	if (systemIds.length === 0) {
+		return {}
+	}
+
+	const universe = getStub<SovereigntyHubUniverseStub>(env.UNIVERSE, 'default')
+	const systemsById = await universe.resolveSolarSystemsByIds(systemIds)
+	const regionIds = [...new Set(Object.values(systemsById).flatMap((system) => (system ? [system.regionId] : [])))]
+	const regionsById = regionIds.length > 0 ? await universe.resolveRegionsByIds(regionIds) : {}
+
+	return Object.fromEntries(
+		Object.entries(systemsById).map(([systemId, system]) => {
+			if (!system) {
+				return [systemId, null]
+			}
+
+			const region = regionsById[system.regionId] ?? null
+			return [
+				systemId,
+				{
+					solarSystemName: system.solarSystemName,
+					regionId: system.regionId,
+					regionName: region?.regionName ?? system.regionId,
+				},
+			]
+		})
+	)
+}
+
+function buildSyntheticSovereigntyStructureRow(
+	hub: typeof structureSovereigntyHubs.$inferSelect,
+	system: typeof structureSovereigntySystems.$inferSelect | null,
+	geography: SovereigntyHubGeography | null
+): DirectCorporationStructureRecord {
+	const lastSyncedAt = hub.lastSyncedAt ?? system?.lastSyncedAt ?? null
+	return {
+		id: hub.structureId,
+		corporationId: hub.corporationId,
+		structureId: hub.structureId,
+		name: hub.name ?? geography?.solarSystemName ?? hub.systemName ?? system?.systemName ?? hub.structureId,
+		typeId: hub.typeId,
+		typeName: 'Sovereignty Hub',
+		systemId: hub.systemId,
+		systemName: geography?.solarSystemName ?? hub.systemName ?? system?.systemName ?? null,
+		regionId: geography?.regionId ?? null,
+		regionName: geography?.regionName ?? null,
+		profileId: 'sovereignty',
+		fuelExpires: null,
+		fuelAmount: null,
+		lastRefilledAt: null,
+		nextReinforceApply: null,
+		nextReinforceHour: null,
+		reinforceHour: null,
+		state: 'online',
+		stateTimerEnd: null,
+		stateTimerStart: null,
+		unanchorsAt: null,
+		lowPower: false,
+		syncStatus: 'ok',
+		syncFailureReason: null,
+		lastSyncedAt,
+		services: [],
+		updatedAt: hub.updatedAt,
+	} as DirectCorporationStructureRecord
 }
 
 async function loadStructureTabDetailData(
@@ -1292,7 +1405,69 @@ async function getVisibleStructureContext(
 	})
 
 	if (!structure) {
-		return null
+		const sovereigntyHub = await db.query.structureSovereigntyHubs.findFirst({
+			where: (() => {
+				const conditions = [eq(structureSovereigntyHubs.structureId, structureId)]
+				if (!accessibleCorporations.hasGlobalAccess) {
+					if (accessibleCorporations.corporationIds.size === 0) {
+						return and(...conditions, eq(structureSovereigntyHubs.corporationId, '__no_access__'))
+					}
+					conditions.push(inArray(structureSovereigntyHubs.corporationId, [...accessibleCorporations.corporationIds]))
+				}
+				return and(...conditions)
+			})(),
+		})
+
+		if (!sovereigntyHub) {
+			return null
+		}
+
+		const corporation = await db.query.managedCorporations.findFirst({
+			where: eq(managedCorporations.corporationId, sovereigntyHub.corporationId),
+			columns: {
+				corporationId: true,
+				name: true,
+				includeInStructureAssetSync: true,
+			},
+		})
+		const systemRow = await db.query.structureSovereigntySystems.findFirst({
+			where: eq(structureSovereigntySystems.sovereigntyHubStructureId, structureId),
+		})
+		const geographyBySystemId = await resolveSovereigntyHubGeographies(env, [sovereigntyHub.systemId])
+		const syntheticStructure = buildSyntheticSovereigntyStructureRow(
+			sovereigntyHub,
+			systemRow ?? null,
+			geographyBySystemId[sovereigntyHub.systemId] ?? null
+		)
+		const structureTab = getStructureTab(syntheticStructure)
+		if (!hasStructureAccessForTab(access, sovereigntyHub.corporationId, structureTab)) {
+			return null
+		}
+
+		const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, sovereigntyHub.corporationId, structureTab)
+		const canEdit = user.is_admin || canEditStructure(access, sovereigntyHub.corporationId, structureTab)
+
+		const [tabData, inventoryBays, fittingItems] = await Promise.all([
+			loadStructureTabDetailData(db, syntheticStructure),
+			loadStructureInventoryDetailData(db, syntheticStructure),
+			loadStructureFittingDetailData(env, syntheticStructure),
+		])
+
+		return {
+			structure: syntheticStructure,
+			corporationName: corporation?.name ?? sovereigntyHub.corporationId,
+			includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
+			config: null,
+			canViewSensitive,
+			canEdit,
+			tabData: {
+				...(tabData ?? {}),
+				inventoryBays,
+			},
+			fittingItems,
+			lastRefilledAt: null,
+			fuelUsage: null,
+		}
 	}
 
 	const config = await db.query.structureConfigs.findFirst({
@@ -1728,6 +1903,174 @@ async function loadVisibleStructureContexts(
 	}
 }
 
+async function loadVisibleSovereigntyHubContexts(
+	env: Env,
+	db: DbClient<DbSchema>,
+	user: SessionUser,
+	query: StructureSovereigntyListQuery
+): Promise<{
+	moduleConfig: StructureModuleConfigResult
+	access: StructureAccessScope
+	contexts: VisibleStructureContext[]
+	hubRows: Array<typeof structureSovereigntyHubs.$inferSelect>
+	systemRows: Array<typeof structureSovereigntySystems.$inferSelect>
+}> {
+	const moduleConfig = await getStructureModuleConfig(db)
+	const access = computeStructureAccess(user.roles, user.is_admin)
+	const accessForTab = getStructureAccessTarget(access, 'sovereignty')
+	if (!hasAnyStructureAccess(accessForTab)) {
+		return {
+			moduleConfig,
+			access,
+			contexts: [],
+			hubRows: [],
+			systemRows: [],
+		}
+	}
+
+	const accessibleCorporations = getAccessibleCorporationIds(access, 'sovereignty')
+	if (!accessibleCorporations.hasGlobalAccess && accessibleCorporations.corporationIds.size === 0) {
+		return {
+			moduleConfig,
+			access,
+			contexts: [],
+			hubRows: [],
+			systemRows: [],
+		}
+	}
+
+	if (query.state && query.state !== 'online') {
+		return {
+			moduleConfig,
+			access,
+			contexts: [],
+			hubRows: [],
+			systemRows: [],
+		}
+	}
+
+	if (query.lowPower === 'true' || query.lowPowerAllowed === 'true') {
+		return {
+			moduleConfig,
+			access,
+			contexts: [],
+			hubRows: [],
+			systemRows: [],
+		}
+	}
+
+	if (query.assignedGroupId && query.assignedGroupId !== '__unassigned__') {
+		return {
+			moduleConfig,
+			access,
+			contexts: [],
+			hubRows: [],
+			systemRows: [],
+		}
+	}
+
+	const corpWhere = (() => {
+		const conditions: StructureWhereCondition[] = []
+		if (query.corporationId) {
+			conditions.push(eq(structureSovereigntyHubs.corporationId, query.corporationId))
+		}
+		if (!accessibleCorporations.hasGlobalAccess) {
+			conditions.push(inArray(structureSovereigntyHubs.corporationId, [...accessibleCorporations.corporationIds]))
+		}
+		if (query.systemId) {
+			conditions.push(eq(structureSovereigntyHubs.systemId, query.systemId))
+		}
+		if (query.typeId) {
+			conditions.push(eq(structureSovereigntyHubs.typeId, query.typeId))
+		}
+		return combineWhereConditions(conditions)
+	})()
+
+	const hubRows = await db.query.structureSovereigntyHubs.findMany({
+		where: corpWhere,
+		orderBy: desc(structureSovereigntyHubs.updatedAt),
+	})
+	if (hubRows.length === 0) {
+		return {
+			moduleConfig,
+			access,
+			contexts: [],
+			hubRows,
+			systemRows: [],
+		}
+	}
+
+	const geographyBySystemId = await resolveSovereigntyHubGeographies(
+		env,
+		[...new Set(hubRows.map((hub) => hub.systemId))]
+	)
+	const hubStructureIds = hubRows.map((hub) => hub.structureId)
+	const systemRows = await db.query.structureSovereigntySystems.findMany({
+		where: combineWhereConditions([
+			inArray(structureSovereigntySystems.sovereigntyHubStructureId, hubStructureIds),
+			query.allianceId ? eq(structureSovereigntySystems.allianceId, query.allianceId) : undefined,
+		]),
+		orderBy: desc(structureSovereigntySystems.updatedAt),
+	})
+	const systemByHubStructureId = new Map(
+		systemRows
+			.filter((row): row is typeof structureSovereigntySystems.$inferSelect & { sovereigntyHubStructureId: string } =>
+				Boolean(row.sovereigntyHubStructureId)
+			)
+			.map((row) => [row.sovereigntyHubStructureId, row])
+	)
+	const corporationIds = [...new Set(hubRows.map((hub) => hub.corporationId))]
+	const corporationRows = corporationIds.length
+		? await db.query.managedCorporations.findMany({
+				where: inArray(managedCorporations.corporationId, corporationIds),
+				columns: {
+					corporationId: true,
+					name: true,
+					includeInStructureAssetSync: true,
+				},
+			})
+		: []
+	const corporationById = new Map(corporationRows.map((row) => [row.corporationId, row] as const))
+
+	return {
+		moduleConfig,
+		access,
+		contexts: hubRows
+			.map<VisibleStructureContext | null>((hub) => {
+				const systemRow = systemByHubStructureId.get(hub.structureId) ?? null
+				const geography = geographyBySystemId[hub.systemId] ?? null
+				const structure = buildSyntheticSovereigntyStructureRow(hub, systemRow, geography)
+				const structureTab = getStructureTab(structure)
+				const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, hub.corporationId, structureTab)
+				const canEdit = user.is_admin || canEditStructure(access, hub.corporationId, structureTab)
+				const corporation = corporationById.get(hub.corporationId)
+
+				return {
+					structure,
+					corporationName: corporation?.name ?? hub.corporationId,
+					includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
+					config: null,
+					canViewSensitive,
+					canEdit,
+					tabData: null,
+					fittingItems: null,
+					lastRefilledAt: null,
+					fuelUsage: null,
+				}
+			})
+			.filter((item): item is VisibleStructureContext => item !== null)
+			.filter((context) => {
+				if (query.regionId && context.structure.regionId !== query.regionId) return false
+				if (query.systemId && context.structure.systemId !== query.systemId) return false
+				if (query.lowPower === 'false' && context.structure.lowPower) return false
+				if (query.lowPowerAllowed === 'false' && context.config?.lowPowerAllowed) return false
+				return true
+			}),
+		hubRows,
+		systemRows,
+	}
+}
+
 async function listVisibleOperationalStructures(
 	db: DbClient<DbSchema>,
 	user: SessionUser,
@@ -1883,8 +2226,8 @@ function buildSovereigntyListItem(input: {
 }): StructureSovereigntyListItem {
 	const { context, systemRow, hubRow } = input
 	const { structure: structureRow, corporationName, canViewSensitive, canEdit } = context
-	const hasSystemSnapshot = systemRow !== null
-	const lastSyncedAt = systemRow?.lastSyncedAt ?? hubRow?.lastSyncedAt ?? structureRow.lastSyncedAt ?? null
+	const hasHubSnapshot = hubRow !== null
+	const lastSyncedAt = hubRow?.lastSyncedAt ?? systemRow?.lastSyncedAt ?? structureRow.lastSyncedAt ?? null
 	const sourceUpdatedAt = systemRow?.updatedAt ?? hubRow?.updatedAt ?? structureRow.updatedAt
 
 	const hubSummary = hubRow ? summarizeStructureSovereigntyHub(hubRow) : null
@@ -1929,10 +2272,10 @@ function buildSovereigntyListItem(input: {
 		resourceWorkforceAllocated: hubSummary?.resourceWorkforceAllocated ?? 0,
 		resourceWorkforceAvailable: hubSummary?.resourceWorkforceAvailable ?? 0,
 		upgradeCount: hubSummary?.upgradeCount ?? 0,
-		syncStatus: hasSystemSnapshot ? getSnapshotSyncStatus(lastSyncedAt) : 'warning',
-		syncFailureReason: hasSystemSnapshot
+		syncStatus: hasHubSnapshot ? getSnapshotSyncStatus(lastSyncedAt) : 'warning',
+		syncFailureReason: hasHubSnapshot
 			? null
-			: 'Sovereignty snapshot has not been ingested yet for this structure.',
+			: 'Sovereignty hub snapshot has not been ingested yet for this structure.',
 		lastSyncedAt: toIso(lastSyncedAt),
 		updatedAt: sourceUpdatedAt ? sourceUpdatedAt.toISOString() : structureRow.updatedAt.toISOString(),
 		canViewSensitive,
@@ -2010,23 +2353,18 @@ function buildMiningListItem(input: {
 }
 
 export async function listSovereigntyStructures(
+	env: Env,
 	db: DbClient<DbSchema>,
 	user: SessionUser,
 	query: StructureSovereigntyListQuery = {}
 ): Promise<StructureListResponse<StructureSovereigntyListItem>> {
-	const { moduleConfig, contexts, access } = await loadVisibleStructureContexts(db, user, {
-		corporationId: query.corporationId,
-		assignedGroupId: query.assignedGroupId,
-		lowPower: query.lowPower,
-		lowPowerAllowed: query.lowPowerAllowed,
-		regionId: query.regionId,
-		systemId: query.systemId,
-		state: query.state,
-		typeId: query.typeId,
-	})
-
-	const accessForTab = getStructureAccessTarget(access, 'sovereignty')
-	if (!hasAnyStructureAccess(accessForTab)) {
+	const { moduleConfig, contexts, access, hubRows, systemRows } = await loadVisibleSovereigntyHubContexts(
+		env,
+		db,
+		user,
+		query
+	)
+	if (!hasAnyStructureAccess(getStructureAccessTarget(access, 'sovereignty'))) {
 		return {
 			items: [],
 			pagination: {
@@ -2047,70 +2385,28 @@ export async function listSovereigntyStructures(
 		}
 	}
 
-	const sovereigntyContexts = contexts.filter((context) => getStructureTab(context.structure) === 'sovereignty')
-	const structureIds = sovereigntyContexts.map((context) => context.structure.structureId)
-
-	if (structureIds.length === 0) {
-		return {
-			items: [],
-			pagination: {
-				page: 1,
-				pageSize: query.pageSize ?? 25,
-				totalCount: 0,
-				totalPages: 1,
-				hasNextPage: false,
-				hasPreviousPage: false,
-			},
-			filterOptions: emptyStructureFilterOptions(),
-			summary: {
-				total: 0,
-				lowFuel: 0,
-				lowPower: 0,
-				reinforced: 0,
-			},
-		}
-	}
-
-	const systemWhere = (() => {
-		const conditions: StructureWhereCondition[] = []
-		if (query.allianceId) {
-			conditions.push(eq(structureSovereigntySystems.allianceId, query.allianceId))
-		}
-		return combineWhereConditions(conditions)
-	})()
-
-	const systemRows = await db.query.structureSovereigntySystems.findMany({
-		where: combineWhereConditions([
-			inArray(structureSovereigntySystems.sovereigntyHubStructureId, structureIds),
-			systemWhere,
-		]),
-		orderBy: desc(structureSovereigntySystems.updatedAt),
-	})
+	const hubById = new Map(hubRows.map((row) => [row.structureId, row] as const))
 	const systemByHubStructureId = new Map(
 		systemRows
 			.filter((row): row is typeof structureSovereigntySystems.$inferSelect & { sovereigntyHubStructureId: string } =>
 				Boolean(row.sovereigntyHubStructureId)
 			)
-			.map((row) => [row.sovereigntyHubStructureId, row])
+			.map((row) => [row.sovereigntyHubStructureId, row] as const)
 	)
-	const hubRows = await db.query.structureSovereigntyHubs.findMany({
-		where: inArray(structureSovereigntyHubs.structureId, structureIds),
-	})
-	const hubById = new Map(hubRows.map((row) => [row.structureId, row]))
-
-	const items = sovereigntyContexts.map((context) => {
-		const systemRow = systemByHubStructureId.get(context.structure.structureId) ?? null
-		const hubRow = hubById.get(context.structure.structureId) ?? null
-		return buildSovereigntyListItem({
+	const items = contexts.map((context) =>
+		buildSovereigntyListItem({
 			context,
-			systemRow,
-			hubRow,
+			systemRow: systemByHubStructureId.get(context.structure.structureId) ?? null,
+			hubRow: hubById.get(context.structure.structureId) ?? null,
 		})
-	})
+	)
+	const filteredItems = query.allianceId
+		? items.filter((item) => item.allianceId === query.allianceId)
+		: items
 
 	const sortBy = query.sortBy ?? 'fuel'
 	const sortDirection = query.sortDirection ?? 'asc'
-	const sortedItems = sortStructures(items, sortBy, sortDirection)
+	const sortedItems = sortStructures(filteredItems, sortBy, sortDirection)
 	const pageSize = Math.min(Math.max(query.pageSize ?? 25, 1), STRUCTURE_LIST_PAGE_SIZE_MAX)
 	const totalCount = sortedItems.length
 	const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
@@ -2128,8 +2424,8 @@ export async function listSovereigntyStructures(
 			hasNextPage: page < totalPages,
 			hasPreviousPage: page > 1,
 		},
-		filterOptions: buildStructureFilterOptions(items),
-		summary: buildStructureSummary(items, moduleConfig),
+		filterOptions: buildStructureFilterOptions(filteredItems),
+		summary: buildStructureSummary(filteredItems, moduleConfig),
 	}
 }
 
@@ -2493,14 +2789,6 @@ export async function syncCorporationStructures(
 			newState: structure.state,
 			detectedAt: now,
 			sourceSyncAt: structure.lastSyncedAt ?? now,
-			rawPayload: {
-				structureId: structure.structureId,
-				corporationId,
-				name: structure.name,
-				systemId: structure.systemId,
-				state: structure.state,
-				previousState: previous.state,
-			},
 		})
 	}
 

--- a/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
+++ b/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+	const getStubMock = vi.fn()
+	return { getStubMock }
+})
+
+vi.mock('@repo/hono-helpers', () => ({
+	logger: {
+		debug: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	},
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: mocks.getStubMock,
+}))
+
+import { getVisibleStructureDetail, listSovereigntyStructures } from '../../../services/structures.service'
+
+function makeDb() {
+	const corporationStructures = {
+		findFirst: vi.fn().mockResolvedValue(null),
+		findMany: vi.fn().mockResolvedValue([]),
+	}
+	const structureModuleConfig = {
+		findFirst: vi.fn().mockResolvedValue({
+			id: 'default',
+			lowFuelTimeThresholdHours: 12,
+			criticalFuelTimeThresholdHours: 4,
+			lowFuelAmountThreshold: 0,
+			criticalFuelAmountThreshold: 0,
+			updatedBy: null,
+			createdAt: new Date('2026-01-01T00:00:00Z'),
+			updatedAt: new Date('2026-01-01T00:00:00Z'),
+		}),
+	}
+	const structureConfigs = {
+		findFirst: vi.fn().mockResolvedValue(null),
+	}
+	const managedCorporations = {
+		findMany: vi.fn().mockResolvedValue([
+			{
+				corporationId: 'corp-1',
+				name: 'Test Corp',
+				includeInStructureAssetSync: true,
+			},
+		]),
+		findFirst: vi.fn().mockResolvedValue({
+			corporationId: 'corp-1',
+			name: 'Test Corp',
+			includeInStructureAssetSync: true,
+		}),
+	}
+	const universeStub = {
+		resolveSolarSystemsByIds: vi.fn().mockResolvedValue({
+			'30000142': {
+				solarSystemId: '30000142',
+				solarSystemName: 'Jita',
+				regionId: '10000002',
+				constellationId: '20000020',
+				securityStatus: '0.9',
+			},
+		}),
+		resolveRegionsByIds: vi.fn().mockResolvedValue({
+			10000002: {
+				regionId: '10000002',
+				regionName: 'The Forge',
+			},
+		}),
+	}
+	const corporationStructureInventory = {
+		findMany: vi.fn().mockResolvedValue([]),
+	}
+	const structureSovereigntyHubs = {
+		findMany: vi.fn().mockResolvedValue([
+			{
+				structureId: 'hub-1',
+				corporationId: 'corp-1',
+				systemId: '30000142',
+				systemName: 'Jita',
+				name: 'Jita Hub',
+				typeId: '32458',
+				fuelAccessListId: null,
+				controllerAllianceId: 'alliance-1',
+				reagentBayLastUpdated: new Date('2026-07-12T19:36:46.834Z'),
+				reagentBay: {
+					lastUpdated: '2026-07-12T19:36:46.834Z',
+					reagents: [
+						{
+							typeId: '81144',
+							securedStock: 10,
+							unsecuredStock: 5,
+							lastCycle: '2026-07-12T19:00:00Z',
+						},
+					],
+				},
+				resources: {
+					power: { allocated: 100, available: 200 },
+					workforce: { allocated: 300, available: 400 },
+				},
+				upgrades: [
+					{
+						typeId: '87710',
+						powerState: 'Online',
+					},
+				],
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				workforceTransport: {},
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		]),
+		findFirst: vi.fn().mockResolvedValue({
+			structureId: 'hub-1',
+			corporationId: 'corp-1',
+			systemId: '30000142',
+			systemName: 'Jita',
+			name: 'Jita Hub',
+			typeId: '32458',
+			fuelAccessListId: null,
+			controllerAllianceId: 'alliance-1',
+			reagentBayLastUpdated: new Date('2026-07-12T19:36:46.834Z'),
+			reagentBay: {
+				lastUpdated: '2026-07-12T19:36:46.834Z',
+				reagents: [],
+			},
+			resources: {
+				power: { allocated: 0, available: 0 },
+				workforce: { allocated: 0, available: 0 },
+			},
+			upgrades: [],
+			vulnerabilityWindowStart: null,
+			vulnerabilityWindowEnd: null,
+			workforceTransport: {},
+			sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+			lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+			updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+		}),
+	}
+	const structureSovereigntySystems = {
+		findMany: vi.fn().mockResolvedValue([
+			{
+				systemId: '30000142',
+				systemName: 'Jita',
+				corporationId: 'corp-1',
+				claimType: 'alliance',
+				allianceId: 'alliance-1',
+				corporationClaimantId: null,
+				factionId: null,
+				claimedSince: new Date('2026-07-12T18:00:00Z'),
+				sovereigntyHubStructureId: 'hub-1',
+				isCapitalSystem: false,
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				activityDefenseMultiplier: '1.2',
+				militaryLevel: 2,
+				industrialLevel: 3,
+				strategicLevel: 4,
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		]),
+		findFirst: vi.fn().mockResolvedValue({
+			systemId: '30000142',
+			systemName: 'Jita',
+			corporationId: 'corp-1',
+			claimType: 'alliance',
+			allianceId: 'alliance-1',
+			corporationClaimantId: null,
+			factionId: null,
+			claimedSince: new Date('2026-07-12T18:00:00Z'),
+			sovereigntyHubStructureId: 'hub-1',
+			isCapitalSystem: false,
+			vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+			vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+			activityDefenseMultiplier: '1.2',
+			militaryLevel: 2,
+			industrialLevel: 3,
+			strategicLevel: 4,
+			sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+			lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+			updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+		}),
+	}
+
+	return {
+		universeStub,
+		query: {
+			corporationStructures,
+			structureModuleConfig,
+			structureConfigs,
+			managedCorporations,
+			corporationStructureInventory,
+			structureSovereigntyHubs,
+			structureSovereigntySystems,
+		},
+	}
+}
+
+describe('sovereignty hub model', () => {
+	it('lists sovereignty hubs without requiring corporation structures rows', async () => {
+		const db = makeDb()
+		mocks.getStubMock.mockReturnValue(db.universeStub)
+
+		const result = await listSovereigntyStructures(
+			{
+				UNIVERSE: {} as never,
+			} as never,
+			db as never,
+			{
+				id: 'user-1',
+				is_admin: true,
+				roles: [],
+			}
+		)
+
+		expect(mocks.getStubMock).toHaveBeenCalledWith({}, 'default')
+		expect(db.query.corporationStructures.findMany).not.toHaveBeenCalled()
+		expect(result.items).toHaveLength(1)
+		expect(result.items[0]).toMatchObject({
+			structureId: 'hub-1',
+			corporationId: 'corp-1',
+			corporationName: 'Test Corp',
+			typeId: '32458',
+			typeName: 'Sovereignty Hub',
+			systemId: '30000142',
+			systemName: 'Jita',
+			regionId: '10000002',
+			regionName: 'The Forge',
+			claimType: 'alliance',
+			sovereigntyHubStructureId: 'hub-1',
+			controllerAllianceId: 'alliance-1',
+		})
+	})
+
+	it('filters sovereignty hubs by region using universe geography', async () => {
+		const db = makeDb()
+		mocks.getStubMock.mockReturnValue(db.universeStub)
+
+		const result = await listSovereigntyStructures(
+			{
+				UNIVERSE: {} as never,
+			} as never,
+			db as never,
+			{
+				id: 'user-1',
+				is_admin: true,
+				roles: [],
+			},
+			{
+				regionId: '10000002',
+			}
+		)
+
+		expect(result.items).toHaveLength(1)
+		expect(result.items[0]?.regionId).toBe('10000002')
+	})
+
+	it('loads sovereignty hub details even when the base structure row is absent', async () => {
+		const db = makeDb()
+		mocks.getStubMock.mockReturnValue(db.universeStub)
+
+		const result = await getVisibleStructureDetail(
+			{
+				UNIVERSE: {} as never,
+				EVE_CORPORATION_DATA: {} as never,
+			} as never,
+			db as never,
+			{
+				id: 'user-1',
+				is_admin: true,
+				roles: [],
+			},
+			'hub-1'
+		)
+
+		expect(result).not.toBeNull()
+		expect(result).toMatchObject({
+			structureId: 'hub-1',
+			corporationId: 'corp-1',
+			name: 'Jita Hub',
+			typeId: '32458',
+			typeName: 'Sovereignty Hub',
+			systemId: '30000142',
+			systemName: 'Jita',
+			regionId: '10000002',
+			regionName: 'The Forge',
+		})
+		expect(result?.sovereignty).toMatchObject({
+			claimType: 'alliance',
+			sovereigntyHubStructureId: 'hub-1',
+			controllerAllianceId: 'alliance-1',
+		})
+		expect(result?.sovereignty?.hub).toMatchObject({
+			reagentCount: 1,
+			resourcePowerAllocated: 100,
+			resourceWorkforceAllocated: 300,
+			upgradeCount: 1,
+		})
+	})
+})

--- a/apps/structures/wrangler.jsonc
+++ b/apps/structures/wrangler.jsonc
@@ -25,6 +25,11 @@
 				"name": "EVE_CORPORATION_DATA",
 				"class_name": "EveCorporationData",
 				"script_name": "eve-corporation-data"
+			},
+			{
+				"name": "UNIVERSE",
+				"class_name": "Universe",
+				"script_name": "universe"
 			}
 		]
 	}

--- a/apps/ui/src/client/components/inventory-bays-table.tsx
+++ b/apps/ui/src/client/components/inventory-bays-table.tsx
@@ -22,6 +22,7 @@ export interface InventoryBaysTableProps {
 	searchPlaceholder?: string
 	className?: string
 	renderItemIcon?: (item: InventoryDisplayItem) => ReactNode
+	renderItemDetails?: (item: InventoryDisplayItem) => ReactNode
 }
 
 function formatCount(value: number): string {
@@ -34,6 +35,7 @@ export function InventoryBaysTable({
 	searchPlaceholder = 'Search inventory bays...',
 	className,
 	renderItemIcon,
+	renderItemDetails,
 }: InventoryBaysTableProps) {
 	const [search, setSearch] = useState('')
 	const [expandedBays, setExpandedBays] = useState<Set<string>>(new Set())
@@ -170,8 +172,8 @@ export function InventoryBaysTable({
 											<TableCell className="text-right font-mono">{formatCount(bay.totalStacks)}</TableCell>
 											<TableCell className="text-right font-mono">{formatCount(bay.totalQuantity)}</TableCell>
 										</TableRow>
-										{isExpanded ? (
-											<TableRow className="bg-muted/20">
+											{isExpanded ? (
+												<TableRow className="bg-muted/20">
 												<TableCell colSpan={3} className="px-0 py-0">
 													<div className="border-l-2 border-muted px-4 py-3">
 														<Table>
@@ -186,16 +188,21 @@ export function InventoryBaysTable({
 																{bay.items.length > 0 ? (
 																	bay.items.map((item) => (
 																		<TableRow key={`${bay.locationFlag}-${item.typeId}`}>
-																			<TableCell>
-																				<div className="flex items-start gap-2">
-																					{renderItemIcon ? (
-																						<div className="mt-0.5 shrink-0">{renderItemIcon(item)}</div>
-																					) : null}
-																					<div className="min-w-0">
-																						<div className="font-medium">{item.typeName ?? item.typeId}</div>
+																				<TableCell>
+																					<div className="flex items-start gap-2">
+																						{renderItemIcon ? (
+																							<div className="mt-0.5 shrink-0">{renderItemIcon(item)}</div>
+																						) : null}
+																						<div className="min-w-0">
+																							<div className="font-medium">{item.typeName ?? item.typeId}</div>
+																							{renderItemDetails ? (
+																								<div className="text-xs text-muted-foreground">
+																									{renderItemDetails(item)}
+																								</div>
+																							) : null}
+																						</div>
 																					</div>
-																				</div>
-																			</TableCell>
+																				</TableCell>
 																			<TableCell className="text-right font-mono">{formatCount(item.quantity)}</TableCell>
 																			<TableCell className="text-right font-mono">{formatCount(item.stackCount)}</TableCell>
 																		</TableRow>

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -806,6 +806,33 @@ export interface StructureSovereigntyHubSummary {
 	controllerAllianceId: string | null
 	reagentBayLastUpdated: string | null
 	reagentCount: number
+	reagentBay: {
+		lastUpdated: string
+		reagents: Array<{
+			typeId: string
+			securedStock: number
+			unsecuredStock: number
+			lastCycle: string
+		}>
+	}
+	resources: {
+		power: {
+			allocated: number
+			available: number
+		}
+		workforce: {
+			allocated: number
+			available: number
+		}
+	}
+	upgrades: Array<{
+		typeId: string
+		powerState: string
+	}>
+	workforceTransport: {
+		configuration: Record<string, unknown>
+		state: Record<string, unknown>
+	}
 	totalSecuredStock: number
 	totalUnsecuredStock: number
 	resourcePowerAllocated: number

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -21,9 +21,11 @@ import { useAuth } from '@/hooks/useAuth'
 import { useGroups } from '@/hooks/useGroups'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
+import { useSystemDetails } from '@/hooks/useLocationSearch'
 import { InventoryBaysTable } from '@/components/inventory-bays-table'
 import { CorporationLogo } from '@/components/corporation-logo'
 import { StructureFuelUsageChart } from '@/components/structure-fuel-usage-chart'
+import { Skeleton } from '@/components/ui/skeleton'
 import { FittingPanel } from '@repo/eve-fitting/fitting-panel'
 import { FittingSlotTable } from '@repo/eve-fitting/fitting-slot-table'
 import type { FittingDisplayItem, FittingShipSlotType } from '@repo/eve-fitting/flags'
@@ -31,6 +33,7 @@ import {
 	api,
 	type StructureAssetsDebugResult,
 	type StructureDetailResult,
+	type StructureInventoryBay,
 } from '@/lib/api'
 import { typeIconUrl, typeImageUrl, typeRenderUrl } from '@/lib/eve-images'
 import { formatDateTimeLong } from '@/lib/date-utils'
@@ -138,6 +141,176 @@ function formatNullableNumber(value: number | null | undefined): string {
 function formatBurnRate(value: number | null | undefined): string {
 	if (value === null || value === undefined) return '-'
 	return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}/hr`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+type WorkforceTransportSource = {
+	solarSystemId: string
+	amount: number | null
+}
+
+type ParsedWorkforceTransportSection =
+	| {
+			mode: 'import' | 'export'
+			sources: WorkforceTransportSource[]
+	  }
+	| {
+			mode: 'transit'
+			sources: []
+	  }
+	| {
+			mode: 'unknown'
+			sources: []
+	  }
+
+function parseWorkforceTransportSources(value: unknown): WorkforceTransportSource[] {
+	if (!Array.isArray(value)) {
+		return []
+	}
+
+	return value.flatMap((entry) => {
+		if (!isRecord(entry)) {
+			return []
+		}
+
+		const sourceId = entry.solar_system_id ?? entry.solarSystemId
+		if (sourceId === null || sourceId === undefined) {
+			return []
+		}
+
+		const amount =
+			typeof entry.amount === 'number'
+				? entry.amount
+				: typeof entry.amount === 'string' && entry.amount.trim() !== '' && Number.isFinite(Number(entry.amount))
+					? Number(entry.amount)
+					: null
+		return [
+			{
+				solarSystemId: String(sourceId),
+				amount,
+			},
+		]
+	})
+}
+
+function parseWorkforceTransportSection(section: unknown): ParsedWorkforceTransportSection {
+	if (!isRecord(section)) {
+		return { mode: 'unknown', sources: [] }
+	}
+
+	if ('import' in section && isRecord(section.import)) {
+		return {
+			mode: 'import',
+			sources: parseWorkforceTransportSources(section.import.sources),
+		}
+	}
+
+	if ('export' in section && isRecord(section.export)) {
+		return {
+			mode: 'export',
+			sources: parseWorkforceTransportSources(section.export.sources),
+		}
+	}
+
+	if (section.transit === true) {
+		return { mode: 'transit', sources: [] }
+	}
+
+	return { mode: 'unknown', sources: [] }
+}
+
+function formatWorkforceTransportMode(mode: ParsedWorkforceTransportSection['mode']): string {
+	switch (mode) {
+		case 'import':
+			return 'Import'
+		case 'export':
+			return 'Export'
+		case 'transit':
+			return 'Transit'
+		default:
+			return 'Unrecognized'
+	}
+}
+
+function workforceTransportBadgeVariant(mode: ParsedWorkforceTransportSection['mode']): BadgeVariant {
+	return mode === 'unknown' ? 'ghost' : 'success'
+}
+
+function WorkforceTransportSystemName({ systemId }: { systemId: string }) {
+	const { data: systemDetails, isLoading } = useSystemDetails(systemId)
+
+	if (isLoading) {
+		return <Skeleton className="h-8 w-32" />
+	}
+
+	return (
+		<div className="space-y-0.5">
+			<div className="font-medium">{systemDetails?.name ?? systemId}</div>
+			<div className="text-xs text-muted-foreground">System ID {systemId}</div>
+		</div>
+	)
+}
+
+function WorkforceTransportSection({
+	label,
+	section,
+}: {
+	label: string
+	section: Record<string, unknown> | null | undefined
+}) {
+	const parsed = parseWorkforceTransportSection(section)
+
+	return (
+		<div className="rounded-lg border border-border/60 bg-muted/20 p-4">
+			<div className="flex items-start justify-between gap-3">
+				<div>
+					<div className="font-medium">{label}</div>
+					<div className="text-xs text-muted-foreground">
+						{parsed.mode === 'transit'
+							? 'This hub is configured for transit routing.'
+							: parsed.mode === 'unknown'
+								? 'No recognizable workforce transport configuration was recorded.'
+								: `This hub is configured for ${formatWorkforceTransportMode(parsed.mode).toLowerCase()} routing.`}
+					</div>
+				</div>
+				<Badge variant={workforceTransportBadgeVariant(parsed.mode)}>
+					{formatWorkforceTransportMode(parsed.mode)}
+				</Badge>
+			</div>
+
+			{parsed.mode !== 'unknown' && parsed.sources.length > 0 ? (
+				<div className="mt-4 overflow-hidden rounded-md border border-border/60 bg-background">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Source System</TableHead>
+								<TableHead>Amount</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{parsed.sources.map((source) => (
+								<TableRow key={`${label}-${source.solarSystemId}`}>
+									<TableCell>
+										<WorkforceTransportSystemName systemId={source.solarSystemId} />
+									</TableCell>
+									<TableCell>{formatNullableNumber(source.amount)}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			) : (
+				<div className="mt-4 rounded-md border border-dashed border-border/60 bg-background px-3 py-2 text-sm text-muted-foreground">
+					{parsed.mode === 'transit'
+						? 'Transit mode does not list source systems.'
+						: 'No source systems recorded.'}
+				</div>
+			)}
+		</div>
+	)
 }
 
 function InventoryItemIcon({ typeId }: { typeId: string }) {
@@ -302,6 +475,41 @@ export default function StructuresDetailPage() {
 	const hasSovereigntySummary = structureFamily === 'sovereignty' && structure.sovereignty
 	const hasSkyhookSummary = structureFamily === 'skyhooks' && structure.skyhook
 	const hasMiningSummary = structureFamily === 'mining-citadels'
+	type SovereigntyReagent = NonNullable<NonNullable<StructureDetailResult['sovereignty']>['hub']>['reagentBay']['reagents'][number]
+	const sovereigntyReagentBays = useMemo<StructureInventoryBay[]>(() => {
+		const hub = structure.sovereignty?.hub
+		if (!hub) {
+			return []
+		}
+
+		const totalQuantity = hub.reagentBay.reagents.reduce(
+			(accumulator, reagent) => accumulator + reagent.securedStock + reagent.unsecuredStock,
+			0
+		)
+
+		return [
+			{
+				locationFlag: 'SovereigntyReagentBay',
+				label: 'Reagent Bay',
+				totalQuantity,
+				totalStacks: hub.reagentBay.reagents.length,
+				items: hub.reagentBay.reagents.map((reagent) => ({
+					typeId: reagent.typeId,
+					typeName: null,
+					quantity: reagent.securedStock + reagent.unsecuredStock,
+					stackCount: 1,
+				})),
+			},
+		]
+	}, [structure.sovereignty?.hub])
+	const sovereigntyReagentDetailsByTypeId = useMemo(() => {
+		const hub = structure.sovereignty?.hub
+		if (!hub) {
+			return new Map<string, SovereigntyReagent>()
+		}
+
+		return new Map(hub.reagentBay.reagents.map((reagent) => [reagent.typeId, reagent] as const))
+	}, [structure.sovereignty?.hub])
 
 	const handleSave = async () => {
 		await updateMutation.mutateAsync({
@@ -563,57 +771,218 @@ export default function StructuresDetailPage() {
 			</div>
 
 			{hasSovereigntySummary && (
-				<Card>
-					<CardHeader>
-						<CardTitle>Sovereignty State</CardTitle>
-						<CardDescription>System ownership and hub snapshot for this sovereignty structure.</CardDescription>
-					</CardHeader>
-					<CardContent className="grid gap-4 md:grid-cols-2 text-sm">
-						<div>
-							<div className="text-muted-foreground">Activity Defense Multiplier</div>
-							<div className="font-medium">
-								{structure.sovereignty?.activityDefenseMultiplier ?? '-'}
+				<div className="space-y-4">
+					<Card>
+						<CardHeader>
+							<CardTitle>Sovereignty State</CardTitle>
+							<CardDescription>
+								System ownership and the currently linked sovereignty hub snapshot.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="grid gap-4 md:grid-cols-2 text-sm">
+							<div>
+								<div className="text-muted-foreground">Activity Defense Multiplier</div>
+								<div className="font-medium">
+									{structure.sovereignty?.activityDefenseMultiplier ?? '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Claimed Since</div>
-							<div className="font-medium">{formatNullableDateTime(structure.sovereignty?.claimedSince)}</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Capital System</div>
-							<div className="font-medium">{structure.sovereignty?.isCapitalSystem ? 'Yes' : 'No'}</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Sovereignty Hub</div>
-							<div className="font-medium">
-								{structure.sovereignty?.sovereigntyHubStructureId ?? '-'}
+							<div>
+								<div className="text-muted-foreground">Claimed Since</div>
+								<div className="font-medium">{formatNullableDateTime(structure.sovereignty?.claimedSince)}</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Controller Alliance</div>
-							<div className="font-medium">
-								{structure.sovereignty?.hub?.controllerAllianceId ?? '-'}
+							<div>
+								<div className="text-muted-foreground">Capital System</div>
+								<div className="font-medium">{structure.sovereignty?.isCapitalSystem ? 'Yes' : 'No'}</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Vulnerability Window</div>
-							<div className="font-medium">
-								{structure.sovereignty?.vulnerabilityWindowStart &&
-								structure.sovereignty?.vulnerabilityWindowEnd
-									? `${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowStart)} - ${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowEnd)}`
-									: formatNullableDateTime(structure.sovereignty?.vulnerabilityWindowEnd)}
+							<div>
+								<div className="text-muted-foreground">Sovereignty Hub</div>
+								<div className="font-medium">
+									{structure.sovereignty?.sovereigntyHubStructureId ?? '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Hub Resources</div>
-							<div className="font-medium">
-								{structure.sovereignty?.hub
-									? `${formatNullableNumber(structure.sovereignty.hub.resourcePowerAllocated)} / ${formatNullableNumber(structure.sovereignty.hub.resourcePowerAvailable)} power, ${formatNullableNumber(structure.sovereignty.hub.resourceWorkforceAllocated)} / ${formatNullableNumber(structure.sovereignty.hub.resourceWorkforceAvailable)} workforce`
-									: '-'}
+							<div>
+								<div className="text-muted-foreground">Controller Alliance</div>
+								<div className="font-medium">
+									{structure.sovereignty?.hub?.controllerAllianceId ?? '-'}
+								</div>
 							</div>
-						</div>
-					</CardContent>
-				</Card>
+							<div>
+								<div className="text-muted-foreground">Vulnerability Window</div>
+								<div className="font-medium">
+									{structure.sovereignty?.vulnerabilityWindowStart &&
+									structure.sovereignty?.vulnerabilityWindowEnd
+										? `${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowStart)} - ${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowEnd)}`
+										: formatNullableDateTime(structure.sovereignty?.vulnerabilityWindowEnd)}
+								</div>
+							</div>
+							<div>
+								<div className="text-muted-foreground">System Resources</div>
+								<div className="font-medium">
+									{structure.sovereignty?.hub
+										? `${formatNullableNumber(structure.sovereignty.hub.resourcePowerAllocated)} / ${formatNullableNumber(structure.sovereignty.hub.resourcePowerAvailable)} power, ${formatNullableNumber(structure.sovereignty.hub.resourceWorkforceAllocated)} / ${formatNullableNumber(structure.sovereignty.hub.resourceWorkforceAvailable)} workforce`
+										: '-'}
+								</div>
+							</div>
+							<div>
+								<div className="text-muted-foreground">Fuel Access List</div>
+								<div className="font-medium">
+									{structure.sovereignty?.hub?.fuelAccessListId ?? '-'}
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+
+						<Card>
+							<CardHeader>
+								<CardTitle>Hub Configuration</CardTitle>
+								<CardDescription>
+									Workforce transport routing and the hub's current resource allocation.
+								</CardDescription>
+							</CardHeader>
+							<CardContent className="space-y-6 text-sm">
+								<div className="grid gap-4 lg:grid-cols-2">
+									<WorkforceTransportSection
+										label="Workforce Transport Configuration"
+										section={structure.sovereignty?.hub?.workforceTransport?.configuration}
+									/>
+									<WorkforceTransportSection
+										label="Workforce Transport State"
+										section={structure.sovereignty?.hub?.workforceTransport?.state}
+									/>
+								</div>
+
+								<div className="grid gap-4 md:grid-cols-2">
+									<div className="rounded-lg border border-border/60 bg-muted/20 p-4">
+										<div className="text-xs uppercase tracking-wide text-muted-foreground">Power Allocation</div>
+										<div className="mt-2 grid grid-cols-2 gap-4">
+											<div>
+												<div className="text-muted-foreground">Allocated</div>
+												<div className="font-medium">
+													{formatNullableNumber(structure.sovereignty?.hub?.resourcePowerAllocated)}
+												</div>
+											</div>
+											<div>
+												<div className="text-muted-foreground">Available</div>
+												<div className="font-medium">
+													{formatNullableNumber(structure.sovereignty?.hub?.resourcePowerAvailable)}
+												</div>
+											</div>
+										</div>
+									</div>
+
+									<div className="rounded-lg border border-border/60 bg-muted/20 p-4">
+										<div className="text-xs uppercase tracking-wide text-muted-foreground">Workforce Allocation</div>
+										<div className="mt-2 grid grid-cols-2 gap-4">
+											<div>
+												<div className="text-muted-foreground">Allocated</div>
+												<div className="font-medium">
+													{formatNullableNumber(structure.sovereignty?.hub?.resourceWorkforceAllocated)}
+												</div>
+											</div>
+											<div>
+												<div className="text-muted-foreground">Available</div>
+												<div className="font-medium">
+													{formatNullableNumber(structure.sovereignty?.hub?.resourceWorkforceAvailable)}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+							</CardContent>
+						</Card>
+
+						<Card>
+							<CardHeader>
+								<CardTitle>Reagent Bay</CardTitle>
+								<CardDescription>
+									Current reagent bay contents and resource totals for the sovereignty hub.
+								</CardDescription>
+							</CardHeader>
+							<CardContent className="space-y-4">
+								<div className="grid gap-4 md:grid-cols-3 text-sm">
+									<div>
+										<div className="text-muted-foreground">Last Updated</div>
+									<div className="font-medium">
+										{formatNullableDateTime(structure.sovereignty?.hub?.reagentBayLastUpdated)}
+									</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">Reagent Count</div>
+									<div className="font-medium">{structure.sovereignty?.hub?.reagentCount ?? 0}</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">Stock Totals</div>
+										<div className="font-medium">
+											{structure.sovereignty?.hub
+												? `${formatNullableNumber(structure.sovereignty.hub.totalSecuredStock)} secured, ${formatNullableNumber(structure.sovereignty.hub.totalUnsecuredStock)} unsecured`
+												: '-'}
+										</div>
+									</div>
+								</div>
+								<InventoryBaysTable
+									bays={sovereigntyReagentBays}
+									emptyLabel="No reagents reported."
+									searchPlaceholder="Search reagent bay..."
+									renderItemIcon={(item) => <InventoryItemIcon typeId={item.typeId} />}
+									renderItemDetails={(item) => {
+										const reagent = sovereigntyReagentDetailsByTypeId.get(item.typeId)
+										if (!reagent) {
+											return null
+										}
+
+										return (
+											<span>
+												Secured {formatNullableNumber(reagent.securedStock)} · Unsecured{' '}
+												{formatNullableNumber(reagent.unsecuredStock)} · Last cycle{' '}
+												{formatNullableDateTime(reagent.lastCycle)}
+											</span>
+										)
+									}}
+								/>
+							</CardContent>
+						</Card>
+
+						<Card>
+							<CardHeader>
+							<CardTitle>Upgrades</CardTitle>
+							<CardDescription>
+								Installed sovereignty hub upgrades and their current power state.
+							</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+									{structure.sovereignty?.hub?.upgrades.length ? (
+										structure.sovereignty.hub.upgrades.map((upgrade) => (
+											<Card key={`${upgrade.typeId}-${upgrade.powerState}`} className="border-border/60 bg-muted/20">
+												<CardContent className="space-y-3 p-4">
+													<div className="flex items-start justify-between gap-3">
+														<div className="space-y-1">
+															<div className="text-xs uppercase tracking-wide text-muted-foreground">
+																Installed Upgrade
+															</div>
+															<div className="font-medium">{upgrade.typeId}</div>
+														</div>
+														<Badge
+															variant={upgrade.powerState.toLowerCase() === 'online' ? 'success' : 'ghost'}
+														>
+															{upgrade.powerState}
+														</Badge>
+													</div>
+													<div className="text-sm text-muted-foreground">
+														Sovereignty hub upgrade slot currently reporting this state.
+													</div>
+												</CardContent>
+											</Card>
+										))
+									) : (
+										<div className="rounded-lg border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
+											No upgrades reported.
+										</div>
+									)}
+								</div>
+							</CardContent>
+						</Card>
+				</div>
 			)}
 
 			{hasSkyhookSummary && (

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -192,7 +192,6 @@ export interface EsiSovereigntySystem {
 	military_level?: number | null
 	industrial_level?: number | null
 	strategic_level?: number | null
-	raw?: Record<string, unknown>
 }
 
 /**

--- a/packages/structures-db-schema/src/index.ts
+++ b/packages/structures-db-schema/src/index.ts
@@ -82,7 +82,6 @@ export const structureStateEvents = pgTable(
 		newState: text('new_state').notNull(),
 		detectedAt: timestamp('detected_at', { withTimezone: true }).defaultNow().notNull(),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
-		rawPayload: jsonb('raw_payload').$type<Record<string, unknown>>().notNull().default({}),
 	},
 	(table) => [
 		index('structure_state_events_structure_id_idx').on(table.structureId),
@@ -106,10 +105,7 @@ export const structureSovereigntySystems = pgTable(
 		corporationClaimantId: text('corporation_claimant_id'),
 		factionId: text('faction_id'),
 		claimedSince: timestamp('claimed_since', { withTimezone: true }),
-		sovereigntyHubStructureId: text('sovereignty_hub_structure_id').references(
-			() => corporationStructures.structureId,
-			{ onDelete: 'set null' }
-		),
+		sovereigntyHubStructureId: text('sovereignty_hub_structure_id'),
 		isCapitalSystem: boolean('is_capital_system'),
 		vulnerabilityWindowStart: timestamp('vulnerability_window_start', { withTimezone: true }),
 		vulnerabilityWindowEnd: timestamp('vulnerability_window_end', { withTimezone: true }),
@@ -122,12 +118,14 @@ export const structureSovereigntySystems = pgTable(
 		strategicLevel: integer('strategic_level'),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
-		rawPayload: jsonb('raw_payload').$type<Record<string, unknown>>().notNull().default({}),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [
 		index('structure_sovereignty_systems_corporation_id_idx').on(table.corporationId),
 		index('structure_sovereignty_systems_alliance_id_idx').on(table.allianceId),
+		index('structure_sovereignty_systems_sovereignty_hub_structure_id_idx').on(
+			table.sovereigntyHubStructureId
+		),
 		index('structure_sovereignty_systems_last_synced_at_idx').on(table.lastSyncedAt),
 	]
 )
@@ -135,9 +133,7 @@ export const structureSovereigntySystems = pgTable(
 export const structureSovereigntyHubs = pgTable(
 	'structure_sovereignty_hubs',
 	{
-		structureId: text('structure_id')
-			.primaryKey()
-			.references(() => corporationStructures.structureId, { onDelete: 'cascade' }),
+		structureId: text('structure_id').primaryKey(),
 		corporationId: text('corporation_id')
 			.notNull()
 			.references(() => managedCorporations.corporationId, { onDelete: 'cascade' }),
@@ -190,7 +186,6 @@ export const structureSovereigntyHubs = pgTable(
 		workforceTransport: jsonb('workforce_transport').$type<Record<string, unknown>>().notNull().default({}),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
-		rawPayload: jsonb('raw_payload').$type<Record<string, unknown>>().notNull().default({}),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [
@@ -239,7 +234,6 @@ export const structureSkyhookStates = pgTable(
 		lastObservedAt: timestamp('last_observed_at', { withTimezone: true }),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
-		rawPayload: jsonb('raw_payload').$type<Record<string, unknown>>().notNull().default({}),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [
@@ -272,7 +266,6 @@ export const structureMiningStates = pgTable(
 		naturalDecayTime: timestamp('natural_decay_time', { withTimezone: true }),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
-		rawPayload: jsonb('raw_payload').$type<Record<string, unknown>>().notNull().default({}),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Continues the sovereignty hub work from #508: corrects the sovereignty hub structure type ID, decouples sovereignty hub/system storage from `corporation_structures`, and surfaces full hub configuration (reagent bay, resources, upgrades, workforce transport) through the Structures API and UI.

## Changes
- **eve-corporation-data**: fixed `SOVEREIGNTY_HUB_TYPE_ID` from `35835` to `32458`; dropped `raw_payload`/`owner_id` fields from mining, skyhook, and sovereignty hub/system storage; reworked snapshot syncing (`storeSovereigntySystems`, `storeSovereigntyHubs`, `storeSkyhooks`, `storeMiningExtractions`, structure cleanup) to diff existing vs. incoming rows and delete only the departed IDs in batches instead of unconditional/`NOT IN` deletes; `storeSkyhooks` now looks up existing base structures by type ID rather than by the incoming structure ID list so departed skyhooks are still found during cleanup.
- **structures-db-schema**: dropped `raw_payload` columns from `structure_state_events`, `structure_sovereignty_systems`, `structure_sovereignty_hubs`, `structure_skyhook_states`, and `structure_mining_states`; removed the foreign keys from `structure_sovereignty_hubs.structure_id` and `structure_sovereignty_systems.sovereignty_hub_structure_id` to `corporation_structures` (hubs are no longer stored as corporation structures); added an index on `sovereignty_hub_structure_id`; new migration `0022`.
- **structures worker/service**: added a `UNIVERSE` DO binding; sovereignty listing and detail lookups now read hub/system rows directly (`loadVisibleSovereigntyHubContexts`, `buildSyntheticSovereigntyStructureRow`, `resolveSovereigntyHubGeographies`) instead of requiring a matching row in `corporation_structures`, resolving system/region names via the Universe DO; hub summaries now expose full `reagentBay`, `resources`, `upgrades`, and `workforceTransport` data.
- **ui**: `structures-detail` page renders hub configuration — workforce transport (import/export/transit), power/workforce allocation, reagent bay contents, and installed upgrades; `InventoryBaysTable` gained a `renderItemDetails` prop to support the reagent bay item details.

## Testing
- Updated unit tests for the corrected type ID and the new diff-based cleanup behavior (`structure-prune-cleanup.test.ts`, `esi-fetch.structure-enrichment.test.ts`, `structure-mining-storage.test.ts`, `structure-enrichment.test.ts`).
- Added `apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts` covering the new sovereignty hub listing/detail model.
<!-- claude:end -->