### PR TITLE
add structures details permission level

### DIFF
--- a/apps/core/src/routes/__tests__/structures.route.test.ts
+++ b/apps/core/src/routes/__tests__/structures.route.test.ts
@@ -1,0 +1,122 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import structuresRoutes from '../structures'
+import { getCachedUserPermissions } from '../../lib/groups-cache'
+
+import type { SessionUser } from '../../context'
+
+const structuresMocks = vi.hoisted(() => ({
+	listCitadelStructures: vi.fn(),
+}))
+
+vi.mock('../../lib/groups-cache', () => ({
+	getCachedUserPermissions: vi.fn(),
+}))
+
+function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'user-1',
+		mainCharacterId: 'main-1',
+		sessionId: 'session-1',
+		characters: [],
+		is_admin: false,
+		roles: [],
+		discordUserId: null,
+		...overrides,
+	}
+}
+
+function createApp(user?: SessionUser) {
+	const app = new Hono<{ Bindings: any; Variables: { user?: SessionUser } }>()
+
+	if (user) {
+		app.use('*', async (c, next) => {
+			c.set('user', user)
+			await next()
+		})
+	}
+
+	app.route('/api/structures', structuresRoutes)
+	return app
+}
+
+describe('structures routes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(getCachedUserPermissions).mockResolvedValue([])
+		structuresMocks.listCitadelStructures.mockResolvedValue({
+			items: [
+				{
+					structureId: 'structure-1',
+					corporationId: 'corp-1',
+					corporationName: 'Test Corp',
+					name: 'Structure One',
+					typeId: '35832',
+					typeName: 'Astrahus',
+					systemId: '30000142',
+					systemName: 'Jita',
+					regionId: '10000002',
+					regionName: 'The Forge',
+					state: 'online',
+					nextStateAt: null,
+					fuelExpires: null,
+					fuelAmount: 2000,
+					lowPower: false,
+					hidden: false,
+					lowPowerAllowed: false,
+					assignedGroupId: null,
+					syncStatus: 'ok',
+					syncFailureReason: null,
+					lastSyncedAt: '2026-01-01T00:00:00.000Z',
+					canViewDetails: false,
+					updatedAt: '2026-01-02T00:00:00.000Z',
+				},
+			],
+			pagination: {
+				page: 1,
+				pageSize: 25,
+				totalCount: 1,
+				totalPages: 1,
+				hasNextPage: false,
+				hasPreviousPage: false,
+			},
+			filterOptions: {
+				corporations: [],
+				regions: [],
+				systems: [],
+				states: [],
+				types: [],
+				assignedGroups: [],
+				alliances: [],
+				planets: [],
+				raidableStates: [],
+			},
+			summary: {
+				total: 1,
+				lowFuel: 0,
+				lowPower: 0,
+				reinforced: 0,
+			},
+		})
+	})
+
+	it('strips updatedAt from list responses before sending them to the browser', async () => {
+		const app = createApp(makeUser())
+		const response = await app.request(
+			'/api/structures/citadels',
+			{},
+			{
+				STRUCTURES: {
+					listCitadelStructures: structuresMocks.listCitadelStructures,
+				},
+			} as any
+		)
+
+		expect(response.status).toBe(200)
+		const body = (await response.json()) as {
+			items: Array<Record<string, unknown>>
+		}
+		expect(body.items[0]).not.toHaveProperty('updatedAt')
+	})
+})

--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -38,6 +38,8 @@ const structureListSortFields = [
 	'system',
 	'type',
 	'state',
+	'magmaticGasEstimatedDepletionAt',
+	'superionicIceEstimatedDepletionAt',
 ] as const
 
 const structureListPagingSchema = z.object({
@@ -352,6 +354,22 @@ async function enrichStructureDetailTypeNames(
 	}
 }
 
+function stripUpdatedAtFromStructureItem(item: any): any {
+	if (!item || typeof item !== 'object') {
+		return item
+	}
+
+	const { updatedAt: _updatedAt, ...rest } = item as Record<string, unknown>
+	return rest
+}
+
+function stripUpdatedAtFromStructureListResponse(response: any): any {
+	return {
+		...response,
+		items: response.items.map((item: any) => stripUpdatedAtFromStructureItem(item)),
+	}
+}
+
 async function enrichSovereigntyStructureListResponse(
 	env: App['Bindings'],
 	response: StructureSovereigntyListResponse
@@ -565,7 +583,11 @@ async function handleCitadelStructuresRequest(c: Context<App>): Promise<Response
 			typeId: c.req.query('typeId') || undefined,
 		}) satisfies StructureCitadelListQuery
 
-		return c.json(await c.env.STRUCTURES.listCitadelStructures(await getStructureActor(c), query))
+		return c.json(
+			stripUpdatedAtFromStructureListResponse(
+				await c.env.STRUCTURES.listCitadelStructures(await getStructureActor(c), query)
+			)
+		)
 	} catch (error) {
 		return c.json(
 			{
@@ -598,7 +620,9 @@ async function handleNavigationStructuresRequest(c: Context<App>): Promise<Respo
 			typeId: c.req.query('typeId') || undefined,
 		}) satisfies StructureNavigationListQuery
 		return c.json(
-			await c.env.STRUCTURES.listNavigationStructures(await getStructureActor(c), query)
+			stripUpdatedAtFromStructureListResponse(
+				await c.env.STRUCTURES.listNavigationStructures(await getStructureActor(c), query)
+			)
 		)
 	} catch (error) {
 		return c.json(
@@ -630,7 +654,11 @@ async function handleSovereigntyStructuresRequest(c: Context<App>): Promise<Resp
 			vulnerabilityState: c.req.query('vulnerabilityState') || undefined,
 		}) satisfies StructureSovereigntyListQuery
 		const response = await c.env.STRUCTURES.listSovereigntyStructures(await getStructureActor(c), query)
-		return c.json(await enrichSovereigntyStructureListResponse(c.env, response))
+		return c.json(
+			stripUpdatedAtFromStructureListResponse(
+				await enrichSovereigntyStructureListResponse(c.env, response)
+			)
+		)
 	} catch (error) {
 		return c.json(
 			{
@@ -664,7 +692,11 @@ async function handleSkyhookStructuresRequest(c: Context<App>): Promise<Response
 			planetId: c.req.query('planetId') || undefined,
 			isRaidable: c.req.query('isRaidable') || undefined,
 		}) satisfies StructureSkyhookListQuery
-		return c.json(await c.env.STRUCTURES.listSkyhookStructures(await getStructureActor(c), query))
+		return c.json(
+			stripUpdatedAtFromStructureListResponse(
+				await c.env.STRUCTURES.listSkyhookStructures(await getStructureActor(c), query)
+			)
+		)
 	} catch (error) {
 		return c.json(
 			{
@@ -697,7 +729,11 @@ async function handleMiningStructuresRequest(c: Context<App>): Promise<Response>
 			typeId: c.req.query('typeId') || undefined,
 			planetId: c.req.query('planetId') || undefined,
 		}) satisfies StructureMiningListQuery
-		return c.json(await c.env.STRUCTURES.listMoonDrillStructures(await getStructureActor(c), query))
+		return c.json(
+			stripUpdatedAtFromStructureListResponse(
+				await c.env.STRUCTURES.listMoonDrillStructures(await getStructureActor(c), query)
+			)
+		)
 	} catch (error) {
 		return c.json(
 			{
@@ -731,7 +767,9 @@ async function handleMiningCitadelsStructuresRequest(c: Context<App>): Promise<R
 			planetId: c.req.query('planetId') || undefined,
 		}) satisfies StructureMiningListQuery
 		return c.json(
-			await c.env.STRUCTURES.listMiningCitadelStructures(await getStructureActor(c), query)
+			stripUpdatedAtFromStructureListResponse(
+				await c.env.STRUCTURES.listMiningCitadelStructures(await getStructureActor(c), query)
+			)
 		)
 	} catch (error) {
 		return c.json(
@@ -813,7 +851,11 @@ app.get('/:structureId', async (c) => {
 		if (!structure) {
 			return c.json({ error: 'Structure not found' }, 404)
 		}
-		return c.json(await enrichStructureDetailTypeNames(c.env, structure as StructureDetailResponse))
+		return c.json(
+			stripUpdatedAtFromStructureItem(
+				await enrichStructureDetailTypeNames(c.env, structure as StructureDetailResponse)
+			)
+		)
 	} catch (error) {
 		return c.json(
 			{
@@ -844,7 +886,11 @@ app.patch('/:structureId/config', async (c) => {
 		if (!structure) {
 			return c.json({ error: 'Structure not found' }, 404)
 		}
-		return c.json(await enrichStructureDetailTypeNames(c.env, structure as StructureDetailResponse))
+		return c.json(
+			stripUpdatedAtFromStructureItem(
+				await enrichStructureDetailTypeNames(c.env, structure as StructureDetailResponse)
+			)
+		)
 	} catch (error) {
 		if (error instanceof z.ZodError) {
 			return c.json({ error: 'Invalid structure config payload', issues: error.issues }, 400)

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -173,7 +173,7 @@ export interface StructureSovereigntyListItem extends StructureListItem {
 	claimType: 'alliance' | 'faction' | 'unclaimed'
 	allianceId: string | null
 	allianceName: string | null
-	controllerAllianceName?: string | null
+	controllerAllianceName: string | null
 	corporationClaimantId: string | null
 	factionId: string | null
 	claimedSince: string | null
@@ -1062,6 +1062,7 @@ function buildSyntheticSovereigntyStructureRow(
 		systemName: geography?.solarSystemName ?? hub.systemName ?? system?.systemName ?? null,
 		regionId: geography?.regionId ?? null,
 		regionName: geography?.regionName ?? null,
+		profileId: 'sovereignty',
 		fuelExpires: null,
 		fuelAmount: null,
 		lastRefilledAt: null,
@@ -2606,7 +2607,7 @@ function buildSovereigntyListItem(input: {
 	context: VisibleStructureContext
 	systemRow: typeof structureSovereigntySystems.$inferSelect | null
 	hubRow: typeof structureSovereigntyHubs.$inferSelect | null
-}): RepoStructureSovereigntyListItem {
+}): StructureSovereigntyListItem {
 	const { context, systemRow, hubRow } = input
 	const { structure: structureRow, corporationName, canViewSensitive, canEdit } = context
 	const hasHubSnapshot = hubRow !== null
@@ -2676,8 +2677,6 @@ function buildSovereigntyListItem(input: {
 		updatedAt: sourceUpdatedAt
 			? sourceUpdatedAt.toISOString()
 			: structureRow.updatedAt.toISOString(),
-		canViewSensitive,
-		canEdit,
 	}
 }
 
@@ -2810,10 +2809,10 @@ export async function listSovereigntyStructures(
 	const end = start + pageSize
 
 	return {
-		items: sortedItems
-			.slice(start, end)
-			.map((item) => items.find((row) => row.structureId === item.structureId)!)
-			.filter((item): item is RepoStructureSovereigntyListItem => Boolean(item)),
+		items: sortedItems.slice(start, end).map((item) => {
+			const { updatedAt: _updatedAt, ...rest } = item
+			return rest
+		}) as RepoStructureSovereigntyListItem[],
 		pagination: {
 			page,
 			pageSize,

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -70,6 +70,8 @@ export type StructureListSortField =
 	| 'nextStateAt'
 	| 'fuel'
 	| 'activityDefenseMultiplier'
+	| 'magmaticGasEstimatedDepletionAt'
+	| 'superionicIceEstimatedDepletionAt'
 	| 'name'
 	| 'corporation'
 	| 'region'
@@ -121,9 +123,11 @@ export interface StructureListResponse<TItem = StructureListItem> {
 
 interface StructurePermissionAccessTarget {
 	viewAll: boolean
+	detailsAll: boolean
 	sensitiveAll: boolean
 	managerAll: boolean
 	viewCorporationIds: Set<string>
+	detailsCorporationIds: Set<string>
 	sensitiveCorporationIds: Set<string>
 	managerCorporationIds: Set<string>
 }
@@ -146,7 +150,6 @@ export interface StructureListItem {
 	systemName: string | null
 	regionId: string | null
 	regionName: string | null
-	profileId: string
 	state: string
 	nextStateAt: string | null
 	fuelExpires: string | null
@@ -159,8 +162,7 @@ export interface StructureListItem {
 	syncFailureReason: string | null
 	lastSyncedAt: string | null
 	updatedAt: string
-	canViewSensitive: boolean
-	canEdit: boolean
+	canViewDetails: boolean
 }
 
 export interface StructureNavigationListItem extends StructureListItem {
@@ -201,8 +203,6 @@ export interface StructureSovereigntyListItem extends StructureListItem {
 	syncFailureReason: string | null
 	lastSyncedAt: string | null
 	updatedAt: string
-	canViewSensitive: boolean
-	canEdit: boolean
 }
 
 export interface StructureSkyhookListItem extends StructureListItem {
@@ -223,8 +223,6 @@ export interface StructureSkyhookListItem extends StructureListItem {
 	syncFailureReason: string | null
 	lastSyncedAt: string | null
 	updatedAt: string
-	canViewSensitive: boolean
-	canEdit: boolean
 }
 
 export interface StructureMiningListItem extends StructureListItem {
@@ -239,8 +237,6 @@ export interface StructureMiningListItem extends StructureListItem {
 	syncFailureReason: string | null
 	lastSyncedAt: string | null
 	updatedAt: string
-	canViewSensitive: boolean
-	canEdit: boolean
 }
 
 export interface StructureSovereigntyHubSummary {
@@ -351,8 +347,10 @@ interface StructureTabData {
 	inventoryBays?: StructureInventoryBaySummary[]
 }
 
-export interface StructureDetailResult extends StructureListItem {
+export interface StructureDetailResult extends Omit<StructureListItem, 'canViewDetails'> {
 	includeInStructureAssetSync: boolean
+	canViewSensitive: boolean
+	canEdit: boolean
 	services: Array<{
 		name: string
 		state: string
@@ -443,9 +441,11 @@ const STRUCTURE_ACCESS_TABS: StructureTab[] = [
 function createStructurePermissionAccessTarget(): StructurePermissionAccessTarget {
 	return {
 		viewAll: false,
+		detailsAll: false,
 		sensitiveAll: false,
 		managerAll: false,
 		viewCorporationIds: new Set<string>(),
+		detailsCorporationIds: new Set<string>(),
 		sensitiveCorporationIds: new Set<string>(),
 		managerCorporationIds: new Set<string>(),
 	}
@@ -457,7 +457,10 @@ function addParsedStructurePermissionToTarget(
 ): void {
 	if (parsed.scope === STRUCTURE_PERMISSION_SCOPE_ALL) {
 		target.viewAll = true
-		if (parsed.role === 'manager' || parsed.role === 'sensitive') {
+		if (parsed.role === 'details' || parsed.role === 'sensitive' || parsed.role === 'manager') {
+			target.detailsAll = true
+		}
+		if (parsed.role === 'sensitive' || parsed.role === 'manager') {
 			target.sensitiveAll = true
 		}
 		if (parsed.role === 'manager') {
@@ -471,7 +474,10 @@ function addParsedStructurePermissionToTarget(
 	}
 
 	target.viewCorporationIds.add(parsed.corporationId)
-	if (parsed.role === 'manager' || parsed.role === 'sensitive') {
+	if (parsed.role === 'details' || parsed.role === 'sensitive' || parsed.role === 'manager') {
+		target.detailsCorporationIds.add(parsed.corporationId)
+	}
+	if (parsed.role === 'sensitive' || parsed.role === 'manager') {
 		target.sensitiveCorporationIds.add(parsed.corporationId)
 	}
 	if (parsed.role === 'manager') {
@@ -484,14 +490,24 @@ function buildStructureAccessTargetSummary(
 	corporationId: string
 ): {
 	canView: boolean
+	canViewDetails: boolean
 	canViewSensitive: boolean
 	canEdit: boolean
 } {
 	const canView =
 		access.viewAll ||
+		access.detailsAll ||
 		access.sensitiveAll ||
 		access.managerAll ||
 		access.viewCorporationIds.has(corporationId) ||
+		access.detailsCorporationIds.has(corporationId) ||
+		access.sensitiveCorporationIds.has(corporationId) ||
+		access.managerCorporationIds.has(corporationId)
+	const canViewDetails =
+		access.detailsAll ||
+		access.sensitiveAll ||
+		access.managerAll ||
+		access.detailsCorporationIds.has(corporationId) ||
 		access.sensitiveCorporationIds.has(corporationId) ||
 		access.managerCorporationIds.has(corporationId)
 	const canViewSensitive =
@@ -503,6 +519,7 @@ function buildStructureAccessTargetSummary(
 
 	return {
 		canView,
+		canViewDetails,
 		canViewSensitive,
 		canEdit,
 	}
@@ -514,11 +531,16 @@ function getStructureAccessTarget(
 ): StructurePermissionAccessTarget {
 	return {
 		viewAll: access.all.viewAll || access.tabs[tab].viewAll,
+		detailsAll: access.all.detailsAll || access.tabs[tab].detailsAll,
 		sensitiveAll: access.all.sensitiveAll || access.tabs[tab].sensitiveAll,
 		managerAll: access.all.managerAll || access.tabs[tab].managerAll,
 		viewCorporationIds: new Set([
 			...access.all.viewCorporationIds,
 			...access.tabs[tab].viewCorporationIds,
+		]),
+		detailsCorporationIds: new Set([
+			...access.all.detailsCorporationIds,
+			...access.tabs[tab].detailsCorporationIds,
 		]),
 		sensitiveCorporationIds: new Set([
 			...access.all.sensitiveCorporationIds,
@@ -534,9 +556,11 @@ function getStructureAccessTarget(
 function hasAnyStructureAccess(target: StructurePermissionAccessTarget): boolean {
 	return (
 		target.viewAll ||
+		target.detailsAll ||
 		target.sensitiveAll ||
 		target.managerAll ||
 		target.viewCorporationIds.size > 0 ||
+		target.detailsCorporationIds.size > 0 ||
 		target.sensitiveCorporationIds.size > 0 ||
 		target.managerCorporationIds.size > 0
 	)
@@ -549,6 +573,15 @@ function hasStructureAccessForTab(
 ): boolean {
 	const target = getStructureAccessTarget(access, tab)
 	return buildStructureAccessTargetSummary(target, corporationId).canView
+}
+
+function canViewDetailsStructure(
+	access: StructureAccessScope,
+	corporationId: string,
+	tab: StructureTab
+): boolean {
+	const target = getStructureAccessTarget(access, tab)
+	return buildStructureAccessTargetSummary(target, corporationId).canViewDetails
 }
 
 function canViewSensitiveStructure(
@@ -586,6 +619,9 @@ function getAccessibleCorporationIds(
 		for (const corporationId of target.viewCorporationIds) {
 			corporationIds.add(corporationId)
 		}
+		for (const corporationId of target.detailsCorporationIds) {
+			corporationIds.add(corporationId)
+		}
 		for (const corporationId of target.sensitiveCorporationIds) {
 			corporationIds.add(corporationId)
 		}
@@ -602,9 +638,11 @@ function computeStructureAccess(roles: string[], isAdmin: boolean): StructureAcc
 		return {
 			all: {
 				viewAll: true,
+				detailsAll: true,
 				sensitiveAll: true,
 				managerAll: true,
 				viewCorporationIds: new Set<string>(),
+				detailsCorporationIds: new Set<string>(),
 				sensitiveCorporationIds: new Set<string>(),
 				managerCorporationIds: new Set<string>(),
 			},
@@ -613,9 +651,11 @@ function computeStructureAccess(roles: string[], isAdmin: boolean): StructureAcc
 					tab,
 					{
 						viewAll: true,
+						detailsAll: true,
 						sensitiveAll: true,
 						managerAll: true,
 						viewCorporationIds: new Set<string>(),
+						detailsCorporationIds: new Set<string>(),
 						sensitiveCorporationIds: new Set<string>(),
 						managerCorporationIds: new Set<string>(),
 					},
@@ -929,7 +969,7 @@ function summarizeStructureMining(
 }
 
 function buildStructureListItem(context: VisibleStructureContext): StructureListItem {
-	const { structure, corporationName, config, canViewSensitive, canEdit } = context
+	const { structure, corporationName, config, canViewDetails } = context
 	const nextStateAt =
 		structure.stateTimerEnd ?? structure.nextReinforceApply ?? structure.unanchorsAt
 
@@ -944,7 +984,6 @@ function buildStructureListItem(context: VisibleStructureContext): StructureList
 		systemName: structure.systemName,
 		regionId: structure.regionId,
 		regionName: structure.regionName,
-		profileId: structure.profileId,
 		state: structure.state,
 		nextStateAt: toIso(nextStateAt),
 		fuelExpires: toIso(structure.fuelExpires),
@@ -957,8 +996,7 @@ function buildStructureListItem(context: VisibleStructureContext): StructureList
 		syncFailureReason: structure.syncFailureReason,
 		lastSyncedAt: toIso(structure.lastSyncedAt),
 		updatedAt: structure.updatedAt.toISOString(),
-		canViewSensitive,
-		canEdit,
+		canViewDetails,
 	}
 }
 
@@ -1024,7 +1062,6 @@ function buildSyntheticSovereigntyStructureRow(
 		systemName: geography?.solarSystemName ?? hub.systemName ?? system?.systemName ?? null,
 		regionId: geography?.regionId ?? null,
 		regionName: geography?.regionName ?? null,
-		profileId: 'sovereignty',
 		fuelExpires: null,
 		fuelAmount: null,
 		lastRefilledAt: null,
@@ -1463,6 +1500,7 @@ interface VisibleStructureContext {
 	corporationName: string
 	includeInStructureAssetSync: boolean
 	config: typeof structureConfigs.$inferSelect | null
+	canViewDetails: boolean
 	canViewSensitive: boolean
 	canEdit: boolean
 	tabData: StructureTabData | null
@@ -1492,10 +1530,12 @@ function matchesStructureTab(
 }
 
 function buildStructureDetailResult(context: VisibleStructureContext): StructureDetailResult {
-	const structure = buildStructureListItem(context)
+	const { canViewDetails: _canViewDetails, ...structure } = buildStructureListItem(context)
 	return {
 		...structure,
 		includeInStructureAssetSync: context.includeInStructureAssetSync,
+		canViewSensitive: context.canViewSensitive,
+		canEdit: context.canEdit,
 		services: context.structure.services ?? [],
 		stateTimerStart: toIso(context.structure.stateTimerStart),
 		stateTimerEnd: toIso(context.structure.stateTimerEnd),
@@ -1527,8 +1567,12 @@ async function getVisibleStructureContext(
 	env: Env,
 	db: DbClient<DbSchema>,
 	user: SessionUser,
-	structureId: string
+	structureId: string,
+	options: {
+		requireDetailsPermission?: boolean
+	} = {}
 ): Promise<VisibleStructureContext | null> {
+	const requireDetailsPermission = options.requireDetailsPermission ?? false
 	const access = computeStructureAccess(user.roles, user.is_admin)
 	const accessibleCorporations = getAccessibleCorporationIds(access)
 	const structure = await db.query.corporationStructures.findFirst({
@@ -1592,6 +1636,11 @@ async function getVisibleStructureContext(
 			return null
 		}
 
+		const canViewDetails =
+			user.is_admin || canViewDetailsStructure(access, sovereigntyHub.corporationId, structureTab)
+		if (requireDetailsPermission && !canViewDetails) {
+			return null
+		}
 		const canViewSensitive =
 			user.is_admin || canViewSensitiveStructure(access, sovereigntyHub.corporationId, structureTab)
 		const canEdit =
@@ -1608,6 +1657,7 @@ async function getVisibleStructureContext(
 			corporationName: corporation?.name ?? sovereigntyHub.corporationId,
 			includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
 			config: null,
+			canViewDetails,
 			canViewSensitive,
 			canEdit,
 			tabData: {
@@ -1636,6 +1686,10 @@ async function getVisibleStructureContext(
 		return null
 	}
 
+	const canViewDetails = user.is_admin || canViewDetailsStructure(access, structure.corporationId, structureTab)
+	if (requireDetailsPermission && !canViewDetails) {
+		return null
+	}
 	const canViewSensitive =
 		user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
 	const canEdit = user.is_admin || canEditStructure(access, structure.corporationId, structureTab)
@@ -1654,6 +1708,7 @@ async function getVisibleStructureContext(
 		corporationName: corporation?.name ?? structure.corporationId,
 		includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
 		config: config ?? null,
+		canViewDetails,
 		canViewSensitive,
 		canEdit,
 		tabData: {
@@ -1681,12 +1736,16 @@ function getStructureSortValue(
 			return structure.fuelExpires
 				? new Date(structure.fuelExpires).getTime()
 				: (structure.fuelAmount ?? Number.POSITIVE_INFINITY)
-		case 'activityDefenseMultiplier':
-			return parseNullableNumber(
-				(structure as StructureSovereigntyListItem).activityDefenseMultiplier ?? null
-			)
-		case 'name':
-			return structure.name
+	case 'activityDefenseMultiplier':
+		return parseNullableNumber(
+			(structure as StructureSovereigntyListItem).activityDefenseMultiplier ?? null
+		)
+	case 'magmaticGasEstimatedDepletionAt':
+		return (structure as StructureSovereigntyListItem).magmaticGasEstimatedDepletionAt
+	case 'superionicIceEstimatedDepletionAt':
+		return (structure as StructureSovereigntyListItem).superionicIceEstimatedDepletionAt
+	case 'name':
+		return structure.name
 		case 'corporation':
 			return structure.corporationName
 		case 'region':
@@ -1736,6 +1795,13 @@ function sortStructures(
 				comparison = compareNullableNumbers(
 					getStructureSortValue(left, sortBy) as number | null | undefined,
 					getStructureSortValue(right, sortBy) as number | null | undefined
+				)
+				break
+			case 'magmaticGasEstimatedDepletionAt':
+			case 'superionicIceEstimatedDepletionAt':
+				comparison = compareNullableDates(
+					getStructureSortValue(left, sortBy) as string | null | undefined,
+					getStructureSortValue(right, sortBy) as string | null | undefined
 				)
 				break
 			case 'fuel':
@@ -2191,6 +2257,8 @@ async function loadVisibleStructureContexts(
 			.map<VisibleStructureContext | null>((structure) => {
 				const config = configsByStructureId.get(structure.structureId) ?? null
 				const structureTab = getStructureTab(structure)
+				const canViewDetails =
+					user.is_admin || canViewDetailsStructure(access, structure.corporationId, structureTab)
 				const canViewSensitive =
 					user.is_admin || canViewSensitiveStructure(access, structure.corporationId, structureTab)
 				const canEdit =
@@ -2206,6 +2274,7 @@ async function loadVisibleStructureContexts(
 					corporationName: corporation?.name ?? structure.corporationId,
 					includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
 					config,
+					canViewDetails,
 					canViewSensitive,
 					canEdit,
 					tabData: null,
@@ -2349,6 +2418,8 @@ async function loadVisibleSovereigntyHubContexts(
 				const geography = geographyBySystemId[hub.systemId] ?? null
 				const structure = buildSyntheticSovereigntyStructureRow(hub, systemRow, geography)
 				const structureTab = getStructureTab(structure)
+				const canViewDetails =
+					user.is_admin || canViewDetailsStructure(access, hub.corporationId, structureTab)
 				const canViewSensitive =
 					user.is_admin || canViewSensitiveStructure(access, hub.corporationId, structureTab)
 				const canEdit = user.is_admin || canEditStructure(access, hub.corporationId, structureTab)
@@ -2359,6 +2430,7 @@ async function loadVisibleSovereigntyHubContexts(
 					corporationName: corporation?.name ?? hub.corporationId,
 					includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
 					config: null,
+					canViewDetails,
 					canViewSensitive,
 					canEdit,
 					tabData: null,
@@ -3018,7 +3090,9 @@ export async function getVisibleStructureDetail(
 	user: SessionUser,
 	structureId: string
 ): Promise<StructureDetailResult | null> {
-	const context = await getVisibleStructureContext(env, db, user, structureId)
+	const context = await getVisibleStructureContext(env, db, user, structureId, {
+		requireDetailsPermission: true,
+	})
 	if (!context) {
 		return null
 	}

--- a/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
+++ b/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
@@ -441,6 +441,154 @@ describe('sovereignty hub model', () => {
 		expect(result.items.map((item) => item.activityDefenseMultiplier)).toEqual(['2.0', '10.0'])
 	})
 
+	it('sorts sovereignty hubs by magmatic gas depletion time', async () => {
+		const db = makeDb()
+		mocks.getStubMock.mockReturnValue(db.universeStub)
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(
+			new Date('2026-07-12T00:00:00Z').getTime()
+		)
+		db.query.structureSovereigntyHubs.findMany.mockResolvedValue([
+			{
+				structureId: 'hub-slow',
+				corporationId: 'corp-1',
+				systemId: '30000142',
+				systemName: 'Jita',
+				name: 'Slow Gas Hub',
+				typeId: '32458',
+				fuelAccessListId: null,
+				controllerAllianceId: 'alliance-1',
+				reagentBayLastUpdated: new Date('2026-07-12T19:36:46.834Z'),
+				reagentBay: {
+					lastUpdated: '2026-07-12T19:36:46.834Z',
+					reagents: [
+						{
+							typeId: '81143',
+							amount: 20,
+							burningPerHour: 1,
+							lastCycle: '2026-07-12T18:30:00Z',
+						},
+					],
+				},
+				resources: {
+					power: { allocated: 100, available: 200 },
+					workforce: { allocated: 300, available: 400 },
+				},
+				upgrades: [],
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				workforceTransport: {
+					configuration: { mode: 'unknown', systems: [] },
+					state: { mode: 'unknown', systems: [] },
+				},
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+			{
+				structureId: 'hub-fast',
+				corporationId: 'corp-1',
+				systemId: '30000143',
+				systemName: 'Perimeter',
+				name: 'Fast Gas Hub',
+				typeId: '32458',
+				fuelAccessListId: null,
+				controllerAllianceId: 'alliance-1',
+				reagentBayLastUpdated: new Date('2026-07-12T19:36:46.834Z'),
+				reagentBay: {
+					lastUpdated: '2026-07-12T19:36:46.834Z',
+					reagents: [
+						{
+							typeId: '81143',
+							amount: 10,
+							burningPerHour: 5,
+							lastCycle: '2026-07-12T18:30:00Z',
+						},
+					],
+				},
+				resources: {
+					power: { allocated: 100, available: 200 },
+					workforce: { allocated: 300, available: 400 },
+				},
+				upgrades: [],
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				workforceTransport: {
+					configuration: { mode: 'unknown', systems: [] },
+					state: { mode: 'unknown', systems: [] },
+				},
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		])
+		db.query.structureSovereigntySystems.findMany.mockResolvedValue([
+			{
+				systemId: '30000142',
+				systemName: 'Jita',
+				corporationId: 'corp-1',
+				claimType: 'alliance',
+				allianceId: 'alliance-1',
+				corporationClaimantId: null,
+				factionId: null,
+				claimedSince: new Date('2026-07-12T18:00:00Z'),
+				sovereigntyHubStructureId: 'hub-slow',
+				isCapitalSystem: false,
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				activityDefenseMultiplier: '1.2',
+				militaryLevel: 2,
+				industrialLevel: 3,
+				strategicLevel: 4,
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+			{
+				systemId: '30000143',
+				systemName: 'Perimeter',
+				corporationId: 'corp-1',
+				claimType: 'alliance',
+				allianceId: 'alliance-1',
+				corporationClaimantId: null,
+				factionId: null,
+				claimedSince: new Date('2026-07-12T18:00:00Z'),
+				sovereigntyHubStructureId: 'hub-fast',
+				isCapitalSystem: false,
+				vulnerabilityWindowStart: new Date('2026-07-13T08:40:00Z'),
+				vulnerabilityWindowEnd: new Date('2026-07-13T15:20:00Z'),
+				activityDefenseMultiplier: '1.2',
+				militaryLevel: 2,
+				industrialLevel: 3,
+				strategicLevel: 4,
+				sourceSyncAt: new Date('2026-07-12T19:36:47.369Z'),
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		])
+
+		try {
+			const result = await listSovereigntyStructures(
+				{
+					UNIVERSE: {} as never,
+				} as never,
+				db as never,
+				{
+					id: 'user-1',
+					is_admin: true,
+					roles: [],
+				},
+				{
+					sortBy: 'magmaticGasEstimatedDepletionAt',
+					sortDirection: 'asc',
+				}
+			)
+
+			expect(result.items.map((item) => item.structureId)).toEqual(['hub-fast', 'hub-slow'])
+		} finally {
+			nowSpy.mockRestore()
+		}
+	})
+
 	it('loads sovereignty hub details even when the base structure row is absent', async () => {
 		const db = makeDb()
 		mocks.getStubMock.mockReturnValue(db.universeStub)

--- a/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
+++ b/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
@@ -225,7 +225,6 @@ describe('structure permission gating', () => {
 			'structure-1'
 		)
 		expect(detailsResult).not.toBeNull()
-		expect(detailsResult?.canViewDetails).toBe(true)
 		expect(detailsResult?.canEdit).toBe(false)
 	})
 

--- a/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
+++ b/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
@@ -14,6 +14,7 @@ vi.mock('@repo/hono-helpers', () => ({
 }))
 
 import {
+	getVisibleStructureDetail,
 	listMiningCitadelStructures,
 	listMoonDrillStructures,
 	listVisibleStructures,
@@ -34,7 +35,6 @@ function makeDb(
 			systemName: string
 			regionId: string
 			regionName: string
-			profileId: string
 			state: string
 			nextReinforceApply: null
 			stateTimerEnd: null
@@ -77,7 +77,6 @@ function makeDb(
 				systemName: 'Jita',
 				regionId: '10000002',
 				regionName: 'The Forge',
-				profileId: 'profile-1',
 				state: 'online',
 				nextReinforceApply: null,
 				stateTimerEnd: null,
@@ -137,6 +136,9 @@ function makeDb(
 			findFirst: vi.fn().mockResolvedValue(null),
 			findMany: vi.fn().mockResolvedValue(options.miningStates ?? []),
 		},
+		corporationStructureInventory: {
+			findMany: vi.fn().mockResolvedValue([]),
+		},
 	}
 
 	return { query } as unknown as FakeDb
@@ -159,7 +161,23 @@ describe('structure permission gating', () => {
 		expect(db.query.corporationStructures.findMany).toHaveBeenCalledTimes(1)
 		expect(result.items).toHaveLength(1)
 		expect(result.items[0]?.structureId).toBe('structure-1')
+		expect(result.items[0]?.canViewDetails).toBe(false)
 		expect(result.summary.total).toBe(1)
+	})
+
+	it('returns visible structures for all-scope details permissions', async () => {
+		const db = makeDb()
+
+		const result = await listVisibleStructures(db as never, {
+			id: 'user-1d',
+			is_admin: false,
+			roles: ['urn:structures:all:details'],
+		})
+
+		expect(db.query.corporationStructures.findMany).toHaveBeenCalledTimes(1)
+		expect(result.items).toHaveLength(1)
+		expect(result.items[0]?.structureId).toBe('structure-1')
+		expect(result.items[0]?.canViewDetails).toBe(true)
 	})
 
 	it('returns corporation-scoped structures when the user only has a corp-scoped viewer permission', async () => {
@@ -174,6 +192,41 @@ describe('structure permission gating', () => {
 		expect(db.query.corporationStructures.findMany).toHaveBeenCalledTimes(1)
 		expect(result.items).toHaveLength(1)
 		expect(result.items[0]?.corporationId).toBe('corp-1')
+		expect(result.items[0]?.canViewDetails).toBe(false)
+	})
+
+	it('allows detail access for details permission and denies it for viewer-only access', async () => {
+		const db = makeDb()
+		const env = {
+			UNIVERSE: {} as never,
+			EVE_CORPORATION_DATA: {} as never,
+		}
+
+		const viewerResult = await getVisibleStructureDetail(
+			env as never,
+			db as never,
+			{
+				id: 'user-viewer',
+				is_admin: false,
+				roles: ['urn:structures:all:viewer'],
+			},
+			'structure-1'
+		)
+		expect(viewerResult).toBeNull()
+
+		const detailsResult = await getVisibleStructureDetail(
+			env as never,
+			db as never,
+			{
+				id: 'user-details',
+				is_admin: false,
+				roles: ['urn:structures:all:details'],
+			},
+			'structure-1'
+		)
+		expect(detailsResult).not.toBeNull()
+		expect(detailsResult?.canViewDetails).toBe(true)
+		expect(detailsResult?.canEdit).toBe(false)
 	})
 
 	it('does not leak citadels to a tab-scoped moon-drills permission', async () => {
@@ -202,7 +255,6 @@ describe('structure permission gating', () => {
 					systemName: 'Jita',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-1',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -242,7 +294,6 @@ describe('structure permission gating', () => {
 					systemName: 'Jita',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-1',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -283,7 +334,6 @@ describe('structure permission gating', () => {
 					systemName: 'Jita',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-1',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -306,7 +356,6 @@ describe('structure permission gating', () => {
 		})
 
 		expect(sensitiveResult.items).toHaveLength(1)
-		expect(sensitiveResult.items[0]?.canEdit).toBe(false)
 
 		const managerResult = await listMoonDrillStructures(db as never, {
 			id: 'user-4d',
@@ -315,7 +364,6 @@ describe('structure permission gating', () => {
 		})
 
 		expect(managerResult.items).toHaveLength(1)
-		expect(managerResult.items[0]?.canEdit).toBe(true)
 	})
 
 	it('returns mining snapshot data for mining citadels when permissioned', async () => {
@@ -331,7 +379,6 @@ describe('structure permission gating', () => {
 					systemName: 'Jita',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-1',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -396,7 +443,6 @@ describe('structure permission gating', () => {
 					systemName: 'Jita',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-1',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -419,7 +465,6 @@ describe('structure permission gating', () => {
 					systemName: 'Perimeter',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-2',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -459,7 +504,6 @@ describe('structure permission gating', () => {
 					systemName: 'Jita',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-1',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -482,7 +526,6 @@ describe('structure permission gating', () => {
 					systemName: 'Perimeter',
 					regionId: '10000002',
 					regionName: 'The Forge',
-					profileId: 'profile-2',
 					state: 'online',
 					nextReinforceApply: null,
 					stateTimerEnd: null,
@@ -542,7 +585,6 @@ describe('structure permission gating', () => {
 
 		expect(sensitiveResult.items).toHaveLength(1)
 		expect(sensitiveResult.items[0]?.structureId).toBe('structure-1')
-		expect(sensitiveResult.items[0]?.canEdit).toBe(false)
 
 		const corpSensitiveResult = await listVisibleStructures(db as never, {
 			id: 'user-5b',
@@ -552,7 +594,6 @@ describe('structure permission gating', () => {
 
 		expect(corpSensitiveResult.items).toHaveLength(1)
 		expect(corpSensitiveResult.items[0]?.structureId).toBe('structure-1')
-		expect(corpSensitiveResult.items[0]?.canEdit).toBe(false)
 
 		const corpManagerResult = await listVisibleStructures(db as never, {
 			id: 'user-5c',
@@ -562,7 +603,6 @@ describe('structure permission gating', () => {
 
 		expect(corpManagerResult.items).toHaveLength(1)
 		expect(corpManagerResult.items[0]?.structureId).toBe('structure-1')
-		expect(corpManagerResult.items[0]?.canEdit).toBe(true)
 
 		const managerResult = await listVisibleStructures(db as never, {
 			id: 'user-6',
@@ -572,6 +612,5 @@ describe('structure permission gating', () => {
 
 		expect(managerResult.items).toHaveLength(1)
 		expect(managerResult.items[0]?.structureId).toBe('structure-1')
-		expect(managerResult.items[0]?.canEdit).toBe(true)
 	})
 })

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -722,12 +722,14 @@ export interface CreateCorporationAlertDestinationRequest {
 	isEnabled?: boolean
 }
 
-export type StructurePermissionRole = 'viewer' | 'manager' | 'sensitive'
+export type StructurePermissionRole = 'viewer' | 'details' | 'sensitive' | 'manager'
 export type StructureListSortBy =
 	| 'updatedAt'
 	| 'nextStateAt'
 	| 'fuel'
 	| 'activityDefenseMultiplier'
+	| 'magmaticGasEstimatedDepletionAt'
+	| 'superionicIceEstimatedDepletionAt'
 	| 'name'
 	| 'corporation'
 	| 'region'
@@ -798,7 +800,6 @@ export interface StructureListBaseItem {
 	regionId: string | null
 	regionName: string | null
 	state: string
-	profileId: string
 	nextStateAt: string | null
 	fuelExpires: string | null
 	fuelAmount: number | null
@@ -809,9 +810,7 @@ export interface StructureListBaseItem {
 	syncStatus: 'ok' | 'warning' | 'error'
 	syncFailureReason: string | null
 	lastSyncedAt: string | null
-	updatedAt: string
-	canViewSensitive: boolean
-	canEdit: boolean
+	canViewDetails: boolean
 }
 
 export interface StructureCitadelListItem extends StructureListBaseItem {}
@@ -961,8 +960,10 @@ export interface StructureFittingItem {
 	isConsumable?: boolean
 }
 
-export interface StructureDetailResult extends StructureCitadelListItem {
+export interface StructureDetailResult extends Omit<StructureCitadelListItem, 'canViewDetails'> {
 	includeInStructureAssetSync: boolean
+	canViewSensitive: boolean
+	canEdit: boolean
 	services: Array<{
 		name: string
 		state: string

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -16,7 +16,7 @@ import { Link, Navigate, useParams } from 'react-router-dom'
 
 import { FittingPanel } from '@repo/eve-fitting/fitting-panel'
 import { FittingSlotTable } from '@repo/eve-fitting/fitting-slot-table'
-import { hasAnyStructurePermission } from '@repo/groups'
+import { hasAnyStructurePermission, hasStructureDetailsPermission } from '@repo/groups'
 import {
 	getStructureTabForTypeId,
 	isReinforcedStructureState,
@@ -517,7 +517,8 @@ export default function StructuresDetailPage() {
 	const { user, isLoading: authLoading } = useAuth()
 	const { permissions, isLoading: permissionsLoading } = useUserPermissions()
 	const canViewStructures = user?.is_admin === true || hasAnyStructurePermission(permissions)
-	const canAccess = canViewStructures && Boolean(structureId)
+	const canViewStructureDetails = user?.is_admin === true || hasStructureDetailsPermission(permissions)
+	const canAccess = canViewStructureDetails && Boolean(structureId)
 	const {
 		data: structure,
 		isLoading,
@@ -630,6 +631,10 @@ export default function StructuresDetailPage() {
 	}, [sovereigntyStructures])
 	if (!authLoading && !permissionsLoading && !canViewStructures) {
 		return <Navigate to="/dashboard" replace />
+	}
+
+	if (!authLoading && !permissionsLoading && canViewStructures && !canViewStructureDetails) {
+		return <Navigate to="/structures" replace />
 	}
 
 	if (!structureId) {

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -3,7 +3,6 @@ import {
 	ArrowRight,
 	ArrowUp,
 	ArrowUpDown,
-	Building2,
 	Filter,
 	RefreshCcw,
 	Shield,
@@ -14,6 +13,7 @@ import { Link, Navigate } from 'react-router-dom'
 import {
 	hasAllStructureManagerPermission,
 	hasAnyStructurePermission,
+	hasStructureDetailsPermission,
 	hasStructureTabPermission,
 } from '@repo/groups'
 import { STRUCTURE_TABS, isReinforcedStructureState, type StructureTab } from '@repo/structures'
@@ -234,6 +234,7 @@ export default function StructuresPage() {
 	const { data: groups = [] } = useGroups({ limit: 100 })
 	const { permissions, isLoading: permissionsLoading } = useUserPermissions()
 	const canViewStructures = user?.is_admin === true || hasAnyStructurePermission(permissions)
+	const canViewStructureDetails = user?.is_admin === true || hasStructureDetailsPermission(permissions)
 	const canManageStructures =
 		user?.is_admin === true || hasAllStructureManagerPermission(permissions)
 	const tableState = useStructureTableUiState((state) => state)
@@ -978,8 +979,14 @@ export default function StructuresPage() {
 										{isSovereigntyTab ? (
 											<>
 												<SortableHead field="activityDefenseMultiplier" label="ADM" />
-												<TableHead>Magmatic Gas</TableHead>
-												<TableHead>Superionic Ice</TableHead>
+												<SortableHead
+													field="magmaticGasEstimatedDepletionAt"
+													label="Magmatic Gas"
+												/>
+												<SortableHead
+													field="superionicIceEstimatedDepletionAt"
+													label="Superionic Ice"
+												/>
 												<TableHead>Workforce</TableHead>
 												<TableHead>Power</TableHead>
 											</>
@@ -999,9 +1006,11 @@ export default function StructuresPage() {
 											</>
 										) : null}
 										<TableHead>Sync</TableHead>
-										<TableHead className="sticky right-0 z-20 table-header-bg border-l border-border/50 text-right">
-											Actions
-										</TableHead>
+										{canViewStructureDetails && (
+											<TableHead className="sticky right-0 z-20 table-header-bg border-l border-border/50 text-right">
+												Actions
+											</TableHead>
+										)}
 									</TableRow>
 								</TableHeader>
 								<TableBody>
@@ -1223,21 +1232,20 @@ export default function StructuresPage() {
 																description={structureSyncStatusDescription(structure)}
 															/>
 														</TableCell>
-														<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
-															{structure.canEdit ? (
-																<Button asChild size="sm" variant="ghost">
-																	<Link to={`/structures/${structure.structureId}`}>
-																		<ArrowRight className="h-4 w-4" />
-																		Details
-																	</Link>
-																</Button>
-															) : (
-																<Badge variant="ghost" className="justify-center">
-																	<Building2 className="h-3 w-3" />
-																	View only
-																</Badge>
-															)}
-														</TableCell>
+														{canViewStructureDetails && (
+															<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
+																{structure.canViewDetails ? (
+																	<Button asChild size="sm" variant="ghost">
+																		<Link to={`/structures/${structure.structureId}`}>
+																			<ArrowRight className="h-4 w-4" />
+																			Details
+																		</Link>
+																	</Button>
+																) : (
+																	<span className="text-sm text-muted-foreground">-</span>
+																)}
+															</TableCell>
+														)}
 													</TableRow>
 												)
 											})}

--- a/packages/groups/src/permissions.ts
+++ b/packages/groups/src/permissions.ts
@@ -220,7 +220,7 @@ export interface GetMultiGroupMemberPermissionsResponse {
  * The scope is encoded directly into the URN so the UI and authorization helpers can
  * reason about the visibility target without needing extra lookup state.
  */
-export const STRUCTURE_PERMISSION_ROLES = ['viewer', 'manager', 'sensitive'] as const
+export const STRUCTURE_PERMISSION_ROLES = ['viewer', 'details', 'sensitive', 'manager'] as const
 export type StructurePermissionRole = (typeof STRUCTURE_PERMISSION_ROLES)[number]
 
 export const STRUCTURE_PERMISSION_TABS = [
@@ -360,6 +360,17 @@ export function hasStructureManagerPermission(permissions: Array<PermissionLike>
 	})
 }
 
+export function hasStructureDetailsPermission(permissions: Array<PermissionLike>): boolean {
+	return permissions.some((permission) => {
+		const parsed = parseStructurePermissionUrn(permission.urn)
+		if (!parsed) {
+			return false
+		}
+
+		return parsed.role === 'details' || parsed.role === 'sensitive' || parsed.role === 'manager'
+	})
+}
+
 export function hasStructureSensitivePermission(permissions: Array<PermissionLike>): boolean {
 	return permissions.some((permission) => {
 		const parsed = parseStructurePermissionUrn(permission.urn)
@@ -368,6 +379,21 @@ export function hasStructureSensitivePermission(permissions: Array<PermissionLik
 		}
 
 		return parsed.role === 'manager' || parsed.role === 'sensitive'
+	})
+}
+
+export function hasAllStructureDetailsPermission(permissions: Array<PermissionLike>): boolean {
+	return permissions.some((permission) => {
+		const parsed = parseStructurePermissionUrn(permission.urn)
+		if (!parsed || parsed.scope !== 'all') {
+			return false
+		}
+
+		return (
+			parsed.role === 'details' ||
+			parsed.role === 'sensitive' ||
+			parsed.role === 'manager'
+		)
 	})
 }
 

--- a/packages/groups/src/test/unit/permissions.test.ts
+++ b/packages/groups/src/test/unit/permissions.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest'
 import {
 	buildStructurePermissionUrn,
 	buildStructureTabPermissionUrn,
+	hasAllStructureDetailsPermission,
 	hasAllStructureManagerPermission,
 	hasAllStructureSensitivePermission,
 	hasAnyStructurePermission,
+	hasStructureDetailsPermission,
 	hasStructureManagerPermission,
 	hasStructureSensitivePermission,
 	hasStructureTabPermission,
@@ -40,6 +42,19 @@ describe('structure permission utilities', () => {
 		})
 	})
 
+	it('builds and parses corporation-scoped details URNs', () => {
+		const urn = buildStructurePermissionUrn('1234567890', 'details')
+
+		expect(urn).toBe('urn:structures:1234567890:details')
+		expect(isStructurePermissionUrn(urn)).toBe(true)
+		expect(parseStructurePermissionUrn(urn)).toEqual({
+			tab: 'all',
+			scope: 'corp',
+			corporationId: '1234567890',
+			role: 'details',
+		})
+	})
+
 	it('builds and parses corporation-scoped sensitive URNs', () => {
 		const urn = buildStructurePermissionUrn('1234567890', 'sensitive')
 
@@ -63,6 +78,18 @@ describe('structure permission utilities', () => {
 			scope: 'all',
 			corporationId: null,
 			role: 'viewer',
+		})
+	})
+
+	it('builds and parses tab-scoped details URNs', () => {
+		const urn = buildStructureTabPermissionUrn('moon-drills', '1234567890', 'details')
+
+		expect(urn).toBe('urn:structures:moon-drills:1234567890:details')
+		expect(parseStructurePermissionUrn(urn)).toEqual({
+			tab: 'moon-drills',
+			scope: 'corp',
+			corporationId: '1234567890',
+			role: 'details',
 		})
 	})
 
@@ -130,6 +157,7 @@ describe('structure permission utilities', () => {
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:all:viewer' }])).toBe(true)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:1001:viewer' }])).toBe(true)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:all:view' }])).toBe(false)
+		expect(hasAnyStructurePermission([{ urn: 'urn:structures:all:details' }])).toBe(true)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:all:manager' }])).toBe(true)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:1001:sensitive' }])).toBe(true)
 		expect(hasAnyStructurePermission([{ urn: 'urn:structures:moon-drills:all:viewer' }])).toBe(true)
@@ -148,15 +176,28 @@ describe('structure permission utilities', () => {
 	it('only treats manager structure URNs as manager access', () => {
 		expect(hasStructureManagerPermission([{ urn: 'urn:structures:all:viewer' }])).toBe(false)
 		expect(hasStructureManagerPermission([{ urn: 'urn:structures:1001:viewer' }])).toBe(false)
+		expect(hasStructureManagerPermission([{ urn: 'urn:structures:all:details' }])).toBe(false)
 		expect(hasStructureManagerPermission([{ urn: 'urn:structures:all:manager' }])).toBe(true)
 		expect(hasStructureManagerPermission([{ urn: 'urn:structures:1001:manager' }])).toBe(true)
 		expect(hasStructureManagerPermission([{ urn: 'urn:structures:1001:sensitive' }])).toBe(false)
 		expect(hasStructureManagerPermission([{ urn: 'urn:srp:reviewer' }])).toBe(false)
 	})
 
+	it('treats details structure URNs as read-only detail access', () => {
+		expect(hasStructureDetailsPermission([{ urn: 'urn:structures:all:viewer' }])).toBe(false)
+		expect(hasStructureDetailsPermission([{ urn: 'urn:structures:1001:viewer' }])).toBe(false)
+		expect(hasStructureDetailsPermission([{ urn: 'urn:structures:all:details' }])).toBe(true)
+		expect(hasStructureDetailsPermission([{ urn: 'urn:structures:1001:details' }])).toBe(true)
+		expect(hasStructureDetailsPermission([{ urn: 'urn:structures:all:sensitive' }])).toBe(true)
+		expect(hasStructureDetailsPermission([{ urn: 'urn:structures:1001:sensitive' }])).toBe(true)
+		expect(hasStructureDetailsPermission([{ urn: 'urn:structures:all:manager' }])).toBe(true)
+		expect(hasStructureDetailsPermission([{ urn: 'urn:srp:reviewer' }])).toBe(false)
+	})
+
 	it('treats sensitive structure URNs as read-only sensitive access', () => {
 		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:all:viewer' }])).toBe(false)
 		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:1001:viewer' }])).toBe(false)
+		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:all:details' }])).toBe(false)
 		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:all:manager' }])).toBe(true)
 		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:1001:manager' }])).toBe(true)
 		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:all:sensitive' }])).toBe(true)
@@ -169,6 +210,15 @@ describe('structure permission utilities', () => {
 		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:1001:sensitive' }])).toBe(true)
 		expect(hasStructureManagerPermission([{ urn: 'urn:structures:1001:manager' }])).toBe(true)
 		expect(hasStructureSensitivePermission([{ urn: 'urn:structures:1001:manager' }])).toBe(true)
+	})
+
+	it('only treats all-scope details URNs as all-scope detail access', () => {
+		expect(hasAllStructureDetailsPermission([{ urn: 'urn:structures:all:viewer' }])).toBe(false)
+		expect(hasAllStructureDetailsPermission([{ urn: 'urn:structures:1001:details' }])).toBe(false)
+		expect(hasAllStructureDetailsPermission([{ urn: 'urn:structures:all:details' }])).toBe(true)
+		expect(hasAllStructureDetailsPermission([{ urn: 'urn:structures:all:sensitive' }])).toBe(true)
+		expect(hasAllStructureDetailsPermission([{ urn: 'urn:structures:all:manager' }])).toBe(true)
+		expect(hasAllStructureDetailsPermission([{ urn: 'urn:srp:reviewer' }])).toBe(false)
 	})
 
 	it('only treats all-scope manager URNs as manager access', () => {

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -1,4 +1,4 @@
-export type StructurePermissionRole = 'viewer' | 'manager' | 'sensitive'
+export type StructurePermissionRole = 'viewer' | 'details' | 'sensitive' | 'manager'
 export type CorporationAlertDestinationType = 'discord_channel' | 'discord_user' | 'discord_webhook' | 'group'
 export type StructureTab =
 	| 'citadels'
@@ -12,6 +12,8 @@ export type StructureListSortBy =
 	| 'nextStateAt'
 	| 'fuel'
 	| 'activityDefenseMultiplier'
+	| 'magmaticGasEstimatedDepletionAt'
+	| 'superionicIceEstimatedDepletionAt'
 	| 'name'
 	| 'corporation'
 	| 'region'
@@ -203,7 +205,6 @@ export interface StructureSovereigntyListItem {
 	state: string
 	typeId: string
 	typeName: string | null
-	profileId: string
 	nextStateAt: string | null
 	fuelExpires: string | null
 	fuelAmount: number | null
@@ -243,9 +244,7 @@ export interface StructureSovereigntyListItem {
 	syncStatus: 'ok' | 'warning' | 'error'
 	syncFailureReason: string | null
 	lastSyncedAt: string | null
-	updatedAt: string
-	canViewSensitive: boolean
-	canEdit: boolean
+	canViewDetails: boolean
 }
 
 export interface StructureSovereigntyListResponse {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a new `details` structure permission role that sits between `viewer` and `sensitive`, gating access to the structure detail page separately from the summary list. It also makes the sovereignty hub gas/ice depletion columns sortable, strips the internal `updatedAt` field from structure API responses, and removes the unused `profileId` field from structure list items.

## Changes
- Add `details` to `STRUCTURE_PERMISSION_ROLES` (`viewer | details | sensitive | manager`) and add `hasStructureDetailsPermission` / `hasAllStructureDetailsPermission` helpers in `@repo/groups`.
- Replace the per-item `canViewSensitive`/`canEdit` flags on structure list responses with a single `canViewDetails` flag, computed from `details`/`sensitive`/`manager` role grants; `canViewSensitive`/`canEdit` remain only on the structure detail result.
- Enforce the new permission server-side: `getVisibleStructureDetail` now requires details-level access and returns `null` (404) otherwise.
- Update the UI structures list and detail routes to check `hasStructureDetailsPermission`, hiding the Actions column / redirecting away from the detail page when the user lacks access.
- Make `magmaticGasEstimatedDepletionAt` and `superionicIceEstimatedDepletionAt` sortable columns for sovereignty hub structures (previously static, unsortable columns).
- Strip `updatedAt` from all structure list/detail JSON responses before sending them to the browser (`stripUpdatedAtFromStructureItem`/`stripUpdatedAtFromStructureListResponse`).
- Remove the unused `profileId` field from `StructureListItem`/`StructureSovereigntyListItem` and related UI types.

## Testing
- Added unit tests for the new permission helpers (`packages/groups/src/test/unit/permissions.test.ts`).
- Added unit tests for details-permission gating and sovereignty hub sort-by-depletion-time behavior (`apps/structures/src/test/unit/services/structure-permission-gating.test.ts`, `sovereignty-hub-model.test.ts`).
- Added a new route test asserting `updatedAt` is stripped from citadel list responses (`apps/core/src/routes/__tests__/structures.route.test.ts`).
<!-- claude:end -->