### PR TITLE
fix listing uncategorized groups query error

### DIFF
--- a/apps/groups/src/durable-object.ts
+++ b/apps/groups/src/durable-object.ts
@@ -2558,7 +2558,13 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		logger.log('[DO] listPermissions - Start, categoryId:', categoryId)
 
 		try {
-			const whereClause = categoryId ? eq(permissions.categoryId, categoryId) : undefined
+			const normalizedCategoryId = categoryId?.trim()
+			const whereClause =
+				normalizedCategoryId === 'uncategorized'
+					? isNull(permissions.categoryId)
+					: normalizedCategoryId
+						? eq(permissions.categoryId, normalizedCategoryId)
+						: undefined
 			logger.log('[DO] listPermissions - whereClause:', whereClause)
 
 			logger.log('[DO] listPermissions - About to query database')

--- a/apps/groups/src/test/integration/api.test.ts
+++ b/apps/groups/src/test/integration/api.test.ts
@@ -130,6 +130,47 @@ describe('Groups Durable Object - Categories', () => {
 	})
 })
 
+describe('Groups Durable Object - Global Permissions', () => {
+	it('should list uncategorized permissions when filtering by uncategorized', async () => {
+		const stub = getStub<Groups>(testEnv.GROUPS, 'test-permissions-uncategorized')
+
+		const category = await stub.createCategory(
+			{
+				name: 'Categorized Permissions Test',
+				visibility: 'public',
+			},
+			ADMIN_USER_ID
+		)
+
+		const categorizedPermission = await stub.createPermission(
+			{
+				urn: 'urn:broadcasts:test:categorized:send',
+				name: 'Categorized Permission',
+				categoryId: category.id,
+			},
+			ADMIN_USER_ID
+		)
+
+		const uncategorizedPermission = await stub.createPermission(
+			{
+				urn: 'urn:broadcasts:test:uncategorized:send',
+				name: 'Uncategorized Permission',
+			},
+			ADMIN_USER_ID
+		)
+
+		const uncategorizedPermissions = await stub.listPermissions('uncategorized')
+
+		expect(uncategorizedPermissions.some((permission) => permission.id === uncategorizedPermission.id)).toBe(
+			true
+		)
+		expect(uncategorizedPermissions.some((permission) => permission.id === categorizedPermission.id)).toBe(
+			false
+		)
+		expect(uncategorizedPermissions.every((permission) => permission.category === null)).toBe(true)
+	})
+})
+
 describe('Groups Durable Object - Groups', () => {
 	it('should create a group', async () => {
 		const stub = getStub<Groups>(testEnv.GROUPS, 'test-group-create')


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes `listPermissions` in the Groups Durable Object so filtering by the special `"uncategorized"` value actually returns permissions with no category, instead of querying for a literal `categoryId` equal to the string `"uncategorized"`.

## Changes
- In `apps/groups/src/durable-object.ts`, `listPermissions` now trims `categoryId` and builds the where clause based on three cases: `"uncategorized"` → `isNull(permissions.categoryId)`, a non-empty id → `eq(permissions.categoryId, normalizedCategoryId)`, otherwise → no filter (list all).
- Added an integration test covering the uncategorized-filter case: creates a categorized and an uncategorized permission, then asserts `listPermissions('uncategorized')` returns only the uncategorized one.

## Testing
- New integration test added in `apps/groups/src/test/integration/api.test.ts` verifying `listPermissions('uncategorized')` excludes categorized permissions and only returns permissions with `category === null`.
<!-- claude:end -->