### PR TITLE
set explicit workflow instance retention via a shared createWorkflow helper

### DIFF
--- a/apps/bills/package.json
+++ b/apps/bills/package.json
@@ -24,6 +24,7 @@
 	"dependencies": {
 		"@neondatabase/serverless": "1.0.2",
 		"@repo/bills": "workspace:*",
+		"@repo/core": "workspace:*",
 		"@repo/db-utils": "workspace:*",
 		"@repo/discord": "workspace:*",
 		"@repo/do-utils": "workspace:*",
@@ -31,8 +32,8 @@
 		"@repo/eve-corporation-data": "workspace:*",
 		"@repo/groups": "workspace:*",
 		"@repo/hono-helpers": "workspace:*",
-		"@repo/core": "workspace:*",
 		"@repo/worker-utils": "workspace:*",
+		"@repo/workflow-utils": "workspace:*",
 		"drizzle-orm": "0.44.7",
 		"hono": "4.10.6",
 		"workers-tagged-logger": "0.13.7"

--- a/apps/bills/src/durable-object.ts
+++ b/apps/bills/src/durable-object.ts
@@ -3,6 +3,7 @@ import { and, eq, isNull, lte } from 'drizzle-orm'
 
 import { getStub } from '@repo/do-utils'
 import { logger, toErrorLogDetails } from '@repo/hono-helpers'
+import { createWorkflowBatch } from '@repo/workflow-utils'
 
 import { createDb } from './db'
 import { BillService } from './services/bill.service'
@@ -663,7 +664,7 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 			return
 		}
 
-		await this.env.BILL_DISCORD_NOTIFY.createBatch(
+		await createWorkflowBatch(this.env.BILL_DISCORD_NOTIFY, 
 			pendingRows.map((row) => ({
 				id: `bill-notify-immediate-${row.id}-${Date.now()}`,
 				params: { notificationEventId: row.id },

--- a/apps/bills/src/scheduled.ts
+++ b/apps/bills/src/scheduled.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray, isNull, lte, or } from 'drizzle-orm'
 
 import { getStub } from '@repo/do-utils'
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
+import { createWorkflowBatch } from '@repo/workflow-utils'
 
 import { createDb } from './db'
 import { billNotificationEvents, bills, billSchedules } from './db/schema'
@@ -82,7 +83,7 @@ async function refreshBillPayments(env: Env, options: { scheduledTimeMs: number 
 		const batchResults = await Promise.allSettled(
 			batches.map(async (batch, batchIndex) => {
 				try {
-					const instances = await env.BILL_PAYMENT_STATUS_CHECK.createBatch(batch)
+					const instances = await createWorkflowBatch(env.BILL_PAYMENT_STATUS_CHECK, batch)
 
 					refreshLogger.info('[Bills] Created workflow batch', {
 						batchIndex: batchIndex + 1,
@@ -207,7 +208,7 @@ async function enqueueDueSchedules(env: Env, options: { scheduledTimeMs: number 
 		const batchResults = await Promise.allSettled(
 			batches.map(async (batch, batchIndex) => {
 				try {
-					const instances = await env.BILLS_SCHEDULE_EXECUTOR.createBatch(batch)
+					const instances = await createWorkflowBatch(env.BILLS_SCHEDULE_EXECUTOR, batch)
 					scheduleLogger.info('[Bills] Created schedule workflow batch', {
 						batchIndex: batchIndex + 1,
 						totalBatches: batches.length,
@@ -365,7 +366,7 @@ async function dispatchPendingNotificationWorkflows(
 		let created = 0
 		for (let i = 0; i < workflowOptions.length; i += BATCH_SIZE) {
 			const batch = workflowOptions.slice(i, i + BATCH_SIZE)
-			const instances = await env.BILL_DISCORD_NOTIFY.createBatch(batch)
+			const instances = await createWorkflowBatch(env.BILL_DISCORD_NOTIFY, batch)
 			created += instances.length
 		}
 

--- a/apps/core/src/lib/workflow-triggers.ts
+++ b/apps/core/src/lib/workflow-triggers.ts
@@ -1,5 +1,6 @@
 import { eq } from '@repo/db-utils'
 import { logger } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { users } from '../db/schema'
 import { isMumbleFeatureEnabled } from './mumble-feature'
@@ -92,7 +93,7 @@ export async function triggerDiscordRefreshWorkflow({
 			hardStripAllRoles,
 			jitterDelaySeconds,
 		}
-		const instance = await env.USER_DISCORD_REFRESH_WORKFLOW.create({
+		const instance = await createWorkflow(env.USER_DISCORD_REFRESH_WORKFLOW, {
 			id: createDiscordRefreshWorkflowId(source, userId),
 			params,
 		})
@@ -182,7 +183,7 @@ export async function triggerMumbleRefreshWorkflow({
 			source,
 			jitterDelaySeconds,
 		}
-		const instance = await env.USER_MUMBLE_REFRESH_WORKFLOW.create({
+		const instance = await createWorkflow(env.USER_MUMBLE_REFRESH_WORKFLOW, {
 			id: createMumbleRefreshWorkflowId(source, userIds),
 			params,
 		})
@@ -246,7 +247,7 @@ export async function triggerUserRefreshWorkflow({
 			.set({ lastRefreshWorkflowAttempt: new Date() })
 			.where(eq(users.id, userId))
 
-		const instance = await env.USER_REFRESH_WORKFLOW.create({
+		const instance = await createWorkflow(env.USER_REFRESH_WORKFLOW, {
 			id: createUserRefreshWorkflowId(source, userId),
 			params: { userId, refreshMode, suppressDiscordRefresh, forceTokenValidation },
 		})

--- a/apps/core/src/routes/__tests__/structures.route.test.ts
+++ b/apps/core/src/routes/__tests__/structures.route.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import structuresRoutes from '../structures'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 
+import { DEFAULT_WORKFLOW_RETENTION } from '@repo/workflow-utils'
+
 import type { SessionUser } from '../../context'
 
 const structuresMocks = vi.hoisted(() => ({
@@ -202,6 +204,7 @@ describe('structures routes', () => {
 				structureId: 'structure-1',
 				structureName: 'Structure One',
 			},
+			retention: DEFAULT_WORKFLOW_RETENTION,
 		})
 		const startBody = (await startResponse.json()) as {
 			workflowInstanceId: string

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -38,6 +38,7 @@ import type { Legacy } from '@repo/legacy'
 import type { TempopOAuthMetadata } from '../db/schema'
 import type { App } from '../context'
 import { logger } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 /**
  * Authentication routes
@@ -728,7 +729,7 @@ auth.get('/callback', async (c) => {
 					.set({ lastRefreshWorkflowAttempt: new Date() })
 					.where(eq(users.id, stateUserId))
 
-				await c.env.USER_REFRESH_WORKFLOW.create({
+				await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
 					id: createUserRefreshWorkflowId('link', stateUserId),
 					params: { userId: stateUserId, refreshMode: 'event' },
 				})
@@ -865,7 +866,7 @@ auth.get('/callback', async (c) => {
 						.set({ lastRefreshWorkflowAttempt: new Date() })
 						.where(eq(users.id, user.id))
 
-					await c.env.USER_REFRESH_WORKFLOW.create({
+					await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
 						id: createUserRefreshWorkflowId('login', user.id),
 						params: { userId: user.id, refreshMode: 'event' },
 					})
@@ -1029,7 +1030,7 @@ auth.post('/claim-main', async (c) => {
 				.set({ lastRefreshWorkflowAttempt: new Date() })
 				.where(eq(users.id, user.id))
 
-			await c.env.USER_REFRESH_WORKFLOW.create({
+			await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
 				id: createUserRefreshWorkflowId('login', user.id),
 				params: { userId: user.id, refreshMode: 'event' },
 			})
@@ -1164,7 +1165,7 @@ auth.post('/link-character', requireAuth(), async (c) => {
 				.set({ lastRefreshWorkflowAttempt: new Date() })
 				.where(eq(users.id, user.id))
 
-			await c.env.USER_REFRESH_WORKFLOW.create({
+			await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
 				id: createUserRefreshWorkflowId('link', user.id),
 				params: { userId: user.id, refreshMode: 'event' },
 			})

--- a/apps/core/src/routes/discord-servers.ts
+++ b/apps/core/src/routes/discord-servers.ts
@@ -9,6 +9,7 @@ import {
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { ResourceType, RoleAttachmentType } from '@repo/groups'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import {
 	corporationDiscordServers,
@@ -682,7 +683,7 @@ app.post('/:id/audit/runs', requireAuth(), requireAdmin(), async (c) => {
 				status: discordMemberAuditRuns.status,
 			})
 
-		await c.env.DISCORD_MEMBER_AUDIT_WORKFLOW.create({
+		await createWorkflow(c.env.DISCORD_MEMBER_AUDIT_WORKFLOW, {
 			id: workflowId,
 			params: {
 				runId: run.id,

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -35,6 +35,7 @@ import type { Markets } from '@repo/markets'
 import type { Universe } from '@repo/universe'
 import type { App } from '../context'
 import { logger } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 // ─── Permission URNs ─────────────────────────────────────────────────────────
 
@@ -1234,7 +1235,7 @@ moonScanRoutes.post('/moons/verified/export', async (c) => {
 	}
 	const { sortBy: _sortBy, sortDir: _sortDir, page: _page, pageSize: _pageSize, ...exportQuery } = query.data
 
-	const workflow = await c.env.EXPORT_WORKFLOW.create({
+	const workflow = await createWorkflow(c.env.EXPORT_WORKFLOW, {
 		params: {
 			kind: 'moon-scan-verified',
 			userId: user.id,

--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -15,6 +15,7 @@ import {
 	WithdrawSRPRequestSchema,
 } from '@repo/srp'
 import { buildCsvLine, createR2MultipartTextWriter, parseDateOrNull } from '@repo/worker-utils'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from '../db'
 import { managedCorporations, userCharacters } from '../db/schema'
@@ -1961,7 +1962,7 @@ srp.post('/requests/paid/export', async (c) => {
 		return c.json({ error: dateRange.error }, 400)
 	}
 
-	const workflow = await c.env.EXPORT_WORKFLOW.create({
+	const workflow = await createWorkflow(c.env.EXPORT_WORKFLOW, {
 		params: {
 			kind: 'srp-paid-requests',
 			userId: user.id,
@@ -2336,7 +2337,7 @@ srp.post('/payments/wallet-history/export', async (c) => {
 		return c.json({ error: dateRange.error }, 400)
 	}
 
-	const workflow = await c.env.EXPORT_WORKFLOW.create({
+	const workflow = await createWorkflow(c.env.EXPORT_WORKFLOW, {
 		params: {
 			kind: 'srp-wallet-history',
 			userId: user.id,

--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import { getStub } from '@repo/do-utils'
 import { hasAllStructureManagerPermission } from '@repo/groups'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import {
@@ -389,7 +390,7 @@ app.post('/:structureId/assets-debug', async (c) => {
 			return c.json({ error: 'Structure not found' }, 404)
 		}
 
-		const workflow = await c.env.EXPORT_WORKFLOW.create({
+		const workflow = await createWorkflow(c.env.EXPORT_WORKFLOW, {
 			params: {
 				kind: 'structure-assets-debug',
 				userId: user.id,

--- a/apps/eve-character-data/src/durable-object.ts
+++ b/apps/eve-character-data/src/durable-object.ts
@@ -51,6 +51,7 @@ import type {
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
 import type { Env } from './context'
 import { logger } from '@repo/hono-helpers'
+import { createWorkflowBatch } from '@repo/workflow-utils'
 
 /**
  * EveCharacterData Durable Object
@@ -1842,7 +1843,7 @@ export class EveCharacterDataDO extends DurableObject<Env> implements EveCharact
 			for (let i = 0; i < workflows.length; i += BATCH_SIZE) {
 				const batch = workflows.slice(i, i + BATCH_SIZE)
 				try {
-					await this.env.EVE_CHARACTER_SYNC.createBatch(batch)
+					await createWorkflowBatch(this.env.EVE_CHARACTER_SYNC, batch)
 					created += batch.length
 					createdIds.push(...batch.map((entry: { id: string }) => entry.id))
 				} catch {

--- a/apps/eve-character-data/src/index.ts
+++ b/apps/eve-character-data/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 
 import { logger, withNotFound, withOnError, withWorkersLogger } from '@repo/hono-helpers'
+import { createWorkflowBatch } from '@repo/workflow-utils'
 
 import { EveCharacterDataDO } from './durable-object'
 import { buildUserSyncWorkflowOptions } from './workflows/build-user-sync-workflow-options'
@@ -88,7 +89,7 @@ async function scheduledHandler(event: ScheduledEvent, env: Env): Promise<void> 
 						firstWorkflowId: batch[0]?.id ?? null,
 						lastWorkflowId: batch[batch.length - 1]?.id ?? null,
 					})
-					const instances = await env.EVE_CHARACTER_SYNC.createBatch(batch)
+					const instances = await createWorkflowBatch(env.EVE_CHARACTER_SYNC, batch)
 					created += batch.length
 					logger.info('[EveCharacterData] Dispatched character sync workflow batch', {
 						pageIndex,

--- a/apps/eve-corporation-data/src/index.ts
+++ b/apps/eve-corporation-data/src/index.ts
@@ -9,6 +9,7 @@ import {
 	withWorkerLogContext,
 	withWorkersLogger,
 } from '@repo/hono-helpers'
+import { createWorkflowBatch } from '@repo/workflow-utils'
 
 import { EveCorporationDataDO } from './durable-object'
 import { scheduledHandler } from './scheduled'
@@ -106,7 +107,7 @@ export class EveCorporationDataWorker extends WorkerEntrypoint<Env> {
 		for (let i = 0; i < workflowOptions.length; i += BATCH_SIZE) {
 			const batch = workflowOptions.slice(i, i + BATCH_SIZE)
 			try {
-				const instances = await this.env.EVE_CORPORATION_SYNC.createBatch(batch)
+				const instances = await createWorkflowBatch(this.env.EVE_CORPORATION_SYNC, batch)
 				for (const [index, instance] of instances.entries()) {
 					workflows.push({
 						corporationId: batch[index]!.params.corporationId,

--- a/apps/eve-corporation-data/src/scheduled.ts
+++ b/apps/eve-corporation-data/src/scheduled.ts
@@ -1,4 +1,5 @@
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import {
 	computeNextAttemptAtMs,
@@ -272,7 +273,7 @@ async function createWorkflowInstance(
 			// No existing instance, proceed to create new one.
 		}
 
-		const instance = await env.EVE_CORPORATION_SYNC.create({
+		const instance = await createWorkflow(env.EVE_CORPORATION_SYNC, {
 			id: `${corporationId}-${Date.now()}`,
 			params: {
 				corporationId,

--- a/apps/fulcrum/src/durable-object.ts
+++ b/apps/fulcrum/src/durable-object.ts
@@ -12,6 +12,7 @@ import type {
 	ReportSectionName,
 } from '@repo/fulcrum'
 import { DEFAULT_RETENTION_DAYS, RETENTION_POLICIES } from '@repo/fulcrum'
+import { createWorkflow } from '@repo/workflow-utils'
 import { createDb } from './db'
 import { stripHtmlToPlainText } from './workflows/processors/helpers/html-stripper'
 import type { DbClient } from './db/queries'
@@ -132,7 +133,7 @@ export class FulcrumDO extends DurableObject<Env, {}> implements Fulcrum {
 			sendDm,
 		}
 		try {
-			const workflowInstance = await this.env.CHARACTER_REPORT_WORKFLOW.create({
+			const workflowInstance = await createWorkflow(this.env.CHARACTER_REPORT_WORKFLOW, {
 				id: `${characterId}-${reportId}-${Date.now()}`,
 				params: workflowParams,
 			})
@@ -175,7 +176,7 @@ export class FulcrumDO extends DurableObject<Env, {}> implements Fulcrum {
 			throw new Error('At least one characterId is required for bulk report generation')
 		}
 
-		const workflowInstance = await this.env.BULK_CHARACTER_REPORT_WORKFLOW.create({
+		const workflowInstance = await createWorkflow(this.env.BULK_CHARACTER_REPORT_WORKFLOW, {
 			id: `bulk-${requestorUserId}-${Date.now()}-${crypto.randomUUID()}`,
 			params: {
 				characterIds: dedupedCharacterIds,

--- a/apps/fulcrum/src/queue.ts
+++ b/apps/fulcrum/src/queue.ts
@@ -5,6 +5,7 @@
 
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
 import { DEFAULT_RETENTION_DAYS, RETENTION_POLICIES } from '@repo/fulcrum'
+import { createWorkflow } from '@repo/workflow-utils'
 import { createDb } from './db'
 import * as queries from './db/queries'
 import { sendReportFailedDM } from './lib/discord-webhook'
@@ -84,7 +85,7 @@ export async function handleCharacterReportsQueue(
 					sendDm,
 				}
 
-				const workflowInstance = await env.CHARACTER_REPORT_WORKFLOW.create({
+				const workflowInstance = await createWorkflow(env.CHARACTER_REPORT_WORKFLOW, {
 					id: `${characterId}-${reportId}-${Date.now()}`,
 					params: workflowParams,
 				})

--- a/apps/fulcrum/src/workflows/bulk-character-report.runner.ts
+++ b/apps/fulcrum/src/workflows/bulk-character-report.runner.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_RETENTION_DAYS, RETENTION_POLICIES } from '@repo/fulcrum'
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from '../db'
 import * as queries from '../db/queries'
@@ -47,10 +48,12 @@ function sleep(ms: number): Promise<void> {
 
 type StepDo = <T>(name: string, config: unknown, fn: () => Promise<T>) => Promise<T>
 
-type CharacterWorkflowBinding = {
-	create: (input: { id: string; params: { reportId: string; characterId: string; targetUserId?: string; sendDm: boolean } }) => Promise<{ id: string }>
-	get: (id: string) => Promise<{ status: () => Promise<{ status: string }> }>
-}
+type CharacterWorkflowBinding = Workflow<{
+	reportId: string
+	characterId: string
+	targetUserId?: string
+	sendDm: boolean
+}>
 
 type RunnerEnv = {
 	DATABASE_URL: string
@@ -132,7 +135,7 @@ export async function runBulkCharacterReportWorkflow(
 						})
 
 						try {
-							const childWorkflowInstance = await env.CHARACTER_REPORT_WORKFLOW.create({
+							const childWorkflowInstance = await createWorkflow(env.CHARACTER_REPORT_WORKFLOW, {
 								id: `${characterId}-${reportId}-${Date.now()}-${crypto.randomUUID()}`,
 								params: {
 									reportId,

--- a/apps/markets/src/scheduled.ts
+++ b/apps/markets/src/scheduled.ts
@@ -1,6 +1,7 @@
 import { sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from './db'
 
@@ -54,7 +55,7 @@ export async function scheduledHandler(_event: ScheduledEvent, env: Env): Promis
 
 		logger.info(`[scheduledHandler] Dispatching price snapshot for ${targetDate} hour ${hour}`)
 
-		await env.DAILY_PRICE_BATCH_WORKFLOW.create({
+		await createWorkflow(env.DAILY_PRICE_BATCH_WORKFLOW, {
 			id: `price-snapshot-${targetDate}-${hour}`,
 			params: { targetDate },
 		})

--- a/apps/srp/package.json
+++ b/apps/srp/package.json
@@ -36,6 +36,7 @@
 		"@repo/srp": "workspace:*",
 		"@repo/universe": "workspace:*",
 		"@repo/worker-utils": "workspace:*",
+		"@repo/workflow-utils": "workspace:*",
 		"drizzle-orm": "0.44.7",
 		"hono": "4.10.6",
 		"workers-tagged-logger": "0.13.7"

--- a/apps/srp/src/recent-loss-refresh-coordinator.ts
+++ b/apps/srp/src/recent-loss-refresh-coordinator.ts
@@ -1,5 +1,7 @@
 import { DurableObject } from 'cloudflare:workers'
 
+import { createWorkflow } from '@repo/workflow-utils'
+
 import type {
 	RecentLossRefreshCharacterInput,
 	RecentLossRefreshCoordinator,
@@ -145,7 +147,7 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 		await this.rescheduleCleanup()
 
 		try {
-			await this.env.SRP_RECENT_LOSS_REFRESH_WORKFLOW.create({
+			await createWorkflow(this.env.SRP_RECENT_LOSS_REFRESH_WORKFLOW, {
 				id: workflowInstanceId,
 				params: {
 					userId,

--- a/apps/srp/src/scheduled.ts
+++ b/apps/srp/src/scheduled.ts
@@ -1,6 +1,7 @@
 import { and, eq } from 'drizzle-orm'
 
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
+import { createWorkflowBatch } from '@repo/workflow-utils'
 
 import { createDb } from './db'
 import { srpRequests } from './db/schema'
@@ -42,7 +43,7 @@ async function refreshPendingPaymentChecks(
 		const batchResults = await Promise.allSettled(
 			batches.map(async (batch, batchIndex) => {
 				try {
-					const instances = await env.SRP_PAYMENT_STATUS_CHECK.createBatch(batch)
+					const instances = await createWorkflowBatch(env.SRP_PAYMENT_STATUS_CHECK, batch)
 					refreshLogger.info('[SRP] Created payment-check workflow batch', {
 						batchIndex: batchIndex + 1,
 						totalBatches: batches.length,

--- a/packages/workflow-utils/src/create-workflow.ts
+++ b/packages/workflow-utils/src/create-workflow.ts
@@ -1,0 +1,123 @@
+/**
+ * Workflow instance creation with a default retention policy.
+ *
+ * Retention is INSTANCE-level: it is set per `create()` / per `createBatch()` entry and
+ * governs how long a finished run's state (step outputs, status, per-step failure records)
+ * and logs survive. There is no step-level equivalent — `WorkflowStepConfig` carries only
+ * `retries` and `timeout`, and there is no wrangler.jsonc or account-level setting.
+ *
+ * Create every instance through `createWorkflow` / `createWorkflowBatch` rather than calling
+ * `binding.create()` directly, so the policy stays applied as new call sites are added.
+ */
+
+/**
+ * Retention duration, string form only.
+ *
+ * The platform also accepts a bare `number`, but it is MILLISECONDS — `3600` is one hour,
+ * not one second. Neither the type system nor CI would catch that, so the number branch of
+ * `WorkflowRetentionDuration` is excluded here deliberately.
+ */
+export type RetentionDuration = Extract<WorkflowRetentionDuration, string>
+
+export interface WorkflowRetentionPolicy {
+	successRetention: RetentionDuration
+	errorRetention: RetentionDuration
+}
+
+/**
+ * Retention applied to every instance created through this module.
+ *
+ * The account plan sets only the ceiling (30 days on Paid); per-instance retention can
+ * shorten it, never extend it.
+ *
+ * `successRetention: '1 hour'` clears the longest read-back window in this repo by ~4x:
+ * apps/core persists a USER_REFRESH_WORKFLOW instance id and a later cron tick reads its
+ * status back, bounded by that Durable Object's 15 minute pending TTL. Not lower: no
+ * minimum is documented, the REST schema declares no floor, and miniflare ignores
+ * `retention` entirely — so `wrangler dev` and every vitest-pool-workers test here are
+ * blind to this field, and a shorter value cannot be validated before deploy.
+ *
+ * `errorRetention: '7 days'` matches the Workers Logs window. Retained error state is
+ * currently the only per-step failure attribution that exists, because no workflow in this
+ * repo reports to Sentry (`withSentry` wraps the Hono app; workflow classes are exported
+ * outside it). Shorten only once workflow errors reach Sentry.
+ */
+export const DEFAULT_WORKFLOW_RETENTION = {
+	successRetention: '1 hour',
+	errorRetention: '7 days',
+} as const satisfies WorkflowRetentionPolicy
+
+/**
+ * Options for {@link createWorkflow} / {@link createWorkflowBatch}.
+ *
+ * Identical to `WorkflowInstanceCreateOptions` except that `retention` is partial and is
+ * merged over {@link DEFAULT_WORKFLOW_RETENTION}. Override only when a specific reader
+ * needs a longer window than the default.
+ */
+export type CreateWorkflowOptions<PARAMS = unknown> = Omit<
+	WorkflowInstanceCreateOptions<PARAMS>,
+	'retention'
+> & {
+	retention?: Partial<WorkflowRetentionPolicy>
+}
+
+/**
+ * Resolve each field independently so an explicitly-passed `undefined` falls back to the
+ * default rather than clearing it (which the platform reads as unset, i.e. 30 days).
+ */
+function withDefaultRetention<PARAMS>(
+	options: CreateWorkflowOptions<PARAMS>
+): WorkflowInstanceCreateOptions<PARAMS> {
+	const { retention, ...rest } = options
+	return {
+		...rest,
+		retention: {
+			successRetention: retention?.successRetention ?? DEFAULT_WORKFLOW_RETENTION.successRetention,
+			errorRetention: retention?.errorRetention ?? DEFAULT_WORKFLOW_RETENTION.errorRetention,
+		},
+	}
+}
+
+/**
+ * Create a Workflow instance with the default retention policy applied.
+ *
+ * @param workflow - The Workflow binding, e.g. `env.USER_REFRESH_WORKFLOW`
+ * @param options - Standard create options; `retention` is merged over the default
+ *
+ * @example
+ * ```typescript
+ * const instance = await createWorkflow(env.USER_REFRESH_WORKFLOW, {
+ *   id: workflowId,
+ *   params: { userId },
+ * })
+ * ```
+ */
+export async function createWorkflow<PARAMS = unknown>(
+	workflow: Workflow<PARAMS>,
+	options: CreateWorkflowOptions<PARAMS> = {}
+): Promise<WorkflowInstance> {
+	return workflow.create(withDefaultRetention(options))
+}
+
+/**
+ * Create a batch of Workflow instances with the default retention policy applied to each.
+ *
+ * Retention has no batch-level form — `createBatch` takes the same per-entry options as
+ * `create`, so the policy is applied to every element.
+ *
+ * @param workflow - The Workflow binding, e.g. `env.BILL_DISCORD_NOTIFY`
+ * @param batch - Per-instance create options; limited to 100 instances per call
+ *
+ * @example
+ * ```typescript
+ * const instances = await createWorkflowBatch(env.BILL_DISCORD_NOTIFY,
+ *   bills.map((bill) => ({ params: { billId: bill.id } }))
+ * )
+ * ```
+ */
+export async function createWorkflowBatch<PARAMS = unknown>(
+	workflow: Workflow<PARAMS>,
+	batch: CreateWorkflowOptions<PARAMS>[]
+): Promise<WorkflowInstance[]> {
+	return workflow.createBatch(batch.map((options) => withDefaultRetention(options)))
+}

--- a/packages/workflow-utils/src/index.ts
+++ b/packages/workflow-utils/src/index.ts
@@ -2,7 +2,22 @@
  * @repo/workflow-utils
  *
  * Shared utilities and helpers for building Cloudflare Workflows.
- * Provides context management, R2 intermediate storage, and step configuration.
+ * Provides instance creation, context management, R2 intermediate storage, and step
+ * configuration.
+ *
+ * ## Creating instances
+ *
+ * Always create instances via `createWorkflow` / `createWorkflowBatch` rather than calling
+ * `binding.create()` directly — they apply the shared retention policy.
+ *
+ * ```typescript
+ * import { createWorkflow } from '@repo/workflow-utils'
+ *
+ * const instance = await createWorkflow(env.MY_WORKFLOW, {
+ *   id: myId,
+ *   params: { hello: 'world' },
+ * })
+ * ```
  *
  * ## Quick Start
  *
@@ -42,6 +57,16 @@
 
 // Types
 export type { Logger, WorkflowContext, StepResult } from './types'
+
+// Instance creation with the default retention policy — use instead of binding.create()
+export {
+	createWorkflow,
+	createWorkflowBatch,
+	DEFAULT_WORKFLOW_RETENTION,
+	type CreateWorkflowOptions,
+	type RetentionDuration,
+	type WorkflowRetentionPolicy,
+} from './create-workflow'
 
 // Context factory
 export { createWorkflowContext } from './types'

--- a/packages/workflow-utils/src/test/create-workflow.test.ts
+++ b/packages/workflow-utils/src/test/create-workflow.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createWorkflow, createWorkflowBatch, DEFAULT_WORKFLOW_RETENTION } from '../index'
+
+import type { CreateWorkflowOptions } from '../index'
+
+/**
+ * Minimal stand-in for a Workflow binding that records the options it was called with.
+ * miniflare's Workflow binding ignores `retention` entirely, so asserting against a real
+ * binding would pass regardless of what this module does.
+ */
+function mockWorkflow<PARAMS = unknown>() {
+	const create = vi.fn(async (options?: WorkflowInstanceCreateOptions<PARAMS>) => ({
+		id: 'instance-1',
+		options,
+	}))
+	const createBatch = vi.fn(async (batch: WorkflowInstanceCreateOptions<PARAMS>[]) =>
+		batch.map((options, i) => ({ id: `instance-${i}`, options }))
+	)
+	return { create, createBatch } as unknown as Workflow<PARAMS> & {
+		create: typeof create
+		createBatch: typeof createBatch
+	}
+}
+
+describe('createWorkflow', () => {
+	it('applies the default retention policy', async () => {
+		const workflow = mockWorkflow()
+
+		await createWorkflow(workflow, { id: 'abc', params: { userId: '1' } })
+
+		expect(workflow.create).toHaveBeenCalledWith({
+			id: 'abc',
+			params: { userId: '1' },
+			retention: DEFAULT_WORKFLOW_RETENTION,
+		})
+	})
+
+	it('applies retention when called with no options', async () => {
+		const workflow = mockWorkflow()
+
+		await createWorkflow(workflow)
+
+		expect(workflow.create).toHaveBeenCalledWith({ retention: DEFAULT_WORKFLOW_RETENTION })
+	})
+
+	it('merges a partial override over the default, leaving the other field intact', async () => {
+		const workflow = mockWorkflow()
+
+		await createWorkflow(workflow, { retention: { successRetention: '6 hours' } })
+
+		expect(workflow.create).toHaveBeenCalledWith({
+			retention: {
+				successRetention: '6 hours',
+				errorRetention: DEFAULT_WORKFLOW_RETENTION.errorRetention,
+			},
+		})
+	})
+
+	it('falls back to the default when an override field is explicitly undefined', async () => {
+		const workflow = mockWorkflow()
+
+		// `strict` without `exactOptionalPropertyTypes` allows this; propagating the undefined
+		// would silently revert retention to the 30-day account default.
+		const options: CreateWorkflowOptions = { retention: { successRetention: undefined } }
+		await createWorkflow(workflow, options)
+
+		expect(workflow.create).toHaveBeenCalledWith({ retention: DEFAULT_WORKFLOW_RETENTION })
+	})
+
+	it('does not leak a `retention` key into params', async () => {
+		const workflow = mockWorkflow<{ userId: string }>()
+
+		await createWorkflow(workflow, { params: { userId: '1' } })
+
+		const [options] = workflow.create.mock.calls[0]!
+		expect(options?.params).toEqual({ userId: '1' })
+	})
+})
+
+describe('createWorkflowBatch', () => {
+	it('applies the default retention to every entry', async () => {
+		const workflow = mockWorkflow<{ billId: string }>()
+
+		await createWorkflowBatch(workflow, [
+			{ id: 'a', params: { billId: '1' } },
+			{ id: 'b', params: { billId: '2' } },
+		])
+
+		expect(workflow.createBatch).toHaveBeenCalledWith([
+			{ id: 'a', params: { billId: '1' }, retention: DEFAULT_WORKFLOW_RETENTION },
+			{ id: 'b', params: { billId: '2' }, retention: DEFAULT_WORKFLOW_RETENTION },
+		])
+	})
+
+	it('honors a per-entry override without affecting siblings', async () => {
+		const workflow = mockWorkflow()
+
+		await createWorkflowBatch(workflow, [
+			{ id: 'a', retention: { errorRetention: '30 days' } },
+			{ id: 'b' },
+		])
+
+		expect(workflow.createBatch).toHaveBeenCalledWith([
+			{
+				id: 'a',
+				retention: {
+					successRetention: DEFAULT_WORKFLOW_RETENTION.successRetention,
+					errorRetention: '30 days',
+				},
+			},
+			{ id: 'b', retention: DEFAULT_WORKFLOW_RETENTION },
+		])
+	})
+
+	it('passes an empty batch through without calling into a retention merge', async () => {
+		const workflow = mockWorkflow()
+
+		await createWorkflowBatch(workflow, [])
+
+		expect(workflow.createBatch).toHaveBeenCalledWith([])
+	})
+})
+
+describe('DEFAULT_WORKFLOW_RETENTION', () => {
+	it('uses string durations, never bare numbers (which the platform reads as milliseconds)', () => {
+		expect(typeof DEFAULT_WORKFLOW_RETENTION.successRetention).toBe('string')
+		expect(typeof DEFAULT_WORKFLOW_RETENTION.errorRetention).toBe('string')
+	})
+
+	it('retains success state well past the 15 minute pending-refresh TTL in apps/core', () => {
+		// apps/core/src/durable-object.ts PENDING_TTL_MS = 15 minutes bounds the longest
+		// read-back window in the repo; success retention must clear it with margin.
+		expect(DEFAULT_WORKFLOW_RETENTION.successRetention).toBe('1 hour')
+	})
+})

--- a/packages/workflow-utils/vitest.config.ts
+++ b/packages/workflow-utils/vitest.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vitest/config'
+import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config'
 
-export default defineConfig({
+// This package's sources import `cloudflare:workflows` / `cloudflare:workers`, which only
+// resolve inside the workers runtime — plain node vitest cannot collect these suites.
+export default defineWorkersConfig({
 	test: {
 		globals: true,
+		poolOptions: {
+			workers: {
+				wrangler: { configPath: './wrangler.jsonc' },
+			},
+		},
 	},
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,9 @@ importers:
       '@repo/worker-utils':
         specifier: workspace:*
         version: link:../../packages/worker-utils
+      '@repo/workflow-utils':
+        specifier: workspace:*
+        version: link:../../packages/workflow-utils
       drizzle-orm:
         specifier: 0.44.7
         version: 0.44.7(@cloudflare/workers-types@4.20260501.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(bun-types@1.3.2(@types/react@19.2.6))(mysql2@3.15.3)
@@ -2388,6 +2391,9 @@ importers:
       '@repo/worker-utils':
         specifier: workspace:*
         version: link:../../packages/worker-utils
+      '@repo/workflow-utils':
+        specifier: workspace:*
+        version: link:../../packages/workflow-utils
       drizzle-orm:
         specifier: 0.44.7
         version: 0.44.7(@cloudflare/workers-types@4.20260501.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(bun-types@1.3.2(@types/react@19.2.6))(mysql2@3.15.3)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Cloudflare Workflow instance retention was previously left unset (defaulting to the account maximum, 30 days on Paid). This PR introduces a shared `createWorkflow` / `createWorkflowBatch` helper in `@repo/workflow-utils` that applies an explicit `{ successRetention: '1 hour', errorRetention: '7 days' }` policy to every workflow instance, and routes all 27 existing creation call sites through it.

## Changes
- Add `createWorkflow` / `createWorkflowBatch` to `packages/workflow-utils/src/create-workflow.ts`, which merge a caller-supplied partial `retention` over `DEFAULT_WORKFLOW_RETENTION` (`successRetention: '1 hour'`, `errorRetention: '7 days'`) and reject the numeric-milliseconds form of `WorkflowRetentionDuration` at the type level.
- Replace direct `env.<WORKFLOW>.create()` / `.createBatch()` calls with the new helpers across `apps/bills`, `apps/core`, `apps/eve-character-data`, `apps/eve-corporation-data`, `apps/fulcrum`, `apps/markets`, and `apps/srp`.
- Add `@repo/workflow-utils` as a dependency of `apps/bills` and `apps/srp`, which previously had no way to reach it.
- Switch `packages/workflow-utils/vitest.config.ts` to `defineWorkersConfig` so its existing 20 tests (which import `cloudflare:workflows`) are actually collected and run.

## Testing
- Added `packages/workflow-utils/src/test/create-workflow.test.ts` covering the new helpers.
- Fixed the package's Vitest config so its test suite runs under `@cloudflare/vitest-pool-workers` instead of being silently skipped.
<!-- claude:end -->