### PR TITLE
preserve existing skyhook rows is geography lookup fails

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -3095,6 +3095,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			)
 
 		if (synthesizedRows.length === 0) {
+			if (skyhooks.length > 0) {
+				logger.warn('[storeSkyhooks] Preserving existing skyhook snapshot because synthesis failed', {
+					corporationId,
+					skyhookCount: skyhooks.length,
+				})
+				return
+			}
 			await this.getDb()
 				.delete(structureSkyhookStates)
 				.where(eq(structureSkyhookStates.corporationId, corporationId))

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -89,6 +89,7 @@ import type {
 	EsiSovereigntyHub,
 	EsiSovereigntySystem,
 	EveCorporationData,
+	SkyhookStoreResult,
 	SearchAssetsFilters,
 	WalletJournalWindowFilters,
 	WalletTransactionWindowFilters,
@@ -2958,7 +2959,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	/**
 	 * Store skyhook snapshots (workflow-friendly)
 	 */
-	async storeSkyhooks(corporationId: string, skyhooks: EsiCorporationSkyhook[]): Promise<void> {
+	async storeSkyhooks(
+		corporationId: string,
+		skyhooks: EsiCorporationSkyhook[]
+	): Promise<SkyhookStoreResult> {
 		const now = new Date()
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const existingRows = await this.getDb().query.structureSkyhookStates.findMany({
@@ -3100,7 +3104,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					corporationId,
 					skyhookCount: skyhooks.length,
 				})
-				return
+				return { prunedCount: 0 }
 			}
 			await this.getDb()
 				.delete(structureSkyhookStates)
@@ -3113,7 +3117,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						eq(corporationStructures.typeId, ORBITAL_SKYHOOK_TYPE_ID)
 					)
 				)
-			return
+			return { prunedCount: existingRows.length }
 		}
 
 		const baseValues = synthesizedRows.map((row) => row.baseStructure)
@@ -3221,6 +3225,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					)
 				)
 		})
+
+		return { prunedCount: departedStateIds.length }
 	}
 
 	/**

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -538,7 +538,7 @@ export async function fetchCorporationSkyhooks(
 	}
 
 	const listing = await tokenStore.fetchEsi<RawCorporationSkyhooksListing>(
-		`/corporations/${corporationId}/structures/skyhooks?page=1`,
+		`/corporations/${corporationId}/structures/skyhooks`,
 		characterId,
 		{ cacheMode: 'no-store' }
 	)

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -78,6 +78,12 @@ describe('esi structure enrichment ownership handling', () => {
 			'211',
 			{ cacheMode: 'no-store' }
 		)
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			1,
+			'/corporations/98000001/structures/skyhooks',
+			'211',
+			{ cacheMode: 'no-store' }
+		)
 		expect(tokenStore.fetchEsi).not.toHaveBeenCalledWith(
 			'/universe/structures/71001',
 			'211',

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -273,4 +273,30 @@ describe('structure prune cleanup', () => {
 		expect(db.delete).not.toHaveBeenCalled()
 		expect(db.insert).not.toHaveBeenCalled()
 	})
+
+	it('returns the number of skyhooks pruned when the upstream listing is empty', async () => {
+		const db = makeDb()
+		db.query.corporationStructures.findMany = vi.fn().mockResolvedValue([])
+		db.query.structureSkyhookStates.findMany = vi.fn().mockResolvedValue([
+			{
+				structureId: 'skyhook-1',
+				planetName: 'Planet One',
+				systemName: 'Jita',
+				name: 'Skyhook One',
+			},
+		])
+
+		mocks.getStub.mockReturnValue({
+			resolvePlanetGeographyByIds: vi.fn().mockResolvedValue({}),
+			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({}),
+			resolveRegionsByIds: vi.fn().mockResolvedValue({}),
+		})
+
+		const instance = createDoInstance(db)
+
+		await expect(instance.storeSkyhooks('corp-1', [])).resolves.toEqual({ prunedCount: 1 })
+		expect(db.delete).toHaveBeenCalledTimes(2)
+		expect(db.delete).toHaveBeenNthCalledWith(1, structureSkyhookStates)
+		expect(db.delete).toHaveBeenNthCalledWith(2, corporationStructures)
+	})
 })

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -16,9 +16,13 @@ const mocks = vi.hoisted(() => {
 	const values = vi.fn(() => ({ onConflictDoUpdate }))
 	const insert = vi.fn(() => ({ values }))
 	const deleteMock = vi.fn()
+	const resolvePlanetGeographyByIds = vi.fn()
 	const resolveSolarSystemsByIds = vi.fn()
+	const resolveRegionsByIds = vi.fn()
 	const getStub = vi.fn(() => ({
+		resolvePlanetGeographyByIds,
 		resolveSolarSystemsByIds,
+		resolveRegionsByIds,
 	}))
 
 	return {
@@ -27,7 +31,9 @@ const mocks = vi.hoisted(() => {
 		values,
 		insert,
 		deleteMock,
+		resolvePlanetGeographyByIds,
 		resolveSolarSystemsByIds,
+		resolveRegionsByIds,
 		getStub,
 	}
 })
@@ -222,5 +228,49 @@ describe('structure prune cleanup', () => {
 			},
 		})
 		expect(db.delete).not.toHaveBeenCalled()
+	})
+
+	it('preserves existing skyhook snapshots when upstream skyhooks cannot be synthesized', async () => {
+		const db = makeDb()
+		db.query.corporationStructures.findMany = vi.fn().mockResolvedValue([])
+		db.query.structureSkyhookStates.findMany = vi.fn().mockResolvedValue([
+			{
+				structureId: 'skyhook-1',
+				planetName: 'Planet One',
+				systemName: 'Jita',
+				name: 'Skyhook One',
+			},
+		])
+
+		mocks.getStub.mockReturnValue({
+			resolvePlanetGeographyByIds: vi.fn().mockResolvedValue({
+				401: null,
+			}),
+			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({}),
+			resolveRegionsByIds: vi.fn().mockResolvedValue({}),
+		})
+
+		const instance = createDoInstance(db)
+
+		await instance.storeSkyhooks('corp-1', [
+			{
+				structure_id: 'skyhook-1',
+				planet_id: '401',
+				corporation_id: 'corp-1',
+				state: 'active',
+				is_active: true,
+				effective_workforce: 0,
+				reagents: [],
+				reinforcement_timer: null,
+				theft_vulnerability: null,
+				is_raidable: false,
+				becomes_raidable_at: null,
+				vulnerable_at: null,
+				raw: { id: 1 },
+			} as never,
+		])
+
+		expect(db.delete).not.toHaveBeenCalled()
+		expect(db.insert).not.toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -289,6 +289,89 @@ describe('EveCorporationSyncWorkflow', () => {
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
+	it('includes skyhook listing and prune metrics in the structures sync stats', async () => {
+		vi.clearAllMocks()
+		const { env, updateCorporationAuthHealth } = createWorkflowEnv()
+		const workflowEnv = env as any
+		workflowEnv.STRUCTURE_ENRICHMENT_ENABLED = true
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockResolvedValue([
+			{
+				structure_id: 'structure-1',
+				type_id: '35832',
+			},
+		])
+		fetchSovereigntyEnrichmentMock.mockResolvedValue(null)
+		fetchSkyhookEnrichmentMock.mockResolvedValue({
+			skyhooks: [
+				{
+					structure_id: 'skyhook-1',
+				},
+			],
+		})
+		storeStructuresMock.mockResolvedValue(undefined)
+		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
+		storeSkyhookEnrichmentMock.mockResolvedValue({ prunedCount: 2 })
+		storeMiningEnrichmentMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 0 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, workflowEnv)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-structures-metrics',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+			stats: {
+				structuresCount: 1,
+				skyhooksCount: 1,
+				skyhooksReturnedCount: 1,
+				skyhooksPrunedCount: 2,
+			},
+		})
+
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
+	})
+
 	it('skips mining enrichment for moon-drills and still continues to asset sync', async () => {
 		vi.clearAllMocks()
 		const { env, updateCorporationAuthHealth } = createWorkflowEnv()

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -6,6 +6,7 @@ import { shouldSuppressDirectorUnhealthyOnStructureEnrichmentAuthFailure } from 
 import { createTokenStore, getCorporationDataStub } from '../../utils/services'
 import { readSharedSovereigntySystemsByIds } from '../../utils/sovereignty-systems-cache'
 import type { Universe } from '@repo/universe'
+import type { SkyhookStoreResult } from '@repo/eve-corporation-data'
 
 import type { Env } from '../../../context'
 
@@ -181,16 +182,17 @@ export async function storeSkyhookEnrichment(
 	env: Env,
 	corporationId: string,
 	enrichment: SkyhookEnrichmentData
-): Promise<void> {
+): Promise<SkyhookStoreResult> {
 	const corpData = getCorporationDataStub(env, corporationId)
-	await Promise.all([
-		corpData.storeSkyhooks(corporationId, enrichment.skyhooks),
-	])
+	const result = await corpData.storeSkyhooks(corporationId, enrichment.skyhooks)
 
 	logger.info('[StructuresStep] Stored skyhook enrichment', {
 		corporationId,
 		skyhooks: enrichment.skyhooks.length,
+		prunedSkyhooks: result.prunedCount,
 	})
+
+	return result
 }
 
 export async function fetchMiningEnrichment(

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -745,6 +745,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 					ReturnType<typeof fetchSovereigntyEnrichment>
 				> = null
 				let skyhookEnrichment: Awaited<ReturnType<typeof fetchSkyhookEnrichment>> = null
+				let skyhookStoreResult: { prunedCount: number } | null = null
 				let miningExtractions: Awaited<ReturnType<typeof fetchMiningEnrichment>> | null = null
 
 				if (structures) {
@@ -826,13 +827,17 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						}
 						if (skyhookEnrichment) {
 							const fetchedSkyhookEnrichment = skyhookEnrichment
-							await step.do('store-structure-skyhook-enrichment', {}, async () => {
-								await storeSkyhookEnrichment(
-									this.env,
-									corporationId,
-									fetchedSkyhookEnrichment
-								)
-							})
+							skyhookStoreResult = await step.do(
+								'store-structure-skyhook-enrichment',
+								{},
+								async () => {
+									return await storeSkyhookEnrichment(
+										this.env,
+										corporationId,
+										fetchedSkyhookEnrichment
+									)
+								}
+							)
 						}
 					} else if (structureEnrichmentEnabled && structureEnrichmentCooldownActive) {
 						logger.info('[EveCorporationSyncWorkflow] Skipping structure enrichment due to cooldown', {
@@ -848,6 +853,8 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 							sovereigntySystemsCount: sovereigntyEnrichment?.sovereigntySystems?.length ?? 0,
 							sovereigntyHubsCount: sovereigntyEnrichment?.sovereigntyHubs.length ?? 0,
 							skyhooksCount: skyhookEnrichment?.skyhooks.length ?? 0,
+							skyhooksReturnedCount: skyhookEnrichment?.skyhooks.length ?? 0,
+							skyhooksPrunedCount: skyhookStoreResult?.prunedCount ?? 0,
 							miningExtractionsCount: miningExtractions?.length ?? 0,
 						},
 					}

--- a/apps/eve-corporation-data/src/workflows/types.ts
+++ b/apps/eve-corporation-data/src/workflows/types.ts
@@ -42,6 +42,8 @@ export interface SyncStats {
 	sovereigntySystemsCount?: number
 	sovereigntyHubsCount?: number
 	skyhooksCount?: number
+	skyhooksReturnedCount?: number
+	skyhooksPrunedCount?: number
 	miningExtractionsCount?: number
 	ordersCount?: number
 	contractsCount?: number

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -444,6 +444,10 @@ export interface WalletTransactionsStoreResult {
 	persistedNewRows: number
 }
 
+export interface SkyhookStoreResult {
+	prunedCount: number
+}
+
 /**
  * Corporation configuration data
  */
@@ -1339,7 +1343,7 @@ export interface EveCorporationData {
 	/**
 	 * Store skyhook snapshots (workflow-friendly)
 	 */
-	storeSkyhooks(corporationId: string, skyhooks: EsiCorporationSkyhook[]): Promise<void>
+	storeSkyhooks(corporationId: string, skyhooks: EsiCorporationSkyhook[]): Promise<SkyhookStoreResult>
 
 	/**
 	 * Store mining extraction snapshots (workflow-friendly)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes `storeSkyhooks` in the EVE corporation data Durable Object so a transient geography-lookup failure doesn't wipe out previously stored skyhook structures, corrects the ESI skyhooks endpoint URL (which was incorrectly paginated), and adds prune/return metrics for the skyhook sync step so cleanup activity is observable in sync stats.

## Changes
- In `apps/eve-corporation-data/src/durable-object.ts`, `storeSkyhooks` now returns a `SkyhookStoreResult` (`{ prunedCount }`) instead of `void`. When `synthesizedRows` is empty but ESI actually returned skyhooks, it logs a warning and returns early (`prunedCount: 0`) instead of deleting the existing `structureSkyhookStates`/`corporationStructures` rows; the delete path is now only taken when ESI reports zero skyhooks, and reports how many rows were pruned.
- In `apps/eve-corporation-data/src/services/esi-fetch.ts`, `fetchCorporationSkyhooks` now calls `/corporations/{corporationId}/structures/skyhooks` without the `?page=1` query param, since this endpoint doesn't paginate.
- Added the `SkyhookStoreResult` type to `packages/eve-corporation-data/src/index.ts` and updated the `EveCorporationData.storeSkyhooks` interface signature to match.
- `storeSkyhookEnrichment` (`apps/eve-corporation-data/src/workflows/steps/structures/index.ts`) now returns the `SkyhookStoreResult` and logs the pruned count.
- `EveCorporationSyncWorkflow` (`apps/eve-corporation-data/src/workflows/sync-workflow.ts`) captures the skyhook store result and adds `skyhooksReturnedCount`/`skyhooksPrunedCount` to the structures sync stats (`apps/eve-corporation-data/src/workflows/types.ts`).

## Testing
- Added a unit test in `structure-prune-cleanup.test.ts` that simulates a geography lookup failure (`resolvePlanetGeographyByIds` returning `null` for the planet) and asserts existing rows are preserved (no `delete`/`insert` calls).
- Added a unit test asserting `storeSkyhooks` returns `{ prunedCount: N }` and issues the expected deletes when the upstream skyhook listing is genuinely empty.
- Updated `esi-fetch.structure-enrichment.test.ts` to assert the skyhooks endpoint is called without the page query param.
- Added a `sync-workflow.test.ts` case asserting `skyhooksCount`, `skyhooksReturnedCount`, and `skyhooksPrunedCount` are populated correctly in the structures sync stats.
<!-- claude:end -->