### PR TITLE
restore misisng name columns and move planet/moon columns for minin

### DIFF
--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -3097,7 +3097,7 @@ function buildMiningCitadelListItem(input: {
 	const { context, miningExtractionRow, moonGeographyRow } = input
 	const { structure: structureRow } = context
 	const hasMiningSnapshot = miningExtractionRow !== null && moonGeographyRow !== null
-	const { name: _structureName, ...structureBase } = buildStructureListItem(context)
+	const structureBase = buildStructureListItem(context)
 
 	return {
 		...structureBase,

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -986,6 +986,7 @@ export default function StructuresPage() {
 	const renderMiningCitadelRows = (items: StructureMiningCitadelListItem[]) =>
 		items.map((structure) => {
 			const displayMoonName = stripLeadingContextName(structure.moonName, structure.planetName)
+			const displayStructureName = stripLeadingContextName(structure.name, structure.systemName)
 
 			return (
 				<TableRow key={structure.structureId}>
@@ -994,6 +995,13 @@ export default function StructuresPage() {
 					</TableCell>
 					<TableCell className="font-medium">{structure.regionName ?? structure.regionId ?? '-'}</TableCell>
 					<TableCell>{structure.systemName ?? structure.systemId}</TableCell>
+					<TableCell>{structure.planetName ?? structure.planetId ?? '-'}</TableCell>
+					<TableCell title={structure.moonName ?? structure.moonId}>{displayMoonName}</TableCell>
+					<TableCell className="max-w-[18rem]">
+						<span className="truncate font-medium" title={structure.name}>
+							{displayStructureName}
+						</span>
+					</TableCell>
 					<TableCell className="max-w-[18rem]">
 						<div className="flex min-w-0 items-center gap-2">
 							<CorporationLogo
@@ -1046,8 +1054,6 @@ export default function StructuresPage() {
 					<TableCell>
 						{structure.assignedGroupId ? groupNameById.get(structure.assignedGroupId) ?? structure.assignedGroupId : '-'}
 					</TableCell>
-					<TableCell title={structure.moonName ?? structure.moonId}>{displayMoonName}</TableCell>
-					<TableCell>{structure.planetName ?? structure.planetId ?? '-'}</TableCell>
 					<TableCell>{formatNullableDateTime(structure.chunkArrivalTime)}</TableCell>
 					<TableCell>{formatNullableDateTime(structure.naturalDecayTime)}</TableCell>
 					<TableCell>
@@ -1730,6 +1736,9 @@ export default function StructuresPage() {
 												<SortableHead field="state" label="State" />
 												<SortableHead field="region" label="Region" />
 												<SortableHead field="system" label="System" />
+												<SortableHead field="planet" label="Planet" />
+												<TableHead>Moon</TableHead>
+												<SortableHead field="name" label="Name" />
 												<SortableHead field="corporation" label="Corporation" />
 												<SortableHead field="type" label="Type" />
 												<SortableHead field="fuel" label="Fuel" />
@@ -1737,8 +1746,6 @@ export default function StructuresPage() {
 												<TableHead>LP Allowed</TableHead>
 												<SortableHead field="nextStateAt" label="Next State In" />
 												<TableHead>Group</TableHead>
-												<TableHead>Moon</TableHead>
-												<TableHead>Planet</TableHead>
 												<TableHead>Chunk Arrival</TableHead>
 												<TableHead>Natural Decay</TableHead>
 												<TableHead>Sync</TableHead>

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -497,6 +497,7 @@ export interface StructureMoonDrillListItem
 
 export interface StructureMiningCitadelListItem
 	extends StructureIdentity, StructureSyncState, StructureConfig, StructureMoonGeography {
+	name: string
 	state: string
 	typeId: string
 	typeName: string | null


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the mining citadel structures table: the structure `name` field had been dropped from the list item builder, and the Planet/Moon/Name columns were positioned after several unrelated columns instead of next to System.

## Changes
- `structures.service.ts`: stop stripping `name` out of `buildStructureListItem` when building mining citadel list items, so the structure name is preserved.
- `packages/structures`: add `name: string` to the `StructureMiningCitadelListItem` interface.
- `apps/ui` structures page: move the Planet, Moon, and Name columns (and their table cells) to immediately follow the System column instead of after Group, and render the structure name with a truncated/tooltip display similar to the moon name.
<!-- claude:end -->