### PR TITLE
feat: read-only services access audit (Mumble + Discord member-corp scan)

### DIFF
--- a/apps/core/.migrations/0043_whole_bromley.sql
+++ b/apps/core/.migrations/0043_whole_bromley.sql
@@ -1,0 +1,63 @@
+CREATE TABLE "service_access_audit_rows" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"main_character_id" text,
+	"main_character_name" text,
+	"eligible" boolean NOT NULL,
+	"reason" text NOT NULL,
+	"corporation_ids" text[] DEFAULT '{}' NOT NULL,
+	"has_discord_link" boolean DEFAULT false NOT NULL,
+	"mumble_status" text DEFAULT 'pending' NOT NULL,
+	"mumble_error_message" text,
+	"discord_status" text DEFAULT 'pending' NOT NULL,
+	"discord_error_message" text,
+	"mumble_login_name" text,
+	"mumble_display_name" text,
+	"mumble_groups" text[],
+	"mumble_was_enabled" boolean,
+	"discord_roles_removed" text[],
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "service_access_audit_rows_run_user_unique" UNIQUE("run_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "service_access_audit_runs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"scan_workflow_instance_id" text,
+	"enforce_workflow_instance_id" text,
+	"status" text DEFAULT 'scanning' NOT NULL,
+	"active_lock" text,
+	"initiated_by_user_id" uuid,
+	"enforced_by_user_id" uuid,
+	"enforce_reason" text,
+	"member_corporation_ids" text[] DEFAULT '{}' NOT NULL,
+	"member_corp_count" integer DEFAULT 0 NOT NULL,
+	"scanned" integer DEFAULT 0 NOT NULL,
+	"in_population" integer DEFAULT 0 NOT NULL,
+	"eligible_count" integer DEFAULT 0 NOT NULL,
+	"ineligible_count" integer DEFAULT 0 NOT NULL,
+	"blast_radius_tripped" boolean DEFAULT false NOT NULL,
+	"error_message" text,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"completed_at" timestamp with time zone,
+	"enforce_started_at" timestamp with time zone,
+	"enforce_completed_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "service_access_audit_runs_scan_workflow_instance_id_unique" UNIQUE("scan_workflow_instance_id"),
+	CONSTRAINT "service_access_audit_runs_enforce_workflow_instance_id_unique" UNIQUE("enforce_workflow_instance_id"),
+	CONSTRAINT "service_access_audit_runs_active_lock_unique" UNIQUE("active_lock")
+);
+--> statement-breakpoint
+ALTER TABLE "service_access_audit_rows" ADD CONSTRAINT "service_access_audit_rows_run_id_service_access_audit_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."service_access_audit_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "service_access_audit_rows" ADD CONSTRAINT "service_access_audit_rows_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD CONSTRAINT "service_access_audit_runs_initiated_by_user_id_users_id_fk" FOREIGN KEY ("initiated_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD CONSTRAINT "service_access_audit_runs_enforced_by_user_id_users_id_fk" FOREIGN KEY ("enforced_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "service_access_audit_rows_run_eligible_idx" ON "service_access_audit_rows" USING btree ("run_id","eligible");--> statement-breakpoint
+CREATE INDEX "service_access_audit_rows_run_reason_idx" ON "service_access_audit_rows" USING btree ("run_id","reason");--> statement-breakpoint
+CREATE INDEX "service_access_audit_rows_run_mumble_status_idx" ON "service_access_audit_rows" USING btree ("run_id","mumble_status");--> statement-breakpoint
+CREATE INDEX "service_access_audit_rows_run_discord_status_idx" ON "service_access_audit_rows" USING btree ("run_id","discord_status");--> statement-breakpoint
+CREATE INDEX "service_access_audit_runs_status_started_idx" ON "service_access_audit_runs" USING btree ("status","started_at");--> statement-breakpoint
+CREATE INDEX "service_access_audit_runs_expires_at_idx" ON "service_access_audit_runs" USING btree ("expires_at");

--- a/apps/core/.migrations/0044_shiny_the_order.sql
+++ b/apps/core/.migrations/0044_shiny_the_order.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "service_access_audit_runs" ADD COLUMN "basis_suspect" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD COLUMN "basis_compared_to_count" integer;--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD COLUMN "basis_removed_corporation_ids" text[];--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD COLUMN "basis_note" text;

--- a/apps/core/.migrations/meta/0043_snapshot.json
+++ b/apps/core/.migrations/meta/0043_snapshot.json
@@ -1,0 +1,5480 @@
+{
+  "id": "13d7aed0-c01e-4d14-8655-2b5fa935937e",
+  "prevId": "c9dc70f2-8f3e-4cb2-823c-2942631853f3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_destinations": {
+      "name": "alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_destinations_scope_idx": {
+          "name": "alert_destinations_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_alert_type_idx": {
+          "name": "alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_type_idx": {
+          "name": "alert_destinations_type_idx",
+          "columns": [
+            {
+              "expression": "destination_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_enabled_idx": {
+          "name": "alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_core_user_id_users_id_fk": {
+          "name": "alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_created_by_users_id_fk": {
+          "name": "alert_destinations_created_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_updated_by_users_id_fk": {
+          "name": "alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_configs": {
+      "name": "corporation_alert_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_ids": {
+          "name": "destination_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_alert_configs_corp_idx": {
+          "name": "corporation_alert_configs_corp_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_alert_type_idx": {
+          "name": "corporation_alert_configs_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_enabled_idx": {
+          "name": "corporation_alert_configs_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_corp_alert_type_idx": {
+          "name": "corporation_alert_configs_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_configs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_alert_configs_corp_alert_type_unique": {
+          "name": "corporation_alert_configs_corp_alert_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "alert_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_destinations": {
+      "name": "corporation_alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_alert_destinations_corp_id_idx": {
+          "name": "corp_alert_destinations_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_alert_type_idx": {
+          "name": "corp_alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_enabled_idx": {
+          "name": "corp_alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_corp_alert_type_idx": {
+          "name": "corp_alert_destinations_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_core_user_id_users_id_fk": {
+          "name": "corporation_alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_created_by_users_id_fk": {
+          "name": "corporation_alert_destinations_created_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_updated_by_users_id_fk": {
+          "name": "corporation_alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_invites": {
+      "name": "corporation_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_discord_invites_corp_id_idx": {
+          "name": "corporation_discord_invites_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_user_id_idx": {
+          "name": "corporation_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_server_id_idx": {
+          "name": "corporation_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_created_at_idx": {
+          "name": "corporation_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_user_id_users_id_fk": {
+          "name": "corporation_discord_invites_user_id_users_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_nickname_configs": {
+      "name": "corporation_discord_server_nickname_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'corp'"
+        },
+        "custom_ticker": {
+          "name": "custom_ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_nickname_configs_attachment_idx": {
+          "name": "corp_discord_server_nickname_configs_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_nickname_configs",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_nickname_config": {
+          "name": "unique_corp_discord_server_nickname_config",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_roles": {
+      "name": "corporation_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_roles_attachment_idx": {
+          "name": "corp_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_role": {
+          "name": "unique_corp_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_scenario_roles": {
+      "name": "corporation_discord_server_scenario_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_scenario_roles_attachment_idx": {
+          "name": "corp_discord_server_scenario_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_scenario_role": {
+          "name": "unique_corp_discord_server_scenario_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_servers": {
+      "name": "corporation_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_servers_corp_id_idx": {
+          "name": "corp_discord_servers_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_id_idx": {
+          "name": "corp_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_auto_assign_idx": {
+          "name": "corp_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"corporation_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_discord_servers_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server": {
+          "name": "unique_corp_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_categories": {
+      "name": "discord_command_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_categories_sort_order_idx": {
+          "name": "discord_command_categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_categories_name_unique": {
+          "name": "discord_command_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_permissions": {
+      "name": "discord_command_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_permissions_command_id_idx": {
+          "name": "discord_command_permissions_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_command_permissions_permission_id_idx": {
+          "name": "discord_command_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_command_permissions_command_id_discord_commands_id_fk": {
+          "name": "discord_command_permissions_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_command_permissions",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_permissions_command_permission_unique": {
+          "name": "discord_command_permissions_command_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_commands": {
+      "name": "discord_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static_response'"
+        },
+        "response_template": {
+          "name": "response_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_commands_name_idx": {
+          "name": "discord_commands_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_type_idx": {
+          "name": "discord_commands_type_idx",
+          "columns": [
+            {
+              "expression": "command_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_is_active_idx": {
+          "name": "discord_commands_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_category_id_idx": {
+          "name": "discord_commands_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_commands_category_id_discord_command_categories_id_fk": {
+          "name": "discord_commands_category_id_discord_command_categories_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "discord_command_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discord_commands_created_by_users_id_fk": {
+          "name": "discord_commands_created_by_users_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_commands_name_unique": {
+          "name": "discord_commands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_rows": {
+      "name": "discord_member_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discriminator": {
+          "name": "discriminator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_ids": {
+          "name": "role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "linked": {
+          "name": "linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_rows_run_linked_user_idx": {
+          "name": "discord_member_audit_rows_run_linked_user_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk": {
+          "name": "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "discord_member_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_rows_core_user_id_users_id_fk": {
+          "name": "discord_member_audit_rows_core_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_rows_run_discord_user_unique": {
+          "name": "discord_member_audit_rows_run_discord_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_runs": {
+      "name": "discord_member_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_count": {
+          "name": "linked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unlinked_count": {
+          "name": "unlinked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_runs_server_started_idx": {
+          "name": "discord_member_audit_runs_server_started_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_member_audit_runs_status_idx": {
+          "name": "discord_member_audit_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_runs_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_member_audit_runs_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "discord_member_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_runs_workflow_instance_id_unique": {
+          "name": "discord_member_audit_runs_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_roles": {
+      "name": "discord_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_roles_server_id_idx": {
+          "name": "discord_roles_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_roles_server_auto_apply_active_idx": {
+          "name": "discord_roles_server_auto_apply_active_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_apply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_roles\".\"auto_apply\" = true AND \"discord_roles\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_roles_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_roles_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_roles",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_discord_server_role": {
+          "name": "unique_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_server_commands": {
+      "name": "discord_server_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_command_id": {
+          "name": "discord_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_server_commands_server_id_idx": {
+          "name": "discord_server_commands_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_server_commands_command_id_idx": {
+          "name": "discord_server_commands_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_server_commands_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_server_commands_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_command_id_discord_commands_id_fk": {
+          "name": "discord_server_commands_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_created_by_users_id_fk": {
+          "name": "discord_server_commands_created_by_users_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_server_commands_server_command_unique": {
+          "name": "discord_server_commands_server_command_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "command_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_servers": {
+      "name": "discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "manage_nicknames": {
+          "name": "manage_nicknames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_servers_guild_id_idx": {
+          "name": "discord_servers_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_servers_active_idx": {
+          "name": "discord_servers_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_servers\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_servers_created_by_users_id_fk": {
+          "name": "discord_servers_created_by_users_id_fk",
+          "tableFrom": "discord_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_servers_guild_id_unique": {
+          "name": "discord_servers_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guild_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_decay_config": {
+      "name": "dkp_decay_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_decay_config_active_idx": {
+          "name": "dkp_decay_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dkp_decay_config\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_decay_config_effective_from_idx": {
+          "name": "dkp_decay_config_effective_from_idx",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_decay_config_created_by_users_id_fk": {
+          "name": "dkp_decay_config_created_by_users_id_fk",
+          "tableFrom": "dkp_decay_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_transactions": {
+      "name": "dkp_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_reason": {
+          "name": "award_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_transactions_user_earned_idx": {
+          "name": "dkp_transactions_user_earned_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_user_source_idx": {
+          "name": "dkp_transactions_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_character_earned_idx": {
+          "name": "dkp_transactions_character_earned_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_corp_earned_idx": {
+          "name": "dkp_transactions_corp_earned_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_earned_at_idx": {
+          "name": "dkp_transactions_earned_at_idx",
+          "columns": [
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_type_idx": {
+          "name": "dkp_transactions_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_id_idx": {
+          "name": "dkp_transactions_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_awarded_by_idx": {
+          "name": "dkp_transactions_awarded_by_idx",
+          "columns": [
+            {
+              "expression": "awarded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_transactions_user_id_users_id_fk": {
+          "name": "dkp_transactions_user_id_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "dkp_transactions_awarded_by_users_id_fk": {
+          "name": "dkp_transactions_awarded_by_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "awarded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_corporations": {
+      "name": "managed_corporations",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_character_id": {
+          "name": "assigned_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_character_name": {
+          "name": "assigned_character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "healthy_director_count": {
+          "name": "healthy_director_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_member_corporation": {
+          "name": "is_member_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_alt_corp": {
+          "name": "is_alt_corp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_special_purpose": {
+          "name": "is_special_purpose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recruiting": {
+          "name": "is_recruiting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_corporations_name_idx": {
+          "name": "managed_corporations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_ticker_idx": {
+          "name": "managed_corporations_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_assigned_character_id_idx": {
+          "name": "managed_corporations_assigned_character_id_idx",
+          "columns": [
+            {
+              "expression": "assigned_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_is_active_idx": {
+          "name": "managed_corporations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_background_refresh_idx": {
+          "name": "managed_corporations_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_structure_asset_sync_idx": {
+          "name": "managed_corporations_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_member_idx": {
+          "name": "managed_corporations_corporation_id_is_member_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_member_corporation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_alt_idx": {
+          "name": "managed_corporations_corporation_id_is_alt_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_alt_corp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_special_purpose_idx": {
+          "name": "managed_corporations_corporation_id_is_special_purpose_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_special_purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_corporations_configured_by_users_id_fk": {
+          "name": "managed_corporations_configured_by_users_id_fk",
+          "tableFrom": "managed_corporations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_credential_handoffs": {
+      "name": "mumble_tempop_credential_handoffs",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mumble_tempop_credential_handoffs_expires_at_idx": {
+          "name": "mumble_tempop_credential_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_credential_handoffs",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_guests": {
+      "name": "mumble_tempop_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corp_ticker": {
+          "name": "corp_ticker",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_name": {
+          "name": "login_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mumble_tempop_guests_tempop_id_idx": {
+          "name": "mumble_tempop_guests_tempop_id_idx",
+          "columns": [
+            {
+              "expression": "tempop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_guests",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempop_guests_subject_id_unique": {
+          "name": "mumble_tempop_guests_subject_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id"
+          ]
+        },
+        "mumble_tempop_guests_tempop_character_uq": {
+          "name": "mumble_tempop_guests_tempop_character_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tempop_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempops": {
+      "name": "mumble_tempops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mumble_tempops_status_expires_at_idx": {
+          "name": "mumble_tempops_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mumble_tempops_creator_user_id_idx": {
+          "name": "mumble_tempops_creator_user_id_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempops_creator_user_id_users_id_fk": {
+          "name": "mumble_tempops_creator_user_id_users_id_fk",
+          "tableFrom": "mumble_tempops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempops_short_code_unique": {
+          "name": "mumble_tempops_short_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_code"
+          ]
+        },
+        "mumble_tempops_key_hash_unique": {
+          "name": "mumble_tempops_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_type": {
+          "name": "flow_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_forum_config": {
+      "name": "pm_forum_config",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forum_channel_id": {
+          "name": "forum_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_open_id": {
+          "name": "tag_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_closed_id": {
+          "name": "tag_closed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_resolved_id": {
+          "name": "tag_resolved_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_voided_id": {
+          "name": "tag_voided_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_access_audit_rows": {
+      "name": "service_access_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible": {
+          "name": "eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_ids": {
+          "name": "corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "has_discord_link": {
+          "name": "has_discord_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mumble_status": {
+          "name": "mumble_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "mumble_error_message": {
+          "name": "mumble_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_status": {
+          "name": "discord_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "discord_error_message": {
+          "name": "discord_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_login_name": {
+          "name": "mumble_login_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_display_name": {
+          "name": "mumble_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_groups": {
+          "name": "mumble_groups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_was_enabled": {
+          "name": "mumble_was_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_roles_removed": {
+          "name": "discord_roles_removed",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_access_audit_rows_run_eligible_idx": {
+          "name": "service_access_audit_rows_run_eligible_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eligible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_reason_idx": {
+          "name": "service_access_audit_rows_run_reason_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_mumble_status_idx": {
+          "name": "service_access_audit_rows_run_mumble_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mumble_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_discord_status_idx": {
+          "name": "service_access_audit_rows_run_discord_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_access_audit_rows_run_id_service_access_audit_runs_id_fk": {
+          "name": "service_access_audit_rows_run_id_service_access_audit_runs_id_fk",
+          "tableFrom": "service_access_audit_rows",
+          "tableTo": "service_access_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_access_audit_rows_user_id_users_id_fk": {
+          "name": "service_access_audit_rows_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_access_audit_rows_run_user_unique": {
+          "name": "service_access_audit_rows_run_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_access_audit_runs": {
+      "name": "service_access_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_workflow_instance_id": {
+          "name": "scan_workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_workflow_instance_id": {
+          "name": "enforce_workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scanning'"
+        },
+        "active_lock": {
+          "name": "active_lock",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_by_user_id": {
+          "name": "enforced_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_reason": {
+          "name": "enforce_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_corporation_ids": {
+          "name": "member_corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "member_corp_count": {
+          "name": "member_corp_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "in_population": {
+          "name": "in_population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "eligible_count": {
+          "name": "eligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ineligible_count": {
+          "name": "ineligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blast_radius_tripped": {
+          "name": "blast_radius_tripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_started_at": {
+          "name": "enforce_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_completed_at": {
+          "name": "enforce_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_access_audit_runs_status_started_idx": {
+          "name": "service_access_audit_runs_status_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_runs_expires_at_idx": {
+          "name": "service_access_audit_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_access_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "service_access_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "service_access_audit_runs_enforced_by_user_id_users_id_fk": {
+          "name": "service_access_audit_runs_enforced_by_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enforced_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_access_audit_runs_scan_workflow_instance_id_unique": {
+          "name": "service_access_audit_runs_scan_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scan_workflow_instance_id"
+          ]
+        },
+        "service_access_audit_runs_enforce_workflow_instance_id_unique": {
+          "name": "service_access_audit_runs_enforce_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "enforce_workflow_instance_id"
+          ]
+        },
+        "service_access_audit_runs_active_lock_unique": {
+          "name": "service_access_audit_runs_active_lock_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_lock"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_services": {
+      "name": "core_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_services_enabled_idx": {
+          "name": "core_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_name_idx": {
+          "name": "core_services_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_slug_idx": {
+          "name": "core_services_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_external_links": {
+      "name": "sidebar_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidebar_external_links_sort_order_idx": {
+          "name": "sidebar_external_links_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_log": {
+      "name": "user_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_activity_log_user_id_idx": {
+          "name": "user_activity_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_action_idx": {
+          "name": "user_activity_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_timestamp_idx": {
+          "name": "user_activity_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_log_user_id_users_id_fk": {
+          "name": "user_activity_log_user_id_users_id_fk",
+          "tableFrom": "user_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_characters": {
+      "name": "user_characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_owner_hash": {
+          "name": "character_owner_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_character_refresh": {
+          "name": "last_character_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_characters_user_id_idx": {
+          "name": "user_characters_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_character_id_idx": {
+          "name": "user_characters_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_is_primary_idx": {
+          "name": "user_characters_is_primary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_status_idx": {
+          "name": "user_characters_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_deleted_idx": {
+          "name": "user_characters_deleted_idx",
+          "columns": [
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_id_idx": {
+          "name": "user_characters_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_id_idx": {
+          "name": "user_characters_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_name_idx": {
+          "name": "user_characters_corporation_name_idx",
+          "columns": [
+            {
+              "expression": "corporation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_name_idx": {
+          "name": "user_characters_alliance_name_idx",
+          "columns": [
+            {
+              "expression": "alliance_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_characters_user_id_users_id_fk": {
+          "name": "user_characters_user_id_users_id_fk",
+          "tableFrom": "user_characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_characters_character_id_unique": {
+          "name": "user_characters_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fingerprints": {
+      "name": "user_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_fingerprints_user_id_idx": {
+          "name": "user_fingerprints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_fingerprint_idx": {
+          "name": "user_fingerprints_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_user_id_fingerprint_idx": {
+          "name": "user_fingerprints_user_id_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fingerprints_user_id_users_id_fk": {
+          "name": "user_fingerprints_user_id_users_id_fk",
+          "tableFrom": "user_fingerprints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ip_addresses": {
+      "name": "user_ip_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addr": {
+          "name": "addr",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address_hash": {
+          "name": "ip_address_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_ip_addresses_user_id_idx": {
+          "name": "user_ip_addresses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_ip_addresses_ip_address_idx": {
+          "name": "user_ip_addresses_ip_address_idx",
+          "columns": [
+            {
+              "expression": "addr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ip_addresses_user_id_users_id_fk": {
+          "name": "user_ip_addresses_user_id_users_id_fk",
+          "tableFrom": "user_ip_addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_ip_addresses_user_ip_unique": {
+          "name": "user_ip_addresses_user_ip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "addr"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_user_services": {
+      "name": "core_user_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_user_services_user_id_idx": {
+          "name": "core_user_services_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_service_id_idx": {
+          "name": "core_user_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_user_id_service_id_idx": {
+          "name": "core_user_services_user_id_service_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_enabled_idx": {
+          "name": "core_user_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "core_user_services_user_id_users_id_fk": {
+          "name": "core_user_services_user_id_users_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "core_user_services_service_id_core_services_id_fk": {
+          "name": "core_user_services_service_id_core_services_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "core_services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_user_services_user_id_service_id_unique": {
+          "name": "core_user_services_user_id_service_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "service_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_session_token_idx": {
+          "name": "user_sessions_session_token_idx",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sessions_session_token_unique": {
+          "name": "user_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "immunitas": {
+          "name": "immunitas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_discord_refresh": {
+          "name": "last_discord_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "legacy_auth_user_id": {
+          "name": "legacy_auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_username": {
+          "name": "legacy_auth_user_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_email_hash": {
+          "name": "legacy_auth_user_email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow": {
+          "name": "last_refresh_workflow",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow_attempt": {
+          "name": "last_refresh_workflow_attempt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_main_character_id_idx": {
+          "name": "users_main_character_id_idx",
+          "columns": [
+            {
+              "expression": "main_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_discord_user_id_idx": {
+          "name": "users_discord_user_id_idx",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_discord_refresh_idx": {
+          "name": "users_last_discord_refresh_idx",
+          "columns": [
+            {
+              "expression": "last_discord_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_id_idx": {
+          "name": "users_legacy_auth_user_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_username_idx": {
+          "name": "users_legacy_auth_user_username_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_email_hash_idx": {
+          "name": "users_legacy_auth_user_email_hash_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_idx": {
+          "name": "users_last_refresh_workflow_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_attempt_idx": {
+          "name": "users_last_refresh_workflow_attempt_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow_attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_main_character_id_unique": {
+          "name": "users_main_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "main_character_id"
+          ]
+        },
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_user_id"
+          ]
+        },
+        "users_legacy_auth_user_id_unique": {
+          "name": "users_legacy_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_id"
+          ]
+        },
+        "users_legacy_auth_user_username_unique": {
+          "name": "users_legacy_auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_username"
+          ]
+        },
+        "users_legacy_auth_user_email_hash_unique": {
+          "name": "users_legacy_auth_user_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/.migrations/meta/0044_snapshot.json
+++ b/apps/core/.migrations/meta/0044_snapshot.json
@@ -1,0 +1,5505 @@
+{
+  "id": "dc107001-40bf-4609-914b-05f9aae1ec55",
+  "prevId": "13d7aed0-c01e-4d14-8655-2b5fa935937e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_destinations": {
+      "name": "alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_destinations_scope_idx": {
+          "name": "alert_destinations_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_alert_type_idx": {
+          "name": "alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_type_idx": {
+          "name": "alert_destinations_type_idx",
+          "columns": [
+            {
+              "expression": "destination_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_enabled_idx": {
+          "name": "alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_core_user_id_users_id_fk": {
+          "name": "alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_created_by_users_id_fk": {
+          "name": "alert_destinations_created_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_updated_by_users_id_fk": {
+          "name": "alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_configs": {
+      "name": "corporation_alert_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_ids": {
+          "name": "destination_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_alert_configs_corp_idx": {
+          "name": "corporation_alert_configs_corp_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_alert_type_idx": {
+          "name": "corporation_alert_configs_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_enabled_idx": {
+          "name": "corporation_alert_configs_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_corp_alert_type_idx": {
+          "name": "corporation_alert_configs_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_configs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_alert_configs_corp_alert_type_unique": {
+          "name": "corporation_alert_configs_corp_alert_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "alert_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_destinations": {
+      "name": "corporation_alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_alert_destinations_corp_id_idx": {
+          "name": "corp_alert_destinations_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_alert_type_idx": {
+          "name": "corp_alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_enabled_idx": {
+          "name": "corp_alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_corp_alert_type_idx": {
+          "name": "corp_alert_destinations_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_core_user_id_users_id_fk": {
+          "name": "corporation_alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_created_by_users_id_fk": {
+          "name": "corporation_alert_destinations_created_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_updated_by_users_id_fk": {
+          "name": "corporation_alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_invites": {
+      "name": "corporation_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_discord_invites_corp_id_idx": {
+          "name": "corporation_discord_invites_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_user_id_idx": {
+          "name": "corporation_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_server_id_idx": {
+          "name": "corporation_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_created_at_idx": {
+          "name": "corporation_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_user_id_users_id_fk": {
+          "name": "corporation_discord_invites_user_id_users_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_nickname_configs": {
+      "name": "corporation_discord_server_nickname_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'corp'"
+        },
+        "custom_ticker": {
+          "name": "custom_ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_nickname_configs_attachment_idx": {
+          "name": "corp_discord_server_nickname_configs_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_nickname_configs",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_nickname_config": {
+          "name": "unique_corp_discord_server_nickname_config",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_roles": {
+      "name": "corporation_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_roles_attachment_idx": {
+          "name": "corp_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_role": {
+          "name": "unique_corp_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_scenario_roles": {
+      "name": "corporation_discord_server_scenario_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_scenario_roles_attachment_idx": {
+          "name": "corp_discord_server_scenario_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_scenario_role": {
+          "name": "unique_corp_discord_server_scenario_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_servers": {
+      "name": "corporation_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_servers_corp_id_idx": {
+          "name": "corp_discord_servers_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_id_idx": {
+          "name": "corp_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_auto_assign_idx": {
+          "name": "corp_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"corporation_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_discord_servers_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server": {
+          "name": "unique_corp_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_categories": {
+      "name": "discord_command_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_categories_sort_order_idx": {
+          "name": "discord_command_categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_categories_name_unique": {
+          "name": "discord_command_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_permissions": {
+      "name": "discord_command_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_permissions_command_id_idx": {
+          "name": "discord_command_permissions_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_command_permissions_permission_id_idx": {
+          "name": "discord_command_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_command_permissions_command_id_discord_commands_id_fk": {
+          "name": "discord_command_permissions_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_command_permissions",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_permissions_command_permission_unique": {
+          "name": "discord_command_permissions_command_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_commands": {
+      "name": "discord_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static_response'"
+        },
+        "response_template": {
+          "name": "response_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_commands_name_idx": {
+          "name": "discord_commands_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_type_idx": {
+          "name": "discord_commands_type_idx",
+          "columns": [
+            {
+              "expression": "command_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_is_active_idx": {
+          "name": "discord_commands_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_category_id_idx": {
+          "name": "discord_commands_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_commands_category_id_discord_command_categories_id_fk": {
+          "name": "discord_commands_category_id_discord_command_categories_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "discord_command_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discord_commands_created_by_users_id_fk": {
+          "name": "discord_commands_created_by_users_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_commands_name_unique": {
+          "name": "discord_commands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_rows": {
+      "name": "discord_member_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discriminator": {
+          "name": "discriminator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_ids": {
+          "name": "role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "linked": {
+          "name": "linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_rows_run_linked_user_idx": {
+          "name": "discord_member_audit_rows_run_linked_user_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk": {
+          "name": "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "discord_member_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_rows_core_user_id_users_id_fk": {
+          "name": "discord_member_audit_rows_core_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_rows_run_discord_user_unique": {
+          "name": "discord_member_audit_rows_run_discord_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_runs": {
+      "name": "discord_member_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_count": {
+          "name": "linked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unlinked_count": {
+          "name": "unlinked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_runs_server_started_idx": {
+          "name": "discord_member_audit_runs_server_started_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_member_audit_runs_status_idx": {
+          "name": "discord_member_audit_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_runs_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_member_audit_runs_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "discord_member_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_runs_workflow_instance_id_unique": {
+          "name": "discord_member_audit_runs_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_roles": {
+      "name": "discord_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_roles_server_id_idx": {
+          "name": "discord_roles_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_roles_server_auto_apply_active_idx": {
+          "name": "discord_roles_server_auto_apply_active_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_apply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_roles\".\"auto_apply\" = true AND \"discord_roles\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_roles_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_roles_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_roles",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_discord_server_role": {
+          "name": "unique_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_server_commands": {
+      "name": "discord_server_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_command_id": {
+          "name": "discord_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_server_commands_server_id_idx": {
+          "name": "discord_server_commands_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_server_commands_command_id_idx": {
+          "name": "discord_server_commands_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_server_commands_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_server_commands_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_command_id_discord_commands_id_fk": {
+          "name": "discord_server_commands_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_created_by_users_id_fk": {
+          "name": "discord_server_commands_created_by_users_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_server_commands_server_command_unique": {
+          "name": "discord_server_commands_server_command_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "command_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_servers": {
+      "name": "discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "manage_nicknames": {
+          "name": "manage_nicknames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_servers_guild_id_idx": {
+          "name": "discord_servers_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_servers_active_idx": {
+          "name": "discord_servers_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_servers\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_servers_created_by_users_id_fk": {
+          "name": "discord_servers_created_by_users_id_fk",
+          "tableFrom": "discord_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_servers_guild_id_unique": {
+          "name": "discord_servers_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guild_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_decay_config": {
+      "name": "dkp_decay_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_decay_config_active_idx": {
+          "name": "dkp_decay_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dkp_decay_config\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_decay_config_effective_from_idx": {
+          "name": "dkp_decay_config_effective_from_idx",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_decay_config_created_by_users_id_fk": {
+          "name": "dkp_decay_config_created_by_users_id_fk",
+          "tableFrom": "dkp_decay_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_transactions": {
+      "name": "dkp_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_reason": {
+          "name": "award_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_transactions_user_earned_idx": {
+          "name": "dkp_transactions_user_earned_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_user_source_idx": {
+          "name": "dkp_transactions_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_character_earned_idx": {
+          "name": "dkp_transactions_character_earned_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_corp_earned_idx": {
+          "name": "dkp_transactions_corp_earned_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_earned_at_idx": {
+          "name": "dkp_transactions_earned_at_idx",
+          "columns": [
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_type_idx": {
+          "name": "dkp_transactions_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_id_idx": {
+          "name": "dkp_transactions_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_awarded_by_idx": {
+          "name": "dkp_transactions_awarded_by_idx",
+          "columns": [
+            {
+              "expression": "awarded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_transactions_user_id_users_id_fk": {
+          "name": "dkp_transactions_user_id_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "dkp_transactions_awarded_by_users_id_fk": {
+          "name": "dkp_transactions_awarded_by_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "awarded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_corporations": {
+      "name": "managed_corporations",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_character_id": {
+          "name": "assigned_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_character_name": {
+          "name": "assigned_character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "healthy_director_count": {
+          "name": "healthy_director_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_member_corporation": {
+          "name": "is_member_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_alt_corp": {
+          "name": "is_alt_corp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_special_purpose": {
+          "name": "is_special_purpose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recruiting": {
+          "name": "is_recruiting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_corporations_name_idx": {
+          "name": "managed_corporations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_ticker_idx": {
+          "name": "managed_corporations_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_assigned_character_id_idx": {
+          "name": "managed_corporations_assigned_character_id_idx",
+          "columns": [
+            {
+              "expression": "assigned_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_is_active_idx": {
+          "name": "managed_corporations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_background_refresh_idx": {
+          "name": "managed_corporations_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_structure_asset_sync_idx": {
+          "name": "managed_corporations_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_member_idx": {
+          "name": "managed_corporations_corporation_id_is_member_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_member_corporation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_alt_idx": {
+          "name": "managed_corporations_corporation_id_is_alt_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_alt_corp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_special_purpose_idx": {
+          "name": "managed_corporations_corporation_id_is_special_purpose_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_special_purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_corporations_configured_by_users_id_fk": {
+          "name": "managed_corporations_configured_by_users_id_fk",
+          "tableFrom": "managed_corporations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_credential_handoffs": {
+      "name": "mumble_tempop_credential_handoffs",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mumble_tempop_credential_handoffs_expires_at_idx": {
+          "name": "mumble_tempop_credential_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_credential_handoffs",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_guests": {
+      "name": "mumble_tempop_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corp_ticker": {
+          "name": "corp_ticker",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_name": {
+          "name": "login_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mumble_tempop_guests_tempop_id_idx": {
+          "name": "mumble_tempop_guests_tempop_id_idx",
+          "columns": [
+            {
+              "expression": "tempop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_guests",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempop_guests_subject_id_unique": {
+          "name": "mumble_tempop_guests_subject_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id"
+          ]
+        },
+        "mumble_tempop_guests_tempop_character_uq": {
+          "name": "mumble_tempop_guests_tempop_character_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tempop_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempops": {
+      "name": "mumble_tempops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mumble_tempops_status_expires_at_idx": {
+          "name": "mumble_tempops_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mumble_tempops_creator_user_id_idx": {
+          "name": "mumble_tempops_creator_user_id_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempops_creator_user_id_users_id_fk": {
+          "name": "mumble_tempops_creator_user_id_users_id_fk",
+          "tableFrom": "mumble_tempops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempops_short_code_unique": {
+          "name": "mumble_tempops_short_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_code"
+          ]
+        },
+        "mumble_tempops_key_hash_unique": {
+          "name": "mumble_tempops_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_type": {
+          "name": "flow_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_forum_config": {
+      "name": "pm_forum_config",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forum_channel_id": {
+          "name": "forum_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_open_id": {
+          "name": "tag_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_closed_id": {
+          "name": "tag_closed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_resolved_id": {
+          "name": "tag_resolved_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_voided_id": {
+          "name": "tag_voided_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_access_audit_rows": {
+      "name": "service_access_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible": {
+          "name": "eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_ids": {
+          "name": "corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "has_discord_link": {
+          "name": "has_discord_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mumble_status": {
+          "name": "mumble_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "mumble_error_message": {
+          "name": "mumble_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_status": {
+          "name": "discord_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "discord_error_message": {
+          "name": "discord_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_login_name": {
+          "name": "mumble_login_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_display_name": {
+          "name": "mumble_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_groups": {
+          "name": "mumble_groups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_was_enabled": {
+          "name": "mumble_was_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_roles_removed": {
+          "name": "discord_roles_removed",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_access_audit_rows_run_eligible_idx": {
+          "name": "service_access_audit_rows_run_eligible_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eligible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_reason_idx": {
+          "name": "service_access_audit_rows_run_reason_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_mumble_status_idx": {
+          "name": "service_access_audit_rows_run_mumble_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mumble_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_discord_status_idx": {
+          "name": "service_access_audit_rows_run_discord_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_access_audit_rows_run_id_service_access_audit_runs_id_fk": {
+          "name": "service_access_audit_rows_run_id_service_access_audit_runs_id_fk",
+          "tableFrom": "service_access_audit_rows",
+          "tableTo": "service_access_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_access_audit_rows_user_id_users_id_fk": {
+          "name": "service_access_audit_rows_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_access_audit_rows_run_user_unique": {
+          "name": "service_access_audit_rows_run_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_access_audit_runs": {
+      "name": "service_access_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_workflow_instance_id": {
+          "name": "scan_workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_workflow_instance_id": {
+          "name": "enforce_workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scanning'"
+        },
+        "active_lock": {
+          "name": "active_lock",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_by_user_id": {
+          "name": "enforced_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_reason": {
+          "name": "enforce_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_corporation_ids": {
+          "name": "member_corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "member_corp_count": {
+          "name": "member_corp_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "basis_suspect": {
+          "name": "basis_suspect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "basis_compared_to_count": {
+          "name": "basis_compared_to_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_removed_corporation_ids": {
+          "name": "basis_removed_corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_note": {
+          "name": "basis_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "in_population": {
+          "name": "in_population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "eligible_count": {
+          "name": "eligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ineligible_count": {
+          "name": "ineligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blast_radius_tripped": {
+          "name": "blast_radius_tripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_started_at": {
+          "name": "enforce_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_completed_at": {
+          "name": "enforce_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_access_audit_runs_status_started_idx": {
+          "name": "service_access_audit_runs_status_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_runs_expires_at_idx": {
+          "name": "service_access_audit_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_access_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "service_access_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "service_access_audit_runs_enforced_by_user_id_users_id_fk": {
+          "name": "service_access_audit_runs_enforced_by_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enforced_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_access_audit_runs_scan_workflow_instance_id_unique": {
+          "name": "service_access_audit_runs_scan_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scan_workflow_instance_id"
+          ]
+        },
+        "service_access_audit_runs_enforce_workflow_instance_id_unique": {
+          "name": "service_access_audit_runs_enforce_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "enforce_workflow_instance_id"
+          ]
+        },
+        "service_access_audit_runs_active_lock_unique": {
+          "name": "service_access_audit_runs_active_lock_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_lock"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_services": {
+      "name": "core_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_services_enabled_idx": {
+          "name": "core_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_name_idx": {
+          "name": "core_services_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_slug_idx": {
+          "name": "core_services_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_external_links": {
+      "name": "sidebar_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidebar_external_links_sort_order_idx": {
+          "name": "sidebar_external_links_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_log": {
+      "name": "user_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_activity_log_user_id_idx": {
+          "name": "user_activity_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_action_idx": {
+          "name": "user_activity_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_timestamp_idx": {
+          "name": "user_activity_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_log_user_id_users_id_fk": {
+          "name": "user_activity_log_user_id_users_id_fk",
+          "tableFrom": "user_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_characters": {
+      "name": "user_characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_owner_hash": {
+          "name": "character_owner_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_character_refresh": {
+          "name": "last_character_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_characters_user_id_idx": {
+          "name": "user_characters_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_character_id_idx": {
+          "name": "user_characters_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_is_primary_idx": {
+          "name": "user_characters_is_primary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_status_idx": {
+          "name": "user_characters_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_deleted_idx": {
+          "name": "user_characters_deleted_idx",
+          "columns": [
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_id_idx": {
+          "name": "user_characters_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_id_idx": {
+          "name": "user_characters_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_name_idx": {
+          "name": "user_characters_corporation_name_idx",
+          "columns": [
+            {
+              "expression": "corporation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_name_idx": {
+          "name": "user_characters_alliance_name_idx",
+          "columns": [
+            {
+              "expression": "alliance_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_characters_user_id_users_id_fk": {
+          "name": "user_characters_user_id_users_id_fk",
+          "tableFrom": "user_characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_characters_character_id_unique": {
+          "name": "user_characters_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fingerprints": {
+      "name": "user_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_fingerprints_user_id_idx": {
+          "name": "user_fingerprints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_fingerprint_idx": {
+          "name": "user_fingerprints_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_user_id_fingerprint_idx": {
+          "name": "user_fingerprints_user_id_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fingerprints_user_id_users_id_fk": {
+          "name": "user_fingerprints_user_id_users_id_fk",
+          "tableFrom": "user_fingerprints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ip_addresses": {
+      "name": "user_ip_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addr": {
+          "name": "addr",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address_hash": {
+          "name": "ip_address_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_ip_addresses_user_id_idx": {
+          "name": "user_ip_addresses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_ip_addresses_ip_address_idx": {
+          "name": "user_ip_addresses_ip_address_idx",
+          "columns": [
+            {
+              "expression": "addr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ip_addresses_user_id_users_id_fk": {
+          "name": "user_ip_addresses_user_id_users_id_fk",
+          "tableFrom": "user_ip_addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_ip_addresses_user_ip_unique": {
+          "name": "user_ip_addresses_user_ip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "addr"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_user_services": {
+      "name": "core_user_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_user_services_user_id_idx": {
+          "name": "core_user_services_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_service_id_idx": {
+          "name": "core_user_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_user_id_service_id_idx": {
+          "name": "core_user_services_user_id_service_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_enabled_idx": {
+          "name": "core_user_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "core_user_services_user_id_users_id_fk": {
+          "name": "core_user_services_user_id_users_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "core_user_services_service_id_core_services_id_fk": {
+          "name": "core_user_services_service_id_core_services_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "core_services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_user_services_user_id_service_id_unique": {
+          "name": "core_user_services_user_id_service_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "service_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_session_token_idx": {
+          "name": "user_sessions_session_token_idx",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sessions_session_token_unique": {
+          "name": "user_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "immunitas": {
+          "name": "immunitas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_discord_refresh": {
+          "name": "last_discord_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "legacy_auth_user_id": {
+          "name": "legacy_auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_username": {
+          "name": "legacy_auth_user_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_email_hash": {
+          "name": "legacy_auth_user_email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow": {
+          "name": "last_refresh_workflow",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow_attempt": {
+          "name": "last_refresh_workflow_attempt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_main_character_id_idx": {
+          "name": "users_main_character_id_idx",
+          "columns": [
+            {
+              "expression": "main_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_discord_user_id_idx": {
+          "name": "users_discord_user_id_idx",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_discord_refresh_idx": {
+          "name": "users_last_discord_refresh_idx",
+          "columns": [
+            {
+              "expression": "last_discord_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_id_idx": {
+          "name": "users_legacy_auth_user_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_username_idx": {
+          "name": "users_legacy_auth_user_username_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_email_hash_idx": {
+          "name": "users_legacy_auth_user_email_hash_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_idx": {
+          "name": "users_last_refresh_workflow_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_attempt_idx": {
+          "name": "users_last_refresh_workflow_attempt_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow_attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_main_character_id_unique": {
+          "name": "users_main_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "main_character_id"
+          ]
+        },
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_user_id"
+          ]
+        },
+        "users_legacy_auth_user_id_unique": {
+          "name": "users_legacy_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_id"
+          ]
+        },
+        "users_legacy_auth_user_username_unique": {
+          "name": "users_legacy_auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_username"
+          ]
+        },
+        "users_legacy_auth_user_email_hash_unique": {
+          "name": "users_legacy_auth_user_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/.migrations/meta/_journal.json
+++ b/apps/core/.migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1783567591406,
       "tag": "0042_even_blazing_skull",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1784157634176,
+      "tag": "0043_whole_bromley",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/.migrations/meta/_journal.json
+++ b/apps/core/.migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1784157634176,
       "tag": "0043_whole_bromley",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784160455764,
+      "tag": "0044_shiny_the_order",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/__tests__/service-access-audit-schema.test.ts
+++ b/apps/core/src/__tests__/service-access-audit-schema.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDb } from '../db'
+import { SERVICE_ELIGIBILITY_REASONS } from '../db/schema'
+
+import type { ServiceEligibilityReason } from '../lib/service-eligibility'
+
+/**
+ * NOTE ON HOW REGISTRATION ACTUALLY WORKS HERE — this is counter-intuitive and
+ * was got wrong once already.
+ *
+ * db/index.ts does `import * as schema from './schema'` and hands that MODULE
+ * NAMESPACE to drizzle, so every exported pgTable and Relations object is picked
+ * up automatically. A table is registered by being `export`ed — nothing more.
+ *
+ * The hand-maintained `export const schema = { ... }` list at the bottom of
+ * schema.ts is NOT what drizzle consumes and has no consumer at all; several
+ * live tables (pm_forum_config among them) are absent from it and work fine. New
+ * tables are added to it for consistency with the file's convention, but do not
+ * believe an assertion on that object — it proves nothing.
+ *
+ * What these tests pin is the real failure mode: a table that is defined but not
+ * exported gets no `db.query` namespace, and fails at runtime rather than at
+ * typecheck (`db.insert(table)` still compiles).
+ */
+describe('service access audit schema', () => {
+	const db = createDb('postgresql://user:pass@localhost/db')
+	const query = db.query as Record<string, unknown>
+
+	it('exposes a db.query namespace for both audit tables', () => {
+		expect(query.serviceAccessAuditRuns).toBeDefined()
+		expect(query.serviceAccessAuditRows).toBeDefined()
+	})
+
+	it('proves that check is not vacuous: an unknown table has no namespace', () => {
+		// Guards the assertion above against silently passing for any name at all.
+		expect(query.serviceAccessAuditNonsense).toBeUndefined()
+	})
+
+	it('can follow the run -> rows relation', async () => {
+		// Relations are picked up from the module namespace too. If the *Relations
+		// exports were dropped, `with: { rows: true }` would throw here rather than
+		// at some later runtime. The query is never executed — building it is the
+		// assertion, so no database is touched.
+		expect(() =>
+			db.query.serviceAccessAuditRuns.findFirst({ with: { rows: true } }).toSQL()
+		).not.toThrow()
+	})
+
+	it('can follow the row -> run and row -> user relations', () => {
+		expect(() =>
+			db.query.serviceAccessAuditRows.findFirst({ with: { run: true, user: true } }).toSQL()
+		).not.toThrow()
+	})
+
+	it('can follow both users FKs on a run independently', () => {
+		// initiatedByUserId and enforcedByUserId both point at `users`, so this is
+		// the query that would break if they were ever conflated.
+		expect(() =>
+			db.query.serviceAccessAuditRuns
+				.findFirst({ with: { initiatedByUser: true, enforcedByUser: true } })
+				.toSQL()
+		).not.toThrow()
+	})
+})
+
+describe('eligibility reason enum', () => {
+	it('is the single source for both the Postgres enum and the TS union', () => {
+		// If these drift, the scan writes a reason the column rejects. The typed
+		// assignment is the compile-time half; the list is the runtime half.
+		const reasons: ServiceEligibilityReason[] = [...SERVICE_ELIGIBILITY_REASONS]
+		expect(reasons).toEqual([
+			'member_corp',
+			'admin_exempt',
+			'no_characters',
+			'null_corp',
+			'only_deleted_member_char',
+			'unmanaged_corp',
+			'no_user_row',
+		])
+	})
+
+	it('partitions cleanly into eligible and ineligible reasons', () => {
+		const eligible: ServiceEligibilityReason[] = ['member_corp', 'admin_exempt']
+		const ineligible = SERVICE_ELIGIBILITY_REASONS.filter((reason) => !eligible.includes(reason))
+		// A newly added reason must be deliberately classified rather than silently
+		// defaulting to "ineligible" in a UI breakdown.
+		expect(eligible.length + ineligible.length).toBe(SERVICE_ELIGIBILITY_REASONS.length)
+		expect(ineligible).not.toContain('member_corp')
+	})
+})

--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -12,6 +12,7 @@ import type { CsvExportWorkflowParams } from './workflows/csv-export.workflow'
 import type { UserDiscordRefreshWorkflowParams } from './workflows/user-discord-refresh.workflow'
 import type { UserMumbleRefreshWorkflowParams } from './workflows/user-mumble-refresh.workflow'
 import type { DiscordMemberAuditWorkflowParams } from './workflows/discord-member-audit.workflow'
+import type { ServiceAccessAuditWorkflowParams } from './workflows/service-access-audit.workflow'
 import type { UserRefreshWorkflowParams } from './workflows/user-refresh.workflow'
 
 export type Env = SharedHonoEnv & {
@@ -68,6 +69,8 @@ export type Env = SharedHonoEnv & {
 	USER_DISCORD_REFRESH_WORKFLOW: Workflow<UserDiscordRefreshWorkflowParams>
 	/** Discord Member Audit Workflow binding */
 	DISCORD_MEMBER_AUDIT_WORKFLOW: Workflow<DiscordMemberAuditWorkflowParams>
+	/** Service Access Audit Workflow binding (read-only eligibility scan) */
+	SERVICE_ACCESS_AUDIT_WORKFLOW: Workflow<ServiceAccessAuditWorkflowParams>
 	/** User Mumble Refresh Workflow binding */
 	USER_MUMBLE_REFRESH_WORKFLOW: Workflow<UserMumbleRefreshWorkflowParams>
 	/** CSV Export Workflow binding */

--- a/apps/core/src/db/schema.ts
+++ b/apps/core/src/db/schema.ts
@@ -1454,6 +1454,25 @@ export const serviceAccessAuditRuns = pgTable(
 		 */
 		memberCorporationIds: text('member_corporation_ids').array().notNull().default([]),
 		memberCorpCount: integer('member_corp_count').notNull().default(0),
+		/**
+		 * The basis shrank against the recent high-water mark. INFORMATIONAL for a
+		 * scan — a scan is read-only and blocking it would refuse the tool's primary
+		 * use case, since de-flagging corps is how a corp legitimately stops being a
+		 * member corp AND it shrinks the basis by construction.
+		 * ENFORCEMENT MUST HARD-REFUSE on a suspect, unacknowledged basis.
+		 */
+		basisSuspect: boolean('basis_suspect').notNull().default(false),
+		/** The high-water count this run's basis was compared against; null on the
+		 * bootstrap run, where nothing has validated the basis. */
+		basisComparedToCount: integer('basis_compared_to_count'),
+		/**
+		 * Exactly which corporations left the basis since the high-water run. A
+		 * count ratio cannot distinguish "an operator de-flagged 13 corps" from "the
+		 * table got truncated"; this list lets a human do it in seconds.
+		 */
+		basisRemovedCorporationIds: text('basis_removed_corporation_ids').array(),
+		/** Operator-facing explanation of the diff; null unless basisSuspect. */
+		basisNote: text('basis_note'),
 		/** Every user row walked, including eligible ones. */
 		scanned: integer('scanned').notNull().default(0),
 		/** Users holding a Mumble account or a Discord link — reported alongside

--- a/apps/core/src/db/schema.ts
+++ b/apps/core/src/db/schema.ts
@@ -1364,6 +1364,257 @@ export const mumbleTempopGuestsRelations = relations(mumbleTempopGuests, ({ one 
 }))
 
 /**
+ * Why a user landed on the eligible/ineligible side of the services rule.
+ *
+ * Declared here rather than in lib/service-eligibility.ts so the Postgres enum
+ * and the TypeScript union are literally the same list and cannot drift — the
+ * rule module imports this. (The dependency only runs this direction:
+ * service-eligibility.ts already imports this schema, so the reverse would be a
+ * cycle.)
+ *
+ * Diagnostic only: a subcode never changes the outcome. "3,900 null_corp" is a
+ * recognisably broken ESI sync; "3,900 ineligible" is unreviewable at 04:00.
+ */
+export const SERVICE_ELIGIBILITY_REASONS = [
+	/** Eligible: a non-deleted character sits in a member corporation. */
+	'member_corp',
+	/** Eligible: no member-corp attachment, but `users.is_admin`. */
+	'admin_exempt',
+	/** Ineligible: no non-deleted characters at all. */
+	'no_characters',
+	/** Ineligible: characters exist, every one has a NULL corporation. */
+	'null_corp',
+	/** Ineligible: the qualifying character(s) are soft-deleted. */
+	'only_deleted_member_char',
+	/** Ineligible: has corporations, none flagged `is_member_corporation`. */
+	'unmanaged_corp',
+	/** Ineligible: no `users` row exists. */
+	'no_user_row',
+] as const
+
+/**
+ * Service Access Audit Runs
+ *
+ * Break-glass tool: scan every user against the member-corporation rule, review
+ * the blast radius, then on explicit confirmation revoke the ineligible.
+ *
+ * NOT a reuse of discord_member_audit_runs/rows. That pair is guild-scoped
+ * (discord_server_id NOT NULL cascade) and keyed unique(run_id, discord_user_id)
+ * with discord_user_id NOT NULL. This audit is user-keyed and MUST include users
+ * with no Discord account at all, so reuse would mean nullable-ing five NOT NULL
+ * columns and rekeying a live table.
+ */
+export const serviceAccessAuditRuns = pgTable(
+	'service_access_audit_runs',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		scanWorkflowInstanceId: text('scan_workflow_instance_id').unique(),
+		enforceWorkflowInstanceId: text('enforce_workflow_instance_id').unique(),
+		status: text('status', {
+			enum: [
+				/** Scan in flight. */
+				'scanning',
+				/** A basis assertion tripped. Terminal, and NOT overridable. */
+				'blocked',
+				/** Scan done, ineligible users found, waiting on a human. */
+				'awaiting_confirmation',
+				/** Enforcement in flight. */
+				'enforcing',
+				'completed',
+				/** Enforced, but some rows failed. Distinct so it cannot read as clean. */
+				'completed_with_errors',
+				'failed',
+				'cancelled',
+			],
+		})
+			.notNull()
+			.default('scanning'),
+		/**
+		 * Holds a constant while the run is non-terminal, NULL once terminal.
+		 * Postgres ignores NULLs in unique indexes, so this permits exactly one
+		 * live run and a concurrent insert 23505s. No DO, no distributed lock.
+		 */
+		activeLock: text('active_lock'),
+		/** 'set null', NOT the precedent's cascade: deleting the admin must not
+		 * erase the record of what they did. */
+		initiatedByUserId: uuid('initiated_by_user_id').references(() => users.id, {
+			onDelete: 'set null',
+		}),
+		enforcedByUserId: uuid('enforced_by_user_id').references(() => users.id, {
+			onDelete: 'set null',
+		}),
+		/** Free-text justification captured at confirmation time. */
+		enforceReason: text('enforce_reason'),
+		/**
+		 * THE ELIGIBILITY BASIS, snapshotted. `is_member_corporation` is
+		 * `.default(false).notNull()` — the basis defaults to the REVOKING value, so
+		 * an empty or half-restored managed_corporations does not degrade the rule,
+		 * it inverts it. Snapshotted so a run can be audited after the fact and so
+		 * the next run can assert the basis did not shrink.
+		 */
+		memberCorporationIds: text('member_corporation_ids').array().notNull().default([]),
+		memberCorpCount: integer('member_corp_count').notNull().default(0),
+		/** Every user row walked, including eligible ones. */
+		scanned: integer('scanned').notNull().default(0),
+		/** Users holding a Mumble account or a Discord link — reported alongside
+		 * `scanned` and never instead of it: an emergency tool must not silently
+		 * narrow its own denominator. */
+		inPopulation: integer('in_population').notNull().default(0),
+		eligibleCount: integer('eligible_count').notNull().default(0),
+		ineligibleCount: integer('ineligible_count').notNull().default(0),
+		/** Set when the >20% heuristic trips; overridable by the typed phrase,
+		 * unlike a basis assertion. */
+		blastRadiusTripped: boolean('blast_radius_tripped').notNull().default(false),
+		errorMessage: text('error_message'),
+		startedAt: timestamp('started_at', { withTimezone: true }).defaultNow().notNull(),
+		completedAt: timestamp('completed_at', { withTimezone: true }),
+		enforceStartedAt: timestamp('enforce_started_at', { withTimezone: true }),
+		enforceCompletedAt: timestamp('enforce_completed_at', { withTimezone: true }),
+		/** Retention horizon. Swept by a FILTERED branch that must never touch a
+		 * live run — unlike the discord-audit cleanup, which truncates
+		 * unconditionally at midnight. */
+		expiresAt: timestamp('expires_at', { withTimezone: true }),
+		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+	},
+	(table) => [
+		index('service_access_audit_runs_status_started_idx').on(table.status, table.startedAt),
+		index('service_access_audit_runs_expires_at_idx').on(table.expiresAt),
+		unique('service_access_audit_runs_active_lock_unique').on(table.activeLock),
+	]
+)
+
+/**
+ * Service Access Audit Rows — one per user per run.
+ *
+ * Unlike the discord-audit rows (write-once inserts, wiped wholesale), these are
+ * mutated by enforcement, hence `updatedAt` and the per-service statuses.
+ */
+export const serviceAccessAuditRows = pgTable(
+	'service_access_audit_rows',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		runId: uuid('run_id')
+			.notNull()
+			.references(() => serviceAccessAuditRuns.id, { onDelete: 'cascade' }),
+		userId: uuid('user_id')
+			.notNull()
+			.references(() => users.id, { onDelete: 'cascade' }),
+		/** Snapshotted so the row stays readable when the character is renamed or
+		 * unlinked. Counts are abstract; names are not. */
+		mainCharacterId: text('main_character_id'),
+		mainCharacterName: text('main_character_name'),
+		eligible: boolean('eligible').notNull(),
+		reason: text('reason', { enum: SERVICE_ELIGIBILITY_REASONS }).notNull(),
+		/** Corporations held at scan time — the evidence for the verdict. */
+		corporationIds: text('corporation_ids').array().notNull().default([]),
+		hasDiscordLink: boolean('has_discord_link').notNull().default(false),
+
+		/**
+		 * Mumble enforcement outcome.
+		 * `queued` is NOT `deleted`: the DO persists control-plane failures and
+		 * retries by alarm, so the account is live until observed absent.
+		 * `confirmed_absent` is the ONLY value that may count toward the number
+		 * shown to an operator — a mutation's own return value must never be the
+		 * evidence of its success.
+		 */
+		mumbleStatus: text('mumble_status', {
+			enum: [
+				'pending',
+				'skipped',
+				'not_provisioned',
+				'queued',
+				'confirmed_absent',
+				'verify_failed',
+				'failed',
+				'unknown',
+			],
+		})
+			.notNull()
+			.default('pending'),
+		mumbleErrorMessage: text('mumble_error_message'),
+		/**
+		 * Discord enforcement outcome.
+		 * `not_in_guild` is a terminal SUCCESS (access is definitionally revoked),
+		 * not a failure. `no_op_unverified` is the amber case where the primitive
+		 * returned no per-guild results at all — indistinguishable from "did
+		 * nothing", so it is never counted as stripped.
+		 */
+		discordStatus: text('discord_status', {
+			enum: [
+				'pending',
+				'skipped',
+				'not_linked',
+				'stripped',
+				'no_change',
+				'not_in_guild',
+				'no_op_unverified',
+				'failed',
+				'unknown',
+			],
+		})
+			.notNull()
+			.default('pending'),
+		discordErrorMessage: text('discord_error_message'),
+
+		/**
+		 * RECONSTRUCTION SNAPSHOT — captured BEFORE the mutation, by the worker
+		 * that mutates. Mumble deletion is irreversible and there is no bulk
+		 * re-provision, so this is the only record of what existed. Do not cut it.
+		 */
+		mumbleLoginName: text('mumble_login_name'),
+		mumbleDisplayName: text('mumble_display_name'),
+		mumbleGroups: text('mumble_groups').array(),
+		mumbleWasEnabled: boolean('mumble_was_enabled'),
+		/** Written by the enforcement child from its own return value. */
+		discordRolesRemoved: text('discord_roles_removed').array(),
+
+		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+	},
+	(table) => [
+		index('service_access_audit_rows_run_eligible_idx').on(table.runId, table.eligible),
+		index('service_access_audit_rows_run_reason_idx').on(table.runId, table.reason),
+		index('service_access_audit_rows_run_mumble_status_idx').on(table.runId, table.mumbleStatus),
+		index('service_access_audit_rows_run_discord_status_idx').on(table.runId, table.discordStatus),
+		unique('service_access_audit_rows_run_user_unique').on(table.runId, table.userId),
+	]
+)
+
+export const serviceAccessAuditRunsRelations = relations(
+	serviceAccessAuditRuns,
+	({ one, many }) => ({
+		// Both FKs point at `users`. relationName is not strictly required while
+		// usersRelations declares no back-reference to this table (fields/references
+		// are explicit, so drizzle can already tell them apart) — it is set so that
+		// adding a `many(serviceAccessAuditRuns)` there later cannot make the pair
+		// ambiguous.
+		initiatedByUser: one(users, {
+			fields: [serviceAccessAuditRuns.initiatedByUserId],
+			references: [users.id],
+			relationName: 'serviceAccessAuditRunInitiatedBy',
+		}),
+		enforcedByUser: one(users, {
+			fields: [serviceAccessAuditRuns.enforcedByUserId],
+			references: [users.id],
+			relationName: 'serviceAccessAuditRunEnforcedBy',
+		}),
+		rows: many(serviceAccessAuditRows),
+	})
+)
+
+export const serviceAccessAuditRowsRelations = relations(serviceAccessAuditRows, ({ one }) => ({
+	run: one(serviceAccessAuditRuns, {
+		fields: [serviceAccessAuditRows.runId],
+		references: [serviceAccessAuditRuns.id],
+	}),
+	user: one(users, {
+		fields: [serviceAccessAuditRows.userId],
+		references: [users.id],
+	}),
+}))
+
+/**
  * Export schema for db client
  */
 export const schema = {
@@ -1396,6 +1647,8 @@ export const schema = {
 	mumbleTempops,
 	mumbleTempopGuests,
 	mumbleTempopCredentialHandoffs,
+	serviceAccessAuditRuns,
+	serviceAccessAuditRows,
 	usersRelations,
 	userCharactersRelations,
 	userSessionsRelations,
@@ -1421,6 +1674,8 @@ export const schema = {
 	dkpDecayConfigRelations,
 	mumbleTempopsRelations,
 	mumbleTempopGuestsRelations,
+	serviceAccessAuditRunsRelations,
+	serviceAccessAuditRowsRelations,
 }
 
 /**

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -63,6 +63,7 @@ import { handleOAuthDevProxyRequest, isOAuthDevProxyPath } from './routes/oauth-
 import pastesRoutes, { publicPasteRoutes } from './routes/pastes'
 import predictionMarketsRoutes from './routes/prediction-markets'
 import predictionMarketsAdminRoutes from './routes/prediction-markets-admin'
+import servicesAuditRoutes from './routes/services-audit'
 import sessionRoutes from './routes/session'
 import skillPlansRoutes from './routes/skill-plans'
 import skillsRoutes from './routes/skills'
@@ -163,6 +164,7 @@ const app = new Hono<App>()
 	.route('/api/corporation-tax', corporationTaxRoutes)
 	.route('/api/corporations', corporationsRoutes)
 	.route('/api/discord-servers', discordServersRoutes)
+	.route('/api/services-audit', servicesAuditRoutes) // Read-only service access audit (admin)
 	.route('/api/discord-commands', discordCommandsRoutes)
 	.route('/api/dkp', dkpRoutes)
 	.route('/api/doctrines', doctrinesRoutes)
@@ -1185,3 +1187,4 @@ export { UserDiscordRefreshWorkflow } from './workflows/user-discord-refresh.wor
 export { DiscordMemberAuditWorkflow } from './workflows/discord-member-audit.workflow'
 export { UserMumbleRefreshWorkflow } from './workflows/user-mumble-refresh.workflow'
 export { CsvExportWorkflow } from './workflows/csv-export.workflow'
+export { ServiceAccessAuditWorkflow } from './workflows/service-access-audit.workflow'

--- a/apps/core/src/lib/__tests__/service-eligibility-basis.test.ts
+++ b/apps/core/src/lib/__tests__/service-eligibility-basis.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { evaluateBasis, evaluateBlastRadius, getBasisBaseline } from '../service-eligibility-basis'
+
+import type { BasisBaseline } from '../service-eligibility-basis'
+
+/**
+ * THE BASIS GUARD'S TESTS.
+ *
+ * `evaluateBasis` is pure precisely so it can be pinned exhaustively without a
+ * Postgres fixture. This is the logic whose failure is silent and catastrophic in
+ * BOTH directions:
+ *
+ *  - Too lax on a collapsed basis: the scan reports that nearly every non-admin
+ *    should lose their account, the admins reading it are exempt and see nothing
+ *    wrong with their own access, and the number looks exactly like what a real
+ *    incident would produce.
+ *  - Too strict on a shrinking basis: the tool refuses to run during the exact
+ *    emergency it exists for. An earlier version did this, unoverridably.
+ */
+
+const NO_BASELINE: BasisBaseline = { memberCorpCount: null, corporationIds: [] }
+
+function corps(n: number): string[] {
+	return Array.from({ length: n }, (_, i) => `corp-${i + 1}`)
+}
+
+function baselineOf(count: number, ids?: string[]): BasisBaseline {
+	return { memberCorpCount: count, corporationIds: ids ?? corps(count) }
+}
+
+describe('evaluateBasis', () => {
+	describe('THE ONLY HARD BLOCK: an empty basis', () => {
+		it('blocks when zero corporations are flagged as member corporations', () => {
+			const verdict = evaluateBasis({
+				corporationIds: [],
+				memberCorpCount: 0,
+				baseline: baselineOf(50),
+			})
+			expect(verdict.blocked).toBe(true)
+			if (!verdict.blocked) throw new Error('unreachable')
+			// The message is the product here — it is what an operator reads at 04:00.
+			expect(verdict.errorMessage).toMatch(/cannot be overridden/i)
+			expect(verdict.errorMessage).toMatch(/managed_corporations/)
+		})
+
+		it('blocks on an empty basis even with no baseline to compare against', () => {
+			const verdict = evaluateBasis({
+				corporationIds: [],
+				memberCorpCount: 0,
+				baseline: NO_BASELINE,
+			})
+			expect(verdict.blocked).toBe(true)
+		})
+
+		it('allows the smallest legitimate basis: exactly one member corporation', () => {
+			const verdict = evaluateBasis({
+				corporationIds: ['corp-1'],
+				memberCorpCount: 1,
+				baseline: NO_BASELINE,
+			})
+			expect(verdict.blocked).toBe(false)
+		})
+	})
+
+	describe('THE REGRESSION THIS MODULE EXISTS FOR: a shrinking basis must not block', () => {
+		// An earlier design hard-blocked any >20% shrink, reasoning that "corps
+		// leaving does not shrink the basis". That is FALSE: de-flagging a corp IS
+		// how a corp leaves (routes/corporations/index.ts sets is_member_corporation
+		// = false and fires 'corp-member-flag-disabled'), and it shrinks the basis by
+		// construction. The block therefore refused the tool's primary use case, and
+		// was unoverridable while doing it. These tests exist so nobody re-adds it.
+
+		it('does NOT block the emergency workflow: corps de-flagged, basis shrinks, scan proceeds', () => {
+			// 13 of 50 corps de-flagged => 37 remain => 74% retained, below the old
+			// 80% floor. This MUST run: it is the exact scenario the tool is for.
+			const verdict = evaluateBasis({
+				corporationIds: corps(50).slice(0, 37),
+				memberCorpCount: 37,
+				baseline: baselineOf(50),
+			})
+			expect(verdict.blocked).toBe(false)
+			if (verdict.blocked) throw new Error('unreachable')
+			expect(verdict.basisSuspect).toBe(true)
+			// And it must NAME the corps — that is how a human tells "I did that"
+			// from "something is broken". A count ratio cannot.
+			expect(verdict.removedCorporationIds).toHaveLength(13)
+			expect(verdict.removedCorporationIds).toContain('corp-38')
+			expect(verdict.basisNote).toMatch(/13 corporation\(s\) left the basis/)
+		})
+
+		it('does not block even a catastrophic shrink — it flags it', () => {
+			// 200 -> 1 is almost certainly a broken restore. The scan still runs,
+			// because a read-only scan is exactly how you diagnose that; blocking it
+			// removes the diagnosis. Enforcement is what must refuse.
+			const verdict = evaluateBasis({
+				corporationIds: ['corp-1'],
+				memberCorpCount: 1,
+				baseline: baselineOf(200),
+			})
+			expect(verdict.blocked).toBe(false)
+			if (verdict.blocked) throw new Error('unreachable')
+			expect(verdict.basisSuspect).toBe(true)
+			expect(verdict.removedCorporationIds).toHaveLength(199)
+			expect(verdict.basisNote).toMatch(/NOT TRUSTWORTHY/)
+			expect(verdict.basisNote).toMatch(/Enforcement will refuse/)
+		})
+	})
+
+	describe('the suspect threshold', () => {
+		it('is not suspect exactly at the 80% floor', () => {
+			const verdict = evaluateBasis({
+				corporationIds: corps(40),
+				memberCorpCount: 40,
+				baseline: baselineOf(50),
+			})
+			expect(verdict.blocked).toBe(false)
+			if (verdict.blocked) throw new Error('unreachable')
+			expect(verdict.basisSuspect).toBe(false)
+			expect(verdict.basisNote).toBeNull()
+		})
+
+		it('is suspect just below the floor', () => {
+			const verdict = evaluateBasis({
+				corporationIds: corps(39),
+				memberCorpCount: 39,
+				baseline: baselineOf(50),
+			})
+			expect(verdict.blocked).toBe(false)
+			if (verdict.blocked) throw new Error('unreachable')
+			expect(verdict.basisSuspect).toBe(true)
+		})
+
+		it('is not suspect when the basis grows', () => {
+			const verdict = evaluateBasis({
+				corporationIds: corps(60),
+				memberCorpCount: 60,
+				baseline: baselineOf(50),
+			})
+			expect(verdict.blocked).toBe(false)
+			if (verdict.blocked) throw new Error('unreachable')
+			expect(verdict.basisSuspect).toBe(false)
+			expect(verdict.removedCorporationIds).toHaveLength(0)
+		})
+
+		it('reports the compared-against count so the verdict is auditable', () => {
+			const verdict = evaluateBasis({
+				corporationIds: corps(30),
+				memberCorpCount: 30,
+				baseline: baselineOf(50),
+			})
+			expect(verdict.comparedToMemberCorpCount).toBe(50)
+		})
+	})
+
+	describe('bootstrap', () => {
+		it('flags a run with no baseline, and cannot be suspect', () => {
+			const verdict = evaluateBasis({
+				corporationIds: corps(3),
+				memberCorpCount: 3,
+				baseline: NO_BASELINE,
+			})
+			expect(verdict.blocked).toBe(false)
+			if (verdict.blocked) throw new Error('unreachable')
+			expect(verdict.bootstrap).toBe(true)
+			// Nothing to compare against, so "suspect" would be a guess. The UI's job
+			// is to show the corp count prominently instead.
+			expect(verdict.basisSuspect).toBe(false)
+			expect(verdict.comparedToMemberCorpCount).toBeNull()
+		})
+	})
+})
+
+describe('getBasisBaseline', () => {
+	function dbWithRuns(runs: Array<{ memberCorpCount: number; memberCorporationIds: string[] }>) {
+		return {
+			query: {
+				serviceAccessAuditRuns: {
+					findMany: vi.fn().mockResolvedValue(runs),
+				},
+			},
+		} as never
+	}
+
+	it('returns the MAXIMUM count, not the most recent', async () => {
+		// THE RATCHET: baselining against the PREVIOUS run lets a sequence of
+		// individually-legal drops (50 -> 41 -> 34 -> 28, each >80% of the last) walk
+		// the floor to nothing and never trip. Against a maximum it cannot be walked.
+		const baseline = await getBasisBaseline(
+			dbWithRuns([
+				{ memberCorpCount: 50, memberCorporationIds: corps(50) },
+				{ memberCorpCount: 41, memberCorporationIds: corps(41) },
+				{ memberCorpCount: 34, memberCorporationIds: corps(34) },
+				{ memberCorpCount: 28, memberCorporationIds: corps(28) },
+			])
+		)
+		expect(baseline.memberCorpCount).toBe(50)
+	})
+
+	it('cannot be poisoned by a corrupt run, because corruption only ever shrinks', async () => {
+		// A bootstrap or corrupt run must never become the trusted reference. It
+		// structurally cannot: a small value never raises a maximum. That property
+		// is the whole reason this is MAX rather than "most recent".
+		const baseline = await getBasisBaseline(
+			dbWithRuns([
+				{ memberCorpCount: 200, memberCorporationIds: corps(200) },
+				{ memberCorpCount: 1, memberCorporationIds: ['corp-1'] },
+			])
+		)
+		expect(baseline.memberCorpCount).toBe(200)
+	})
+
+	it('carries the winning run’s corporation ids, for the set difference', async () => {
+		const baseline = await getBasisBaseline(
+			dbWithRuns([
+				{ memberCorpCount: 2, memberCorporationIds: ['corp-1', 'corp-2'] },
+				{ memberCorpCount: 3, memberCorporationIds: ['corp-1', 'corp-2', 'corp-3'] },
+			])
+		)
+		expect(baseline.corporationIds).toEqual(['corp-1', 'corp-2', 'corp-3'])
+	})
+
+	it('returns a null baseline when no good run exists (bootstrap)', async () => {
+		const baseline = await getBasisBaseline(dbWithRuns([]))
+		expect(baseline.memberCorpCount).toBeNull()
+		expect(baseline.corporationIds).toEqual([])
+	})
+
+	it('end to end: a walked-down sequence still trips against the max', async () => {
+		const baseline = await getBasisBaseline(
+			dbWithRuns([
+				{ memberCorpCount: 50, memberCorporationIds: corps(50) },
+				{ memberCorpCount: 41, memberCorporationIds: corps(41) },
+				{ memberCorpCount: 34, memberCorporationIds: corps(34) },
+			])
+		)
+		// 28 is >80% of 34 (the most recent), so a "most recent" baseline would wave
+		// it through. Against the max of 50 it is 56% and gets flagged.
+		const verdict = evaluateBasis({ corporationIds: corps(28), memberCorpCount: 28, baseline })
+		expect(verdict.blocked).toBe(false)
+		if (verdict.blocked) throw new Error('unreachable')
+		expect(verdict.basisSuspect).toBe(true)
+		expect(verdict.comparedToMemberCorpCount).toBe(50)
+	})
+})
+
+describe('evaluateBlastRadius (soft heuristic)', () => {
+	it('trips above 20% ineligible once past the absolute floor', () => {
+		expect(evaluateBlastRadius({ scanned: 1000, ineligibleCount: 300 })).toBe(true)
+	})
+
+	it('does not trip at exactly 20%', () => {
+		expect(evaluateBlastRadius({ scanned: 1000, ineligibleCount: 200 })).toBe(false)
+	})
+
+	it('does not trip below the absolute floor of 25, however bad the ratio looks', () => {
+		// A 3-user dev database is 100% ineligible and that means nothing.
+		expect(evaluateBlastRadius({ scanned: 3, ineligibleCount: 3 })).toBe(false)
+		expect(evaluateBlastRadius({ scanned: 30, ineligibleCount: 24 })).toBe(false)
+	})
+
+	it('trips at the floor when the ratio is also exceeded', () => {
+		expect(evaluateBlastRadius({ scanned: 100, ineligibleCount: 25 })).toBe(true)
+	})
+
+	it('does not divide by zero on an empty scan', () => {
+		expect(evaluateBlastRadius({ scanned: 0, ineligibleCount: 0 })).toBe(false)
+	})
+})

--- a/apps/core/src/lib/__tests__/service-eligibility.test.ts
+++ b/apps/core/src/lib/__tests__/service-eligibility.test.ts
@@ -1,0 +1,247 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { deriveServiceEligibility, hasMemberCorporationAttachment } from '../service-eligibility'
+
+import type { ServiceEligibilitySignals } from '../service-eligibility'
+
+/**
+ * INDEPENDENT reference implementation of the rule, written from the prose spec
+ * rather than from the implementation. If `deriveServiceEligibility` is ever
+ * "simplified" into disagreeing with this, the exhaustive test below fails.
+ *
+ * The rule: eligible iff a non-deleted character sits in a member corporation,
+ * OR the user is an admin.
+ */
+function referenceIsEligible(signals: ServiceEligibilitySignals): boolean {
+	return signals.hasMemberCorpCharacter || signals.isAdmin
+}
+
+/** All 2^5 = 32 signal combinations. */
+function allSignalCombinations(): ServiceEligibilitySignals[] {
+	const combos: ServiceEligibilitySignals[] = []
+	for (let mask = 0; mask < 32; mask++) {
+		combos.push({
+			isAdmin: Boolean(mask & 1),
+			hasMemberCorpCharacter: Boolean(mask & 2),
+			hasAnyCharacter: Boolean(mask & 4),
+			hasAnyCorporation: Boolean(mask & 8),
+			hadDeletedMemberCorpCharacter: Boolean(mask & 16),
+		})
+	}
+	return combos
+}
+
+const USER_ID = '123e4567-e89b-12d3-a456-426614174000'
+
+describe('deriveServiceEligibility', () => {
+	it('agrees with the independent reference on every one of the 32 signal combinations', () => {
+		for (const signals of allSignalCombinations()) {
+			const verdict = deriveServiceEligibility(USER_ID, signals)
+			expect(verdict.eligible, `signals: ${JSON.stringify(signals)}`).toBe(
+				referenceIsEligible(signals)
+			)
+		}
+	})
+
+	it('never lets a diagnostic subcode change the outcome', () => {
+		// Every ineligible reason must in fact be ineligible, and vice versa.
+		const eligibleReasons = new Set(['member_corp', 'admin_exempt'])
+		for (const signals of allSignalCombinations()) {
+			const verdict = deriveServiceEligibility(USER_ID, signals)
+			expect(eligibleReasons.has(verdict.reason), `signals: ${JSON.stringify(signals)}`).toBe(
+				verdict.eligible
+			)
+		}
+	})
+
+	it('treats a member-corp attachment as decisive even for a non-admin with no other signals', () => {
+		expect(
+			deriveServiceEligibility(USER_ID, {
+				isAdmin: false,
+				hasMemberCorpCharacter: true,
+				hasAnyCharacter: true,
+				hasAnyCorporation: true,
+				hadDeletedMemberCorpCharacter: false,
+			})
+		).toEqual({ userId: USER_ID, eligible: true, reason: 'member_corp' })
+	})
+
+	it('exempts admins who have no member-corp attachment, and says so explicitly', () => {
+		// Anti-lockout: the incident responder must not revoke their own comms.
+		expect(
+			deriveServiceEligibility(USER_ID, {
+				isAdmin: true,
+				hasMemberCorpCharacter: false,
+				hasAnyCharacter: false,
+				hasAnyCorporation: false,
+				hadDeletedMemberCorpCharacter: false,
+			})
+		).toEqual({ userId: USER_ID, eligible: true, reason: 'admin_exempt' })
+	})
+
+	it('reports member_corp (not admin_exempt) for an admin who IS in a member corp', () => {
+		// Otherwise the admin_exempt count reads as "admins with no corp" and is useless.
+		expect(
+			deriveServiceEligibility(USER_ID, {
+				isAdmin: true,
+				hasMemberCorpCharacter: true,
+				hasAnyCharacter: true,
+				hasAnyCorporation: true,
+				hadDeletedMemberCorpCharacter: false,
+			}).reason
+		).toBe('member_corp')
+	})
+
+	describe('ineligible subcodes, most specific first', () => {
+		const base: ServiceEligibilitySignals = {
+			isAdmin: false,
+			hasMemberCorpCharacter: false,
+			hasAnyCharacter: true,
+			hasAnyCorporation: true,
+			hadDeletedMemberCorpCharacter: false,
+		}
+
+		it('no_characters when the user has no non-deleted characters', () => {
+			expect(
+				deriveServiceEligibility(USER_ID, { ...base, hasAnyCharacter: false, hasAnyCorporation: false })
+					.reason
+			).toBe('no_characters')
+		})
+
+		it('only_deleted_member_char when the qualifying character was soft-deleted', () => {
+			expect(
+				deriveServiceEligibility(USER_ID, { ...base, hadDeletedMemberCorpCharacter: true }).reason
+			).toBe('only_deleted_member_char')
+		})
+
+		it('null_corp when characters exist but none carries a corporation', () => {
+			// The signature of a broken ESI sync — must be distinguishable at a glance.
+			expect(deriveServiceEligibility(USER_ID, { ...base, hasAnyCorporation: false }).reason).toBe(
+				'null_corp'
+			)
+		})
+
+		it('unmanaged_corp when the user has corporations, none of them member corps', () => {
+			expect(deriveServiceEligibility(USER_ID, base).reason).toBe('unmanaged_corp')
+		})
+	})
+})
+
+describe('hasMemberCorporationAttachment', () => {
+	function dbWith(characters: Array<{ corporationId: string | null }>, memberCorps: string[]) {
+		return {
+			query: {
+				userCharacters: {
+					findMany: vi.fn().mockResolvedValue(characters),
+				},
+				managedCorporations: {
+					findMany: vi
+						.fn()
+						.mockResolvedValue(memberCorps.map((corporationId) => ({ corporationId }))),
+				},
+			},
+		} as never
+	}
+
+	it('is true when any character sits in a member corporation', async () => {
+		await expect(
+			hasMemberCorporationAttachment(dbWith([{ corporationId: 'corp-1' }], ['corp-1']), USER_ID)
+		).resolves.toBe(true)
+	})
+
+	it('is true when only ONE of several characters qualifies', async () => {
+		await expect(
+			hasMemberCorporationAttachment(
+				dbWith([{ corporationId: 'corp-9' }, { corporationId: 'corp-1' }], ['corp-1']),
+				USER_ID
+			)
+		).resolves.toBe(true)
+	})
+
+	it('is false when the user has characters in no member corporation', async () => {
+		await expect(
+			hasMemberCorporationAttachment(dbWith([{ corporationId: 'corp-2' }], ['corp-1']), USER_ID)
+		).resolves.toBe(false)
+	})
+
+	it('is false when the user has no characters at all', async () => {
+		await expect(hasMemberCorporationAttachment(dbWith([], ['corp-1']), USER_ID)).resolves.toBe(
+			false
+		)
+	})
+
+	it('is false when every character has a NULL corporation', async () => {
+		// A NULL corporationId must never match a NULL-ish member corp id.
+		await expect(
+			hasMemberCorporationAttachment(dbWith([{ corporationId: null }], ['corp-1']), USER_ID)
+		).resolves.toBe(false)
+	})
+
+	it('is false when the member corporation basis is empty', async () => {
+		// The catastrophe case: an empty/half-restored managed_corporations makes
+		// EVERY non-admin ineligible. The predicate is correct to return false here
+		// — which is exactly why the caller must run the basis circuit breaker.
+		await expect(
+			hasMemberCorporationAttachment(dbWith([{ corporationId: 'corp-1' }], []), USER_ID)
+		).resolves.toBe(false)
+	})
+
+	it('filters deleted characters in SQL, not in JS', async () => {
+		// The soft-delete filter must be part of the WHERE clause. If it ever moves
+		// to a JS .filter(), the set-based scan (which cannot see JS) silently diverges.
+		const db = dbWith([{ corporationId: 'corp-1' }], ['corp-1'])
+		await hasMemberCorporationAttachment(db, USER_ID)
+		const call = (db as unknown as { query: { userCharacters: { findMany: ReturnType<typeof vi.fn> } } })
+			.query.userCharacters.findMany.mock.calls[0][0]
+		expect(call.where).toBeDefined()
+	})
+})
+
+describe('the rule’s deliberate exclusions (guards against well-meaning tidying)', () => {
+	// `import.meta.url` is passed as a string: the ambient `URL` here is the
+	// Workers one, which is not assignable to node's.
+	const source = readFileSync(
+		join(dirname(fileURLToPath(import.meta.url)), '..', 'service-eligibility.ts'),
+		'utf8'
+	)
+
+	// These guards assert on CODE, never on prose. The module docblock names the
+	// excluded columns in order to explain them, so matching raw source would make
+	// every guard self-fail on its own documentation.
+	const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+	// Everything below is ABSENT ON PURPOSE. Each one, if added, silently changes
+	// who loses their account. See the module docblock for the reasoning.
+	it.each([
+		['is_active / isActive', /\bis_active\b|\bisActive\b/],
+		['alliance_id / allianceId', /\balliance_id\b|\ballianceId\b/],
+		['is_alt_corp / isAltCorp', /\bis_alt_corp\b|\bisAltCorp\b/],
+		['is_special_purpose / isSpecialPurpose', /\bis_special_purpose\b|\bisSpecialPurpose\b/],
+		['has_valid_token / hasValidToken', /\bhas_valid_token\b|\bhasValidToken\b/],
+		['is_primary / isPrimary', /\bis_primary\b|\bisPrimary\b/],
+	])('does not filter on %s', (_label, pattern) => {
+		expect(code).not.toMatch(pattern)
+	})
+
+	it('does filter on the two predicates the rule IS made of', () => {
+		expect(code).toMatch(/is_member_corporation = true/)
+		expect(code).toMatch(/uc\.deleted = false/)
+	})
+
+	it('uses EXISTS rather than count(*), which would return bigint', () => {
+		// CLAUDE.md: the Neon driver serialises bigint badly. count(*) is bigint.
+		expect(code).not.toMatch(/count\(\*\)/)
+		expect(code).toMatch(/EXISTS \(/)
+	})
+
+	it('drives from `users` so that users with zero characters are not silently dropped', () => {
+		// A LEFT JOIN + WHERE on the right-hand side would spare exactly the
+		// no_characters population — the most likely target profile.
+		expect(code).toMatch(/FROM users u/)
+		expect(code).not.toMatch(/LEFT JOIN/i)
+	})
+})

--- a/apps/core/src/lib/mumble-feature.ts
+++ b/apps/core/src/lib/mumble-feature.ts
@@ -21,3 +21,87 @@ export async function isMumbleFeatureEnabled(env: Pick<Env, 'FEATURES'>): Promis
 		return false
 	}
 }
+
+/**
+ * Why this exists ALONGSIDE the lenient check rather than replacing it.
+ *
+ * `isMumbleFeatureEnabled` collapses three genuinely different states —
+ * "binding missing", "FEATURES DO unreachable", "flag deliberately off" — into a
+ * single `false`. For a background side effect that is correct and must not
+ * change: failing closed is the safe default and the caller has nothing useful
+ * to do with the distinction anyway.
+ *
+ * For an operator staring at an audit run, that same collapse destroys the
+ * signal. "Mumble enforcement would no-op" and "we could not tell whether Mumble
+ * enforcement would no-op" demand opposite responses, and the lenient form
+ * reports them identically.
+ */
+export type MumbleFeatureState =
+	/** The flag is registered and true. Enforcement would act. */
+	| { enabled: true; state: 'enabled' }
+	/** The flag is reachable and is off/unset. Enforcement would silently no-op. */
+	| { enabled: false; state: 'flag_off'; message: string }
+	/** No FEATURES binding on this worker. A deploy/config fault, not a flag. */
+	| { enabled: false; state: 'binding_missing'; message: string }
+	/** The binding exists but the DO could not be reached. State is UNKNOWN. */
+	| { enabled: false; state: 'unreachable'; message: string }
+
+/**
+ * Resolve the Mumble feature flag, preserving the distinction between "off",
+ * "misconfigured" and "unknown".
+ *
+ * READ-ONLY USE ONLY (increment 3): the result is *reported* on the audit run so
+ * an operator can see, before committing to anything, that enforcement would
+ * silently no-op. It must never gate a mutation — the mutating path has its own
+ * fail-closed check, and gating on `unreachable` here would let a transient DO
+ * blip read as "feature off".
+ *
+ * Deliberately does NOT throw: a scan whose flag lookup failed is still a valid,
+ * useful scan. The failure is data on the run, not an abort.
+ */
+export async function isMumbleFeatureEnabledStrict(
+	env: Pick<Env, 'FEATURES'>
+): Promise<MumbleFeatureState> {
+	if (!env.FEATURES) {
+		return {
+			enabled: false,
+			state: 'binding_missing',
+			message:
+				'The FEATURES Durable Object binding is missing from this worker, so the Mumble feature flag could not be read. ' +
+				'This is a deployment/configuration fault rather than a feature toggle: add the FEATURES binding to wrangler.jsonc and redeploy. ' +
+				'Mumble enforcement would silently do nothing until this is fixed.',
+		}
+	}
+
+	let value: unknown
+	try {
+		const stub = getStub<Features>(env.FEATURES, 'default')
+		value = await stub.checkFlag(MUMBLE_FEATURE_FLAG_KEY)
+	} catch (error) {
+		return {
+			enabled: false,
+			state: 'unreachable',
+			message:
+				`The FEATURES Durable Object could not be reached, so the Mumble feature flag state is UNKNOWN (not "off"): ${
+					error instanceof Error ? error.message : String(error)
+				}. ` +
+				'Treat Mumble enforcement as unpredictable until a scan reports a definite flag state.',
+		}
+	}
+
+	// checkFlag returns null for an unregistered flag and the raw value otherwise,
+	// so only an exact `true` means enabled. Anything else is off-or-unset —
+	// which is reachable-and-negative, distinct from the two cases above.
+	if (value === true) {
+		return { enabled: true, state: 'enabled' }
+	}
+
+	return {
+		enabled: false,
+		state: 'flag_off',
+		message:
+			`The Mumble feature flag ("${MUMBLE_FEATURE_FLAG_KEY}") is reachable but not enabled (value: ${JSON.stringify(value) ?? 'undefined'}). ` +
+			'This scan is unaffected — it is read-only — but Mumble enforcement would silently do nothing while the flag is off. ' +
+			'Enable the flag before relying on Mumble revocation.',
+	}
+}

--- a/apps/core/src/lib/service-eligibility-basis.ts
+++ b/apps/core/src/lib/service-eligibility-basis.ts
@@ -1,0 +1,263 @@
+import { gte, inArray, sql } from '@repo/db-utils'
+
+import type { DbClient, schema } from '../db'
+
+/**
+ * THE BASIS GUARD.
+ *
+ * `managed_corporations.is_member_corporation` is `.default(false).notNull()`
+ * (db/schema.ts). THE BASIS DEFAULTS TO THE REVOKING VALUE. An empty or
+ * half-restored `managed_corporations` therefore does not *degrade* the
+ * eligibility rule, it INVERTS it: every non-admin becomes a revocation target.
+ *
+ * And admins are exempt (`admin_exempt`), so THE OPERATORS RUNNING THIS TOOL ARE
+ * STRUCTURALLY THE LAST PEOPLE TO NOTICE. Their own access is intact; the tool
+ * reports a large, confident, entirely wrong number; and at 04:00 during an
+ * incident a large number is exactly what they are braced to see.
+ *
+ * ── WHY A SHRINKING BASIS IS *NOT* BLOCKED (this was got wrong once) ──
+ *
+ * An earlier design hard-blocked any scan whose basis shrank >20%, on the stated
+ * grounds that "corps leaving changes who is ineligible without shrinking the
+ * basis". THAT IS FALSE, and it inverted the tool's purpose.
+ *
+ * De-flagging a corporation IS how a corp stops being a member corp: there is an
+ * admin route that sets `is_member_corporation = false` and fires a
+ * `corp-member-flag-disabled` Discord refresh (routes/corporations/index.ts).
+ * So the primary emergency workflow — corps defect, an admin de-flags them, the
+ * audit sweeps their members — SHRINKS THE BASIS BY CONSTRUCTION. A hard block on
+ * shrink would refuse to run in exactly the incident it was built for, and would
+ * be unoverridable while doing it.
+ *
+ * A count ratio cannot tell "an operator de-flagged 13 corps" from "the table got
+ * truncated". A SET DIFFERENCE can be read by a human in two seconds: the
+ * operator who just de-flagged 13 corps recognises their names instantly, and 199
+ * vanished corps are self-evidently a fault. So we snapshot the basis IDs and
+ * report exactly which corporations left.
+ *
+ * ── WHERE THE TEETH ACTUALLY BELONG ──
+ *
+ * A SCAN IS READ-ONLY AND CANNOT HURT ANYONE. Blocking it is pure downside: it
+ * prevents the legitimate workflow AND prevents diagnosis, since a scan's output
+ * is precisely what reveals a broken basis. The catastrophe this guard exists to
+ * prevent is MASS REVOCATION on a corrupt basis, and revocation happens at
+ * ENFORCE, not at scan.
+ *
+ * Therefore:
+ *   - count < 1        -> BLOCK the scan. Genuinely unambiguous; see below.
+ *   - basis shrank     -> DO NOT BLOCK. Record `basisSuspect` + the removed corp
+ *                         ids, and surface them loudly.
+ *   - ineligible ratio -> DO NOT BLOCK. Record `blastRadiusTripped`.
+ *
+ * >>> ENFORCEMENT (increment 7, NOT YET BUILT) MUST HARD-REFUSE to act on a run
+ * >>> whose `basisSuspect` is true and unacknowledged. That refusal is the real
+ * >>> circuit breaker. This module only ever informs. <<<
+ */
+
+/**
+ * Below this the basis is not "small", it is broken.
+ *
+ * This is the one genuinely unambiguous case, and the only one that blocks. With
+ * zero member corps the rule degenerates to "revoke every non-admin", which is
+ * never the correct output of a scan — an alliance with zero member corporations
+ * has nobody to audit. A brand-new deployment with no corps configured also lands
+ * here, and blocking is the right answer there too.
+ */
+const MIN_MEMBER_CORP_COUNT = 1
+
+/**
+ * A basis retaining less than this fraction of the recent high-water mark is
+ * flagged `basisSuspect` — reported, never blocked.
+ */
+const BASIS_SHRINK_SUSPECT_RATIO = 0.8
+
+/** Trailing window for the high-water baseline. Wide enough that a corrupt run
+ * cannot outlive the good runs around it; narrow enough that a LEGITIMATE
+ * permanent shrink stops being flagged once it has settled, instead of crying
+ * wolf forever. */
+const BASIS_BASELINE_WINDOW_DAYS = 30
+
+/** Blast-radius heuristic. Soft: flags, never blocks. */
+const BLAST_RADIUS_RATIO = 0.2
+
+/** Below this absolute count the ratio is meaningless — a 3-user dev database is
+ * 100% ineligible and that tells you nothing. */
+const BLAST_RADIUS_ABSOLUTE_FLOOR = 25
+
+/**
+ * Statuses whose basis reading is trustworthy enough to inform the baseline.
+ * `awaiting_confirmation` counts: its scan succeeded and merely found work.
+ * `blocked`/`failed`/`cancelled` do not — their basis is either the broken one or
+ * was never fully read.
+ */
+const BASELINE_STATUSES = ['completed', 'awaiting_confirmation', 'completed_with_errors'] as const
+
+export interface BasisBaseline {
+	/** High-water member-corp count across recent good runs; null on bootstrap. */
+	memberCorpCount: number | null
+	/** The basis snapshot of the run that set the high-water mark, for the set
+	 * difference. Empty when there is no baseline. */
+	corporationIds: string[]
+}
+
+/**
+ * The baseline is the MAXIMUM member-corp count over recent good runs — NOT the
+ * most recent one.
+ *
+ * This single choice kills two bugs at once, and both are worth stating because
+ * "most recent" is the intuitive implementation:
+ *
+ *  1. THE RATCHET. If each run baselines against its predecessor, a sequence of
+ *     individually-legal drops (50 -> 41 -> 34 -> 28 -> 23, each >80% of the last)
+ *     walks the floor to nothing and never trips. Against a maximum, the floor
+ *     cannot be walked down.
+ *  2. BASELINE POISONING. A bootstrap or corrupt run must never become the
+ *     trusted reference. It cannot: corruption SHRINKS the basis, and a small
+ *     value can never raise a maximum. The guard is monotonic against precisely
+ *     the failure mode it fears.
+ *
+ * The trailing window is what lets a legitimate, permanent shrink stop being
+ * flagged once it ages out — without it, de-flagging 13 corps would flag every
+ * scan forever.
+ */
+export async function getBasisBaseline(
+	db: DbClient<typeof schema>,
+	options?: { now?: Date }
+): Promise<BasisBaseline> {
+	const now = options?.now ?? new Date()
+	const windowStart = new Date(now.getTime() - BASIS_BASELINE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+
+	const candidates = await db.query.serviceAccessAuditRuns.findMany({
+		where: (runs, { and }) =>
+			and(
+				inArray(runs.status, [...BASELINE_STATUSES]),
+				gte(runs.startedAt, windowStart),
+				// A run that was itself flagged suspect is a poor reference: its basis
+				// is the one nobody has vouched for. Excluding it costs nothing,
+				// because a suspect run's count is by definition BELOW the high-water
+				// mark it was compared against, so it could not have won the max anyway.
+				sql`${runs.basisSuspect} = false`
+			),
+		columns: { memberCorpCount: true, memberCorporationIds: true },
+	})
+
+	if (candidates.length === 0) {
+		return { memberCorpCount: null, corporationIds: [] }
+	}
+
+	const best = candidates.reduce((winner, candidate) =>
+		candidate.memberCorpCount > winner.memberCorpCount ? candidate : winner
+	)
+
+	return { memberCorpCount: best.memberCorpCount, corporationIds: best.memberCorporationIds ?? [] }
+}
+
+export interface BasisVerdictOk {
+	blocked: false
+	/** True when no baseline exists. The UI must surface the corp count
+	 * prominently — on this path nothing has validated it. */
+	bootstrap: boolean
+	/** The basis shrank against the recent high-water mark. INFORMATIONAL for a
+	 * scan; enforcement must refuse on it. */
+	basisSuspect: boolean
+	corporationIds: string[]
+	memberCorpCount: number
+	comparedToMemberCorpCount: number | null
+	/** Exactly which corporations left the basis. The whole point: a human reads
+	 * this and knows in seconds whether it was them or a fault. */
+	removedCorporationIds: string[]
+	/** Non-null when basisSuspect. Explains the diff; does not scold. */
+	basisNote: string | null
+}
+
+export interface BasisVerdictBlocked {
+	blocked: true
+	corporationIds: string[]
+	memberCorpCount: number
+	comparedToMemberCorpCount: number | null
+	/** Operator-actionable. Says what broke, what the numbers were, and what to do
+	 * — a bare "assertion failed" at 04:00 is not a message, it is a riddle. */
+	errorMessage: string
+}
+
+export type BasisVerdict = BasisVerdictOk | BasisVerdictBlocked
+
+/**
+ * Evaluate the basis. PURE — takes the numbers, returns a verdict, touches no
+ * database. Deliberate: this is the logic whose failure is silent and
+ * catastrophic, so it must be exhaustively testable with no Postgres fixture.
+ */
+export function evaluateBasis(options: {
+	corporationIds: string[]
+	memberCorpCount: number
+	baseline: BasisBaseline
+}): BasisVerdict {
+	const { corporationIds, memberCorpCount, baseline } = options
+	const baselineCount = baseline.memberCorpCount
+
+	// ── THE ONLY HARD BLOCK: the basis is empty. ──
+	// Unoverridable. With zero member corps the rule says "revoke everyone except
+	// admins". There is no state of the world where that is a scan's correct
+	// output rather than the signature of a broken managed_corporations.
+	if (memberCorpCount < MIN_MEMBER_CORP_COUNT) {
+		return {
+			blocked: true,
+			corporationIds,
+			memberCorpCount,
+			comparedToMemberCorpCount: baselineCount,
+			errorMessage:
+				`BLOCKED: no corporations are flagged as member corporations (member_corp_count=${memberCorpCount}). ` +
+				`The eligibility rule would mark every non-admin user ineligible, so this scan was aborted before writing any rows. ` +
+				`This almost always means managed_corporations is empty, half-restored, or mid-sync — not that the alliance has no members. ` +
+				`Fix managed_corporations (verify is_member_corporation is set on the expected corps), then start a new scan. ` +
+				`This check cannot be overridden.`,
+		}
+	}
+
+	const removedCorporationIds =
+		baseline.corporationIds.length > 0
+			? baseline.corporationIds.filter((id) => !corporationIds.includes(id))
+			: []
+
+	// ── SOFT: the basis shrank against the recent high-water mark. ──
+	// Reported, not blocked. See the module docblock: de-flagging corps is the
+	// legitimate mechanism AND it shrinks the basis, so a block here would refuse
+	// the tool's primary use case.
+	const suspect =
+		baselineCount !== null &&
+		baselineCount > 0 &&
+		memberCorpCount < BASIS_SHRINK_SUSPECT_RATIO * baselineCount
+
+	return {
+		blocked: false,
+		bootstrap: baselineCount === null,
+		basisSuspect: suspect,
+		corporationIds,
+		memberCorpCount,
+		comparedToMemberCorpCount: baselineCount,
+		removedCorporationIds,
+		basisNote: suspect
+			? `The member-corporation basis shrank from ${baselineCount} to ${memberCorpCount} ` +
+				`(${((memberCorpCount / (baselineCount || 1)) * 100).toFixed(1)}% retained) versus the highest basis seen in the last ` +
+				`${BASIS_BASELINE_WINDOW_DAYS} days. ${removedCorporationIds.length} corporation(s) left the basis. ` +
+				`If you de-flagged them, this is expected and the scan below is correct. If you do not recognise them, ` +
+				`managed_corporations may be half-restored or mid-sync and THIS SCAN'S RESULTS ARE NOT TRUSTWORTHY. ` +
+				`Enforcement will refuse to act on this run until the basis is confirmed.`
+			: null,
+	}
+}
+
+/**
+ * The blast-radius heuristic, evaluated on the scan's OUTCOME at finalize.
+ * Never blocks: it flags. The operator sees the flag next to the actual row list
+ * and decides. Gated on an absolute floor so small populations don't cry wolf.
+ */
+export function evaluateBlastRadius(options: {
+	scanned: number
+	ineligibleCount: number
+}): boolean {
+	const { scanned, ineligibleCount } = options
+	if (scanned <= 0) return false
+	if (ineligibleCount < BLAST_RADIUS_ABSOLUTE_FLOOR) return false
+	return ineligibleCount / scanned > BLAST_RADIUS_RATIO
+}

--- a/apps/core/src/lib/service-eligibility.ts
+++ b/apps/core/src/lib/service-eligibility.ts
@@ -3,6 +3,7 @@ import { and, eq, sql } from '@repo/db-utils'
 import { managedCorporations, userCharacters } from '../db/schema'
 
 import type { DbClient, schema } from '../db'
+import type { SERVICE_ELIGIBILITY_REASONS } from '../db/schema'
 
 /**
  * THE SERVICES ELIGIBILITY RULE — stated once, here.
@@ -33,21 +34,13 @@ import type { DbClient, schema } from '../db'
  * predicate. The equivalence test in __tests__/service-eligibility.test.ts pins
  * each of these exclusions.
  */
-export type ServiceEligibilityReason =
-	/** Eligible: at least one non-deleted character in a member corporation. */
-	| 'member_corp'
-	/** Eligible: no member-corp attachment, but `users.is_admin` is true. */
-	| 'admin_exempt'
-	/** Ineligible: the user has no non-deleted characters at all. */
-	| 'no_characters'
-	/** Ineligible: has non-deleted characters, but every one has a NULL corporation. */
-	| 'null_corp'
-	/** Ineligible: the only member-corp character(s) are soft-deleted. */
-	| 'only_deleted_member_char'
-	/** Ineligible: has corporations, none flagged `is_member_corporation`. */
-	| 'unmanaged_corp'
-	/** Ineligible: no `users` row exists for this id. */
-	| 'no_user_row'
+/**
+ * Derived from the schema's const so the TypeScript union and the Postgres enum
+ * are the same list by construction — the scan cannot write a reason the column
+ * would reject. See SERVICE_ELIGIBILITY_REASONS in db/schema.ts for each
+ * subcode's meaning.
+ */
+export type ServiceEligibilityReason = (typeof SERVICE_ELIGIBILITY_REASONS)[number]
 
 export interface ServiceEligibilityVerdict {
 	userId: string

--- a/apps/core/src/lib/service-eligibility.ts
+++ b/apps/core/src/lib/service-eligibility.ts
@@ -1,0 +1,254 @@
+import { and, eq, sql } from '@repo/db-utils'
+
+import { managedCorporations, userCharacters } from '../db/schema'
+
+import type { DbClient, schema } from '../db'
+
+/**
+ * THE SERVICES ELIGIBILITY RULE — stated once, here.
+ *
+ *   A user is ELIGIBLE for services iff they have at least one non-deleted
+ *   character whose corporation is flagged `is_member_corporation = true`,
+ *   OR they are a site admin.
+ *
+ * This mirrors the rule Mumble already enforces today (see `getUserGroupNames`
+ * in services/mumble.service.ts): a user with no member-corporation attachment
+ * and no admin flag receives zero groups.
+ *
+ * WHAT IS DELIBERATELY ABSENT, AND MUST STAY ABSENT:
+ *
+ * - `managedCorporations.isActive`   — a member corp with isActive=false STILL
+ *   grants Mumble access today. Adding this filter would silently widen every
+ *   revocation beyond current behaviour. (discord.service.ts applies isActive to
+ *   its own role rule; that divergence is tracked separately and is NOT resolved
+ *   here.)
+ * - `managedCorporations.isAltCorp` / `isSpecialPurpose` — no filter in the rule.
+ * - `userCharacters.allianceId` — alliance membership does NOT qualify on its own.
+ *   (workflows/steps/user-roles/reconcile-affiliation-groups.ts uses a looser
+ *   rule that also accepts any allianceId. That rule governs a different
+ *   subsystem and is NOT the rule here.)
+ * - `userCharacters.hasValidToken` / `status` / `is_primary` — not part of the rule.
+ *
+ * Changing any of the above changes who loses their account. Do not "tidy" this
+ * predicate. The equivalence test in __tests__/service-eligibility.test.ts pins
+ * each of these exclusions.
+ */
+export type ServiceEligibilityReason =
+	/** Eligible: at least one non-deleted character in a member corporation. */
+	| 'member_corp'
+	/** Eligible: no member-corp attachment, but `users.is_admin` is true. */
+	| 'admin_exempt'
+	/** Ineligible: the user has no non-deleted characters at all. */
+	| 'no_characters'
+	/** Ineligible: has non-deleted characters, but every one has a NULL corporation. */
+	| 'null_corp'
+	/** Ineligible: the only member-corp character(s) are soft-deleted. */
+	| 'only_deleted_member_char'
+	/** Ineligible: has corporations, none flagged `is_member_corporation`. */
+	| 'unmanaged_corp'
+	/** Ineligible: no `users` row exists for this id. */
+	| 'no_user_row'
+
+export interface ServiceEligibilityVerdict {
+	userId: string
+	eligible: boolean
+	reason: ServiceEligibilityReason
+}
+
+/** The raw signals the rule is derived from. Kept separate so the per-user and
+ * set-based forms can share one derivation and therefore cannot drift. */
+export interface ServiceEligibilitySignals {
+	/** `users.is_admin`. */
+	isAdmin: boolean
+	/** A non-deleted character exists in a corp with `is_member_corporation = true`. */
+	hasMemberCorpCharacter: boolean
+	/** Any non-deleted character exists. */
+	hasAnyCharacter: boolean
+	/** Any non-deleted character has a non-NULL `corporation_id`. */
+	hasAnyCorporation: boolean
+	/** A *deleted* character exists in a member corp — diagnostic only, never
+	 * part of the eligibility decision. */
+	hadDeletedMemberCorpCharacter: boolean
+}
+
+/**
+ * Derive the verdict from the signals. THIS IS THE ONLY PLACE THE RULE IS
+ * DECIDED — both the per-user and the set-based forms funnel through it, which
+ * is what makes the equivalence test meaningful.
+ */
+export function deriveServiceEligibility(
+	userId: string,
+	signals: ServiceEligibilitySignals
+): ServiceEligibilityVerdict {
+	// The rule itself: member-corp attachment, or admin.
+	if (signals.hasMemberCorpCharacter) {
+		return { userId, eligible: true, reason: 'member_corp' }
+	}
+	if (signals.isAdmin) {
+		// Deliberate anti-lockout: admins keep access with no member corp so an
+		// incident responder cannot revoke their own comms mid-incident.
+		return { userId, eligible: true, reason: 'admin_exempt' }
+	}
+
+	// Ineligible. Everything below only picks the most specific diagnostic
+	// subcode — it cannot change the outcome. Ordered most-informative first:
+	// "3,900 null_corp" is a broken ESI sync; "3,900 ineligible" is unreviewable.
+	if (!signals.hasAnyCharacter) {
+		return { userId, eligible: false, reason: 'no_characters' }
+	}
+	if (signals.hadDeletedMemberCorpCharacter) {
+		return { userId, eligible: false, reason: 'only_deleted_member_char' }
+	}
+	if (!signals.hasAnyCorporation) {
+		return { userId, eligible: false, reason: 'null_corp' }
+	}
+	return { userId, eligible: false, reason: 'unmanaged_corp' }
+}
+
+/**
+ * Per-user corporation attachment check.
+ *
+ * Query shape is load-bearing: services/mumble.service.ts delegates to this, and
+ * its tests mock `userCharacters.findMany` + `managedCorporations.findMany`
+ * directly.
+ */
+export async function hasMemberCorporationAttachment(
+	db: DbClient<typeof schema>,
+	userId: string
+): Promise<boolean> {
+	const [characters, memberCorporations] = await Promise.all([
+		db.query.userCharacters.findMany({
+			where: and(eq(userCharacters.userId, userId), eq(userCharacters.isDeleted, false)),
+			columns: {
+				corporationId: true,
+			},
+		}),
+		db.query.managedCorporations.findMany({
+			where: eq(managedCorporations.isMemberCorporation, true),
+			columns: {
+				corporationId: true,
+			},
+		}),
+	])
+
+	const memberCorporationIds = new Set(
+		memberCorporations.map((corporation) => corporation.corporationId)
+	)
+	return characters.some(
+		(character) => !!character.corporationId && memberCorporationIds.has(character.corporationId)
+	)
+}
+
+/** One row of the set-based scan. `eligible`/`reason` are derived, never selected. */
+export interface ServiceEligibilityScanRow extends ServiceEligibilityVerdict {
+	/** `users.discord_user_id IS NOT NULL` — population membership, not eligibility. */
+	hasDiscordLink: boolean
+	signals: ServiceEligibilitySignals
+}
+
+/**
+ * SET-BASED eligibility for a keyset-paginated page of users.
+ *
+ * One SQL statement per page. The per-user form costs ~2 queries per user AND
+ * re-reads the entire `managed_corporations` table on every call, so a naive
+ * per-user scan would exceed the Workers 10k-subrequest ceiling at roughly 1,600
+ * users. This does not.
+ *
+ * `users` is the DRIVING TABLE and the joins are lateral EXISTS subqueries —
+ * never a LEFT JOIN with a WHERE on the right side, which would silently drop
+ * rows. Every EXISTS is index-backed (`user_characters_user_id_idx`,
+ * `user_characters_corporation_id_idx`,
+ * `managed_corporations_corporation_id_is_member_idx`).
+ *
+ * Booleans, not counts: `count(*)` returns bigint, which the Neon driver
+ * serialises badly (see CLAUDE.md). EXISTS also short-circuits.
+ *
+ * @param afterUserId - keyset cursor; pass undefined for the first page
+ */
+export async function scanUserEligibilityPage(
+	db: DbClient<typeof schema>,
+	options: { afterUserId?: string; limit: number }
+): Promise<ServiceEligibilityScanRow[]> {
+	const { afterUserId, limit } = options
+
+	const result = await db.execute<{
+		id: string
+		is_admin: boolean
+		has_discord_link: boolean
+		has_member_corp_character: boolean
+		has_any_character: boolean
+		has_any_corporation: boolean
+		had_deleted_member_corp_character: boolean
+	}>(sql`
+		SELECT
+			u.id,
+			u.is_admin,
+			(u.discord_user_id IS NOT NULL) AS has_discord_link,
+			EXISTS (
+				SELECT 1 FROM user_characters uc
+				JOIN managed_corporations mc
+					ON mc.corporation_id = uc.corporation_id
+					AND mc.is_member_corporation = true
+				WHERE uc.user_id = u.id AND uc.deleted = false
+			) AS has_member_corp_character,
+			EXISTS (
+				SELECT 1 FROM user_characters uc
+				WHERE uc.user_id = u.id AND uc.deleted = false
+			) AS has_any_character,
+			EXISTS (
+				SELECT 1 FROM user_characters uc
+				WHERE uc.user_id = u.id AND uc.deleted = false AND uc.corporation_id IS NOT NULL
+			) AS has_any_corporation,
+			EXISTS (
+				SELECT 1 FROM user_characters uc
+				JOIN managed_corporations mc
+					ON mc.corporation_id = uc.corporation_id
+					AND mc.is_member_corporation = true
+				WHERE uc.user_id = u.id AND uc.deleted = true
+			) AS had_deleted_member_corp_character
+		FROM users u
+		${afterUserId ? sql`WHERE u.id > ${afterUserId}::uuid` : sql``}
+		ORDER BY u.id
+		LIMIT ${limit}
+	`)
+
+	return result.rows.map((row) => {
+		const signals: ServiceEligibilitySignals = {
+			isAdmin: row.is_admin,
+			hasMemberCorpCharacter: row.has_member_corp_character,
+			hasAnyCharacter: row.has_any_character,
+			hasAnyCorporation: row.has_any_corporation,
+			hadDeletedMemberCorpCharacter: row.had_deleted_member_corp_character,
+		}
+		return {
+			...deriveServiceEligibility(row.id, signals),
+			hasDiscordLink: row.has_discord_link,
+			signals,
+		}
+	})
+}
+
+/**
+ * The eligibility BASIS: every corporation the rule currently treats as a member
+ * corporation.
+ *
+ * This is snapshotted onto every run because it is the input that can silently
+ * invert the rule. `is_member_corporation` is `.default(false).notNull()`
+ * (db/schema.ts) — i.e. the basis DEFAULTS TO THE REVOKING VALUE. An empty or
+ * half-restored `managed_corporations` does not degrade the rule, it inverts it,
+ * and every non-admin becomes a target. Callers MUST run the basis assertions in
+ * lib/service-eligibility-basis.ts before acting on a scan.
+ */
+export async function getMemberCorporationBasis(
+	db: DbClient<typeof schema>
+): Promise<{ corporationIds: string[]; count: number }> {
+	const rows = await db.query.managedCorporations.findMany({
+		where: eq(managedCorporations.isMemberCorporation, true),
+		columns: {
+			corporationId: true,
+		},
+	})
+
+	const corporationIds = rows.map((row) => row.corporationId)
+	return { corporationIds, count: corporationIds.length }
+}

--- a/apps/core/src/routes/__tests__/services-audit.route.test.ts
+++ b/apps/core/src/routes/__tests__/services-audit.route.test.ts
@@ -1,0 +1,349 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import servicesAuditRoutes from '../services-audit'
+
+import type { SessionUser } from '../../context'
+
+/**
+ * Routes for the READ-ONLY service access audit. The router's
+ * requireAuth()+requireAdmin() guards are mocked to pass-through here so these
+ * tests exercise the handlers; the getStub/getDiscordStub mocks are the
+ * mechanism that proves no route issues a service RPC.
+ */
+const { getStubMock, getDiscordStubMock, createWorkflowMock } = vi.hoisted(() => ({
+	getStubMock: vi.fn(),
+	getDiscordStubMock: vi.fn(),
+	createWorkflowMock: vi.fn(),
+}))
+
+vi.mock('../../middleware/session', () => ({
+	requireAuth: () => async (_c: unknown, next: () => Promise<void>) => next(),
+	requireAdmin: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+vi.mock('@repo/do-utils', () => ({ getStub: getStubMock }))
+vi.mock('@repo/discord', () => ({
+	getDiscordStub: getDiscordStubMock,
+	DISCORD_EXCLUDED_AUTH_ROLE_IDS: new Set<string>(),
+}))
+vi.mock('@repo/workflow-utils', () => ({ createWorkflow: createWorkflowMock }))
+vi.mock('../../db', () => ({ createDb: vi.fn() }))
+
+const RUN_ID = '11111111-1111-4111-8111-111111111111'
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'admin-1',
+		mainCharacterId: 'm',
+		sessionId: 's',
+		characters: [],
+		is_admin: true,
+		roles: [],
+		discordUserId: null,
+		...over,
+	} as SessionUser
+}
+
+const env = { SERVICE_ACCESS_AUDIT_WORKFLOW: {}, FEATURES: {} } as never
+
+function createApp(db: unknown, user: SessionUser = makeUser()) {
+	const app = new Hono<{
+		Bindings: Record<string, unknown>
+		Variables: { user?: SessionUser; db?: unknown }
+	}>()
+	app.use('*', async (c, next) => {
+		c.set('user', user)
+		c.set('db', db)
+		await next()
+	})
+	app.route('/api/services-audit', servicesAuditRoutes)
+	return app
+}
+
+function post(db: unknown, path = '/runs') {
+	return createApp(db).request(`/api/services-audit${path}`, { method: 'POST' }, env)
+}
+
+/** Postgres unique-violation, as the driver surfaces it. */
+function uniqueViolation(nested = false): Error {
+	const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), {
+		code: '23505',
+	})
+	if (!nested) return pgError
+	// MEMORY: the Neon driver has been seen wrapping the real error on .cause.
+	return Object.assign(new Error('Failed query'), { cause: pgError })
+}
+
+/** A db whose run insert resolves to one row. */
+function makeInsertingDb(onInsert?: () => void) {
+	return {
+		insert: vi.fn(() => ({
+			values: () => ({
+				returning: async () => {
+					onInsert?.()
+					return [{ id: RUN_ID, status: 'scanning' }]
+				},
+			}),
+		})),
+		update: vi.fn(() => ({ set: () => ({ where: async () => undefined }) })),
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	getStubMock.mockReturnValue({ checkFlag: vi.fn(async () => true) })
+	createWorkflowMock.mockResolvedValue({ id: 'instance-1' })
+})
+
+describe('POST /runs', () => {
+	it('starts a scan and returns 201 with the run and workflow instance ids', async () => {
+		const res = await post(makeInsertingDb())
+
+		// 201, deliberately: the discord-servers precedent returns a bare 200.
+		expect(res.status).toBe(201)
+		const body = (await res.json()) as Record<string, unknown>
+		expect(body).toMatchObject({ runId: RUN_ID, status: 'scanning' })
+		expect(body.workflowInstanceId).toMatch(/^service-access-audit-/)
+
+		// Created via createWorkflow (retention policy is centralised there), and
+		// the row and the instance share the minted id.
+		expect(createWorkflowMock).toHaveBeenCalledTimes(1)
+		const [, options] = createWorkflowMock.mock.calls[0] as [unknown, Record<string, unknown>]
+		expect(options.id).toBe(body.workflowInstanceId)
+		expect(options.params).toMatchObject({ runId: RUN_ID, initiatedByUserId: 'admin-1' })
+	})
+
+	it('409s when a live run already holds the active lock', async () => {
+		const db = {
+			insert: vi.fn(() => ({
+				values: () => ({
+					returning: async () => {
+						throw uniqueViolation()
+					},
+				}),
+			})),
+			update: vi.fn(),
+		}
+
+		const res = await post(db)
+
+		expect(res.status).toBe(409)
+		expect(await res.json()).toMatchObject({
+			error: 'A service access audit run is already in progress',
+		})
+		// No workflow may be created for a run that never got the lock.
+		expect(createWorkflowMock).not.toHaveBeenCalled()
+	})
+
+	it('409s when the driver nests the unique violation on error.cause', async () => {
+		const db = {
+			insert: vi.fn(() => ({
+				values: () => ({
+					returning: async () => {
+						throw uniqueViolation(true)
+					},
+				}),
+			})),
+			update: vi.fn(),
+		}
+
+		expect((await post(db)).status).toBe(409)
+	})
+
+	it('does NOT report an unrelated database error as 409', async () => {
+		// A broad try/catch would tell an operator "a run is already live" during an
+		// emergency when in fact the database is simply broken.
+		const db = {
+			insert: vi.fn(() => ({
+				values: () => ({
+					returning: async () => {
+						throw new Error('connection refused')
+					},
+				}),
+			})),
+			update: vi.fn(),
+		}
+
+		const res = await post(db)
+		expect(res.status).toBe(500)
+		expect(await res.json()).toMatchObject({ error: 'Failed to start audit run' })
+	})
+
+	it('CONCURRENT starts: exactly one 201 and one 409', async () => {
+		// The lock is a UNIQUE index on active_lock, so the loser 23505s. This is a
+		// race-free insert, not a check-then-insert.
+		let lockHeld = false
+		const db = {
+			insert: vi.fn(() => ({
+				values: () => ({
+					returning: async () => {
+						if (lockHeld) throw uniqueViolation()
+						lockHeld = true
+						return [{ id: RUN_ID, status: 'scanning' }]
+					},
+				}),
+			})),
+			update: vi.fn(() => ({ set: () => ({ where: async () => undefined }) })),
+		}
+
+		const [a, b] = await Promise.all([post(db), post(db)])
+		const statuses = [a.status, b.status].sort()
+
+		expect(statuses).toEqual([201, 409])
+		expect(createWorkflowMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('RELEASES the lock when the workflow fails to start', async () => {
+		// Otherwise the lock is held forever by a run whose workflow will never run
+		// and therefore will never NULL it — bricking the tool with no UI recovery.
+		const sets: Array<Record<string, unknown>> = []
+		const db = {
+			insert: vi.fn(() => ({
+				values: () => ({ returning: async () => [{ id: RUN_ID, status: 'scanning' }] }),
+			})),
+			update: vi.fn(() => ({
+				set: (values: Record<string, unknown>) => {
+					sets.push(values)
+					return { where: async () => undefined }
+				},
+			})),
+		}
+		createWorkflowMock.mockRejectedValue(new Error('workflows unavailable'))
+
+		const res = await post(db)
+
+		expect(res.status).toBe(500)
+		expect(sets).toHaveLength(1)
+		expect(sets[0]).toMatchObject({ status: 'failed', activeLock: null })
+	})
+
+	it('issues no service RPCs', async () => {
+		await post(makeInsertingDb())
+
+		expect(getStubMock).not.toHaveBeenCalled()
+		expect(getDiscordStubMock).not.toHaveBeenCalled()
+	})
+})
+
+describe('GET /runs/:id', () => {
+	function makeReadDb(run: Record<string, unknown> | undefined) {
+		return {
+			query: {
+				serviceAccessAuditRuns: { findFirst: vi.fn(async () => run) },
+				serviceAccessAuditRows: { findMany: vi.fn(async () => []) },
+			},
+			select: vi.fn(() => ({
+				from: () => ({ where: () => ({ groupBy: async () => [] }) }),
+			})),
+		}
+	}
+
+	it('404s for an unknown run', async () => {
+		const app = createApp(makeReadDb(undefined))
+		const res = await app.request(`/api/services-audit/runs/${RUN_ID}`, {}, env)
+		expect(res.status).toBe(404)
+	})
+
+	it('reports the Mumble flag state and is explicit that the denominator is Discord-only', async () => {
+		getStubMock.mockReturnValue({ checkFlag: vi.fn(async () => false) })
+		const app = createApp(
+			makeReadDb({ id: RUN_ID, status: 'awaiting_confirmation', memberCorpCount: 12 })
+		)
+
+		const res = await app.request(`/api/services-audit/runs/${RUN_ID}`, {}, env)
+		const body = (await res.json()) as Record<string, unknown>
+
+		expect(res.status).toBe(200)
+		// The flag is off => enforcement would silently no-op. The UI must be able
+		// to say that, distinctly from "we could not tell".
+		expect(body.mumbleFeature).toMatchObject({ enabled: false, state: 'flag_off' })
+		// The scan cannot know Mumble provisioning without an RPC, so it must not
+		// pretend inPopulation is a complete denominator.
+		expect(body.mumblePopulationKnown).toBe(false)
+		expect(body.inPopulationBasis).toBe('discord_link_only')
+	})
+
+	it('distinguishes an unreachable FEATURES DO from a disabled flag', async () => {
+		getStubMock.mockImplementation(() => {
+			throw new Error('DO down')
+		})
+		const app = createApp(makeReadDb({ id: RUN_ID, status: 'completed' }))
+
+		const res = await app.request(`/api/services-audit/runs/${RUN_ID}`, {}, env)
+		const body = (await res.json()) as Record<string, unknown>
+
+		expect(body.mumbleFeature).toMatchObject({ enabled: false, state: 'unreachable' })
+	})
+})
+
+describe('GET /runs/:id/rows', () => {
+	function makeRowsDb() {
+		return {
+			select: vi.fn(() => ({ from: () => ({ where: async () => [{ count: 3 }] }) })),
+			query: {
+				serviceAccessAuditRows: {
+					// Takes its args explicitly so the limit/offset pushed into SQL are
+					// observable to the assertions below.
+					findMany: vi.fn(async (_args?: Record<string, unknown>) => [
+						{ id: 'r1', userId: 'u1', reason: 'unmanaged_corp', eligible: false },
+					]),
+				},
+			},
+		}
+	}
+
+	it('paginates in SQL and returns pagination metadata', async () => {
+		const db = makeRowsDb()
+		const app = createApp(db)
+
+		const res = await app.request(
+			`/api/services-audit/runs/${RUN_ID}/rows?page=2&pageSize=10`,
+			{},
+			env
+		)
+		const body = (await res.json()) as Record<string, unknown>
+
+		expect(res.status).toBe(200)
+		expect(body.pagination).toMatchObject({ page: 2, pageSize: 10, totalCount: 3 })
+		// Filtering/pagination must be pushed into SQL — the existing discord audit
+		// slices in JS, which is fatal under a 5s poll.
+		const findManyArgs = db.query.serviceAccessAuditRows.findMany.mock.calls[0]?.[0] as
+			| Record<string, unknown>
+			| undefined
+		expect(findManyArgs).toMatchObject({ limit: 10, offset: 10 })
+	})
+
+	it('rejects an unknown reason subcode', async () => {
+		const app = createApp(makeRowsDb())
+		const res = await app.request(
+			`/api/services-audit/runs/${RUN_ID}/rows?reason=not_a_reason`,
+			{},
+			env
+		)
+		expect(res.status).toBe(400)
+	})
+
+	it('rejects an oversized pageSize rather than letting it through', async () => {
+		const app = createApp(makeRowsDb())
+		const res = await app.request(
+			`/api/services-audit/runs/${RUN_ID}/rows?pageSize=10000`,
+			{},
+			env
+		)
+		expect(res.status).toBe(400)
+	})
+})
+
+describe('the enforcement surface does not exist yet', () => {
+	it('exposes no enforce/confirm route', async () => {
+		// Increment 3 is read-only on purpose: nobody should be able to revoke
+		// anything until the real ineligible count has been measured. A route that
+		// exists is a route that gets called at 04:00.
+		const db = makeInsertingDb()
+		for (const path of ['/runs/enforce', `/runs/${RUN_ID}/enforce`, `/runs/${RUN_ID}/confirm`]) {
+			const res = await post(db, path)
+			expect(res.status).toBe(404)
+		}
+		expect(createWorkflowMock).not.toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/routes/services-audit.ts
+++ b/apps/core/src/routes/services-audit.ts
@@ -1,0 +1,393 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+
+import { and, asc, desc, eq, sql } from '@repo/db-utils'
+import { logger } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
+
+import { serviceAccessAuditRows, serviceAccessAuditRuns } from '../db/schema'
+import { isMumbleFeatureEnabledStrict } from '../lib/mumble-feature'
+import { requireAdmin, requireAuth } from '../middleware/session'
+
+import type { App } from '../context'
+import type { ServiceEligibilityReason } from '../lib/service-eligibility'
+
+/**
+ * SERVICE ACCESS AUDIT — READ-ONLY API.
+ *
+ * Every route here reads. There is deliberately NO enforce route, no
+ * confirm route and no cancel-enforce route, because enforcement is not built:
+ * the point of shipping the scan alone is to learn the real ineligible count
+ * before anyone commits to revoking accounts on an estimate. A route that
+ * exists is a route that gets called at 04:00.
+ *
+ * `POST /runs` and `POST /runs/:id/cancel` mutate only this app's own audit
+ * tables. Neither issues a single Mumble or Discord RPC.
+ */
+const app = new Hono<App>()
+
+/** Non-terminal statuses: a run in one of these still holds the active lock. */
+const LIVE_STATUSES = ['scanning', 'enforcing'] as const
+
+const ALL_REASONS: ServiceEligibilityReason[] = [
+	'member_corp',
+	'admin_exempt',
+	'no_characters',
+	'null_corp',
+	'only_deleted_member_char',
+	'unmanaged_corp',
+	'no_user_row',
+]
+
+/** House style: local z.object + safeParse in the handler. There is ZERO
+ * zValidator in apps/core/src — do not introduce it here. */
+const rowsQuerySchema = z.object({
+	reason: z.enum(ALL_REASONS as [ServiceEligibilityReason, ...ServiceEligibilityReason[]]).optional(),
+	eligible: z.enum(['true', 'false']).optional(),
+	page: z.coerce.number().int().min(1).default(1),
+	pageSize: z.coerce.number().int().min(1).max(100).default(50),
+})
+
+/**
+ * Duck-typed unique-violation check. There is no shared helper for this in the
+ * repo (the only precedent is a private method on
+ * apps/broadcasts/src/durable-object.ts:521).
+ *
+ * Checks `.cause` as well as the top level: the Neon serverless driver has been
+ * observed surfacing the real Postgres error on `error.cause` rather than on the
+ * error itself. Duck-typed on the code — never string-matched on the message.
+ */
+function isUniqueViolation(error: unknown): boolean {
+	const hasCode = (value: unknown): boolean =>
+		typeof value === 'object' &&
+		value !== null &&
+		typeof (value as { code?: unknown }).code === 'string' &&
+		(value as { code: string }).code === '23505'
+
+	if (hasCode(error)) return true
+	if (typeof error === 'object' && error !== null) {
+		return hasCode((error as { cause?: unknown }).cause)
+	}
+	return false
+}
+
+/**
+ * POST /services-audit/runs
+ * Start a READ-ONLY eligibility scan.
+ */
+app.post('/runs', requireAuth(), requireAdmin(), async (c) => {
+	const user = c.get('user')
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not available' }, 500)
+	if (!user) return c.json({ error: 'Unauthorized' }, 401)
+
+	// Mint the id BEFORE the insert so the row and the workflow instance share it,
+	// which is what makes scanWorkflowInstanceId's unique constraint meaningful.
+	const workflowId = `service-access-audit-${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}-${Date.now().toString(36)}`
+
+	let run: { id: string; status: string } | undefined
+	try {
+		// ONLY the insert is inside this try. A broad try/catch around the whole
+		// handler would report an unrelated 23505 as "a run is already live" — a
+		// lie told to an operator during an emergency.
+		;[run] = await db
+			.insert(serviceAccessAuditRuns)
+			.values({
+				scanWorkflowInstanceId: workflowId,
+				initiatedByUserId: user.id,
+				status: 'scanning',
+				// UNIQUE, NULL when terminal => exactly one live run. A concurrent
+				// insert 23505s rather than racing a check-then-insert.
+				activeLock: 'live',
+			})
+			.returning({
+				id: serviceAccessAuditRuns.id,
+				status: serviceAccessAuditRuns.status,
+			})
+	} catch (error) {
+		if (isUniqueViolation(error)) {
+			return c.json(
+				{ error: 'A service access audit run is already in progress' },
+				409
+			)
+		}
+		logger.error('[ServicesAudit] Failed to create audit run', { error: String(error) })
+		return c.json({ error: 'Failed to start audit run' }, 500)
+	}
+
+	if (!run) {
+		logger.error('[ServicesAudit] Insert returned no run row')
+		return c.json({ error: 'Failed to start audit run' }, 500)
+	}
+
+	try {
+		await createWorkflow(c.env.SERVICE_ACCESS_AUDIT_WORKFLOW, {
+			id: workflowId,
+			params: { runId: run.id, initiatedByUserId: user.id, phase: 'scan' as const },
+		})
+	} catch (error) {
+		// The row already holds the lock. If the workflow never starts, nothing will
+		// ever NULL that lock, and every subsequent POST /runs 409s forever with no
+		// way to recover from the UI. Release it here.
+		await db
+			.update(serviceAccessAuditRuns)
+			.set({
+				status: 'failed',
+				activeLock: null,
+				errorMessage: 'The scan workflow failed to start; no scan was performed.',
+				completedAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.where(eq(serviceAccessAuditRuns.id, run.id))
+
+		logger.error('[ServicesAudit] Failed to start scan workflow', {
+			runId: run.id,
+			error: String(error),
+		})
+		return c.json({ error: 'Failed to start audit workflow' }, 500)
+	}
+
+	// 201 is a deliberate departure from the discord-servers precedent (which
+	// returns a bare 200) — this creates a resource.
+	return c.json({ runId: run.id, workflowInstanceId: workflowId, status: run.status }, 201)
+})
+
+/**
+ * GET /services-audit/runs
+ * List recent runs, newest first.
+ */
+app.get('/runs', requireAuth(), requireAdmin(), async (c) => {
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not available' }, 500)
+
+	try {
+		const runs = await db.query.serviceAccessAuditRuns.findMany({
+			orderBy: desc(serviceAccessAuditRuns.startedAt),
+			limit: 25,
+			columns: {
+				id: true,
+				status: true,
+				memberCorpCount: true,
+				scanned: true,
+				inPopulation: true,
+				eligibleCount: true,
+				ineligibleCount: true,
+				blastRadiusTripped: true,
+				// A suspect basis means this run's numbers may be untrustworthy. It
+				// must reach the list, not just the detail view — an operator scanning
+				// a list of runs has to see which ones not to believe.
+				basisSuspect: true,
+				errorMessage: true,
+				startedAt: true,
+				completedAt: true,
+			},
+		})
+
+		return c.json({ items: runs })
+	} catch (error) {
+		logger.error('[ServicesAudit] Failed to list audit runs', { error: String(error) })
+		return c.json({ error: 'Failed to list audit runs' }, 500)
+	}
+})
+
+/**
+ * GET /services-audit/runs/:id
+ * Run status, the reason breakdown, and a small sample of affected names.
+ */
+app.get('/runs/:id', requireAuth(), requireAdmin(), async (c) => {
+	const runId = c.req.param('id')
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not available' }, 500)
+
+	try {
+		const run = await db.query.serviceAccessAuditRuns.findFirst({
+			where: eq(serviceAccessAuditRuns.id, runId),
+		})
+		if (!run) return c.json({ error: 'Audit run not found' }, 404)
+
+		// Breakdown BY SUBCODE, aggregated in SQL. One "ineligible" number is
+		// unreviewable; "3,900 null_corp" is a recognisably broken ESI sync.
+		const breakdown = await db
+			.select({
+				reason: serviceAccessAuditRows.reason,
+				eligible: serviceAccessAuditRows.eligible,
+				count: sql<number>`count(*)::int`,
+			})
+			.from(serviceAccessAuditRows)
+			.where(eq(serviceAccessAuditRows.runId, runId))
+			.groupBy(serviceAccessAuditRows.reason, serviceAccessAuditRows.eligible)
+
+		// Names, not counts: someone must be able to recognise a person who
+		// obviously should not be on this list.
+		const sample = await db.query.serviceAccessAuditRows.findMany({
+			where: and(
+				eq(serviceAccessAuditRows.runId, runId),
+				eq(serviceAccessAuditRows.eligible, false)
+			),
+			limit: 10,
+			columns: {
+				userId: true,
+				mainCharacterId: true,
+				mainCharacterName: true,
+				reason: true,
+				hasDiscordLink: true,
+			},
+		})
+
+		// Resolved live rather than snapshotted at scan time: the flag's state NOW
+		// is what predicts whether enforcement would no-op, and a scan-time value
+		// would already be stale by the time an operator reads this.
+		const mumbleFeature = await isMumbleFeatureEnabledStrict(c.env)
+
+		return c.json({
+			...run,
+			reasonBreakdown: breakdown,
+			sample,
+			mumbleFeature,
+			/**
+			 * HONEST DENOMINATOR. `inPopulation` counts Discord-linked users ONLY.
+			 * Mumble provisioning state lives exclusively in the Mumble Durable
+			 * Object, and determining it would require a service RPC — which this
+			 * read-only increment forbids. (`core_user_services` looks like it would
+			 * answer this, but it is dead: nothing in the codebase ever writes it.)
+			 * So a user with a Mumble account and no Discord link is NOT counted here.
+			 * The UI must say so rather than imply the denominator is complete.
+			 */
+			mumblePopulationKnown: false,
+			inPopulationBasis: 'discord_link_only' as const,
+		})
+	} catch (error) {
+		logger.error('[ServicesAudit] Failed to read audit run', { runId, error: String(error) })
+		return c.json({ error: 'Failed to read audit run' }, 500)
+	}
+})
+
+/**
+ * GET /services-audit/runs/:id/rows
+ * Paginated rows. Filtering and pagination happen IN SQL — the existing discord
+ * audit's row read does per-user DO calls and slices in JS, which is fatal under
+ * a 5s poll.
+ */
+app.get('/runs/:id/rows', requireAuth(), requireAdmin(), async (c) => {
+	const runId = c.req.param('id')
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not available' }, 500)
+
+	const parsed = rowsQuerySchema.safeParse({
+		reason: c.req.query('reason'),
+		eligible: c.req.query('eligible'),
+		page: c.req.query('page') ?? undefined,
+		pageSize: c.req.query('pageSize') ?? undefined,
+	})
+	if (!parsed.success) {
+		return c.json({ error: 'Invalid query', details: parsed.error.flatten() }, 400)
+	}
+	const { reason, eligible, page, pageSize } = parsed.data
+
+	try {
+		const conditions = [eq(serviceAccessAuditRows.runId, runId)]
+		if (reason) conditions.push(eq(serviceAccessAuditRows.reason, reason))
+		if (eligible) conditions.push(eq(serviceAccessAuditRows.eligible, eligible === 'true'))
+		const where = and(...conditions)
+
+		const [totalRow] = await db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(serviceAccessAuditRows)
+			.where(where)
+		const totalCount = totalRow?.count ?? 0
+
+		const rows = await db.query.serviceAccessAuditRows.findMany({
+			where,
+			// Order by userId, NOT createdAt. Rows are written one INSERT per scan
+			// page, so `now()` is the transaction timestamp and all 500 rows of a
+			// batch share a byte-identical createdAt. Postgres may return a tie group
+			// in any order per query, so OFFSET paging over it silently duplicates
+			// some people and omits others — in a review UI whose entire job is
+			// showing an operator who is about to lose their account. userId is
+			// unique per run and covered by service_access_audit_rows_run_user_unique.
+			orderBy: asc(serviceAccessAuditRows.userId),
+			limit: pageSize,
+			offset: (page - 1) * pageSize,
+			columns: {
+				id: true,
+				userId: true,
+				mainCharacterId: true,
+				mainCharacterName: true,
+				eligible: true,
+				reason: true,
+				corporationIds: true,
+				hasDiscordLink: true,
+			},
+		})
+
+		return c.json({
+			rows,
+			pagination: {
+				page,
+				pageSize,
+				totalCount,
+				totalPages: Math.max(Math.ceil(totalCount / pageSize), 1),
+			},
+		})
+	} catch (error) {
+		logger.error('[ServicesAudit] Failed to read audit rows', { runId, error: String(error) })
+		return c.json({ error: 'Failed to read audit rows' }, 500)
+	}
+})
+
+/**
+ * POST /services-audit/runs/:id/cancel
+ * Cancel a live SCAN and release the lock.
+ *
+ * Cancelling a scan is safe precisely because the scan is read-only — there is
+ * nothing half-done to unwind. This is NOT a cancel-enforce, which would be a
+ * different and much harder problem.
+ *
+ * KNOWN LIMITATION: this marks the RUN cancelled and releases the lock, but does
+ * not terminate the workflow instance. An in-flight scan keeps paging and its
+ * finalize step will overwrite status='cancelled' with its own terminal status.
+ * Harmless today — the scan only reads and its finalize also NULLs the lock — but
+ * it means "cancelled" is not yet a guarantee that the scan stopped. Before
+ * enforcement exists, this must gain a real terminate (or a status re-check
+ * inside the workflow), because cancelling an ENFORCE run has to actually stop it.
+ */
+app.post('/runs/:id/cancel', requireAuth(), requireAdmin(), async (c) => {
+	const runId = c.req.param('id')
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not available' }, 500)
+
+	try {
+		// Conditional on a live status, so this cannot resurrect-then-null the lock
+		// of an already-terminal run.
+		const cancelled = await db
+			.update(serviceAccessAuditRuns)
+			.set({
+				status: 'cancelled',
+				activeLock: null,
+				errorMessage: 'Cancelled by an administrator.',
+				completedAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(serviceAccessAuditRuns.id, runId),
+					sql`${serviceAccessAuditRuns.status} IN (${sql.join(
+						LIVE_STATUSES.map((status) => sql`${status}`),
+						sql`, `
+					)})`
+				)
+			)
+			.returning({ id: serviceAccessAuditRuns.id })
+
+		if (cancelled.length === 0) {
+			return c.json({ error: 'No live audit run with that id' }, 404)
+		}
+
+		return c.json({ runId, status: 'cancelled' })
+	} catch (error) {
+		logger.error('[ServicesAudit] Failed to cancel audit run', { runId, error: String(error) })
+		return c.json({ error: 'Failed to cancel audit run' }, 500)
+	}
+})
+
+export default app

--- a/apps/core/src/services/mumble.service.ts
+++ b/apps/core/src/services/mumble.service.ts
@@ -7,13 +7,8 @@ import { parseMumbleError } from '@repo/mumble'
 import { createDb } from '../db'
 import { getCachedUserRoles } from '../lib/groups-cache'
 import { isMumbleFeatureEnabled } from '../lib/mumble-feature'
-import {
-	managedCorporations,
-	mumbleTempopGuests,
-	mumbleTempops,
-	userCharacters,
-	users,
-} from '../db/schema'
+import { hasMemberCorporationAttachment } from '../lib/service-eligibility'
+import { mumbleTempopGuests, mumbleTempops, userCharacters, users } from '../db/schema'
 
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
@@ -175,31 +170,6 @@ async function isUserBlacklisted(env: Env, userId: string): Promise<boolean> {
 	return hrStub.isUserBlacklisted(userId)
 }
 
-async function hasMemberCorporationAttachment(env: Env, userId: string): Promise<boolean> {
-	const db = createDb(env.DATABASE_URL)
-	const [characters, memberCorporations] = await Promise.all([
-		db.query.userCharacters.findMany({
-			where: and(eq(userCharacters.userId, userId), eq(userCharacters.isDeleted, false)),
-			columns: {
-				corporationId: true,
-			},
-		}),
-		db.query.managedCorporations.findMany({
-			where: eq(managedCorporations.isMemberCorporation, true),
-			columns: {
-				corporationId: true,
-			},
-		}),
-	])
-
-	const memberCorporationIds = new Set(
-		memberCorporations.map((corporation) => corporation.corporationId)
-	)
-	return characters.some(
-		(character) => !!character.corporationId && memberCorporationIds.has(character.corporationId)
-	)
-}
-
 async function runWithConcurrencyLimit<T, R>(
 	items: T[],
 	limit: number,
@@ -252,7 +222,7 @@ async function getUserGroupNames(
 				is_admin: true,
 			},
 		}),
-		hasMemberCorporationAttachment(env, userId),
+		hasMemberCorporationAttachment(db, userId),
 		getCachedUserRoles(env, userId),
 	])
 	const isAllianceMember = roleAttachments.some(

--- a/apps/core/src/workflows/__tests__/service-access-audit.workflow.test.ts
+++ b/apps/core/src/workflows/__tests__/service-access-audit.workflow.test.ts
@@ -1,0 +1,506 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ServiceAccessAuditWorkflow } from '../service-access-audit.workflow'
+
+import type { ServiceAccessAuditWorkflowParams } from '../service-access-audit.workflow'
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+
+/**
+ * `cloudflare:workers` is aliased to src/test/mocks/cloudflare-workers.ts by
+ * vitest.unit.config.ts, so WorkflowEntrypoint needs no vi.mock here.
+ */
+
+const { createDbMock, getStubMock, getDiscordStubMock, captureExceptionMock } = vi.hoisted(() => ({
+	createDbMock: vi.fn(),
+	getStubMock: vi.fn(),
+	getDiscordStubMock: vi.fn(),
+	captureExceptionMock: vi.fn(),
+}))
+
+vi.mock('../../db', () => ({ createDb: createDbMock }))
+
+/**
+ * THE ZERO-RPC HARNESS. Mocking both stub factories at the module-graph level is
+ * what lets us assert that a scan issues NO service calls: a real Mumble call
+ * would surface as a getStub call, and a real Discord call as a getDiscordStub
+ * call. Nothing else can reach those services.
+ */
+vi.mock('@repo/do-utils', () => ({ getStub: getStubMock }))
+vi.mock('@repo/discord', () => ({
+	getDiscordStub: getDiscordStubMock,
+	DISCORD_EXCLUDED_AUTH_ROLE_IDS: new Set<string>(),
+}))
+vi.mock('@repo/hono-helpers', () => ({
+	captureException: captureExceptionMock,
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const RUN_ID = '11111111-1111-4111-8111-111111111111'
+
+/**
+ * Reconstruct a drizzle sql template's text so db.execute calls can be routed by
+ * content rather than by brittle call-ordering.
+ *
+ * MUST recurse: drizzle nests sql`` fragments (e.g. the keyset
+ * `WHERE u.id > ${cursor}` in scanUserEligibilityPage) as child SQL objects
+ * rather than flattening them into string chunks. A non-recursive version
+ * silently fails to see the cursor clause, which makes the fake serve page 1
+ * forever.
+ */
+function sqlText(query: unknown): string {
+	if (typeof query === 'string') return query
+	if (query === null || typeof query !== 'object') return ''
+
+	const node = query as { queryChunks?: unknown[]; value?: unknown }
+	if (Array.isArray(node.queryChunks)) {
+		return node.queryChunks.map(sqlText).join('')
+	}
+	// StringChunk holds its text in a `value` array.
+	if (Array.isArray(node.value)) return node.value.join('')
+	return ''
+}
+
+interface ScanUserFixture {
+	id: string
+	is_admin: boolean
+	has_discord_link: boolean
+	has_member_corp_character: boolean
+	has_any_character: boolean
+	has_any_corporation: boolean
+	had_deleted_member_corp_character: boolean
+}
+
+function makeDb(options: {
+	memberCorporationIds?: string[]
+	lastGoodMemberCorpCount?: number | null
+	users?: ScanUserFixture[]
+}) {
+	const memberCorporationIds = options.memberCorporationIds ?? ['1000001', '1000002']
+	const users = options.users ?? []
+
+	const insertedRows: Array<Record<string, unknown>> = []
+	const runUpdates: Array<Record<string, unknown>> = []
+
+	// The finalize aggregate is computed from the rows actually inserted — this
+	// mirrors the real SQL aggregate and is what makes the "counters cannot
+	// double-count on retry" property observable in a unit test.
+	const aggregate = () => {
+		const unique = new Map(insertedRows.map((row) => [row.userId as string, row]))
+		const rows = [...unique.values()]
+		return {
+			scanned: rows.length,
+			eligible_count: rows.filter((r) => r.eligible === true).length,
+			ineligible_count: rows.filter((r) => r.eligible === false).length,
+			in_population: rows.filter((r) => r.hasDiscordLink === true).length,
+		}
+	}
+
+	const db = {
+		query: {
+			managedCorporations: {
+				findMany: vi.fn(async () =>
+					memberCorporationIds.map((corporationId) => ({ corporationId }))
+				),
+			},
+			serviceAccessAuditRuns: {
+				// getBasisBaseline takes the MAX over recent good runs, so it reads a
+				// list rather than the single latest row.
+				findMany: vi.fn(async () =>
+					options.lastGoodMemberCorpCount === null ||
+					options.lastGoodMemberCorpCount === undefined
+						? []
+						: [
+								{
+									memberCorpCount: options.lastGoodMemberCorpCount,
+									memberCorporationIds: Array.from(
+										{ length: options.lastGoodMemberCorpCount },
+										(_, i) => `baseline-corp-${i + 1}`
+									),
+								},
+							]
+				),
+			},
+		},
+		execute: vi.fn(async (query: unknown) => {
+			const text = sqlText(query)
+
+			// scanUserEligibilityPage — keyset page over users.
+			// Keysets off the ACTUAL cursor param in the query, not off a hidden
+			// counter: a fake that ignores the cursor would serve page 1 forever and
+			// mask a genuinely broken cursor behind correct-looking totals.
+			if (text.includes('AS has_member_corp_character')) {
+				const cursor = /u\.id > ([^:\s]+)::uuid/.exec(text)?.[1]
+				const start = cursor ? users.findIndex((u) => u.id === cursor) + 1 : 0
+				return { rows: users.slice(start, start + 500) }
+			}
+
+			// fetchUserEnrichment — main character + corporations for the page.
+			// Only returns users actually named in the query, so an enrichment call
+			// that failed to scope to its page would show up as missing names.
+			if (text.includes('AS corporation_ids')) {
+				return {
+					rows: users
+						.filter((user) => text.includes(user.id))
+						.map((user) => ({
+							id: user.id,
+							main_character_id: `char-${user.id}`,
+							main_character_name: `Pilot ${user.id}`,
+							corporation_ids: user.has_any_corporation ? ['1000001'] : [],
+						})),
+				}
+			}
+
+			// finalize aggregate.
+			if (text.includes('AS scanned')) {
+				return { rows: [aggregate()] }
+			}
+
+			throw new Error(`Unexpected db.execute call: ${text}`)
+		}),
+		insert: vi.fn(() => ({
+			values: (rows: Array<Record<string, unknown>>) => ({
+				onConflictDoNothing: async () => {
+					insertedRows.push(...rows)
+				},
+			}),
+		})),
+		update: vi.fn(() => ({
+			set: (values: Record<string, unknown>) => ({
+				where: async () => {
+					runUpdates.push(values)
+				},
+			}),
+		})),
+	}
+
+	return { db, insertedRows, runUpdates }
+}
+
+/** Fake step: runs the callback inline, tolerating both step.do(name, fn) and
+ * step.do(name, config, fn). */
+function makeStep(): WorkflowStep {
+	return {
+		do: async (_name: string, configOrFn: unknown, maybeFn?: unknown) => {
+			const fn = typeof configOrFn === 'function' ? configOrFn : maybeFn
+			return (fn as () => Promise<unknown>)()
+		},
+		sleep: async () => undefined,
+	} as unknown as WorkflowStep
+}
+
+function makeEvent(): WorkflowEvent<ServiceAccessAuditWorkflowParams> {
+	return {
+		payload: { runId: RUN_ID, initiatedByUserId: 'admin-1' },
+		timestamp: new Date(),
+		instanceId: 'instance-1',
+	} as WorkflowEvent<ServiceAccessAuditWorkflowParams>
+}
+
+function makeEnv() {
+	return {
+		DATABASE_URL: 'postgres://fake',
+		FEATURES: {},
+	} as never
+}
+
+function runWorkflow(env = makeEnv()) {
+	const workflow = new ServiceAccessAuditWorkflow({} as never, env)
+	return workflow.run(makeEvent(), makeStep())
+}
+
+/** A user fixture that lands on a given eligibility reason. */
+function user(id: string, over: Partial<ScanUserFixture> = {}): ScanUserFixture {
+	return {
+		id,
+		is_admin: false,
+		has_discord_link: true,
+		has_member_corp_character: true,
+		has_any_character: true,
+		has_any_corporation: true,
+		had_deleted_member_corp_character: false,
+		...over,
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	// Default: feature flag reachable and enabled.
+	getStubMock.mockReturnValue({ checkFlag: vi.fn(async () => true) })
+})
+
+describe('ServiceAccessAuditWorkflow — the circuit breaker', () => {
+	it('BLOCKS and writes ZERO rows when managed_corporations is empty', async () => {
+		const { db, insertedRows, runUpdates } = makeDb({
+			memberCorporationIds: [],
+			lastGoodMemberCorpCount: 50,
+			users: [user('u1'), user('u2')],
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		// THE core property: a blocked run must not act on an inverted rule.
+		expect(insertedRows).toHaveLength(0)
+		expect(db.insert).not.toHaveBeenCalled()
+
+		const blockedUpdate = runUpdates.find((u) => u.status === 'blocked')
+		expect(blockedUpdate).toBeDefined()
+		expect(blockedUpdate?.errorMessage).toContain('cannot be overridden')
+		// Terminal => the one-live-run lock is released.
+		expect(blockedUpdate?.activeLock).toBeNull()
+
+		// A blocked run is a terminal OUTCOME, not an error: it must not be reported
+		// to Sentry, and it must never be overwritten by status='failed'.
+		expect(captureExceptionMock).not.toHaveBeenCalled()
+		expect(runUpdates.some((u) => u.status === 'failed')).toBe(false)
+	})
+
+	it('does NOT block a shrunken basis — it scans and records basisSuspect', async () => {
+		// THE REGRESSION. An earlier version hard-blocked any >20% shrink, on the
+		// false premise that "corps leaving does not shrink the basis". De-flagging a
+		// corp IS how a corp leaves (routes/corporations/index.ts) and it shrinks the
+		// basis by construction — so blocking here refused the tool's primary use
+		// case, unoverridably. A scan is read-only and cannot hurt anyone; the teeth
+		// belong at enforcement.
+		const { db, insertedRows, runUpdates } = makeDb({
+			memberCorporationIds: ['1000001', '1000002'],
+			lastGoodMemberCorpCount: 50,
+			users: [user('u1')],
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		expect(runUpdates.find((u) => u.status === 'blocked')).toBeUndefined()
+		// It scanned.
+		expect(insertedRows.length).toBeGreaterThan(0)
+		// And it told the operator exactly what changed, rather than just a ratio.
+		const suspectUpdate = runUpdates.find((u) => u.basisSuspect === true)
+		expect(suspectUpdate).toBeDefined()
+		expect(suspectUpdate?.basisComparedToCount).toBe(50)
+		expect(suspectUpdate?.basisNote).toContain('corporation(s) left the basis')
+		expect(suspectUpdate?.basisRemovedCorporationIds as string[]).not.toHaveLength(0)
+	})
+
+	it('does NOT block when the basis is intact, even if many users are ineligible', async () => {
+		// The asymmetry: a real defection must not be blocked by the basis check.
+		const users = Array.from({ length: 40 }, (_, i) =>
+			user(`u${i}`, i < 30 ? { has_member_corp_character: false } : {})
+		)
+		const { db, runUpdates } = makeDb({
+			memberCorporationIds: Array.from({ length: 50 }, (_, i) => `${i}`),
+			lastGoodMemberCorpCount: 50,
+			users,
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		expect(runUpdates.some((u) => u.status === 'blocked')).toBe(false)
+		const finalize = runUpdates.find((u) => u.status === 'awaiting_confirmation')
+		expect(finalize).toBeDefined()
+		// The soft heuristic flags it instead — 30/40 = 75%, past the 25 floor.
+		expect(finalize?.blastRadiusTripped).toBe(true)
+	})
+})
+
+describe('ServiceAccessAuditWorkflow — read-only guarantee', () => {
+	it('issues ZERO Mumble and ZERO Discord RPCs during a full scan', async () => {
+		const { db } = makeDb({
+			memberCorporationIds: ['1000001'],
+			lastGoodMemberCorpCount: 1,
+			users: [user('u1'), user('u2', { has_member_corp_character: false })],
+		})
+		createDbMock.mockReturnValue(db)
+
+		const env = makeEnv() as unknown as { FEATURES: object; MUMBLE?: unknown }
+		await runWorkflow(env as never)
+
+		// Discord is never reached at all.
+		expect(getDiscordStubMock).not.toHaveBeenCalled()
+
+		// getStub is reached exactly once, and ONLY for the FEATURES flag read —
+		// which reads a flag, not a service. No Mumble binding is ever passed.
+		const stubBindings = getStubMock.mock.calls.map((call) => call[0])
+		expect(stubBindings).toEqual([env.FEATURES])
+	})
+})
+
+describe('ServiceAccessAuditWorkflow — counters', () => {
+	it('derives counters and the reason breakdown from the rows, matching hand-computed fixtures', async () => {
+		const users = [
+			// 2 eligible via member corp.
+			user('a1'),
+			user('a2'),
+			// 1 eligible via admin exemption (no member corp, but is_admin).
+			user('a3', { is_admin: true, has_member_corp_character: false }),
+			// 1 ineligible: no characters at all.
+			user('b1', {
+				has_member_corp_character: false,
+				has_any_character: false,
+				has_any_corporation: false,
+			}),
+			// 1 ineligible: characters exist, all corps NULL.
+			user('b2', { has_member_corp_character: false, has_any_corporation: false }),
+			// 1 ineligible: only a deleted member-corp character.
+			user('b3', { has_member_corp_character: false, had_deleted_member_corp_character: true }),
+			// 1 ineligible: in corps, none of them member corps. No Discord link.
+			user('b4', { has_member_corp_character: false, has_discord_link: false }),
+		]
+		const { db, insertedRows, runUpdates } = makeDb({
+			memberCorporationIds: ['1000001'],
+			lastGoodMemberCorpCount: 1,
+			users,
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		const finalize = runUpdates.find(
+			(u) => u.status === 'awaiting_confirmation' || u.status === 'completed'
+		)
+		expect(finalize).toMatchObject({
+			status: 'awaiting_confirmation',
+			scanned: 7,
+			eligibleCount: 3,
+			ineligibleCount: 4,
+			// Discord-linked only: b4 has no link. This is the HONEST denominator —
+			// Mumble provisioning is not knowable without an RPC.
+			inPopulation: 6,
+			// 4/7 is past 20% but only 4 ineligible — below the absolute floor of 25.
+			blastRadiusTripped: false,
+			activeLock: null,
+		})
+
+		// The reason subcodes are what make a big number reviewable.
+		const reasons = insertedRows.map((row) => row.reason)
+		expect(reasons).toEqual([
+			'member_corp',
+			'member_corp',
+			'admin_exempt',
+			'no_characters',
+			'null_corp',
+			'only_deleted_member_char',
+			'unmanaged_corp',
+		])
+
+		// Names, not just counts.
+		expect(insertedRows[0]).toMatchObject({
+			runId: RUN_ID,
+			userId: 'a1',
+			mainCharacterName: 'Pilot a1',
+		})
+	})
+
+	it('walks every page via the keyset cursor and counts each user exactly once', async () => {
+		// 1,200 users => 3 pages of 500/500/200 plus a final empty page. Pins that
+		// the cursor actually advances: a cursor that failed to advance would serve
+		// page 1 forever, and because the inserts are onConflictDoNothing the
+		// duplicate rows would vanish and the totals would still LOOK correct.
+		const users = Array.from({ length: 1200 }, (_, i) =>
+			user(`u${String(i).padStart(4, '0')}`)
+		)
+		const { db, insertedRows, runUpdates } = makeDb({
+			memberCorporationIds: ['1000001'],
+			lastGoodMemberCorpCount: 1,
+			users,
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		expect(insertedRows).toHaveLength(1200)
+		expect(new Set(insertedRows.map((r) => r.userId)).size).toBe(1200)
+		expect(runUpdates.find((u) => u.status === 'completed')).toMatchObject({
+			scanned: 1200,
+			eligibleCount: 1200,
+		})
+	})
+
+	it("completes (not awaiting_confirmation) when nobody is ineligible, and still releases the lock", async () => {
+		const { db, runUpdates } = makeDb({
+			memberCorporationIds: ['1000001'],
+			lastGoodMemberCorpCount: 1,
+			users: [user('a1'), user('a2')],
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		const finalize = runUpdates.find((u) => u.status === 'completed')
+		expect(finalize).toMatchObject({
+			status: 'completed',
+			scanned: 2,
+			ineligibleCount: 0,
+			activeLock: null,
+		})
+	})
+})
+
+describe('ServiceAccessAuditWorkflow — failure path', () => {
+	it('NULLs the activeLock, reports to Sentry, and RE-THROWS when the scan fails', async () => {
+		const { db, runUpdates } = makeDb({
+			memberCorporationIds: ['1000001'],
+			lastGoodMemberCorpCount: 1,
+			users: [user('u1')],
+		})
+		const boom = new Error('neon exploded')
+		db.insert.mockImplementation(() => {
+			throw boom
+		})
+		createDbMock.mockReturnValue(db)
+
+		// RE-THROW is load-bearing: returning instead would make the Workflows
+		// engine record this instance as SUCCESSFUL and destroy failure attribution.
+		await expect(runWorkflow()).rejects.toThrow('neon exploded')
+
+		const failed = runUpdates.find((u) => u.status === 'failed')
+		expect(failed).toBeDefined()
+		// If this regresses, one crashed run bricks the emergency tool permanently:
+		// the lock's unique index would 409 every later POST /runs with no UI recovery.
+		expect(failed?.activeLock).toBeNull()
+		expect(failed?.errorMessage).toContain('neon exploded')
+
+		expect(captureExceptionMock).toHaveBeenCalledWith(
+			boom,
+			expect.objectContaining({
+				tags: expect.objectContaining({ workflow: 'ServiceAccessAuditWorkflow', runId: RUN_ID }),
+			})
+		)
+	})
+})
+
+describe('ServiceAccessAuditWorkflow — Mumble feature reporting', () => {
+	it('scans anyway when the Mumble flag is off, rather than refusing to start', async () => {
+		// A scan that refuses to run tells the operator nothing. A scan that runs
+		// and reports "flag off" tells them enforcement would silently no-op.
+		getStubMock.mockReturnValue({ checkFlag: vi.fn(async () => false) })
+		const { db, runUpdates } = makeDb({
+			memberCorporationIds: ['1000001'],
+			lastGoodMemberCorpCount: 1,
+			users: [user('u1', { has_member_corp_character: false })],
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		expect(runUpdates.some((u) => u.status === 'awaiting_confirmation')).toBe(true)
+	})
+
+	it('scans anyway when the FEATURES DO is unreachable', async () => {
+		getStubMock.mockImplementation(() => {
+			throw new Error('DO unreachable')
+		})
+		const { db, runUpdates } = makeDb({
+			memberCorporationIds: ['1000001'],
+			lastGoodMemberCorpCount: 1,
+			users: [user('u1')],
+		})
+		createDbMock.mockReturnValue(db)
+
+		await runWorkflow()
+
+		// An unreachable flag DO must not abort a read-only scan.
+		expect(runUpdates.some((u) => u.status === 'completed')).toBe(true)
+	})
+})

--- a/apps/core/src/workflows/service-access-audit.workflow.ts
+++ b/apps/core/src/workflows/service-access-audit.workflow.ts
@@ -1,0 +1,390 @@
+import { WorkflowEntrypoint } from 'cloudflare:workers'
+
+import { eq, sql } from '@repo/db-utils'
+import { captureException, logger } from '@repo/hono-helpers'
+import { defaultStepConfig, strictStepConfig } from '@repo/workflow-utils'
+
+import { createDb } from '../db'
+import { serviceAccessAuditRows, serviceAccessAuditRuns } from '../db/schema'
+import { isMumbleFeatureEnabledStrict } from '../lib/mumble-feature'
+import {
+	evaluateBasis,
+	evaluateBlastRadius,
+	getBasisBaseline,
+} from '../lib/service-eligibility-basis'
+import { getMemberCorporationBasis, scanUserEligibilityPage } from '../lib/service-eligibility'
+
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import type { DbClient, schema } from '../db'
+import type { Env } from '../context'
+
+/**
+ * SERVICE ACCESS AUDIT — SCAN PHASE. 100% READ-ONLY.
+ *
+ * This workflow issues ZERO service RPCs. It never touches the Mumble DO and
+ * never touches Discord. It reads Postgres and writes Postgres rows describing
+ * what enforcement *would* do. That is the entire point of shipping the scan
+ * before the enforcement: the real ineligible count has never been measured, and
+ * nobody should commit to revoking accounts on an estimate.
+ *
+ * The tests pin this by mocking `@repo/do-utils` and `@repo/discord` and
+ * asserting neither stub factory is ever called.
+ */
+export interface ServiceAccessAuditWorkflowParams {
+	runId: string
+	initiatedByUserId: string | null
+	/** Only 'scan' exists today. Present so the enforcement phase can be added as
+	 * a discriminated branch rather than as a second workflow that duplicates the
+	 * basis assertions — a second copy of the breaker is a second thing to get
+	 * wrong. */
+	phase?: 'scan'
+}
+
+/** Keyset page size. One SQL statement per page (see scanUserEligibilityPage). */
+const SCAN_PAGE_SIZE = 500
+
+/**
+ * Guards against an unbounded loop if the keyset cursor ever fails to advance.
+ * 500 pages x 500 = 250k users, comfortably above the real population.
+ */
+const MAX_SCAN_PAGES = 500
+
+type AuditRowInsert = typeof serviceAccessAuditRows.$inferInsert
+
+interface UserEnrichment {
+	mainCharacterId: string | null
+	mainCharacterName: string | null
+	corporationIds: string[]
+}
+
+/**
+ * Set-based enrichment for one page of users: main character identity + every
+ * corporation held at scan time.
+ *
+ * SET-BASED, one statement per page — NOT a per-user lookup. A per-user lookup
+ * here would reintroduce exactly the subrequest blowup that
+ * `scanUserEligibilityPage` exists to avoid.
+ *
+ * Names, not just counts: an operator reviewing 400 pending revocations needs to
+ * recognise people. "400 ineligible" is unreviewable; a list of names is
+ * reviewable, and someone spotting a name that obviously should not be there is
+ * the last line of defence before enforcement.
+ *
+ * NOTE `uc.deleted` — the Drizzle property is `isDeleted` but the COLUMN is
+ * `deleted` (db/schema.ts:178). Hand-written SQL must use the column name.
+ */
+async function fetchUserEnrichment(
+	db: DbClient<typeof schema>,
+	userIds: string[]
+): Promise<Map<string, UserEnrichment>> {
+	if (userIds.length === 0) return new Map()
+
+	const idList = sql.join(
+		userIds.map((id) => sql`${id}::uuid`),
+		sql`, `
+	)
+
+	const result = await db.execute<{
+		id: string
+		main_character_id: string | null
+		main_character_name: string | null
+		corporation_ids: string[] | null
+	}>(sql`
+		SELECT
+			u.id,
+			u.main_character_id,
+			(
+				SELECT uc.character_name
+				FROM user_characters uc
+				WHERE uc.user_id = u.id AND uc.character_id = u.main_character_id
+				LIMIT 1
+			) AS main_character_name,
+			COALESCE(
+				array_agg(DISTINCT uc2.corporation_id)
+					FILTER (WHERE uc2.corporation_id IS NOT NULL AND uc2.deleted = false),
+				'{}'
+			) AS corporation_ids
+		FROM users u
+		LEFT JOIN user_characters uc2 ON uc2.user_id = u.id
+		WHERE u.id IN (${idList})
+		GROUP BY u.id, u.main_character_id
+	`)
+
+	return new Map(
+		result.rows.map((row) => [
+			row.id,
+			{
+				mainCharacterId: row.main_character_id,
+				mainCharacterName: row.main_character_name,
+				corporationIds: row.corporation_ids ?? [],
+			},
+		])
+	)
+}
+
+export class ServiceAccessAuditWorkflow extends WorkflowEntrypoint<
+	Env,
+	ServiceAccessAuditWorkflowParams
+> {
+	async run(
+		event: WorkflowEvent<ServiceAccessAuditWorkflowParams>,
+		step: WorkflowStep
+	): Promise<void> {
+		const { runId } = event.payload
+		const db = createDb(this.env.DATABASE_URL)
+
+		try {
+			// ── 1. PREFLIGHT: THE BASIS GUARD ──
+			// strictStepConfig (1 retry), NOT defaultStepConfig: an empty
+			// managed_corporations is not a transient fault. Retrying it three times
+			// with exponential backoff only delays an abort that is already certain.
+			//
+			// Only an EMPTY basis blocks. A shrunken basis is recorded as suspect and
+			// the scan proceeds: a scan is read-only, and de-flagging corps is both
+			// the legitimate way a corp leaves AND a guaranteed way to shrink the
+			// basis, so blocking on shrink would refuse the primary use case. See
+			// lib/service-eligibility-basis.ts.
+			const basis = await step.do('preflight-basis', strictStepConfig, async () => {
+				const { corporationIds, count: memberCorpCount } = await getMemberCorporationBasis(db)
+				const baseline = await getBasisBaseline(db)
+
+				const verdict = evaluateBasis({ corporationIds, memberCorpCount, baseline })
+
+				if (verdict.blocked) {
+					// A blocked run is a correct TERMINAL OUTCOME, not an exception.
+					// Throwing here would trip the catch, which would overwrite
+					// status='blocked' with status='failed' and destroy the
+					// operator-actionable errorMessage — the one thing that tells them
+					// what to fix. So: write the terminal state, then return.
+					logger.warn('[ServicesAudit] Basis assertion tripped; aborting scan', {
+						runId,
+						memberCorpCount: verdict.memberCorpCount,
+						comparedToMemberCorpCount: verdict.comparedToMemberCorpCount,
+					})
+					await db
+						.update(serviceAccessAuditRuns)
+						.set({
+							status: 'blocked',
+							// Terminal => release the one-live-run lock.
+							activeLock: null,
+							memberCorporationIds: verdict.corporationIds,
+							memberCorpCount: verdict.memberCorpCount,
+							errorMessage: verdict.errorMessage,
+							completedAt: new Date(),
+							updatedAt: new Date(),
+						})
+						.where(eq(serviceAccessAuditRuns.id, runId))
+
+					return { blocked: true as const }
+				}
+
+				if (verdict.basisSuspect) {
+					// Not fatal, but the operator must not read this run's numbers
+					// without seeing which corporations left.
+					logger.warn('[ServicesAudit] Basis shrank versus the recent high-water mark', {
+						runId,
+						memberCorpCount: verdict.memberCorpCount,
+						comparedToMemberCorpCount: verdict.comparedToMemberCorpCount,
+						removedCorporationCount: verdict.removedCorporationIds.length,
+					})
+				}
+
+				// Snapshot the basis onto the run BEFORE scanning, so a run that dies
+				// mid-scan still records the basis it was about to act on.
+				await db
+					.update(serviceAccessAuditRuns)
+					.set({
+						memberCorporationIds: verdict.corporationIds,
+						memberCorpCount: verdict.memberCorpCount,
+						basisSuspect: verdict.basisSuspect,
+						basisComparedToCount: verdict.comparedToMemberCorpCount,
+						basisRemovedCorporationIds: verdict.removedCorporationIds,
+						basisNote: verdict.basisNote,
+						updatedAt: new Date(),
+					})
+					.where(eq(serviceAccessAuditRuns.id, runId))
+
+				return {
+					blocked: false as const,
+					memberCorpCount: verdict.memberCorpCount,
+					bootstrap: verdict.bootstrap,
+					basisSuspect: verdict.basisSuspect,
+				}
+			})
+
+			if (basis.blocked) {
+				// No rows written. Do not scan. Do not pass go.
+				return
+			}
+
+			if (basis.bootstrap) {
+				logger.warn('[ServicesAudit] No prior good run; basis is unvalidated', {
+					runId,
+					memberCorpCount: basis.memberCorpCount,
+				})
+			}
+
+			// ── 2. REPORT (never gate) the Mumble feature state ──
+			// Read-only: this predicts that enforcement would silently no-op. It must
+			// not stop the scan — a scan that refuses to run tells the operator
+			// nothing, whereas a scan that runs and reports "flag off" tells them
+			// their eventual enforcement would do nothing.
+			const mumbleFeature = await step.do('report-mumble-feature-state', strictStepConfig, () =>
+				isMumbleFeatureEnabledStrict(this.env)
+			)
+			if (!mumbleFeature.enabled) {
+				logger.warn('[ServicesAudit] Mumble feature is not enabled', {
+					runId,
+					state: mumbleFeature.state,
+					detail: mumbleFeature.message,
+				})
+			}
+
+			// ── 3. PAGED SCAN ──
+			// Each page's READ and its INSERTS happen inside ONE step.do, so a
+			// transient Neon error retries just that page instead of unwinding the
+			// whole run. (The discord-member-audit precedent does its inserts outside
+			// step.do; that is exactly the bug this avoids.)
+			let afterUserId: string | undefined
+			let page = 0
+
+			while (page < MAX_SCAN_PAGES) {
+				page++
+				// Step names must be deterministic across replays: driven by a counter,
+				// never by a timestamp or a user id.
+				const lastUserId: string | null = await step.do(
+					`scan-page-${page}`,
+					defaultStepConfig,
+					async () => {
+						const scanRows = await scanUserEligibilityPage(db, {
+							afterUserId,
+							limit: SCAN_PAGE_SIZE,
+						})
+						if (scanRows.length === 0) return null
+
+						const enrichment = await fetchUserEnrichment(
+							db,
+							scanRows.map((row) => row.userId)
+						)
+
+						const inserts: AuditRowInsert[] = scanRows.map((row) => {
+							const extra = enrichment.get(row.userId)
+							return {
+								runId,
+								userId: row.userId,
+								mainCharacterId: extra?.mainCharacterId ?? null,
+								mainCharacterName: extra?.mainCharacterName ?? null,
+								eligible: row.eligible,
+								reason: row.reason,
+								corporationIds: extra?.corporationIds ?? [],
+								hasDiscordLink: row.hasDiscordLink,
+							}
+						})
+
+						// Idempotent on unique(runId, userId): a step retry re-inserts the
+						// same page and is a no-op rather than a duplicate-key failure.
+						await db.insert(serviceAccessAuditRows).values(inserts).onConflictDoNothing()
+
+						return scanRows[scanRows.length - 1]?.userId ?? null
+					}
+				)
+
+				if (lastUserId === null) break
+				afterUserId = lastUserId
+			}
+
+			if (page >= MAX_SCAN_PAGES) {
+				logger.error('[ServicesAudit] Scan hit the page ceiling; results may be truncated', {
+					runId,
+					maxScanPages: MAX_SCAN_PAGES,
+				})
+			}
+
+			// ── 4. FINALIZE ──
+			// Counters come from a SQL AGGREGATE over the rows that were actually
+			// written. NEVER from an accumulator in the workflow body: with inserts
+			// inside step.do, a step retry re-runs the closure and an accumulator
+			// would double-count. The rows are the single source of truth.
+			await step.do('finalize', defaultStepConfig, async () => {
+				const aggregate = await db.execute<{
+					scanned: number
+					eligible_count: number
+					ineligible_count: number
+					in_population: number
+				}>(sql`
+					SELECT
+						count(*)::int AS scanned,
+						count(*) FILTER (WHERE eligible)::int AS eligible_count,
+						count(*) FILTER (WHERE NOT eligible)::int AS ineligible_count,
+						count(*) FILTER (WHERE has_discord_link)::int AS in_population
+					FROM service_access_audit_rows
+					WHERE run_id = ${runId}::uuid
+				`)
+
+				const row = aggregate.rows[0]
+				const scanned = row?.scanned ?? 0
+				const eligibleCount = row?.eligible_count ?? 0
+				const ineligibleCount = row?.ineligible_count ?? 0
+				const inPopulation = row?.in_population ?? 0
+
+				const blastRadiusTripped = evaluateBlastRadius({ scanned, ineligibleCount })
+
+				await db
+					.update(serviceAccessAuditRuns)
+					.set({
+						// Ineligible users found => a human must look. Zero => nothing to
+						// confirm, so the run is simply done.
+						status: ineligibleCount > 0 ? 'awaiting_confirmation' : 'completed',
+						// Terminal => release the one-live-run lock.
+						activeLock: null,
+						scanned,
+						inPopulation,
+						eligibleCount,
+						ineligibleCount,
+						blastRadiusTripped,
+						completedAt: new Date(),
+						updatedAt: new Date(),
+					})
+					.where(eq(serviceAccessAuditRuns.id, runId))
+
+				logger.info('[ServicesAudit] Scan complete', {
+					runId,
+					scanned,
+					eligibleCount,
+					ineligibleCount,
+					blastRadiusTripped,
+				})
+			})
+		} catch (error) {
+			captureException(error as Error, {
+				tags: { workflow: 'ServiceAccessAuditWorkflow', runId },
+			})
+			// logger.error alongside captureException: this workflow class is exported
+			// outside the withSentry wrapper (index.ts), so Sentry delivery from here
+			// is unverified. The log line is the thing known to reach somewhere.
+			logger.error('[ServicesAudit] Scan failed', { runId, error: String(error) })
+
+			await step.do('mark-failed', strictStepConfig, async () => {
+				await db
+					.update(serviceAccessAuditRuns)
+					.set({
+						status: 'failed',
+						// Terminal => release the one-live-run lock. MISSING THIS BRICKS THE
+						// TOOL: the lock's unique index would 409 every subsequent POST /runs
+						// forever, with no way to clear it from the UI.
+						activeLock: null,
+						errorMessage: error instanceof Error ? error.message : String(error),
+						completedAt: new Date(),
+						updatedAt: new Date(),
+					})
+					.where(eq(serviceAccessAuditRuns.id, runId))
+			})
+
+			// RE-THROW. Returning here (as the discord-member-audit precedent does)
+			// makes the Workflows engine record the instance as SUCCESSFUL: the
+			// dashboard goes green, errorRetention never applies, and the per-step
+			// failure attribution is destroyed.
+			throw error
+		}
+	}
+}

--- a/apps/core/vitest.unit.config.ts
+++ b/apps/core/vitest.unit.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 		include: [
 			'src/routes/__tests__/**/*.test.ts',
 			'src/services/__tests__/**/*.test.ts',
+			'src/lib/__tests__/**/*.test.ts',
 			'src/workflows/**/*.test.ts',
 			'src/__tests__/**/*.test.ts',
 		],

--- a/apps/core/vitest.unit.config.ts
+++ b/apps/core/vitest.unit.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
 		alias: {
 			'cloudflare:workers': new URL('./src/test/mocks/cloudflare-workers.ts', import.meta.url)
 				.pathname,
+			// @repo/workflow-utils re-exports NonRetryableError from
+			// 'cloudflare:workflows', so any test that imports the shared step-config
+			// presets fails to load without this. The shim exports NonRetryableError
+			// already; point both virtual modules at it.
+			'cloudflare:workflows': new URL('./src/test/mocks/cloudflare-workers.ts', import.meta.url)
+				.pathname,
 		},
 	},
 	test: {

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -248,6 +248,11 @@
 			"name": "user-mumble-refresh-workflow",
 			"binding": "USER_MUMBLE_REFRESH_WORKFLOW",
 			"class_name": "UserMumbleRefreshWorkflow"
+		},
+		{
+			"name": "service-access-audit-workflow",
+			"binding": "SERVICE_ACCESS_AUDIT_WORKFLOW",
+			"class_name": "ServiceAccessAuditWorkflow"
 		}
 	]
 }

--- a/apps/ui/src/client/components/admin-nav.tsx
+++ b/apps/ui/src/client/components/admin-nav.tsx
@@ -15,6 +15,7 @@ import {
 	Radio,
 	Receipt,
 	ScrollText,
+	ShieldAlert,
 	ShieldBan,
 	UserCircle,
 	Users,
@@ -155,6 +156,14 @@ export function AdminNav({ onNavigate }: AdminNavProps) {
 			label: 'External Links',
 			href: '/admin/external-links',
 			icon: Link2,
+		},
+		{
+			// Top-level, NOT nested under Discord: this audit covers Mumble as well,
+			// and `isDiscordRoute` only auto-opens that menu for /admin/discord-*.
+			// An emergency tool nobody can find at 04:00 is not shipped.
+			label: 'Services Audit',
+			href: '/admin/services-audit',
+			icon: ShieldAlert,
 		},
 		{
 			label: 'Blacklist',

--- a/apps/ui/src/client/hooks/useServicesAudit.ts
+++ b/apps/ui/src/client/hooks/useServicesAudit.ts
@@ -1,0 +1,138 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { api } from '@/lib/api'
+
+import type {
+	ServiceEligibilityReasonCode,
+	ServicesAuditRunDetail,
+	ServicesAuditRunStatus,
+	ServicesAuditRunSummary,
+} from '@/lib/api'
+
+/**
+ * SERVICE ACCESS AUDIT — READ-ONLY hooks.
+ *
+ * There is deliberately no enforce mutation here. Enforcement is not built, and
+ * the whole point of shipping the scan alone is to learn the real ineligible
+ * count before anyone commits to acting on it.
+ */
+
+/**
+ * Statuses at which a run is finished and will never change again. Polling MUST
+ * stop here — a blocked run that keeps polling forever is exactly the failure
+ * this page exists to catch, and nobody notices because the page looks busy
+ * rather than broken.
+ */
+const TERMINAL_STATUSES: readonly ServicesAuditRunStatus[] = [
+	'blocked',
+	'awaiting_confirmation',
+	'completed',
+	'completed_with_errors',
+	'failed',
+	'cancelled',
+]
+
+export function isTerminalRunStatus(status: ServicesAuditRunStatus | undefined): boolean {
+	return status !== undefined && TERMINAL_STATUSES.includes(status)
+}
+
+const POLL_INTERVAL_MS = 5_000
+
+export interface ServicesAuditRowFilters {
+	reason?: ServiceEligibilityReasonCode
+	eligible?: boolean
+	page?: number
+	pageSize?: number
+}
+
+export const servicesAuditKeys = {
+	all: ['admin', 'services-audit'] as const,
+	runs: () => [...servicesAuditKeys.all, 'runs'] as const,
+	run: (runId: string) => [...servicesAuditKeys.runs(), runId] as const,
+	rows: (runId: string, filters?: ServicesAuditRowFilters) =>
+		[...servicesAuditKeys.run(runId), 'rows', filters] as const,
+}
+
+/**
+ * The run list. Polls while ANY run is live so a scan started in another tab (or
+ * by another admin) shows up without a manual reload.
+ */
+export function useServicesAuditRuns() {
+	return useQuery({
+		queryKey: servicesAuditKeys.runs(),
+		queryFn: () => api.getServicesAuditRuns(),
+		staleTime: 1000 * 5,
+		refetchInterval: (query) => {
+			const items: ServicesAuditRunSummary[] | undefined = query.state.data?.items
+			if (!items) return false
+			return items.some((run) => !isTerminalRunStatus(run.status)) ? POLL_INTERVAL_MS : false
+		},
+	})
+}
+
+/**
+ * A single run. Polls every 5s ONLY while the scan is live and self-terminates on
+ * any terminal status.
+ *
+ * Returns `false` when the status is unknown (first load, or an error): an
+ * unknown status must never mean "keep polling forever".
+ */
+export function useServicesAuditRun(runId: string) {
+	return useQuery<ServicesAuditRunDetail>({
+		queryKey: servicesAuditKeys.run(runId),
+		queryFn: () => api.getServicesAuditRun(runId),
+		enabled: !!runId,
+		staleTime: 1000 * 5,
+		refetchInterval: (query) => {
+			const status = query.state.data?.status
+			if (!status) return false
+			return isTerminalRunStatus(status) ? false : POLL_INTERVAL_MS
+		},
+	})
+}
+
+/**
+ * Paginated rows for a run. Filtering and pagination happen server-side, in SQL —
+ * the rows list can be tens of thousands long and must never be sliced here.
+ */
+export function useServicesAuditRunRows(runId: string, filters: ServicesAuditRowFilters = {}) {
+	return useQuery({
+		queryKey: servicesAuditKeys.rows(runId, filters),
+		queryFn: () => api.getServicesAuditRunRows(runId, filters),
+		enabled: !!runId,
+		staleTime: 1000 * 5,
+	})
+}
+
+export function useStartServicesAuditScan() {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: () => api.startServicesAuditScan(),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: servicesAuditKeys.runs(),
+				refetchType: 'active',
+			})
+		},
+	})
+}
+
+/**
+ * Cancels a live SCAN. Safe precisely because the scan is read-only — there is
+ * nothing half-done to unwind.
+ *
+ * NOTE (matches the server's documented limitation): this releases the lock and
+ * marks the run cancelled, but does not terminate the workflow instance, whose
+ * finalize step may still overwrite the status. Harmless while the scan only
+ * reads.
+ */
+export function useCancelServicesAuditScan() {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: (runId: string) => api.cancelServicesAuditScan(runId),
+		onSuccess: (_data, runId) => {
+			void queryClient.invalidateQueries({ queryKey: servicesAuditKeys.runs() })
+			void queryClient.invalidateQueries({ queryKey: servicesAuditKeys.run(runId) })
+		},
+	})
+}

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -1310,6 +1310,124 @@ export interface CleanupDiscordGuildAuditResponse {
 	deletedRuns: number
 }
 
+// ---------------------------------------------------------------------------
+// Service access audit (READ-ONLY).
+//
+// Mirrors apps/core/src/routes/services-audit.ts. There is deliberately no
+// enforce/confirm shape here: enforcement is not built, and a client method that
+// exists is a client method that gets called.
+// ---------------------------------------------------------------------------
+
+export type ServiceEligibilityReasonCode =
+	| 'member_corp'
+	| 'admin_exempt'
+	| 'no_characters'
+	| 'null_corp'
+	| 'only_deleted_member_char'
+	| 'unmanaged_corp'
+	| 'no_user_row'
+
+export type ServicesAuditRunStatus =
+	| 'scanning'
+	| 'blocked'
+	| 'awaiting_confirmation'
+	| 'enforcing'
+	| 'completed'
+	| 'completed_with_errors'
+	| 'failed'
+	| 'cancelled'
+
+export interface ServicesAuditRunSummary {
+	id: string
+	status: ServicesAuditRunStatus
+	/** The eligibility BASIS. Reported as prominently as the ineligible count:
+	 * an inverted basis is what makes an ineligible count wrong. */
+	memberCorpCount: number
+	scanned: number
+	inPopulation: number
+	eligibleCount: number
+	ineligibleCount: number
+	blastRadiusTripped: boolean
+	/**
+	 * The basis shrank against the recent high-water mark, so THIS RUN'S NUMBERS
+	 * MAY BE WRONG. Present on the summary (not just the detail) because someone
+	 * looking at a list of runs has to see which ones not to believe.
+	 */
+	basisSuspect: boolean
+	errorMessage: string | null
+	startedAt: string | null
+	completedAt: string | null
+}
+
+/** Discriminated union: "off" and "we could not tell" are different answers. */
+export type ServicesAuditMumbleFeature =
+	| { enabled: true; state: 'enabled' }
+	| { enabled: false; state: 'flag_off' | 'binding_missing' | 'unreachable'; message: string }
+
+export interface ServicesAuditSampleRow {
+	userId: string
+	mainCharacterId: string | null
+	mainCharacterName: string | null
+	reason: ServiceEligibilityReasonCode
+	hasDiscordLink: boolean
+}
+
+export interface ServicesAuditRunDetail extends ServicesAuditRunSummary {
+	memberCorporationIds: string[]
+	initiatedByUserId: string | null
+	scanWorkflowInstanceId: string | null
+	/** The high-water basis count this run was compared against; null on the very
+	 * first run, where nothing has validated the basis. */
+	basisComparedToCount: number | null
+	/**
+	 * Exactly which corporations left the basis since the high-water run. THIS IS
+	 * THE POINT: a count ratio cannot tell "an operator de-flagged 13 corps" from
+	 * "the table got truncated", but a human reading 13 familiar names can.
+	 */
+	basisRemovedCorporationIds: string[] | null
+	/** Operator-facing explanation of the diff; null unless basisSuspect. */
+	basisNote: string | null
+	/** Grouped by (reason, eligible) in SQL — NOT one "ineligible" total. */
+	reasonBreakdown: Array<{
+		reason: ServiceEligibilityReasonCode
+		eligible: boolean
+		count: number
+	}>
+	sample: ServicesAuditSampleRow[]
+	mumbleFeature: ServicesAuditMumbleFeature
+	/** false => `inPopulation` counts Discord-linked users only. The UI must say
+	 * so rather than imply the denominator is complete. */
+	mumblePopulationKnown: boolean
+	inPopulationBasis: 'discord_link_only'
+}
+
+export interface ServicesAuditRow {
+	id: string
+	userId: string
+	mainCharacterId: string | null
+	mainCharacterName: string | null
+	eligible: boolean
+	reason: ServiceEligibilityReasonCode
+	corporationIds: string[]
+	hasDiscordLink: boolean
+}
+
+export interface ServicesAuditRowsResponse {
+	rows: ServicesAuditRow[]
+	pagination: {
+		page: number
+		pageSize: number
+		totalCount: number
+		totalPages: number
+	}
+}
+
+export interface StartServicesAuditScanResponse {
+	runId: string
+	workflowInstanceId: string
+	status: ServicesAuditRunStatus
+}
+
 export interface DiscordGuildAuditStripRolesResponse {
 	guildId: string
 	guildName: string
@@ -3715,6 +3833,41 @@ export class ApiClient {
 
 	async cleanupDiscordGuildAudit(serverId: string): Promise<CleanupDiscordGuildAuditResponse> {
 		return this.post(`/discord-servers/${serverId}/audit/cleanup`)
+	}
+
+	// --- Service access audit (READ-ONLY; no enforce method exists on purpose) ---
+
+	async getServicesAuditRuns(): Promise<{ items: ServicesAuditRunSummary[] }> {
+		return this.get('/services-audit/runs')
+	}
+
+	async getServicesAuditRun(runId: string): Promise<ServicesAuditRunDetail> {
+		return this.get(`/services-audit/runs/${runId}`)
+	}
+
+	async getServicesAuditRunRows(
+		runId: string,
+		params: {
+			reason?: ServiceEligibilityReasonCode
+			eligible?: boolean
+			page?: number
+			pageSize?: number
+		} = {}
+	): Promise<ServicesAuditRowsResponse> {
+		const query = new URLSearchParams()
+		if (params.reason) query.set('reason', params.reason)
+		if (typeof params.eligible === 'boolean') query.set('eligible', String(params.eligible))
+		if (params.page) query.set('page', String(params.page))
+		if (params.pageSize) query.set('pageSize', String(params.pageSize))
+		return this.get(`/services-audit/runs/${runId}/rows?${query.toString()}`)
+	}
+
+	async startServicesAuditScan(): Promise<StartServicesAuditScanResponse> {
+		return this.post('/services-audit/runs')
+	}
+
+	async cancelServicesAuditScan(runId: string): Promise<{ runId: string; status: string }> {
+		return this.post(`/services-audit/runs/${runId}/cancel`)
 	}
 
 	async stripDiscordGuildRoles(

--- a/apps/ui/src/client/routes/admin/services-audit.tsx
+++ b/apps/ui/src/client/routes/admin/services-audit.tsx
@@ -1,0 +1,681 @@
+import { AlertTriangle, Ban, Play, ShieldAlert, ShieldCheck } from 'lucide-react'
+import { useState } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { LoadingInline, LoadingSpinner } from '@/components/ui/loading'
+import { PageHeader } from '@/components/ui/page-header'
+import { Select } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import {
+	isTerminalRunStatus,
+	useCancelServicesAuditScan,
+	useServicesAuditRun,
+	useServicesAuditRunRows,
+	useServicesAuditRuns,
+	useStartServicesAuditScan,
+} from '@/hooks/useServicesAudit'
+import { characterPortraitUrl } from '@/lib/eve-images'
+
+import type { BadgeVariant } from '@/components/ui/badge'
+import type {
+	ServiceEligibilityReasonCode,
+	ServicesAuditRunDetail,
+	ServicesAuditRunStatus,
+} from '@/lib/api'
+import type { ComponentType } from 'react'
+
+/**
+ * SERVICE ACCESS AUDIT — READ-ONLY.
+ *
+ * This page reports. It does not act. There is deliberately no enforce button,
+ * no confirm dialog and no enforce API call anywhere in this file, because
+ * enforcement is not built: the point of shipping the scan alone is to learn the
+ * real ineligible count before anyone commits to revoking accounts on an
+ * estimate.
+ *
+ * The page's job is to let a human decide whether to TRUST the number. That is
+ * why the member-corp basis is rendered as prominently as the ineligible count
+ * (an inverted basis is what makes an ineligible count wrong), why the reason
+ * breakdown is shown by subcode rather than as one total (3,900 `null_corp` is a
+ * broken ESI sync, not 3,900 infiltrators), and why names are shown at all
+ * (somebody must be able to recognise a person who obviously should not be on
+ * the list).
+ */
+
+const REASON_LABELS: Record<ServiceEligibilityReasonCode, string> = {
+	member_corp: 'In a member corporation',
+	admin_exempt: 'Admin (exempt)',
+	no_characters: 'No characters',
+	null_corp: 'No corporation on record',
+	only_deleted_member_char: 'Only deleted member characters',
+	unmanaged_corp: 'Corporation is not a member corp',
+	no_user_row: 'No user row',
+}
+
+const REASON_ORDER: ServiceEligibilityReasonCode[] = [
+	'member_corp',
+	'admin_exempt',
+	'unmanaged_corp',
+	'null_corp',
+	'only_deleted_member_char',
+	'no_characters',
+	'no_user_row',
+]
+
+function reasonBadgeVariant(reason: ServiceEligibilityReasonCode): BadgeVariant {
+	if (reason === 'member_corp') return 'success'
+	if (reason === 'admin_exempt') return 'secondary'
+	// `null_corp` and `no_user_row` are the two subcodes most likely to mean
+	// "our data is broken" rather than "this person should lose access".
+	if (reason === 'null_corp' || reason === 'no_user_row') return 'warning'
+	return 'destructive'
+}
+
+const STATUS_VARIANTS: Record<ServicesAuditRunStatus, BadgeVariant> = {
+	scanning: 'default',
+	blocked: 'destructive',
+	awaiting_confirmation: 'warning',
+	enforcing: 'warning',
+	completed: 'success',
+	completed_with_errors: 'warning',
+	failed: 'destructive',
+	cancelled: 'ghost',
+}
+
+const STATUS_LABELS: Record<ServicesAuditRunStatus, string> = {
+	scanning: 'Scanning',
+	blocked: 'Blocked',
+	awaiting_confirmation: 'Ineligible users found',
+	enforcing: 'Enforcing',
+	completed: 'Completed',
+	completed_with_errors: 'Completed with errors',
+	failed: 'Failed',
+	cancelled: 'Cancelled',
+}
+
+function formatTimestamp(value: string | null): string {
+	if (!value) return '—'
+	const date = new Date(value)
+	return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString()
+}
+
+function StatTile({
+	label,
+	value,
+	hint,
+	icon: Icon,
+	emphasis,
+}: {
+	label: string
+	value: string
+	hint: string
+	icon?: ComponentType<{ className?: string }>
+	emphasis?: 'danger' | 'warning'
+}) {
+	return (
+		<Card className={emphasis === 'danger' ? 'border-destructive/60' : undefined}>
+			<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+				<CardTitle className="text-sm font-medium">{label}</CardTitle>
+				{Icon && <Icon className="h-4 w-4 text-muted-foreground" />}
+			</CardHeader>
+			<CardContent>
+				<div
+					className={
+						emphasis === 'danger'
+							? 'text-2xl font-bold text-destructive'
+							: emphasis === 'warning'
+								? 'text-2xl font-bold text-warning'
+								: 'text-2xl font-bold'
+					}
+				>
+					{value}
+				</div>
+				<p className="text-xs text-muted-foreground mt-1">{hint}</p>
+			</CardContent>
+		</Card>
+	)
+}
+
+/**
+ * The blocked banner. Rendered before anything else and visually unmistakable —
+ * a blocked run's counts are meaningless and must never be read as a result.
+ *
+ * Only an EMPTY basis blocks. That is the one unambiguous case.
+ */
+function BlockedBanner({ run }: { run: ServicesAuditRunDetail }) {
+	return (
+		<Card className="border-destructive bg-destructive/10">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-destructive">
+					<ShieldAlert className="h-5 w-5" />
+					Run blocked — no corporations are flagged as member corporations
+				</CardTitle>
+				<CardDescription className="text-destructive/90">
+					No rows were written and nothing was scanned. This is not overridable.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<p className="text-sm whitespace-pre-wrap">
+					{run.errorMessage ?? 'No error message was recorded on this run.'}
+				</p>
+				<p className="text-xs text-muted-foreground">
+					Because <code>is_member_corporation</code> defaults to false, an empty corporation list
+					does not weaken the eligibility rule — it inverts it, making every non-admin look
+					ineligible. Fix the corporation data, then scan again.
+				</p>
+			</CardContent>
+		</Card>
+	)
+}
+
+/**
+ * The suspect-basis banner. This is the tool's most important safety message.
+ *
+ * A shrinking basis deliberately does NOT block: de-flagging a corporation is
+ * how a corp legitimately stops being a member corp, and it shrinks the basis by
+ * construction — so blocking would refuse the tool's primary emergency use case.
+ * Instead we show WHICH corporations left, because a count ratio cannot tell "I
+ * de-flagged those 13" from "the table is half-restored", and a human reading the
+ * names can do it in seconds.
+ */
+function BasisSuspectBanner({ run }: { run: ServicesAuditRunDetail }) {
+	const removed = run.basisRemovedCorporationIds ?? []
+	return (
+		<Card className="border-amber-500 bg-amber-500/10">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+					<ShieldAlert className="h-5 w-5" />
+					The member-corporation basis shrank — check this before trusting the numbers below
+				</CardTitle>
+				<CardDescription>
+					{run.memberCorpCount} member corporation{run.memberCorpCount === 1 ? '' : 's'} now, versus
+					a high of {run.basisComparedToCount} in the last 30 days.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<p className="text-sm whitespace-pre-wrap">{run.basisNote}</p>
+				{removed.length > 0 && (
+					<div>
+						<p className="text-xs font-medium mb-1">
+							{removed.length} corporation{removed.length === 1 ? '' : 's'} left the basis:
+						</p>
+						<p className="text-xs font-mono text-muted-foreground break-all">
+							{removed.join(', ')}
+						</p>
+						<p className="text-xs text-muted-foreground mt-2">
+							Recognise them? Then you de-flagged them and this scan is correct. Don’t recognise
+							them? <code>managed_corporations</code> may be half-restored or mid-sync, and the
+							counts below are not trustworthy.
+						</p>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	)
+}
+
+export default function AdminServicesAuditPage() {
+	usePageTitle('Admin - Services Audit')
+
+	const [selectedRunId, setSelectedRunId] = useState<string>('')
+	const [reasonFilter, setReasonFilter] = useState<string>('all')
+	const [page, setPage] = useState(1)
+	const [pageSize, setPageSize] = useState(25)
+
+	const runsQuery = useServicesAuditRuns()
+	const runs = runsQuery.data?.items ?? []
+
+	// Default to the newest run without needing an effect: the server returns runs
+	// newest-first, and an explicit selection always wins.
+	const activeRunId = selectedRunId || runs[0]?.id || ''
+
+	const runQuery = useServicesAuditRun(activeRunId)
+	const run = runQuery.data
+
+	const rowsQuery = useServicesAuditRunRows(activeRunId, {
+		reason: reasonFilter === 'all' ? undefined : (reasonFilter as ServiceEligibilityReasonCode),
+		page,
+		pageSize,
+	})
+
+	const startScan = useStartServicesAuditScan()
+	const cancelScan = useCancelServicesAuditScan()
+
+	const anyRunLive = runs.some((item) => !isTerminalRunStatus(item.status))
+
+	const ineligibleBreakdown = (run?.reasonBreakdown ?? [])
+		.filter((entry) => !entry.eligible)
+		.sort((a, b) => REASON_ORDER.indexOf(a.reason) - REASON_ORDER.indexOf(b.reason))
+	const eligibleBreakdown = (run?.reasonBreakdown ?? [])
+		.filter((entry) => entry.eligible)
+		.sort((a, b) => REASON_ORDER.indexOf(a.reason) - REASON_ORDER.indexOf(b.reason))
+
+	const runOptions = runs.map((item) => ({
+		value: item.id,
+		// A suspect basis is marked in the PICKER, not only inside the run: someone
+		// choosing between runs has to see which ones not to believe before they
+		// have read a single number.
+		label: `${STATUS_LABELS[item.status]}${item.basisSuspect ? ' ⚠ basis' : ''} — ${formatTimestamp(item.startedAt)}`,
+		description: `${item.ineligibleCount.toLocaleString()} ineligible of ${item.scanned.toLocaleString()} scanned · basis ${item.memberCorpCount.toLocaleString()} corps${item.basisSuspect ? ' (shrank — numbers may be wrong)' : ''}`,
+	}))
+
+	const reasonOptions = [
+		{ value: 'all', label: 'All reasons' },
+		...REASON_ORDER.map((reason) => ({ value: reason, label: REASON_LABELS[reason] })),
+	]
+
+	return (
+		<div className="space-y-6">
+			<PageHeader
+				title="Services Audit"
+				description="Read-only scan of who is eligible for Mumble and Discord access, based on membership of a member corporation."
+				action={
+					<Button
+						onClick={() => startScan.mutate()}
+						disabled={startScan.isPending || anyRunLive}
+						title={anyRunLive ? 'A scan is already in progress' : undefined}
+					>
+						{startScan.isPending ? <LoadingInline className="mr-2" /> : <Play className="mr-2 h-4 w-4" />}
+						Start scan
+					</Button>
+				}
+			/>
+
+			{/* Nothing on this page acts. Say so once, plainly, at the top. */}
+			<Card className="border-primary/40 bg-primary/5">
+				<CardContent className="flex items-start gap-3 pt-6">
+					<ShieldCheck className="h-5 w-5 flex-shrink-0 text-primary" />
+					<div className="space-y-1 text-sm">
+						<p className="font-medium">This tool only reports. Nothing here revokes anything.</p>
+						<p className="text-muted-foreground">
+							No Mumble account is deleted and no Discord role is removed by this page. Enforcement
+							is not built yet. A scan tells you how many accounts <em>would</em> be affected so
+							that decision can be made on a real number rather than an estimate.
+						</p>
+					</div>
+				</CardContent>
+			</Card>
+
+			{startScan.isError && (
+				<Card className="border-destructive">
+					<CardContent className="pt-6 text-sm text-destructive">
+						Failed to start scan: {startScan.error.message}
+					</CardContent>
+				</Card>
+			)}
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Runs</CardTitle>
+					<CardDescription>The 25 most recent scans, newest first.</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{runsQuery.isLoading ? (
+						<LoadingSpinner size="sm" label="Loading runs..." />
+					) : runsQuery.isError ? (
+						<p className="text-sm text-destructive">
+							Failed to load runs: {runsQuery.error.message}
+						</p>
+					) : runs.length === 0 ? (
+						<p className="py-8 text-center text-muted-foreground">
+							No scans have been run yet. Start one to see who is currently ineligible.
+						</p>
+					) : (
+						<div className="max-w-xl">
+							<Select
+								options={runOptions}
+								value={activeRunId}
+								onValueChange={(value) => {
+									setSelectedRunId(value)
+									setPage(1)
+								}}
+								placeholder="Select a run"
+							/>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+
+			{activeRunId && runQuery.isLoading && <LoadingSpinner size="sm" label="Loading run..." />}
+
+			{runQuery.isError && (
+				<Card className="border-destructive">
+					<CardContent className="pt-6 text-sm text-destructive">
+						Failed to load run: {runQuery.error.message}
+					</CardContent>
+				</Card>
+			)}
+
+			{run && (
+				<>
+					{run.status === 'blocked' && <BlockedBanner run={run} />}
+					{run.basisSuspect && run.status !== 'blocked' && <BasisSuspectBanner run={run} />}
+
+					{run.status === 'failed' && (
+						<Card className="border-destructive">
+							<CardHeader>
+								<CardTitle className="flex items-center gap-2 text-destructive">
+									<AlertTriangle className="h-5 w-5" />
+									Run failed
+								</CardTitle>
+							</CardHeader>
+							<CardContent className="text-sm">
+								{run.errorMessage ?? 'No error message was recorded on this run.'}
+							</CardContent>
+						</Card>
+					)}
+
+					<Card>
+						<CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+							<div className="space-y-1">
+								<CardTitle className="flex items-center gap-2">
+									<Badge variant={STATUS_VARIANTS[run.status]}>{STATUS_LABELS[run.status]}</Badge>
+									{!isTerminalRunStatus(run.status) && (
+										<span className="text-sm font-normal text-muted-foreground">
+											Refreshing every 5s
+										</span>
+									)}
+								</CardTitle>
+								<CardDescription>
+									Started {formatTimestamp(run.startedAt)} · Completed{' '}
+									{formatTimestamp(run.completedAt)}
+								</CardDescription>
+							</div>
+							{!isTerminalRunStatus(run.status) && (
+								<Button
+									variant="secondary"
+									onClick={() => cancelScan.mutate(run.id)}
+									disabled={cancelScan.isPending}
+								>
+									{cancelScan.isPending ? (
+										<LoadingInline className="mr-2" />
+									) : (
+										<Ban className="mr-2 h-4 w-4" />
+									)}
+									Cancel scan
+								</Button>
+							)}
+						</CardHeader>
+						<CardContent className="space-y-6">
+							{/* The basis is a headline number, not a footnote: it is the thing
+							    that decides whether the ineligible count means anything. */}
+							<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+								<StatTile
+									label="Member corporations (basis)"
+									value={run.memberCorpCount.toLocaleString()}
+									hint="Corps that confer eligibility. If this looks wrong, every count below is wrong."
+									icon={ShieldCheck}
+									emphasis={run.memberCorpCount < 1 ? 'danger' : undefined}
+								/>
+								<StatTile
+									label="Users scanned"
+									value={run.scanned.toLocaleString()}
+									hint="Every user row walked, eligible or not."
+								/>
+								<StatTile
+									label="In population"
+									value={run.inPopulation.toLocaleString()}
+									hint={
+										run.mumblePopulationKnown
+											? 'Users holding a Discord link or a Mumble account.'
+											: 'Discord-linked users ONLY — see the note below.'
+									}
+									emphasis={run.mumblePopulationKnown ? undefined : 'warning'}
+								/>
+								<StatTile
+									label="Ineligible"
+									value={run.ineligibleCount.toLocaleString()}
+									hint="Would be affected if enforcement existed. Nothing has been revoked."
+									icon={ShieldAlert}
+									emphasis={run.ineligibleCount > 0 ? 'danger' : undefined}
+								/>
+							</div>
+
+							{/* An incomplete denominator that presents itself as complete is
+							    worse than no denominator. Say what it does not cover. */}
+							{!run.mumblePopulationKnown && (
+								<div className="rounded-md border border-warning/50 bg-warning/10 p-3 text-sm">
+									<p className="font-medium text-warning">The population figure is incomplete.</p>
+									<p className="mt-1 text-muted-foreground">
+										&ldquo;In population&rdquo; counts Discord-linked users only (
+										<code>{run.inPopulationBasis}</code>). Mumble provisioning state lives in the
+										Mumble service and cannot be read without a service call, which this read-only
+										scan does not make. A user with a Mumble account but no Discord link is{' '}
+										<strong>not</strong> counted here, so the true affected population may be larger
+										than this number.
+									</p>
+								</div>
+							)}
+
+							{run.blastRadiusTripped && (
+								<div className="rounded-md border border-warning/50 bg-warning/10 p-3 text-sm">
+									<p className="flex items-center gap-2 font-medium text-warning">
+										<AlertTriangle className="h-4 w-4" />
+										Unusually large blast radius
+									</p>
+									<p className="mt-1 text-muted-foreground">
+										More than 20% of scanned users came back ineligible. The eligibility basis
+										passed its checks, so this may be genuine — but check the reason breakdown
+										below before believing it. A single dominant subcode usually means broken data
+										rather than a broken alliance.
+									</p>
+								</div>
+							)}
+
+							{!run.mumbleFeature.enabled && (
+								<div className="rounded-md border border-warning/50 bg-warning/10 p-3 text-sm">
+									<p className="font-medium text-warning">
+										Mumble feature state: {run.mumbleFeature.state.replace(/_/g, ' ')}
+									</p>
+									<p className="mt-1 text-muted-foreground">{run.mumbleFeature.message}</p>
+								</div>
+							)}
+
+							<div className="space-y-3">
+								<div>
+									<h3 className="text-sm font-medium">Ineligible by reason</h3>
+									<p className="text-xs text-muted-foreground">
+										Subcodes, not a single total. A large <code>null_corp</code> or{' '}
+										<code>no_characters</code> group points at a data problem, not at people.
+									</p>
+								</div>
+								{ineligibleBreakdown.length === 0 ? (
+									<p className="text-sm text-muted-foreground">No ineligible users in this run.</p>
+								) : (
+									<div className="flex flex-wrap gap-2">
+										{ineligibleBreakdown.map((entry) => (
+											<Badge key={entry.reason} variant={reasonBadgeVariant(entry.reason)}>
+												{REASON_LABELS[entry.reason]}: {entry.count.toLocaleString()}
+											</Badge>
+										))}
+									</div>
+								)}
+								{eligibleBreakdown.length > 0 && (
+									<>
+										<h3 className="pt-2 text-sm font-medium">Eligible by reason</h3>
+										<div className="flex flex-wrap gap-2">
+											{eligibleBreakdown.map((entry) => (
+												<Badge key={entry.reason} variant={reasonBadgeVariant(entry.reason)}>
+													{REASON_LABELS[entry.reason]}: {entry.count.toLocaleString()}
+												</Badge>
+											))}
+										</div>
+									</>
+								)}
+							</div>
+
+							{run.sample.length > 0 && (
+								<div className="space-y-3">
+									<div>
+										<h3 className="text-sm font-medium">Sample of affected people</h3>
+										<p className="text-xs text-muted-foreground">
+											Up to 10 names. If you recognise someone here who obviously should keep
+											access, stop and investigate the basis rather than the person.
+										</p>
+									</div>
+									<div className="flex flex-wrap gap-2">
+										{run.sample.map((sampleRow) => (
+											<div
+												key={sampleRow.userId}
+												className="flex items-center gap-2 rounded-md border border-border px-2 py-1"
+											>
+												{sampleRow.mainCharacterId && (
+													<img
+														src={characterPortraitUrl(sampleRow.mainCharacterId, 32)}
+														alt=""
+														className="h-6 w-6 rounded-full"
+													/>
+												)}
+												<span className="text-sm">
+													{sampleRow.mainCharacterName ?? sampleRow.userId}
+												</span>
+												<Badge variant={reasonBadgeVariant(sampleRow.reason)}>
+													{REASON_LABELS[sampleRow.reason]}
+												</Badge>
+											</div>
+										))}
+									</div>
+								</div>
+							)}
+
+							{run.ineligibleCount > 0 && isTerminalRunStatus(run.status) && run.status !== 'blocked' && (
+								<div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+									<p className="font-medium">
+										{run.ineligibleCount.toLocaleString()} users are ineligible. Nothing has been
+										revoked.
+									</p>
+									<p className="mt-1 text-muted-foreground">
+										No Mumble account has been deleted and no Discord role has been removed.
+										Enforcement is not built yet — this run is a report, and it will stay a report.
+									</p>
+								</div>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Rows</CardTitle>
+							<CardDescription>
+								Every user this scan recorded. Filtering and pagination happen server-side.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="space-y-4">
+							<div className="max-w-sm">
+								<Select
+									options={reasonOptions}
+									value={reasonFilter}
+									onValueChange={(value) => {
+										setReasonFilter(value)
+										setPage(1)
+									}}
+									placeholder="Filter by reason"
+								/>
+							</div>
+
+							<UserSearchPaginationControls
+								totalCount={rowsQuery.data?.pagination.totalCount ?? 0}
+								page={page}
+								pageSize={pageSize}
+								pageSizeOptions={[10, 25, 50, 100]}
+								onPageChange={setPage}
+								onPageSizeChange={(nextPageSize) => {
+									setPageSize(nextPageSize)
+									setPage(1)
+								}}
+							/>
+
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Character</TableHead>
+										<TableHead>Eligible</TableHead>
+										<TableHead>Reason</TableHead>
+										<TableHead>Discord linked</TableHead>
+										<TableHead>Corporations</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{rowsQuery.isLoading ? (
+										<TableRow>
+											<TableCell colSpan={5}>
+												<LoadingSpinner size="sm" label="Loading rows..." />
+											</TableCell>
+										</TableRow>
+									) : rowsQuery.isError ? (
+										<TableRow>
+											<TableCell colSpan={5} className="py-8 text-center text-destructive">
+												Failed to load rows: {rowsQuery.error.message}
+											</TableCell>
+										</TableRow>
+									) : (rowsQuery.data?.rows.length ?? 0) === 0 ? (
+										<TableRow>
+											<TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+												No rows match this filter.
+											</TableCell>
+										</TableRow>
+									) : (
+										rowsQuery.data?.rows.map((row) => (
+											<TableRow key={row.id}>
+												<TableCell>
+													<div className="flex items-center gap-2">
+														{row.mainCharacterId && (
+															<img
+																src={characterPortraitUrl(row.mainCharacterId, 32)}
+																alt=""
+																className="h-6 w-6 rounded-full"
+															/>
+														)}
+														<span>{row.mainCharacterName ?? row.userId}</span>
+													</div>
+												</TableCell>
+												<TableCell>
+													<Badge variant={row.eligible ? 'success' : 'destructive'}>
+														{row.eligible ? 'Eligible' : 'Ineligible'}
+													</Badge>
+												</TableCell>
+												<TableCell>
+													<Badge variant={reasonBadgeVariant(row.reason)}>
+														{REASON_LABELS[row.reason]}
+													</Badge>
+												</TableCell>
+												<TableCell>
+													{row.hasDiscordLink ? (
+														<Badge variant="default">Linked</Badge>
+													) : (
+														<Badge variant="ghost">Not linked</Badge>
+													)}
+												</TableCell>
+												<TableCell className="text-muted-foreground">
+													{row.corporationIds.length > 0 ? row.corporationIds.join(', ') : '—'}
+												</TableCell>
+											</TableRow>
+										))
+									)}
+								</TableBody>
+							</Table>
+
+							<div className="border-t border-border pt-4">
+								<UserSearchPaginationControls
+									totalCount={rowsQuery.data?.pagination.totalCount ?? 0}
+									page={page}
+									pageSize={pageSize}
+									pageSizeOptions={[10, 25, 50, 100]}
+									onPageChange={setPage}
+									onPageSizeChange={(nextPageSize) => {
+										setPageSize(nextPageSize)
+										setPage(1)
+									}}
+								/>
+							</div>
+						</CardContent>
+					</Card>
+				</>
+			)}
+		</div>
+	)
+}

--- a/apps/ui/src/client/routes/route-groups/admin-routes.tsx
+++ b/apps/ui/src/client/routes/route-groups/admin-routes.tsx
@@ -46,6 +46,7 @@ import AdminLegacyMigrationsPage from '@/routes/admin/legacy-migrations'
 import AdminPastesPage from '@/routes/admin/pastes'
 import AdminPermissionCategoriesPage from '@/routes/admin/permissions/categories'
 import AdminGlobalPermissionsPage from '@/routes/admin/permissions/global'
+import AdminServicesAuditPage from '@/routes/admin/services-audit'
 import AdminStructuresPage from '@/routes/admin/structures'
 import AdminThirdPartyAppsPage from '@/routes/admin/third-party-apps'
 import AdminUserActivityPage from '@/routes/admin/user-activity'
@@ -93,6 +94,7 @@ export const adminRouteElements = (
 		<Route path="structures" element={<AdminStructuresPage />} />
 		<Route path="discord-servers" element={<AdminDiscordServersPage />} />
 		<Route path="discord-audit" element={<AdminDiscordAuditPage />} />
+		<Route path="services-audit" element={<AdminServicesAuditPage />} />
 		<Route path="eve-character-sync" element={<AdminEveCharacterSyncPage />} />
 		<Route path="discord-servers/:serverId/roles" element={<AdminDiscordServerRolesPage />} />
 		<Route path="discord-servers/:serverId/commands" element={<AdminDiscordServerCommandsPage />} />


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Adds a read-only audit tool for the member-corporation eligibility rule that gates Mumble and Discord service access — it scans every user and reports who would be found ineligible, but performs zero writes to Mumble or Discord. Enforcement is intentionally out of scope for this PR.

## Changes

- **Shared eligibility rule** (`lib/service-eligibility.ts`): extracts the member-corporation rule previously inlined in `mumble.service.ts` into `deriveServiceEligibility()`, with both a per-user form (`hasMemberCorporationAttachment`) and a set-based, keyset-paginated form (`scanUserEligibilityPage`) so a full scan doesn't blow the Workers subrequest ceiling. Diagnostic reason subcodes (`no_characters`, `null_corp`, `only_deleted_member_char`, `unmanaged_corp`, `admin_exempt`) are added for reporting only.
- **Schema** (migrations `0043`/`0044`, `db/schema.ts`): new `service_access_audit_runs` and `service_access_audit_rows` tables (deliberately not reusing the Discord audit tables, which are guild-scoped and Discord-user-keyed). Includes an `active_lock` unique-constraint-based single-run lock, a snapshotted basis (`member_corporation_ids`/`member_corp_count`), and per-service status columns. Migrations are generated but not applied.
- **Scan workflow** (`workflows/service-access-audit.workflow.ts`): a Cloudflare Workflow that pages through all users, evaluates eligibility via the shared rule, and records results with idempotent (`onConflictDoNothing`) inserts and retry-safe counters. Includes a basis-shrink guard that flags (but does not block) a shrinking member-corp basis, baselined against the trailing 30-day max to avoid ratchet/poisoning issues; only blocks when the basis count drops to zero.
- **API route** (`routes/services-audit.ts`, wired into `index.ts`/`context.ts`): endpoints to trigger/list scan runs and fetch their rows, ordered by `userId` for stable pagination.
- **Admin UI** (`routes/admin/services-audit.tsx`, `useServicesAudit.ts`, nav/route-group registration): a report-only admin page surfacing the basis, suspect-basis warnings (with the specific corporations that dropped out), per-reason-subcode breakdowns, and sample affected users. No enforce action exists in the UI.
- **Test config** (`vitest.unit.config.ts`): adds a `cloudflare:workflows` alias and includes `src/lib/__tests__`, which brings previously-uncollected unit test files into the suite.

## Testing

- Added unit tests for the eligibility rule and its exclusions/guard behavior (`service-eligibility.test.ts`, `service-eligibility-basis.test.ts`), the schema (`service-access-audit-schema.test.ts`), the workflow (`service-access-audit.workflow.test.ts`, including asserting zero Mumble/Discord writes), and the route (`services-audit.route.test.ts`).
- Existing `mumble.service.ts` eligibility tests pass unmodified.
- Migrations were generated via `just db-generate core` and verified to produce no drift on a second run, but are not applied — applying them is left to the operator.
- The admin UI page has not been rendered in a browser or exercised against a live API.
<!-- claude:end -->