### PR TITLE
add admin managed group join type

### DIFF
--- a/apps/core/src/routes/__tests__/groups.admins.route.test.ts
+++ b/apps/core/src/routes/__tests__/groups.admins.route.test.ts
@@ -1,34 +1,66 @@
 import { Hono } from 'hono'
+import { createExecutionContext } from 'cloudflare:test'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStub } from '@repo/do-utils'
 
 import groupsRoutes from '../groups'
+import { createDb } from '../../db'
 
 import type { SessionUser } from '../../context'
+
+const serviceMocks = vi.hoisted(() => ({
+	waitUntilWithTelemetry: vi.fn((_: unknown, __: string, task: () => Promise<unknown>) => {
+		void task()
+	}),
+	triggerDiscordRefreshWorkflow: vi.fn(),
+	triggerMumbleRefreshWorkflow: vi.fn(),
+}))
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
 }))
 
-vi.mock('../../middleware/session', () => ({
-	requireAuth:
+vi.mock('../../db', () => ({
+	createDb: vi.fn(),
+}))
+
+vi.mock('../../lib/background-task', () => ({
+	waitUntilWithTelemetry: serviceMocks.waitUntilWithTelemetry,
+}))
+
+vi.mock('../../lib/workflow-triggers', () => ({
+	triggerDiscordRefreshWorkflow: serviceMocks.triggerDiscordRefreshWorkflow,
+	triggerMumbleRefreshWorkflow: serviceMocks.triggerMumbleRefreshWorkflow,
+}))
+
+vi.mock('../../middleware/session', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../middleware/session')>()
+
+	const passThrough =
 		() =>
 			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
 				await next()
-			},
-	requireAdmin:
-		() =>
-			async (c: any, next: () => Promise<void>): Promise<Response | void> => {
-				const user = c.get('user')
-				if (!user?.is_admin) {
-					return c.json({ error: 'Forbidden' }, 403)
-				}
-				await next()
-			},
-}))
+			}
+
+	return {
+		...actual,
+		requireAuth: passThrough,
+		requireAllianceMember: passThrough,
+		requireAdmin:
+			() =>
+				async (c: any, next: () => Promise<void>): Promise<Response | void> => {
+					const user = c.get('user')
+					if (!user?.is_admin) {
+						return c.json({ error: 'Forbidden' }, 403)
+					}
+					await next()
+				},
+	}
+})
 
 const getStubMock = vi.mocked(getStub)
+const createDbMock = vi.mocked(createDb)
 
 function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 	return {
@@ -68,6 +100,8 @@ describe('groups admin membership routes', () => {
 	let groupsStub: {
 		addAdmin: ReturnType<typeof vi.fn>
 		removeAdmin: ReturnType<typeof vi.fn>
+		getGroup: ReturnType<typeof vi.fn>
+		addMember: ReturnType<typeof vi.fn>
 	}
 
 	beforeEach(() => {
@@ -75,12 +109,24 @@ describe('groups admin membership routes', () => {
 		groupsStub = {
 			addAdmin: vi.fn(),
 			removeAdmin: vi.fn(),
+			getGroup: vi.fn(),
+			addMember: vi.fn(),
 		}
 
 		getStubMock.mockImplementation((binding: unknown) => {
 			if (binding === env.GROUPS) return groupsStub as any
 			throw new Error('Unexpected binding')
 		})
+
+			createDbMock.mockReturnValue({
+				query: {
+					userCharacters: {
+						findFirst: vi.fn(),
+					},
+				},
+			} as any)
+			serviceMocks.triggerDiscordRefreshWorkflow.mockResolvedValue(undefined)
+			serviceMocks.triggerMumbleRefreshWorkflow.mockResolvedValue(undefined)
 	})
 
 	it('allows non-site-admin group owner flow to add an admin (DO enforces ownership)', async () => {
@@ -109,5 +155,40 @@ describe('groups admin membership routes', () => {
 
 		expect(res.status).toBe(200)
 		expect(groupsStub.removeAdmin).toHaveBeenCalledWith('group-1', 'owner-user', 'target-user', false)
+	})
+
+	it('forces site-admin direct member adds through the admin-managed endpoint', async () => {
+		const user = makeUser({ id: 'admin-user', is_admin: true })
+		const app = createApp(user)
+		const findFirst = vi.fn().mockResolvedValue({ userId: 'target-user' })
+		const executionCtx = createExecutionContext()
+
+		createDbMock.mockReturnValue({
+			query: {
+				userCharacters: {
+					findFirst,
+				},
+			},
+		} as any)
+
+		groupsStub.getGroup.mockResolvedValue({
+			id: 'group-1',
+			joinMode: 'admin_managed',
+		})
+
+		const res = await app.request(
+			'/api/groups/group-1/members',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ characterName: 'Target Main' }),
+			},
+			env,
+			executionCtx
+		)
+
+		expect(res.status).toBe(200)
+		expect(groupsStub.addMember).toHaveBeenCalledWith('group-1', 'admin-user', 'target-user')
+		expect(findFirst).toHaveBeenCalled()
 	})
 })

--- a/apps/core/src/routes/groups.ts
+++ b/apps/core/src/routes/groups.ts
@@ -2,10 +2,11 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 
 import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
-import { and } from '@repo/db-utils'
+import { and, eq } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 
 import { createDb } from '../db'
+import { userCharacters } from '../db/schema.js'
 import { waitUntilWithTelemetry } from '../lib/background-task'
 import {
 	dispatchGroupApplicationSubmittedAlert,
@@ -1596,6 +1597,92 @@ groups.delete(
 				if (error.message.includes('not found')) {
 					return c.json({ error: 'Group or admin not found' }, 404)
 				}
+				return c.json({ error: error.message }, 400)
+			}
+			throw error
+		}
+	}
+)
+
+/**
+ * POST /:groupId/members
+ *
+ * Force-add a member to an admin-managed group (site admin only)
+ */
+groups.post(
+	'/:groupId/members',
+	requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }),
+	requireAdmin(),
+	async (c) => {
+		const user = c.get('user')!
+		const groupId = c.req.param('groupId')
+		const body = await c.req.json()
+		const groupsDO = getStub<Groups>(c.env.GROUPS, 'default')
+
+		if (!body.characterName) {
+			return c.json({ error: 'characterName is required' }, 400)
+		}
+
+		try {
+			const group = await groupsDO.getGroup(groupId, user.id)
+			if (!group) {
+				return c.json({ error: 'Group not found' }, 404)
+			}
+
+			if (group.joinMode !== 'admin_managed') {
+				return c.json({ error: 'Direct member adds are reserved for admin-managed groups' }, 400)
+			}
+
+			const db = createDb(c.env.DATABASE_URL)
+			const targetUser = await db.query.userCharacters.findFirst({
+				where: and(eq(userCharacters.is_primary, true), eq(userCharacters.characterName, body.characterName)),
+				columns: {
+					userId: true,
+				},
+			})
+
+			if (!targetUser) {
+				return c.json({ error: `Character '${body.characterName}' not found` }, 404)
+			}
+
+			await groupsDO.addMember(groupId, user.id, targetUser.userId)
+			clearUserCache(targetUser.userId)
+
+			waitUntilWithTelemetry(
+				c.executionCtx,
+				'groups.discord-refresh.force-add-member',
+				() =>
+					triggerDiscordRefreshWorkflow({
+						env: c.env,
+						userId: targetUser.userId,
+						source: 'group-forced-added',
+					}),
+				{
+					userId: targetUser.userId,
+					groupId,
+					source: 'group-forced-added',
+				}
+			)
+
+			waitUntilWithTelemetry(
+				c.executionCtx,
+				'groups.mumble-refresh.force-add-member',
+				() =>
+					triggerMumbleRefreshWorkflow({
+						env: c.env,
+						userIds: [targetUser.userId],
+						source: 'group-forced-added',
+					}),
+				{
+					userId: targetUser.userId,
+					groupId,
+					source: 'group-forced-added',
+				}
+			)
+
+			return c.json({ success: true }, 200)
+		} catch (error) {
+			if (error instanceof Error) {
 				return c.json({ error: error.message }, 400)
 			}
 			throw error

--- a/apps/groups/.migrations/0022_pale_betty_brant.sql
+++ b/apps/groups/.migrations/0022_pale_betty_brant.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."join_mode" ADD VALUE 'admin_managed';

--- a/apps/groups/.migrations/meta/0022_snapshot.json
+++ b/apps/groups/.migrations/meta/0022_snapshot.json
@@ -1,0 +1,2224 @@
+{
+  "id": "ed4ab9b4-8dc9-4bec-9f6f-e92692623573",
+  "prevId": "c19da600-e716-4c9c-887c-f877aee9432e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "allow_group_creation": {
+          "name": "allow_group_creation",
+          "type": "category_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'anyone'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_visibility_idx": {
+          "name": "categories_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_permissions": {
+      "name": "corporation_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_permissions_corp_id_idx": {
+          "name": "corporation_permissions_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_permissions_permission_id_idx": {
+          "name": "corporation_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_permissions_permission_id_permissions_id_fk": {
+          "name": "corporation_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "corporation_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corporation_permission": {
+          "name": "unique_corporation_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_admins": {
+      "name": "group_admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "designated_at": {
+          "name": "designated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_admins_group_id_idx": {
+          "name": "group_admins_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_admins_user_id_idx": {
+          "name": "group_admins_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_admins_user_group_idx": {
+          "name": "group_admins_user_group_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_admins_group_id_groups_id_fk": {
+          "name": "group_admins_group_id_groups_id_fk",
+          "tableFrom": "group_admins",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_admin": {
+          "name": "unique_group_admin",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_discord_invites": {
+      "name": "group_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_discord_server_id": {
+          "name": "group_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_discord_invites_group_id_idx": {
+          "name": "group_discord_invites_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_invites_server_id_idx": {
+          "name": "group_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "group_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_invites_user_id_idx": {
+          "name": "group_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_invites_created_at_idx": {
+          "name": "group_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_discord_invites_group_id_groups_id_fk": {
+          "name": "group_discord_invites_group_id_groups_id_fk",
+          "tableFrom": "group_discord_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_discord_invites_group_discord_server_id_group_discord_servers_id_fk": {
+          "name": "group_discord_invites_group_discord_server_id_group_discord_servers_id_fk",
+          "tableFrom": "group_discord_invites",
+          "tableTo": "group_discord_servers",
+          "columnsFrom": [
+            "group_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_discord_server_roles": {
+      "name": "group_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_discord_server_id": {
+          "name": "group_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_type": {
+          "name": "membership_type",
+          "type": "group_discord_server_membership_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_discord_server_roles_attachment_idx": {
+          "name": "group_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "group_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_server_roles_membership_type_idx": {
+          "name": "group_discord_server_roles_membership_type_idx",
+          "columns": [
+            {
+              "expression": "membership_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_discord_server_roles_group_discord_server_id_group_discord_servers_id_fk": {
+          "name": "group_discord_server_roles_group_discord_server_id_group_discord_servers_id_fk",
+          "tableFrom": "group_discord_server_roles",
+          "tableTo": "group_discord_servers",
+          "columnsFrom": [
+            "group_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_discord_server_role": {
+          "name": "unique_group_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_discord_servers": {
+      "name": "group_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_discord_servers_group_id_idx": {
+          "name": "group_discord_servers_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_servers_server_id_idx": {
+          "name": "group_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_servers_auto_invite_idx": {
+          "name": "group_discord_servers_auto_invite_idx",
+          "columns": [
+            {
+              "expression": "auto_invite",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_discord_servers_server_auto_assign_idx": {
+          "name": "group_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"group_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_discord_servers_group_id_groups_id_fk": {
+          "name": "group_discord_servers_group_id_groups_id_fk",
+          "tableFrom": "group_discord_servers",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_discord_server": {
+          "name": "unique_group_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invitations": {
+      "name": "group_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_main_character_id": {
+          "name": "invitee_main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "group_invitations_group_id_idx": {
+          "name": "group_invitations_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invitations_invitee_user_id_idx": {
+          "name": "group_invitations_invitee_user_id_idx",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invitations_status_idx": {
+          "name": "group_invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invitations_expires_at_idx": {
+          "name": "group_invitations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invitations_group_id_groups_id_fk": {
+          "name": "group_invitations_group_id_groups_id_fk",
+          "tableFrom": "group_invitations",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invite_code_redemptions": {
+      "name": "group_invite_code_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invite_code_id": {
+          "name": "invite_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_invite_code_redemptions_invite_code_id_idx": {
+          "name": "group_invite_code_redemptions_invite_code_id_idx",
+          "columns": [
+            {
+              "expression": "invite_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invite_code_redemptions_user_id_idx": {
+          "name": "group_invite_code_redemptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invite_code_redemptions_invite_code_id_group_invite_codes_id_fk": {
+          "name": "group_invite_code_redemptions_invite_code_id_group_invite_codes_id_fk",
+          "tableFrom": "group_invite_code_redemptions",
+          "tableTo": "group_invite_codes",
+          "columnsFrom": [
+            "invite_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_code_redemption": {
+          "name": "unique_code_redemption",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invite_codes": {
+      "name": "group_invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_uses": {
+          "name": "current_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "group_invite_codes_group_id_idx": {
+          "name": "group_invite_codes_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invite_codes_code_idx": {
+          "name": "group_invite_codes_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_invite_codes_expires_at_idx": {
+          "name": "group_invite_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invite_codes_group_id_groups_id_fk": {
+          "name": "group_invite_codes_group_id_groups_id_fk",
+          "tableFrom": "group_invite_codes",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invite_codes_code_unique": {
+          "name": "group_invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_join_requests": {
+      "name": "group_join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "group_join_requests_group_id_idx": {
+          "name": "group_join_requests_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_join_requests_user_id_idx": {
+          "name": "group_join_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_join_requests_status_idx": {
+          "name": "group_join_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_join_requests_group_user_status_idx": {
+          "name": "group_join_requests_group_user_status_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pending_join_request": {
+          "name": "unique_pending_join_request",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"group_join_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_join_requests_group_id_groups_id_fk": {
+          "name": "group_join_requests_group_id_groups_id_fk",
+          "tableFrom": "group_join_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_members_group_id_idx": {
+          "name": "group_members_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_members_user_id_idx": {
+          "name": "group_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_members_user_group_idx": {
+          "name": "group_members_user_group_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_member": {
+          "name": "unique_group_member",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_permissions": {
+      "name": "group_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_urn": {
+          "name": "custom_urn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_description": {
+          "name": "custom_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "permission_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_permissions_group_id_idx": {
+          "name": "group_permissions_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_permissions_permission_id_idx": {
+          "name": "group_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_permissions_custom_urn_idx": {
+          "name": "group_permissions_custom_urn_idx",
+          "columns": [
+            {
+              "expression": "custom_urn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_permissions_group_id_groups_id_fk": {
+          "name": "group_permissions_group_id_groups_id_fk",
+          "tableFrom": "group_permissions",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_permissions_permission_id_permissions_id_fk": {
+          "name": "group_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "group_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_permission": {
+          "name": "unique_group_permission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "join_mode": {
+          "name": "join_mode",
+          "type": "join_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "mumble_sync_enabled": {
+          "name": "mumble_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mumble_ticker": {
+          "name": "mumble_ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_category_id_idx": {
+          "name": "groups_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_owner_id_idx": {
+          "name": "groups_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_visibility_idx": {
+          "name": "groups_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_category_id_categories_id_fk": {
+          "name": "groups_category_id_categories_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_name_per_category": {
+          "name": "unique_group_name_per_category",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_categories": {
+      "name": "permission_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permission_categories_name_idx": {
+          "name": "permission_categories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permission_categories_name_unique": {
+          "name": "permission_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "urn": {
+          "name": "urn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_urn_idx": {
+          "name": "permissions_urn_idx",
+          "columns": [
+            {
+              "expression": "urn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_category_id_idx": {
+          "name": "permissions_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_category_id_permission_categories_id_fk": {
+          "name": "permissions_category_id_permission_categories_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "permission_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_urn_unique": {
+          "name": "permissions_urn_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "urn"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups_role_attachments": {
+      "name": "groups_role_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attached_to_type": {
+          "name": "attached_to_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attached_to_id": {
+          "name": "attached_to_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_meta": {
+          "name": "resource_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_role_attachments_role_id_idx": {
+          "name": "groups_role_attachments_role_id_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_attached_to_type_idx": {
+          "name": "groups_role_attachments_attached_to_type_idx",
+          "columns": [
+            {
+              "expression": "attached_to_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_attached_to_id_idx": {
+          "name": "groups_role_attachments_attached_to_id_idx",
+          "columns": [
+            {
+              "expression": "attached_to_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_resource_id_idx": {
+          "name": "groups_role_attachments_resource_id_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_role_attachments_resource_type_idx": {
+          "name": "groups_role_attachments_resource_type_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_role_attachments_role_id_groups_roles_id_fk": {
+          "name": "groups_role_attachments_role_id_groups_roles_id_fk",
+          "tableFrom": "groups_role_attachments",
+          "tableTo": "groups_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_role_attachment": {
+          "name": "unique_group_role_attachment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role_id",
+            "attached_to_type",
+            "attached_to_id",
+            "resource_id",
+            "resource_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups_roles": {
+      "name": "groups_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owned_by": {
+          "name": "owned_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_roles_owned_by_idx": {
+          "name": "groups_roles_owned_by_idx",
+          "columns": [
+            {
+              "expression": "owned_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_roles_name_idx": {
+          "name": "groups_roles_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_group_role": {
+          "name": "unique_group_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owned_by",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.category_permission": {
+      "name": "category_permission",
+      "schema": "public",
+      "values": [
+        "anyone",
+        "admin_only"
+      ]
+    },
+    "public.group_discord_server_membership_type": {
+      "name": "group_discord_server_membership_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "owner_admin"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "expired",
+        "cancelled"
+      ]
+    },
+    "public.join_mode": {
+      "name": "join_mode",
+      "schema": "public",
+      "values": [
+        "open",
+        "approval",
+        "invitation_only",
+        "admin_managed"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.permission_target": {
+      "name": "permission_target",
+      "schema": "public",
+      "values": [
+        "all_members",
+        "all_admins",
+        "owner_only",
+        "owner_and_admins"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "hidden",
+        "system"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/groups/.migrations/meta/_journal.json
+++ b/apps/groups/.migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1783503889730,
       "tag": "0021_glossy_slapstick",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1784005549232,
+      "tag": "0022_pale_betty_brant",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/groups/src/db/schema.ts
+++ b/apps/groups/src/db/schema.ts
@@ -26,7 +26,7 @@ export const visibilityEnum = pgEnum('visibility', ['public', 'hidden', 'system'
 export const categoryPermissionEnum = pgEnum('category_permission', ['anyone', 'admin_only'])
 
 /** Group join modes */
-export const joinModeEnum = pgEnum('join_mode', ['open', 'approval', 'invitation_only'])
+export const joinModeEnum = pgEnum('join_mode', ['open', 'approval', 'invitation_only', 'admin_managed'])
 
 /** Invitation status */
 export const invitationStatusEnum = pgEnum('invitation_status', [

--- a/apps/groups/src/durable-object.ts
+++ b/apps/groups/src/durable-object.ts
@@ -136,6 +136,12 @@ function hasMumbleSettingsInput(data: {
 	return data.mumbleSyncEnabled !== undefined || data.mumbleTicker !== undefined
 }
 
+function hasSiteAdminOnlyGroupSettingsInput(data: {
+	joinMode?: CreateGroupRequest['joinMode'] | UpdateGroupRequest['joinMode']
+}): boolean {
+	return data.joinMode === 'admin_managed'
+}
+
 /**
  * Groups Durable Object
  *
@@ -266,6 +272,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 
 		if (!isSiteAdmin && hasMumbleSettingsInput(data)) {
 			throw new Error('Only site admins can configure Mumble settings')
+		}
+
+		if (!isSiteAdmin && hasSiteAdminOnlyGroupSettingsInput(data)) {
+			throw new Error('Only site admins can configure admin-managed groups')
 		}
 
 		// Create the group
@@ -528,6 +538,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			throw new Error('Only site admins can configure Mumble settings')
 		}
 
+		if (!isSiteAdmin && hasSiteAdminOnlyGroupSettingsInput(data)) {
+			throw new Error('Only site admins can configure admin-managed groups')
+		}
+
 		const updates: Partial<typeof groups.$inferInsert> = {}
 
 		if (data.name !== undefined) updates.name = data.name
@@ -636,6 +650,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
+		}
+
 		// Can only join open groups via this method
 		if (group.joinMode !== 'open') {
 			throw new Error('Group is not open for joining. Use join request or invitation.')
@@ -664,6 +682,41 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		this.invalidateUserPermissionsCache(actorId)
 	}
 
+	async addMember(groupId: string, actorId: string, targetUserId: string): Promise<void> {
+		const group = await this.db.query.groups.findFirst({
+			where: eq(groups.id, groupId),
+		})
+
+		if (!group) {
+			throw new Error('Group not found')
+		}
+
+		if (group.joinMode !== 'admin_managed') {
+			throw new Error('Direct member adds are reserved for admin-managed groups')
+		}
+
+		const isSiteAdmin = await this.isUserSiteAdmin(actorId)
+		if (!isSiteAdmin) {
+			throw new Error('Only site admins can add members to admin-managed groups')
+		}
+
+		const isMember = await this.isUserMember(groupId, targetUserId)
+		if (isMember) {
+			throw new Error('Already a member of this group')
+		}
+
+		await this.db.insert(groupMembers).values({
+			groupId,
+			userId: targetUserId,
+		})
+
+		await this.cancelPendingJoinRequests(groupId, targetUserId)
+		await this.cancelPendingInvitations(groupId, targetUserId)
+
+		this.invalidateGroupMembersCache(groupId)
+		this.invalidateUserPermissionsCache(targetUserId)
+	}
+
 	async leaveGroup(groupId: string, actorId: string): Promise<void> {
 		const group = await this.db.query.groups.findFirst({
 			where: eq(groups.id, groupId),
@@ -671,6 +724,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 
 		if (!group) {
 			throw new Error('Group not found')
+		}
+
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members can only be removed by a site admin.')
 		}
 
 		// Owner cannot leave (must transfer ownership first)
@@ -989,6 +1046,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
+		}
+
 		// Can only create join requests for approval-mode groups
 		if (group.joinMode !== 'approval') {
 			throw new Error('Group does not accept join requests')
@@ -1079,6 +1140,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 
 		if (!group) {
 			throw new Error('Group not found')
+		}
+
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
 		}
 
 		const [isGroupAdmin, isSiteAdmin] = await Promise.all([
@@ -1186,6 +1251,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
+		}
+
 		const [isGroupAdmin, isSiteAdmin] = await Promise.all([
 			this.isUserGroupAdmin(data.groupId, actorId),
 			this.isUserSiteAdmin(actorId),
@@ -1286,6 +1355,9 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 	async acceptInvitation(invitationId: string, actorId: string): Promise<void> {
 		const invitation = await this.db.query.groupInvitations.findFirst({
 			where: eq(groupInvitations.id, invitationId),
+			with: {
+				group: true,
+			},
 		})
 
 		if (!invitation) {
@@ -1298,6 +1370,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 
 		if (invitation.status !== 'pending') {
 			throw new Error('Invitation is not pending')
+		}
+
+		if (invitation.group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
 		}
 
 		// Check if expired
@@ -1469,6 +1545,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Invite codes are disabled.')
+		}
+
 		const [isGroupAdmin, isSiteAdmin] = await Promise.all([
 			this.isUserGroupAdmin(data.groupId, actorId),
 			this.isUserSiteAdmin(actorId),
@@ -1597,7 +1677,8 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		const isRevoked = inviteCode.revokedAt !== null
 		const hasRemainingUses =
 			inviteCode.maxUses === null || inviteCode.currentUses < inviteCode.maxUses
-		const isValid = !isExpired && !isRevoked && hasRemainingUses
+		const isAdminManaged = inviteCode.group.joinMode === 'admin_managed'
+		const isValid = !isExpired && !isRevoked && hasRemainingUses && !isAdminManaged
 
 		// Build group details directly (bypass permission checks since invite code is the authorization)
 		const group = inviteCode.group
@@ -1661,6 +1742,8 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 				errorMessage = 'This invite code has expired'
 			} else if (!hasRemainingUses) {
 				errorMessage = 'This invite code has reached its usage limit'
+			} else if (isAdminManaged) {
+				errorMessage = 'This group is admin managed and cannot be joined with an invite code'
 			}
 		}
 
@@ -1688,6 +1771,10 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 
 		if (!inviteCode) {
 			throw new Error('Invalid invite code')
+		}
+
+		if (inviteCode.group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members can only be added by a site admin.')
 		}
 
 		// Check if revoked
@@ -3090,9 +3177,32 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 						category: true,
 					},
 				},
-				group: true,
 			},
 		})
+	}
+
+	/**
+	 * Fetch minimal group metadata needed for permission resolution.
+	 * Avoid loading the full group record so auth/session does not depend on
+	 * unrelated group columns that may still be migrating.
+	 */
+	private async getGroupOwnershipMap(
+		groupIds: string[]
+	): Promise<Map<string, { ownerId: string; name: string }>> {
+		if (groupIds.length === 0) {
+			return new Map()
+		}
+
+		const rows = await this.db
+			.select({
+				id: groups.id,
+				ownerId: groups.ownerId,
+				name: groups.name,
+			})
+			.from(groups)
+			.where(inArray(groups.id, groupIds))
+
+		return new Map(rows.map((group) => [group.id, { ownerId: group.ownerId, name: group.name }]))
 	}
 
 	/**
@@ -3216,7 +3326,8 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 	 */
 	private buildUserPermission(
 		groupPerm: Awaited<ReturnType<typeof this.getGroupPermissionsForGroups>>[number],
-		userId: string
+		userId: string,
+		groupInfo?: { ownerId: string; name: string }
 	): UserPermission {
 		// Determine URN and name based on whether this is global or group-scoped
 		const urn = groupPerm.permissionId ? groupPerm.permission!.urn : groupPerm.customUrn!
@@ -3236,7 +3347,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			description,
 			category: category ? this.mapPermissionCategory(category) : null,
 			groupId: groupPerm.groupId,
-			groupName: groupPerm.group.name,
+			groupName: groupInfo?.name ?? groupPerm.groupId,
 			targetType: groupPerm.targetType,
 			source: groupPerm.permissionId ? 'global' : 'group_scoped',
 		}
@@ -3248,12 +3359,14 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 	private resolveUserPermissions(
 		groupPerms: Awaited<ReturnType<typeof this.getGroupPermissionsForGroups>>,
 		userId: string,
-		adminGroupIds: Set<string>
+		adminGroupIds: Set<string>,
+		groupInfoMap: Map<string, { ownerId: string; name: string }>
 	): UserPermission[] {
 		const resolvedPermissions: UserPermission[] = []
 
 		for (const gp of groupPerms) {
-			const isOwner = gp.group.ownerId === userId
+			const groupInfo = groupInfoMap.get(gp.groupId)
+			const isOwner = groupInfo?.ownerId === userId
 			const isAdmin = adminGroupIds.has(gp.groupId)
 
 			// Determine if user gets this permission based on target type
@@ -3261,7 +3374,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 				continue
 			}
 
-			resolvedPermissions.push(this.buildUserPermission(gp, userId))
+			resolvedPermissions.push(this.buildUserPermission(gp, userId, groupInfo))
 		}
 
 		return resolvedPermissions
@@ -3294,13 +3407,19 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			})
 
 			// Get user's admin roles and group permissions
-			const [adminGroupIds, groupPerms] = await Promise.all([
+			const [adminGroupIds, groupPerms, groupInfoMap] = await Promise.all([
 				this.getUserAdminGroupIds(userId, groupIds),
 				this.getGroupPermissionsForGroups(groupIds),
+				this.getGroupOwnershipMap(groupIds),
 			])
 
 			// Resolve permissions based on user's role in each group
-			groupPermissions = this.resolveUserPermissions(groupPerms, userId, adminGroupIds)
+			groupPermissions = this.resolveUserPermissions(
+				groupPerms,
+				userId,
+				adminGroupIds,
+				groupInfoMap
+			)
 		} else {
 			logger.log('[getUserPermissions] User has no group memberships', { userId })
 		}
@@ -3403,9 +3522,6 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		// STEP 1: Batch fetch all group memberships for uncached users
 		const allMemberships = await this.db.query.groupMembers.findMany({
 			where: inArray(groupMembers.userId, uncachedUserIds),
-			with: {
-				group: true,
-			},
 		})
 
 		// Build user -> memberships map
@@ -3443,7 +3559,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		}
 
 		// STEP 4: Batch fetch admin roles and group permissions (shared data)
-		const [allAdminRoles, allGroupPerms] = await Promise.all([
+		const [allAdminRoles, allGroupPerms, allGroupInfoRows] = await Promise.all([
 			allGroupIds.size > 0
 				? this.db.query.groupAdmins.findMany({
 						where: and(
@@ -3453,6 +3569,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 					})
 				: [],
 			allGroupIds.size > 0 ? this.getGroupPermissionsForGroups(Array.from(allGroupIds)) : [],
+			allGroupIds.size > 0 ? this.getGroupOwnershipMap(Array.from(allGroupIds)) : new Map(),
 		])
 
 		// Build user -> admin groupIds map
@@ -3472,6 +3589,8 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			}
 			groupPermsMap.get(gp.groupId)!.push(gp)
 		}
+
+		const groupInfoMap = allGroupInfoRows
 
 		// STEP 5: Fetch corporation permissions (with caching)
 		const corpPermissions = await this.getCorporationPermissionsForCorporations(
@@ -3498,8 +3617,8 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 			const groupPermissions: UserPermission[] = []
 			for (const membership of memberships) {
 				const groupId = membership.groupId
-				const group = membership.group
-				const isOwner = group.ownerId === userId
+				const group = groupInfoMap.get(groupId)
+				const isOwner = group?.ownerId === userId
 				const isAdmin = adminGroupIds.has(groupId)
 
 				const permsForGroup = groupPermsMap.get(groupId) || []
@@ -3507,7 +3626,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 					if (!this.userHasPermission(gp.targetType, isOwner, isAdmin)) {
 						continue
 					}
-					groupPermissions.push(this.buildUserPermission(gp, userId))
+					groupPermissions.push(this.buildUserPermission(gp, userId, group))
 				}
 			}
 

--- a/apps/groups/src/services/group-service.ts
+++ b/apps/groups/src/services/group-service.ts
@@ -42,6 +42,12 @@ function hasMumbleSettingsInput(data: {
 	return data.mumbleSyncEnabled !== undefined || data.mumbleTicker !== undefined
 }
 
+function hasSiteAdminOnlyGroupSettingsInput(data: {
+	joinMode?: CreateGroupRequest['joinMode'] | UpdateGroupRequest['joinMode']
+}): boolean {
+	return data.joinMode === 'admin_managed'
+}
+
 export class GroupService {
 	constructor(private ctx: ServiceContext) {}
 
@@ -80,6 +86,10 @@ export class GroupService {
 
 		if (!isAdmin && hasMumbleSettingsInput(data)) {
 			throw new Error('Only site admins can configure Mumble settings')
+		}
+
+		if (!isAdmin && hasSiteAdminOnlyGroupSettingsInput(data)) {
+			throw new Error('Only site admins can configure admin-managed groups')
 		}
 
 		// Create the group
@@ -275,6 +285,10 @@ export class GroupService {
 			throw new Error('Only site admins can configure Mumble settings')
 		}
 
+		if (!isAdmin && hasSiteAdminOnlyGroupSettingsInput(data)) {
+			throw new Error('Only site admins can configure admin-managed groups')
+		}
+
 		const updates: Partial<typeof groups.$inferInsert> = {}
 
 		if (data.name !== undefined) updates.name = data.name
@@ -284,7 +298,6 @@ export class GroupService {
 		if (data.mumbleSyncEnabled !== undefined) updates.mumbleSyncEnabled = data.mumbleSyncEnabled
 		if (data.mumbleTicker !== undefined) updates.mumbleTicker = normalizeMumbleTicker(data.mumbleTicker)
 		if (data.categoryId !== undefined) updates.categoryId = data.categoryId
-
 		updates.updatedAt = new Date()
 
 		const [updated] = await this.ctx.db

--- a/apps/groups/src/services/invitation-service.ts
+++ b/apps/groups/src/services/invitation-service.ts
@@ -48,6 +48,10 @@ export class InvitationService {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
+		}
+
 		const inviterIsAdmin = await isUserGroupAdmin(this.ctx, data.groupId, inviterId)
 
 		if (!canModerateGroup(group, inviterId, inviterIsAdmin)) {
@@ -133,6 +137,9 @@ export class InvitationService {
 	async acceptInvitation(invitationId: string, userId: string): Promise<void> {
 		const invitation = await this.ctx.db.query.groupInvitations.findFirst({
 			where: eq(groupInvitations.id, invitationId),
+			with: {
+				group: true,
+			},
 		})
 
 		if (!invitation) {
@@ -145,6 +152,10 @@ export class InvitationService {
 
 		if (invitation.status !== 'pending') {
 			throw new Error('Invitation is not pending')
+		}
+
+		if (invitation.group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
 		}
 
 		if (invitation.expiresAt && invitation.expiresAt < new Date()) {
@@ -225,6 +236,10 @@ export class InvitationService {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Invite codes are disabled.')
+		}
+
 		const creatorIsAdmin = await isUserGroupAdmin(this.ctx, data.groupId, createdBy)
 
 		if (!canManageGroup(group, createdBy, creatorIsAdmin)) {
@@ -258,6 +273,10 @@ export class InvitationService {
 
 		if (!group) {
 			throw new Error('Group not found')
+		}
+
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Invite codes are disabled.')
 		}
 
 		const isAdmin = await isUserGroupAdmin(this.ctx, groupId, userId)
@@ -317,6 +336,28 @@ export class InvitationService {
 
 		if (!inviteCode) {
 			return null // Return null if invite code not found
+		}
+
+		if (inviteCode.group.joinMode === 'admin_managed') {
+			return {
+				group: {
+					...mapGroup(inviteCode.group),
+					category: mapCategory(inviteCode.group.category),
+					memberCount: await getGroupMemberCount(this.ctx, inviteCode.group.id),
+					isOwner: userId ? inviteCode.group.ownerId === userId : false,
+					isAdmin: userId ? await isUserGroupAdmin(this.ctx, inviteCode.group.id, userId) : false,
+					isMember: userId ? await isUserMember(this.ctx, inviteCode.group.id, userId) : false,
+				},
+				inviteCode: {
+					isValid: false,
+					isExpired: false,
+					isRevoked: false,
+					hasRemainingUses: true,
+					expiresAt: inviteCode.expiresAt,
+				},
+				canJoin: false,
+				errorMessage: 'This group is admin managed and cannot be joined with an invite code',
+			}
 		}
 
 		const now = new Date()
@@ -414,6 +455,14 @@ export class InvitationService {
 		}
 
 		const group = inviteCode.group
+
+		if (group.joinMode === 'admin_managed') {
+			return {
+				success: false,
+				group: mapGroup(group),
+				message: 'This group is admin managed. Members must be added by a site admin.',
+			}
+		}
 
 		// Check if user is already a member
 		const isMember = await isUserMember(this.ctx, group.id, userId)

--- a/apps/groups/src/services/join-request-service.ts
+++ b/apps/groups/src/services/join-request-service.ts
@@ -31,6 +31,10 @@ export class JoinRequestService {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
+		}
+
 		// Can only create join requests for approval-mode groups
 		if (group.joinMode !== 'approval') {
 			throw new Error('Group does not accept join requests')
@@ -121,6 +125,10 @@ export class JoinRequestService {
 
 		if (!group) {
 			throw new Error('Group not found')
+		}
+
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
 		}
 
 		const isAdmin = await isUserGroupAdmin(this.ctx, request.groupId, adminUserId)

--- a/apps/groups/src/services/membership-service.ts
+++ b/apps/groups/src/services/membership-service.ts
@@ -143,6 +143,10 @@ export class MembershipService {
 			throw new Error('Group not found')
 		}
 
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members must be added by a site admin.')
+		}
+
 		// Can only join open groups via this method
 		if (group.joinMode !== 'open') {
 			throw new Error('Group is not open for joining. Use join request or invitation.')
@@ -178,6 +182,10 @@ export class MembershipService {
 
 		if (!group) {
 			throw new Error('Group not found')
+		}
+
+		if (group.joinMode === 'admin_managed') {
+			throw new Error('This group is admin managed. Members can only be removed by a site admin.')
 		}
 
 		// Owner cannot leave (must transfer ownership first)

--- a/apps/groups/src/test/integration/api.test.ts
+++ b/apps/groups/src/test/integration/api.test.ts
@@ -161,6 +161,52 @@ describe('Groups Durable Object - Groups', () => {
 		expect(group.mumbleTicker).toBeNull()
 	})
 
+	it('should allow a site admin to create an admin-managed group', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-create-admin-managed')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Locked Group Category',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		const group = await stub.createGroup(
+			{
+				categoryId: category.id,
+				name: 'Admin Managed Group',
+				joinMode: 'admin_managed',
+			},
+			ADMIN_USER_ID
+		)
+
+		expect(group.joinMode).toBe('admin_managed')
+	})
+
+	it('should reject non-admin attempts to create an admin-managed group', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-create-admin-managed-denied')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Locked Denied Category',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		await expect(
+			stub.createGroup(
+				{
+					categoryId: category.id,
+					name: 'Should Not Admin Manage',
+					joinMode: 'admin_managed',
+				},
+				USER_1_ID
+			)
+		).rejects.toThrow('Only site admins can configure admin-managed groups')
+	})
+
 	it('should allow a site admin to create a group with mumble settings', async () => {
 		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-create-admin-mumble')
 
@@ -386,6 +432,121 @@ describe('Groups Durable Object - Groups', () => {
 
 		expect(updated.mumbleSyncEnabled).toBe(true)
 		expect(updated.mumbleTicker).toBe('FC123')
+	})
+
+	it('should allow a site admin to toggle admin-managed groups', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-update-admin-managed-admin')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Update Locked Category',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		const group = await stub.createGroup(
+			{
+				categoryId: category.id,
+				name: 'Admin Managed Toggle Group',
+			},
+			USER_1_ID
+		)
+
+		const updated = await stub.updateGroup(
+			group.id,
+			{
+				joinMode: 'admin_managed',
+			},
+			ADMIN_USER_ID
+		)
+
+		expect(updated.joinMode).toBe('admin_managed')
+	})
+
+	it('should reject non-admin attempts to toggle admin-managed groups', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-update-admin-managed-denied')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Update Locked Denied Category',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		const group = await stub.createGroup(
+			{
+				categoryId: category.id,
+				name: 'Admin Managed Toggle Denied Group',
+			},
+			USER_1_ID
+		)
+
+		await expect(
+			stub.updateGroup(
+				group.id,
+				{
+					joinMode: 'admin_managed',
+				},
+				USER_1_ID
+			)
+		).rejects.toThrow('Only site admins can configure admin-managed groups')
+	})
+
+	it('should allow a site admin to force-add a member to an admin-managed group and block self-leave', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-force-add-admin-managed')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Force Add Locked Category',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		const group = await stub.createGroup(
+			{
+				categoryId: category.id,
+				name: 'Force Add Admin Managed Group',
+				joinMode: 'admin_managed',
+			},
+			ADMIN_USER_ID
+		)
+
+		await stub.addMember(group.id, ADMIN_USER_ID, USER_2_ID)
+
+		const members = await stub.getGroupMembers(group.id, ADMIN_USER_ID)
+		expect(members.some((member) => member.userId === USER_2_ID)).toBe(true)
+
+		await expect(stub.leaveGroup(group.id, USER_2_ID)).rejects.toThrow(
+			'This group is admin managed. Members can only be removed by a site admin.'
+		)
+	})
+
+	it('should block direct self-join for admin-managed groups', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-admin-managed-join-blocked')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Admin Managed Join Blocked Category',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		const group = await stub.createGroup(
+			{
+				categoryId: category.id,
+				name: 'Admin Managed Join Blocked Group',
+				joinMode: 'admin_managed',
+			},
+			ADMIN_USER_ID
+		)
+
+		await expect(stub.joinGroup(group.id, USER_2_ID)).rejects.toThrow(
+			'This group is admin managed. Members must be added by a site admin.'
+		)
 	})
 
 	it('should reject an invalid mumble ticker when updating a group', async () => {
@@ -637,6 +798,37 @@ describe('Groups Durable Object - Invite Codes', () => {
 		expect(result.code).toBeDefined()
 		expect(result.code.code).toBeTruthy()
 		expect(result.code.maxUses).toBe(10)
+	})
+
+	it('should reject invite code creation for admin-managed groups', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-invite-code-admin-managed-reject')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Admin Managed Invite Code Category',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		const group = await stub.createGroup(
+			{
+				categoryId: category.id,
+				name: 'Admin Managed Invite Code Group',
+				joinMode: 'admin_managed',
+			},
+			ADMIN_USER_ID
+		)
+
+		await expect(
+			stub.createInviteCode(
+				{
+					groupId: group.id,
+					expiresInDays: 7,
+				},
+				ADMIN_USER_ID
+			)
+		).rejects.toThrow('Invite codes are disabled')
 	})
 
 	it('should list invite codes', async () => {

--- a/apps/ui/src/client/components/edit-group-dialog.tsx
+++ b/apps/ui/src/client/components/edit-group-dialog.tsx
@@ -22,6 +22,7 @@ interface EditGroupDialogProps {
 	open: boolean
 	onOpenChange: (open: boolean) => void
 	onSubmit: (data: UpdateGroupRequest) => Promise<void>
+	canEditAdminManaged?: boolean
 }
 
 export function EditGroupDialog({
@@ -30,6 +31,7 @@ export function EditGroupDialog({
 	open,
 	onOpenChange,
 	onSubmit,
+	canEditAdminManaged = false,
 }: EditGroupDialogProps) {
 	const [formData, setFormData] = useState<UpdateGroupRequest>({
 		categoryId: group.categoryId,
@@ -197,6 +199,14 @@ export function EditGroupDialog({
 								{ value: 'invitation_only',
 									label: 'Invitation Only (invite required)',
 								},
+								...(canEditAdminManaged
+									? [
+											{
+												value: 'admin_managed',
+												label: 'Admin managed (site admins add members)',
+											},
+									  ]
+									: []),
 							]}
 							disabled={isSubmitting}
 						/>

--- a/apps/ui/src/client/components/group-form.tsx
+++ b/apps/ui/src/client/components/group-form.tsx
@@ -13,9 +13,16 @@ interface GroupFormProps {
 	onSubmit: (data: CreateGroupRequest) => void
 	onCancel: () => void
 	isSubmitting?: boolean
+	canEditAdminManaged?: boolean
 }
 
-export function GroupForm({ categories, onSubmit, onCancel, isSubmitting }: GroupFormProps) {
+export function GroupForm({
+	categories,
+	onSubmit,
+	onCancel,
+	isSubmitting,
+	canEditAdminManaged = false,
+}: GroupFormProps) {
 	const [formData, setFormData] = useState<CreateGroupRequest>({
 		categoryId: '',
 		name: '',
@@ -149,6 +156,14 @@ export function GroupForm({ categories, onSubmit, onCancel, isSubmitting }: Grou
 						{ value: 'invitation_only',
 							label: 'Invitation Only (invite required)',
 						},
+						...(canEditAdminManaged
+							? [
+									{
+										value: 'admin_managed',
+										label: 'Admin managed (site admins add members)',
+									},
+							  ]
+							: []),
 					]}
 					disabled={isSubmitting}
 				/>

--- a/apps/ui/src/client/components/invite-member-form.tsx
+++ b/apps/ui/src/client/components/invite-member-form.tsx
@@ -1,17 +1,21 @@
 import { useEffect, useState } from 'react'
 
-import { useCreateInvitation, useSearchCharacters } from '@/hooks/useGroups'
+import { useAddGroupMember, useCreateInvitation, useSearchCharacters } from '@/hooks/useGroups'
 
 import { Button } from './ui/button'
 import { Card } from './ui/card'
 import { Select } from './ui/select'
 
+import type { GroupWithDetails } from '@/lib/api'
+
 interface InviteMemberFormProps {
-	groupId: string
+	group: GroupWithDetails
+	allowDirectAdd?: boolean
 	onSuccess?: () => void
 }
 
-export function InviteMemberForm({ groupId, onSuccess }: InviteMemberFormProps) {
+export function InviteMemberForm({ group, allowDirectAdd = false, onSuccess }: InviteMemberFormProps) {
+	const isAdminManaged = group.joinMode === 'admin_managed'
 	const [searchQuery, setSearchQuery] = useState('')
 	const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
 	const [selectedCharacter, setSelectedCharacter] = useState<string>('')
@@ -20,6 +24,7 @@ export function InviteMemberForm({ groupId, onSuccess }: InviteMemberFormProps) 
 
 	const { data: searchResults, isLoading: isSearching } = useSearchCharacters(debouncedSearchQuery)
 	const createInvitation = useCreateInvitation()
+	const addGroupMember = useAddGroupMember()
 
 	// Debounce search query - only update after 400ms of no typing
 	useEffect(() => {
@@ -43,6 +48,17 @@ export function InviteMemberForm({ groupId, onSuccess }: InviteMemberFormProps) 
 		setSuccessMessage(null)
 	}
 
+	if (isAdminManaged && !allowDirectAdd) {
+		return (
+			<Card className="p-4 border-dashed">
+				<h3 className="text-lg font-semibold mb-2">Admin Managed Group</h3>
+				<p className="text-sm text-muted-foreground">
+					This group is admin managed. Members can only be added by site admins.
+				</p>
+			</Card>
+		)
+	}
+
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault()
 		setErrorMessage(null)
@@ -56,12 +72,19 @@ export function InviteMemberForm({ groupId, onSuccess }: InviteMemberFormProps) 
 		}
 
 		try {
-			await createInvitation.mutateAsync({
-				groupId,
-				characterName,
-			})
-
-			setSuccessMessage(`Invitation sent to ${characterName}`)
+			if (isAdminManaged) {
+				await addGroupMember.mutateAsync({
+					groupId: group.id,
+					characterName,
+				})
+				setSuccessMessage(`Member added directly: ${characterName}`)
+			} else {
+				await createInvitation.mutateAsync({
+					groupId: group.id,
+					characterName,
+				})
+				setSuccessMessage(`Invitation sent to ${characterName}`)
+			}
 			setSearchQuery('')
 			setSelectedCharacter('')
 			onSuccess?.()
@@ -75,7 +98,7 @@ export function InviteMemberForm({ groupId, onSuccess }: InviteMemberFormProps) 
 
 	return (
 		<Card className="p-4">
-			<h3 className="text-lg font-semibold mb-3">Invite Member</h3>
+			<h3 className="text-lg font-semibold mb-3">{isAdminManaged ? 'Add User' : 'Invite Member'}</h3>
 
 			<form onSubmit={handleSubmit} className="space-y-3">
 				<div className="flex gap-2">
@@ -112,8 +135,17 @@ export function InviteMemberForm({ groupId, onSuccess }: InviteMemberFormProps) 
 						loadingText="Searching..."
 						emptyText="No characters found"
 					/>
-					<Button type="submit" disabled={createInvitation.isPending || !searchQuery.trim()}>
-						{createInvitation.isPending ? 'Sending...' : 'Invite'}
+					<Button
+						type="submit"
+						disabled={(isAdminManaged ? addGroupMember.isPending : createInvitation.isPending) || !searchQuery.trim()}
+					>
+						{isAdminManaged
+							? addGroupMember.isPending
+								? 'Adding...'
+								: 'Add User'
+							: createInvitation.isPending
+								? 'Sending...'
+								: 'Invite'}
 					</Button>
 				</div>
 
@@ -130,7 +162,8 @@ export function InviteMemberForm({ groupId, onSuccess }: InviteMemberFormProps) 
 				)}
 
 				<p className="text-xs text-muted-foreground">
-					Start typing to search for characters. Only main characters can be invited.
+					Start typing to search for characters. Only main characters can be{' '}
+					{isAdminManaged ? 'added directly' : 'invited'}.
 				</p>
 			</form>
 		</Card>

--- a/apps/ui/src/client/components/join-button.tsx
+++ b/apps/ui/src/client/components/join-button.tsx
@@ -65,6 +65,15 @@ export function JoinButton({ group, onSuccess }: JoinButtonProps) {
 		return null
 	}
 
+	if (group.joinMode === 'admin_managed') {
+		return (
+			<Button disabled variant="ghost">
+				<UserPlus className="h-4 w-4" />
+				Managed by Admins
+			</Button>
+		)
+	}
+
 	if (group.hasPendingJoinRequest) {
 		return (
 			<Button disabled variant="ghost">

--- a/apps/ui/src/client/components/join-mode-badge.tsx
+++ b/apps/ui/src/client/components/join-mode-badge.tsx
@@ -21,6 +21,10 @@ export function JoinModeBadge({ joinMode, className }: JoinModeBadgeProps) {
 			variant: 'ghost' as const,
 			label: 'Invitation Only',
 		},
+		admin_managed: {
+			variant: 'secondary' as const,
+			label: 'Admin Managed',
+		},
 	}
 
 	const { variant, label } = config[joinMode]

--- a/apps/ui/src/client/components/leave-button.tsx
+++ b/apps/ui/src/client/components/leave-button.tsx
@@ -52,6 +52,14 @@ export function LeaveButton({ group, onSuccess }: LeaveButtonProps) {
 		)
 	}
 
+	if (group.joinMode === 'admin_managed') {
+		return (
+			<Button disabled variant="ghost">
+				Managed by Admins
+			</Button>
+		)
+	}
+
 	return (
 		<>
 			<Button variant="destructive" onClick={() => setConfirmOpen(true)}>

--- a/apps/ui/src/client/hooks/useGroups.ts
+++ b/apps/ui/src/client/hooks/useGroups.ts
@@ -223,6 +223,26 @@ export function useLeaveGroup() {
 }
 
 /**
+ * Directly add a member to an admin-managed group
+ */
+export function useAddGroupMember() {
+	const queryClient = useQueryClient()
+
+	return useApiMutation({
+		mutationFn: ({ groupId, characterName }: { groupId: string; characterName: string }) =>
+			api.addGroupMember(groupId, characterName),
+		successMessage: 'Member added successfully',
+		onSuccess: async (_, variables) => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: groupKeys.detail(variables.groupId) }),
+				queryClient.invalidateQueries({ queryKey: ['admin', 'group-members', 'list', variables.groupId] }),
+				queryClient.invalidateQueries({ queryKey: groupKeys.all }),
+			])
+		},
+	})
+}
+
+/**
  * Create a join request
  */
 export function useCreateJoinRequest() {

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -198,7 +198,7 @@ export function logApiError(error: unknown, fallbackRequestInfo?: ApiRequestDebu
 
 export type Visibility = 'public' | 'hidden' | 'system'
 export type CategoryPermission = 'anyone' | 'admin_only'
-export type JoinMode = 'open' | 'approval' | 'invitation_only'
+export type JoinMode = 'open' | 'approval' | 'invitation_only' | 'admin_managed'
 
 export interface Category {
 	id: string
@@ -2919,6 +2919,10 @@ export class ApiClient {
 	// User-Facing Group Operations
 	async joinGroup(id: string): Promise<void> {
 		return this.post(`/groups/${id}/join`)
+	}
+
+	async addGroupMember(id: string, characterName: string): Promise<void> {
+		return this.post(`/groups/${id}/members`, { characterName })
 	}
 
 	async leaveGroup(id: string): Promise<void> {

--- a/apps/ui/src/client/routes/admin/group-detail.tsx
+++ b/apps/ui/src/client/routes/admin/group-detail.tsx
@@ -99,6 +99,7 @@ export default function GroupDetailPage() {
 	const { user } = useAuth()
 	const queryClient = useQueryClient()
 	const { data: group, isLoading: groupLoading } = useGroup(groupId!)
+	const isAdminManaged = group?.joinMode === 'admin_managed'
 	const { data: categories = [] } = useCategories()
 	const updateGroup = useUpdateGroup()
 	const deleteGroup = useDeleteGroup()
@@ -120,7 +121,7 @@ export default function GroupDetailPage() {
 	const refreshServerRoles = useRefreshGroupDiscordServerRoles()
 
 	// Invite code hooks
-	const { data: inviteCodes = [] } = useGroupInviteCodes(groupId!)
+	const { data: inviteCodes = [] } = useGroupInviteCodes(groupId!, Boolean(group && !isAdminManaged))
 	const createInviteCode = useCreateInviteCode()
 	const revokeInviteCode = useRevokeInviteCode()
 
@@ -688,16 +689,17 @@ export default function GroupDetailPage() {
 			</div>
 
 			{/* Invite Member Form */}
-			<InviteMemberForm groupId={groupId!} />
+			<InviteMemberForm group={group} allowDirectAdd={user?.is_admin ?? false} />
 
 			{/* Pending Invitations */}
-			<PendingInvitationsList groupId={groupId!} />
+			{!isAdminManaged && <PendingInvitationsList groupId={groupId!} />}
 
 			{/* Pending Join Requests */}
-			<PendingJoinRequestsList groupId={groupId!} />
+			{!isAdminManaged && <PendingJoinRequestsList groupId={groupId!} />}
 
 			{/* Invite Codes */}
-			<Card>
+			{!isAdminManaged && (
+				<Card>
 				<CardHeader>
 					<div className="flex items-center justify-between">
 						<div>
@@ -887,7 +889,8 @@ export default function GroupDetailPage() {
 						</DialogContent>
 					</Dialog>
 				</CardContent>
-			</Card>
+				</Card>
+			)}
 
 			{/* Discord Servers */}
 			<Card>
@@ -1553,6 +1556,7 @@ export default function GroupDetailPage() {
 					open={editGroupDialogOpen}
 					onOpenChange={setEditGroupDialogOpen}
 					onSubmit={handleEditGroup}
+					canEditAdminManaged={user?.is_admin ?? false}
 				/>
 			)}
 

--- a/apps/ui/src/client/routes/admin/groups.tsx
+++ b/apps/ui/src/client/routes/admin/groups.tsx
@@ -16,6 +16,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
 import { useCategories } from '@/hooks/useCategories'
+import { useAuth } from '@/hooks/useAuth'
 import { useCreateGroup, useGroups } from '@/hooks/useGroups'
 import { usePageTitle } from '@/hooks/usePageTitle'
 
@@ -23,6 +24,7 @@ import type { CreateGroupRequest, GroupsFilters } from '@/lib/api'
 
 export default function GroupsPage() {
 	usePageTitle('Admin - Groups')
+	const { user } = useAuth()
 	const [filters, setFilters] = useState<GroupsFilters>({})
 	const { data: groups, isLoading: groupsLoading } = useGroups(filters)
 	const { data: categories } = useCategories()
@@ -246,6 +248,7 @@ export default function GroupsPage() {
 						onSubmit={handleCreate}
 						onCancel={() => setCreateDialogOpen(false)}
 						isSubmitting={createGroup.isPending}
+						canEditAdminManaged={user?.is_admin ?? false}
 					/>
 				</DialogContent>
 			</Dialog>

--- a/apps/ui/src/client/routes/group-detail.tsx
+++ b/apps/ui/src/client/routes/group-detail.tsx
@@ -41,6 +41,7 @@ export default function GroupDetailPage() {
 	const { showSuccess, showError } = useMessage()
 	const { data: group, isLoading } = useGroup(groupId!)
 	const canManageGroup = Boolean(group?.isOwner || group?.isAdmin)
+	const isAdminManaged = group?.joinMode === 'admin_managed'
 	const { data: members, isLoading: membersLoading } = useGroupMembers(groupId!, canManageGroup)
 
 	// Member management hooks
@@ -48,7 +49,7 @@ export default function GroupDetailPage() {
 	const toggleAdmin = useToggleAdmin()
 
 	// Invite code hooks
-	const { data: inviteCodes = [] } = useGroupInviteCodes(groupId!, canManageGroup)
+	const { data: inviteCodes = [] } = useGroupInviteCodes(groupId!, canManageGroup && !isAdminManaged)
 	const createInviteCode = useCreateInviteCode()
 	const revokeInviteCode = useRevokeInviteCode()
 
@@ -226,13 +227,13 @@ export default function GroupDetailPage() {
 				)}
 
 				{/* Pending Join Requests - Owner/Admin Only */}
-				{canManageGroup && <PendingJoinRequestsList groupId={groupId!} />}
+				{canManageGroup && !isAdminManaged && <PendingJoinRequestsList groupId={groupId!} />}
 
 				{/* Invite Member Form - Owner/Admin Only */}
-				{canManageGroup && <InviteMemberForm groupId={groupId!} />}
+				{canManageGroup && <InviteMemberForm group={group} allowDirectAdd={user?.is_admin ?? false} />}
 
 				{/* Invite Codes - Owner/Admin Only */}
-				{canManageGroup && (
+				{canManageGroup && !isAdminManaged && (
 					<Card>
 						<CardHeader>
 							<div className="flex items-center justify-between">

--- a/packages/groups/src/index.ts
+++ b/packages/groups/src/index.ts
@@ -49,7 +49,7 @@ export * from './permissions'
 
 export type Visibility = 'public' | 'hidden' | 'system'
 export type CategoryPermission = 'anyone' | 'admin_only'
-export type JoinMode = 'open' | 'approval' | 'invitation_only'
+export type JoinMode = 'open' | 'approval' | 'invitation_only' | 'admin_managed'
 export type InvitationStatus = 'pending' | 'accepted' | 'declined' | 'expired' | 'cancelled'
 export type JoinRequestStatus = 'pending' | 'approved' | 'rejected' | 'cancelled'
 export type GroupDiscordMembershipType = 'member' | 'owner_admin'
@@ -362,8 +362,11 @@ export interface Groups {
 	 * Membership Operations
 	 */
 
-	/** Join an open group */
+	/** Join a group according to its join mode */
 	joinGroup(groupId: string, actorId: string): Promise<void>
+
+	/** Force-add a member to an admin-managed group (site admin only) */
+	addMember(groupId: string, actorId: string, targetUserId: string): Promise<void>
 
 	/** Leave a group */
 	leaveGroup(groupId: string, actorId: string): Promise<void>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a new \`admin_managed\` group join mode where members can only be added or removed by site admins, replacing self-service join/approval/invitation flows for those groups. Includes a new site-admin-only API endpoint to force-add a member by character name, plus corresponding UI updates.

## Changes
- Added \`admin_managed\` to the \`join_mode\` Postgres enum (new migration \`0022_pale_betty_brant.sql\`) and to the shared \`JoinMode\` type in \`packages/groups\` and the UI API client.
- \`GroupsDO\` and \`GroupService\`: restrict setting \`joinMode: admin_managed\` on create/update to site admins; block \`joinGroup\`, \`leaveGroup\`, join requests, invitations, and invite code creation/redemption for admin-managed groups.
- Added \`addMember(groupId, actorId, targetUserId)\` to the \`Groups\` DO/service interface for site admins to force-add a member, cancelling any pending join requests/invitations for that user.
- Refactored group-permission resolution (\`getUserPermissions\` and its batch-cached path) to fetch minimal owner/name info via a new \`getGroupOwnershipMap\` helper instead of loading the full joined \`group\` relation.
- New \`POST /:groupId/members\` route in \`apps/core/src/routes/groups.ts\`: site-admin-only endpoint that resolves a target user from their primary character name, calls \`addMember\` on the Groups DO, clears the user cache, and triggers Discord/Mumble refresh workflows.
- UI: \`GroupForm\`/\`EditGroupDialog\` expose the "Admin managed" option only for site admins; \`JoinButton\`/\`LeaveButton\` show a disabled "Managed by Admins" state; \`JoinModeBadge\` gets a new badge variant; \`InviteMemberForm\` switches to a direct "Add User" flow for admin-managed groups when the caller is a site admin; group detail pages hide invite codes/join requests/pending invitations for admin-managed groups; new \`useAddGroupMember\` hook wired to the new endpoint.

## Testing
- Added integration tests (\`apps/groups/src/test/integration/api.test.ts\`) covering: site admin vs. non-admin creating/updating an admin-managed group, force-adding a member and blocking self-leave, blocking direct join, and blocking invite code creation for admin-managed groups.
- Updated core route unit tests (\`groups.admins.route.test.ts\`) for the new force-add-member endpoint, mocking \`createDb\`, \`background-task\`, and \`workflow-triggers\`.
<!-- claude:end -->