### PR TITLE
fix structure assets ingest

### DIFF
--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -92,6 +92,8 @@ export type Env = SharedHonoEnv & {
 	MOON_SCAN_EXPORTS: R2Bucket
 	/** SRP export artifact bucket */
 	SRP_EXPORTS: R2Bucket
+	/** Structure asset debug artifact bucket */
+	STRUCTURE_ASSETS_DEBUG_EXPORTS: R2Bucket
 	/** Markets Durable Object binding */
 	MARKETS: DurableObjectNamespace
 	/** Mumble Durable Object binding */

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -16,9 +16,11 @@ import {
 import { createDb } from './db'
 import { discordMemberAuditRuns, userCharacters, userIpAddresses, users } from './db/schema'
 import { CoreDO } from './durable-object'
+import { cleanupExpiredExportArtifacts } from './lib/export-retention'
 import { waitUntilWithTelemetry } from './lib/background-task'
 import { IMMUNITAS_ALERT_DRAIN_CRON } from './lib/immunitas-alerts'
 import { TOKEN_INVALID_ALERT_DRAIN_CRON } from './lib/token-invalid-alerts'
+import { getStructureAssetsDebugBucket } from './lib/structure-assets-debug'
 import { triggerDiscordRefreshWorkflow, triggerUserRefreshWorkflow } from './lib/workflow-triggers'
 import { csrfProtection } from './middleware/csrf'
 import { sessionMiddleware } from './middleware/session'
@@ -222,6 +224,12 @@ export default {
 							}
 						})
 						.catch((error) => captureException(error as Error, { tags: { job: 'pm-reconcile' } }))
+				)
+
+				ctx.waitUntil(
+					cleanupExpiredExportArtifacts(getStructureAssetsDebugBucket(env), 'structure-assets-debug').catch(
+						(error) => captureException(error as Error, { tags: { job: 'structure-assets-debug-cleanup' } })
+					)
 				)
 			}
 

--- a/apps/core/src/lib/structure-assets-debug.ts
+++ b/apps/core/src/lib/structure-assets-debug.ts
@@ -1,0 +1,137 @@
+import { getStub } from '@repo/do-utils'
+import { parseFittingSlotFlag } from '@repo/eve-fitting/flags'
+import { getInventoryBayLabel } from '@repo/inventory-display'
+
+import { getExportArtifactExpiresAtIso, isExportArtifactExpired } from './export-retention'
+
+import type { Env } from '../context'
+import type { Universe } from '@repo/universe'
+
+export interface StructureAssetsDebugItem {
+	itemId: string
+	typeId: string
+	typeName: string | null
+	quantity: number
+	isSingleton: boolean
+	locationId: string
+	locationType: string
+	locationFlag: string
+	locationFlagLabel: string
+	updatedAt: string
+}
+
+export interface StructureAssetsDebugResult {
+	corporationId: string
+	corporationName: string
+	structureId: string
+	structureName: string
+	fetchedAt: string
+	fetchedAssetCount: number
+	itemCount: number
+	items: StructureAssetsDebugItem[]
+}
+
+export interface StructureAssetsDebugWorkflowParams {
+	kind: 'structure-assets-debug'
+	userId: string
+	corporationId: string
+	corporationName: string
+	structureId: string
+	structureName: string
+}
+
+export const STRUCTURE_ASSETS_DEBUG_EXPORT_BUCKET_PREFIX = 'structure-assets-debug'
+
+export function getStructureAssetsDebugBucket(env: Pick<Env, 'STRUCTURE_ASSETS_DEBUG_EXPORTS'>): R2Bucket {
+	return env.STRUCTURE_ASSETS_DEBUG_EXPORTS
+}
+
+export function buildStructureAssetsDebugExportKey(exportId: string): string {
+	return `${STRUCTURE_ASSETS_DEBUG_EXPORT_BUCKET_PREFIX}/${exportId}.json`
+}
+
+export function buildStructureAssetsDebugFileName(exportId: string): string {
+	return `structure-assets-debug-${exportId.slice(0, 8)}.json`
+}
+
+export function getStructureAssetLocationLabel(locationFlag: string): string {
+	const fittingSlot = parseFittingSlotFlag(locationFlag)
+	if (fittingSlot) {
+		return `${fittingSlot.flagName} ${fittingSlot.slotIndex}`
+	}
+
+	return getInventoryBayLabel(locationFlag)
+}
+
+export async function enrichStructureAssetsDebugTypeNames(
+	env: Pick<Env, 'UNIVERSE'>,
+	items: StructureAssetsDebugItem[]
+): Promise<StructureAssetsDebugItem[]> {
+	if (items.length === 0) {
+		return items
+	}
+
+	const typeIds = Array.from(new Set(items.map((item) => item.typeId)))
+	if (typeIds.length === 0) {
+		return items
+	}
+
+	const universe = getStub<Universe>(env.UNIVERSE, 'default')
+	const typeNameMap: Record<string, string> = {}
+	const batchSize = 1000
+
+	for (let index = 0; index < typeIds.length; index += batchSize) {
+		const batch = typeIds.slice(index, index + batchSize)
+		const resolved = await universe.resolveTypeNamesByIds(batch)
+		for (const [typeId, typeData] of Object.entries(resolved)) {
+			typeNameMap[typeId] = typeData?.typeName ?? typeId
+		}
+	}
+
+	return items.map((item) => ({
+		...item,
+		typeName: typeNameMap[item.typeId] ?? item.typeId,
+	}))
+}
+
+export async function writeStructureAssetsDebugArtifact(args: {
+	bucket: R2Bucket
+	exportKey: string
+	fileName: string
+	expiresAt: string
+	result: StructureAssetsDebugResult
+}): Promise<number> {
+	await args.bucket.put(args.exportKey, JSON.stringify(args.result), {
+		httpMetadata: {
+			contentType: 'application/json; charset=utf-8',
+		},
+		customMetadata: {
+			fileName: args.fileName,
+			expiresAt: args.expiresAt,
+		},
+	})
+
+	return args.result.itemCount
+}
+
+export async function readStructureAssetsDebugArtifact(
+	bucket: R2Bucket,
+	exportKey: string
+): Promise<StructureAssetsDebugResult | null> {
+	const object = await bucket.get(exportKey)
+	if (!object) {
+		return null
+	}
+
+	if (isExportArtifactExpired(object.customMetadata?.expiresAt)) {
+		await bucket.delete(exportKey).catch(() => {})
+		return null
+	}
+
+	const text = await object.text()
+	return JSON.parse(text) as StructureAssetsDebugResult
+}
+
+export function getStructureAssetsDebugExpiresAtIso(): string {
+	return getExportArtifactExpiresAtIso()
+}

--- a/apps/core/src/routes/__tests__/structures.route.test.ts
+++ b/apps/core/src/routes/__tests__/structures.route.test.ts
@@ -8,6 +8,7 @@ import type { SessionUser } from '../../context'
 
 const structuresMocks = vi.hoisted(() => ({
 	listCitadelStructures: vi.fn(),
+	getVisibleStructureDetail: vi.fn(),
 }))
 
 vi.mock('../../lib/groups-cache', () => ({
@@ -45,6 +46,12 @@ describe('structures routes', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		vi.mocked(getCachedUserPermissions).mockResolvedValue([])
+		structuresMocks.getVisibleStructureDetail.mockResolvedValue({
+			corporationId: 'corp-1',
+			corporationName: 'Test Corp',
+			structureId: 'structure-1',
+			name: 'Structure One',
+		})
 		structuresMocks.listCitadelStructures.mockResolvedValue({
 			items: [
 				{
@@ -118,5 +125,109 @@ describe('structures routes', () => {
 			items: Array<Record<string, unknown>>
 		}
 		expect(body.items[0]).not.toHaveProperty('updatedAt')
+	})
+
+	it('queues structure asset debug as a workflow and exposes status/download endpoints', async () => {
+		const exportWorkflow = {
+			create: vi.fn().mockResolvedValue({ id: 'workflow-1' }),
+			get: vi.fn().mockResolvedValue({
+				status: vi.fn().mockResolvedValue({
+					status: 'completed',
+					output: { status: 'completed' },
+				}),
+			}),
+		}
+		const storedArtifact = {
+			text: vi.fn().mockResolvedValue(
+				JSON.stringify({
+					corporationId: 'corp-1',
+					corporationName: 'Test Corp',
+					structureId: 'structure-1',
+					structureName: 'Structure One',
+					fetchedAt: '2026-07-13T00:00:00.000Z',
+					fetchedAssetCount: 2,
+					itemCount: 1,
+					items: [],
+				})
+			),
+			customMetadata: {
+				fileName: 'structure-assets-debug-workflow-1.json',
+				expiresAt: '2030-07-13T23:59:00.000Z',
+			},
+			httpMetadata: {
+				contentType: 'application/json; charset=utf-8',
+			},
+		}
+		const debugBucket = {
+			get: vi.fn().mockResolvedValue(storedArtifact),
+			delete: vi.fn().mockResolvedValue(undefined),
+		}
+
+		const app = createApp(makeUser({ is_admin: true }))
+		const env = {
+			STRUCTURES: {
+				getVisibleStructureDetail: structuresMocks.getVisibleStructureDetail,
+			},
+			EXPORT_WORKFLOW: exportWorkflow,
+			STRUCTURE_ASSETS_DEBUG_EXPORTS: debugBucket,
+		} as any
+
+		const startResponse = await app.request(
+			'/api/structures/structure-1/assets-debug',
+			{ method: 'POST' },
+			env
+		)
+		expect(startResponse.status).toBe(202)
+		expect(exportWorkflow.create).toHaveBeenCalledWith({
+			params: {
+				kind: 'structure-assets-debug',
+				userId: 'user-1',
+				corporationId: 'corp-1',
+				corporationName: 'Test Corp',
+				structureId: 'structure-1',
+				structureName: 'Structure One',
+			},
+		})
+		const startBody = (await startResponse.json()) as {
+			workflowInstanceId: string
+			exportId: string
+			fileName: string
+			status: string
+		}
+		expect(startBody).toMatchObject({
+			workflowInstanceId: 'workflow-1',
+			exportId: 'workflow-1',
+			fileName: 'structure-assets-debug-workflow.json',
+			status: 'queued',
+		})
+
+		const statusResponse = await app.request(
+			'/api/structures/structure-1/assets-debug/workflow-1',
+			{},
+			env
+		)
+		expect(statusResponse.status).toBe(200)
+		const statusBody = (await statusResponse.json()) as {
+			workflowInstanceId: string
+			status: string
+			rawStatus: string
+			output: unknown
+		}
+		expect(statusBody).toMatchObject({
+			workflowInstanceId: 'workflow-1',
+			status: 'completed',
+			rawStatus: 'completed',
+		})
+
+		const downloadResponse = await app.request(
+			'/api/structures/structure-1/assets-debug/workflow-1/download',
+			{},
+			env
+		)
+		expect(debugBucket.get).toHaveBeenCalledWith('structure-assets-debug/workflow-1.json')
+		expect(downloadResponse.status).toBe(200)
+		expect(debugBucket.delete).toHaveBeenCalledWith('structure-assets-debug/workflow-1.json')
+		const downloadBody = (await downloadResponse.json()) as { corporationId: string; items: [] }
+		expect(downloadBody.corporationId).toBe('corp-1')
 	})
 })

--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -2,15 +2,19 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 
 import { getStub } from '@repo/do-utils'
-import { parseFittingSlotFlag } from '@repo/eve-fitting/flags'
 import { hasAllStructureManagerPermission } from '@repo/groups'
-import { getInventoryBayLabel } from '@repo/inventory-display'
 
 import { getCachedUserPermissions } from '../lib/groups-cache'
+import {
+	buildStructureAssetsDebugExportKey,
+	buildStructureAssetsDebugFileName,
+	getStructureAssetsDebugBucket,
+	readStructureAssetsDebugArtifact,
+} from '../lib/structure-assets-debug'
+import { normalizeWorkflowStatus } from '../lib/workflow-status'
 import { EntityResolverService } from '../services/entity-resolver.service'
 
 import type { Context } from 'hono'
-import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type {
 	StructureCitadelListQuery,
@@ -171,30 +175,6 @@ interface StructureDetailResponse {
 	[key: string]: unknown
 }
 
-interface StructureAssetsDebugItemView {
-	itemId: string
-	typeId: string
-	typeName: string | null
-	quantity: number
-	isSingleton: boolean
-	locationId: string
-	locationType: string
-	locationFlag: string
-	locationFlagLabel: string
-	updatedAt: string
-}
-
-interface StructureAssetsDebugResponse {
-	corporationId: string
-	corporationName: string
-	structureId: string
-	structureName: string
-	fetchedAt: string
-	fetchedAssetCount: number
-	itemCount: number
-	items: StructureAssetsDebugItemView[]
-}
-
 async function getStructureActor(c: Context<App>) {
 	const user = c.get('user')
 	if (!user) {
@@ -228,13 +208,12 @@ function getUniverseStub(env: App['Bindings']): Universe {
 	return getStub<Universe>(env.UNIVERSE, 'default')
 }
 
-function getStructureAssetLocationLabel(locationFlag: string): string {
-	const fittingSlot = parseFittingSlotFlag(locationFlag)
-	if (fittingSlot) {
-		return `${fittingSlot.flagName} ${fittingSlot.slotIndex}`
+function getExecutionContextOrNull(c: { executionCtx?: ExecutionContext }): ExecutionContext | null {
+	try {
+		return c.executionCtx ?? null
+	} catch {
+		return null
 	}
-
-	return getInventoryBayLabel(locationFlag)
 }
 
 async function enrichStructureDetailTypeNames(
@@ -415,37 +394,6 @@ async function enrichSovereigntyStructureListResponse(
 	}
 }
 
-async function enrichStructureAssetsDebugTypeNames(
-	env: App['Bindings'],
-	items: StructureAssetsDebugItemView[]
-): Promise<StructureAssetsDebugItemView[]> {
-	if (items.length === 0) {
-		return items
-	}
-
-	const typeIds = Array.from(new Set(items.map((item) => item.typeId)))
-	if (typeIds.length === 0) {
-		return items
-	}
-
-	const universe = getUniverseStub(env)
-	const typeNameMap: Record<string, string> = {}
-	const batchSize = 1000
-
-	for (let index = 0; index < typeIds.length; index += batchSize) {
-		const batch = typeIds.slice(index, index + batchSize)
-		const resolved = await universe.resolveTypeNamesByIds(batch)
-		for (const [typeId, typeData] of Object.entries(resolved)) {
-			typeNameMap[typeId] = typeData?.typeName ?? typeId
-		}
-	}
-
-	return items.map((item) => ({
-		...item,
-		typeName: typeNameMap[item.typeId] ?? item.typeId,
-	}))
-}
-
 app.get('/', async (c) => {
 	return handleCitadelStructuresRequest(c)
 })
@@ -504,61 +452,95 @@ app.post('/:structureId/assets-debug', async (c) => {
 			return c.json({ error: 'Structure not found' }, 404)
 		}
 
-		const corpData = getStub<EveCorporationData>(
-			c.env.EVE_CORPORATION_DATA,
-			structure.corporationId
-		)
-		const { assetsCount } = await corpData.fetchAssets(structure.corporationId, true)
-		const rawItems = await corpData.searchAssets(structure.corporationId, {
-			locationId: structure.structureId,
-			locationType: 'item',
-			limit: 10000,
+		const workflow = await c.env.EXPORT_WORKFLOW.create({
+			params: {
+				kind: 'structure-assets-debug',
+				userId: user.id,
+				corporationId: structure.corporationId,
+				corporationName: structure.corporationName ?? structure.corporationId,
+				structureId: structure.structureId,
+				structureName: structure.name ?? structure.structureId,
+			},
 		})
 
-		const items = await enrichStructureAssetsDebugTypeNames(
-			c.env,
-			rawItems
-				.map((item) => ({
-					itemId: item.itemId,
-					typeId: item.typeId,
-					typeName: null,
-					quantity: item.quantity,
-					isSingleton: item.isSingleton,
-					locationId: item.locationId,
-					locationType: item.locationType,
-					locationFlag: item.locationFlag,
-					locationFlagLabel: getStructureAssetLocationLabel(item.locationFlag),
-					updatedAt: item.updatedAt.toISOString(),
-				}))
-				.sort(
-					(left, right) =>
-						left.locationFlagLabel.localeCompare(right.locationFlagLabel) ||
-						left.typeId.localeCompare(right.typeId) ||
-						left.itemId.localeCompare(right.itemId)
-				)
+		return c.json(
+			{
+				workflowInstanceId: workflow.id,
+				exportId: workflow.id,
+				fileName: buildStructureAssetsDebugFileName(workflow.id),
+				status: 'queued',
+			},
+			202
 		)
-
-		const response: StructureAssetsDebugResponse = {
-			corporationId: structure.corporationId,
-			corporationName: structure.corporationName ?? structure.corporationId,
-			structureId: structure.structureId,
-			structureName: structure.name ?? structure.structureId,
-			fetchedAt: new Date().toISOString(),
-			fetchedAssetCount: assetsCount,
-			itemCount: items.length,
-			items,
-		}
-
-		return c.json(response)
 	} catch (error) {
 		return c.json(
 			{
 				error:
-					error instanceof Error ? error.message : 'Failed to fetch structure assets debug data',
+					error instanceof Error ? error.message : 'Failed to queue structure assets debug export',
 			},
 			500
 		)
 	}
+})
+
+app.get('/:structureId/assets-debug/:workflowInstanceId', async (c) => {
+	const user = c.get('user')
+	if (!user) {
+		return c.json({ error: 'Unauthorized' }, 401)
+	}
+	if (!user.is_admin) {
+		return c.json({ error: 'Requires site administrator permission' }, 403)
+	}
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const workflow = await c.env.EXPORT_WORKFLOW.get(workflowInstanceId)
+	const status = await workflow.status()
+	const outputStatus =
+		status.output && typeof status.output === 'object' && 'status' in status.output
+			? String((status.output as { status?: string }).status ?? '')
+			: undefined
+	return c.json({
+		workflowInstanceId,
+		status: normalizeWorkflowStatus(status.status, outputStatus),
+		rawStatus: status.status,
+		output: status.output ?? null,
+	})
+})
+
+app.get('/:structureId/assets-debug/:workflowInstanceId/download', async (c) => {
+	const user = c.get('user')
+	if (!user) {
+		return c.json({ error: 'Unauthorized' }, 401)
+	}
+	if (!user.is_admin) {
+		return c.json({ error: 'Requires site administrator permission' }, 403)
+	}
+
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!workflowInstanceId) {
+		return c.json({ error: 'workflowInstanceId is required' }, 400)
+	}
+
+	const bucket = getStructureAssetsDebugBucket(c.env)
+	const exportKey = buildStructureAssetsDebugExportKey(workflowInstanceId)
+	const artifact = await readStructureAssetsDebugArtifact(bucket, exportKey)
+	if (!artifact) {
+		return c.json({ error: 'Export not found' }, 404)
+	}
+
+	const executionCtx = getExecutionContextOrNull(c)
+	const cleanup = bucket.delete(exportKey).catch(() => {})
+	if (executionCtx) {
+		executionCtx.waitUntil(cleanup)
+	} else {
+		void cleanup
+	}
+
+	return c.json(artifact)
 })
 
 async function handleCitadelStructuresRequest(c: Context<App>): Promise<Response> {

--- a/apps/core/src/test/unit/workflows/csv-export.workflow.test.ts
+++ b/apps/core/src/test/unit/workflows/csv-export.workflow.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { CsvExportWorkflow } from '../../../workflows/csv-export.workflow'
+
+import type { WorkflowStep } from 'cloudflare:workers'
+
+const getStubMock = vi.fn()
+const moonWriteMock = vi.fn()
+const srpPaidWriteMock = vi.fn()
+const srpWalletWriteMock = vi.fn()
+
+vi.mock('cloudflare:workers', () => {
+	class WorkflowEntrypoint<Env = unknown, Params = unknown> {
+		protected readonly ctx: unknown
+		protected readonly env: Env
+
+		constructor(ctx: unknown, env: Env) {
+			this.ctx = ctx
+			this.env = env
+		}
+
+		// eslint-disable-next-line @typescript-eslint/require-await
+		async run(_event: unknown, _step: unknown): Promise<Params> {
+			throw new Error('WorkflowEntrypoint.run is not implemented in unit-test shim')
+		}
+	}
+
+	return {
+		WorkflowEntrypoint,
+		WorkflowEvent: class WorkflowEvent {},
+		WorkflowStep: class WorkflowStep {},
+	}
+})
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: (...args: unknown[]) => getStubMock(...args),
+}))
+
+vi.mock('../../../routes/moon-scan', () => ({
+	buildVerifiedMoonsExportFileName: () => 'verified-moons.csv',
+	buildVerifiedMoonsExportKey: () => 'moon-export-key',
+	getVerifiedMoonsExportBucket: () => ({ name: 'MOON_SCAN_EXPORTS' }),
+	buildVerifiedMoonSummaryRecords: vi.fn(),
+	writeVerifiedMoonsExportToBucket: (...args: unknown[]) => moonWriteMock(...args),
+}))
+
+vi.mock('../../../routes/srp', () => ({
+	buildSrpPaidRequestsExportFileName: () => 'srp-paid.csv',
+	buildSrpPaidRequestsExportKey: () => 'srp-paid-key',
+	buildSrpWalletHistoryExportFileName: () => 'srp-wallet.csv',
+	buildSrpWalletHistoryExportKey: () => 'srp-wallet-key',
+	getSrpExportBucket: () => ({ name: 'SRP_EXPORTS' }),
+	parseSrpCsvExportDateRange: () => ({
+		dateFrom: '2026-07-01T00:00:00.000Z',
+		dateTo: '2026-07-31T23:59:59.999Z',
+		startDate: new Date('2026-07-01T00:00:00.000Z'),
+		endDate: new Date('2026-07-31T23:59:59.999Z'),
+	}),
+	writeSrpPaidRequestsExportToBucket: (...args: unknown[]) => srpPaidWriteMock(...args),
+	writeSrpWalletHistoryExportToBucket: (...args: unknown[]) => srpWalletWriteMock(...args),
+}))
+
+function createStep() {
+	const doMock = vi.fn(async (_name: string, optionsOrHandler: unknown, maybeHandler?: () => unknown) => {
+		const handler =
+			typeof optionsOrHandler === 'function'
+				? (optionsOrHandler as () => unknown)
+				: (maybeHandler as () => unknown)
+		return await handler()
+	})
+
+	return {
+		step: { do: doMock } as unknown as WorkflowStep,
+	}
+}
+
+describe('CsvExportWorkflow structure assets debug export', () => {
+	it('writes the debug artifact to R2 using the workflow job', async () => {
+		const bucketPut = vi.fn().mockResolvedValue(undefined)
+		const bucket = {
+			put: bucketPut,
+		}
+		const corpData = {
+			fetchAssets: vi.fn().mockResolvedValue({ assetsCount: 2 }),
+			searchAssets: vi.fn().mockResolvedValue([
+				{
+					itemId: 'item-1',
+					typeId: '35832',
+					quantity: 1,
+					isSingleton: true,
+					locationId: 'structure-1',
+					locationType: 'item',
+					locationFlag: 'ServiceSlot0',
+					updatedAt: new Date('2026-07-13T00:00:00.000Z'),
+				},
+			]),
+		}
+		const universe = {
+			resolveTypeNamesByIds: vi.fn().mockResolvedValue({
+				'35832': { typeName: 'Astrahus' },
+			}),
+		}
+
+		getStubMock.mockImplementation((binding: unknown) => {
+			if (binding && typeof binding === 'object' && 'name' in binding && binding.name === 'EVE_CORPORATION_DATA') {
+				return corpData
+			}
+			if (binding && typeof binding === 'object' && 'name' in binding && binding.name === 'UNIVERSE') {
+				return universe
+			}
+			if (binding && typeof binding === 'object' && 'name' in binding && binding.name === 'STRUCTURE_ASSETS_DEBUG_EXPORTS') {
+				return bucket
+			}
+			return {}
+		})
+
+		const workflow = new CsvExportWorkflow({} as ExecutionContext, {
+			EVE_CORPORATION_DATA: { name: 'EVE_CORPORATION_DATA' },
+			UNIVERSE: { name: 'UNIVERSE' },
+			STRUCTURE_ASSETS_DEBUG_EXPORTS: bucket,
+		} as never)
+		const { step } = createStep()
+
+		const result = await workflow.run(
+			{
+				payload: {
+					kind: 'structure-assets-debug',
+					userId: 'user-1',
+					corporationId: 'corp-1',
+					corporationName: 'Test Corp',
+					structureId: 'structure-1',
+					structureName: 'Structure One',
+				},
+				instanceId: 'workflow-1',
+				timestamp: new Date('2026-07-13T00:00:00.000Z'),
+			} as never,
+			step
+		)
+
+		expect(result).toMatchObject({
+			status: 'completed',
+			workflowInstanceId: 'workflow-1',
+			kind: 'structure-assets-debug',
+			exportId: 'workflow-1',
+			rowCount: 1,
+		})
+		expect(corpData.fetchAssets).toHaveBeenCalledWith('corp-1', true)
+		expect(corpData.searchAssets).toHaveBeenCalledWith('corp-1', {
+			locationId: 'structure-1',
+			locationType: 'item',
+		})
+		expect(universe.resolveTypeNamesByIds).toHaveBeenCalledWith(['35832'])
+		expect(bucketPut).toHaveBeenCalledTimes(1)
+
+		const [exportKey, body, options] = bucketPut.mock.calls[0] as [
+			string,
+			string,
+			{ customMetadata?: { fileName?: string; expiresAt?: string } }
+		]
+		expect(exportKey).toBe('structure-assets-debug/workflow-1.json')
+		expect(options.customMetadata?.fileName).toBe('structure-assets-debug-workflow.json')
+		expect(options.customMetadata?.expiresAt).toBeTruthy()
+		const artifact = JSON.parse(body) as {
+			corporationId: string
+			structureId: string
+			itemCount: number
+			items: Array<{ typeName: string | null }>
+		}
+		expect(artifact).toMatchObject({
+			corporationId: 'corp-1',
+			structureId: 'structure-1',
+			itemCount: 1,
+		})
+		expect(artifact.items[0]?.typeName).toBe('Astrahus')
+	})
+})

--- a/apps/core/src/workflows/csv-export.workflow.ts
+++ b/apps/core/src/workflows/csv-export.workflow.ts
@@ -3,6 +3,15 @@ import { WorkflowEntrypoint } from 'cloudflare:workers'
 import { getStub } from '@repo/do-utils'
 
 import { getExportArtifactExpiresAtIso } from '../lib/export-retention'
+import {
+	buildStructureAssetsDebugExportKey,
+	buildStructureAssetsDebugFileName,
+	enrichStructureAssetsDebugTypeNames,
+	getStructureAssetsDebugBucket,
+	getStructureAssetLocationLabel,
+	type StructureAssetsDebugWorkflowParams,
+	writeStructureAssetsDebugArtifact,
+} from '../lib/structure-assets-debug'
 
 import {
 	buildVerifiedMoonsExportFileName,
@@ -24,6 +33,7 @@ import {
 } from '../routes/srp'
 
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { MoonScanDO } from '@repo/moon-scan'
 import type { Universe } from '@repo/universe'
 import type { Env } from '../context'
@@ -53,6 +63,7 @@ export type CsvExportWorkflowParams =
 			dateFrom: string
 			dateTo: string
 	  }
+	| StructureAssetsDebugWorkflowParams
 
 export type CsvExportWorkflowKind = CsvExportWorkflowParams['kind']
 
@@ -78,6 +89,72 @@ function chunkArray<T>(items: readonly T[], size: number): T[][] {
 		chunks.push(items.slice(index, index + size) as T[])
 	}
 	return chunks
+}
+
+async function runStructureAssetsDebugExport(
+	env: Env,
+	workflowInstanceId: string,
+	params: StructureAssetsDebugWorkflowParams
+): Promise<{ fileName: string; expiresAt: string; rowCount: number }> {
+	const corpData = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, params.corporationId)
+	const expiresAt = getExportArtifactExpiresAtIso()
+	const exportKey = buildStructureAssetsDebugExportKey(workflowInstanceId)
+	const fileName = buildStructureAssetsDebugFileName(workflowInstanceId)
+	const bucket = getStructureAssetsDebugBucket(env)
+
+	const { assetsCount: fetchedAssetCount } = await corpData.fetchAssets(
+		params.corporationId,
+		true
+	)
+	const rawItems = await corpData.searchAssets(params.corporationId, {
+		locationId: params.structureId,
+		locationType: 'item',
+	})
+	const items = await enrichStructureAssetsDebugTypeNames(
+		env,
+		rawItems
+			.map((item) => ({
+				itemId: item.itemId,
+				typeId: item.typeId,
+				typeName: null,
+				quantity: item.quantity,
+				isSingleton: item.isSingleton,
+				locationId: item.locationId,
+				locationType: item.locationType,
+				locationFlag: item.locationFlag,
+				locationFlagLabel: getStructureAssetLocationLabel(item.locationFlag),
+				updatedAt: item.updatedAt.toISOString(),
+			}))
+			.sort(
+				(left, right) =>
+					left.locationFlagLabel.localeCompare(right.locationFlagLabel) ||
+					left.typeId.localeCompare(right.typeId) ||
+					left.itemId.localeCompare(right.itemId)
+			)
+	)
+
+	await writeStructureAssetsDebugArtifact({
+		bucket,
+		exportKey,
+		fileName,
+		expiresAt,
+		result: {
+			corporationId: params.corporationId,
+			corporationName: params.corporationName,
+			structureId: params.structureId,
+			structureName: params.structureName,
+			fetchedAt: new Date().toISOString(),
+			fetchedAssetCount,
+			itemCount: items.length,
+			items,
+		},
+	})
+
+	return {
+		fileName,
+		expiresAt,
+		rowCount: items.length,
+	}
 }
 
 async function runMoonScanExport(
@@ -231,6 +308,8 @@ export class CsvExportWorkflow extends WorkflowEntrypoint<Env, CsvExportWorkflow
 							return await runSrpPaidRequestsExport(this.env, workflowInstanceId, payload)
 						case 'srp-wallet-history':
 							return await runSrpWalletHistoryExport(this.env, workflowInstanceId, payload)
+						case 'structure-assets-debug':
+							return await runStructureAssetsDebugExport(this.env, workflowInstanceId, payload)
 					}
 				}
 			)

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -51,6 +51,10 @@
 		{
 			"binding": "SRP_EXPORTS",
 			"bucket_name": "srp-exports"
+		},
+		{
+			"binding": "STRUCTURE_ASSETS_DEBUG_EXPORTS",
+			"bucket_name": "structure-assets-debug-exports"
 		}
 	],
 	"durable_objects": {

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from 'cloudflare:workers'
 
-import { and, desc, eq, gt, gte, inArray, lte, notInArray, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, gt, gte, inArray, lte, notInArray, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { parseDateOrNull } from '@repo/worker-utils'
@@ -35,8 +35,8 @@ import { DirectorManager } from './services/director-manager'
 import * as esiFetch from './services/esi-fetch'
 import { preserveStructureHydrationFields } from './services/structure-hydration'
 import {
-	filterStructureInventoryAssets,
 	summarizeFuelBlockUnitsByStructure,
+	projectStructureInventoryFromStoredAssets,
 } from './services/structure-inventory'
 
 import type { SQL } from 'drizzle-orm'
@@ -1860,6 +1860,53 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 
 		return new Set(rows.map((row) => row.structureId))
+	}
+
+	private async rebuildStructureInventoryFromStoredAssets(
+		corporationId: string,
+		ownedStructureIds: ReadonlySet<string>
+	): Promise<StructureInventoryRowInput[]> {
+		const structureIds = [...ownedStructureIds]
+		if (structureIds.length === 0) {
+			return []
+		}
+
+		const projectedRows: StructureInventoryRowInput[] = []
+		const BATCH_SIZE = 100
+		for (let i = 0; i < structureIds.length; i += BATCH_SIZE) {
+			const batch = structureIds.slice(i, i + BATCH_SIZE)
+			const rawAssets = await this.getDb().query.corporationAssets.findMany({
+				where: and(
+					eq(corporationAssets.corporationId, corporationId),
+					inArray(corporationAssets.locationId, batch),
+					eq(corporationAssets.locationType, 'item')
+				),
+				orderBy: [
+					asc(corporationAssets.locationId),
+					asc(corporationAssets.locationFlag),
+					asc(corporationAssets.typeId),
+					asc(corporationAssets.itemId),
+				],
+			})
+
+			projectedRows.push(
+				...projectStructureInventoryFromStoredAssets(
+					corporationId,
+					ownedStructureIds,
+					rawAssets.map((asset) => ({
+						itemId: asset.itemId,
+						isSingleton: asset.isSingleton,
+						locationFlag: asset.locationFlag,
+						locationId: asset.locationId,
+						locationType: asset.locationType,
+						quantity: asset.quantity,
+						typeId: asset.typeId,
+					}))
+				)
+			)
+		}
+
+		return projectedRows
 	}
 
 	async storeStructureInventory(
@@ -3892,42 +3939,25 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const basePath = `/corporations/${corporationId}/assets`
-		const inventoryRows: StructureInventoryRowInput[] = []
 		try {
 			logger.info(
-				'[EveCorporationData] fetchAndStoreStructureInventoryByCharacter: Fetching structure inventory',
+				'[EveCorporationData] fetchAndStoreStructureInventoryByCharacter: Refreshing raw assets and rebuilding structure inventory',
 				{
 					corporationId,
 					ownedStructureCount: ownedStructureIds.size,
 				}
 			)
-			const result = await syncAssetsPaged({
-				fetchPage: (page) =>
-					tokenStore.fetchEsi(`${basePath}?page=${page}`, characterId, {
-						cacheMode: 'no-store',
-					}) as Promise<EsiResponse<RawEsiAsset[]>>,
-				storeAssets: async (assets) => {
-					inventoryRows.push(
-						...filterStructureInventoryAssets(corporationId, ownedStructureIds, assets)
-					)
-				},
-				onProgress: ({ page, totalPages, totalAssets }) => {
-					if (page % 10 === 0 || page === totalPages) {
-						logger.debug('[fetchAndStoreStructureInventory] Page progress', {
-							corporationId,
-							page,
-							totalPages,
-							totalAssets,
-						})
-					}
-				},
-			})
+			const result = await this.fetchAndStoreAssetsByCharacter(corporationId, characterId)
+			const inventoryRows = await this.rebuildStructureInventoryFromStoredAssets(
+				corporationId,
+				ownedStructureIds
+			)
 
 			await this.storeStructureInventory(corporationId, inventoryRows)
 			await this.updateCorporationSyncTimestamp(corporationId, 'assetsLastSync')
 			logger.info('[EveCorporationData] Stored structure inventory snapshot', {
 				corporationId,
-				fetchedAssetCount: result.assetsCount,
+				fetchedAssetCount: result,
 				storedInventoryCount: inventoryRows.length,
 			})
 
@@ -4346,12 +4376,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 */
 	async fetchAssetsData(corporationId: string, forceRefresh = false): Promise<void> {
 		this.assertNonNpcCorporation(corporationId)
-		await this.fetchAndStoreStructures(corporationId, forceRefresh).catch((e) =>
-			logger.error('Structures fetch failed:', e instanceof Error ? e.message : String(e))
-		)
-		await this.fetchAndStoreStructureInventory(corporationId, forceRefresh).catch((e) =>
-			logger.error('Structure inventory fetch failed:', e instanceof Error ? e.message : String(e))
-		)
+		await this.fetchAndStoreStructures(corporationId, forceRefresh)
+		await this.fetchAndStoreStructureInventory(corporationId, forceRefresh)
 	}
 
 	/**
@@ -5225,6 +5251,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 		const results = await this.getDb().query.corporationAssets.findMany({
 			where: and(...where),
+			orderBy: [desc(corporationAssets.updatedAt), asc(corporationAssets.itemId)],
 			limit: filters?.limit,
 		})
 		return results
@@ -5265,7 +5292,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async getStructureInventory(
 		corporationId: string,
 		structureId?: string,
-		limit = 10000
+		limit?: number
 	): Promise<CorporationStructureInventoryData[]> {
 		const where = structureId
 			? and(
@@ -5276,6 +5303,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		const results = await this.getDb().query.corporationStructureInventory.findMany({
 			where,
+			orderBy: [
+				asc(corporationStructureInventory.structureId),
+				asc(corporationStructureInventory.locationFlag),
+				asc(corporationStructureInventory.typeId),
+				asc(corporationStructureInventory.itemId),
+			],
 			limit,
 		})
 

--- a/apps/eve-corporation-data/src/services/structure-inventory.ts
+++ b/apps/eve-corporation-data/src/services/structure-inventory.ts
@@ -24,10 +24,57 @@ export interface StructureInventoryRowInput {
 	typeId: string
 }
 
+export interface StructureInventoryAssetSource {
+	itemId: string
+	isSingleton: boolean
+	locationFlag: string
+	locationId: string
+	locationType: string
+	quantity: number
+	typeId: string
+}
+
 export function isStructureInventoryLocationFlag(locationFlag: string): boolean {
 	return STRUCTURE_INVENTORY_LOCATION_FLAG_PREFIXES.some((prefix) =>
 		locationFlag.startsWith(prefix)
 	)
+}
+
+function projectStructureInventoryAssetRows(
+	corporationId: string,
+	ownedStructureIds: ReadonlySet<string>,
+	assets: ReadonlyArray<StructureInventoryAssetSource>
+): StructureInventoryRowInput[] {
+	if (ownedStructureIds.size === 0 || assets.length === 0) {
+		return []
+	}
+
+	return assets.flatMap((asset) => {
+		if (asset.locationType !== 'item') {
+			return []
+		}
+
+		if (!ownedStructureIds.has(String(asset.locationId))) {
+			return []
+		}
+
+		if (!isStructureInventoryLocationFlag(asset.locationFlag)) {
+			return []
+		}
+
+		return [
+			{
+				corporationId: String(corporationId),
+				structureId: String(asset.locationId),
+				itemId: String(asset.itemId),
+				isSingleton: asset.isSingleton,
+				locationFlag: asset.locationFlag,
+				locationType: asset.locationType,
+				quantity: asset.quantity,
+				typeId: String(asset.typeId),
+			},
+		]
+	})
 }
 
 export function filterStructureInventoryAssets(
@@ -35,36 +82,27 @@ export function filterStructureInventoryAssets(
 	ownedStructureIds: ReadonlySet<string>,
 	assets: EsiCorporationAsset[]
 ): StructureInventoryRowInput[] {
-	if (ownedStructureIds.size === 0 || assets.length === 0) {
-		return []
-	}
+	return projectStructureInventoryAssetRows(
+		corporationId,
+		ownedStructureIds,
+		assets.map((asset) => ({
+			itemId: String(asset.item_id),
+			isSingleton: asset.is_singleton,
+			locationFlag: asset.location_flag,
+			locationId: String(asset.location_id),
+			locationType: asset.location_type,
+			quantity: asset.quantity,
+			typeId: String(asset.type_id),
+		}))
+	)
+}
 
-	return assets.flatMap((asset) => {
-		if (asset.location_type !== 'item') {
-			return []
-		}
-
-		if (!ownedStructureIds.has(String(asset.location_id))) {
-			return []
-		}
-
-		if (!isStructureInventoryLocationFlag(asset.location_flag)) {
-			return []
-		}
-
-		return [
-			{
-				corporationId: String(corporationId),
-				structureId: String(asset.location_id),
-				itemId: String(asset.item_id),
-				isSingleton: asset.is_singleton,
-				locationFlag: asset.location_flag,
-				locationType: asset.location_type,
-				quantity: asset.quantity,
-				typeId: String(asset.type_id),
-			},
-		]
-	})
+export function projectStructureInventoryFromStoredAssets(
+	corporationId: string,
+	ownedStructureIds: ReadonlySet<string>,
+	assets: ReadonlyArray<StructureInventoryAssetSource>
+): StructureInventoryRowInput[] {
+	return projectStructureInventoryAssetRows(corporationId, ownedStructureIds, assets)
 }
 
 export function summarizeFuelBlockUnitsByStructure(

--- a/apps/eve-corporation-data/src/test/unit/durable-object.assets.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/durable-object.assets.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { EveCorporationDataDO } from '../../durable-object'
+
+describe('EveCorporationDataDO asset refresh', () => {
+	it('propagates structure inventory refresh failures instead of swallowing them', async () => {
+		const instance = new EveCorporationDataDO(
+			{} as DurableObjectState,
+			{
+				DATABASE_URL: 'postgres://example',
+				UNIVERSE: {} as never,
+				EVE_TOKEN_STORE: {} as never,
+			} as never
+		)
+
+		const fetchAndStoreStructures = vi.fn().mockResolvedValue(undefined)
+		const fetchAndStoreStructureInventory = vi
+			.fn()
+			.mockRejectedValue(new Error('inventory refresh failed'))
+
+		;(instance as any).fetchAndStoreStructures = fetchAndStoreStructures
+		;(instance as any).fetchAndStoreStructureInventory = fetchAndStoreStructureInventory
+
+		await expect(instance.fetchAssetsData('98000001', true)).rejects.toThrow(
+			'inventory refresh failed'
+		)
+		expect(fetchAndStoreStructures).toHaveBeenCalledWith('98000001', true)
+		expect(fetchAndStoreStructureInventory).toHaveBeenCalledWith('98000001', true)
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/services/structure-inventory.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-inventory.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	filterStructureInventoryAssets,
 	isStructureInventoryLocationFlag,
+	projectStructureInventoryFromStoredAssets,
 } from '../../../services/structure-inventory'
 
 describe('structure inventory filtering', () => {
@@ -106,6 +107,55 @@ describe('structure inventory filtering', () => {
 				locationType: 'item',
 				quantity: 99,
 				typeId: '12345',
+			},
+		])
+	})
+
+	it('projects stored raw assets into structure inventory rows', () => {
+		const inventory = projectStructureInventoryFromStoredAssets(
+			'98000001',
+			new Set(['1001']),
+			[
+				{
+					itemId: '100',
+					isSingleton: false,
+					locationFlag: 'Cargo',
+					locationId: '1001',
+					locationType: 'item',
+					quantity: 12,
+					typeId: '37843',
+				},
+				{
+					itemId: '101',
+					isSingleton: false,
+					locationFlag: 'ServiceSlot0',
+					locationId: '1001',
+					locationType: 'item',
+					quantity: 1,
+					typeId: '35894',
+				},
+				{
+					itemId: '102',
+					isSingleton: false,
+					locationFlag: 'Cargo',
+					locationId: '9999',
+					locationType: 'item',
+					quantity: 1,
+					typeId: '37844',
+				},
+			]
+		)
+
+		expect(inventory).toEqual([
+			{
+				corporationId: '98000001',
+				structureId: '1001',
+				itemId: '100',
+				isSingleton: false,
+				locationFlag: 'Cargo',
+				locationType: 'item',
+				quantity: 12,
+				typeId: '37843',
 			},
 		])
 	})

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -1179,7 +1179,6 @@ async function loadStructureFittingDetailData(
 		const rawAssets = await corpData.searchAssets(structure.corporationId, {
 			locationId: structure.structureId,
 			locationType: 'item',
-			limit: 10000,
 		})
 
 		return rawAssets

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -3522,8 +3522,46 @@ export class ApiClient {
 		return this.get(`/structures/${structureId}`)
 	}
 
-	async fetchStructureAssetsDebug(structureId: string): Promise<StructureAssetsDebugResult> {
-		return this.post(`/structures/${structureId}/assets-debug`)
+	async requestStructureAssetsDebug(structureId: string): Promise<{
+		workflowInstanceId: string
+		exportId: string
+		fileName: string
+		status: 'queued'
+	}> {
+		return this.post(`/structures/${structureId}/assets-debug`, {})
+	}
+
+	async getStructureAssetsDebugStatus(
+		structureId: string,
+		workflowInstanceId: string
+	): Promise<{
+		workflowInstanceId: string
+		status: 'queued' | 'running' | 'completed' | 'failed' | 'unknown'
+		rawStatus?: string
+		output: unknown | null
+	}> {
+		return this.get(`/structures/${structureId}/assets-debug/${workflowInstanceId}`)
+	}
+
+	async downloadStructureAssetsDebug(
+		structureId: string,
+		workflowInstanceId: string
+	): Promise<StructureAssetsDebugResult> {
+		const response = await fetch(
+			`/api/structures/${structureId}/assets-debug/${workflowInstanceId}/download`,
+			{
+				credentials: 'include',
+				headers: {
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+			}
+		)
+		if (!response.ok) {
+			const message = await response.text()
+			throw new Error(message || 'Failed to download structure assets debug data')
+		}
+
+		return (await response.json()) as StructureAssetsDebugResult
 	}
 
 	async updateStructureConfig(

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -59,6 +59,7 @@ import { api } from '@/lib/api'
 import { formatDateTimeLong } from '@/lib/date-utils'
 import { formatDurationMs } from '@/lib/duration-utils'
 import { allianceLogoUrl, typeIconUrl, typeImageUrl, typeRenderUrl } from '@/lib/eve-images'
+import toast from '@/lib/toast'
 
 import type { FittingDisplayItem, FittingShipSlotType } from '@repo/eve-fitting/flags'
 import type { BadgeVariant } from '@/components/ui/badge'
@@ -534,6 +535,10 @@ export default function StructuresDetailPage() {
 	const [lowPowerAllowed, setLowPowerAllowed] = useState(false)
 	const [assignedGroupId, setAssignedGroupId] = useState('')
 	const [assetsDebug, setAssetsDebug] = useState<StructureAssetsDebugResult | null>(null)
+	const [pendingAssetsDebug, setPendingAssetsDebug] = useState<{
+		workflowInstanceId: string
+		fileName: string
+	} | null>(null)
 
 	const isAdmin = user?.is_admin === true
 
@@ -548,6 +553,7 @@ export default function StructuresDetailPage() {
 
 	useEffect(() => {
 		setAssetsDebug(null)
+		setPendingAssetsDebug(null)
 	}, [structureId])
 
 	const groupOptions = useMemo<SelectOption[]>(() => {
@@ -576,13 +582,71 @@ export default function StructuresDetailPage() {
 	})
 
 	const debugAssetsMutation = useApiMutation({
-		mutationFn: () => api.fetchStructureAssetsDebug(structureId!),
-		successMessage: (result) =>
-			`Fetched ${result.fetchedAssetCount.toLocaleString()} raw assets and found ${result.itemCount.toLocaleString()} rows for this structure.`,
+		mutationFn: () => api.requestStructureAssetsDebug(structureId!),
+		showSuccessToast: false,
 		onSuccess: (result) => {
-			setAssetsDebug(result)
+			setPendingAssetsDebug({
+				workflowInstanceId: result.workflowInstanceId,
+				fileName: result.fileName,
+			})
 		},
 	})
+
+	const assetsDebugStatusQuery = useQuery({
+		queryKey: ['structures', structureId, 'assets-debug', pendingAssetsDebug?.workflowInstanceId ?? null],
+		queryFn: () =>
+			api.getStructureAssetsDebugStatus(structureId!, pendingAssetsDebug!.workflowInstanceId),
+		enabled: Boolean(pendingAssetsDebug?.workflowInstanceId),
+		refetchInterval: (query) => {
+			const status = query.state.data?.status
+			return status === 'queued' || status === 'running' || status === undefined ? 5000 : false
+		},
+		refetchOnWindowFocus: false,
+	})
+	const assetsDebugStatus = assetsDebugStatusQuery.data?.status
+	const isAssetsDebugPolling =
+		Boolean(pendingAssetsDebug) &&
+		(assetsDebugStatus === undefined ||
+			assetsDebugStatus === 'queued' ||
+			assetsDebugStatus === 'running')
+	const isAssetsDebugBusy = debugAssetsMutation.isPending || isAssetsDebugPolling
+
+	useEffect(() => {
+		if (!pendingAssetsDebug) return
+		if (!assetsDebugStatusQuery.data) return
+
+		if (assetsDebugStatusQuery.data.status === 'completed') {
+			void (async () => {
+				try {
+					const result = await api.downloadStructureAssetsDebug(
+						structureId!,
+						pendingAssetsDebug.workflowInstanceId
+					)
+					setAssetsDebug(result)
+					toast.success(
+						`Fetched ${result.fetchedAssetCount.toLocaleString()} raw assets and found ${result.itemCount.toLocaleString()} rows for this structure.`
+					)
+				} catch (error) {
+					toast.error(
+						error instanceof Error
+							? error.message
+							: 'Failed to download structure assets debug data'
+					)
+				} finally {
+					setPendingAssetsDebug(null)
+				}
+			})()
+			return
+		}
+
+		if (
+			assetsDebugStatusQuery.data.status === 'failed' ||
+			assetsDebugStatusQuery.data.status === 'unknown'
+		) {
+			toast.error('Failed to generate structure assets debug data.')
+			setPendingAssetsDebug(null)
+		}
+	}, [assetsDebugStatusQuery.data, pendingAssetsDebug, structureId])
 	const fittingItems = useMemo(() => {
 		if (!structure) {
 			return []
@@ -715,16 +779,26 @@ export default function StructuresDetailPage() {
 							<CardDescription>Current synced state and operational metadata.</CardDescription>
 						</div>
 						{isAdmin && (
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => void debugAssetsMutation.mutateAsync()}
-								loading={debugAssetsMutation.isPending}
-								loadingText="Fetching..."
-							>
-								<Search className="h-4 w-4" />
-								Debug Assets
-							</Button>
+							<div className="flex items-center gap-3">
+								{isAssetsDebugPolling ? (
+									<span className="text-xs text-muted-foreground">
+										Generating asset debug snapshot...
+									</span>
+								) : null}
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => {
+										if (isAssetsDebugBusy) return
+										void debugAssetsMutation.mutateAsync()
+									}}
+									loading={isAssetsDebugBusy}
+									loadingText={isAssetsDebugPolling ? 'Generating...' : 'Queueing...'}
+								>
+									<Search className="h-4 w-4" />
+									Debug Assets
+								</Button>
+							</div>
 						)}
 					</CardHeader>
 						<CardContent className="space-y-4 text-sm">
@@ -1414,7 +1488,7 @@ export default function StructuresDetailPage() {
 					</Card>
 				)}
 
-			{isAdmin && assetsDebug && assetsDebug.items.length > 0 ? (
+			{isAdmin && assetsDebug ? (
 				<Card>
 					<CardHeader>
 						<CardTitle>Asset Debug</CardTitle>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes structure assets ingest reliability and moves the "Debug Assets" structure inspector to an async workflow so it no longer risks Worker request timeouts on large corporations. Structure inventory is now rebuilt from persisted raw assets instead of being derived inline during the paginated ESI fetch, and inventory-fetch failures are no longer silently swallowed.

## Changes
- **Structure inventory rebuild**: `fetchAndStoreStructureInventoryByCharacter` now stores raw assets via `fetchAndStoreAssetsByCharacter` and then rebuilds structure inventory rows from the stored `corporationAssets` table (`rebuildStructureInventoryFromStoredAssets`), instead of filtering assets page-by-page during the ESI sync. Added `projectStructureInventoryFromStoredAssets` (and refactored `filterStructureInventoryAssets` to share the same projection logic with a normalized `StructureInventoryAssetSource` shape).
- **Error propagation**: `fetchAssetsData` no longer catches/swallows errors from `fetchAndStoreStructures` / `fetchAndStoreStructureInventory` — failures now propagate so callers see them.
- **Deterministic ordering & unbounded queries**: `searchAssets` and `getStructureInventory` now apply explicit `orderBy` clauses; `getStructureInventory`'s `limit` is now optional (defaults to unbounded), and the fitting-detail asset lookup in `apps/structures` no longer caps results at 10,000.
- **Async "Debug Assets" export**: The `/structures/:structureId/assets-debug` endpoint now queues a `structure-assets-debug` job on `EXPORT_WORKFLOW` (via `CsvExportWorkflow`) instead of computing the response synchronously, returning `202` with a `workflowInstanceId`/`exportId`. New endpoints `GET /:structureId/assets-debug/:workflowInstanceId` (status) and `GET /:structureId/assets-debug/:workflowInstanceId/download` (fetch + delete the artifact) support polling and retrieval.
- **New R2 bucket**: `STRUCTURE_ASSETS_DEBUG_EXPORTS` binding added to `apps/core` (`wrangler.jsonc`, `context.ts`) for storing debug export artifacts, with expiry-based cleanup wired into the existing cron export-retention job.
- **New `structure-assets-debug` lib**: extracted artifact read/write, type-name enrichment, and location-label helpers into `apps/core/src/lib/structure-assets-debug.ts`, shared between the route and the `CsvExportWorkflow`.
- **UI**: `structures-detail.tsx` now kicks off the export, polls status every 5s via React Query, and downloads/toasts on completion or failure, replacing the previous synchronous fetch-and-display flow. `ApiClient` gained `requestStructureAssetsDebug`, `getStructureAssetsDebugStatus`, and `downloadStructureAssetsDebug` in place of `fetchStructureAssetsDebug`.

## Testing
- Added/updated unit tests: `structures.route.test.ts` (queue → status → download flow), `csv-export.workflow.test.ts` (new `structure-assets-debug` workflow case), `durable-object.assets.test.ts` (asserts inventory-refresh failures propagate instead of being swallowed), and `structure-inventory.test.ts` (`projectStructureInventoryFromStoredAssets`).
<!-- claude:end -->