### PR TITLE
add structure sync cooldown to match ESI cache

### DIFF
--- a/apps/core/src/routes/__tests__/structures.route.test.ts
+++ b/apps/core/src/routes/__tests__/structures.route.test.ts
@@ -10,9 +10,24 @@ const structuresMocks = vi.hoisted(() => ({
 	listCitadelStructures: vi.fn(),
 	getVisibleStructureDetail: vi.fn(),
 }))
+const corpDataMocks = vi.hoisted(() => ({
+	rebuildStructureInventorySnapshot: vi.fn(),
+}))
+const corpDataNamespace = vi.hoisted(
+	() => ({ __ns: 'EVE_CORPORATION_DATA' } as unknown as DurableObjectNamespace)
+)
 
 vi.mock('../../lib/groups-cache', () => ({
 	getCachedUserPermissions: vi.fn(),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: (namespace: unknown) =>
+		namespace === corpDataNamespace
+			? {
+					rebuildStructureInventorySnapshot: corpDataMocks.rebuildStructureInventorySnapshot,
+				}
+			: {},
 }))
 
 function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
@@ -229,5 +244,42 @@ describe('structures routes', () => {
 		expect(debugBucket.delete).toHaveBeenCalledWith('structure-assets-debug/workflow-1.json')
 		const downloadBody = (await downloadResponse.json()) as { corporationId: string; items: [] }
 		expect(downloadBody.corporationId).toBe('corp-1')
+	})
+
+	it('rebuilds a structure inventory snapshot for site admins', async () => {
+		corpDataMocks.rebuildStructureInventorySnapshot.mockResolvedValue({
+			inventoryCount: 42,
+		})
+
+		const app = createApp(makeUser({ is_admin: true }))
+		const env = {
+			STRUCTURES: {
+				getVisibleStructureDetail: structuresMocks.getVisibleStructureDetail,
+			},
+			EVE_CORPORATION_DATA: corpDataNamespace,
+		} as any
+
+		const response = await app.request(
+			'/api/structures/structure-1/inventory-rebuild',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(structuresMocks.getVisibleStructureDetail).toHaveBeenCalled()
+		expect(corpDataMocks.rebuildStructureInventorySnapshot).toHaveBeenCalledWith(
+			'corp-1',
+			'structure-1'
+		)
+		const body = (await response.json()) as {
+			structureId: string
+			corporationId: string
+			inventoryCount: number
+		}
+		expect(body).toEqual({
+			structureId: 'structure-1',
+			corporationId: 'corp-1',
+			inventoryCount: 42,
+		})
 	})
 })

--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -27,6 +27,7 @@ import type {
 	UpdateStructureConfigInput,
 	UpdateStructureModuleConfigInput,
 } from '@repo/structures'
+import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { TypeMetadata, Universe } from '@repo/universe'
 import type { App } from '../context'
 
@@ -477,6 +478,50 @@ app.post('/:structureId/assets-debug', async (c) => {
 			{
 				error:
 					error instanceof Error ? error.message : 'Failed to queue structure assets debug export',
+			},
+			500
+		)
+	}
+})
+
+app.post('/:structureId/inventory-rebuild', async (c) => {
+	const user = c.get('user')
+	if (!user) {
+		return c.json({ error: 'Unauthorized' }, 401)
+	}
+	if (!user.is_admin) {
+		return c.json({ error: 'Requires site administrator permission' }, 403)
+	}
+
+	const structureId = c.req.param('structureId')
+	try {
+		const actor = await getStructureActor(c)
+		const structure = (await c.env.STRUCTURES.getVisibleStructureDetail(actor, structureId)) as {
+			corporationId: string
+			structureId: string
+		} | null
+		if (!structure) {
+			return c.json({ error: 'Structure not found' }, 404)
+		}
+
+		const corpData = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, structure.corporationId)
+		const result = await corpData.rebuildStructureInventorySnapshot(
+			structure.corporationId,
+			structure.structureId
+		)
+
+		return c.json({
+			structureId: structure.structureId,
+			corporationId: structure.corporationId,
+			inventoryCount: result.inventoryCount,
+		})
+	} catch (error) {
+		return c.json(
+			{
+				error:
+					error instanceof Error
+						? error.message
+						: 'Failed to rebuild structure inventory snapshot',
 			},
 			500
 		)

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -799,12 +799,17 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 */
 	async getCorporationSyncConfig(
 		corporationId: string
-	): Promise<{ includeInBackgroundRefresh: boolean; includeInStructureAssetSync: boolean } | null> {
+	): Promise<{
+		includeInBackgroundRefresh: boolean
+		includeInStructureAssetSync: boolean
+		structuresLastSync: Date | null
+	} | null> {
 		const config = await this.getDb().query.corporationConfig.findFirst({
 			where: eq(corporationConfig.corporationId, corporationId),
 			columns: {
 				includeInBackgroundRefresh: true,
 				includeInStructureAssetSync: true,
+				structuresLastSync: true,
 			},
 		})
 
@@ -815,6 +820,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		return {
 			includeInBackgroundRefresh: config.includeInBackgroundRefresh,
 			includeInStructureAssetSync: config.includeInStructureAssetSync,
+			structuresLastSync: config.structuresLastSync,
 		}
 	}
 
@@ -2357,6 +2363,58 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					},
 				})
 		}
+	}
+
+	async rebuildStructureInventorySnapshot(
+		corporationId: string,
+		structureId: string
+	): Promise<{ inventoryCount: number }> {
+		this.assertNonNpcCorporation(corporationId)
+
+		const ownedStructureIds = new Set([String(structureId)])
+		const inventoryRows = await this.rebuildStructureInventoryFromStoredAssets(
+			corporationId,
+			ownedStructureIds
+		)
+		const rowsForStructure = inventoryRows.filter(
+			(row) => row.structureId === String(structureId)
+		)
+
+		const db = this.getDb()
+		await db
+			.delete(corporationStructureInventory)
+			.where(
+				and(
+					eq(corporationStructureInventory.corporationId, corporationId),
+					eq(corporationStructureInventory.structureId, String(structureId))
+				)
+			)
+
+		const BATCH_SIZE = 100
+		for (let i = 0; i < rowsForStructure.length; i += BATCH_SIZE) {
+			const batch = rowsForStructure.slice(i, i + BATCH_SIZE)
+			await db.insert(corporationStructureInventory).values(
+				batch.map((row) => ({
+					corporationId: String(corporationId),
+					structureId: row.structureId,
+					itemId: row.itemId,
+					isSingleton: row.isSingleton,
+					locationFlag: row.locationFlag,
+					locationType: row.locationType,
+					quantity: row.quantity,
+					typeId: row.typeId,
+					updatedAt: new Date(),
+				}))
+			)
+		}
+
+		logger.info('[EveCorporationData] Rebuilt structure inventory snapshot from stored assets', {
+			corporationId,
+			structureId: String(structureId),
+			inventoryCount: rowsForStructure.length,
+		})
+
+		return { inventoryCount: rowsForStructure.length }
 	}
 
 	/**

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -119,6 +119,7 @@ function createWorkflowEnv() {
 		getCorporationSyncConfig: vi.fn().mockResolvedValue({
 			includeInBackgroundRefresh: true,
 			includeInStructureAssetSync: true,
+			structuresLastSync: null,
 		}),
 		getDirectors: vi.fn().mockResolvedValue([{ isHealthy: true }]),
 	}
@@ -444,6 +445,86 @@ describe('EveCorporationSyncWorkflow', () => {
 		expect(storeMiningEnrichmentMock).not.toHaveBeenCalled()
 		expect(executedStepNames).toContain('sync-assets')
 		expect(syncAssetsMock).toHaveBeenCalledWith(workflowEnv, '693378155', '900000001', ['2000001'])
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
+	})
+
+	it('skips sovereignty and skyhook enrichment when the structure sync is within the cooldown window', async () => {
+		vi.clearAllMocks()
+		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
+		const workflowEnv = env as any
+		workflowEnv.STRUCTURE_ENRICHMENT_ENABLED = true
+		corpDataStub.getCorporationSyncConfig.mockResolvedValue({
+			includeInBackgroundRefresh: true,
+			includeInStructureAssetSync: true,
+			structuresLastSync: new Date('2026-07-12T18:50:00.000Z'),
+		})
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockResolvedValue([
+			{
+				structure_id: '1000001',
+				type_id: '35833',
+			},
+		])
+		storeStructuresMock.mockResolvedValue(undefined)
+		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
+		storeSkyhookEnrichmentMock.mockResolvedValue(undefined)
+		storeMiningEnrichmentMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, workflowEnv)
+		const { step, executedStepNames } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures', 'assets'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-4',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(fetchSovereigntyEnrichmentMock).not.toHaveBeenCalled()
+		expect(fetchSkyhookEnrichmentMock).not.toHaveBeenCalled()
+		expect(fetchMiningEnrichmentMock).not.toHaveBeenCalled()
+		expect(executedStepNames).not.toContain('store-structure-sovereignty-enrichment')
+		expect(executedStepNames).not.toContain('store-structure-skyhook-enrichment')
+		expect(executedStepNames).not.toContain('store-structure-mining-enrichment')
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -70,9 +70,14 @@ import type {
 
 const STEP_RETRY_OPTIONS = esiRetryOptions
 const MINING_CITADEL_STRUCTURE_TYPE_IDS = new Set(['35833', '35834'])
+const STRUCTURE_ENRICHMENT_COOLDOWN_HOURS = 1
 
 function isMiningCitadelStructure(structure: Pick<EsiCorporationStructure, 'type_id'>): boolean {
 	return MINING_CITADEL_STRUCTURE_TYPE_IDS.has(structure.type_id)
+}
+
+function addHours(date: Date, hours: number): Date {
+	return new Date(date.getTime() + hours * 60 * 60 * 1000)
 }
 
 function readEnvFlag(value: boolean | string | undefined, defaultValue: boolean): boolean {
@@ -191,6 +196,13 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			)
 
 			const structureAssetSyncEnabled = corporationConfig?.includeInStructureAssetSync ?? false
+			const structureEnrichmentNextAllowedAt = corporationConfig?.structuresLastSync
+				? addHours(corporationConfig.structuresLastSync, STRUCTURE_ENRICHMENT_COOLDOWN_HOURS)
+				: null
+			const workflowObservedAt = event.timestamp ?? new Date()
+			const structureEnrichmentCooldownActive =
+				structureEnrichmentNextAllowedAt !== null &&
+				structureEnrichmentNextAllowedAt > workflowObservedAt
 			const shouldSync = createShouldSyncPredicate(dataTypes, {
 				disabledDataTypes: assetsSyncEnabled && structureAssetSyncEnabled ? [] : ['assets'],
 			})
@@ -736,7 +748,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 				let miningExtractions: Awaited<ReturnType<typeof fetchMiningEnrichment>> | null = null
 
 				if (structures) {
-					if (structureEnrichmentEnabled) {
+					if (structureEnrichmentEnabled && !structureEnrichmentCooldownActive) {
 						try {
 							sovereigntyEnrichment = await runDirectorStepWithFailover({
 								stepName: 'fetch-structure-sovereignty-enrichment',
@@ -822,7 +834,11 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 								)
 							})
 						}
-
+					} else if (structureEnrichmentEnabled && structureEnrichmentCooldownActive) {
+						logger.info('[EveCorporationSyncWorkflow] Skipping structure enrichment due to cooldown', {
+							corporationId,
+							nextAllowedAt: structureEnrichmentNextAllowedAt?.toISOString() ?? null,
+						})
 					}
 
 					structuresSync = {

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -3535,6 +3535,14 @@ export class ApiClient {
 		return this.post(`/structures/${structureId}/assets-debug`, {})
 	}
 
+	async requestStructureInventoryRebuild(structureId: string): Promise<{
+		structureId: string
+		corporationId: string
+		inventoryCount: number
+	}> {
+		return this.post(`/structures/${structureId}/inventory-rebuild`, {})
+	}
+
 	async getStructureAssetsDebugStatus(
 		structureId: string,
 		workflowInstanceId: string

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -592,6 +592,20 @@ export default function StructuresDetailPage() {
 		},
 	})
 
+	const rebuildInventoryMutation = useApiMutation({
+		mutationFn: () => api.requestStructureInventoryRebuild(structureId!),
+		showSuccessToast: false,
+		onSuccess: async (result) => {
+			toast.success(
+				`Rebuilt the structure inventory snapshot with ${result.inventoryCount.toLocaleString()} row${result.inventoryCount === 1 ? '' : 's'}.`
+			)
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: ['structures'] }),
+				queryClient.invalidateQueries({ queryKey: ['structures', structureId] }),
+			])
+		},
+	})
+
 	const assetsDebugStatusQuery = useQuery({
 		queryKey: ['structures', structureId, 'assets-debug', pendingAssetsDebug?.workflowInstanceId ?? null],
 		queryFn: () =>
@@ -610,6 +624,7 @@ export default function StructuresDetailPage() {
 			assetsDebugStatus === 'queued' ||
 			assetsDebugStatus === 'running')
 	const isAssetsDebugBusy = debugAssetsMutation.isPending || isAssetsDebugPolling
+	const isInventoryRebuildBusy = rebuildInventoryMutation.isPending
 
 	useEffect(() => {
 		if (!pendingAssetsDebug) return
@@ -792,11 +807,24 @@ export default function StructuresDetailPage() {
 										if (isAssetsDebugBusy) return
 										void debugAssetsMutation.mutateAsync()
 									}}
-									loading={isAssetsDebugBusy}
-									loadingText={isAssetsDebugPolling ? 'Generating...' : 'Queueing...'}
+										loading={isAssetsDebugBusy}
+										loadingText={isAssetsDebugPolling ? 'Generating...' : 'Queueing...'}
+									>
+										<Search className="h-4 w-4" />
+										Debug Assets
+									</Button>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => {
+										if (isInventoryRebuildBusy) return
+										void rebuildInventoryMutation.mutateAsync()
+									}}
+									loading={isInventoryRebuildBusy}
+									loadingText="Rebuilding..."
 								>
-									<Search className="h-4 w-4" />
-									Debug Assets
+									<Recycle className="h-4 w-4" />
+									Rebuild Inventory Snapshot
 								</Button>
 							</div>
 						)}

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -463,6 +463,7 @@ export interface CorporationConfigData extends CorporationLastSyncData {
 export interface CorporationSyncConfigData {
 	includeInBackgroundRefresh: boolean
 	includeInStructureAssetSync: boolean
+	structuresLastSync: Date | null
 }
 
 export interface CorporationNeedingRefreshData {
@@ -1269,6 +1270,15 @@ export interface EveCorporationData {
 			typeId: string
 		}>
 	): Promise<void>
+
+	/**
+	 * Rebuild the stored inventory snapshot for a single structure from already-ingested assets.
+	 * This avoids a live ESI fetch and only refreshes the targeted structure rows.
+	 */
+	rebuildStructureInventorySnapshot(
+		corporationId: string,
+		structureId: string
+	): Promise<{ inventoryCount: number }>
 
 	/**
 	 * Fetch and store corporation assets using a specific director character.


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a cooldown so structure sovereignty/skyhook/mining enrichment isn't re-fetched from ESI more often than the ESI cache actually refreshes, and adds an admin-only tool to rebuild a single structure's stored inventory snapshot from already-ingested assets (no live ESI fetch) as a manual fallback.

## Changes
- `apps/eve-corporation-data`: track `structuresLastSync` in `getCorporationSyncConfig`/`CorporationSyncConfigData`, and skip structure sovereignty/skyhook/mining enrichment fetches in the sync workflow when the last sync is within a 1-hour cooldown window.
- `apps/eve-corporation-data`: add `rebuildStructureInventorySnapshot(corporationId, structureId)` DO method that recomputes inventory rows for a structure from stored assets and replaces the existing `corporationStructureInventory` rows for that structure.
- `apps/core`: add `POST /structures/:structureId/inventory-rebuild` route, restricted to site admins, that resolves the structure via `getStructureActor`/`getVisibleStructureDetail` and calls the new DO method.
- `apps/ui`: add `ApiClient.requestStructureInventoryRebuild` and a "Rebuild Inventory Snapshot" button on the structure detail page with a success toast and query invalidation.

## Testing
- Added a workflow unit test verifying sovereignty/skyhook/mining enrichment steps are skipped when `structuresLastSync` is within the cooldown window.
- Added a route test for `POST /structures/:structureId/inventory-rebuild` covering the admin-only rebuild flow and response shape.
<!-- claude:end -->