### PR TITLE
ci: make GitHub workflows work with the merge queue

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,40 +1,91 @@
 name: Branches
 
-# Runs on the pull_request event only (not push). Previously this listened to
-# both, so every branch push triggered two identical "Check" runs — one for the
-# push and one for the PR's synchronize event. The pull_request event is the
-# better signal anyway: it tests the simulated merge into main, not the raw tip.
+# Runs on the pull_request event (not push). Listening to both meant every branch
+# push triggered two identical "Check" runs — one for the push and one for the
+# PR's synchronize event. The pull_request event is the better signal anyway: it
+# tests the simulated merge into main, not the raw tip.
 on:
   pull_request:
     branches: ['main']
-    # Skip CI when a PR touches only docs / changelogs / editor config — nothing
-    # that affects the build, types, lint, or tests. paths-ignore fails open: a
-    # PR is only skipped when EVERY changed file matches, so a mixed doc+code PR
-    # still runs.
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.changeset/**'
-      - '.vscode/**'
-      - '.cursor/**'
-      - '.claude/**'
-      - '.editorconfig'
-  # merge_group can't be path-filtered (GitHub always runs it fully) — that's the
-  # behavior we want: a complete check right before the commit lands in the queue.
+  # Required for the merge queue: without this trigger, "Check" is never reported
+  # for a queued commit and the queue times out waiting for it.
   merge_group:
 
-# If several commits are pushed to a PR in quick succession, cancel the older
-# in-flight run and keep only the newest — no point checking a superseded diff.
+# Cancel superseded PR runs, but NEVER cancel a merge_group run: the queue reads
+# a cancelled check as a failure and ejects the PR. Merge group refs are unique
+# per queue entry, so there is nothing to supersede there anyway.
 concurrency:
-  group: branches-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: branches-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 env:
   FORCE_COLOR: 1
 
 jobs:
+  # Docs-only PRs used to be skipped with a workflow-level `paths-ignore`. That is
+  # incompatible with required status checks: a workflow skipped by path filtering
+  # never reports its check at all, so "Check" sits Pending forever and the PR can
+  # never be merged or queued. A job skipped by an `if:` condition instead reports
+  # Success, which is what lets a docs-only PR through. So the path decision has to
+  # be made here, in a job, rather than in the `on:` block.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Check for non-doc changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # merge_group has no PR and cannot be path-filtered by GitHub — always run
+          # the full check on the exact commit that is about to land.
+          if [ -z "${PR:-}" ]; then
+            echo 'Not a pull_request event — running full checks.'
+            echo 'code=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')"
+
+          # Anything left after dropping the ignorable paths means real code changed.
+          # A mixed doc+code PR therefore still runs, same as paths-ignore did.
+          code="$(printf '%s\n' "$files" | grep -Ev \
+            -e '\.md$' \
+            -e '^docs/' \
+            -e '^\.changeset/' \
+            -e '^\.vscode/' \
+            -e '^\.cursor/' \
+            -e '^\.claude/' \
+            -e '^\.editorconfig$' \
+            || true)"
+
+          if [ -n "$code" ]; then
+            echo 'Code changed — running checks.'
+            echo 'code=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'Only docs/config changed — skipping checks.'
+            echo 'code=false' >> "$GITHUB_OUTPUT"
+          fi
+
   check:
     name: Check
+    needs: changes
+    # Fail safe: only an explicit 'false' skips. If the changes job errored, its
+    # output is empty and the checks run rather than silently reporting Success.
+    if: needs.changes.outputs.code != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Makes the `Branches` workflow compatible with GitHub's merge queue. Previously, docs-only PRs were skipped entirely via `paths-ignore`, which means the `Check` status never gets reported at all — the merge queue waits forever on a check that will never post, so a docs-only PR could never be queued or merged.

## Changes
- Moves the docs-only skip logic out of the workflow-level `on.pull_request.paths-ignore` and into a new `changes` job that queries the PR's changed files via the GitHub API and sets a `code` output.
- The `check` job now depends on `changes` and is skipped via `if: needs.changes.outputs.code != 'false'` — a job skipped by `if:` reports Success (unlike a workflow skipped by path filtering), which is what actually lets a docs-only PR pass the merge queue's required check.
- The `if:` guard only skips on an explicit `'false'`, so if the `changes` job errors (empty output) the checks still run instead of silently reporting Success.
- For `merge_group` events (no associated PR), the `changes` job always reports `code=true` since GitHub can't path-filter merge group runs.
- Concurrency grouping now keys on event type + PR number/ref, and only cancels in-progress runs for `pull_request` events — `merge_group` runs are never cancelled, since the queue treats a cancelled check as a failure and ejects the PR.
- Adds `permissions: contents: read` at the workflow level and `contents: read` / `pull-requests: read` on the new `changes` job.

## Testing
No automated tests included; verification would be to open a docs-only PR and a mixed doc+code PR and confirm the `Check` status reports Success/runs as expected in both direct PR and merge-queue contexts.
<!-- claude:end -->