### PR TITLE
fix(prediction-markets): use a valid positive twoOfNThreshold in the admin-override tests

### DIFF
--- a/apps/prediction-markets/src/test/integration/money-flow.int.test.ts
+++ b/apps/prediction-markets/src/test/integration/money-flow.int.test.ts
@@ -291,14 +291,16 @@ suite('bet idempotency', () => {
 suite('admin override resolve', () => {
 	it('lets a site admin resolve a market they created AND bet on, collapsing two-of-N in one step', async () => {
 		const [adminCreator, u1, u2] = [1, 3, 4].map(uuid)
-		// twoOfNThreshold '0' ⇒ requiresTwoOfN is true for EVERY market (pool ≥ 0), so a normal resolve
-		// would only PROPOSE and await a second distinct signer. rake 0 + reward band 0 keeps the payout
-		// arithmetic exact and self-contained.
+		// twoOfNThreshold '1' ⇒ requiresTwoOfN (pool >= threshold) is true for every market that has
+		// taken a bet, so a normal resolve would only PROPOSE and await a second distinct signer. The
+		// threshold must be a POSITIVE integer (updateConfig and the admin route both reject '0'), and
+		// '1' is the lowest value that means "always" for any market with money in it — which this one
+		// has. rake 0 + reward band 0 keeps the payout arithmetic exact and self-contained.
 		await governance.updateConfig(deps, {
 			actorUserId: ADMIN,
 			defaultRakeBps: 0,
 			defaultMinStake: '1',
-			twoOfNThreshold: '0',
+			twoOfNThreshold: '1',
 			creatorRewardMinBps: 0,
 			creatorRewardMaxBps: 0,
 		})
@@ -384,7 +386,9 @@ suite('admin override resolve', () => {
 			actorUserId: ADMIN,
 			defaultRakeBps: 0,
 			defaultMinStake: '1',
-			twoOfNThreshold: '0', // every market is two-of-N ⇒ a normal resolve only PROPOSES
+			// Lowest POSITIVE threshold ('0' is rejected): every market holding a bet is two-of-N ⇒ a
+			// normal resolve only PROPOSES.
+			twoOfNThreshold: '1',
 			creatorRewardMinBps: 0,
 			creatorRewardMaxBps: 0,
 		})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes two failing "admin override resolve" integration tests in the prediction-markets money-flow suite by replacing an invalid `twoOfNThreshold: '0'` with the lowest valid positive value, `'1'`.

## Changes
- In `apps/prediction-markets/src/test/integration/money-flow.int.test.ts`, changed `twoOfNThreshold` from `'0'` to `'1'` in both "admin override resolve" tests, since the threshold must be a positive integer (enforced by `updateConfig`, the admin route's zod refine, and the threshold-impact guard) and `'0'` caused `updateConfig` to throw `INVALID_THRESHOLD`.
- Updated the accompanying comments to explain that `'1'` is behaviourally equivalent to the original intent: since each test places bets before resolving, `requiresTwoOfN` (`totalPool >= threshold`) is still true for every market, so a normal resolve still only proposes and awaits a second signer.

## Testing
Verified against Postgres that all 9 money-flow tests now pass (previously 2 failed / 7 passed). This suite is opt-in via Neon credentials and is skipped in CI when `NEON_*` env vars are unset.
<!-- claude:end -->