### PR TITLE
refactor sov hub UX

### DIFF
--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -1,11 +1,17 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-import { parseFittingSlotFlag } from '@repo/eve-fitting/flags'
-import { getInventoryBayLabel } from '@repo/inventory-display'
 import { getStub } from '@repo/do-utils'
+import { parseFittingSlotFlag } from '@repo/eve-fitting/flags'
 import { hasAllStructureManagerPermission } from '@repo/groups'
+import { getInventoryBayLabel } from '@repo/inventory-display'
 
+import { getCachedUserPermissions } from '../lib/groups-cache'
+import { EntityResolverService } from '../services/entity-resolver.service'
+
+import type { Context } from 'hono'
+import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { EveTokenStore } from '@repo/eve-token-store'
 import type {
 	StructureCitadelListQuery,
 	StructureMiningListQuery,
@@ -13,14 +19,12 @@ import type {
 	StructureOverviewMetrics,
 	StructureSkyhookListQuery,
 	StructureSovereigntyListQuery,
+	StructureSovereigntyListResponse,
 	UpdateStructureConfigInput,
 	UpdateStructureModuleConfigInput,
 } from '@repo/structures'
-import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { TypeMetadata, Universe } from '@repo/universe'
-import type { Context } from 'hono'
 import type { App } from '../context'
-import { getCachedUserPermissions } from '../lib/groups-cache'
 
 const app = new Hono<App>()
 
@@ -58,8 +62,13 @@ const citadelStructureListQuerySchema = structureCommonListQuerySchema
 
 const navigationStructureListQuerySchema = structureCommonListQuerySchema
 
-const sovereigntyStructureListQuerySchema = structureCommonListQuerySchema.extend({
-	allianceId: z.string().trim().min(1).optional(),
+const sovereigntyStructureListQuerySchema = structureListPagingSchema.extend({
+	corporationId: z.string().trim().min(1).optional(),
+	assignedGroupId: z.string().trim().min(1).optional(),
+	regionId: z.string().trim().min(1).optional(),
+	systemId: z.string().trim().min(1).optional(),
+	controllerAllianceId: z.string().trim().min(1).optional(),
+	vulnerabilityState: z.enum(['vulnerable', 'invulnerable', 'reinforced']).optional(),
 })
 
 const skyhookStructureListQuerySchema = structureCommonListQuerySchema.extend({
@@ -112,6 +121,27 @@ interface StructureFittingItemView {
 interface StructureDetailResponse {
 	inventoryBays?: StructureInventoryBayView[]
 	fittingItems?: StructureFittingItemView[]
+	sovereignty?: {
+		hub?: {
+			controllerAllianceId?: string | null
+			controllerAllianceName?: string | null
+			reagentBay?: {
+				lastUpdated: string
+				reagents: Array<{
+					typeId: string
+					typeName?: string | null
+					securedStock: number
+					unsecuredStock: number
+					lastCycle: string
+				}>
+			}
+			upgrades?: Array<{
+				typeId: string
+				typeName?: string | null
+				powerState: string
+			}>
+		} | null
+	} | null
 	includeInStructureAssetSync?: boolean
 	[key: string]: unknown
 }
@@ -186,24 +216,50 @@ async function enrichStructureDetailTypeNames(
 	env: App['Bindings'],
 	structure: StructureDetailResponse
 ): Promise<StructureDetailResponse> {
-	if (
-		(!structure.inventoryBays || structure.inventoryBays.length === 0) &&
-		(!structure.fittingItems || structure.fittingItems.length === 0)
-	) {
+	const sovereigntyHub = structure.sovereignty?.hub ?? null
+	const allianceIds = sovereigntyHub?.controllerAllianceId
+		? [sovereigntyHub.controllerAllianceId]
+		: []
+	const structureTypeIds = new Set<string>([
+		...(structure.inventoryBays?.flatMap((bay) => bay.items.map((item) => item.typeId)) ?? []),
+		...(structure.fittingItems?.map((item) => item.typeId) ?? []),
+		...(sovereigntyHub?.reagentBay?.reagents.map((reagent) => reagent.typeId) ?? []),
+		...(sovereigntyHub?.upgrades?.map((upgrade) => upgrade.typeId) ?? []),
+	])
+	if (structureTypeIds.size === 0 && allianceIds.length === 0) {
 		return structure
 	}
 
-	const typeIds = Array.from(
-		new Set([
-			...(structure.inventoryBays?.flatMap((bay) => bay.items.map((item) => item.typeId)) ?? []),
-			...(structure.fittingItems?.map((item) => item.typeId) ?? []),
-		])
-	)
+	const typeIds = Array.from(structureTypeIds)
 	if (typeIds.length === 0) {
-		return structure
+		const allianceNameMap =
+			allianceIds.length > 0
+				? await new EntityResolverService(
+						getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
+					).resolveEntityNames(allianceIds)
+				: new Map<string, string>()
+
+		return {
+			...structure,
+			sovereignty: sovereigntyHub
+				? {
+						...structure.sovereignty,
+						hub: {
+							...sovereigntyHub,
+							controllerAllianceName: sovereigntyHub.controllerAllianceId
+								? (allianceNameMap.get(sovereigntyHub.controllerAllianceId) ?? null)
+								: null,
+						},
+					}
+				: structure.sovereignty,
+		}
 	}
 
 	const universe = getUniverseStub(env)
+	const allianceResolver =
+		allianceIds.length > 0
+			? new EntityResolverService(getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default'))
+			: null
 	const typeNameMap: Record<string, string> = {}
 	const typeMetaMap: Record<string, TypeMetadata> = {}
 	const batchSize = 1000
@@ -211,8 +267,8 @@ async function enrichStructureDetailTypeNames(
 	for (let index = 0; index < typeIds.length; index += batchSize) {
 		const batch = typeIds.slice(index, index + batchSize)
 		const [resolvedNames, resolvedMeta] = await Promise.all([
-			universe.resolveTypeNamesByIds(batch).catch(() => ({} as Record<string, null>)),
-			universe.resolveTypeMetadataByIds(batch).catch(() => ({} as Record<string, TypeMetadata>)),
+			universe.resolveTypeNamesByIds(batch).catch(() => ({}) as Record<string, null>),
+			universe.resolveTypeMetadataByIds(batch).catch(() => ({}) as Record<string, TypeMetadata>),
 		])
 		for (const [typeId, typeData] of Object.entries(resolvedNames)) {
 			typeNameMap[typeId] = typeData?.typeName ?? typeId
@@ -221,6 +277,11 @@ async function enrichStructureDetailTypeNames(
 			typeMetaMap[typeId] = typeMeta
 		}
 	}
+
+	const allianceNameMap =
+		allianceResolver !== null
+			? await allianceResolver.resolveEntityNames(allianceIds)
+			: new Map<string, string>()
 
 	return {
 		...structure,
@@ -241,6 +302,74 @@ async function enrichStructureDetailTypeNames(
 			typeName: typeNameMap[item.typeId] ?? item.typeId,
 			...(typeMetaMap[item.typeId]?.categoryName === 'Charge' ? { isConsumable: true } : {}),
 		})),
+		sovereignty: sovereigntyHub
+			? {
+					...structure.sovereignty,
+					hub: {
+						...sovereigntyHub,
+						controllerAllianceName: sovereigntyHub.controllerAllianceId
+							? (allianceNameMap.get(sovereigntyHub.controllerAllianceId) ?? null)
+							: null,
+						reagentBay: sovereigntyHub.reagentBay
+							? {
+									...sovereigntyHub.reagentBay,
+									reagents: sovereigntyHub.reagentBay.reagents.map((reagent) => ({
+										...reagent,
+										typeName: typeNameMap[reagent.typeId] ?? reagent.typeId,
+									})),
+								}
+							: sovereigntyHub.reagentBay,
+						upgrades: sovereigntyHub.upgrades?.map((upgrade) => ({
+							...upgrade,
+							typeName: typeNameMap[upgrade.typeId] ?? upgrade.typeId,
+						})),
+					},
+				}
+			: structure.sovereignty,
+	}
+}
+
+async function enrichSovereigntyStructureListResponse(
+	env: App['Bindings'],
+	response: StructureSovereigntyListResponse
+): Promise<StructureSovereigntyListResponse> {
+	const allianceIds = [
+		...new Set(
+			[
+				...response.items.map((item) => item.controllerAllianceId),
+				...response.filterOptions.controllerAlliances.map((option) => option.value),
+			].filter((value): value is string => Boolean(value))
+		),
+	]
+
+	if (allianceIds.length === 0) {
+		return response
+	}
+
+	const allianceNameMap = await new EntityResolverService(
+		getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
+	).resolveEntityNames(allianceIds)
+
+	return {
+		...response,
+		items: response.items.map((item) =>
+			item.controllerAllianceId
+				? {
+						...item,
+						controllerAllianceName:
+							allianceNameMap.get(item.controllerAllianceId) ??
+							item.controllerAllianceName ??
+							item.controllerAllianceId,
+					}
+				: item
+		),
+		filterOptions: {
+			...response.filterOptions,
+			controllerAlliances: response.filterOptions.controllerAlliances.map((option) => ({
+				...option,
+				label: allianceNameMap.get(option.value) ?? option.label ?? option.value,
+			})),
+		},
 	}
 }
 
@@ -323,19 +452,20 @@ app.post('/:structureId/assets-debug', async (c) => {
 	const structureId = c.req.param('structureId')
 	try {
 		const actor = await getStructureActor(c)
-		const structure = (await c.env.STRUCTURES.getVisibleStructureDetail(actor, structureId)) as
-			| {
-					corporationId: string
-					corporationName: string | null
-					structureId: string
-					name: string | null
-			  }
-			| null
+		const structure = (await c.env.STRUCTURES.getVisibleStructureDetail(actor, structureId)) as {
+			corporationId: string
+			corporationName: string | null
+			structureId: string
+			name: string | null
+		} | null
 		if (!structure) {
 			return c.json({ error: 'Structure not found' }, 404)
 		}
 
-		const corpData = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, structure.corporationId)
+		const corpData = getStub<EveCorporationData>(
+			c.env.EVE_CORPORATION_DATA,
+			structure.corporationId
+		)
 		const { assetsCount } = await corpData.fetchAssets(structure.corporationId, true)
 		const rawItems = await corpData.searchAssets(structure.corporationId, {
 			locationId: structure.structureId,
@@ -358,10 +488,11 @@ app.post('/:structureId/assets-debug', async (c) => {
 					locationFlagLabel: getStructureAssetLocationLabel(item.locationFlag),
 					updatedAt: item.updatedAt.toISOString(),
 				}))
-				.sort((left, right) =>
-					left.locationFlagLabel.localeCompare(right.locationFlagLabel) ||
-					left.typeId.localeCompare(right.typeId) ||
-					left.itemId.localeCompare(right.itemId)
+				.sort(
+					(left, right) =>
+						left.locationFlagLabel.localeCompare(right.locationFlagLabel) ||
+						left.typeId.localeCompare(right.typeId) ||
+						left.itemId.localeCompare(right.itemId)
 				)
 		)
 
@@ -380,7 +511,8 @@ app.post('/:structureId/assets-debug', async (c) => {
 	} catch (error) {
 		return c.json(
 			{
-				error: error instanceof Error ? error.message : 'Failed to fetch structure assets debug data',
+				error:
+					error instanceof Error ? error.message : 'Failed to fetch structure assets debug data',
 			},
 			500
 		)
@@ -441,7 +573,9 @@ async function handleNavigationStructuresRequest(c: Context<App>): Promise<Respo
 			state: c.req.query('state') || undefined,
 			typeId: c.req.query('typeId') || undefined,
 		}) satisfies StructureNavigationListQuery
-		return c.json(await c.env.STRUCTURES.listNavigationStructures(await getStructureActor(c), query))
+		return c.json(
+			await c.env.STRUCTURES.listNavigationStructures(await getStructureActor(c), query)
+		)
 	} catch (error) {
 		return c.json(
 			{
@@ -466,15 +600,13 @@ async function handleSovereigntyStructuresRequest(c: Context<App>): Promise<Resp
 			sortDirection: c.req.query('sortDirection') || undefined,
 			corporationId: c.req.query('corporationId') || undefined,
 			assignedGroupId: c.req.query('assignedGroupId') || undefined,
-			lowPower: c.req.query('lowPower') || undefined,
-			lowPowerAllowed: c.req.query('lowPowerAllowed') || undefined,
 			regionId: c.req.query('regionId') || undefined,
 			systemId: c.req.query('systemId') || undefined,
-			state: c.req.query('state') || undefined,
-			typeId: c.req.query('typeId') || undefined,
-			allianceId: c.req.query('allianceId') || undefined,
+			controllerAllianceId: c.req.query('controllerAllianceId') || undefined,
+			vulnerabilityState: c.req.query('vulnerabilityState') || undefined,
 		}) satisfies StructureSovereigntyListQuery
-		return c.json(await c.env.STRUCTURES.listSovereigntyStructures(await getStructureActor(c), query))
+		const response = await c.env.STRUCTURES.listSovereigntyStructures(await getStructureActor(c), query)
+		return c.json(await enrichSovereigntyStructureListResponse(c.env, response))
 	} catch (error) {
 		return c.json(
 			{
@@ -526,8 +658,8 @@ async function handleMiningStructuresRequest(c: Context<App>): Promise<Response>
 	}
 
 	try {
-	const query = miningStructureListQuerySchema.parse({
-		page: c.req.query('page'),
+		const query = miningStructureListQuerySchema.parse({
+			page: c.req.query('page'),
 			pageSize: c.req.query('pageSize'),
 			sortBy: c.req.query('sortBy') || undefined,
 			sortDirection: c.req.query('sortDirection') || undefined,
@@ -539,8 +671,8 @@ async function handleMiningStructuresRequest(c: Context<App>): Promise<Response>
 			systemId: c.req.query('systemId') || undefined,
 			state: c.req.query('state') || undefined,
 			typeId: c.req.query('typeId') || undefined,
-		planetId: c.req.query('planetId') || undefined,
-	}) satisfies StructureMiningListQuery
+			planetId: c.req.query('planetId') || undefined,
+		}) satisfies StructureMiningListQuery
 		return c.json(await c.env.STRUCTURES.listMoonDrillStructures(await getStructureActor(c), query))
 	} catch (error) {
 		return c.json(
@@ -574,7 +706,9 @@ async function handleMiningCitadelsStructuresRequest(c: Context<App>): Promise<R
 			typeId: c.req.query('typeId') || undefined,
 			planetId: c.req.query('planetId') || undefined,
 		}) satisfies StructureMiningListQuery
-		return c.json(await c.env.STRUCTURES.listMiningCitadelStructures(await getStructureActor(c), query))
+		return c.json(
+			await c.env.STRUCTURES.listMiningCitadelStructures(await getStructureActor(c), query)
+		)
 	} catch (error) {
 		return c.json(
 			{
@@ -593,7 +727,9 @@ async function handleStructureOverviewRequest(c: Context<App>): Promise<Response
 
 	try {
 		return c.json(
-			(await c.env.STRUCTURES.getStructureOverviewMetrics(await getStructureActor(c))) satisfies StructureOverviewMetrics
+			(await c.env.STRUCTURES.getStructureOverviewMetrics(
+				await getStructureActor(c)
+			)) satisfies StructureOverviewMetrics
 		)
 	} catch (error) {
 		return c.json(
@@ -624,8 +760,12 @@ app.patch('/config', async (c) => {
 	}
 
 	try {
-		const body = structureModuleConfigSchema.parse(await c.req.json()) satisfies UpdateStructureModuleConfigInput
-		return c.json(await c.env.STRUCTURES.updateStructureModuleConfig(await getStructureActor(c), body))
+		const body = structureModuleConfigSchema.parse(
+			await c.req.json()
+		) satisfies UpdateStructureModuleConfigInput
+		return c.json(
+			await c.env.STRUCTURES.updateStructureModuleConfig(await getStructureActor(c), body)
+		)
 	} catch (error) {
 		if (error instanceof z.ZodError) {
 			return c.json({ error: 'Invalid structure config payload', issues: error.issues }, 400)
@@ -642,7 +782,10 @@ app.get('/:structureId', async (c) => {
 
 	const structureId = c.req.param('structureId')
 	try {
-		const structure = await c.env.STRUCTURES.getVisibleStructureDetail(await getStructureActor(c), structureId)
+		const structure = await c.env.STRUCTURES.getVisibleStructureDetail(
+			await getStructureActor(c),
+			structureId
+		)
 		if (!structure) {
 			return c.json({ error: 'Structure not found' }, 404)
 		}
@@ -666,8 +809,14 @@ app.patch('/:structureId/config', async (c) => {
 	const structureId = c.req.param('structureId')
 
 	try {
-		const body = updateStructureConfigSchema.parse(await c.req.json()) satisfies UpdateStructureConfigInput
-		const structure = await c.env.STRUCTURES.updateStructureConfig(await getStructureActor(c), structureId, body)
+		const body = updateStructureConfigSchema.parse(
+			await c.req.json()
+		) satisfies UpdateStructureConfigInput
+		const structure = await c.env.STRUCTURES.updateStructureConfig(
+			await getStructureActor(c),
+			structureId,
+			body
+		)
 		if (!structure) {
 			return c.json({ error: 'Structure not found' }, 404)
 		}

--- a/apps/structures/src/index.ts
+++ b/apps/structures/src/index.ts
@@ -41,6 +41,7 @@ import type {
 	StructureNavigationListQuery,
 	StructureSkyhookListQuery,
 	StructureSovereigntyListQuery,
+	StructureSovereigntyListResponse,
 	StructureListQuery,
 	StructureOverviewMetrics,
 	StructuresWorker,
@@ -81,7 +82,7 @@ export class StructuresWorkerEntrypoint extends WorkerEntrypoint<Env> implements
 	async listSovereigntyStructures(
 		actor: StructureActor,
 		query: StructureSovereigntyListQuery = {}
-	): Promise<unknown> {
+	): Promise<StructureSovereigntyListResponse> {
 		return listSovereigntyStructures(this.env, this.getDb(), actor, query)
 	}
 

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -1,40 +1,26 @@
+import { managedCorporations } from '@repo/core-db-schema'
 import { and, desc, eq, inArray, isNotNull } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import { logger } from '@repo/hono-helpers'
-
 import {
 	corporationStructureInventory,
 	corporationStructures,
 	structureFuelLog,
 } from '@repo/eve-corporation-data-db-schema'
-import { managedCorporations } from '@repo/core-db-schema'
+import { parseFittingSlotFlag } from '@repo/eve-fitting/flags'
+import {
+	parseStructurePermissionUrn,
+	STRUCTURE_PERMISSION_ROLES,
+	STRUCTURE_PERMISSION_SCOPE_ALL,
+} from '@repo/groups'
+import { logger } from '@repo/hono-helpers'
+import { summarizeInventoryRows } from '@repo/inventory-display'
+import { getStructureTabForTypeId, isReinforcedStructureState } from '@repo/structures'
 import {
 	structureMiningStates,
 	structureSkyhookStates,
 	structureSovereigntyHubs,
 	structureSovereigntySystems,
 } from '@repo/structures-db-schema'
-import {
-	summarizeInventoryRows,
-	type InventoryDisplayBay,
-} from '@repo/inventory-display'
-import { parseFittingSlotFlag } from '@repo/eve-fitting/flags'
-import type {
-	StructureCitadelListQuery,
-	StructureMiningListQuery,
-	StructureNavigationListQuery,
-	StructureSkyhookListQuery,
-	StructureSovereigntyListQuery,
-	StructureOverviewMetrics,
-	StructureTab,
-} from '@repo/structures'
-import { getStructureTabForTypeId, isReinforcedStructureState } from '@repo/structures'
-import type { EveCorporationData } from '@repo/eve-corporation-data'
-import {
-	STRUCTURE_PERMISSION_ROLES,
-	STRUCTURE_PERMISSION_SCOPE_ALL,
-	parseStructurePermissionUrn,
-} from '@repo/groups'
 
 import {
 	structureConfigs,
@@ -44,15 +30,32 @@ import {
 	structureModuleConfig,
 	structureStateEvents,
 } from '../db/schema'
-import type { DbSchema } from '../db'
-
-import type { DbClient } from '@repo/db-utils'
-import type { Env, SessionUser } from '../context'
 import {
 	aggregateFuelBurnRatePerHour,
 	buildStructureFuelUsageHistory,
-	type StructureFuelHistorySample,
-	type StructureFuelUsageHistory,
+} from './structure-fuel-history'
+
+import type { DbClient } from '@repo/db-utils'
+import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { InventoryDisplayBay } from '@repo/inventory-display'
+import type {
+	StructureCitadelListQuery,
+	StructureMiningListQuery,
+	StructureNavigationListQuery,
+	StructureOverviewMetrics,
+	StructureSovereigntyListFilterOptions as RepoStructureSovereigntyListFilterOptions,
+	StructureSovereigntyListItem as RepoStructureSovereigntyListItem,
+	StructureSovereigntyListResponse as RepoStructureSovereigntyListResponse,
+	StructureSovereigntyListSummary as RepoStructureSovereigntyListSummary,
+	StructureSkyhookListQuery,
+	StructureSovereigntyListQuery,
+	StructureTab,
+} from '@repo/structures'
+import type { Env, SessionUser } from '../context'
+import type { DbSchema } from '../db'
+import type {
+	StructureFuelHistorySample,
+	StructureFuelUsageHistory,
 } from './structure-fuel-history'
 
 const STRUCTURE_LIST_PAGE_SIZE_MAX = 100
@@ -61,6 +64,7 @@ export type StructureListSortField =
 	| 'updatedAt'
 	| 'nextStateAt'
 	| 'fuel'
+	| 'activityDefenseMultiplier'
 	| 'name'
 	| 'corporation'
 	| 'region'
@@ -79,6 +83,7 @@ export interface StructureListFilterOptions {
 	regions: StructureListFilterOptionsEntry[]
 	systems: StructureListFilterOptionsEntry[]
 	states: StructureListFilterOptionsEntry[]
+	vulnerabilityStates?: StructureListFilterOptionsEntry[]
 	types: StructureListFilterOptionsEntry[]
 	assignedGroups: StructureListFilterOptionsEntry[]
 	alliances: StructureListFilterOptionsEntry[]
@@ -123,6 +128,8 @@ interface StructureAccessScope {
 	tabs: Record<StructureTab, StructurePermissionAccessTarget>
 }
 
+type SovereigntyVulnerabilityState = 'vulnerable' | 'invulnerable' | 'reinforced' | 'unknown'
+
 export interface StructureListItem {
 	structureId: string
 	corporationId: string
@@ -158,6 +165,7 @@ export interface StructureNavigationListItem extends StructureListItem {
 export interface StructureSovereigntyListItem extends StructureListItem {
 	claimType: 'alliance' | 'faction' | 'unclaimed'
 	allianceId: string | null
+	controllerAllianceName?: string | null
 	corporationClaimantId: string | null
 	factionId: string | null
 	claimedSince: string | null
@@ -228,12 +236,14 @@ export interface StructureMiningListItem extends StructureListItem {
 export interface StructureSovereigntyHubSummary {
 	fuelAccessListId: string | null
 	controllerAllianceId: string | null
+	controllerAllianceName?: string | null
 	reagentBayLastUpdated: string | null
 	reagentCount: number
 	reagentBay: {
 		lastUpdated: string
 		reagents: Array<{
 			typeId: string
+			typeName?: string | null
 			securedStock: number
 			unsecuredStock: number
 			lastCycle: string
@@ -251,6 +261,7 @@ export interface StructureSovereigntyHubSummary {
 	}
 	upgrades: Array<{
 		typeId: string
+		typeName?: string | null
 		powerState: string
 	}>
 	workforceTransport: {
@@ -492,7 +503,10 @@ function buildStructureAccessTargetSummary(
 	}
 }
 
-function getStructureAccessTarget(access: StructureAccessScope, tab: StructureTab): StructurePermissionAccessTarget {
+function getStructureAccessTarget(
+	access: StructureAccessScope,
+	tab: StructureTab
+): StructurePermissionAccessTarget {
 	return {
 		viewAll: access.all.viewAll || access.tabs[tab].viewAll,
 		sensitiveAll: access.all.sensitiveAll || access.tabs[tab].sensitiveAll,
@@ -523,17 +537,29 @@ function hasAnyStructureAccess(target: StructurePermissionAccessTarget): boolean
 	)
 }
 
-function hasStructureAccessForTab(access: StructureAccessScope, corporationId: string, tab: StructureTab): boolean {
+function hasStructureAccessForTab(
+	access: StructureAccessScope,
+	corporationId: string,
+	tab: StructureTab
+): boolean {
 	const target = getStructureAccessTarget(access, tab)
 	return buildStructureAccessTargetSummary(target, corporationId).canView
 }
 
-function canViewSensitiveStructure(access: StructureAccessScope, corporationId: string, tab: StructureTab): boolean {
+function canViewSensitiveStructure(
+	access: StructureAccessScope,
+	corporationId: string,
+	tab: StructureTab
+): boolean {
 	const target = getStructureAccessTarget(access, tab)
 	return buildStructureAccessTargetSummary(target, corporationId).canViewSensitive
 }
 
-function canEditStructure(access: StructureAccessScope, corporationId: string, tab: StructureTab): boolean {
+function canEditStructure(
+	access: StructureAccessScope,
+	corporationId: string,
+	tab: StructureTab
+): boolean {
 	const target = getStructureAccessTarget(access, tab)
 	return buildStructureAccessTargetSummary(target, corporationId).canEdit
 }
@@ -542,7 +568,9 @@ function getAccessibleCorporationIds(
 	access: StructureAccessScope,
 	tab?: StructureTab
 ): { hasGlobalAccess: boolean; corporationIds: Set<string> } {
-	const targets = tab ? [access.all, access.tabs[tab]] : [access.all, ...STRUCTURE_ACCESS_TABS.map((entry) => access.tabs[entry])]
+	const targets = tab
+		? [access.all, access.tabs[tab]]
+		: [access.all, ...STRUCTURE_ACCESS_TABS.map((entry) => access.tabs[entry])]
 	const corporationIds = new Set<string>()
 	let hasGlobalAccess = false
 
@@ -621,7 +649,10 @@ function toIso(value: Date | null | undefined): string | null {
 	return value ? value.toISOString() : null
 }
 
-function compareNullableStrings(left: string | null | undefined, right: string | null | undefined): number {
+function compareNullableStrings(
+	left: string | null | undefined,
+	right: string | null | undefined
+): number {
 	const normalizedLeft = left ?? ''
 	const normalizedRight = right ?? ''
 	return normalizedLeft.localeCompare(normalizedRight)
@@ -653,19 +684,25 @@ function compareNullableNumbers(
 	return left - right
 }
 
+function parseNullableNumber(value: string | number | null | undefined): number | null {
+	if (value === null || value === undefined || value === '') return null
+	const parsed = typeof value === 'number' ? value : Number.parseFloat(value)
+	return Number.isFinite(parsed) ? parsed : null
+}
+
 type StructureWhereCondition = NonNullable<Parameters<typeof and>[number]>
 
 type SovereigntyHubUniverseStub = {
-	resolveSolarSystemsByIds(systemIds: string[]): Promise<
-		Record<string, { solarSystemName: string; regionId: string } | null>
-	>
+	resolveSolarSystemsByIds(
+		systemIds: string[]
+	): Promise<Record<string, { solarSystemName: string; regionId: string } | null>>
 	resolveRegionsByIds(regionIds: string[]): Promise<Record<string, { regionName: string } | null>>
 }
 
-function combineWhereConditions(
-	conditions: Array<StructureWhereCondition | undefined>
-): any {
-	const defined = conditions.filter((condition): condition is StructureWhereCondition => condition !== undefined)
+function combineWhereConditions(conditions: Array<StructureWhereCondition | undefined>): any {
+	const defined = conditions.filter(
+		(condition): condition is StructureWhereCondition => condition !== undefined
+	)
 	if (defined.length === 0) return undefined
 	if (defined.length === 1) return defined[0]
 	return and(...defined)
@@ -675,7 +712,10 @@ function isFuelBelowThreshold(
 	structure: Pick<StructureListItem, 'fuelAmount' | 'fuelExpires'>,
 	moduleConfig: Pick<
 		StructureModuleConfigResult,
-		'lowFuelTimeThresholdHours' | 'criticalFuelTimeThresholdHours' | 'lowFuelAmountThreshold' | 'criticalFuelAmountThreshold'
+		| 'lowFuelTimeThresholdHours'
+		| 'criticalFuelTimeThresholdHours'
+		| 'lowFuelAmountThreshold'
+		| 'criticalFuelAmountThreshold'
 	>
 ): boolean {
 	if (structure.fuelAmount !== null) {
@@ -694,7 +734,10 @@ function summarizeStructureSovereigntyHub(
 	hub: typeof structureSovereigntyHubs.$inferSelect
 ): StructureSovereigntyHubSummary {
 	const reagentTotals = hub.reagentBay.reagents.reduce(
-		(accumulator: { secured: number; unsecured: number }, reagent: { securedStock: number; unsecuredStock: number }) => {
+		(
+			accumulator: { secured: number; unsecured: number },
+			reagent: { securedStock: number; unsecuredStock: number }
+		) => {
 			accumulator.secured += reagent.securedStock
 			accumulator.unsecured += reagent.unsecuredStock
 			return accumulator
@@ -705,12 +748,15 @@ function summarizeStructureSovereigntyHub(
 	return {
 		fuelAccessListId: hub.fuelAccessListId ?? null,
 		controllerAllianceId: hub.controllerAllianceId ?? null,
-		reagentBayLastUpdated: hub.reagentBayLastUpdated ? hub.reagentBayLastUpdated.toISOString() : null,
+		reagentBayLastUpdated: hub.reagentBayLastUpdated
+			? hub.reagentBayLastUpdated.toISOString()
+			: null,
 		reagentCount: hub.reagentBay.reagents.length,
 		reagentBay: hub.reagentBay,
 		resources: hub.resources,
 		upgrades: hub.upgrades,
-		workforceTransport: hub.workforceTransport as StructureSovereigntyHubSummary['workforceTransport'],
+		workforceTransport:
+			hub.workforceTransport as StructureSovereigntyHubSummary['workforceTransport'],
 		totalSecuredStock: reagentTotals.secured,
 		totalUnsecuredStock: reagentTotals.unsecured,
 		resourcePowerAllocated: hub.resources.power.allocated,
@@ -718,8 +764,12 @@ function summarizeStructureSovereigntyHub(
 		resourceWorkforceAllocated: hub.resources.workforce.allocated,
 		resourceWorkforceAvailable: hub.resources.workforce.available,
 		upgradeCount: hub.upgrades.length,
-		vulnerabilityWindowStart: hub.vulnerabilityWindowStart ? hub.vulnerabilityWindowStart.toISOString() : null,
-		vulnerabilityWindowEnd: hub.vulnerabilityWindowEnd ? hub.vulnerabilityWindowEnd.toISOString() : null,
+		vulnerabilityWindowStart: hub.vulnerabilityWindowStart
+			? hub.vulnerabilityWindowStart.toISOString()
+			: null,
+		vulnerabilityWindowEnd: hub.vulnerabilityWindowEnd
+			? hub.vulnerabilityWindowEnd.toISOString()
+			: null,
 	}
 }
 
@@ -764,7 +814,10 @@ function summarizeStructureSkyhook(
 	}
 
 	const reagentTotals = skyhook.reagents.reduce(
-		(accumulator: { secured: number; unsecured: number }, reagent: { securedStock: number; unsecuredStock: number }) => {
+		(
+			accumulator: { secured: number; unsecured: number },
+			reagent: { securedStock: number; unsecuredStock: number }
+		) => {
 			accumulator.secured += reagent.securedStock
 			accumulator.unsecured += reagent.unsecuredStock
 			return accumulator
@@ -783,9 +836,15 @@ function summarizeStructureSkyhook(
 		totalReagents: skyhook.reagents.length,
 		totalSecuredStock: reagentTotals.secured,
 		totalUnsecuredStock: reagentTotals.unsecured,
-		reinforcementTimerEnd: skyhook.reinforcementTimerEnd ? skyhook.reinforcementTimerEnd.toISOString() : null,
-		theftVulnerabilityStart: skyhook.theftVulnerabilityStart ? skyhook.theftVulnerabilityStart.toISOString() : null,
-		theftVulnerabilityEnd: skyhook.theftVulnerabilityEnd ? skyhook.theftVulnerabilityEnd.toISOString() : null,
+		reinforcementTimerEnd: skyhook.reinforcementTimerEnd
+			? skyhook.reinforcementTimerEnd.toISOString()
+			: null,
+		theftVulnerabilityStart: skyhook.theftVulnerabilityStart
+			? skyhook.theftVulnerabilityStart.toISOString()
+			: null,
+		theftVulnerabilityEnd: skyhook.theftVulnerabilityEnd
+			? skyhook.theftVulnerabilityEnd.toISOString()
+			: null,
 		isRaidable: skyhook.isRaidable,
 		becomesRaidableAt: skyhook.becomesRaidableAt ? skyhook.becomesRaidableAt.toISOString() : null,
 		vulnerableAt: skyhook.vulnerableAt ? skyhook.vulnerableAt.toISOString() : null,
@@ -816,7 +875,8 @@ function summarizeStructureMining(
 
 function buildStructureListItem(context: VisibleStructureContext): StructureListItem {
 	const { structure, corporationName, config, canViewSensitive, canEdit } = context
-	const nextStateAt = structure.stateTimerEnd ?? structure.nextReinforceApply ?? structure.unanchorsAt
+	const nextStateAt =
+		structure.stateTimerEnd ?? structure.nextReinforceApply ?? structure.unanchorsAt
 
 	return {
 		structureId: structure.structureId,
@@ -863,7 +923,9 @@ async function resolveSovereigntyHubGeographies(
 
 	const universe = getStub<SovereigntyHubUniverseStub>(env.UNIVERSE, 'default')
 	const systemsById = await universe.resolveSolarSystemsByIds(systemIds)
-	const regionIds = [...new Set(Object.values(systemsById).flatMap((system) => (system ? [system.regionId] : [])))]
+	const regionIds = [
+		...new Set(Object.values(systemsById).flatMap((system) => (system ? [system.regionId] : []))),
+	]
 	const regionsById = regionIds.length > 0 ? await universe.resolveRegionsByIds(regionIds) : {}
 
 	return Object.fromEntries(
@@ -895,7 +957,12 @@ function buildSyntheticSovereigntyStructureRow(
 		id: hub.structureId,
 		corporationId: hub.corporationId,
 		structureId: hub.structureId,
-		name: hub.name ?? geography?.solarSystemName ?? hub.systemName ?? system?.systemName ?? hub.structureId,
+		name:
+			hub.name ??
+			geography?.solarSystemName ??
+			hub.systemName ??
+			system?.systemName ??
+			hub.structureId,
 		typeId: hub.typeId,
 		typeName: 'Sovereignty Hub',
 		systemId: hub.systemId,
@@ -1106,7 +1173,10 @@ export async function upsertStructureGroupSetting(
 	return created
 }
 
-export async function deleteStructureGroupSetting(db: DbClient<DbSchema>, input: DeleteStructureGroupSettingInput) {
+export async function deleteStructureGroupSetting(
+	db: DbClient<DbSchema>,
+	input: DeleteStructureGroupSettingInput
+) {
 	const [deleted] = await db
 		.delete(structureGroupSettings)
 		.where(eq(structureGroupSettings.groupId, input.groupId))
@@ -1178,7 +1248,9 @@ async function getOrCreateStructureModuleConfig(
 	return retried
 }
 
-export async function getStructureModuleConfig(db: DbClient<DbSchema>): Promise<StructureModuleConfigResult> {
+export async function getStructureModuleConfig(
+	db: DbClient<DbSchema>
+): Promise<StructureModuleConfigResult> {
 	const row = await getOrCreateStructureModuleConfig(db)
 	return row
 }
@@ -1193,7 +1265,8 @@ export async function updateStructureModuleConfig(
 		.insert(structureModuleConfig)
 		.values({
 			id: existing.id,
-			lowFuelTimeThresholdHours: input.lowFuelTimeThresholdHours ?? existing.lowFuelTimeThresholdHours,
+			lowFuelTimeThresholdHours:
+				input.lowFuelTimeThresholdHours ?? existing.lowFuelTimeThresholdHours,
 			criticalFuelTimeThresholdHours:
 				input.criticalFuelTimeThresholdHours ?? existing.criticalFuelTimeThresholdHours,
 			lowFuelAmountThreshold: input.lowFuelAmountThreshold ?? existing.lowFuelAmountThreshold,
@@ -1210,8 +1283,7 @@ export async function updateStructureModuleConfig(
 					input.lowFuelTimeThresholdHours ?? existing.lowFuelTimeThresholdHours,
 				criticalFuelTimeThresholdHours:
 					input.criticalFuelTimeThresholdHours ?? existing.criticalFuelTimeThresholdHours,
-				lowFuelAmountThreshold:
-					input.lowFuelAmountThreshold ?? existing.lowFuelAmountThreshold,
+				lowFuelAmountThreshold: input.lowFuelAmountThreshold ?? existing.lowFuelAmountThreshold,
 				criticalFuelAmountThreshold:
 					input.criticalFuelAmountThreshold ?? existing.criticalFuelAmountThreshold,
 				updatedBy: input.updatedBy ?? existing.updatedBy ?? null,
@@ -1248,13 +1320,16 @@ export async function upsertStructureCorporationGroupDefault(
 		return updated
 	}
 
-	const [created] = await db.insert(structureCorporationGroupDefaults).values({
-		corporationId: input.corporationId,
-		groupId: input.groupId,
-		updatedBy: input.updatedBy ?? null,
-		createdAt: now,
-		updatedAt: now,
-	}).returning()
+	const [created] = await db
+		.insert(structureCorporationGroupDefaults)
+		.values({
+			corporationId: input.corporationId,
+			groupId: input.groupId,
+			updatedBy: input.updatedBy ?? null,
+			createdAt: now,
+			updatedAt: now,
+		})
+		.returning()
 	return created
 }
 
@@ -1299,15 +1374,18 @@ export async function upsertStructureGroupAlertConfig(
 		return updated
 	}
 
-	const [created] = await db.insert(structureGroupAlertConfigs).values({
-		groupId: input.groupId,
-		alertType: input.alertType,
-		destinationIds: input.destinationIds,
-		config: input.config,
-		isEnabled: input.isEnabled,
-		createdAt: now,
-		updatedAt: now,
-	}).returning()
+	const [created] = await db
+		.insert(structureGroupAlertConfigs)
+		.values({
+			groupId: input.groupId,
+			alertType: input.alertType,
+			destinationIds: input.destinationIds,
+			config: input.config,
+			isEnabled: input.isEnabled,
+			createdAt: now,
+			updatedAt: now,
+		})
+		.returning()
 	return created
 }
 
@@ -1318,7 +1396,9 @@ export async function deleteStructureGroupAlertConfig(
 ): Promise<void> {
 	await db
 		.delete(structureGroupAlertConfigs)
-		.where(and(eq(structureGroupAlertConfigs.groupId, groupId), eq(structureGroupAlertConfigs.id, id)))
+		.where(
+			and(eq(structureGroupAlertConfigs.groupId, groupId), eq(structureGroupAlertConfigs.id, id))
+		)
 }
 
 type DirectCorporationStructureRecord = typeof corporationStructures.$inferSelect
@@ -1343,11 +1423,16 @@ const EMPTY_STRUCTURE_FUEL_USAGE_HISTORY: StructureFuelUsageHistory = {
 	sampleCount: 0,
 }
 
-export function getStructureTab(structure: Pick<StructureListItem, 'typeId' | 'typeName'>): StructureTab {
+export function getStructureTab(
+	structure: Pick<StructureListItem, 'typeId' | 'typeName'>
+): StructureTab {
 	return getStructureTabForTypeId(structure.typeId, structure.typeName)
 }
 
-function matchesStructureTab(structure: Pick<StructureListItem, 'typeId' | 'typeName'>, tab: StructureTab): boolean {
+function matchesStructureTab(
+	structure: Pick<StructureListItem, 'typeId' | 'typeName'>,
+	tab: StructureTab
+): boolean {
 	return getStructureTab(structure) === tab
 }
 
@@ -1398,7 +1483,9 @@ async function getVisibleStructureContext(
 				if (accessibleCorporations.corporationIds.size === 0) {
 					return and(...conditions, eq(corporationStructures.corporationId, '__no_access__'))
 				}
-				conditions.push(inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds]))
+				conditions.push(
+					inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds])
+				)
 			}
 			return and(...conditions)
 		})(),
@@ -1412,7 +1499,11 @@ async function getVisibleStructureContext(
 					if (accessibleCorporations.corporationIds.size === 0) {
 						return and(...conditions, eq(structureSovereigntyHubs.corporationId, '__no_access__'))
 					}
-					conditions.push(inArray(structureSovereigntyHubs.corporationId, [...accessibleCorporations.corporationIds]))
+					conditions.push(
+						inArray(structureSovereigntyHubs.corporationId, [
+							...accessibleCorporations.corporationIds,
+						])
+					)
 				}
 				return and(...conditions)
 			})(),
@@ -1433,7 +1524,9 @@ async function getVisibleStructureContext(
 		const systemRow = await db.query.structureSovereigntySystems.findFirst({
 			where: eq(structureSovereigntySystems.sovereigntyHubStructureId, structureId),
 		})
-		const geographyBySystemId = await resolveSovereigntyHubGeographies(env, [sovereigntyHub.systemId])
+		const geographyBySystemId = await resolveSovereigntyHubGeographies(env, [
+			sovereigntyHub.systemId,
+		])
 		const syntheticStructure = buildSyntheticSovereigntyStructureRow(
 			sovereigntyHub,
 			systemRow ?? null,
@@ -1444,8 +1537,10 @@ async function getVisibleStructureContext(
 			return null
 		}
 
-		const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, sovereigntyHub.corporationId, structureTab)
-		const canEdit = user.is_admin || canEditStructure(access, sovereigntyHub.corporationId, structureTab)
+		const canViewSensitive =
+			user.is_admin || canViewSensitiveStructure(access, sovereigntyHub.corporationId, structureTab)
+		const canEdit =
+			user.is_admin || canEditStructure(access, sovereigntyHub.corporationId, structureTab)
 
 		const [tabData, inventoryBays, fittingItems] = await Promise.all([
 			loadStructureTabDetailData(db, syntheticStructure),
@@ -1486,7 +1581,8 @@ async function getVisibleStructureContext(
 		return null
 	}
 
-	const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
+	const canViewSensitive =
+		user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
 	const canEdit = user.is_admin || canEditStructure(access, structure.corporationId, structureTab)
 	if (config?.hidden && !canViewSensitive) {
 		return null
@@ -1515,16 +1611,25 @@ async function getVisibleStructureContext(
 	}
 }
 
-function getStructureSortValue(structure: StructureListItem, field: StructureListSortField): string | number {
+function getStructureSortValue(
+	structure: StructureListItem,
+	field: StructureListSortField
+): string | number | null {
 	switch (field) {
 		case 'updatedAt':
 			return new Date(structure.updatedAt).getTime()
 		case 'nextStateAt':
-			return structure.nextStateAt ? new Date(structure.nextStateAt).getTime() : Number.POSITIVE_INFINITY
+			return structure.nextStateAt
+				? new Date(structure.nextStateAt).getTime()
+				: Number.POSITIVE_INFINITY
 		case 'fuel':
 			return structure.fuelExpires
 				? new Date(structure.fuelExpires).getTime()
-				: structure.fuelAmount ?? Number.POSITIVE_INFINITY
+				: (structure.fuelAmount ?? Number.POSITIVE_INFINITY)
+		case 'activityDefenseMultiplier':
+			return parseNullableNumber(
+				(structure as StructureSovereigntyListItem).activityDefenseMultiplier ?? null
+			)
 		case 'name':
 			return structure.name
 		case 'corporation':
@@ -1538,6 +1643,8 @@ function getStructureSortValue(structure: StructureListItem, field: StructureLis
 		case 'state':
 			return structure.state
 	}
+
+	return null
 }
 
 function compareFuelStructures(left: StructureListItem, right: StructureListItem): number {
@@ -1562,7 +1669,7 @@ function sortStructures(
 	const direction = sortDirection === 'asc' ? 1 : -1
 	return [...items].sort((left, right) => {
 		let comparison = 0
-		switch (sortBy) {
+	switch (sortBy) {
 			case 'updatedAt':
 			case 'nextStateAt':
 				comparison = compareNullableDates(
@@ -1570,7 +1677,13 @@ function sortStructures(
 					getStructureSortValue(right, sortBy) as string | null | undefined
 				)
 				break
-		case 'fuel':
+			case 'activityDefenseMultiplier':
+				comparison = compareNullableNumbers(
+					getStructureSortValue(left, sortBy) as number | null | undefined,
+					getStructureSortValue(right, sortBy) as number | null | undefined
+				)
+				break
+			case 'fuel':
 				comparison = compareFuelStructures(left, right)
 				break
 			case 'name':
@@ -1599,14 +1712,26 @@ function sortStructures(
 }
 
 function buildStructureFilterOptions<
-	TItem extends Pick<StructureListItem, 'corporationId' | 'corporationName' | 'systemId' | 'systemName' | 'state' | 'typeId' | 'typeName'> & {
+	TItem extends Pick<
+		StructureListItem,
+		| 'corporationId'
+		| 'corporationName'
+		| 'systemId'
+		| 'systemName'
+		| 'state'
+		| 'typeId'
+		| 'typeName'
+	> & {
 		assignedGroupId?: string | null
 		regionId?: string | null
 		regionName?: string | null
 		allianceId?: string | null
+		allianceName?: string | null
+		controllerAllianceId?: string | null
+		controllerAllianceName?: string | null
 		planetId?: string | null
 		isRaidable?: boolean | null
-	}
+	},
 >(items: TItem[]): StructureListFilterOptions {
 	const corporations = new Map<string, string>()
 	const assignedGroups = new Map<string, string>()
@@ -1614,7 +1739,7 @@ function buildStructureFilterOptions<
 	const systems = new Map<string, string>()
 	const states = new Set<string>()
 	const types = new Map<string, string>()
-	const alliances = new Set<string>()
+	const alliances = new Map<string, string>()
 	const planets = new Map<string, string>()
 	const raidableStates = new Set<string>()
 
@@ -1629,8 +1754,11 @@ function buildStructureFilterOptions<
 		systems.set(structure.systemId, structure.systemName ?? structure.systemId)
 		states.add(structure.state)
 		types.set(structure.typeId, structure.typeName ?? structure.typeId)
-		if (structure.allianceId) {
-			alliances.add(structure.allianceId)
+		const allianceId = structure.controllerAllianceId ?? structure.allianceId
+		if (allianceId) {
+			const allianceName =
+				structure.controllerAllianceName ?? structure.allianceName ?? allianceId
+			alliances.set(allianceId, allianceName)
 		}
 		if (structure.planetId) {
 			planets.set(structure.planetId, structure.planetId)
@@ -1659,9 +1787,9 @@ function buildStructureFilterOptions<
 		types: Array.from(types.entries())
 			.sort((left, right) => left[1].localeCompare(right[1]))
 			.map(([value, label]) => ({ value, label })),
-		alliances: Array.from(alliances.values())
-			.sort((left, right) => left.localeCompare(right))
-			.map((value) => ({ value, label: value })),
+		alliances: Array.from(alliances.entries())
+			.sort((left, right) => left[1].localeCompare(right[1]))
+			.map(([value, label]) => ({ value, label })),
 		planets: Array.from(planets.entries())
 			.sort((left, right) => left[1].localeCompare(right[1]))
 			.map(([value, label]) => ({ value, label })),
@@ -1671,11 +1799,154 @@ function buildStructureFilterOptions<
 	}
 }
 
+function getSovereigntyVulnerabilityState(
+	structure:
+		| Pick<
+				RepoStructureSovereigntyListItem,
+				'vulnerabilityWindowStart' | 'vulnerabilityWindowEnd' | 'state'
+		  >
+		| null
+		| undefined
+): SovereigntyVulnerabilityState {
+	if (!structure?.vulnerabilityWindowStart || !structure?.vulnerabilityWindowEnd) {
+		return 'unknown'
+	}
+
+	if (isReinforcedStructureState(structure.state)) {
+		return 'reinforced'
+	}
+
+	const start = new Date(structure.vulnerabilityWindowStart).getTime()
+	const end = new Date(structure.vulnerabilityWindowEnd).getTime()
+	const now = Date.now()
+	if (Number.isFinite(start) && Number.isFinite(end) && now >= start && now <= end) {
+		return 'vulnerable'
+	}
+
+	return 'invulnerable'
+}
+
+function buildSovereigntyFilterOptions(
+	items: RepoStructureSovereigntyListItem[]
+): RepoStructureSovereigntyListFilterOptions {
+	const corporations = new Map<string, string>()
+	const assignedGroups = new Map<string, string>()
+	const regions = new Map<string, string>()
+	const systems = new Map<string, string>()
+	const controllerAlliances = new Map<string, string>()
+	const vulnerabilityStates = new Set<SovereigntyVulnerabilityState>()
+
+	for (const item of items) {
+		corporations.set(item.corporationId, item.corporationName)
+		if (item.assignedGroupId) {
+			assignedGroups.set(item.assignedGroupId, item.assignedGroupId)
+		}
+		if (item.regionId) {
+			regions.set(item.regionId, item.regionName ?? item.regionId)
+		}
+		systems.set(item.systemId, item.systemName ?? item.systemId)
+		if (item.controllerAllianceId) {
+			controllerAlliances.set(
+				item.controllerAllianceId,
+				item.controllerAllianceName ?? item.controllerAllianceId
+			)
+		}
+		vulnerabilityStates.add(getSovereigntyVulnerabilityState(item))
+	}
+
+	return {
+		corporations: Array.from(corporations.entries())
+			.sort((left, right) => left[1].localeCompare(right[1]))
+			.map(([value, label]) => ({ value, label })),
+		assignedGroups: Array.from(assignedGroups.entries())
+			.sort((left, right) => left[1].localeCompare(right[1]))
+			.map(([value, label]) => ({ value, label })),
+		regions: Array.from(regions.entries())
+			.sort((left, right) => left[1].localeCompare(right[1]))
+			.map(([value, label]) => ({ value, label })),
+		systems: Array.from(systems.entries())
+			.sort((left, right) => left[1].localeCompare(right[1]))
+			.map(([value, label]) => ({ value, label })),
+		controllerAlliances: Array.from(controllerAlliances.entries())
+			.sort((left, right) => left[1].localeCompare(right[1]))
+			.map(([value, label]) => ({ value, label })),
+		vulnerabilityStates: Array.from(vulnerabilityStates.values())
+			.sort((left, right) => left.localeCompare(right))
+			.map((value) => {
+				switch (value) {
+					case 'vulnerable':
+						return { value, label: 'Vulnerable' }
+					case 'invulnerable':
+						return { value, label: 'Invulnerable' }
+					case 'reinforced':
+						return { value, label: 'Reinforced' }
+					case 'unknown':
+						return { value, label: 'Unknown' }
+				}
+			}),
+	}
+}
+
+function buildSovereigntySummary(
+	items: RepoStructureSovereigntyListItem[]
+): RepoStructureSovereigntyListSummary {
+	const summary = {
+		total: items.length,
+		vulnerable: 0,
+		invulnerable: 0,
+		reinforced: 0,
+		unknown: 0,
+	}
+
+	for (const item of items) {
+		switch (getSovereigntyVulnerabilityState(item)) {
+			case 'vulnerable':
+				summary.vulnerable += 1
+				break
+			case 'invulnerable':
+				summary.invulnerable += 1
+				break
+			case 'reinforced':
+				summary.reinforced += 1
+				break
+			case 'unknown':
+				summary.unknown += 1
+				break
+		}
+	}
+
+	return summary
+}
+
+function emptySovereigntyFilterOptions(): RepoStructureSovereigntyListFilterOptions {
+	return {
+		corporations: [],
+		assignedGroups: [],
+		regions: [],
+		systems: [],
+		controllerAlliances: [],
+		vulnerabilityStates: [],
+	}
+}
+
+function emptySovereigntySummary(): RepoStructureSovereigntyListSummary {
+	return {
+		total: 0,
+		vulnerable: 0,
+		invulnerable: 0,
+		reinforced: 0,
+		unknown: 0,
+	}
+}
+
 function buildStructureSummary(
 	items: StructureListItem[],
 	moduleConfig: Pick<
 		StructureModuleConfigResult,
-		'lowFuelTimeThresholdHours' | 'criticalFuelTimeThresholdHours' | 'lowFuelAmountThreshold' | 'criticalFuelAmountThreshold'
+		| 'lowFuelTimeThresholdHours'
+		| 'criticalFuelTimeThresholdHours'
+		| 'lowFuelAmountThreshold'
+		| 'criticalFuelAmountThreshold'
 	>
 ): StructureListSummary {
 	return {
@@ -1810,7 +2081,9 @@ async function loadVisibleStructureContexts(
 			if (accessibleCorporations.corporationIds.size === 0) {
 				return combineWhereConditions([eq(corporationStructures.corporationId, '__no_access__')])
 			}
-			conditions.push(inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds]))
+			conditions.push(
+				inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds])
+			)
 		}
 		if (query.lowPower === 'true') {
 			conditions.push(eq(corporationStructures.lowPower, true))
@@ -1863,8 +2136,10 @@ async function loadVisibleStructureContexts(
 			.map<VisibleStructureContext | null>((structure) => {
 				const config = configsByStructureId.get(structure.structureId) ?? null
 				const structureTab = getStructureTab(structure)
-				const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
-				const canEdit = user.is_admin || canEditStructure(access, structure.corporationId, structureTab)
+				const canViewSensitive =
+					user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
+				const canEdit =
+					user.is_admin || canEditStructure(access, structure.corporationId, structureTab)
 				if (config?.hidden && !canViewSensitive) {
 					return null
 				}
@@ -1886,7 +2161,10 @@ async function loadVisibleStructureContexts(
 			})
 			.filter((item): item is VisibleStructureContext => item !== null)
 			.filter((context) => {
-				if (query.assignedGroupId === '__unassigned__' && context.config?.assignedGroupId !== null) {
+				if (
+					query.assignedGroupId === '__unassigned__' &&
+					context.config?.assignedGroupId !== null
+				) {
 					return false
 				}
 				if (
@@ -1939,49 +2217,18 @@ async function loadVisibleSovereigntyHubContexts(
 		}
 	}
 
-	if (query.state && query.state !== 'online') {
-		return {
-			moduleConfig,
-			access,
-			contexts: [],
-			hubRows: [],
-			systemRows: [],
-		}
-	}
-
-	if (query.lowPower === 'true' || query.lowPowerAllowed === 'true') {
-		return {
-			moduleConfig,
-			access,
-			contexts: [],
-			hubRows: [],
-			systemRows: [],
-		}
-	}
-
-	if (query.assignedGroupId && query.assignedGroupId !== '__unassigned__') {
-		return {
-			moduleConfig,
-			access,
-			contexts: [],
-			hubRows: [],
-			systemRows: [],
-		}
-	}
-
 	const corpWhere = (() => {
 		const conditions: StructureWhereCondition[] = []
 		if (query.corporationId) {
 			conditions.push(eq(structureSovereigntyHubs.corporationId, query.corporationId))
 		}
 		if (!accessibleCorporations.hasGlobalAccess) {
-			conditions.push(inArray(structureSovereigntyHubs.corporationId, [...accessibleCorporations.corporationIds]))
+			conditions.push(
+				inArray(structureSovereigntyHubs.corporationId, [...accessibleCorporations.corporationIds])
+			)
 		}
 		if (query.systemId) {
 			conditions.push(eq(structureSovereigntyHubs.systemId, query.systemId))
-		}
-		if (query.typeId) {
-			conditions.push(eq(structureSovereigntyHubs.typeId, query.typeId))
 		}
 		return combineWhereConditions(conditions)
 	})()
@@ -2000,26 +2247,32 @@ async function loadVisibleSovereigntyHubContexts(
 		}
 	}
 
-	const geographyBySystemId = await resolveSovereigntyHubGeographies(
-		env,
-		[...new Set(hubRows.map((hub) => hub.systemId))]
-	)
-	const hubStructureIds = hubRows.map((hub) => hub.structureId)
+	const filteredHubRows = query.controllerAllianceId
+		? hubRows.filter((hub) => hub.controllerAllianceId === query.controllerAllianceId)
+		: hubRows
+	const geographyBySystemId = await resolveSovereigntyHubGeographies(env, [
+		...new Set(filteredHubRows.map((hub) => hub.systemId)),
+	])
+
+	if (filteredHubRows.length === 0) {
+		return {
+			moduleConfig,
+			access,
+			contexts: [],
+			hubRows: filteredHubRows,
+			systemRows: [],
+		}
+	}
+
+	const filteredSystemIds = filteredHubRows.map((hub) => hub.systemId)
 	const systemRows = await db.query.structureSovereigntySystems.findMany({
-		where: combineWhereConditions([
-			inArray(structureSovereigntySystems.sovereigntyHubStructureId, hubStructureIds),
-			query.allianceId ? eq(structureSovereigntySystems.allianceId, query.allianceId) : undefined,
-		]),
+		where: inArray(structureSovereigntySystems.systemId, filteredSystemIds),
 		orderBy: desc(structureSovereigntySystems.updatedAt),
 	})
-	const systemByHubStructureId = new Map(
-		systemRows
-			.filter((row): row is typeof structureSovereigntySystems.$inferSelect & { sovereigntyHubStructureId: string } =>
-				Boolean(row.sovereigntyHubStructureId)
-			)
-			.map((row) => [row.sovereigntyHubStructureId, row])
+	const systemBySystemId = new Map(
+		systemRows.map((row) => [row.systemId, row] as const)
 	)
-	const corporationIds = [...new Set(hubRows.map((hub) => hub.corporationId))]
+	const corporationIds = [...new Set(filteredHubRows.map((hub) => hub.corporationId))]
 	const corporationRows = corporationIds.length
 		? await db.query.managedCorporations.findMany({
 				where: inArray(managedCorporations.corporationId, corporationIds),
@@ -2035,13 +2288,14 @@ async function loadVisibleSovereigntyHubContexts(
 	return {
 		moduleConfig,
 		access,
-		contexts: hubRows
+		contexts: filteredHubRows
 			.map<VisibleStructureContext | null>((hub) => {
-				const systemRow = systemByHubStructureId.get(hub.structureId) ?? null
+				const systemRow = systemBySystemId.get(hub.systemId) ?? null
 				const geography = geographyBySystemId[hub.systemId] ?? null
 				const structure = buildSyntheticSovereigntyStructureRow(hub, systemRow, geography)
 				const structureTab = getStructureTab(structure)
-				const canViewSensitive = user.is_admin || canViewSensitiveStructure(access, hub.corporationId, structureTab)
+				const canViewSensitive =
+					user.is_admin || canViewSensitiveStructure(access, hub.corporationId, structureTab)
 				const canEdit = user.is_admin || canEditStructure(access, hub.corporationId, structureTab)
 				const corporation = corporationById.get(hub.corporationId)
 
@@ -2062,11 +2316,9 @@ async function loadVisibleSovereigntyHubContexts(
 			.filter((context) => {
 				if (query.regionId && context.structure.regionId !== query.regionId) return false
 				if (query.systemId && context.structure.systemId !== query.systemId) return false
-				if (query.lowPower === 'false' && context.structure.lowPower) return false
-				if (query.lowPowerAllowed === 'false' && context.config?.lowPowerAllowed) return false
 				return true
 			}),
-		hubRows,
+		hubRows: filteredHubRows,
 		systemRows,
 	}
 }
@@ -2139,7 +2391,11 @@ export async function getStructureOverviewMetrics(
 ): Promise<StructureOverviewMetrics> {
 	const { moduleConfig, access, contexts } = await loadVisibleStructureContexts(db, user, {})
 	const visibleContexts = contexts.filter((context) =>
-		hasStructureAccessForTab(access, context.structure.corporationId, getStructureTab(context.structure))
+		hasStructureAccessForTab(
+			access,
+			context.structure.corporationId,
+			getStructureTab(context.structure)
+		)
 	)
 	if (visibleContexts.length === 0) {
 		return emptyStructureOverviewMetrics()
@@ -2223,11 +2479,12 @@ function buildSovereigntyListItem(input: {
 	context: VisibleStructureContext
 	systemRow: typeof structureSovereigntySystems.$inferSelect | null
 	hubRow: typeof structureSovereigntyHubs.$inferSelect | null
-}): StructureSovereigntyListItem {
+}): RepoStructureSovereigntyListItem {
 	const { context, systemRow, hubRow } = input
 	const { structure: structureRow, corporationName, canViewSensitive, canEdit } = context
 	const hasHubSnapshot = hubRow !== null
-	const lastSyncedAt = hubRow?.lastSyncedAt ?? systemRow?.lastSyncedAt ?? structureRow.lastSyncedAt ?? null
+	const lastSyncedAt =
+		hubRow?.lastSyncedAt ?? systemRow?.lastSyncedAt ?? structureRow.lastSyncedAt ?? null
 	const sourceUpdatedAt = systemRow?.updatedAt ?? hubRow?.updatedAt ?? structureRow.updatedAt
 
 	const hubSummary = hubRow ? summarizeStructureSovereigntyHub(hubRow) : null
@@ -2235,7 +2492,10 @@ function buildSovereigntyListItem(input: {
 		structureRow.corporationId,
 		corporationName,
 		structureRow?.name ?? hubRow?.name ?? null,
-		structureRow.typeId ?? hubRow?.typeId ?? systemRow?.sovereigntyHubStructureId ?? 'sovereignty hub',
+		structureRow.typeId ??
+			hubRow?.typeId ??
+			systemRow?.sovereigntyHubStructureId ??
+			'sovereignty hub',
 		structureRow?.typeName ?? hubRow?.name ?? 'Sovereignty Hub',
 		structureRow.systemId,
 		structureRow.systemName ?? null,
@@ -2248,6 +2508,9 @@ function buildSovereigntyListItem(input: {
 		...structureIdentity,
 		claimType: systemRow?.claimType ?? 'unclaimed',
 		allianceId: systemRow?.allianceId ?? null,
+		controllerAllianceName: hubSummary?.controllerAllianceId
+			? (hubSummary.controllerAllianceName ?? null)
+			: null,
 		corporationClaimantId: systemRow?.corporationClaimantId ?? null,
 		factionId: systemRow?.factionId ?? null,
 		claimedSince: toIso(systemRow?.claimedSince ?? null),
@@ -2255,7 +2518,8 @@ function buildSovereigntyListItem(input: {
 		vulnerabilityWindowStart: toIso(systemRow?.vulnerabilityWindowStart ?? null),
 		vulnerabilityWindowEnd: toIso(systemRow?.vulnerabilityWindowEnd ?? null),
 		activityDefenseMultiplier:
-			systemRow?.activityDefenseMultiplier !== null && systemRow?.activityDefenseMultiplier !== undefined
+			systemRow?.activityDefenseMultiplier !== null &&
+			systemRow?.activityDefenseMultiplier !== undefined
 				? String(systemRow.activityDefenseMultiplier)
 				: null,
 		militaryLevel: systemRow?.militaryLevel ?? null,
@@ -2277,7 +2541,9 @@ function buildSovereigntyListItem(input: {
 			? null
 			: 'Sovereignty hub snapshot has not been ingested yet for this structure.',
 		lastSyncedAt: toIso(lastSyncedAt),
-		updatedAt: sourceUpdatedAt ? sourceUpdatedAt.toISOString() : structureRow.updatedAt.toISOString(),
+		updatedAt: sourceUpdatedAt
+			? sourceUpdatedAt.toISOString()
+			: structureRow.updatedAt.toISOString(),
 		canViewSensitive,
 		canEdit,
 	}
@@ -2291,7 +2557,10 @@ function buildSkyhookListItem(input: {
 	const { structure: structureRow } = context
 	const hasSkyhookSnapshot = skyhookRow !== null
 	const reagentTotals = skyhookRow?.reagents.reduce(
-		(accumulator: { secured: number; unsecured: number }, reagent: { securedStock: number; unsecuredStock: number }) => {
+		(
+			accumulator: { secured: number; unsecured: number },
+			reagent: { securedStock: number; unsecuredStock: number }
+		) => {
 			accumulator.secured += reagent.securedStock
 			accumulator.unsecured += reagent.unsecuredStock
 			return accumulator
@@ -2357,13 +2626,9 @@ export async function listSovereigntyStructures(
 	db: DbClient<DbSchema>,
 	user: SessionUser,
 	query: StructureSovereigntyListQuery = {}
-): Promise<StructureListResponse<StructureSovereigntyListItem>> {
-	const { moduleConfig, contexts, access, hubRows, systemRows } = await loadVisibleSovereigntyHubContexts(
-		env,
-		db,
-		user,
-		query
-	)
+): Promise<RepoStructureSovereigntyListResponse> {
+	const { moduleConfig, contexts, access, hubRows, systemRows } =
+		await loadVisibleSovereigntyHubContexts(env, db, user, query)
 	if (!hasAnyStructureAccess(getStructureAccessTarget(access, 'sovereignty'))) {
 		return {
 			items: [],
@@ -2375,33 +2640,31 @@ export async function listSovereigntyStructures(
 				hasNextPage: false,
 				hasPreviousPage: false,
 			},
-			filterOptions: emptyStructureFilterOptions(),
+			filterOptions: emptySovereigntyFilterOptions(),
 			summary: {
 				total: 0,
-				lowFuel: 0,
-				lowPower: 0,
+				vulnerable: 0,
+				invulnerable: 0,
 				reinforced: 0,
+				unknown: 0,
 			},
 		}
 	}
 
 	const hubById = new Map(hubRows.map((row) => [row.structureId, row] as const))
-	const systemByHubStructureId = new Map(
-		systemRows
-			.filter((row): row is typeof structureSovereigntySystems.$inferSelect & { sovereigntyHubStructureId: string } =>
-				Boolean(row.sovereigntyHubStructureId)
-			)
-			.map((row) => [row.sovereigntyHubStructureId, row] as const)
-	)
+	const systemBySystemId = new Map(systemRows.map((row) => [row.systemId, row] as const))
 	const items = contexts.map((context) =>
 		buildSovereigntyListItem({
 			context,
-			systemRow: systemByHubStructureId.get(context.structure.structureId) ?? null,
+			systemRow: systemBySystemId.get(context.structure.systemId) ?? null,
 			hubRow: hubById.get(context.structure.structureId) ?? null,
 		})
 	)
-	const filteredItems = query.allianceId
-		? items.filter((item) => item.allianceId === query.allianceId)
+	const filteredItems = query.vulnerabilityState
+		? items.filter((item) => {
+				const vulnerabilityState = getSovereigntyVulnerabilityState(item)
+				return vulnerabilityState === query.vulnerabilityState
+			})
 		: items
 
 	const sortBy = query.sortBy ?? 'fuel'
@@ -2415,7 +2678,10 @@ export async function listSovereigntyStructures(
 	const end = start + pageSize
 
 	return {
-		items: sortedItems.slice(start, end).map((item) => items.find((row) => row.structureId === item.structureId)!) as StructureSovereigntyListItem[],
+		items: sortedItems
+			.slice(start, end)
+			.map((item) => items.find((row) => row.structureId === item.structureId)!)
+			.filter((item): item is RepoStructureSovereigntyListItem => Boolean(item)),
 		pagination: {
 			page,
 			pageSize,
@@ -2424,8 +2690,8 @@ export async function listSovereigntyStructures(
 			hasNextPage: page < totalPages,
 			hasPreviousPage: page > 1,
 		},
-		filterOptions: buildStructureFilterOptions(filteredItems),
-		summary: buildStructureSummary(filteredItems, moduleConfig),
+		filterOptions: buildSovereigntyFilterOptions(filteredItems),
+		summary: buildSovereigntySummary(filteredItems),
 	}
 }
 
@@ -2467,7 +2733,9 @@ export async function listSkyhookStructures(
 		}
 	}
 
-	const skyhookContexts = contexts.filter((context) => getStructureTab(context.structure) === 'skyhooks')
+	const skyhookContexts = contexts.filter(
+		(context) => getStructureTab(context.structure) === 'skyhooks'
+	)
 	const structureIds = skyhookContexts.map((context) => context.structure.structureId)
 
 	if (structureIds.length === 0) {
@@ -2535,7 +2803,11 @@ export async function listSkyhookStructures(
 	const end = start + pageSize
 
 	return {
-		items: sortedItems.slice(start, end).map((item) => items.find((row) => row.structureId === item.structureId)!) as StructureSkyhookListItem[],
+		items: sortedItems
+			.slice(start, end)
+			.map(
+				(item) => items.find((row) => row.structureId === item.structureId)!
+			) as StructureSkyhookListItem[],
 		pagination: {
 			page,
 			pageSize,
@@ -2646,7 +2918,11 @@ async function listStructuresWithMiningSnapshot(
 	const end = start + pageSize
 
 	return {
-		items: sortedItems.slice(start, end).map((item) => items.find((row) => row.structureId === item.structureId)!) as StructureMiningListItem[],
+		items: sortedItems
+			.slice(start, end)
+			.map(
+				(item) => items.find((row) => row.structureId === item.structureId)!
+			) as StructureMiningListItem[],
 		pagination: {
 			page,
 			pageSize,
@@ -2687,8 +2963,11 @@ export async function getVisibleStructureDetail(
 		return null
 	}
 	context.fuelUsage =
-		(await loadFuelUsageForStructure(db, context.structure.corporationId, context.structure.structureId)) ??
-		EMPTY_STRUCTURE_FUEL_USAGE_HISTORY
+		(await loadFuelUsageForStructure(
+			db,
+			context.structure.corporationId,
+			context.structure.structureId
+		)) ?? EMPTY_STRUCTURE_FUEL_USAGE_HISTORY
 	return buildStructureDetailResult(context)
 }
 
@@ -2706,7 +2985,8 @@ export async function updateStructureConfig(
 
 	const access = computeStructureAccess(user.roles, user.is_admin)
 	const structureTab = getStructureTab(context.structure)
-	const canEdit = user.is_admin || canEditStructure(access, context.structure.corporationId, structureTab)
+	const canEdit =
+		user.is_admin || canEditStructure(access, context.structure.corporationId, structureTab)
 	if (!canEdit) {
 		return null
 	}

--- a/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
+++ b/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
@@ -236,6 +236,16 @@ describe('sovereignty hub model', () => {
 			claimType: 'alliance',
 			sovereigntyHubStructureId: 'hub-1',
 			controllerAllianceId: 'alliance-1',
+			vulnerabilityWindowStart: '2026-07-13T08:40:00.000Z',
+			vulnerabilityWindowEnd: '2026-07-13T15:20:00.000Z',
+			activityDefenseMultiplier: '1.2',
+			militaryLevel: 2,
+			industrialLevel: 3,
+			strategicLevel: 4,
+			resourceWorkforceAllocated: 300,
+			resourceWorkforceAvailable: 400,
+			resourcePowerAllocated: 100,
+			resourcePowerAvailable: 200,
 		})
 	})
 
@@ -260,6 +270,144 @@ describe('sovereignty hub model', () => {
 
 		expect(result.items).toHaveLength(1)
 		expect(result.items[0]?.regionId).toBe('10000002')
+	})
+
+	it('sorts sovereignty hubs by ADM numerically', async () => {
+		const db = makeDb()
+		mocks.getStubMock.mockReturnValue(db.universeStub)
+		db.universeStub.resolveSolarSystemsByIds.mockResolvedValue({
+			'30000142': {
+				solarSystemId: '30000142',
+				solarSystemName: 'Jita',
+				regionId: '10000002',
+				constellationId: '20000020',
+				securityStatus: '0.9',
+			},
+			'30000143': {
+				solarSystemId: '30000143',
+				solarSystemName: 'Perimeter',
+				regionId: '10000002',
+				constellationId: '20000021',
+				securityStatus: '0.8',
+			},
+		})
+		db.query.structureSovereigntyHubs.findMany.mockResolvedValue([
+			{
+				structureId: 'hub-high',
+				corporationId: 'corp-1',
+				systemId: '30000142',
+				systemName: 'Jita',
+				name: 'High ADM Hub',
+				typeId: '32458',
+				fuelAccessListId: null,
+				controllerAllianceId: 'alliance-1',
+				reagentBayLastUpdated: new Date('2026-07-12T19:36:46.834Z'),
+				reagentBay: {
+					lastUpdated: '2026-07-12T19:36:46.834Z',
+					reagents: [],
+				},
+				resources: {
+					power: { allocated: 100, available: 200 },
+					workforce: { allocated: 300, available: 400 },
+				},
+				upgrades: [],
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				workforceTransport: {},
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+			{
+				structureId: 'hub-low',
+				corporationId: 'corp-1',
+				systemId: '30000143',
+				systemName: 'Perimeter',
+				name: 'Low ADM Hub',
+				typeId: '32458',
+				fuelAccessListId: null,
+				controllerAllianceId: 'alliance-1',
+				reagentBayLastUpdated: new Date('2026-07-12T19:36:46.834Z'),
+				reagentBay: {
+					lastUpdated: '2026-07-12T19:36:46.834Z',
+					reagents: [],
+				},
+				resources: {
+					power: { allocated: 100, available: 200 },
+					workforce: { allocated: 300, available: 400 },
+				},
+				upgrades: [],
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				workforceTransport: {},
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		])
+		db.query.structureSovereigntySystems.findMany.mockResolvedValue([
+			{
+				systemId: '30000142',
+				systemName: 'Jita',
+				corporationId: 'corp-1',
+				claimType: 'alliance',
+				allianceId: 'alliance-1',
+				corporationClaimantId: null,
+				factionId: null,
+				claimedSince: new Date('2026-07-12T18:00:00Z'),
+				sovereigntyHubStructureId: 'hub-high',
+				isCapitalSystem: false,
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				activityDefenseMultiplier: '10.0',
+				militaryLevel: 2,
+				industrialLevel: 3,
+				strategicLevel: 4,
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+			{
+				systemId: '30000143',
+				systemName: 'Perimeter',
+				corporationId: 'corp-1',
+				claimType: 'alliance',
+				allianceId: 'alliance-1',
+				corporationClaimantId: null,
+				factionId: null,
+				claimedSince: new Date('2026-07-12T18:00:00Z'),
+				sovereigntyHubStructureId: 'hub-low',
+				isCapitalSystem: false,
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				activityDefenseMultiplier: '2.0',
+				militaryLevel: 2,
+				industrialLevel: 3,
+				strategicLevel: 4,
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		])
+
+		const result = await listSovereigntyStructures(
+			{
+				UNIVERSE: {} as never,
+			} as never,
+			db as never,
+			{
+				id: 'user-1',
+				is_admin: true,
+				roles: [],
+			},
+			{
+				sortBy: 'activityDefenseMultiplier',
+				sortDirection: 'asc',
+			}
+		)
+
+		expect(result.items.map((item) => item.structureId)).toEqual(['hub-low', 'hub-high'])
+		expect(result.items.map((item) => item.activityDefenseMultiplier)).toEqual(['2.0', '10.0'])
 	})
 
 	it('loads sovereignty hub details even when the base structure row is absent', async () => {

--- a/apps/ui/src/client/features/structures/state/structure-table-store.ts
+++ b/apps/ui/src/client/features/structures/state/structure-table-store.ts
@@ -12,8 +12,9 @@ export interface StructureTableFilters {
 	regionId?: string
 	systemId?: string
 	state?: string
+	vulnerabilityState?: 'vulnerable' | 'invulnerable' | 'reinforced'
 	typeId?: string
-	allianceId?: string
+	controllerAllianceId?: string
 	planetId?: string
 	isRaidable?: 'true' | 'false'
 }
@@ -49,8 +50,9 @@ function normalizeFilters(filters: StructureTableFilters): StructureTableFilters
 		regionId: filters.regionId,
 		systemId: filters.systemId,
 		state: filters.state,
+		vulnerabilityState: filters.vulnerabilityState,
 		typeId: filters.typeId,
-		allianceId: filters.allianceId,
+		controllerAllianceId: filters.controllerAllianceId,
 		planetId: filters.planetId,
 		isRaidable: filters.isRaidable,
 	}
@@ -74,7 +76,14 @@ const SKYHOOK_TAB_FILTER_FIELDS = COMMON_TAB_FILTER_FIELDS.filter(
 const TAB_FILTER_FIELDS: Record<StructureTab, Array<keyof StructureTableFilters>> = {
 	citadels: [...COMMON_TAB_FILTER_FIELDS],
 	navigation: [...COMMON_TAB_FILTER_FIELDS],
-	sovereignty: [...COMMON_TAB_FILTER_FIELDS.filter((field) => field !== 'typeId'), 'allianceId'],
+	sovereignty: [
+		'corporationId',
+		'assignedGroupId',
+		'regionId',
+		'systemId',
+		'vulnerabilityState',
+		'controllerAllianceId',
+	],
 	skyhooks: [...SKYHOOK_TAB_FILTER_FIELDS, 'isRaidable'],
 	'mining-citadels': [...COMMON_TAB_FILTER_FIELDS],
 	'moon-drills': [...COMMON_TAB_FILTER_FIELDS],

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -2,6 +2,14 @@
  * API client for making requests to the core worker
  */
 
+import { isDateRangeWithinOneYear } from '../features/srp/utils'
+import { downloadTextFile } from './csv-utils'
+
+import type {
+	SidebarExternalLinkCreateInput,
+	SidebarExternalLinkSummary,
+	SidebarExternalLinkUpdateInput,
+} from '@repo/admin'
 import type { FreightRoute } from '@repo/freight'
 import type { InventoryDisplayBay as SharedInventoryDisplayBay } from '@repo/inventory-display'
 import type {
@@ -10,21 +18,16 @@ import type {
 	StructureNavigationListQuery as RepoStructureNavigationListQuery,
 	StructureOverviewMetrics as RepoStructureOverviewMetrics,
 	StructureSkyhookListQuery as RepoStructureSkyhookListQuery,
+	StructureSovereigntyListFilterOptions as RepoStructureSovereigntyListFilterOptions,
+	StructureSovereigntyListFilterOption as RepoStructureSovereigntyListFilterOption,
+	StructureSovereigntyListItem as RepoStructureSovereigntyListItem,
+	StructureSovereigntyListResponse as RepoStructureSovereigntyListResponse,
+	StructureSovereigntyListSummary as RepoStructureSovereigntyListSummary,
 	StructureSovereigntyListQuery as RepoStructureSovereigntyListQuery,
 } from '@repo/structures'
-import type {
-	SidebarExternalLinkCreateInput,
-	SidebarExternalLinkSummary,
-	SidebarExternalLinkUpdateInput,
-} from '@repo/admin'
-
 import type { TrackingSession } from '../features/fleet-tracking/types'
-import { isDateRangeWithinOneYear } from '../features/srp/utils'
 
-import { downloadTextFile } from './csv-utils'
-
-export const API_BASE_URL =
-	import.meta.env.VITE_API_BASE_URL || '/api'
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 const API_REQUEST_TIMEOUT_MS = 30_000
 
 export interface ApiError {
@@ -140,7 +143,9 @@ type ApiErrorWithLogMarker = Error & {
 	[API_ERROR_LOGGED_SYMBOL]?: boolean
 }
 
-function maskRequestInfo(requestInfo: ApiRequestDebugInfo | undefined): ApiRequestDebugInfo | undefined {
+function maskRequestInfo(
+	requestInfo: ApiRequestDebugInfo | undefined
+): ApiRequestDebugInfo | undefined {
 	if (!requestInfo) return undefined
 	return {
 		...requestInfo,
@@ -158,7 +163,7 @@ function maskRequestInfo(requestInfo: ApiRequestDebugInfo | undefined): ApiReque
 export function logApiError(error: unknown, fallbackRequestInfo?: ApiRequestDebugInfo): void {
 	const requestInfo =
 		error instanceof BaseApiError || error instanceof NetworkError
-			? error.requestInfo ?? fallbackRequestInfo
+			? (error.requestInfo ?? fallbackRequestInfo)
 			: fallbackRequestInfo
 
 	if (error instanceof Error) {
@@ -667,7 +672,11 @@ export interface CorporationDiscordServer {
 	}>
 }
 
-export type CorporationAlertDestinationType = 'discord_channel' | 'discord_user' | 'discord_webhook' | 'group'
+export type CorporationAlertDestinationType =
+	| 'discord_channel'
+	| 'discord_user'
+	| 'discord_webhook'
+	| 'group'
 
 export interface CorporationAlertTypeDefinition {
 	type: string
@@ -716,6 +725,7 @@ export type StructureListSortBy =
 	| 'updatedAt'
 	| 'nextStateAt'
 	| 'fuel'
+	| 'activityDefenseMultiplier'
 	| 'name'
 	| 'corporation'
 	| 'region'
@@ -754,11 +764,16 @@ export interface StructureListFilterOptions {
 	regions: StructureListFilterOption[]
 	systems: StructureListFilterOption[]
 	states: StructureListFilterOption[]
+	vulnerabilityStates?: StructureListFilterOption[]
 	types: StructureListFilterOption[]
 	alliances: StructureListFilterOption[]
 	planets: StructureListFilterOption[]
 	raidableStates: StructureListFilterOption[]
 }
+
+export type StructureSovereigntyListFilterOption = RepoStructureSovereigntyListFilterOption
+export type StructureSovereigntyListFilterOptions = RepoStructureSovereigntyListFilterOptions
+export type StructureSovereigntyListSummary = RepoStructureSovereigntyListSummary
 
 export interface StructureListSummary {
 	total: number
@@ -804,12 +819,14 @@ export interface StructureNavigationListItem extends StructureCitadelListItem {}
 export interface StructureSovereigntyHubSummary {
 	fuelAccessListId: string | null
 	controllerAllianceId: string | null
+	controllerAllianceName?: string | null
 	reagentBayLastUpdated: string | null
 	reagentCount: number
 	reagentBay: {
 		lastUpdated: string
 		reagents: Array<{
 			typeId: string
+			typeName?: string | null
 			securedStock: number
 			unsecuredStock: number
 			lastCycle: string
@@ -827,6 +844,7 @@ export interface StructureSovereigntyHubSummary {
 	}
 	upgrades: Array<{
 		typeId: string
+		typeName?: string | null
 		powerState: string
 	}>
 	workforceTransport: {
@@ -892,31 +910,7 @@ export interface StructureMiningSummary {
 	naturalDecayTime: string | null
 }
 
-export interface StructureSovereigntyListItem extends StructureListBaseItem {
-	claimType: 'alliance' | 'faction' | 'unclaimed'
-	allianceId: string | null
-	corporationClaimantId: string | null
-	factionId: string | null
-	claimedSince: string | null
-	sovereigntyHubStructureId: string | null
-	vulnerabilityWindowStart: string | null
-	vulnerabilityWindowEnd: string | null
-	activityDefenseMultiplier: string | null
-	militaryLevel: number | null
-	industrialLevel: number | null
-	strategicLevel: number | null
-	fuelAccessListId: string | null
-	controllerAllianceId: string | null
-	reagentBayLastUpdated: string | null
-	reagentCount: number
-	totalSecuredStock: number
-	totalUnsecuredStock: number
-	resourcePowerAllocated: number
-	resourcePowerAvailable: number
-	resourceWorkforceAllocated: number
-	resourceWorkforceAvailable: number
-	upgradeCount: number
-}
+export type StructureSovereigntyListItem = RepoStructureSovereigntyListItem
 
 export interface StructureSkyhookListItem extends StructureListBaseItem {
 	planetId: string
@@ -1025,11 +1019,15 @@ export interface StructureListResponse<TItem = StructureCitadelListItem> {
 	summary: StructureListSummary
 }
 
-export interface StructureCitadelListResponse extends StructureListResponse<StructureCitadelListItem> {}
-export interface StructureNavigationListResponse extends StructureListResponse<StructureNavigationListItem> {}
-export interface StructureSovereigntyListResponse extends StructureListResponse<StructureSovereigntyListItem> {}
-export interface StructureSkyhookListResponse extends StructureListResponse<StructureSkyhookListItem> {}
-export interface StructureMiningListResponse extends StructureListResponse<StructureMiningListItem> {}
+export interface StructureCitadelListResponse
+	extends StructureListResponse<StructureCitadelListItem> {}
+export interface StructureNavigationListResponse
+	extends StructureListResponse<StructureNavigationListItem> {}
+export type StructureSovereigntyListResponse = RepoStructureSovereigntyListResponse
+export interface StructureSkyhookListResponse
+	extends StructureListResponse<StructureSkyhookListItem> {}
+export interface StructureMiningListResponse
+	extends StructureListResponse<StructureMiningListItem> {}
 
 export interface UpdateStructureConfigRequest {
 	hidden?: boolean
@@ -1527,14 +1525,14 @@ export interface AdminUser {
 	matchedCharacterId: string | null
 	matchedCharacterName: string | null
 	matchedBy:
-	| 'main_character_name'
-	| 'character_name'
-	| 'character_id'
-	| 'user_id'
-	| 'discord_user_id'
-	| 'discord_username'
-	| 'legacy_auth_username'
-	| null
+		| 'main_character_name'
+		| 'character_name'
+		| 'character_id'
+		| 'user_id'
+		| 'discord_user_id'
+		| 'discord_username'
+		| 'legacy_auth_username'
+		| null
 	createdAt: string
 	updatedAt: string
 }
@@ -1705,7 +1703,12 @@ export interface AdminActivityLogFilters {
 	pageSize?: number
 }
 
-export type LegacyMigrationStatus = 'pending' | 'partially_applied' | 'applied' | 'dismissed' | 'error'
+export type LegacyMigrationStatus =
+	| 'pending'
+	| 'partially_applied'
+	| 'applied'
+	| 'dismissed'
+	| 'error'
 
 export interface LegacyMigrationQueueItem {
 	id: string
@@ -2549,45 +2552,39 @@ export class ApiClient {
 
 				// Throw appropriate error type based on status code
 				switch (response.status) {
-					case 400:
-						{
-							const error = new ValidationError(errorMessage, errorFields, requestInfo)
-							logApiError(error)
-							throw error
-						}
-					case 401:
-						{
-							const error = new AuthenticationError(errorMessage, requestInfo)
-							logApiError(error)
-							throw error
-						}
-					case 403:
-						{
-							const error = new AuthorizationError(errorMessage, requestInfo)
-							logApiError(error)
-							throw error
-						}
-					case 404:
-						{
-							const error = new NotFoundError(errorMessage, requestInfo)
-							logApiError(error)
-							throw error
-						}
+					case 400: {
+						const error = new ValidationError(errorMessage, errorFields, requestInfo)
+						logApiError(error)
+						throw error
+					}
+					case 401: {
+						const error = new AuthenticationError(errorMessage, requestInfo)
+						logApiError(error)
+						throw error
+					}
+					case 403: {
+						const error = new AuthorizationError(errorMessage, requestInfo)
+						logApiError(error)
+						throw error
+					}
+					case 404: {
+						const error = new NotFoundError(errorMessage, requestInfo)
+						logApiError(error)
+						throw error
+					}
 					case 500:
 					case 502:
 					case 503:
-					case 504:
-						{
-							const error = new ServerError(errorMessage, requestInfo)
-							logApiError(error)
-							throw error
-						}
-					default:
-						{
-							const error = new BaseApiError(errorMessage, response.status, requestInfo)
-							logApiError(error)
-							throw error
-						}
+					case 504: {
+						const error = new ServerError(errorMessage, requestInfo)
+						logApiError(error)
+						throw error
+					}
+					default: {
+						const error = new BaseApiError(errorMessage, response.status, requestInfo)
+						logApiError(error)
+						throw error
+					}
 				}
 			}
 
@@ -2599,7 +2596,7 @@ export class ApiClient {
 					{
 						...requestInfo,
 						status: response.status,
-					},
+					}
 				)
 				logApiError(error)
 				throw error
@@ -2634,7 +2631,10 @@ export class ApiClient {
 			}
 
 			// Unknown error
-			const unexpectedError = new NetworkError('An unexpected error occurred. Please try again.', requestInfo)
+			const unexpectedError = new NetworkError(
+				'An unexpected error occurred. Please try again.',
+				requestInfo
+			)
 			logApiError(unexpectedError)
 			throw unexpectedError
 		} finally {
@@ -2712,7 +2712,7 @@ export class ApiClient {
 					{
 						...requestInfo,
 						status: response.status,
-					},
+					}
 				)
 				logApiError(error)
 				throw error
@@ -2736,7 +2736,10 @@ export class ApiClient {
 				throw error
 			}
 
-			const unexpectedError = new NetworkError('An unexpected error occurred. Please try again.', requestInfo)
+			const unexpectedError = new NetworkError(
+				'An unexpected error occurred. Please try again.',
+				requestInfo
+			)
 			logApiError(unexpectedError)
 			throw unexpectedError
 		} finally {
@@ -2818,7 +2821,9 @@ export class ApiClient {
 		return this.get(`/characters/${characterId}/skills`)
 	}
 
-	async getCharacterOwnerships(characterIds: string[]): Promise<Record<string, { userId: string }>> {
+	async getCharacterOwnerships(
+		characterIds: string[]
+	): Promise<Record<string, { userId: string }>> {
 		return this.post('/characters/ownership', { characterIds })
 	}
 
@@ -3317,7 +3322,9 @@ export class ApiClient {
 		return this.patch(`/admin/structures/corporation-defaults/${corporationId}`, data)
 	}
 
-	async getAdminStructureAlertDestinations(groupId: string): Promise<CorporationAlertDestination[]> {
+	async getAdminStructureAlertDestinations(
+		groupId: string
+	): Promise<CorporationAlertDestination[]> {
 		return this.get(`/admin/structures/groups/${groupId}/destinations`)
 	}
 
@@ -3394,7 +3401,9 @@ export class ApiClient {
 		return this.delete(`/admin/navigation/external-links/${id}`)
 	}
 
-	async getCitadelStructures(query: StructureCitadelListQuery = {}): Promise<StructureCitadelListResponse> {
+	async getCitadelStructures(
+		query: StructureCitadelListQuery = {}
+	): Promise<StructureCitadelListResponse> {
 		const params = new URLSearchParams()
 		if (query.page) params.set('page', String(query.page))
 		if (query.pageSize) params.set('pageSize', String(query.pageSize))
@@ -3437,8 +3446,11 @@ export class ApiClient {
 		if (query.sortBy) params.set('sortBy', query.sortBy)
 		if (query.sortDirection) params.set('sortDirection', query.sortDirection)
 		if (query.corporationId) params.set('corporationId', query.corporationId)
+		if (query.assignedGroupId) params.set('assignedGroupId', query.assignedGroupId)
+		if (query.regionId) params.set('regionId', query.regionId)
 		if (query.systemId) params.set('systemId', query.systemId)
-		if (query.allianceId) params.set('allianceId', query.allianceId)
+		if (query.controllerAllianceId) params.set('controllerAllianceId', query.controllerAllianceId)
+		if (query.vulnerabilityState) params.set('vulnerabilityState', query.vulnerabilityState)
 		const queryString = params.toString()
 		return this.get(`/structures/sovereignty${queryString ? `?${queryString}` : ''}`)
 	}
@@ -3460,7 +3472,9 @@ export class ApiClient {
 		return this.get(`/structures/skyhooks${queryString ? `?${queryString}` : ''}`)
 	}
 
-	async getMoonDrillStructures(query: StructureMiningListQuery = {}): Promise<StructureMiningListResponse> {
+	async getMoonDrillStructures(
+		query: StructureMiningListQuery = {}
+	): Promise<StructureMiningListResponse> {
 		const params = new URLSearchParams()
 		if (query.page) params.set('page', String(query.page))
 		if (query.pageSize) params.set('pageSize', String(query.pageSize))
@@ -3490,7 +3504,9 @@ export class ApiClient {
 		return this.get(`/structures/mining-citadels${queryString ? `?${queryString}` : ''}`)
 	}
 
-	async getMiningStructures(query: StructureMiningListQuery = {}): Promise<StructureMiningListResponse> {
+	async getMiningStructures(
+		query: StructureMiningListQuery = {}
+	): Promise<StructureMiningListResponse> {
 		return this.getMoonDrillStructures(query)
 	}
 
@@ -3498,7 +3514,9 @@ export class ApiClient {
 		return this.get('/structures/overview')
 	}
 
-	async getStructures(query: StructureCitadelListQuery = {}): Promise<StructureCitadelListResponse> {
+	async getStructures(
+		query: StructureCitadelListQuery = {}
+	): Promise<StructureCitadelListResponse> {
 		return this.getCitadelStructures(query)
 	}
 
@@ -3693,7 +3711,10 @@ export class ApiClient {
 		return this.post('/discord-commands', data)
 	}
 
-	async updateDiscordCommand(id: string, data: UpdateDiscordCommandRequest): Promise<DiscordCommand> {
+	async updateDiscordCommand(
+		id: string,
+		data: UpdateDiscordCommandRequest
+	): Promise<DiscordCommand> {
 		return this.patch(`/discord-commands/${id}`, data)
 	}
 
@@ -4084,9 +4105,7 @@ export class ApiClient {
 		return this.get(`/hr/legacy/history${query ? `?${query}` : ''}`)
 	}
 
-	async getLegacyHistoryApplication(
-		legacyApplicationId: string
-	): Promise<{
+	async getLegacyHistoryApplication(legacyApplicationId: string): Promise<{
 		application: LegacyHistoryApplication
 		events: LegacyHistoryEvent[]
 		modernUserMatch: LegacyHistoryModernUserMatch | null
@@ -4195,7 +4214,10 @@ export class ApiClient {
 	}
 
 	// Broadcast Templates
-	async getBroadcastTemplates(targetType?: string, targetId?: string): Promise<BroadcastTemplate[]> {
+	async getBroadcastTemplates(
+		targetType?: string,
+		targetId?: string
+	): Promise<BroadcastTemplate[]> {
 		const params = new URLSearchParams()
 		if (targetType) params.set('targetType', targetType)
 		if (targetId) params.set('targetId', targetId)
@@ -4514,7 +4536,9 @@ export class ApiClient {
 		return this.get(`/srp/payments/pending${query ? `?${query}` : ''}`)
 	}
 
-	async getPendingPayoutTotal(params?: { corporationId?: string }): Promise<{ pendingPayoutTotal: string }> {
+	async getPendingPayoutTotal(params?: {
+		corporationId?: string
+	}): Promise<{ pendingPayoutTotal: string }> {
 		const searchParams = new URLSearchParams()
 		if (params?.corporationId) searchParams.set('corporationId', params.corporationId)
 
@@ -4577,9 +4601,9 @@ export class ApiClient {
 		const searchParams = new URLSearchParams()
 		searchParams.set('field', params.field)
 		searchParams.set('q', params.query)
-		const result = await this.get<{ values: Array<{ value: string; label: string; description?: string }> }>(
-			`/srp/payments/wallet-history/search-values?${searchParams.toString()}`
-		)
+		const result = await this.get<{
+			values: Array<{ value: string; label: string; description?: string }>
+		}>(`/srp/payments/wallet-history/search-values?${searchParams.toString()}`)
 		return result.values ?? []
 	}
 
@@ -4589,9 +4613,20 @@ export class ApiClient {
 		alertsOnly?: boolean
 		dateFrom?: string
 		dateTo?: string
-	}): Promise<{ workflowInstanceId: string; exportId: string; fileName: string; status: 'queued' }> {
-		if (!params?.dateFrom || !params?.dateTo || !isDateRangeWithinOneYear(params.dateFrom, params.dateTo)) {
-			throw new Error('Entry date range is required for wallet history export and must not exceed 1 year')
+	}): Promise<{
+		workflowInstanceId: string
+		exportId: string
+		fileName: string
+		status: 'queued'
+	}> {
+		if (
+			!params?.dateFrom ||
+			!params?.dateTo ||
+			!isDateRangeWithinOneYear(params.dateFrom, params.dateTo)
+		) {
+			throw new Error(
+				'Entry date range is required for wallet history export and must not exceed 1 year'
+			)
 		}
 
 		const searchParams = new URLSearchParams()
@@ -4601,13 +4636,16 @@ export class ApiClient {
 		searchParams.set('dateFrom', params.dateFrom)
 		searchParams.set('dateTo', params.dateTo)
 
-		const response = await fetch(`/api/srp/payments/wallet-history/export?${searchParams.toString()}`, {
-			method: 'POST',
-			credentials: 'include',
-			headers: {
-				'X-Requested-With': 'XMLHttpRequest',
-			},
-		})
+		const response = await fetch(
+			`/api/srp/payments/wallet-history/export?${searchParams.toString()}`,
+			{
+				method: 'POST',
+				credentials: 'include',
+				headers: {
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+			}
+		)
 		if (!response.ok) {
 			const message = await response.text()
 			throw new Error(message || 'Failed to request SRP wallet history export')
@@ -4631,12 +4669,15 @@ export class ApiClient {
 	}
 
 	async downloadSrpWalletHistoryCsv(workflowInstanceId: string, fileName: string): Promise<void> {
-		const response = await fetch(`/api/srp/payments/wallet-history/export/${workflowInstanceId}/download`, {
-			credentials: 'include',
-			headers: {
-				'X-Requested-With': 'XMLHttpRequest',
-			},
-		})
+		const response = await fetch(
+			`/api/srp/payments/wallet-history/export/${workflowInstanceId}/download`,
+			{
+				credentials: 'include',
+				headers: {
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+			}
+		)
 		if (!response.ok) {
 			const message = await response.text()
 			throw new Error(message || 'Failed to export SRP wallet history')
@@ -4652,7 +4693,12 @@ export class ApiClient {
 		solarSystemName?: string
 		dateFrom: string
 		dateTo: string
-	}): Promise<{ workflowInstanceId: string; exportId: string; fileName: string; status: 'queued' }> {
+	}): Promise<{
+		workflowInstanceId: string
+		exportId: string
+		fileName: string
+		status: 'queued'
+	}> {
 		if (!isDateRangeWithinOneYear(params.dateFrom, params.dateTo)) {
 			throw new Error('Paid SRP export requires a date range of no more than 1 year')
 		}
@@ -4859,10 +4905,7 @@ export class ApiClient {
 		return this.post(`/srp/requests/${id}/review`, data)
 	}
 
-	async updateReviewState(
-		id: string,
-		data: { newState: string; notes?: string }
-	): Promise<any> {
+	async updateReviewState(id: string, data: { newState: string; notes?: string }): Promise<any> {
 		return this.patch(`/srp/requests/${id}/state`, data)
 	}
 
@@ -4953,11 +4996,17 @@ export class ApiClient {
 		return this.get('/doctrines/categories')
 	}
 
-	async createDoctrineCategory(data: { name: string; sortOrder?: number }): Promise<DoctrineCategory> {
+	async createDoctrineCategory(data: {
+		name: string
+		sortOrder?: number
+	}): Promise<DoctrineCategory> {
 		return this.post('/doctrines/categories', data)
 	}
 
-	async updateDoctrineCategory(id: string, data: { name?: string; sortOrder?: number }): Promise<DoctrineCategory> {
+	async updateDoctrineCategory(
+		id: string,
+		data: { name?: string; sortOrder?: number }
+	): Promise<DoctrineCategory> {
 		return this.patch(`/doctrines/categories/${id}`, data)
 	}
 
@@ -4970,11 +5019,18 @@ export class ApiClient {
 		return this.get('/doctrines/staging-systems')
 	}
 
-	async createStagingSystem(data: { solarSystemId: string; solarSystemName: string; sortOrder?: number }): Promise<StagingSystem> {
+	async createStagingSystem(data: {
+		solarSystemId: string
+		solarSystemName: string
+		sortOrder?: number
+	}): Promise<StagingSystem> {
 		return this.post('/doctrines/staging-systems', data)
 	}
 
-	async updateStagingSystem(id: string, data: { solarSystemId?: string; solarSystemName?: string; sortOrder?: number }): Promise<StagingSystem> {
+	async updateStagingSystem(
+		id: string,
+		data: { solarSystemId?: string; solarSystemName?: string; sortOrder?: number }
+	): Promise<StagingSystem> {
 		return this.patch(`/doctrines/staging-systems/${id}`, data)
 	}
 
@@ -4983,7 +5039,10 @@ export class ApiClient {
 	}
 
 	// Doctrine-Staging
-	async setDoctrineStagingSystem(doctrineId: string, data: { stagingSystemId: string; note: string }): Promise<void> {
+	async setDoctrineStagingSystem(
+		doctrineId: string,
+		data: { stagingSystemId: string; note: string }
+	): Promise<void> {
 		return this.put(`/doctrines/${doctrineId}/staging-systems`, data)
 	}
 
@@ -5023,7 +5082,10 @@ export class ApiClient {
 		return this.get('/doctrines/fittings/with-doctrines')
 	}
 
-	async saveFittingIngame(fittingId: string, characterId: string): Promise<SaveFittingIngameResponse> {
+	async saveFittingIngame(
+		fittingId: string,
+		characterId: string
+	): Promise<SaveFittingIngameResponse> {
 		return this.post(`/doctrines/fittings/${fittingId}/save-ingame`, { characterId })
 	}
 
@@ -5247,7 +5309,10 @@ export class ApiClient {
 		return this.post('/pastes', input)
 	}
 
-	async getMyPastes(limit = 50, offset = 0): Promise<{
+	async getMyPastes(
+		limit = 50,
+		offset = 0
+	): Promise<{
 		items: PasteRecord[]
 		total: number
 		activeCount: number

--- a/apps/ui/src/client/routes/admin/corporation-detail.tsx
+++ b/apps/ui/src/client/routes/admin/corporation-detail.tsx
@@ -597,7 +597,9 @@ export default function CorporationDetailPage() {
 
 	const formatDate = (date: string | Date | null) => {
 		if (!date) return 'Never'
-		return formatDistanceToNow(new Date(date), { addSuffix: true })
+		const parsedDate = date instanceof Date ? date : new Date(date)
+		if (Number.isNaN(parsedDate.getTime())) return 'Never'
+		return formatDistanceToNow(parsedDate, { addSuffix: true })
 	}
 
 	const scenarioRoleConfigs = [

--- a/apps/ui/src/client/routes/admin/corporations.tsx
+++ b/apps/ui/src/client/routes/admin/corporations.tsx
@@ -208,7 +208,9 @@ export default function CorporationsPage() {
 	// Format date (memoized for performance)
 	const formatDate = useCallback((date: string | null) => {
 		if (!date) return 'Never'
-		return formatDistanceToNow(new Date(date), { addSuffix: true })
+		const parsedDate = new Date(date)
+		if (Number.isNaN(parsedDate.getTime())) return 'Never'
+		return formatDistanceToNow(parsedDate, { addSuffix: true })
 	}, [])
 
 	return (

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -1,42 +1,42 @@
-import { ArrowLeft, CircleHelp, Factory, Package, Recycle, Save, Search, Store, Users } from 'lucide-react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+	ArrowLeft,
+	CircleHelp,
+	Factory,
+	Package,
+	Recycle,
+	Save,
+	Search,
+	Shield,
+	Store,
+	Users,
+} from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 
+import { FittingPanel } from '@repo/eve-fitting/fitting-panel'
+import { FittingSlotTable } from '@repo/eve-fitting/fitting-slot-table'
+import { hasAnyStructurePermission } from '@repo/groups'
+import { getStructureTabForTypeId, isReinforcedStructureState } from '@repo/structures'
+
+import { CorporationLogo } from '@/components/corporation-logo'
+import { InventoryBaysTable } from '@/components/inventory-bays-table'
+import { StructureFuelUsageChart } from '@/components/structure-fuel-usage-chart'
+import { StructureStateBadge } from '@/components/structure-state-badge'
+import { StructureSyncStatusBadge } from '@/components/structure-sync-status-badge'
 import { Badge } from '@/components/ui/badge'
-import type { BadgeVariant } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
+import { DurationDisplay } from '@/components/ui/duration-display'
+import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { FilterField } from '@/components/ui/filter-field'
-import { StructureSyncStatusBadge } from '@/components/structure-sync-status-badge'
 import { LoadingPage } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
-import { Select, type SelectOption } from '@/components/ui/select'
-import { EveTimeDisplay } from '@/components/ui/eve-time-display'
-import { DurationDisplay } from '@/components/ui/duration-display'
-import { Switch } from '@/components/ui/switch'
-import { StructureStateBadge } from '@/components/structure-state-badge'
-import { useApiMutation } from '@/hooks/useApiMutation'
-import { useAuth } from '@/hooks/useAuth'
-import { useGroups } from '@/hooks/useGroups'
-import { usePageTitle } from '@/hooks/usePageTitle'
-import { useUserPermissions } from '@/hooks/useUserPermissions'
-import { useSystemDetails } from '@/hooks/useLocationSearch'
-import { InventoryBaysTable } from '@/components/inventory-bays-table'
-import { CorporationLogo } from '@/components/corporation-logo'
-import { StructureFuelUsageChart } from '@/components/structure-fuel-usage-chart'
+import { Progress } from '@/components/ui/progress'
+import { Select } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
-import { FittingPanel } from '@repo/eve-fitting/fitting-panel'
-import { FittingSlotTable } from '@repo/eve-fitting/fitting-slot-table'
-import type { FittingDisplayItem, FittingShipSlotType } from '@repo/eve-fitting/flags'
-import {
-	api,
-	type StructureAssetsDebugResult,
-	type StructureDetailResult,
-	type StructureInventoryBay,
-} from '@/lib/api'
-import { typeIconUrl, typeImageUrl, typeRenderUrl } from '@/lib/eve-images'
-import { formatDateTimeLong } from '@/lib/date-utils'
+import { Switch } from '@/components/ui/switch'
 import {
 	Table,
 	TableBody,
@@ -45,11 +45,24 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { useApiMutation } from '@/hooks/useApiMutation'
+import { useAuth } from '@/hooks/useAuth'
+import { useGroups } from '@/hooks/useGroups'
+import { useSystemDetails } from '@/hooks/useLocationSearch'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import { useUserPermissions } from '@/hooks/useUserPermissions'
+import { api } from '@/lib/api'
+import { formatDateTimeLong } from '@/lib/date-utils'
+import { allianceLogoUrl, typeIconUrl, typeImageUrl, typeRenderUrl } from '@/lib/eve-images'
 
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { hasAnyStructurePermission } from '@repo/groups'
-import { isReinforcedStructureState } from '@repo/structures'
-import { getStructureTabForTypeId } from '@repo/structures'
+import type { FittingDisplayItem, FittingShipSlotType } from '@repo/eve-fitting/flags'
+import type { BadgeVariant } from '@/components/ui/badge'
+import type { SelectOption } from '@/components/ui/select'
+import type {
+	StructureAssetsDebugResult,
+	StructureDetailResult,
+	StructureInventoryBay,
+} from '@/lib/api'
 
 function structureSyncStatusDescription(
 	syncStatus: StructureDetailResult['syncStatus'],
@@ -81,7 +94,10 @@ function structureSyncStatusDescription(
 		)
 	}
 
-	return lastSyncText || 'The latest corporation-data sync completed successfully and the stored snapshot is current.'
+	return (
+		lastSyncText ||
+		'The latest corporation-data sync completed successfully and the stored snapshot is current.'
+	)
 }
 
 function serviceBadgeVariant(state: string): BadgeVariant {
@@ -138,9 +154,49 @@ function formatNullableNumber(value: number | null | undefined): string {
 	return value.toLocaleString()
 }
 
+function getSovereigntyVulnerabilityState(
+	sovereignty: StructureDetailResult['sovereignty'] | null | undefined
+): { label: string; variant: BadgeVariant } {
+	if (!sovereignty?.vulnerabilityWindowStart || !sovereignty?.vulnerabilityWindowEnd) {
+		return { label: 'Unknown', variant: 'ghost' }
+	}
+
+	const start = new Date(sovereignty.vulnerabilityWindowStart).getTime()
+	const end = new Date(sovereignty.vulnerabilityWindowEnd).getTime()
+	const now = Date.now()
+	if (Number.isFinite(start) && Number.isFinite(end) && now >= start && now <= end) {
+		return { label: 'Vulnerable', variant: 'warning' }
+	}
+
+	return { label: 'Invulnerable', variant: 'success' }
+}
+
+function toFiniteNumber(value: unknown): number {
+	const parsed = typeof value === 'number' ? value : Number(value)
+	return Number.isFinite(parsed) ? parsed : 0
+}
+
 function formatBurnRate(value: number | null | undefined): string {
 	if (value === null || value === undefined) return '-'
 	return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}/hr`
+}
+
+function AllianceLogo({ allianceId, allianceName }: { allianceId: string; allianceName?: string | null }) {
+	const [failed, setFailed] = useState(false)
+
+	if (failed) {
+		return <Shield className="h-4 w-4 text-muted-foreground" />
+	}
+
+	return (
+		<img
+			src={allianceLogoUrl(allianceId, 32)}
+			alt={allianceName ? `${allianceName} logo` : 'Alliance logo'}
+			className="h-4 w-4 rounded-sm object-cover"
+			loading="lazy"
+			onError={() => setFailed(true)}
+		/>
+	)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -184,7 +240,9 @@ function parseWorkforceTransportSources(value: unknown): WorkforceTransportSourc
 		const amount =
 			typeof entry.amount === 'number'
 				? entry.amount
-				: typeof entry.amount === 'string' && entry.amount.trim() !== '' && Number.isFinite(Number(entry.amount))
+				: typeof entry.amount === 'string' &&
+					  entry.amount.trim() !== '' &&
+					  Number.isFinite(Number(entry.amount))
 					? Number(entry.amount)
 					: null
 		return [
@@ -235,7 +293,9 @@ function formatWorkforceTransportMode(mode: ParsedWorkforceTransportSection['mod
 	}
 }
 
-function workforceTransportBadgeVariant(mode: ParsedWorkforceTransportSection['mode']): BadgeVariant {
+function workforceTransportBadgeVariant(
+	mode: ParsedWorkforceTransportSection['mode']
+): BadgeVariant {
 	return mode === 'unknown' ? 'ghost' : 'success'
 }
 
@@ -268,13 +328,6 @@ function WorkforceTransportSection({
 			<div className="flex items-start justify-between gap-3">
 				<div>
 					<div className="font-medium">{label}</div>
-					<div className="text-xs text-muted-foreground">
-						{parsed.mode === 'transit'
-							? 'This hub is configured for transit routing.'
-							: parsed.mode === 'unknown'
-								? 'No recognizable workforce transport configuration was recorded.'
-								: `This hub is configured for ${formatWorkforceTransportMode(parsed.mode).toLowerCase()} routing.`}
-					</div>
 				</div>
 				<Badge variant={workforceTransportBadgeVariant(parsed.mode)}>
 					{formatWorkforceTransportMode(parsed.mode)}
@@ -313,6 +366,35 @@ function WorkforceTransportSection({
 	)
 }
 
+function ResourceAllocationCard({
+	label,
+	allocated,
+	available,
+}: {
+	label: string
+	allocated: number | null | undefined
+	available: number | null | undefined
+}) {
+	const allocatedValue = toFiniteNumber(allocated)
+	const availableValue = toFiniteNumber(available)
+	const percentage =
+		availableValue > 0 ? Math.min(100, Math.max(0, (allocatedValue / availableValue) * 100)) : 0
+
+	return (
+		<div className="rounded-lg border border-border/60 bg-muted/20 p-4">
+			<div className="flex items-center justify-between gap-3">
+				<div className="font-medium">{label}</div>
+				<div className="font-mono text-sm tabular-nums">
+					<span>{formatNullableNumber(allocatedValue)}</span>
+					<span className="mx-1 text-muted-foreground">/</span>
+					<span>{formatNullableNumber(availableValue)}</span>
+				</div>
+			</div>
+			<Progress value={percentage} className="mt-3 h-2 bg-border/60" />
+		</div>
+	)
+}
+
 function InventoryItemIcon({ typeId }: { typeId: string }) {
 	const [failed, setFailed] = useState(false)
 
@@ -345,7 +427,9 @@ const FITTING_SLOT_TYPE_BY_NAME: Record<string, FittingShipSlotType> = {
 
 const STRUCTURE_SLOT_TABLE_TYPES: FittingShipSlotType[] = ['high', 'mid', 'low', 'rig']
 
-function structureFittingItemsToDisplayItems(structure: StructureDetailResult): FittingDisplayItem[] {
+function structureFittingItemsToDisplayItems(
+	structure: StructureDetailResult
+): FittingDisplayItem[] {
 	return (structure.fittingItems ?? []).map((item, index) => ({
 		typeId: item.typeId,
 		typeName: item.typeName ?? item.typeId,
@@ -405,8 +489,11 @@ export default function StructuresDetailPage() {
 	}, [groups])
 
 	const updateMutation = useApiMutation({
-		mutationFn: (data: { hidden: boolean; lowPowerAllowed: boolean; assignedGroupId: string | null }) =>
-			api.updateStructureConfig(structureId!, data),
+		mutationFn: (data: {
+			hidden: boolean
+			lowPowerAllowed: boolean
+			assignedGroupId: string | null
+		}) => api.updateStructureConfig(structureId!, data),
 		successMessage: 'Structure configuration saved.',
 		onSuccess: async () => {
 			await Promise.all([
@@ -433,6 +520,44 @@ export default function StructuresDetailPage() {
 	}, [structure])
 	const hasStructureFitting = fittingItems.length > 0
 	const isReinforced = structure ? isReinforcedStructureState(structure.state) : false
+	type SovereigntyReagent = NonNullable<
+		NonNullable<StructureDetailResult['sovereignty']>['hub']
+	>['reagentBay']['reagents'][number]
+	const sovereigntyReagentBays = useMemo<StructureInventoryBay[]>(() => {
+		const hub = structure?.sovereignty?.hub
+		if (!hub) {
+			return []
+		}
+
+		const totalQuantity = hub.reagentBay.reagents.reduce(
+			(accumulator, reagent) =>
+				accumulator + toFiniteNumber(reagent.securedStock) + toFiniteNumber(reagent.unsecuredStock),
+			0
+		)
+
+		return [
+			{
+				locationFlag: 'SovereigntyReagentBay',
+				label: 'Reagent Bay',
+				totalQuantity,
+				totalStacks: hub.reagentBay.reagents.length,
+				items: hub.reagentBay.reagents.map((reagent) => ({
+					typeId: reagent.typeId,
+					typeName: reagent.typeName ?? null,
+					quantity: toFiniteNumber(reagent.securedStock) + toFiniteNumber(reagent.unsecuredStock),
+					stackCount: 1,
+				})),
+			},
+		]
+	}, [structure?.sovereignty?.hub])
+	const sovereigntyReagentDetailsByTypeId = useMemo(() => {
+		const hub = structure?.sovereignty?.hub
+		if (!hub) {
+			return new Map<string, SovereigntyReagent>()
+		}
+
+		return new Map(hub.reagentBay.reagents.map((reagent) => [reagent.typeId, reagent] as const))
+	}, [structure?.sovereignty?.hub])
 
 	if (!authLoading && !permissionsLoading && !canViewStructures) {
 		return <Navigate to="/dashboard" replace />
@@ -475,41 +600,8 @@ export default function StructuresDetailPage() {
 	const hasSovereigntySummary = structureFamily === 'sovereignty' && structure.sovereignty
 	const hasSkyhookSummary = structureFamily === 'skyhooks' && structure.skyhook
 	const hasMiningSummary = structureFamily === 'mining-citadels'
-	type SovereigntyReagent = NonNullable<NonNullable<StructureDetailResult['sovereignty']>['hub']>['reagentBay']['reagents'][number]
-	const sovereigntyReagentBays = useMemo<StructureInventoryBay[]>(() => {
-		const hub = structure.sovereignty?.hub
-		if (!hub) {
-			return []
-		}
-
-		const totalQuantity = hub.reagentBay.reagents.reduce(
-			(accumulator, reagent) => accumulator + reagent.securedStock + reagent.unsecuredStock,
-			0
-		)
-
-		return [
-			{
-				locationFlag: 'SovereigntyReagentBay',
-				label: 'Reagent Bay',
-				totalQuantity,
-				totalStacks: hub.reagentBay.reagents.length,
-				items: hub.reagentBay.reagents.map((reagent) => ({
-					typeId: reagent.typeId,
-					typeName: null,
-					quantity: reagent.securedStock + reagent.unsecuredStock,
-					stackCount: 1,
-				})),
-			},
-		]
-	}, [structure.sovereignty?.hub])
-	const sovereigntyReagentDetailsByTypeId = useMemo(() => {
-		const hub = structure.sovereignty?.hub
-		if (!hub) {
-			return new Map<string, SovereigntyReagent>()
-		}
-
-		return new Map(hub.reagentBay.reagents.map((reagent) => [reagent.typeId, reagent] as const))
-	}, [structure.sovereignty?.hub])
+	const sovereigntyHub = structure.sovereignty?.hub ?? null
+	const sovereigntyVulnerabilityState = getSovereigntyVulnerabilityState(structure.sovereignty)
 
 	const handleSave = async () => {
 		await updateMutation.mutateAsync({
@@ -567,149 +659,230 @@ export default function StructuresDetailPage() {
 							</Button>
 						)}
 					</CardHeader>
-					<CardContent className="space-y-4 text-sm">
-						<div className="grid grid-cols-2 gap-4">
-							<div>
-								<div className="text-muted-foreground">Region</div>
-								<div className="font-medium">{structure.regionName ?? structure.regionId ?? '-'}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">System</div>
-								<div className="font-medium">{structure.systemName ?? structure.systemId}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Type</div>
-								<div className="font-medium">{structure.typeName ?? structure.typeId}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Low Power</div>
-								<div className="font-medium">{structure.lowPower ? 'Yes' : 'No'}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Fuel</div>
-								<div className="font-medium">
-									{structure.fuelAmount !== null ? (
-										`${structure.fuelAmount.toLocaleString()} units`
-									) : structure.fuelExpires ? (
-										<DurationDisplay endDate={structure.fuelExpires} format="compact" />
-									) : (
-										'-'
-									)}
+						<CardContent className="space-y-4 text-sm">
+							<div className="grid grid-cols-2 gap-4">
+								<div>
+									<div className="text-muted-foreground">Region</div>
+									<div className="font-medium">
+										{structure.regionName ?? structure.regionId ?? '-'}
+									</div>
 								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Last Refilled</div>
-								<div className="font-medium">
-									{structure.lastRefilledAt ? (
-										<EveTimeDisplay dateStr={structure.lastRefilledAt} format="compact" />
-									) : (
-										'-'
-									)}
+								<div>
+									<div className="text-muted-foreground">System</div>
+									<div className="font-medium">{structure.systemName ?? structure.systemId}</div>
 								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">State</div>
-								<div className="font-medium">
-									<StructureStateBadge state={structure.state} />
+								<div>
+									<div className="text-muted-foreground">
+										{hasSovereigntySummary ? 'Controlling Alliance' : 'Type'}
+									</div>
+									<div className="font-medium">
+										{hasSovereigntySummary
+											? sovereigntyHub?.controllerAllianceId ? (
+													<div className="flex items-center gap-2">
+														<AllianceLogo
+															allianceId={sovereigntyHub.controllerAllianceId}
+															allianceName={sovereigntyHub.controllerAllianceName}
+														/>
+														<span>
+															{sovereigntyHub.controllerAllianceName ??
+																sovereigntyHub.controllerAllianceId}
+														</span>
+													</div>
+												) : (
+													'-'
+												)
+											: structure.typeName ?? structure.typeId}
+									</div>
 								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">
-									{isReinforced ? 'Reinforced until' : 'Next State'}
-								</div>
-								<div className="font-medium">
-									{structure.nextStateAt ? (
-										<EveTimeDisplay dateStr={structure.nextStateAt} format="compact" />
-									) : (
-										'-'
-									)}
-								</div>
-							</div>
-						</div>
-						<div className="flex flex-wrap gap-2 pt-2">
-							{structure.hidden && <Badge variant="ghost">Hidden</Badge>}
-							{structure.lowPowerAllowed && <Badge variant="success">Low Power Alerts Suppressed</Badge>}
-							{structure.assignedGroupId && <Badge variant="special">Group Assigned</Badge>}
-						</div>
-						<div className="space-y-3">
-							<div className="space-y-2">
-								<div className="text-xs uppercase tracking-wider text-muted-foreground">Reinforcement</div>
-								<div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-sm">
-									<div className="grid gap-3">
+								{!hasSovereigntySummary && (
+									<div>
+										<div className="text-muted-foreground">Low Power</div>
+										<div className="font-medium">{structure.lowPower ? 'Yes' : 'No'}</div>
+									</div>
+								)}
+								{!hasSovereigntySummary && (
+									<>
 										<div>
-											<div className="text-xs text-muted-foreground">Reinforcement Hour</div>
+											<div className="text-muted-foreground">Fuel</div>
 											<div className="font-medium">
-												{formatReinforcementHourUtc(structure.reinforceHour)}
-											</div>
-										</div>
-										<div>
-											<div className="text-xs text-muted-foreground">Next Reinforcement Hour</div>
-											<div className="font-medium">
-												{structure.nextReinforceHour !== null
-													? formatReinforcementHourUtc(structure.nextReinforceHour)
-													: '-'}
-											</div>
-										</div>
-										<div>
-											<div className="text-xs text-muted-foreground">Next Reinforcement Applies</div>
-											<div className="font-medium">
-												{structure.nextReinforceApply ? (
-													<EveTimeDisplay dateStr={structure.nextReinforceApply} format="compact" />
+												{structure.fuelAmount !== null ? (
+													`${structure.fuelAmount.toLocaleString()} units`
+												) : structure.fuelExpires ? (
+													<DurationDisplay endDate={structure.fuelExpires} format="compact" />
 												) : (
 													'-'
 												)}
 											</div>
 										</div>
-									</div>
-								</div>
-							</div>
-							<div className="space-y-2">
-								<div className="text-xs uppercase tracking-wider text-muted-foreground">
-									Structure Services
-								</div>
-								{structure.services.length > 0 ? (
-									<div className="space-y-1.5">
-										{structure.services.map((service) => (
-											<div
-												key={`${service.name}-${service.state}`}
-												className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
-											>
-												<div className="flex min-w-0 items-center gap-2">
-													<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground">
-														{renderServiceIcon(service.name)}
-													</div>
-													<div className="min-w-0">
-														<div className="truncate text-sm font-medium">{service.name}</div>
-													</div>
-												</div>
-												<Badge variant={serviceBadgeVariant(service.state)} className="shrink-0">
-													{formatServiceStateLabel(service.state)}
-												</Badge>
+										<div>
+											<div className="text-muted-foreground">Last Refilled</div>
+											<div className="font-medium">
+												{structure.lastRefilledAt ? (
+													<EveTimeDisplay dateStr={structure.lastRefilledAt} format="compact" />
+												) : (
+													'-'
+												)}
 											</div>
-										))}
-									</div>
-								) : (
-									<div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
-										No structure services were reported for this structure.
+										</div>
+									</>
+								)}
+								{hasSovereigntySummary && (
+									<div>
+										<div className="text-muted-foreground">Claimed Since</div>
+										<div className="font-medium">
+											{formatNullableDateTime(structure.sovereignty?.claimedSince)}
+										</div>
 									</div>
 								)}
-							</div>
-							<div className="space-y-2">
-								<div className="text-xs uppercase tracking-wider text-muted-foreground">Sync Status</div>
-								<div className="rounded-lg border border-border/60 p-4">
-									<div className="mb-3 flex flex-wrap items-center gap-2">
-										{structure.includeInStructureAssetSync && (
-											<Badge variant="success">Asset Sync Enabled</Badge>
+								{hasSovereigntySummary && (
+									<div>
+										<div className="text-muted-foreground">Capital System</div>
+										<div className="font-medium">
+											{structure.sovereignty?.isCapitalSystem ? 'Yes' : 'No'}
+										</div>
+									</div>
+								)}
+								{hasSovereigntySummary && (
+									<div>
+										<div className="text-muted-foreground">Activity Defense Multiplier</div>
+										<div className="font-medium">
+											{structure.sovereignty?.activityDefenseMultiplier ?? '-'}
+										</div>
+									</div>
+								)}
+								<div>
+									<div className="text-muted-foreground">
+										{hasSovereigntySummary ? 'Vulnerability State' : 'State'}
+									</div>
+									<div className="font-medium">
+										{hasSovereigntySummary ? (
+											<Badge variant={sovereigntyVulnerabilityState.variant}>
+												{sovereigntyVulnerabilityState.label}
+											</Badge>
+										) : (
+											<StructureStateBadge state={structure.state} />
 										)}
-									<div className="mt-0.5">
-										<StructureSyncStatusBadge status={structure.syncStatus} description={syncDescription} />
 									</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">
+										{hasSovereigntySummary ? 'Vulnerability Window' : isReinforced ? 'Reinforced until' : 'Next State'}
 									</div>
-									<div className="mt-2 text-sm text-muted-foreground">{syncDescription}</div>
+									<div className="font-medium">
+										{hasSovereigntySummary ? (
+											structure.sovereignty?.vulnerabilityWindowStart &&
+											structure.sovereignty?.vulnerabilityWindowEnd ? (
+												`${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowStart)} - ${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowEnd)}`
+											) : (
+												formatNullableDateTime(structure.sovereignty?.vulnerabilityWindowEnd)
+											)
+										) : structure.nextStateAt ? (
+											<EveTimeDisplay dateStr={structure.nextStateAt} format="compact" />
+										) : (
+											'-'
+										)}
+									</div>
 								</div>
 							</div>
-						</div>
-					</CardContent>
+							<div className="flex flex-wrap gap-2 pt-2">
+								{structure.hidden && <Badge variant="ghost">Hidden</Badge>}
+								{!hasSovereigntySummary && structure.lowPowerAllowed && (
+									<Badge variant="success">Low Power Alerts Suppressed</Badge>
+								)}
+								{structure.assignedGroupId && <Badge variant="special">Group Assigned</Badge>}
+							</div>
+								<div className="space-y-3">
+									{!hasSovereigntySummary && (
+										<div className="space-y-2">
+											<div className="text-xs uppercase tracking-wider text-muted-foreground">
+												Reinforcement
+											</div>
+											<div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-sm">
+												<div className="grid gap-3">
+													<div>
+														<div className="text-xs text-muted-foreground">Reinforcement Hour</div>
+														<div className="font-medium">
+															{formatReinforcementHourUtc(structure.reinforceHour)}
+														</div>
+													</div>
+													<div>
+														<div className="text-xs text-muted-foreground">Next Reinforcement Hour</div>
+														<div className="font-medium">
+															{structure.nextReinforceHour !== null
+																? formatReinforcementHourUtc(structure.nextReinforceHour)
+																: '-'}
+														</div>
+													</div>
+													<div>
+														<div className="text-xs text-muted-foreground">
+															Next Reinforcement Applies
+														</div>
+														<div className="font-medium">
+															{structure.nextReinforceApply ? (
+																<EveTimeDisplay dateStr={structure.nextReinforceApply} format="compact" />
+															) : (
+																'-'
+															)}
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+									)}
+								{!hasSovereigntySummary && (
+									<div className="space-y-2">
+										<div className="text-xs uppercase tracking-wider text-muted-foreground">
+											Structure Services
+										</div>
+										{structure.services.length > 0 ? (
+											<div className="space-y-1.5">
+												{structure.services.map((service) => (
+													<div
+														key={`${service.name}-${service.state}`}
+														className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
+													>
+														<div className="flex min-w-0 items-center gap-2">
+															<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground">
+																{renderServiceIcon(service.name)}
+															</div>
+															<div className="min-w-0">
+																<div className="truncate text-sm font-medium">{service.name}</div>
+															</div>
+														</div>
+														<Badge variant={serviceBadgeVariant(service.state)} className="shrink-0">
+															{formatServiceStateLabel(service.state)}
+														</Badge>
+													</div>
+												))}
+											</div>
+										) : (
+											<div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+												No structure services were reported for this structure.
+											</div>
+										)}
+									</div>
+								)}
+								<div className="space-y-2">
+									<div className="text-xs uppercase tracking-wider text-muted-foreground">
+										Sync Status
+									</div>
+									<div className="rounded-lg border border-border/60 p-4">
+										<div className="mb-3 flex flex-wrap items-center gap-2">
+											{!hasSovereigntySummary && structure.includeInStructureAssetSync && (
+												<Badge variant="success">Asset Sync Enabled</Badge>
+											)}
+											<div className="mt-0.5">
+												<StructureSyncStatusBadge
+													status={structure.syncStatus}
+													description={syncDescription}
+												/>
+											</div>
+										</div>
+										<div className="mt-2 text-sm text-muted-foreground">{syncDescription}</div>
+									</div>
+								</div>
+							</div>
+						</CardContent>
 				</Card>
 
 				<Card>
@@ -729,15 +902,17 @@ export default function StructuresDetailPage() {
 							</div>
 							<Switch checked={hidden} onCheckedChange={setHidden} />
 						</div>
-						<div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-							<div>
-								<div className="font-medium">Low Power Allowed</div>
-								<div className="text-sm text-muted-foreground">
-									Suppress low-power alerts for structures where that is intentional.
+						{!hasSovereigntySummary && (
+							<div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
+								<div>
+									<div className="font-medium">Low Power Allowed</div>
+									<div className="text-sm text-muted-foreground">
+										Suppress low-power alerts for structures where that is intentional.
+									</div>
 								</div>
+								<Switch checked={lowPowerAllowed} onCheckedChange={setLowPowerAllowed} />
 							</div>
-							<Switch checked={lowPowerAllowed} onCheckedChange={setLowPowerAllowed} />
-						</div>
+						)}
 						<FilterField label="Assigned Group">
 							<Select
 								options={groupOptions}
@@ -747,14 +922,16 @@ export default function StructuresDetailPage() {
 							/>
 						</FilterField>
 						<div className="flex items-center justify-end gap-3 pt-2">
-							<Button
-								variant="ghost"
-								onClick={() => {
-									setHidden(structure.hidden)
-									setLowPowerAllowed(structure.lowPowerAllowed)
-									setAssignedGroupId(structure.assignedGroupId ?? '')
-								}}
-							>
+								<Button
+									variant="ghost"
+									onClick={() => {
+										setHidden(structure.hidden)
+										if (!hasSovereigntySummary) {
+											setLowPowerAllowed(structure.lowPowerAllowed)
+										}
+										setAssignedGroupId(structure.assignedGroupId ?? '')
+									}}
+								>
 								Reset
 							</Button>
 							<Button
@@ -774,123 +951,80 @@ export default function StructuresDetailPage() {
 				<div className="space-y-4">
 					<Card>
 						<CardHeader>
-							<CardTitle>Sovereignty State</CardTitle>
+							<CardTitle>Hub Configuration</CardTitle>
 							<CardDescription>
-								System ownership and the currently linked sovereignty hub snapshot.
+								Workforce transport routing and the hub's current resource allocation.
 							</CardDescription>
 						</CardHeader>
-						<CardContent className="grid gap-4 md:grid-cols-2 text-sm">
-							<div>
-								<div className="text-muted-foreground">Activity Defense Multiplier</div>
-								<div className="font-medium">
-									{structure.sovereignty?.activityDefenseMultiplier ?? '-'}
-								</div>
+						<CardContent className="space-y-6 text-sm">
+							<div className="grid gap-4 md:grid-cols-2">
+								<ResourceAllocationCard
+									label="Power Allocation"
+									allocated={sovereigntyHub?.resourcePowerAllocated}
+									available={sovereigntyHub?.resourcePowerAvailable}
+								/>
+								<ResourceAllocationCard
+									label="Workforce Allocation"
+									allocated={sovereigntyHub?.resourceWorkforceAllocated}
+									available={sovereigntyHub?.resourceWorkforceAvailable}
+								/>
 							</div>
-							<div>
-								<div className="text-muted-foreground">Claimed Since</div>
-								<div className="font-medium">{formatNullableDateTime(structure.sovereignty?.claimedSince)}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Capital System</div>
-								<div className="font-medium">{structure.sovereignty?.isCapitalSystem ? 'Yes' : 'No'}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Sovereignty Hub</div>
-								<div className="font-medium">
-									{structure.sovereignty?.sovereigntyHubStructureId ?? '-'}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Controller Alliance</div>
-								<div className="font-medium">
-									{structure.sovereignty?.hub?.controllerAllianceId ?? '-'}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Vulnerability Window</div>
-								<div className="font-medium">
-									{structure.sovereignty?.vulnerabilityWindowStart &&
-									structure.sovereignty?.vulnerabilityWindowEnd
-										? `${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowStart)} - ${formatDateTimeLong(structure.sovereignty.vulnerabilityWindowEnd)}`
-										: formatNullableDateTime(structure.sovereignty?.vulnerabilityWindowEnd)}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">System Resources</div>
-								<div className="font-medium">
-									{structure.sovereignty?.hub
-										? `${formatNullableNumber(structure.sovereignty.hub.resourcePowerAllocated)} / ${formatNullableNumber(structure.sovereignty.hub.resourcePowerAvailable)} power, ${formatNullableNumber(structure.sovereignty.hub.resourceWorkforceAllocated)} / ${formatNullableNumber(structure.sovereignty.hub.resourceWorkforceAvailable)} workforce`
-										: '-'}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Fuel Access List</div>
-								<div className="font-medium">
-									{structure.sovereignty?.hub?.fuelAccessListId ?? '-'}
-								</div>
+
+							<div className="grid gap-4 lg:grid-cols-2">
+								<WorkforceTransportSection
+									label="Workforce Transport Configuration"
+									section={sovereigntyHub?.workforceTransport?.configuration}
+								/>
+								<WorkforceTransportSection
+									label="Workforce Transport State"
+									section={sovereigntyHub?.workforceTransport?.state}
+								/>
 							</div>
 						</CardContent>
 					</Card>
 
+					<div className="grid gap-4 lg:grid-cols-2">
 						<Card>
 							<CardHeader>
-								<CardTitle>Hub Configuration</CardTitle>
+								<CardTitle>Upgrades</CardTitle>
 								<CardDescription>
-									Workforce transport routing and the hub's current resource allocation.
+									Installed sovereignty hub upgrades and their current power state.
 								</CardDescription>
 							</CardHeader>
-							<CardContent className="space-y-6 text-sm">
-								<div className="grid gap-4 lg:grid-cols-2">
-									<WorkforceTransportSection
-										label="Workforce Transport Configuration"
-										section={structure.sovereignty?.hub?.workforceTransport?.configuration}
-									/>
-									<WorkforceTransportSection
-										label="Workforce Transport State"
-										section={structure.sovereignty?.hub?.workforceTransport?.state}
-									/>
-								</div>
-
-								<div className="grid gap-4 md:grid-cols-2">
-									<div className="rounded-lg border border-border/60 bg-muted/20 p-4">
-										<div className="text-xs uppercase tracking-wide text-muted-foreground">Power Allocation</div>
-										<div className="mt-2 grid grid-cols-2 gap-4">
-											<div>
-												<div className="text-muted-foreground">Allocated</div>
-												<div className="font-medium">
-													{formatNullableNumber(structure.sovereignty?.hub?.resourcePowerAllocated)}
+							<CardContent className="space-y-2">
+								{sovereigntyHub?.upgrades?.length ? (
+									<div className="space-y-1.5">
+										{sovereigntyHub.upgrades.map((upgrade) => (
+											<div
+												key={`${upgrade.typeId}-${upgrade.powerState}`}
+												className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
+											>
+												<div className="flex min-w-0 items-center gap-2">
+													<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground">
+														<InventoryItemIcon typeId={upgrade.typeId} />
+													</div>
+													<div className="min-w-0">
+														<div className="truncate text-sm font-medium">
+															{upgrade.typeName ?? upgrade.typeId}
+														</div>
+													</div>
 												</div>
+												<Badge
+													variant={upgrade.powerState.toLowerCase() === 'online' ? 'success' : 'ghost'}
+													className="shrink-0"
+												>
+													{upgrade.powerState}
+												</Badge>
 											</div>
-											<div>
-												<div className="text-muted-foreground">Available</div>
-												<div className="font-medium">
-													{formatNullableNumber(structure.sovereignty?.hub?.resourcePowerAvailable)}
-												</div>
-											</div>
-										</div>
+										))}
 									</div>
-
-									<div className="rounded-lg border border-border/60 bg-muted/20 p-4">
-										<div className="text-xs uppercase tracking-wide text-muted-foreground">Workforce Allocation</div>
-										<div className="mt-2 grid grid-cols-2 gap-4">
-											<div>
-												<div className="text-muted-foreground">Allocated</div>
-												<div className="font-medium">
-													{formatNullableNumber(structure.sovereignty?.hub?.resourceWorkforceAllocated)}
-												</div>
-											</div>
-											<div>
-												<div className="text-muted-foreground">Available</div>
-												<div className="font-medium">
-													{formatNullableNumber(structure.sovereignty?.hub?.resourceWorkforceAvailable)}
-												</div>
-											</div>
-										</div>
+								) : (
+									<div className="rounded-lg border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
+										No upgrades reported.
 									</div>
-								</div>
+								)}
 							</CardContent>
 						</Card>
-
 						<Card>
 							<CardHeader>
 								<CardTitle>Reagent Bay</CardTitle>
@@ -902,19 +1036,19 @@ export default function StructuresDetailPage() {
 								<div className="grid gap-4 md:grid-cols-3 text-sm">
 									<div>
 										<div className="text-muted-foreground">Last Updated</div>
-									<div className="font-medium">
-										{formatNullableDateTime(structure.sovereignty?.hub?.reagentBayLastUpdated)}
-									</div>
-								</div>
-								<div>
-									<div className="text-muted-foreground">Reagent Count</div>
-									<div className="font-medium">{structure.sovereignty?.hub?.reagentCount ?? 0}</div>
-								</div>
-								<div>
-									<div className="text-muted-foreground">Stock Totals</div>
 										<div className="font-medium">
-											{structure.sovereignty?.hub
-												? `${formatNullableNumber(structure.sovereignty.hub.totalSecuredStock)} secured, ${formatNullableNumber(structure.sovereignty.hub.totalUnsecuredStock)} unsecured`
+											{formatNullableDateTime(sovereigntyHub?.reagentBayLastUpdated)}
+										</div>
+									</div>
+									<div>
+										<div className="text-muted-foreground">Reagent Count</div>
+										<div className="font-medium">{sovereigntyHub?.reagentCount ?? 0}</div>
+									</div>
+									<div>
+										<div className="text-muted-foreground">Stock Totals</div>
+										<div className="font-medium">
+											{sovereigntyHub
+												? `${formatNullableNumber(sovereigntyHub.totalSecuredStock)} secured, ${formatNullableNumber(sovereigntyHub.totalUnsecuredStock)} unsecured`
 												: '-'}
 										</div>
 									</div>
@@ -932,56 +1066,16 @@ export default function StructuresDetailPage() {
 
 										return (
 											<span>
-												Secured {formatNullableNumber(reagent.securedStock)} · Unsecured{' '}
-												{formatNullableNumber(reagent.unsecuredStock)} · Last cycle{' '}
-												{formatNullableDateTime(reagent.lastCycle)}
+												Secured {formatNullableNumber(toFiniteNumber(reagent.securedStock))} ·
+												Unsecured {formatNullableNumber(toFiniteNumber(reagent.unsecuredStock))} ·
+												Last cycle {formatNullableDateTime(reagent.lastCycle)}
 											</span>
 										)
 									}}
 								/>
 							</CardContent>
 						</Card>
-
-						<Card>
-							<CardHeader>
-							<CardTitle>Upgrades</CardTitle>
-							<CardDescription>
-								Installed sovereignty hub upgrades and their current power state.
-							</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-									{structure.sovereignty?.hub?.upgrades.length ? (
-										structure.sovereignty.hub.upgrades.map((upgrade) => (
-											<Card key={`${upgrade.typeId}-${upgrade.powerState}`} className="border-border/60 bg-muted/20">
-												<CardContent className="space-y-3 p-4">
-													<div className="flex items-start justify-between gap-3">
-														<div className="space-y-1">
-															<div className="text-xs uppercase tracking-wide text-muted-foreground">
-																Installed Upgrade
-															</div>
-															<div className="font-medium">{upgrade.typeId}</div>
-														</div>
-														<Badge
-															variant={upgrade.powerState.toLowerCase() === 'online' ? 'success' : 'ghost'}
-														>
-															{upgrade.powerState}
-														</Badge>
-													</div>
-													<div className="text-sm text-muted-foreground">
-														Sovereignty hub upgrade slot currently reporting this state.
-													</div>
-												</CardContent>
-											</Card>
-										))
-									) : (
-										<div className="rounded-lg border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
-											No upgrades reported.
-										</div>
-									)}
-								</div>
-							</CardContent>
-						</Card>
+					</div>
 				</div>
 			)}
 
@@ -1006,7 +1100,9 @@ export default function StructuresDetailPage() {
 						</div>
 						<div>
 							<div className="text-muted-foreground">Effective Workforce</div>
-							<div className="font-medium">{formatNullableNumber(structure.skyhook?.effectiveWorkforce)}</div>
+							<div className="font-medium">
+								{formatNullableNumber(structure.skyhook?.effectiveWorkforce)}
+							</div>
 						</div>
 						<div>
 							<div className="text-muted-foreground">Raidable</div>
@@ -1019,7 +1115,8 @@ export default function StructuresDetailPage() {
 						<div>
 							<div className="text-muted-foreground">Theft Vulnerability</div>
 							<div className="font-medium">
-								{structure.skyhook?.theftVulnerabilityStart && structure.skyhook?.theftVulnerabilityEnd
+								{structure.skyhook?.theftVulnerabilityStart &&
+								structure.skyhook?.theftVulnerabilityEnd
 									? `${formatDateTimeLong(structure.skyhook.theftVulnerabilityStart)} - ${formatDateTimeLong(structure.skyhook.theftVulnerabilityEnd)}`
 									: formatNullableDateTime(structure.skyhook?.vulnerableAt)}
 							</div>
@@ -1046,7 +1143,9 @@ export default function StructuresDetailPage() {
 				<Card>
 					<CardHeader>
 						<CardTitle>Mining Extraction</CardTitle>
-						<CardDescription>Last known moon extraction snapshot for this structure.</CardDescription>
+						<CardDescription>
+							Last known moon extraction snapshot for this structure.
+						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-4 text-sm">
 						{!structure.mining ? (
@@ -1055,42 +1154,42 @@ export default function StructuresDetailPage() {
 							</div>
 						) : null}
 						<div className="grid gap-4 md:grid-cols-2">
-						<div>
-							<div className="text-muted-foreground">Moon</div>
-							<div className="font-medium">
-								{structure.mining?.moonName ?? structure.mining?.moonId ?? '-'}
+							<div>
+								<div className="text-muted-foreground">Moon</div>
+								<div className="font-medium">
+									{structure.mining?.moonName ?? structure.mining?.moonId ?? '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Planet</div>
-							<div className="font-medium">
-								{structure.mining?.planetName ?? structure.mining?.planetId ?? '-'}
+							<div>
+								<div className="text-muted-foreground">Planet</div>
+								<div className="font-medium">
+									{structure.mining?.planetName ?? structure.mining?.planetId ?? '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">System</div>
-							<div className="font-medium">
-								{structure.mining?.systemName ?? structure.mining?.systemId ?? '-'}
+							<div>
+								<div className="text-muted-foreground">System</div>
+								<div className="font-medium">
+									{structure.mining?.systemName ?? structure.mining?.systemId ?? '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Extraction Start</div>
-							<div className="font-medium">
-								{formatNullableDateTime(structure.mining?.extractionStartTime)}
+							<div>
+								<div className="text-muted-foreground">Extraction Start</div>
+								<div className="font-medium">
+									{formatNullableDateTime(structure.mining?.extractionStartTime)}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Chunk Arrival</div>
-							<div className="font-medium">
-								{formatNullableDateTime(structure.mining?.chunkArrivalTime)}
+							<div>
+								<div className="text-muted-foreground">Chunk Arrival</div>
+								<div className="font-medium">
+									{formatNullableDateTime(structure.mining?.chunkArrivalTime)}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Natural Decay</div>
-							<div className="font-medium">
-								{formatNullableDateTime(structure.mining?.naturalDecayTime)}
+							<div>
+								<div className="text-muted-foreground">Natural Decay</div>
+								<div className="font-medium">
+									{formatNullableDateTime(structure.mining?.naturalDecayTime)}
+								</div>
 							</div>
-						</div>
 						</div>
 					</CardContent>
 				</Card>
@@ -1101,9 +1200,7 @@ export default function StructuresDetailPage() {
 					<Card>
 						<CardHeader>
 							<CardTitle>Fitting</CardTitle>
-							<CardDescription>
-								Structure fitting from the latest known snapshot.
-							</CardDescription>
+							<CardDescription>Structure fitting from the latest known snapshot.</CardDescription>
 						</CardHeader>
 						<CardContent className="space-y-6">
 							<div className="overflow-x-auto">
@@ -1119,8 +1216,8 @@ export default function StructuresDetailPage() {
 								<div>
 									<div className="text-sm font-medium">Slot Layout</div>
 									<div className="text-sm text-muted-foreground">
-										High, mid, low, and rig slot fittings from the latest structure asset snapshot, with
-										loaded charges and scripts shown beneath their parent modules.
+										High, mid, low, and rig slot fittings from the latest structure asset snapshot,
+										with loaded charges and scripts shown beneath their parent modules.
 									</div>
 								</div>
 								<FittingSlotTable
@@ -1152,41 +1249,46 @@ export default function StructuresDetailPage() {
 				) : null}
 			</div>
 
-			<Card>
-				<CardHeader>
-					<CardTitle>Fuel Usage</CardTitle>
-					<CardDescription>
-						Hourly fuel block count and burn rate over the last 7 days.
-					</CardDescription>
-				</CardHeader>
-				<CardContent className="space-y-5">
-					<div className="grid gap-4 md:grid-cols-3 text-sm">
-						<div>
-							<div className="text-muted-foreground">Current Burn Rate</div>
-							<div className="font-medium">{formatBurnRate(structure.fuelUsage?.fuelBurnRatePerHour)}</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Hourly Samples</div>
-							<div className="font-medium">{structure.fuelUsage?.sampleCount ?? 0}</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Last Refilled</div>
-							<div className="font-medium">
-								{formatNullableDateTime(structure.fuelUsage?.lastRefilledAt)}
+				{!hasSovereigntySummary && (
+					<Card>
+						<CardHeader>
+							<CardTitle>Fuel Usage</CardTitle>
+							<CardDescription>
+								Hourly fuel block count and burn rate over the last 7 days.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="space-y-5">
+							<div className="grid gap-4 md:grid-cols-3 text-sm">
+								<div>
+									<div className="text-muted-foreground">Current Burn Rate</div>
+									<div className="font-medium">
+										{formatBurnRate(structure.fuelUsage?.fuelBurnRatePerHour)}
+									</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">Hourly Samples</div>
+									<div className="font-medium">{structure.fuelUsage?.sampleCount ?? 0}</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">Last Refilled</div>
+									<div className="font-medium">
+										{formatNullableDateTime(structure.fuelUsage?.lastRefilledAt)}
+									</div>
+								</div>
 							</div>
-						</div>
-					</div>
-					<StructureFuelUsageChart points={structure.fuelUsage?.points ?? []} />
-				</CardContent>
-			</Card>
+							<StructureFuelUsageChart points={structure.fuelUsage?.points ?? []} />
+						</CardContent>
+					</Card>
+				)}
 
 			{isAdmin && assetsDebug && assetsDebug.items.length > 0 ? (
 				<Card>
 					<CardHeader>
 						<CardTitle>Asset Debug</CardTitle>
 						<CardDescription>
-							Raw corporation assets fetched for this structure&apos;s owning corporation and filtered to
-							this structure ID. This is a direct asset snapshot, not the grouped inventory view.
+							Raw corporation assets fetched for this structure&apos;s owning corporation and
+							filtered to this structure ID. This is a direct asset snapshot, not the grouped
+							inventory view.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-4">
@@ -1233,13 +1335,17 @@ export default function StructuresDetailPage() {
 														</div>
 													</div>
 												</TableCell>
-												<TableCell className="text-right font-mono">{item.quantity.toLocaleString()}</TableCell>
+												<TableCell className="text-right font-mono">
+													{item.quantity.toLocaleString()}
+												</TableCell>
 												<TableCell>
 													<div className="font-medium">{item.locationFlagLabel}</div>
 													<div className="text-xs text-muted-foreground">{item.locationFlag}</div>
 												</TableCell>
 												<TableCell>{item.locationType}</TableCell>
-												<TableCell className="text-right">{item.isSingleton ? 'Yes' : 'No'}</TableCell>
+												<TableCell className="text-right">
+													{item.isSingleton ? 'Yes' : 'No'}
+												</TableCell>
 												<TableCell className="font-mono text-xs">{item.itemId}</TableCell>
 												<TableCell className="text-xs text-muted-foreground">
 													{formatDateTimeLong(item.updatedAt)}
@@ -1257,7 +1363,6 @@ export default function StructuresDetailPage() {
 					</CardContent>
 				</Card>
 			) : null}
-
 		</Container>
 	)
 }

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -6,6 +6,7 @@ import {
 	Building2,
 	Filter,
 	RefreshCcw,
+	Shield,
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
@@ -15,7 +16,7 @@ import {
 	hasAnyStructurePermission,
 	hasStructureTabPermission,
 } from '@repo/groups'
-import { STRUCTURE_TABS, type StructureTab } from '@repo/structures'
+import { STRUCTURE_TABS, isReinforcedStructureState, type StructureTab } from '@repo/structures'
 
 import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { CorporationLogo } from '@/components/corporation-logo'
@@ -32,6 +33,7 @@ import { PageHeader } from '@/components/ui/page-header'
 import { Select } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { formatDateTimeLong } from '@/lib/date-utils'
+import { allianceLogoUrl } from '@/lib/eve-images'
 import {
 	Table,
 	TableBody,
@@ -47,9 +49,11 @@ import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 import {
 	type StructureListBaseItem,
+	type StructureListFilterOptions,
 	type StructureListSortBy,
 	type StructureMiningListItem,
 	type StructureSkyhookListItem,
+	type StructureSovereigntyListFilterOptions,
 	type StructureSovereigntyListItem,
 } from '@/lib/api'
 import { cn } from '@/lib/utils'
@@ -122,12 +126,64 @@ function formatNullableNumber(value: number | null | undefined): string {
 	return value.toLocaleString()
 }
 
-function formatSovereigntyClaimType(value: 'alliance' | 'faction' | 'unclaimed' | null | undefined): string {
-	if (!value) return '-'
-	return value[0].toUpperCase() + value.slice(1)
+function formatNullableDecimal(
+	value: string | number | null | undefined,
+	fractionDigits = 2
+): string {
+	if (value === null || value === undefined || value === '') return '-'
+	const numericValue = typeof value === 'number' ? value : Number.parseFloat(value)
+	if (!Number.isFinite(numericValue)) return '-'
+	return numericValue.toFixed(fractionDigits)
 }
 
-type PrimaryStructureFilterSlot = 'type' | 'raidable' | 'alliance'
+function getSovereigntyVulnerabilityState(
+	sovereignty:
+		| Pick<
+				StructureSovereigntyListItem,
+				'vulnerabilityWindowStart' | 'vulnerabilityWindowEnd'
+		  >
+		| null
+		| undefined
+): { label: string; variant: 'ghost' | 'warning' | 'success' } {
+	if (!sovereignty?.vulnerabilityWindowStart || !sovereignty?.vulnerabilityWindowEnd) {
+		return { label: 'Unknown', variant: 'ghost' }
+	}
+
+	const start = new Date(sovereignty.vulnerabilityWindowStart).getTime()
+	const end = new Date(sovereignty.vulnerabilityWindowEnd).getTime()
+	const now = Date.now()
+	if (Number.isFinite(start) && Number.isFinite(end) && now >= start && now <= end) {
+		return { label: 'Vulnerable', variant: 'warning' }
+	}
+
+	return { label: 'Invulnerable', variant: 'success' }
+}
+
+function AllianceLogo({
+	allianceId,
+	allianceName,
+}: {
+	allianceId: string
+	allianceName?: string | null
+}) {
+	const [failed, setFailed] = useState(false)
+
+	if (failed) {
+		return <Shield className="h-4 w-4 text-muted-foreground" />
+	}
+
+	return (
+		<img
+			src={allianceLogoUrl(allianceId, 32)}
+			alt={allianceName ? `${allianceName} logo` : 'Alliance logo'}
+			className="h-5 w-5 rounded-sm object-cover"
+			loading="lazy"
+			onError={() => setFailed(true)}
+		/>
+	)
+}
+
+type PrimaryStructureFilterSlot = 'type' | 'raidable'
 
 export default function StructuresPage() {
 	usePageTitle('Structures')
@@ -149,6 +205,9 @@ export default function StructuresPage() {
 	const activeTab = visibleTabs.some((tab) => tab.tab === tableState.tab)
 		? tableState.tab
 		: visibleTabs[0]?.tab ?? tableState.tab
+	const isSovereigntyTab = activeTab === 'sovereignty'
+	const isSkyhooksTab = activeTab === 'skyhooks'
+	const isMiningCitadelTab = activeTab === 'mining-citadels'
 	const [nowMs, setNowMs] = useState(() => Date.now())
 	const { data: moduleConfig } = useStructureModuleConfig()
 	const {
@@ -191,8 +250,12 @@ export default function StructuresPage() {
 			case 'sovereignty':
 				return {
 					...base,
-					...common,
-					allianceId: tableState.filters.allianceId,
+					corporationId: tableState.filters.corporationId,
+					assignedGroupId: tableState.filters.assignedGroupId,
+					regionId: tableState.filters.regionId,
+					systemId: tableState.filters.systemId,
+					controllerAllianceId: tableState.filters.controllerAllianceId,
+					vulnerabilityState: tableState.filters.vulnerabilityState,
 				}
 			case 'skyhooks':
 				return {
@@ -229,6 +292,10 @@ export default function StructuresPage() {
 	const structures = structuresResponse?.items ?? []
 	const pagination = structuresResponse?.pagination
 	const filterOptions = structuresResponse?.filterOptions
+	const genericFilterOptions = filterOptions as StructureListFilterOptions | undefined
+	const sovereigntyFilterOptions = isSovereigntyTab
+		? (filterOptions as StructureSovereigntyListFilterOptions | undefined)
+		: undefined
 	const isInitialLoading = isLoading && !structuresResponse
 	const isSoftLoading = Boolean(structuresResponse) && isFetching
 	const refreshAll = () => {
@@ -306,46 +373,55 @@ export default function StructuresPage() {
 	const stateOptions = useMemo<SelectOption[]>(
 		() =>
 			withAllOption(
-				(filterOptions?.states ?? []).map((option) => ({
-					value: option.value,
-					label: option.label,
-				})),
-				'All States'
+				((isSovereigntyTab
+					? sovereigntyFilterOptions?.vulnerabilityStates ?? []
+					: genericFilterOptions?.states ?? []
+				).map(
+					(option) => ({
+						value: option.value,
+						label: option.label,
+					})
+				)),
+				isSovereigntyTab ? 'All Vulnerability States' : 'All States'
 			),
-		[filterOptions]
+		[genericFilterOptions, isSovereigntyTab, sovereigntyFilterOptions]
 	)
 	const typeOptions = useMemo<SelectOption[]>(
 		() =>
 			withAllOption(
-				(filterOptions?.types ?? []).map((option) => ({
+				(genericFilterOptions?.types ?? []).map((option) => ({
 					value: option.value,
 					label: option.label,
 				})),
 				'All Types'
 			),
-		[filterOptions]
+		[genericFilterOptions]
 	)
 	const allianceOptions = useMemo<SelectOption[]>(
 		() =>
 			withAllOption(
-				(filterOptions?.alliances ?? []).map((option) => ({
+				(
+					isSovereigntyTab
+						? sovereigntyFilterOptions?.controllerAlliances ?? []
+						: genericFilterOptions?.alliances ?? []
+				).map((option) => ({
 					value: option.value,
 					label: option.label,
 				})),
-				'All Alliances'
+				isSovereigntyTab ? 'All Controlling Alliances' : 'All Alliances'
 			),
-		[filterOptions]
+		[genericFilterOptions, isSovereigntyTab, sovereigntyFilterOptions]
 	)
 	const raidableStateOptions = useMemo<SelectOption[]>(
 		() =>
 			withAllOption(
-				(filterOptions?.raidableStates ?? []).map((option) => ({
+				(genericFilterOptions?.raidableStates ?? []).map((option) => ({
 					value: option.value,
 					label: option.label,
 				})),
 				'All Raidable States'
 			),
-		[filterOptions]
+		[genericFilterOptions]
 	)
 	const structuresContentKey = [
 		activeTab,
@@ -353,32 +429,52 @@ export default function StructuresPage() {
 		tableState.pageSize,
 		tableState.sortBy,
 		tableState.sortDirection,
-		tableState.filters.corporationId ?? '',
-		tableState.filters.assignedGroupId ?? '',
-		tableState.filters.lowPower ?? '',
-		tableState.filters.lowPowerAllowed ?? '',
-		tableState.filters.regionId ?? '',
-		tableState.filters.systemId ?? '',
-		tableState.filters.state ?? '',
-		tableState.filters.typeId ?? '',
-		tableState.filters.allianceId ?? '',
-		tableState.filters.planetId ?? '',
-		tableState.filters.isRaidable ?? '',
+		...(isSovereigntyTab
+			? [
+					tableState.filters.corporationId ?? '',
+					tableState.filters.assignedGroupId ?? '',
+					tableState.filters.regionId ?? '',
+					tableState.filters.systemId ?? '',
+					tableState.filters.controllerAllianceId ?? '',
+					tableState.filters.vulnerabilityState ?? '',
+				]
+			: [
+					tableState.filters.corporationId ?? '',
+					tableState.filters.assignedGroupId ?? '',
+					tableState.filters.regionId ?? '',
+					tableState.filters.systemId ?? '',
+					tableState.filters.state ?? '',
+					tableState.filters.lowPower ?? '',
+					tableState.filters.lowPowerAllowed ?? '',
+					tableState.filters.typeId ?? '',
+					tableState.filters.planetId ?? '',
+					tableState.filters.isRaidable ?? '',
+				]),
 	].join(':')
 
-	const activeFilterCount = [
-		tableState.filters.corporationId,
-		tableState.filters.assignedGroupId,
-		tableState.filters.lowPower,
-		tableState.filters.lowPowerAllowed,
-		tableState.filters.regionId,
-		tableState.filters.systemId,
-		tableState.filters.state,
-		tableState.filters.typeId,
-		tableState.filters.allianceId,
-		tableState.filters.planetId,
-		tableState.filters.isRaidable,
-	].filter(Boolean).length
+	const activeFilterCount = (
+		isSovereigntyTab
+			? [
+					tableState.filters.corporationId,
+					tableState.filters.assignedGroupId,
+					tableState.filters.regionId,
+					tableState.filters.systemId,
+					tableState.filters.controllerAllianceId,
+					tableState.filters.vulnerabilityState,
+				]
+			: [
+					tableState.filters.corporationId,
+					tableState.filters.assignedGroupId,
+					tableState.filters.regionId,
+					tableState.filters.systemId,
+					tableState.filters.state,
+					tableState.filters.lowPower,
+					tableState.filters.lowPowerAllowed,
+					tableState.filters.typeId,
+					tableState.filters.planetId,
+					tableState.filters.isRaidable,
+				]
+	).filter(Boolean).length
 
 	const refreshButton = (
 		<Button
@@ -430,13 +526,10 @@ export default function StructuresPage() {
 		</TableHead>
 	)
 
-	const isSovereigntyTab = activeTab === 'sovereignty'
-	const isSkyhooksTab = activeTab === 'skyhooks'
-	const isMiningCitadelTab = activeTab === 'mining-citadels'
 	const primaryFilterSlot: PrimaryStructureFilterSlot = (() => {
 		switch (activeTab) {
 			case 'sovereignty':
-				return 'alliance'
+				return 'type'
 			case 'skyhooks':
 				return 'raidable'
 			case 'citadels':
@@ -445,23 +538,10 @@ export default function StructuresPage() {
 			case 'moon-drills':
 				return 'type'
 		}
+		throw new Error(`Unsupported structures tab for primary filter: ${activeTab}`)
 	})()
 	const primaryFilterControl = (() => {
 		switch (primaryFilterSlot) {
-			case 'alliance':
-				return (
-					<FilterField label="Alliance">
-						<Select
-							options={allianceOptions}
-							value={tableState.filters.allianceId ?? ''}
-							onValueChange={(value) =>
-								setStructureTableFilters({ allianceId: value || undefined })
-							}
-							placeholder="All Alliances"
-							searchable
-						/>
-					</FilterField>
-				)
 			case 'raidable':
 				return (
 					<FilterField label="Raidable">
@@ -489,6 +569,76 @@ export default function StructuresPage() {
 				)
 		}
 	})()
+	const sovereigntyFilterControls = (
+		<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
+			<FilterField label="Region">
+				<Select
+					options={regionOptions}
+					value={tableState.filters.regionId ?? ''}
+					onValueChange={(value) => setStructureTableFilters({ regionId: value || undefined })}
+					placeholder="All Regions"
+					searchable
+				/>
+			</FilterField>
+			<FilterField label="System">
+				<Select
+					options={systemOptions}
+					value={tableState.filters.systemId ?? ''}
+					onValueChange={(value) => setStructureTableFilters({ systemId: value || undefined })}
+					placeholder="All Systems"
+					searchable
+				/>
+			</FilterField>
+			<FilterField label="Corporation">
+				<Select
+					options={corporationOptions}
+					value={tableState.filters.corporationId ?? ''}
+					onValueChange={(value) => setStructureTableFilters({ corporationId: value || undefined })}
+					placeholder="All Corporations"
+					searchable
+				/>
+			</FilterField>
+			<FilterField label="Controlling Alliance">
+				<Select
+					options={allianceOptions}
+					value={tableState.filters.controllerAllianceId ?? ''}
+					onValueChange={(value) =>
+						setStructureTableFilters({ controllerAllianceId: value || undefined })
+					}
+					placeholder="All Controlling Alliances"
+					searchable
+				/>
+			</FilterField>
+			<FilterField label="Vulnerability State">
+				<Select
+					options={stateOptions}
+					value={tableState.filters.vulnerabilityState ?? ''}
+					onValueChange={(value) =>
+						setStructureTableFilters({
+							vulnerabilityState: value
+								? (value as 'vulnerable' | 'invulnerable' | 'reinforced')
+								: undefined,
+						})
+					}
+					placeholder="All Vulnerability States"
+					searchable
+				/>
+			</FilterField>
+			<FilterField label="Group">
+				<Select
+					options={assignedGroupOptions}
+					value={tableState.filters.assignedGroupId ?? ''}
+					onValueChange={(value) =>
+						setStructureTableFilters({
+							assignedGroupId: value || undefined,
+						})
+					}
+					placeholder="All Groups"
+					searchable
+				/>
+			</FilterField>
+		</div>
+	)
 	const commonFilterControls = (
 		<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-4">
 			<FilterField label="Region">
@@ -697,7 +847,7 @@ export default function StructuresPage() {
 						</div>
 					)}
 					<div className="space-y-4">
-						{commonFilterControls}
+						{isSovereigntyTab ? sovereigntyFilterControls : commonFilterControls}
 					</div>
 					<div className="space-y-4 border-t border-border/60 pt-4">
 						<div className="border-b p-3">
@@ -753,61 +903,66 @@ export default function StructuresPage() {
 									No structures were returned for the selected filters.
 								</div>
 							) : (
-						<Table
-							className={cn(
-								'min-w-[118rem]',
-								isSovereigntyTab && 'min-w-[128rem]',
-								isSkyhooksTab && 'min-w-[126rem]',
-								isMiningCitadelTab && 'min-w-[124rem]'
-							)}
-						>
-									<TableHeader>
-										<TableRow>
-											<SortableHead field="region" label="Region" />
-											<SortableHead field="system" label="System" />
-											<SortableHead field="name" label="Name" />
-											<SortableHead field="corporation" label="Corporation" />
-											<SortableHead field="type" label="Type" />
-											<SortableHead field="state" label="State" />
-											<SortableHead field="fuel" label="Fuel" />
-											<TableHead>LP</TableHead>
-											<TableHead>LP Allowed</TableHead>
-											<SortableHead field="nextStateAt" label="Next State In" />
-											<TableHead>Group</TableHead>
-											{isSovereigntyTab ? (
-												<>
-													<TableHead>Claim Type</TableHead>
-													<TableHead>ADM</TableHead>
-													<TableHead>Hub</TableHead>
-													<TableHead>Vulnerability</TableHead>
-												</>
-											) : isSkyhooksTab ? (
-												<>
-													<TableHead>Planet</TableHead>
-													<TableHead>Workforce</TableHead>
-													<TableHead>Raidable</TableHead>
-													<TableHead>Vulnerable</TableHead>
-												</>
-											) : isMiningCitadelTab ? (
-												<>
-													<TableHead>Moon</TableHead>
-													<TableHead>Planet</TableHead>
-													<TableHead>Chunk Arrival</TableHead>
-													<TableHead>Natural Decay</TableHead>
-												</>
-											) : null}
-											<TableHead>Sync</TableHead>
-											<TableHead className="sticky right-0 z-20 table-header-bg border-l border-border/50 text-right">
-												Actions
-											</TableHead>
-										</TableRow>
-									</TableHeader>
-									<TableBody>
-										{structures.map((structure) => {
-											const structureBase = structure as StructureListBaseItem
-											const sovereigntyStructure = structure as StructureSovereigntyListItem
-											const skyhookStructure = structure as StructureSkyhookListItem
-											const miningStructure = structure as StructureMiningListItem
+							<Table
+								className={cn(
+									'min-w-[118rem]',
+									isSovereigntyTab && 'min-w-[128rem]',
+									isSkyhooksTab && 'min-w-[126rem]',
+									isMiningCitadelTab && 'min-w-[124rem]'
+								)}
+							>
+								<TableHeader>
+									<TableRow>
+										<SortableHead field="region" label="Region" />
+										<SortableHead field="system" label="System" />
+										{isSovereigntyTab ? null : <SortableHead field="name" label="Name" />}
+										<SortableHead field="corporation" label="Corporation" />
+										{isSovereigntyTab ? null : <SortableHead field="type" label="Type" />}
+										<SortableHead field="state" label="State" />
+										{isSovereigntyTab ? (
+											<TableHead>Controlling Alliance</TableHead>
+										) : (
+											<>
+												<SortableHead field="fuel" label="Fuel" />
+												<TableHead>LP</TableHead>
+												<TableHead>LP Allowed</TableHead>
+												<SortableHead field="nextStateAt" label="Next State In" />
+											</>
+										)}
+										<TableHead>Group</TableHead>
+										{isSovereigntyTab ? (
+											<>
+												<SortableHead field="activityDefenseMultiplier" label="ADM" />
+												<TableHead>Workforce</TableHead>
+												<TableHead>Power</TableHead>
+											</>
+										) : isSkyhooksTab ? (
+											<>
+												<TableHead>Planet</TableHead>
+												<TableHead>Workforce</TableHead>
+												<TableHead>Raidable</TableHead>
+												<TableHead>Vulnerable</TableHead>
+											</>
+										) : isMiningCitadelTab ? (
+											<>
+												<TableHead>Moon</TableHead>
+												<TableHead>Planet</TableHead>
+												<TableHead>Chunk Arrival</TableHead>
+												<TableHead>Natural Decay</TableHead>
+											</>
+										) : null}
+										<TableHead>Sync</TableHead>
+										<TableHead className="sticky right-0 z-20 table-header-bg border-l border-border/50 text-right">
+											Actions
+										</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{structures.map((structure) => {
+												const structureBase = structure as StructureListBaseItem
+												const sovereigntyStructure = structure as StructureSovereigntyListItem
+												const skyhookStructure = structure as StructureSkyhookListItem
+												const miningStructure = structure as StructureMiningListItem
 											const fuelLabel = structureBase.fuelExpires ? (
 												<DurationDisplay
 													endDate={structureBase.fuelExpires}
@@ -825,143 +980,178 @@ export default function StructuresPage() {
 													structureBase.assignedGroupId)
 												: '-'
 											const isHidden = structureBase.hidden
+											const sovereigntyVulnerabilityState = getSovereigntyVulnerabilityState(
+												sovereigntyStructure
+											)
 
-											return (
-												<TableRow key={structure.structureId}>
-													<TableCell className="font-medium">
-														{structure.regionName ?? structure.regionId ?? '-'}
-													</TableCell>
-													<TableCell>{structure.systemName ?? structure.systemId}</TableCell>
-													<TableCell className="max-w-[16rem]">
-														<div className="flex min-w-0 items-center gap-2">
-															<div className="truncate font-medium">{structure.name}</div>
-															{isHidden && <Badge variant="ghost">Hidden</Badge>}
-														</div>
-														<div className="text-xs text-muted-foreground">
-															{structure.structureId}
-														</div>
-													</TableCell>
-													<TableCell className="max-w-[18rem]">
-														<div className="flex min-w-0 items-center gap-2">
-															<CorporationLogo
-																corporationId={structure.corporationId}
-																corporationName={structure.corporationName}
-															/>
-															<span className="truncate font-medium" title={structure.corporationName}>
-																{structure.corporationName}
-															</span>
-														</div>
-													</TableCell>
-													<TableCell>{structure.typeName ?? structure.typeId}</TableCell>
-													<TableCell>
-														<StructureStateBadge state={structure.state} />
-													</TableCell>
-													<TableCell>{fuelLabel}</TableCell>
-													<TableCell>
-														<Badge variant={structureBase.lowPower ? 'warning' : 'ghost'}>
-															{structureBase.lowPower ? 'Yes' : 'No'}
-														</Badge>
-													</TableCell>
-													<TableCell>
-														<Badge variant={structureBase.lowPowerAllowed ? 'success' : 'ghost'}>
-															{structureBase.lowPowerAllowed ? 'Yes' : 'No'}
-														</Badge>
-													</TableCell>
-													<TableCell>
-														{structureBase.nextStateAt ? (
-															<DurationDisplay
-																endDate={structureBase.nextStateAt}
-																referenceTimeMs={nowMs}
-																maxUnits={3}
-																durationStyle="compact"
-																format="compact"
-															/>
-														) : (
-															'-'
-														)}
-													</TableCell>
-													<TableCell>{groupLabel}</TableCell>
-													{isSovereigntyTab ? (
-														<>
-															<TableCell>
-																{formatSovereigntyClaimType(sovereigntyStructure.claimType)}
-															</TableCell>
-															<TableCell>
-																{sovereigntyStructure.activityDefenseMultiplier ?? '-'}
-															</TableCell>
-															<TableCell>
-																<div className="font-medium">
-																	{sovereigntyStructure.controllerAllianceId ??
-																		sovereigntyStructure.sovereigntyHubStructureId ??
-																		'-'}
+												return (
+													<TableRow key={structure.structureId}>
+														<TableCell className="font-medium">
+															{structure.regionName ?? structure.regionId ?? '-'}
+														</TableCell>
+														<TableCell>{structure.systemName ?? structure.systemId}</TableCell>
+														{!isSovereigntyTab && (
+															<TableCell className="max-w-[16rem]">
+																<div className="flex min-w-0 items-center gap-2">
+																	<div className="truncate font-medium">{structure.name}</div>
+																	{isHidden && <Badge variant="ghost">Hidden</Badge>}
 																</div>
 																<div className="text-xs text-muted-foreground">
-																	{sovereigntyStructure.reagentCount
-																		? `${formatNullableNumber(sovereigntyStructure.resourcePowerAllocated)} / ${formatNullableNumber(sovereigntyStructure.resourcePowerAvailable)} power`
-																		: '-'}
+																	{structure.structureId}
 																</div>
 															</TableCell>
-															<TableCell>
-																{sovereigntyStructure.vulnerabilityWindowStart &&
-																sovereigntyStructure.vulnerabilityWindowEnd
-																	? `${formatDateTimeLong(sovereigntyStructure.vulnerabilityWindowStart)} - ${formatDateTimeLong(sovereigntyStructure.vulnerabilityWindowEnd)}`
-																	: formatNullableDateTime(sovereigntyStructure.vulnerabilityWindowEnd)}
-															</TableCell>
-														</>
-													) : isSkyhooksTab ? (
-														<>
-															<TableCell>{skyhookStructure.planetName ?? skyhookStructure.planetId}</TableCell>
-															<TableCell>
-																{formatNullableNumber(skyhookStructure.effectiveWorkforce)}
-															</TableCell>
-															<TableCell>
-																<Badge variant={skyhookStructure.isRaidable ? 'warning' : 'ghost'}>
-																	{skyhookStructure.isRaidable ? 'Yes' : 'No'}
-																</Badge>
-															</TableCell>
-															<TableCell>
-																{skyhookStructure.theftVulnerabilityStart &&
-																skyhookStructure.theftVulnerabilityEnd
-																	? `${formatDateTimeLong(skyhookStructure.theftVulnerabilityStart)} - ${formatDateTimeLong(skyhookStructure.theftVulnerabilityEnd)}`
-																: formatNullableDateTime(skyhookStructure.vulnerableAt)}
-															</TableCell>
-														</>
-													) : isMiningCitadelTab ? (
-														<>
-															<TableCell>
-																{(miningStructure.moonName ?? miningStructure.moonId) || '-'}
-															</TableCell>
-															<TableCell>
-																{miningStructure.planetName ?? miningStructure.planetId ?? '-'}
-															</TableCell>
-															<TableCell>{formatNullableDateTime(miningStructure.chunkArrivalTime)}</TableCell>
-															<TableCell>{formatNullableDateTime(miningStructure.naturalDecayTime)}</TableCell>
-														</>
-													) : null}
-													<TableCell>
-														<StructureSyncStatusBadge
-															status={structure.syncStatus}
-															description={structureSyncStatusDescription(structure)}
-														/>
-													</TableCell>
-													<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
-														{structure.canEdit ? (
-															<Button asChild size="sm" variant="ghost">
-																<Link to={`/structures/${structure.structureId}`}>
-																	<ArrowRight className="h-4 w-4" />
-																	Details
-																</Link>
-															</Button>
-														) : (
-															<Badge variant="ghost" className="justify-center">
-																<Building2 className="h-3 w-3" />
-																View only
-															</Badge>
 														)}
-													</TableCell>
-												</TableRow>
-											)
-										})}
+														<TableCell className="max-w-[18rem]">
+															<div className="flex min-w-0 items-center gap-2">
+																<CorporationLogo
+																	corporationId={structure.corporationId}
+																	corporationName={structure.corporationName}
+																/>
+																<span className="truncate font-medium" title={structure.corporationName}>
+																	{structure.corporationName}
+																</span>
+															</div>
+														</TableCell>
+														{isSovereigntyTab ? (
+															<>
+																<TableCell>
+																	<div className="space-y-1">
+																		<Badge variant={sovereigntyVulnerabilityState.variant}>
+																			{sovereigntyVulnerabilityState.label}
+																		</Badge>
+																		{isReinforcedStructureState(structureBase.state) && (
+																			<div className="text-xs text-muted-foreground">Reinforced</div>
+																		)}
+																	</div>
+																</TableCell>
+																<TableCell className="max-w-[18rem]">
+																	<div className="flex min-w-0 items-center gap-2">
+																		{sovereigntyStructure.controllerAllianceId ? (
+																			<AllianceLogo
+																				allianceId={sovereigntyStructure.controllerAllianceId}
+																				allianceName={sovereigntyStructure.controllerAllianceName}
+																			/>
+																		) : (
+																			<div className="flex h-5 w-5 items-center justify-center rounded-sm bg-muted text-muted-foreground">
+																				<Shield className="h-3 w-3" />
+																			</div>
+																		)}
+																		<span
+																			className="truncate font-medium"
+																			title={
+																				sovereigntyStructure.controllerAllianceName ??
+																				sovereigntyStructure.controllerAllianceId ??
+																				'-'
+																			}
+																		>
+																			{sovereigntyStructure.controllerAllianceName ??
+																				sovereigntyStructure.controllerAllianceId ??
+																				'-'}
+																		</span>
+																</div>
+															</TableCell>
+															<TableCell>{groupLabel}</TableCell>
+															<TableCell>
+																{formatNullableDecimal(
+																	sovereigntyStructure.activityDefenseMultiplier
+																)}
+															</TableCell>
+															<TableCell>
+																{formatNullableNumber(sovereigntyStructure.resourceWorkforceAllocated)} /{' '}
+																	{formatNullableNumber(sovereigntyStructure.resourceWorkforceAvailable)}
+																</TableCell>
+																<TableCell>
+																	{formatNullableNumber(sovereigntyStructure.resourcePowerAllocated)} /{' '}
+																	{formatNullableNumber(sovereigntyStructure.resourcePowerAvailable)}
+																</TableCell>
+															</>
+														) : (
+															<>
+																<TableCell>{structure.typeName ?? structure.typeId}</TableCell>
+																<TableCell>
+																	<StructureStateBadge state={structure.state} />
+																</TableCell>
+																<TableCell>{fuelLabel}</TableCell>
+																<TableCell>
+																	<Badge variant={structureBase.lowPower ? 'warning' : 'ghost'}>
+																		{structureBase.lowPower ? 'Yes' : 'No'}
+																	</Badge>
+																</TableCell>
+																<TableCell>
+																	<Badge variant={structureBase.lowPowerAllowed ? 'success' : 'ghost'}>
+																		{structureBase.lowPowerAllowed ? 'Yes' : 'No'}
+																	</Badge>
+																</TableCell>
+																<TableCell>
+																	{structureBase.nextStateAt ? (
+																		<DurationDisplay
+																			endDate={structureBase.nextStateAt}
+																			referenceTimeMs={nowMs}
+																			maxUnits={3}
+																			durationStyle="compact"
+																			format="compact"
+																		/>
+																	) : (
+																		'-'
+																	)}
+																</TableCell>
+																<TableCell>{groupLabel}</TableCell>
+															</>
+														)}
+														{isSovereigntyTab ? null : isSkyhooksTab ? (
+															<>
+																<TableCell>{skyhookStructure.planetName ?? skyhookStructure.planetId}</TableCell>
+																<TableCell>
+																	{formatNullableNumber(skyhookStructure.effectiveWorkforce)}
+																</TableCell>
+																<TableCell>
+																	<Badge variant={skyhookStructure.isRaidable ? 'warning' : 'ghost'}>
+																		{skyhookStructure.isRaidable ? 'Yes' : 'No'}
+																	</Badge>
+																</TableCell>
+																<TableCell>
+																	{skyhookStructure.theftVulnerabilityStart &&
+																	skyhookStructure.theftVulnerabilityEnd
+																		? `${formatDateTimeLong(skyhookStructure.theftVulnerabilityStart)} - ${formatDateTimeLong(skyhookStructure.theftVulnerabilityEnd)}`
+																	: formatNullableDateTime(skyhookStructure.vulnerableAt)}
+																</TableCell>
+															</>
+														) : isMiningCitadelTab ? (
+															<>
+																<TableCell>
+																	{(miningStructure.moonName ?? miningStructure.moonId) || '-'}
+																</TableCell>
+																<TableCell>
+																	{miningStructure.planetName ?? miningStructure.planetId ?? '-'}
+																</TableCell>
+																<TableCell>{formatNullableDateTime(miningStructure.chunkArrivalTime)}</TableCell>
+																<TableCell>{formatNullableDateTime(miningStructure.naturalDecayTime)}</TableCell>
+															</>
+														) : null}
+														<TableCell>
+															<StructureSyncStatusBadge
+																status={structure.syncStatus}
+																description={structureSyncStatusDescription(structure)}
+															/>
+														</TableCell>
+														<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
+															{structure.canEdit ? (
+																<Button asChild size="sm" variant="ghost">
+																	<Link to={`/structures/${structure.structureId}`}>
+																		<ArrowRight className="h-4 w-4" />
+																		Details
+																	</Link>
+																</Button>
+															) : (
+																<Badge variant="ghost" className="justify-center">
+																	<Building2 className="h-3 w-3" />
+																	View only
+																</Badge>
+															)}
+														</TableCell>
+													</TableRow>
+												)
+											})}
 								</TableBody>
 							</Table>
 						)}

--- a/packages/db-utils/src/migrate.ts
+++ b/packages/db-utils/src/migrate.ts
@@ -4,7 +4,6 @@ import { resolve } from 'node:path'
 import { sql } from 'drizzle-orm'
 import { migrate as drizzleMigrateHttp } from 'drizzle-orm/neon-http/migrator'
 import { migrate as drizzleMigrateWs } from 'drizzle-orm/neon-serverless/migrator'
-import { logger } from '@repo/hono-helpers/logger'
 
 import type { NeonHttpDatabase } from 'drizzle-orm/neon-http'
 import type { NeonDatabase } from 'drizzle-orm/neon-serverless'
@@ -102,7 +101,7 @@ async function logMigrationPlan(
 	const pending = migrationEntries.filter((entry) => !beforeAppliedHashes.has(entry.hash))
 	const alreadyApplied = migrationEntries.length - pending.length
 
-	logger.info(
+	console.log(
 		`[db:migrate] plan=${JSON.stringify({
 			totalInJournal: migrationEntries.length,
 			alreadyApplied,
@@ -113,9 +112,9 @@ async function logMigrationPlan(
 	)
 
 	if (pending.length > 0) {
-		logger.debug(`[db:migrate] pending tags: ${pending.map((entry) => entry.tag).join(', ')}`)
+		console.debug(`[db:migrate] pending tags: ${pending.map((entry) => entry.tag).join(', ')}`)
 	} else {
-		logger.debug('[db:migrate] no pending migrations detected')
+		console.debug('[db:migrate] no pending migrations detected')
 	}
 
 	return {
@@ -140,7 +139,7 @@ async function logMigrationResult(
 	const newlyAppliedTags = newlyAppliedEntries.map((entry) => entry.tag)
 	const totalApplied = migrationEntries.filter((entry) => afterAppliedHashes.has(entry.hash)).length
 
-	logger.info(
+	console.log(
 		`[db:migrate] result=${JSON.stringify({
 			newlyApplied: newlyAppliedEntries.length,
 			totalApplied,
@@ -150,7 +149,7 @@ async function logMigrationResult(
 	)
 
 	if (newlyAppliedTags.length > 0) {
-		logger.debug(`[db:migrate] applied tags: ${newlyAppliedTags.join(', ')}`)
+		console.debug(`[db:migrate] applied tags: ${newlyAppliedTags.join(', ')}`)
 	}
 }
 
@@ -160,7 +159,7 @@ async function logMigrationResult(
  * @param config - Migration configuration
  */
 export async function migrate(db: NeonHttpDatabase<any>, config: MigrationConfig): Promise<void> {
-	logger.info(`Running migrations from ${config.migrationsFolder}...`)
+	console.log(`Running migrations from ${config.migrationsFolder}...`)
 
 	let plan: {
 		beforeAppliedHashes: Set<string>
@@ -168,7 +167,7 @@ export async function migrate(db: NeonHttpDatabase<any>, config: MigrationConfig
 		migrationsSchema: string
 		migrationsTable: string
 	} | null = null
-	logger.info(
+	console.log(
 		`[db:migrate] config=${JSON.stringify({
 			migrationsFolder: config.migrationsFolder,
 			migrationsSchema: config.migrationsSchema ?? 'drizzle',
@@ -176,7 +175,7 @@ export async function migrate(db: NeonHttpDatabase<any>, config: MigrationConfig
 		})}`
 	)
 	plan = await logMigrationPlan(db, config)
-	logger.info('[db:migrate] starting drizzle migrate (http)')
+	console.log('[db:migrate] starting drizzle migrate (http)')
 
 	await drizzleMigrateHttp(db, {
 		migrationsFolder: config.migrationsFolder,
@@ -192,7 +191,7 @@ export async function migrate(db: NeonHttpDatabase<any>, config: MigrationConfig
 			plan.migrationsTable
 		)
 	}
-	logger.info('[db:migrate] drizzle migrate complete (http)')
+	console.log('[db:migrate] drizzle migrate complete (http)')
 }
 
 /**
@@ -201,7 +200,7 @@ export async function migrate(db: NeonHttpDatabase<any>, config: MigrationConfig
  * @param config - Migration configuration
  */
 export async function migrateWs(db: NeonDatabase<any>, config: MigrationConfig): Promise<void> {
-	logger.info(`Running migrations from ${config.migrationsFolder}...`)
+	console.log(`Running migrations from ${config.migrationsFolder}...`)
 
 	let plan: {
 		beforeAppliedHashes: Set<string>
@@ -209,7 +208,7 @@ export async function migrateWs(db: NeonDatabase<any>, config: MigrationConfig):
 		migrationsSchema: string
 		migrationsTable: string
 	} | null = null
-	logger.info(
+	console.log(
 		`[db:migrate] config=${JSON.stringify({
 			migrationsFolder: config.migrationsFolder,
 			migrationsSchema: config.migrationsSchema ?? 'drizzle',
@@ -217,7 +216,7 @@ export async function migrateWs(db: NeonDatabase<any>, config: MigrationConfig):
 		})}`
 	)
 	plan = await logMigrationPlan(db, config)
-	logger.info('[db:migrate] starting drizzle migrate (ws)')
+	console.log('[db:migrate] starting drizzle migrate (ws)')
 
 	await drizzleMigrateWs(db, {
 		migrationsFolder: config.migrationsFolder,
@@ -233,7 +232,7 @@ export async function migrateWs(db: NeonDatabase<any>, config: MigrationConfig):
 			plan.migrationsTable
 		)
 	}
-	logger.info('[db:migrate] drizzle migrate complete (ws)')
+	console.log('[db:migrate] drizzle migrate complete (ws)')
 
-	logger.info('Migrations completed successfully')
+	console.log('Migrations completed successfully')
 }

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -11,6 +11,7 @@ export type StructureListSortBy =
 	| 'updatedAt'
 	| 'nextStateAt'
 	| 'fuel'
+	| 'activityDefenseMultiplier'
 	| 'name'
 	| 'corporation'
 	| 'region'
@@ -134,10 +135,101 @@ export interface StructureNavigationListQuery extends StructureCommonListQuery {
 	systemId?: string
 }
 
-export interface StructureSovereigntyListQuery extends StructureCommonListQuery {
+export interface StructureSovereigntyListQuery extends StructureListPagingQuery {
 	corporationId?: string
+	assignedGroupId?: string
+	regionId?: string
 	systemId?: string
-	allianceId?: string
+	controllerAllianceId?: string
+	vulnerabilityState?: 'vulnerable' | 'invulnerable' | 'reinforced'
+}
+
+export interface StructureSovereigntyListFilterOption {
+	value: string
+	label: string
+}
+
+export interface StructureSovereigntyListFilterOptions {
+	corporations: StructureSovereigntyListFilterOption[]
+	assignedGroups: StructureSovereigntyListFilterOption[]
+	regions: StructureSovereigntyListFilterOption[]
+	systems: StructureSovereigntyListFilterOption[]
+	controllerAlliances: StructureSovereigntyListFilterOption[]
+	vulnerabilityStates: StructureSovereigntyListFilterOption[]
+}
+
+export interface StructureSovereigntyListSummary {
+	total: number
+	vulnerable: number
+	invulnerable: number
+	reinforced: number
+	unknown: number
+}
+
+export interface StructureSovereigntyListItem {
+	structureId: string
+	corporationId: string
+	corporationName: string
+	systemId: string
+	systemName: string | null
+	regionId: string | null
+	regionName: string | null
+	name: string
+	state: string
+	typeId: string
+	typeName: string | null
+	profileId: string
+	nextStateAt: string | null
+	fuelExpires: string | null
+	fuelAmount: number | null
+	lowPower: boolean
+	hidden: boolean
+	lowPowerAllowed: boolean
+	assignedGroupId: string | null
+	claimType: 'alliance' | 'faction' | 'unclaimed'
+	allianceId: string | null
+	controllerAllianceId: string | null
+	controllerAllianceName: string | null
+	corporationClaimantId: string | null
+	factionId: string | null
+	claimedSince: string | null
+	sovereigntyHubStructureId: string | null
+	vulnerabilityWindowStart: string | null
+	vulnerabilityWindowEnd: string | null
+	activityDefenseMultiplier: string | null
+	militaryLevel: number | null
+	industrialLevel: number | null
+	strategicLevel: number | null
+	fuelAccessListId: string | null
+	reagentBayLastUpdated: string | null
+	reagentCount: number
+	totalSecuredStock: number
+	totalUnsecuredStock: number
+	resourcePowerAllocated: number
+	resourcePowerAvailable: number
+	resourceWorkforceAllocated: number
+	resourceWorkforceAvailable: number
+	upgradeCount: number
+	syncStatus: 'ok' | 'warning' | 'error'
+	syncFailureReason: string | null
+	lastSyncedAt: string | null
+	updatedAt: string
+	canViewSensitive: boolean
+	canEdit: boolean
+}
+
+export interface StructureSovereigntyListResponse {
+	items: StructureSovereigntyListItem[]
+	pagination: {
+		page: number
+		pageSize: number
+		totalCount: number
+		totalPages: number
+		hasNextPage: boolean
+		hasPreviousPage: boolean
+	}
+	filterOptions: StructureSovereigntyListFilterOptions
+	summary: StructureSovereigntyListSummary
 }
 
 export interface StructureOverviewMetrics {
@@ -234,7 +326,10 @@ export interface StructuresWorker {
 	listVisibleStructures(actor: StructureActor, query?: StructureListQuery): Promise<unknown>
 	listCitadelStructures(actor: StructureActor, query?: StructureCitadelListQuery): Promise<unknown>
 	listNavigationStructures(actor: StructureActor, query?: StructureNavigationListQuery): Promise<unknown>
-	listSovereigntyStructures(actor: StructureActor, query?: StructureSovereigntyListQuery): Promise<unknown>
+	listSovereigntyStructures(
+		actor: StructureActor,
+		query?: StructureSovereigntyListQuery
+	): Promise<StructureSovereigntyListResponse>
 	listSkyhookStructures(actor: StructureActor, query?: StructureSkyhookListQuery): Promise<unknown>
 	listMiningStructures(actor: StructureActor, query?: StructureMiningListQuery): Promise<unknown>
 	listMoonDrillStructures(actor: StructureActor, query?: StructureMiningListQuery): Promise<unknown>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Refactors the Sovereignty Hub UX in the Structures app: the sovereignty structure list gets richer server-side filtering/pagination (with resolved alliance names and vulnerability-state filters), and the structure detail page merges the separate "Sovereignty State" card into the main overview so sovereignty structures show controlling alliance, vulnerability window/state, and ADM alongside the standard structure fields. Also fixes a broken `@repo/hono-helpers/logger` import in the migration CLI utility.

## Changes

- **`packages/structures`**: `StructureSovereigntyListQuery`/`StructureSovereigntyListResponse` reworked — paged response now includes `items`, `pagination`, `filterOptions` (corporations, assigned groups, regions, systems, controller alliances, vulnerability states), and a `summary` (vulnerable/invulnerable/reinforced/unknown counts). Query params changed from `allianceId`/`lowPower`/`state`/`typeId` to `corporationId`, `assignedGroupId`, `regionId`, `systemId`, `controllerAllianceId`, and `vulnerabilityState`. Added `activityDefenseMultiplier` as a sortable field.
- **`apps/structures`**: `listSovereigntyStructures` service rewritten to build the new filter options/summary, support numeric sorting by ADM, and expose `controllerAllianceName`/`typeName` fields for hub reagents and upgrades. Added a unit test verifying numeric (not lexicographic) ADM sorting.
- **`apps/core`**: `/structures` sovereignty routes updated for the new query schema; added `enrichSovereigntyStructureListResponse` and extended `enrichStructureDetailTypeNames` to resolve controller alliance names (via `EntityResolverService`) and type names for sovereignty hub reagents/upgrades.
- **`apps/ui`**: Structure list page adds a vulnerability-state badge/column and alliance logos for sovereignty rows; structure detail page removes the standalone "Sovereignty State" card and folds controlling alliance, claimed-since, capital system, vulnerability state/window, and ADM into the main structure info grid. API client types/filters updated to match the new sovereignty list response shape.
- **`packages/db-utils`**: Replaced `logger` (from `@repo/hono-helpers/logger`) with `console.log`/`console.debug` in the migration CLI helper.

## Testing

- Added `apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts` coverage for numeric ADM sorting of sovereignty hubs.
<!-- claude:end -->