### PR TITLE
feat(core): gate the self-service services grant paths on eligibility

### DIFF
--- a/apps/core/src/lib/service-eligibility.ts
+++ b/apps/core/src/lib/service-eligibility.ts
@@ -1,6 +1,6 @@
 import { and, eq, sql } from '@repo/db-utils'
 
-import { managedCorporations, userCharacters } from '../db/schema'
+import { managedCorporations, userCharacters, users } from '../db/schema'
 
 import type { DbClient, schema } from '../db'
 import type { SERVICE_ELIGIBILITY_REASONS } from '../db/schema'
@@ -130,6 +130,44 @@ export async function hasMemberCorporationAttachment(
 	return characters.some(
 		(character) => !!character.corporationId && memberCorporationIds.has(character.corporationId)
 	)
+}
+
+/**
+ * Is this user eligible for services right now?
+ *
+ * Mirrors the hard cut in `getUserGroupNames` exactly
+ * (`if (!hasAttachment && !user?.is_admin) return []` — services/mumble.service.ts):
+ * a member-corp attachment, OR site admin.
+ *
+ * This exists to GATE THE SELF-SERVICE GRANT PATHS. Eligibility is derived state,
+ * not stored state — it is recomputed from `is_member_corporation` on every read —
+ * so revoking access is not a one-shot act: without the same predicate on the
+ * grant paths, a user simply re-grants themselves and the revocation was theatre.
+ *
+ * Gate the ROUTES with this, never the service functions. Two of those service
+ * functions are also called by enforcement itself:
+ * `enforceBlacklistedMumbleAccess` calls `resetMumblePassword` to rotate a
+ * blacklisted user's password *as the lockout*, and a blacklisted user is
+ * ineligible — so a gate inside the service would throw there, be swallowed by
+ * that call's `.catch()`, and leave the blacklisted user's credentials working.
+ * `syncUserDiscordAccess` is likewise shared with the refresh workflow, the admin
+ * route and two RPC surfaces.
+ */
+export async function isUserEligibleForServices(
+	db: DbClient<typeof schema>,
+	userId: string
+): Promise<boolean> {
+	const [user, hasAttachment] = await Promise.all([
+		db.query.users.findFirst({
+			where: eq(users.id, userId),
+			columns: { is_admin: true },
+		}),
+		hasMemberCorporationAttachment(db, userId),
+	])
+
+	// `user?.is_admin` is optional-chained deliberately: a missing users row is
+	// falsy, i.e. ineligible, which matches getUserGroupNames.
+	return hasAttachment || user?.is_admin === true
 }
 
 /** One row of the set-based scan. `eligible`/`reason` are derived, never selected. */

--- a/apps/core/src/middleware/__tests__/service-eligibility.middleware.test.ts
+++ b/apps/core/src/middleware/__tests__/service-eligibility.middleware.test.ts
@@ -1,0 +1,121 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NOT_MEMBER_CORP_CODE, requireServiceEligibility } from '../service-eligibility'
+
+import type { App, SessionUser } from '../../context'
+
+/**
+ * The gate that makes revoking access mean something.
+ *
+ * Eligibility is derived, not stored — recomputed from is_member_corporation on
+ * every read — so without the same predicate on the grant paths a revoked user
+ * just re-grants themselves. These tests pin the gate itself; the route tests
+ * pin that it is actually mounted on the three self-service paths.
+ */
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'user-1',
+		mainCharacterId: 'm',
+		sessionId: 's',
+		characters: [],
+		is_admin: false,
+		roles: [],
+		discordUserId: null,
+		sessionCreatedAt: new Date().toISOString(),
+		...over,
+	} as SessionUser
+}
+
+/** A db whose eligibility answer is driven by the two queries the rule makes. */
+function makeDb(options: { isAdmin?: boolean; memberCorpCharacter?: boolean; noUserRow?: boolean }) {
+	return {
+		query: {
+			users: {
+				findFirst: vi
+					.fn()
+					.mockResolvedValue(
+						options.noUserRow ? undefined : { is_admin: options.isAdmin ?? false }
+					),
+			},
+			userCharacters: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue(options.memberCorpCharacter ? [{ corporationId: 'corp-1' }] : []),
+			},
+			managedCorporations: {
+				findMany: vi.fn().mockResolvedValue([{ corporationId: 'corp-1' }]),
+			},
+		},
+	}
+}
+
+function buildApp(db: unknown, user: SessionUser | undefined) {
+	const app = new Hono<App>()
+	app.use('*', async (c, next) => {
+		if (user) c.set('user', user)
+		c.set('db', db as never)
+		await next()
+	})
+	app.post('/grant', requireServiceEligibility(), (c) => c.json({ granted: true }))
+	return app
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('requireServiceEligibility', () => {
+	it('allows a user with a character in a member corporation', async () => {
+		const app = buildApp(makeDb({ memberCorpCharacter: true }), makeUser())
+		const res = await app.request('/grant', { method: 'POST' })
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ granted: true })
+	})
+
+	it('rejects a user with no character in any member corporation', async () => {
+		const app = buildApp(makeDb({ memberCorpCharacter: false }), makeUser())
+		const res = await app.request('/grant', { method: 'POST' })
+		expect(res.status).toBe(403)
+		// The UI switches on this code to hide the affordance rather than let
+		// someone click a button that can only fail.
+		expect(await res.json()).toMatchObject({ code: NOT_MEMBER_CORP_CODE })
+	})
+
+	it('allows a site admin with no member corporation (anti-lockout)', async () => {
+		// Matches getUserGroupNames' `if (!hasAttachment && !user?.is_admin)`: an
+		// incident responder must not gate themselves out mid-incident.
+		const app = buildApp(makeDb({ memberCorpCharacter: false, isAdmin: true }), makeUser())
+		const res = await app.request('/grant', { method: 'POST' })
+		expect(res.status).toBe(200)
+	})
+
+	it('rejects when no users row exists', async () => {
+		// user?.is_admin is optional-chained, so a missing row is falsy => ineligible.
+		const app = buildApp(makeDb({ memberCorpCharacter: false, noUserRow: true }), makeUser())
+		const res = await app.request('/grant', { method: 'POST' })
+		expect(res.status).toBe(403)
+	})
+
+	it('401s an unauthenticated request', async () => {
+		const app = buildApp(makeDb({ memberCorpCharacter: true }), undefined)
+		const res = await app.request('/grant', { method: 'POST' })
+		expect(res.status).toBe(401)
+	})
+
+	it('FAILS CLOSED when the database is unavailable', async () => {
+		// This guard protects a grant path. An unavailable db must not become an
+		// open door — that would reopen the exact hole the gate exists to close.
+		const app = buildApp(undefined, makeUser())
+		const res = await app.request('/grant', { method: 'POST' })
+		expect(res.status).toBe(500)
+	})
+
+	it('does not consult managed_corporations for an admin short-circuit', async () => {
+		// Both reads are issued in parallel by design; this pins that an admin is
+		// allowed on the is_admin signal rather than by accident of corp data.
+		const db = makeDb({ memberCorpCharacter: false, isAdmin: true })
+		const app = buildApp(db, makeUser({ is_admin: true }))
+		await app.request('/grant', { method: 'POST' })
+		expect(db.query.users.findFirst).toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/middleware/service-eligibility.ts
+++ b/apps/core/src/middleware/service-eligibility.ts
@@ -1,0 +1,73 @@
+import { isUserEligibleForServices } from '../lib/service-eligibility'
+
+import type { MiddlewareHandler } from 'hono'
+import type { App } from '../context'
+
+/**
+ * Response code returned to the client on a 403 from this guard. The UI switches
+ * on it to hide the affordance rather than let someone click a button that can
+ * only fail.
+ */
+export const NOT_MEMBER_CORP_CODE = 'not_member_corp'
+
+/**
+ * Gate a SELF-SERVICE GRANT path on the services eligibility rule: the user must
+ * have a character in a member corporation, or be a site admin.
+ *
+ * ── WHY THIS EXISTS ──
+ *
+ * Eligibility is DERIVED state, not stored state — it is recomputed from
+ * `managed_corporations.is_member_corporation` on every read. So revoking access
+ * is not a one-shot act. Without the same predicate on the grant paths, a user
+ * whose access is revoked simply grants it back to themselves and the revocation
+ * was theatre. `POST /api/discord/join-servers` re-invites and re-grants roles on
+ * demand today, behind nothing but `requireAuth()`.
+ *
+ * ── WHERE TO PUT IT ──
+ *
+ * On ROUTES, never inside the service functions. Two of those services are called
+ * by enforcement itself: `enforceBlacklistedMumbleAccess` calls
+ * `resetMumblePassword` to rotate a blacklisted user's password AS the lockout,
+ * and a blacklisted user is also ineligible — a gate inside the service would
+ * throw there, be swallowed by that call's `.catch()`, and quietly leave the
+ * blacklisted user's credentials working. `syncUserDiscordAccess` is likewise
+ * shared with the refresh workflow, the admin route and two RPC surfaces, none of
+ * which are self-service.
+ *
+ * Gate only the GRANT paths. Reads (e.g. GET /api/mumble/account) stay open — an
+ * ineligible user should still be able to see the state of their own account.
+ *
+ * ── WHAT THIS DOES NOT DO ──
+ *
+ * It does not revoke anything, and it does not stop a background sync from
+ * re-granting roles on a membership event. That convergence problem is a separate
+ * change to the expected-role-set computation.
+ */
+export const requireServiceEligibility = (): MiddlewareHandler<App> => {
+	return async (c, next) => {
+		const user = c.get('user')
+		if (!user) {
+			return c.json({ error: 'Unauthorized' }, 401)
+		}
+
+		const db = c.get('db')
+		if (!db) {
+			// Fail CLOSED. This guard protects a grant path, so an unavailable
+			// database must not become an open door.
+			return c.json({ error: 'Database not available' }, 500)
+		}
+
+		if (!(await isUserEligibleForServices(db, user.id))) {
+			return c.json(
+				{
+					error:
+						'Services access requires a character in a member corporation. If you have recently joined one, your character data may not have synced yet.',
+					code: NOT_MEMBER_CORP_CODE,
+				},
+				403
+			)
+		}
+
+		return next()
+	}
+}

--- a/apps/core/src/routes/__tests__/discord.join-servers.gate.test.ts
+++ b/apps/core/src/routes/__tests__/discord.join-servers.gate.test.ts
@@ -1,0 +1,107 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import discordRoutes from '../discord'
+
+import type { App, SessionUser } from '../../context'
+
+/**
+ * POST /api/discord/join-servers IS THE SELF-HEAL HOLE.
+ *
+ * It calls syncUserDiscordAccess, which invites the user to guilds and re-grants
+ * roles — auto-apply roles are added with no eligibility check at all. Behind
+ * nothing but requireAuth(), it let any revoked user grant their own access back
+ * on demand, which made revoking it pointless.
+ *
+ * The middleware's own tests pin that the rule is right. THIS test pins that the
+ * gate is actually MOUNTED here, and — the part that matters — that a rejected
+ * request never reaches syncUserDiscordAccess at all.
+ */
+
+const { syncUserDiscordAccessMock } = vi.hoisted(() => ({
+	syncUserDiscordAccessMock: vi.fn(),
+}))
+
+vi.mock('../../services/discord.service', () => ({
+	syncUserDiscordAccess: syncUserDiscordAccessMock,
+}))
+vi.mock('../../lib/discord-helpers', () => ({ getDiscordStatus: vi.fn() }))
+vi.mock('../../middleware/session', () => ({
+	requireAuth: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}))
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'user-1',
+		mainCharacterId: 'm',
+		sessionId: 's',
+		characters: [],
+		is_admin: false,
+		roles: [],
+		discordUserId: 'd1',
+		sessionCreatedAt: new Date().toISOString(),
+		...over,
+	} as SessionUser
+}
+
+function makeDb(options: { memberCorpCharacter: boolean; isAdmin?: boolean }) {
+	return {
+		query: {
+			users: { findFirst: vi.fn().mockResolvedValue({ is_admin: options.isAdmin ?? false }) },
+			userCharacters: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue(options.memberCorpCharacter ? [{ corporationId: 'corp-1' }] : []),
+			},
+			managedCorporations: { findMany: vi.fn().mockResolvedValue([{ corporationId: 'corp-1' }]) },
+		},
+	}
+}
+
+function buildApp(db: unknown) {
+	const app = new Hono<App>()
+	app.use('*', async (c, next) => {
+		c.set('user', makeUser())
+		c.set('db', db as never)
+		await next()
+	})
+	app.route('/', discordRoutes)
+	return app
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('POST /join-servers eligibility gate', () => {
+	it('403s an ineligible user and NEVER reaches syncUserDiscordAccess', async () => {
+		const app = buildApp(makeDb({ memberCorpCharacter: false }))
+		const res = await app.request('/join-servers', { method: 'POST' })
+
+		expect(res.status).toBe(403)
+		expect(await res.json()).toMatchObject({ code: 'not_member_corp' })
+		// The load-bearing assertion. If the gate ran but the handler still called
+		// through, the user would be invited and re-granted anyway and the 403 would
+		// be a lie.
+		expect(syncUserDiscordAccessMock).not.toHaveBeenCalled()
+	})
+
+	it('lets an eligible user through to syncUserDiscordAccess', async () => {
+		syncUserDiscordAccessMock.mockResolvedValue({ results: [] })
+		const app = buildApp(makeDb({ memberCorpCharacter: true }))
+		const res = await app.request('/join-servers', { method: 'POST' })
+
+		expect(res.status).toBe(200)
+		// Second arg is the user id; the first is c.env, which is undefined in this
+		// harness and not what this test is about.
+		expect(syncUserDiscordAccessMock).toHaveBeenCalledTimes(1)
+		expect(syncUserDiscordAccessMock.mock.calls[0][1]).toBe('user-1')
+	})
+
+	it('lets a site admin through even with no member corporation', async () => {
+		syncUserDiscordAccessMock.mockResolvedValue({ results: [] })
+		const app = buildApp(makeDb({ memberCorpCharacter: false, isAdmin: true }))
+		const res = await app.request('/join-servers', { method: 'POST' })
+
+		expect(res.status).toBe(200)
+		expect(syncUserDiscordAccessMock).toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/routes/__tests__/mumble.route.test.ts
+++ b/apps/core/src/routes/__tests__/mumble.route.test.ts
@@ -64,14 +64,33 @@ function makeUser(): SessionUser {
 	}
 }
 
-function makeApp(user?: SessionUser) {
-	const app = new Hono<App>()
-	if (user) {
-		app.use('*', async (c, next) => {
-			c.set('user', user)
-			await next()
-		})
+/**
+ * The provision/reset routes are gated on services eligibility, which reads the
+ * db directly. Default the fixture to ELIGIBLE so the existing tests keep testing
+ * what they were written to test (mumble error mapping), and let the gate's own
+ * behaviour be pinned explicitly below.
+ */
+function makeDb(options: { eligible: boolean } = { eligible: true }) {
+	return {
+		query: {
+			users: { findFirst: vi.fn().mockResolvedValue({ is_admin: false }) },
+			userCharacters: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue(options.eligible ? [{ corporationId: 'corp-1' }] : []),
+			},
+			managedCorporations: { findMany: vi.fn().mockResolvedValue([{ corporationId: 'corp-1' }]) },
+		},
 	}
+}
+
+function makeApp(user?: SessionUser, db: unknown = makeDb()) {
+	const app = new Hono<App>()
+	app.use('*', async (c, next) => {
+		if (user) c.set('user', user)
+		c.set('db', db as never)
+		await next()
+	})
 	return app.route('/api/mumble', mumbleRoutes)
 }
 
@@ -216,5 +235,68 @@ describe('POST /api/mumble/account/reset-password', () => {
 		expect(res.status).toBe(200)
 		const body = (await res.json()) as any
 		expect(body.password).toBe('new-password')
+	})
+})
+
+/**
+ * THE SELF-HEAL GATE.
+ *
+ * Deleting someone's Mumble account is pointless if they can re-create it in one
+ * click, and provisioning had no eligibility check at all — the router's
+ * requireAllianceMember() only checks ROLE_CORE_ALLIANCE_MEMBER, which is granted
+ * for ANY character in ANY alliance and is not the member-corp rule.
+ */
+describe('services eligibility gate on the grant paths', () => {
+	it('403s provisioning for a user with no character in a member corporation', async () => {
+		const res = await makeApp(makeUser(), makeDb({ eligible: false })).request(
+			'/api/mumble/account',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(res.status).toBe(403)
+		expect((await res.json()) as any).toMatchObject({ code: 'not_member_corp' })
+		// The load-bearing part: the account must not be created anyway.
+		expect(provisionMumbleAccountMock).not.toHaveBeenCalled()
+	})
+
+	it('403s password reset for an ineligible user, and issues no credentials', async () => {
+		const res = await makeApp(makeUser(), makeDb({ eligible: false })).request(
+			'/api/mumble/account/reset-password',
+			{ method: 'POST' },
+			env
+		)
+
+		expect(res.status).toBe(403)
+		expect(resetMumblePasswordMock).not.toHaveBeenCalled()
+	})
+
+	it('still lets an ineligible user READ their own account', async () => {
+		// Reads are deliberately not gated: someone must be able to see the state of
+		// their own account, and the page needs `eligible` to decide what to offer.
+		getMumbleAccountMock.mockResolvedValue({ loginName: 'Pilot', enabled: true, groups: [] })
+
+		const res = await makeApp(makeUser(), makeDb({ eligible: false })).request(
+			'/api/mumble/account',
+			{},
+			env
+		)
+
+		expect(res.status).toBe(200)
+		const body = (await res.json()) as any
+		expect(body.account).not.toBeNull()
+		expect(body.eligible).toBe(false)
+	})
+
+	it('reports eligible: true for a user with a member-corp character', async () => {
+		getMumbleAccountMock.mockResolvedValue(null)
+
+		const res = await makeApp(makeUser(), makeDb({ eligible: true })).request(
+			'/api/mumble/account',
+			{},
+			env
+		)
+
+		expect(((await res.json()) as any).eligible).toBe(true)
 	})
 })

--- a/apps/core/src/routes/discord.ts
+++ b/apps/core/src/routes/discord.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { logger } from '@repo/hono-helpers'
 
 import { getDiscordStatus } from '../lib/discord-helpers'
+import { requireServiceEligibility } from '../middleware/service-eligibility'
 import { requireAuth } from '../middleware/session'
 import * as discordService from '../services/discord.service'
 
@@ -181,7 +182,7 @@ discord.post('/refresh', requireAuth(), async (c) => {
  *   totalFailed: number
  * }
  */
-discord.post('/join-servers', requireAuth(), async (c) => {
+discord.post('/join-servers', requireAuth(), requireServiceEligibility(), async (c) => {
 	const user = c.get('user')!
 
 	try {

--- a/apps/core/src/routes/mumble.ts
+++ b/apps/core/src/routes/mumble.ts
@@ -4,6 +4,8 @@ import { logger } from '@repo/hono-helpers'
 import { parseMumbleError } from '@repo/mumble'
 import { MUMBLE_FEATURE_FLAG_KEY } from '@repo/features'
 
+import { isUserEligibleForServices } from '../lib/service-eligibility'
+import { requireServiceEligibility } from '../middleware/service-eligibility'
 import { requireAllianceMember } from '../middleware/session'
 import { resolveFlag } from './flags'
 import * as mumbleService from '../services/mumble.service'
@@ -56,14 +58,24 @@ function isRpcTransportLoss(error: unknown): boolean {
 /**
  * GET /api/mumble/account
  * Current user's Mumble account status plus connection info.
+ *
+ * Deliberately NOT gated on eligibility: an ineligible user must still be able to
+ * see the state of their own account. `eligible` is reported so the client can
+ * hide the create/reset affordances rather than offer a button that can only 403.
  */
 mumble.get('/account', async (c) => {
 	const user = c.get('user')!
+	const db = c.get('db')
+
+	// A read must not 500 just because the eligibility probe could not run; the
+	// grant paths have their own fail-closed guard.
+	const eligible = db ? await isUserEligibleForServices(db, user.id).catch(() => false) : false
 
 	try {
 		const account = await mumbleService.getMumbleAccount(c.env, user.id)
 		return c.json({
 			account,
+			eligible,
 			connection: mumbleService.getMumbleConnectionInfo(c.env),
 		})
 	} catch (error) {
@@ -74,6 +86,7 @@ mumble.get('/account', async (c) => {
 			})
 			return c.json({
 				account: null,
+				eligible,
 				connection: mumbleService.getMumbleConnectionInfo(c.env),
 			})
 		}
@@ -88,7 +101,7 @@ mumble.get('/account', async (c) => {
  * Provision a Mumble account for the current user.
  * Returns the one-time password — it is never stored or shown again.
  */
-mumble.post('/account', async (c) => {
+mumble.post('/account', requireServiceEligibility(), async (c) => {
 	const user = c.get('user')!
 
 	try {
@@ -114,7 +127,7 @@ mumble.post('/account', async (c) => {
  * Rotate the current user's Mumble password.
  * Returns the new one-time password — it is never stored or shown again.
  */
-mumble.post('/account/reset-password', async (c) => {
+mumble.post('/account/reset-password', requireServiceEligibility(), async (c) => {
 	const user = c.get('user')!
 
 	try {

--- a/apps/core/vitest.unit.config.ts
+++ b/apps/core/vitest.unit.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
 			'src/routes/__tests__/**/*.test.ts',
 			'src/services/__tests__/**/*.test.ts',
 			'src/lib/__tests__/**/*.test.ts',
+			'src/middleware/__tests__/**/*.test.ts',
 			'src/workflows/**/*.test.ts',
 			'src/__tests__/**/*.test.ts',
 		],

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -2462,6 +2462,14 @@ export interface MumbleAccountStatus {
 
 export interface MumbleAccountResponse {
 	account: MumbleAccountStatus | null
+	/**
+	 * Whether the user currently passes the services eligibility rule: a character
+	 * in a member corporation, or site admin. The read itself is not gated on this
+	 * — you can always see your own account — but creating or resetting is, so the
+	 * client hides those affordances rather than offering a button that can only
+	 * 403.
+	 */
+	eligible: boolean
 	connection: MumbleConnectionInfo
 }
 

--- a/apps/ui/src/client/routes/mumble.tsx
+++ b/apps/ui/src/client/routes/mumble.tsx
@@ -49,6 +49,16 @@ export default function MumblePage() {
 
 	const account = data?.account ?? null
 	const connection = data?.connection
+	/**
+	 * The SERVER's eligibility verdict, not a client guess.
+	 *
+	 * `canAccessMumble(user)` above only checks the alliance-member role, which is
+	 * looser than the rule the API enforces (a character in a member corporation,
+	 * or site admin) — so this page is reachable by users who cannot actually
+	 * provision. Default to false while loading so the affordance appears only once
+	 * the server has said yes.
+	 */
+	const isEligible = data?.eligible === true
 
 	if (authLoading || isLoadingMumbleFeature || (canViewMumblePage && isLoading)) {
 		return (
@@ -138,9 +148,21 @@ export default function MumblePage() {
 								</CardDescription>
 							</CardHeader>
 							<CardContent>
-								<Button onClick={handleProvision} disabled={provision.isPending}>
-									{provision.isPending ? 'Creating…' : 'Create Mumble account'}
-								</Button>
+								{isEligible ? (
+									<Button onClick={handleProvision} disabled={provision.isPending}>
+										{provision.isPending ? 'Creating…' : 'Create Mumble account'}
+									</Button>
+								) : (
+									// The server 403s this now, so offering the button would only
+									// produce a failure the user cannot act on. Say why instead —
+									// and name the recently-joined case, because a lagging character
+									// sync is the one cause the user can neither see nor fix.
+									<p className="text-sm text-muted-foreground">
+										A Mumble account requires a character in a member corporation. If you have
+										recently joined one, your character data may not have synced yet — check back
+										shortly, or contact an admin if it persists.
+									</p>
+								)}
 							</CardContent>
 						</Card>
 					) : null}
@@ -168,14 +190,24 @@ export default function MumblePage() {
 											? `Last connected ${new Date(account.lastAuthenticatedAt).toLocaleString()}`
 											: 'Never connected'}
 									</div>
-									<Button
-										variant="secondary"
-										onClick={() => setResetDialogOpen(true)}
-										disabled={resetPassword.isPending}
-									>
-										<RefreshCw className="h-4 w-4 mr-2" />
-										{resetPassword.isPending ? 'Generating…' : 'Regenerate password'}
-									</Button>
+									{isEligible ? (
+										<Button
+											variant="secondary"
+											onClick={() => setResetDialogOpen(true)}
+											disabled={resetPassword.isPending}
+										>
+											<RefreshCw className="h-4 w-4 mr-2" />
+											{resetPassword.isPending ? 'Generating…' : 'Regenerate password'}
+										</Button>
+									) : (
+										// An account can outlive eligibility: it is still shown above (with
+										// whatever groups it has, which is none), but issuing fresh
+										// credentials for it is gated server-side.
+										<p className="text-sm text-muted-foreground">
+											This account is inactive because you no longer have a character in a member
+											corporation. Password regeneration is unavailable while that is the case.
+										</p>
+									)}
 								</CardContent>
 							</Card>
 


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Closes the self-service "grant yourself access back" hole in the services access audit: `isUserEligibleForServices` (member-corp attachment, or site admin) is now enforced on the Mumble and Discord self-service grant paths, so a user whose access was revoked can no longer regain it just by clicking the same button again.

## Changes

- Add `isUserEligibleForServices(db, userId)` to `apps/core/src/lib/service-eligibility.ts`, mirroring the `getUserGroupNames` hard cut (member-corp attachment OR `is_admin`).
- Add `requireServiceEligibility()` middleware (`apps/core/src/middleware/service-eligibility.ts`) that 401s unauthenticated requests, fails **closed** (500) if the db is unavailable, and otherwise 403s with `code: 'not_member_corp'` when the rule fails.
- Mount the new middleware on the grant paths only: `POST /api/mumble/account`, `POST /api/mumble/account/reset-password`, and `POST /api/discord/join-servers`. Reads (`GET /api/mumble/account`) stay ungated but now report an `eligible` flag.
- Deliberately do not gate inside `resetMumblePassword` / `syncUserDiscordAccess` themselves, since those are also called from enforcement/admin/RPC paths that must not be blocked by this rule.
- UI: `apps/ui/src/client/routes/mumble.tsx` uses the server-reported `eligible` flag (not the looser client-side `canAccessMumble` alliance-member check) to hide the "Create Mumble account" / "Regenerate password" buttons and show an explanatory message instead.
- `MumbleAccountResponse` type in `apps/ui/src/client/lib/api.ts` gains the `eligible: boolean` field.
- Register `src/middleware/__tests__/**/*.test.ts` in `apps/core/vitest.unit.config.ts` (previously matched no include pattern).

## Testing

- New unit tests for the middleware (`service-eligibility.middleware.test.ts`) covering allow/deny for member-corp and admin users, missing-user-row, unauthenticated, and fail-closed-on-db-unavailable cases.
- New route tests pinning that the gate is actually mounted and that a rejected request never reaches `provisionMumbleAccount`, `resetMumblePassword`, or `syncUserDiscordAccess` (`discord.join-servers.gate.test.ts`, additions to `mumble.route.test.ts`).
- Per the commit message, the full suite passes at 774 (up from 757), with 6 pre-existing/unrelated failures.
<!-- claude:end -->