### PR TITLE
fix(core): anchor the basis guard on acknowledgement, not a timer

### DIFF
--- a/apps/core/.migrations/0045_third_legion.sql
+++ b/apps/core/.migrations/0045_third_legion.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "service_access_audit_runs" ADD COLUMN "basis_acknowledged_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD COLUMN "basis_acknowledged_by_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD COLUMN "basis_acknowledged_reason" text;--> statement-breakpoint
+ALTER TABLE "service_access_audit_runs" ADD CONSTRAINT "service_access_audit_runs_basis_acknowledged_by_user_id_users_id_fk" FOREIGN KEY ("basis_acknowledged_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "service_access_audit_runs_basis_acknowledged_at_idx" ON "service_access_audit_runs" USING btree ("basis_acknowledged_at");--> statement-breakpoint
+CREATE INDEX "service_access_audit_runs_member_corp_count_idx" ON "service_access_audit_runs" USING btree ("started_at","member_corp_count");

--- a/apps/core/.migrations/meta/0045_snapshot.json
+++ b/apps/core/.migrations/meta/0045_snapshot.json
@@ -1,0 +1,5572 @@
+{
+  "id": "275cc30b-c39c-4870-af60-908547e75abb",
+  "prevId": "dc107001-40bf-4609-914b-05f9aae1ec55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_destinations": {
+      "name": "alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "alert_destinations_scope_idx": {
+          "name": "alert_destinations_scope_idx",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_alert_type_idx": {
+          "name": "alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_type_idx": {
+          "name": "alert_destinations_type_idx",
+          "columns": [
+            {
+              "expression": "destination_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_destinations_enabled_idx": {
+          "name": "alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_core_user_id_users_id_fk": {
+          "name": "alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_created_by_users_id_fk": {
+          "name": "alert_destinations_created_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "alert_destinations_updated_by_users_id_fk": {
+          "name": "alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_configs": {
+      "name": "corporation_alert_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_ids": {
+          "name": "destination_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_alert_configs_corp_idx": {
+          "name": "corporation_alert_configs_corp_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_alert_type_idx": {
+          "name": "corporation_alert_configs_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_enabled_idx": {
+          "name": "corporation_alert_configs_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_alert_configs_corp_alert_type_idx": {
+          "name": "corporation_alert_configs_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_configs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_configs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_alert_configs_corp_alert_type_unique": {
+          "name": "corporation_alert_configs_corp_alert_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "alert_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_alert_destinations": {
+      "name": "corporation_alert_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_type": {
+          "name": "alert_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_config": {
+          "name": "destination_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_alert_destinations_corp_id_idx": {
+          "name": "corp_alert_destinations_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_alert_type_idx": {
+          "name": "corp_alert_destinations_alert_type_idx",
+          "columns": [
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_enabled_idx": {
+          "name": "corp_alert_destinations_enabled_idx",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_alert_destinations_corp_alert_type_idx": {
+          "name": "corp_alert_destinations_corp_alert_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_alert_destinations_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_alert_destinations_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_core_user_id_users_id_fk": {
+          "name": "corporation_alert_destinations_core_user_id_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_created_by_users_id_fk": {
+          "name": "corporation_alert_destinations_created_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_alert_destinations_updated_by_users_id_fk": {
+          "name": "corporation_alert_destinations_updated_by_users_id_fk",
+          "tableFrom": "corporation_alert_destinations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_invites": {
+      "name": "corporation_discord_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_role_ids": {
+          "name": "assigned_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_discord_invites_corp_id_idx": {
+          "name": "corporation_discord_invites_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_user_id_idx": {
+          "name": "corporation_discord_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_server_id_idx": {
+          "name": "corporation_discord_invites_server_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_discord_invites_created_at_idx": {
+          "name": "corporation_discord_invites_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_invites_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_invites_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_invites_user_id_users_id_fk": {
+          "name": "corporation_discord_invites_user_id_users_id_fk",
+          "tableFrom": "corporation_discord_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_nickname_configs": {
+      "name": "corporation_discord_server_nickname_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'corp'"
+        },
+        "custom_ticker": {
+          "name": "custom_ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_nickname_configs_attachment_idx": {
+          "name": "corp_discord_server_nickname_configs_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_nickname_configs_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_nickname_configs",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_nickname_config": {
+          "name": "unique_corp_discord_server_nickname_config",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_roles": {
+      "name": "corporation_discord_server_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_roles_attachment_idx": {
+          "name": "corp_discord_server_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_role": {
+          "name": "unique_corp_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "discord_role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_server_scenario_roles": {
+      "name": "corporation_discord_server_scenario_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_discord_server_id": {
+          "name": "corporation_discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_role_id": {
+          "name": "discord_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_server_scenario_roles_attachment_idx": {
+          "name": "corp_discord_server_scenario_roles_attachment_idx",
+          "columns": [
+            {
+              "expression": "corporation_discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_corporation_discord_server_id_corporation_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "corporation_discord_servers",
+          "columnsFrom": [
+            "corporation_discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk": {
+          "name": "corporation_discord_server_scenario_roles_discord_role_id_discord_roles_id_fk",
+          "tableFrom": "corporation_discord_server_scenario_roles",
+          "tableTo": "discord_roles",
+          "columnsFrom": [
+            "discord_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server_scenario_role": {
+          "name": "unique_corp_discord_server_scenario_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_discord_server_id",
+            "bucket"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_discord_servers": {
+      "name": "corporation_discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_invite": {
+          "name": "auto_invite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_assign_roles": {
+          "name": "auto_assign_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corp_discord_servers_corp_id_idx": {
+          "name": "corp_discord_servers_corp_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_id_idx": {
+          "name": "corp_discord_servers_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corp_discord_servers_server_auto_assign_idx": {
+          "name": "corp_discord_servers_server_auto_assign_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_assign_roles",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"corporation_discord_servers\".\"auto_assign_roles\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "corporation_discord_servers_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corporation_discord_servers_discord_server_id_discord_servers_id_fk": {
+          "name": "corporation_discord_servers_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "corporation_discord_servers",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_corp_discord_server": {
+          "name": "unique_corp_discord_server",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "discord_server_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_categories": {
+      "name": "discord_command_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_categories_sort_order_idx": {
+          "name": "discord_command_categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_categories_name_unique": {
+          "name": "discord_command_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_command_permissions": {
+      "name": "discord_command_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_command_permissions_command_id_idx": {
+          "name": "discord_command_permissions_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_command_permissions_permission_id_idx": {
+          "name": "discord_command_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_command_permissions_command_id_discord_commands_id_fk": {
+          "name": "discord_command_permissions_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_command_permissions",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_command_permissions_command_permission_unique": {
+          "name": "discord_command_permissions_command_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_id",
+            "permission_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_commands": {
+      "name": "discord_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static_response'"
+        },
+        "response_template": {
+          "name": "response_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_commands_name_idx": {
+          "name": "discord_commands_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_type_idx": {
+          "name": "discord_commands_type_idx",
+          "columns": [
+            {
+              "expression": "command_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_is_active_idx": {
+          "name": "discord_commands_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_commands_category_id_idx": {
+          "name": "discord_commands_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_commands_category_id_discord_command_categories_id_fk": {
+          "name": "discord_commands_category_id_discord_command_categories_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "discord_command_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "discord_commands_created_by_users_id_fk": {
+          "name": "discord_commands_created_by_users_id_fk",
+          "tableFrom": "discord_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_commands_name_unique": {
+          "name": "discord_commands_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_rows": {
+      "name": "discord_member_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discriminator": {
+          "name": "discriminator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_ids": {
+          "name": "role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "linked": {
+          "name": "linked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "core_user_id": {
+          "name": "core_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_rows_run_linked_user_idx": {
+          "name": "discord_member_audit_rows_run_linked_user_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "linked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk": {
+          "name": "discord_member_audit_rows_run_id_discord_member_audit_runs_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "discord_member_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_rows_core_user_id_users_id_fk": {
+          "name": "discord_member_audit_rows_core_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "core_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_rows_run_discord_user_unique": {
+          "name": "discord_member_audit_rows_run_discord_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_member_audit_runs": {
+      "name": "discord_member_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linked_count": {
+          "name": "linked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unlinked_count": {
+          "name": "unlinked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_member_audit_runs_server_started_idx": {
+          "name": "discord_member_audit_runs_server_started_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_member_audit_runs_status_idx": {
+          "name": "discord_member_audit_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_member_audit_runs_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_member_audit_runs_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_member_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "discord_member_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "discord_member_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_member_audit_runs_workflow_instance_id_unique": {
+          "name": "discord_member_audit_runs_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_instance_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_roles": {
+      "name": "discord_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_apply": {
+          "name": "auto_apply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_roles_server_id_idx": {
+          "name": "discord_roles_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_roles_server_auto_apply_active_idx": {
+          "name": "discord_roles_server_auto_apply_active_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_apply",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_roles\".\"auto_apply\" = true AND \"discord_roles\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_roles_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_roles_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_roles",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_discord_server_role": {
+          "name": "unique_discord_server_role",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "role_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_server_commands": {
+      "name": "discord_server_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_server_id": {
+          "name": "discord_server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_command_id": {
+          "name": "discord_command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_server_commands_server_id_idx": {
+          "name": "discord_server_commands_server_id_idx",
+          "columns": [
+            {
+              "expression": "discord_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_server_commands_command_id_idx": {
+          "name": "discord_server_commands_command_id_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_server_commands_discord_server_id_discord_servers_id_fk": {
+          "name": "discord_server_commands_discord_server_id_discord_servers_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_servers",
+          "columnsFrom": [
+            "discord_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_command_id_discord_commands_id_fk": {
+          "name": "discord_server_commands_command_id_discord_commands_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "discord_commands",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_server_commands_created_by_users_id_fk": {
+          "name": "discord_server_commands_created_by_users_id_fk",
+          "tableFrom": "discord_server_commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_server_commands_server_command_unique": {
+          "name": "discord_server_commands_server_command_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_server_id",
+            "command_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_servers": {
+      "name": "discord_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "manage_nicknames": {
+          "name": "manage_nicknames",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_servers_guild_id_idx": {
+          "name": "discord_servers_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_servers_active_idx": {
+          "name": "discord_servers_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discord_servers\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_servers_created_by_users_id_fk": {
+          "name": "discord_servers_created_by_users_id_fk",
+          "tableFrom": "discord_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_servers_guild_id_unique": {
+          "name": "discord_servers_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guild_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_decay_config": {
+      "name": "dkp_decay_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_decay_config_active_idx": {
+          "name": "dkp_decay_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dkp_decay_config\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_decay_config_effective_from_idx": {
+          "name": "dkp_decay_config_effective_from_idx",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_decay_config_created_by_users_id_fk": {
+          "name": "dkp_decay_config_created_by_users_id_fk",
+          "tableFrom": "dkp_decay_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dkp_transactions": {
+      "name": "dkp_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_reason": {
+          "name": "award_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_model": {
+          "name": "decay_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "decay_rate": {
+          "name": "decay_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decay_period_days": {
+          "name": "decay_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dkp_transactions_user_earned_idx": {
+          "name": "dkp_transactions_user_earned_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_user_source_idx": {
+          "name": "dkp_transactions_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_character_earned_idx": {
+          "name": "dkp_transactions_character_earned_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_corp_earned_idx": {
+          "name": "dkp_transactions_corp_earned_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_earned_at_idx": {
+          "name": "dkp_transactions_earned_at_idx",
+          "columns": [
+            {
+              "expression": "earned_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_type_idx": {
+          "name": "dkp_transactions_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_source_id_idx": {
+          "name": "dkp_transactions_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dkp_transactions_awarded_by_idx": {
+          "name": "dkp_transactions_awarded_by_idx",
+          "columns": [
+            {
+              "expression": "awarded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dkp_transactions_user_id_users_id_fk": {
+          "name": "dkp_transactions_user_id_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "dkp_transactions_awarded_by_users_id_fk": {
+          "name": "dkp_transactions_awarded_by_users_id_fk",
+          "tableFrom": "dkp_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "awarded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_corporations": {
+      "name": "managed_corporations",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_character_id": {
+          "name": "assigned_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_character_name": {
+          "name": "assigned_character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "healthy_director_count": {
+          "name": "healthy_director_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "configured_by": {
+          "name": "configured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_member_corporation": {
+          "name": "is_member_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_alt_corp": {
+          "name": "is_alt_corp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_special_purpose": {
+          "name": "is_special_purpose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_recruiting": {
+          "name": "is_recruiting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_corporations_name_idx": {
+          "name": "managed_corporations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_ticker_idx": {
+          "name": "managed_corporations_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_assigned_character_id_idx": {
+          "name": "managed_corporations_assigned_character_id_idx",
+          "columns": [
+            {
+              "expression": "assigned_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_is_active_idx": {
+          "name": "managed_corporations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_background_refresh_idx": {
+          "name": "managed_corporations_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_include_in_structure_asset_sync_idx": {
+          "name": "managed_corporations_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_member_idx": {
+          "name": "managed_corporations_corporation_id_is_member_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_member_corporation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_alt_idx": {
+          "name": "managed_corporations_corporation_id_is_alt_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_alt_corp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_corporations_corporation_id_is_special_purpose_idx": {
+          "name": "managed_corporations_corporation_id_is_special_purpose_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_special_purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_corporations_configured_by_users_id_fk": {
+          "name": "managed_corporations_configured_by_users_id_fk",
+          "tableFrom": "managed_corporations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "configured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_credential_handoffs": {
+      "name": "mumble_tempop_credential_handoffs",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mumble_tempop_credential_handoffs_expires_at_idx": {
+          "name": "mumble_tempop_credential_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_credential_handoffs_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_credential_handoffs",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempop_guests": {
+      "name": "mumble_tempop_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tempop_id": {
+          "name": "tempop_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corp_ticker": {
+          "name": "corp_ticker",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_name": {
+          "name": "login_name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mumble_tempop_guests_tempop_id_idx": {
+          "name": "mumble_tempop_guests_tempop_id_idx",
+          "columns": [
+            {
+              "expression": "tempop_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk": {
+          "name": "mumble_tempop_guests_tempop_id_mumble_tempops_id_fk",
+          "tableFrom": "mumble_tempop_guests",
+          "tableTo": "mumble_tempops",
+          "columnsFrom": [
+            "tempop_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempop_guests_subject_id_unique": {
+          "name": "mumble_tempop_guests_subject_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subject_id"
+          ]
+        },
+        "mumble_tempop_guests_tempop_character_uq": {
+          "name": "mumble_tempop_guests_tempop_character_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tempop_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mumble_tempops": {
+      "name": "mumble_tempops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mumble_tempops_status_expires_at_idx": {
+          "name": "mumble_tempops_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mumble_tempops_creator_user_id_idx": {
+          "name": "mumble_tempops_creator_user_id_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mumble_tempops_creator_user_id_users_id_fk": {
+          "name": "mumble_tempops_creator_user_id_users_id_fk",
+          "tableFrom": "mumble_tempops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mumble_tempops_short_code_unique": {
+          "name": "mumble_tempops_short_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "short_code"
+          ]
+        },
+        "mumble_tempops_key_hash_unique": {
+          "name": "mumble_tempops_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flow_type": {
+          "name": "flow_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_states_expires_at_idx": {
+          "name": "oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pm_forum_config": {
+      "name": "pm_forum_config",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forum_channel_id": {
+          "name": "forum_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_open_id": {
+          "name": "tag_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_closed_id": {
+          "name": "tag_closed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_resolved_id": {
+          "name": "tag_resolved_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_voided_id": {
+          "name": "tag_voided_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_access_audit_rows": {
+      "name": "service_access_audit_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_character_name": {
+          "name": "main_character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligible": {
+          "name": "eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_ids": {
+          "name": "corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "has_discord_link": {
+          "name": "has_discord_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mumble_status": {
+          "name": "mumble_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "mumble_error_message": {
+          "name": "mumble_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_status": {
+          "name": "discord_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "discord_error_message": {
+          "name": "discord_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_login_name": {
+          "name": "mumble_login_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_display_name": {
+          "name": "mumble_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_groups": {
+          "name": "mumble_groups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mumble_was_enabled": {
+          "name": "mumble_was_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_roles_removed": {
+          "name": "discord_roles_removed",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_access_audit_rows_run_eligible_idx": {
+          "name": "service_access_audit_rows_run_eligible_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eligible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_reason_idx": {
+          "name": "service_access_audit_rows_run_reason_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_mumble_status_idx": {
+          "name": "service_access_audit_rows_run_mumble_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mumble_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_rows_run_discord_status_idx": {
+          "name": "service_access_audit_rows_run_discord_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_access_audit_rows_run_id_service_access_audit_runs_id_fk": {
+          "name": "service_access_audit_rows_run_id_service_access_audit_runs_id_fk",
+          "tableFrom": "service_access_audit_rows",
+          "tableTo": "service_access_audit_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_access_audit_rows_user_id_users_id_fk": {
+          "name": "service_access_audit_rows_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_rows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_access_audit_rows_run_user_unique": {
+          "name": "service_access_audit_rows_run_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_access_audit_runs": {
+      "name": "service_access_audit_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_workflow_instance_id": {
+          "name": "scan_workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_workflow_instance_id": {
+          "name": "enforce_workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scanning'"
+        },
+        "active_lock": {
+          "name": "active_lock",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_by_user_id": {
+          "name": "enforced_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_reason": {
+          "name": "enforce_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_corporation_ids": {
+          "name": "member_corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "member_corp_count": {
+          "name": "member_corp_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "basis_suspect": {
+          "name": "basis_suspect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "basis_compared_to_count": {
+          "name": "basis_compared_to_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_removed_corporation_ids": {
+          "name": "basis_removed_corporation_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_note": {
+          "name": "basis_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_acknowledged_at": {
+          "name": "basis_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_acknowledged_by_user_id": {
+          "name": "basis_acknowledged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_acknowledged_reason": {
+          "name": "basis_acknowledged_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "in_population": {
+          "name": "in_population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "eligible_count": {
+          "name": "eligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ineligible_count": {
+          "name": "ineligible_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blast_radius_tripped": {
+          "name": "blast_radius_tripped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_started_at": {
+          "name": "enforce_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_completed_at": {
+          "name": "enforce_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_access_audit_runs_status_started_idx": {
+          "name": "service_access_audit_runs_status_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_runs_expires_at_idx": {
+          "name": "service_access_audit_runs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_runs_basis_acknowledged_at_idx": {
+          "name": "service_access_audit_runs_basis_acknowledged_at_idx",
+          "columns": [
+            {
+              "expression": "basis_acknowledged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_access_audit_runs_member_corp_count_idx": {
+          "name": "service_access_audit_runs_member_corp_count_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "member_corp_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_access_audit_runs_initiated_by_user_id_users_id_fk": {
+          "name": "service_access_audit_runs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "service_access_audit_runs_enforced_by_user_id_users_id_fk": {
+          "name": "service_access_audit_runs_enforced_by_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enforced_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "service_access_audit_runs_basis_acknowledged_by_user_id_users_id_fk": {
+          "name": "service_access_audit_runs_basis_acknowledged_by_user_id_users_id_fk",
+          "tableFrom": "service_access_audit_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "basis_acknowledged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_access_audit_runs_scan_workflow_instance_id_unique": {
+          "name": "service_access_audit_runs_scan_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scan_workflow_instance_id"
+          ]
+        },
+        "service_access_audit_runs_enforce_workflow_instance_id_unique": {
+          "name": "service_access_audit_runs_enforce_workflow_instance_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "enforce_workflow_instance_id"
+          ]
+        },
+        "service_access_audit_runs_active_lock_unique": {
+          "name": "service_access_audit_runs_active_lock_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "active_lock"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_services": {
+      "name": "core_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_services_enabled_idx": {
+          "name": "core_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_name_idx": {
+          "name": "core_services_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_services_slug_idx": {
+          "name": "core_services_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_external_links": {
+      "name": "sidebar_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sidebar_external_links_sort_order_idx": {
+          "name": "sidebar_external_links_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_log": {
+      "name": "user_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_activity_log_user_id_idx": {
+          "name": "user_activity_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_action_idx": {
+          "name": "user_activity_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_timestamp_idx": {
+          "name": "user_activity_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_log_user_id_users_id_fk": {
+          "name": "user_activity_log_user_id_users_id_fk",
+          "tableFrom": "user_activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_characters": {
+      "name": "user_characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_owner_hash": {
+          "name": "character_owner_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_name": {
+          "name": "corporation_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_valid_token": {
+          "name": "has_valid_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_character_refresh": {
+          "name": "last_character_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_characters_user_id_idx": {
+          "name": "user_characters_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_character_id_idx": {
+          "name": "user_characters_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_is_primary_idx": {
+          "name": "user_characters_is_primary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_status_idx": {
+          "name": "user_characters_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_deleted_idx": {
+          "name": "user_characters_deleted_idx",
+          "columns": [
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_id_idx": {
+          "name": "user_characters_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_id_idx": {
+          "name": "user_characters_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_corporation_name_idx": {
+          "name": "user_characters_corporation_name_idx",
+          "columns": [
+            {
+              "expression": "corporation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_characters_alliance_name_idx": {
+          "name": "user_characters_alliance_name_idx",
+          "columns": [
+            {
+              "expression": "alliance_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_characters_user_id_users_id_fk": {
+          "name": "user_characters_user_id_users_id_fk",
+          "tableFrom": "user_characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_characters_character_id_unique": {
+          "name": "user_characters_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fingerprints": {
+      "name": "user_fingerprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_fingerprints_user_id_idx": {
+          "name": "user_fingerprints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_fingerprint_idx": {
+          "name": "user_fingerprints_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_fingerprints_user_id_fingerprint_idx": {
+          "name": "user_fingerprints_user_id_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fingerprints_user_id_users_id_fk": {
+          "name": "user_fingerprints_user_id_users_id_fk",
+          "tableFrom": "user_fingerprints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ip_addresses": {
+      "name": "user_ip_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addr": {
+          "name": "addr",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address_hash": {
+          "name": "ip_address_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_ip_addresses_user_id_idx": {
+          "name": "user_ip_addresses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_ip_addresses_ip_address_idx": {
+          "name": "user_ip_addresses_ip_address_idx",
+          "columns": [
+            {
+              "expression": "addr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ip_addresses_user_id_users_id_fk": {
+          "name": "user_ip_addresses_user_id_users_id_fk",
+          "tableFrom": "user_ip_addresses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_ip_addresses_user_ip_unique": {
+          "name": "user_ip_addresses_user_ip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "addr"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_user_services": {
+      "name": "core_user_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "core_user_services_user_id_idx": {
+          "name": "core_user_services_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_service_id_idx": {
+          "name": "core_user_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_user_id_service_id_idx": {
+          "name": "core_user_services_user_id_service_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "core_user_services_enabled_idx": {
+          "name": "core_user_services_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "core_user_services_user_id_users_id_fk": {
+          "name": "core_user_services_user_id_users_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "core_user_services_service_id_core_services_id_fk": {
+          "name": "core_user_services_service_id_core_services_id_fk",
+          "tableFrom": "core_user_services",
+          "tableTo": "core_services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_user_services_user_id_service_id_unique": {
+          "name": "core_user_services_user_id_service_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "service_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_session_token_idx": {
+          "name": "user_sessions_session_token_idx",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_sessions_session_token_unique": {
+          "name": "user_sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "main_character_id": {
+          "name": "main_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "immunitas": {
+          "name": "immunitas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_discord_refresh": {
+          "name": "last_discord_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "legacy_auth_user_id": {
+          "name": "legacy_auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_username": {
+          "name": "legacy_auth_user_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_auth_user_email_hash": {
+          "name": "legacy_auth_user_email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow": {
+          "name": "last_refresh_workflow",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_workflow_attempt": {
+          "name": "last_refresh_workflow_attempt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_main_character_id_idx": {
+          "name": "users_main_character_id_idx",
+          "columns": [
+            {
+              "expression": "main_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_discord_user_id_idx": {
+          "name": "users_discord_user_id_idx",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_discord_refresh_idx": {
+          "name": "users_last_discord_refresh_idx",
+          "columns": [
+            {
+              "expression": "last_discord_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_id_idx": {
+          "name": "users_legacy_auth_user_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_username_idx": {
+          "name": "users_legacy_auth_user_username_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_auth_user_email_hash_idx": {
+          "name": "users_legacy_auth_user_email_hash_idx",
+          "columns": [
+            {
+              "expression": "legacy_auth_user_email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_idx": {
+          "name": "users_last_refresh_workflow_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_refresh_workflow_attempt_idx": {
+          "name": "users_last_refresh_workflow_attempt_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_workflow_attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_main_character_id_unique": {
+          "name": "users_main_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "main_character_id"
+          ]
+        },
+        "users_discord_user_id_unique": {
+          "name": "users_discord_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_user_id"
+          ]
+        },
+        "users_legacy_auth_user_id_unique": {
+          "name": "users_legacy_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_id"
+          ]
+        },
+        "users_legacy_auth_user_username_unique": {
+          "name": "users_legacy_auth_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_username"
+          ]
+        },
+        "users_legacy_auth_user_email_hash_unique": {
+          "name": "users_legacy_auth_user_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_auth_user_email_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/.migrations/meta/_journal.json
+++ b/apps/core/.migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1784160455764,
       "tag": "0044_shiny_the_order",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1784173144945,
+      "tag": "0045_third_legion",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/db/schema.ts
+++ b/apps/core/src/db/schema.ts
@@ -1473,6 +1473,31 @@ export const serviceAccessAuditRuns = pgTable(
 		basisRemovedCorporationIds: text('basis_removed_corporation_ids').array(),
 		/** Operator-facing explanation of the diff; null unless basisSuspect. */
 		basisNote: text('basis_note'),
+		/**
+		 * A human has confirmed THIS RUN'S BASIS IS CORRECT.
+		 *
+		 * This is the anchor the guard is built on, and the only thing that can
+		 * lower the bar. An acknowledged run becomes the new floor: later runs are
+		 * compared against the highest basis seen since it, not against history
+		 * before it.
+		 *
+		 * It exists because a count alone cannot distinguish "an operator de-flagged
+		 * 13 corps" from "the table is half-restored" — only a human looking at
+		 * WHICH corps left can. Acking records that judgement so the guard stops
+		 * re-asking, without ever silently forgetting it on a timer.
+		 *
+		 * ENFORCEMENT MUST REFUSE to act on a run whose basisSuspect is true and
+		 * whose basisAcknowledgedAt is null. That is the real circuit breaker.
+		 */
+		basisAcknowledgedAt: timestamp('basis_acknowledged_at', { withTimezone: true }),
+		/** Who vouched for it. 'set null' so deleting the admin does not erase the
+		 * fact that the basis was confirmed. */
+		basisAcknowledgedByUserId: uuid('basis_acknowledged_by_user_id').references(() => users.id, {
+			onDelete: 'set null',
+		}),
+		/** Why they believed it. Required at ack time — "13 corps left" is only
+		 * safe if someone can say which, and why that was expected. */
+		basisAcknowledgedReason: text('basis_acknowledged_reason'),
 		/** Every user row walked, including eligible ones. */
 		scanned: integer('scanned').notNull().default(0),
 		/** Users holding a Mumble account or a Discord link — reported alongside
@@ -1499,6 +1524,13 @@ export const serviceAccessAuditRuns = pgTable(
 	(table) => [
 		index('service_access_audit_runs_status_started_idx').on(table.status, table.startedAt),
 		index('service_access_audit_runs_expires_at_idx').on(table.expiresAt),
+		// The baseline query: find the most recently acknowledged run, then the
+		// highest basis since it. Both are ORDER BY ... DESC LIMIT 1 reads.
+		index('service_access_audit_runs_basis_acknowledged_at_idx').on(table.basisAcknowledgedAt),
+		index('service_access_audit_runs_member_corp_count_idx').on(
+			table.startedAt,
+			table.memberCorpCount
+		),
 		unique('service_access_audit_runs_active_lock_unique').on(table.activeLock),
 	]
 )
@@ -1617,6 +1649,11 @@ export const serviceAccessAuditRunsRelations = relations(
 			fields: [serviceAccessAuditRuns.enforcedByUserId],
 			references: [users.id],
 			relationName: 'serviceAccessAuditRunEnforcedBy',
+		}),
+		basisAcknowledgedByUser: one(users, {
+			fields: [serviceAccessAuditRuns.basisAcknowledgedByUserId],
+			references: [users.id],
+			relationName: 'serviceAccessAuditRunBasisAcknowledgedBy',
 		}),
 		rows: many(serviceAccessAuditRows),
 	})

--- a/apps/core/src/lib/__tests__/service-eligibility-basis.test.ts
+++ b/apps/core/src/lib/__tests__/service-eligibility-basis.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import { evaluateBasis, evaluateBlastRadius, getBasisBaseline } from '../service-eligibility-basis'
@@ -19,14 +23,14 @@ import type { BasisBaseline } from '../service-eligibility-basis'
  *    emergency it exists for. An earlier version did this, unoverridably.
  */
 
-const NO_BASELINE: BasisBaseline = { memberCorpCount: null, corporationIds: [] }
+const NO_BASELINE: BasisBaseline = { memberCorpCount: null, corporationIds: [], acknowledgedAt: null }
 
 function corps(n: number): string[] {
 	return Array.from({ length: n }, (_, i) => `corp-${i + 1}`)
 }
 
 function baselineOf(count: number, ids?: string[]): BasisBaseline {
-	return { memberCorpCount: count, corporationIds: ids ?? corps(count) }
+	return { memberCorpCount: count, corporationIds: ids ?? corps(count), acknowledgedAt: null }
 }
 
 describe('evaluateBasis', () => {
@@ -171,79 +175,6 @@ describe('evaluateBasis', () => {
 	})
 })
 
-describe('getBasisBaseline', () => {
-	function dbWithRuns(runs: Array<{ memberCorpCount: number; memberCorporationIds: string[] }>) {
-		return {
-			query: {
-				serviceAccessAuditRuns: {
-					findMany: vi.fn().mockResolvedValue(runs),
-				},
-			},
-		} as never
-	}
-
-	it('returns the MAXIMUM count, not the most recent', async () => {
-		// THE RATCHET: baselining against the PREVIOUS run lets a sequence of
-		// individually-legal drops (50 -> 41 -> 34 -> 28, each >80% of the last) walk
-		// the floor to nothing and never trip. Against a maximum it cannot be walked.
-		const baseline = await getBasisBaseline(
-			dbWithRuns([
-				{ memberCorpCount: 50, memberCorporationIds: corps(50) },
-				{ memberCorpCount: 41, memberCorporationIds: corps(41) },
-				{ memberCorpCount: 34, memberCorporationIds: corps(34) },
-				{ memberCorpCount: 28, memberCorporationIds: corps(28) },
-			])
-		)
-		expect(baseline.memberCorpCount).toBe(50)
-	})
-
-	it('cannot be poisoned by a corrupt run, because corruption only ever shrinks', async () => {
-		// A bootstrap or corrupt run must never become the trusted reference. It
-		// structurally cannot: a small value never raises a maximum. That property
-		// is the whole reason this is MAX rather than "most recent".
-		const baseline = await getBasisBaseline(
-			dbWithRuns([
-				{ memberCorpCount: 200, memberCorporationIds: corps(200) },
-				{ memberCorpCount: 1, memberCorporationIds: ['corp-1'] },
-			])
-		)
-		expect(baseline.memberCorpCount).toBe(200)
-	})
-
-	it('carries the winning run’s corporation ids, for the set difference', async () => {
-		const baseline = await getBasisBaseline(
-			dbWithRuns([
-				{ memberCorpCount: 2, memberCorporationIds: ['corp-1', 'corp-2'] },
-				{ memberCorpCount: 3, memberCorporationIds: ['corp-1', 'corp-2', 'corp-3'] },
-			])
-		)
-		expect(baseline.corporationIds).toEqual(['corp-1', 'corp-2', 'corp-3'])
-	})
-
-	it('returns a null baseline when no good run exists (bootstrap)', async () => {
-		const baseline = await getBasisBaseline(dbWithRuns([]))
-		expect(baseline.memberCorpCount).toBeNull()
-		expect(baseline.corporationIds).toEqual([])
-	})
-
-	it('end to end: a walked-down sequence still trips against the max', async () => {
-		const baseline = await getBasisBaseline(
-			dbWithRuns([
-				{ memberCorpCount: 50, memberCorporationIds: corps(50) },
-				{ memberCorpCount: 41, memberCorporationIds: corps(41) },
-				{ memberCorpCount: 34, memberCorporationIds: corps(34) },
-			])
-		)
-		// 28 is >80% of 34 (the most recent), so a "most recent" baseline would wave
-		// it through. Against the max of 50 it is 56% and gets flagged.
-		const verdict = evaluateBasis({ corporationIds: corps(28), memberCorpCount: 28, baseline })
-		expect(verdict.blocked).toBe(false)
-		if (verdict.blocked) throw new Error('unreachable')
-		expect(verdict.basisSuspect).toBe(true)
-		expect(verdict.comparedToMemberCorpCount).toBe(50)
-	})
-})
-
 describe('evaluateBlastRadius (soft heuristic)', () => {
 	it('trips above 20% ineligible once past the absolute floor', () => {
 		expect(evaluateBlastRadius({ scanned: 1000, ineligibleCount: 300 })).toBe(true)
@@ -265,5 +196,224 @@ describe('evaluateBlastRadius (soft heuristic)', () => {
 
 	it('does not divide by zero on an empty scan', () => {
 		expect(evaluateBlastRadius({ scanned: 0, ineligibleCount: 0 })).toBe(false)
+	})
+})
+
+/**
+ * Render the shape of a drizzle query fragment: its literal SQL text plus the
+ * columns it directly references.
+ *
+ * JSON.stringify cannot be used — drizzle's SQL and Column objects are circular.
+ * A naive deep walk is also useless: it descends into a Column's `table` and
+ * reports EVERY column of that table, so `not.toContain('started_at')` would
+ * always fail. This walks `queryChunks` only, and takes a Column's own name
+ * without following it back to its table.
+ */
+function sqlShape(value: unknown): string {
+	const parts: string[] = []
+	const walk = (node: unknown): void => {
+		if (node === null || typeof node !== 'object') return
+		const record = node as Record<string, unknown>
+
+		// StringChunk: the literal SQL text, e.g. ' >= ' or ' in '.
+		if (Array.isArray(record.value) && record.value.every((v) => typeof v === 'string')) {
+			parts.push((record.value as string[]).join(''))
+			return
+		}
+		// Column: take its own name; do NOT recurse into `.table`.
+		if (typeof record.name === 'string' && 'table' in record) {
+			parts.push(record.name)
+			return
+		}
+		if (Array.isArray(record.queryChunks)) {
+			for (const chunk of record.queryChunks) walk(chunk)
+			return
+		}
+		if (Array.isArray(node)) {
+			for (const item of node) walk(item)
+		}
+	}
+	walk(value)
+	return parts.join(' ')
+}
+
+describe('getBasisBaseline', () => {
+	/**
+	 * The max is now computed by Postgres (`ORDER BY member_corp_count DESC LIMIT
+	 * 1`), not by a JS reduce, so a mocked db cannot test it — and a mock that
+	 * ignores its argument would prove nothing anyway. That was the flaw in the
+	 * previous suite: its "cannot be poisoned by a corrupt run" test was really
+	 * `Math.max(200, 1) === 200` and would have passed with the status filter, the
+	 * suspect filter AND the window all deleted.
+	 *
+	 * So these test the two things that ARE ours: the JS wiring (anchor -> search
+	 * boundary, null handling, passthrough), and the SHAPE of what we ask the
+	 * database for.
+	 */
+	function makeDb(options: {
+		anchor?: { startedAt: Date; basisAcknowledgedAt: Date }
+		best?: { memberCorpCount: number; memberCorporationIds: string[] | null }
+	}) {
+		const calls: Array<Record<string, unknown>> = []
+		let call = 0
+		return {
+			calls,
+			db: {
+				query: {
+					serviceAccessAuditRuns: {
+						findFirst: vi.fn(async (opts: Record<string, unknown>) => {
+							calls.push(opts)
+							// Call 1 is the acknowledgement anchor, call 2 the high-water run.
+							return call++ === 0 ? options.anchor : options.best
+						}),
+					},
+				},
+			} as never,
+		}
+	}
+
+	it('returns a null baseline ONLY when no scan has ever completed', async () => {
+		const { db } = makeDb({ anchor: undefined, best: undefined })
+		const baseline = await getBasisBaseline(db)
+		expect(baseline.memberCorpCount).toBeNull()
+		expect(baseline.corporationIds).toEqual([])
+		expect(baseline.acknowledgedAt).toBeNull()
+	})
+
+	it('REGRESSION: a history of nothing but suspect runs still yields a baseline', async () => {
+		// THE DARK-GUARD BUG. The previous design excluded suspect runs from the
+		// candidate set and bounded it to a 30-day window. After 30 days of
+		// corruption every candidate was suspect => excluded => the set emptied =>
+		// baseline null => "bootstrap" => basisSuspect FALSE. The corrupt basis was
+		// reported as fine, which is precisely the flag enforcement is told to trust.
+		//
+		// There is no suspect filter now, so a suspect run is still a candidate and
+		// a baseline still exists. Exclusion never bought anything: a shrink-corrupted
+		// run's count is below the mark by construction and cannot win a max.
+		const { db } = makeDb({
+			anchor: undefined,
+			best: { memberCorpCount: 5, memberCorporationIds: corps(5) },
+		})
+		const baseline = await getBasisBaseline(db)
+		expect(baseline.memberCorpCount).toBe(5)
+
+		const verdict = evaluateBasis({ corporationIds: corps(5), memberCorpCount: 5, baseline })
+		expect(verdict.blocked).toBe(false)
+		if (verdict.blocked) throw new Error('unreachable')
+		// The point: NOT silently blessed as a fresh bootstrap.
+		expect(verdict.bootstrap).toBe(false)
+	})
+
+	it('asks Postgres for the MAXIMUM, not the latest', async () => {
+		// The ratchet defence lives in this ORDER BY. Baselining against the
+		// PREVIOUS run lets 50 -> 41 -> 34 -> 28 (each >80% of the last) walk the
+		// floor to nothing; against a max it cannot be walked.
+		const { db, calls } = makeDb({
+			anchor: undefined,
+			best: { memberCorpCount: 50, memberCorporationIds: corps(50) },
+		})
+		await getBasisBaseline(db)
+
+		const bestQuery = calls[1]
+		expect(bestQuery.orderBy).toBeDefined()
+		// Ordering by startedAt would silently make this "most recent" again.
+		expect(sqlShape(bestQuery.orderBy)).toContain('member_corp_count')
+	})
+
+	it('bounds the search at the last acknowledged run', async () => {
+		const ackedAt = new Date('2026-07-01T00:00:00Z')
+		const startedAt = new Date('2026-06-30T00:00:00Z')
+		const { db, calls } = makeDb({
+			anchor: { startedAt, basisAcknowledgedAt: ackedAt },
+			best: { memberCorpCount: 37, memberCorporationIds: corps(37) },
+		})
+
+		const baseline = await getBasisBaseline(db)
+
+		expect(baseline.memberCorpCount).toBe(37)
+		// Carried so the UI can say whether anyone has ever vouched for a basis.
+		expect(baseline.acknowledgedAt).toEqual(ackedAt)
+		// Two queries: the anchor, then the high-water run since it.
+		expect(calls).toHaveLength(2)
+		expect(sqlShape(calls[1].where)).toContain('started_at')
+	})
+
+	it('searches all history when nothing has ever been acknowledged', async () => {
+		const { db, calls } = makeDb({
+			anchor: undefined,
+			best: { memberCorpCount: 50, memberCorporationIds: corps(50) },
+		})
+		const baseline = await getBasisBaseline(db)
+
+		expect(baseline.acknowledgedAt).toBeNull()
+		// No anchor => no startedAt lower bound => the whole history informs the max.
+		expect(sqlShape(calls[1].where)).not.toContain('started_at')
+	})
+
+	it('tolerates a run whose corporation ids are null', async () => {
+		const { db } = makeDb({
+			anchor: undefined,
+			best: { memberCorpCount: 3, memberCorporationIds: null },
+		})
+		const baseline = await getBasisBaseline(db)
+		expect(baseline.corporationIds).toEqual([])
+	})
+})
+
+describe('the basis guard’s deliberate absences (regression guards)', () => {
+	// The window and the suspect-exclusion, TOGETHER, produced the dark-guard bug.
+	// Neither may come back.
+	const source = readFileSync(
+		join(dirname(fileURLToPath(import.meta.url)), '..', 'service-eligibility-basis.ts'),
+		'utf8'
+	)
+
+	/**
+	 * getBasisBaseline's body, comments stripped.
+	 *
+	 * Scoped to the function rather than the file because `basisSuspect` appears
+	 * legitimately elsewhere (evaluateBasis returns it) — a file-wide check would
+	 * be a false positive. And matched on the IDENTIFIER, not on guessed syntax: an
+	 * earlier version of this guard tested /basisSuspect\s*=\s*false/, which the
+	 * real code (sql`${runs.basisSuspect} = false`) does not match because of the
+	 * closing brace. It would have sailed straight past a reintroduction.
+	 */
+	const baselineBody = (() => {
+		const start = source.indexOf('export async function getBasisBaseline')
+		const end = source.indexOf('export interface BasisVerdictOk')
+		return source
+			.slice(start, end)
+			.replace(/\/\*[\s\S]*?\*\//g, '')
+			.replace(/\/\/.*$/gm, '')
+	})()
+
+	it('has no trailing window on the baseline', () => {
+		// A window makes the guard forget on a timer, which is how it went dark:
+		// after 30 days of corruption the only good run aged out and the corrupt
+		// basis was reported as a fresh bootstrap. Time is not evidence that a basis
+		// is correct; a human acknowledging it is.
+		//
+		// Asserted as "constructs no dates AT ALL" rather than by guessing at the
+		// syntax of a window. The real function reads its only timestamp from the
+		// anchor row, so any date arithmetic appearing here is a window being
+		// reintroduced. An earlier version of this guard only matched getTime() and
+		// sailed straight past a Date.now() window.
+		expect(source).not.toMatch(/WINDOW_DAYS/)
+		expect(baselineBody).not.toMatch(/new Date\(|Date\.now\(|getTime\(/)
+	})
+
+	it('does not filter the baseline on basisSuspect', () => {
+		// Excluding suspect runs is what let the candidate set empty out and report a
+		// corrupt basis as a fresh bootstrap.
+		expect(baselineBody).not.toMatch(/basisSuspect/)
+	})
+
+	it('anchors the baseline on acknowledgement instead', () => {
+		expect(baselineBody).toMatch(/basisAcknowledgedAt/)
+		expect(baselineBody).toMatch(/isNotNull/)
+	})
+
+	it('orders by member corp count, never by recency', () => {
+		expect(baselineBody).toMatch(/desc\(serviceAccessAuditRuns\.memberCorpCount\)/)
 	})
 })

--- a/apps/core/src/lib/service-eligibility-basis.ts
+++ b/apps/core/src/lib/service-eligibility-basis.ts
@@ -1,4 +1,6 @@
-import { gte, inArray, sql } from '@repo/db-utils'
+import { and, desc, gte, inArray, isNotNull } from '@repo/db-utils'
+
+import { serviceAccessAuditRuns } from '../db/schema'
 
 import type { DbClient, schema } from '../db'
 
@@ -37,11 +39,20 @@ import type { DbClient, schema } from '../db'
  *
  * ── WHERE THE TEETH ACTUALLY BELONG ──
  *
- * A SCAN IS READ-ONLY AND CANNOT HURT ANYONE. Blocking it is pure downside: it
+ * A scan does not WRITE to any service, so blocking it is mostly downside: it
  * prevents the legitimate workflow AND prevents diagnosis, since a scan's output
  * is precisely what reveals a broken basis. The catastrophe this guard exists to
  * prevent is MASS REVOCATION on a corrupt basis, and revocation happens at
- * ENFORCE, not at scan.
+ * ENFORCE.
+ *
+ * But do not mistake that for "a scan cannot hurt anyone" — an earlier version of
+ * this comment said exactly that, and it conflates the write with the ARTIFACT. A
+ * scan's output IS the revocation list: it terminates in
+ * `status: 'awaiting_confirmation'`, and every row carries `mumbleStatus` /
+ * `discordStatus` columns that exist for no reason except for enforcement to
+ * mutate. A scan is harmless; a scan's CONCLUSION is not. That is why a suspect
+ * basis must be carried on the run and honoured downstream rather than merely
+ * logged.
  *
  * Therefore:
  *   - count < 1        -> BLOCK the scan. Genuinely unambiguous; see below.
@@ -50,8 +61,10 @@ import type { DbClient, schema } from '../db'
  *   - ineligible ratio -> DO NOT BLOCK. Record `blastRadiusTripped`.
  *
  * >>> ENFORCEMENT (increment 7, NOT YET BUILT) MUST HARD-REFUSE to act on a run
- * >>> whose `basisSuspect` is true and unacknowledged. That refusal is the real
- * >>> circuit breaker. This module only ever informs. <<<
+ * >>> whose `basisSuspect` is true and whose `basisAcknowledgedAt` is null.
+ * >>> That refusal is the real circuit breaker. This module only ever informs.
+ * >>> The acknowledgement column and route exist as of this change — when that
+ * >>> promise was first written, they did not, which made it a lie. <<<
  */
 
 /**
@@ -66,16 +79,10 @@ import type { DbClient, schema } from '../db'
 const MIN_MEMBER_CORP_COUNT = 1
 
 /**
- * A basis retaining less than this fraction of the recent high-water mark is
- * flagged `basisSuspect` — reported, never blocked.
+ * A basis retaining less than this fraction of the high-water mark is flagged
+ * `basisSuspect` — reported, never blocked.
  */
 const BASIS_SHRINK_SUSPECT_RATIO = 0.8
-
-/** Trailing window for the high-water baseline. Wide enough that a corrupt run
- * cannot outlive the good runs around it; narrow enough that a LEGITIMATE
- * permanent shrink stops being flagged once it has settled, instead of crying
- * wolf forever. */
-const BASIS_BASELINE_WINDOW_DAYS = 30
 
 /** Blast-radius heuristic. Soft: flags, never blocks. */
 const BLAST_RADIUS_RATIO = 0.2
@@ -93,72 +100,120 @@ const BLAST_RADIUS_ABSOLUTE_FLOOR = 25
 const BASELINE_STATUSES = ['completed', 'awaiting_confirmation', 'completed_with_errors'] as const
 
 export interface BasisBaseline {
-	/** High-water member-corp count across recent good runs; null on bootstrap. */
+	/** High-water member-corp count since the last acknowledged run; null only
+	 * when no scan has ever completed. */
 	memberCorpCount: number | null
 	/** The basis snapshot of the run that set the high-water mark, for the set
 	 * difference. Empty when there is no baseline. */
 	corporationIds: string[]
+	/** When an operator last vouched for a basis. null = never; the guard is
+	 * comparing against unvouched history. */
+	acknowledgedAt: Date | null
 }
 
 /**
- * The baseline is the MAXIMUM member-corp count over recent good runs — NOT the
- * most recent one.
+ * The baseline is the HIGHEST member-corp count seen since the last
+ * ACKNOWLEDGED run — never the most recent run, and never bounded by a timer.
  *
- * This single choice kills two bugs at once, and both are worth stating because
- * "most recent" is the intuitive implementation:
+ * ── WHY MAX, NOT "MOST RECENT" ──
  *
- *  1. THE RATCHET. If each run baselines against its predecessor, a sequence of
- *     individually-legal drops (50 -> 41 -> 34 -> 28 -> 23, each >80% of the last)
- *     walks the floor to nothing and never trips. Against a maximum, the floor
- *     cannot be walked down.
- *  2. BASELINE POISONING. A bootstrap or corrupt run must never become the
- *     trusted reference. It cannot: corruption SHRINKS the basis, and a small
- *     value can never raise a maximum. The guard is monotonic against precisely
- *     the failure mode it fears.
+ * THE RATCHET. If each run baselines against its predecessor, a sequence of
+ * individually-legal drops (50 -> 41 -> 34 -> 28 -> 23, each >80% of the last)
+ * walks the floor to nothing and never trips. Against a maximum it cannot.
  *
- * The trailing window is what lets a legitimate, permanent shrink stop being
- * flagged once it ages out — without it, de-flagging 13 corps would flag every
- * scan forever.
+ * ── WHY AN ACK, NOT A TRAILING WINDOW ──
+ *
+ * A previous version took the max over a trailing 30-day window and excluded
+ * suspect runs from the candidate set. Both were wrong, and together they made
+ * the guard SILENTLY GO DARK on exactly the corruption it exists to catch:
+ *
+ *   Day 0:    200 corps, good run.                        baseline = 200
+ *   Day 1-30: basis corrupted to 5. Every run flags suspect
+ *             — and every suspect run is excluded.
+ *   Day 31:   the day-0 run ages out of the window. Every
+ *             remaining candidate is suspect => excluded =>
+ *             candidate set EMPTY => baseline null =>
+ *             "bootstrap" => basisSuspect: FALSE.
+ *
+ * The corrupt basis is then reported as fine. The old comment claimed excluding
+ * suspect runs "costs nothing, because a suspect run could not have won the max
+ * anyway" — that is true of the MAX and false of the guard: exclusion did not
+ * cost the maximum, it cost the EXISTENCE of a baseline. The same failure fires
+ * immediately, not in 30 days, wherever scans are less frequent than the window.
+ *
+ * The window existed only to stop a LEGITIMATE permanent shrink (an operator
+ * de-flags 13 corps) from crying wolf forever. An acknowledgement does that job
+ * correctly: it is a human saying "this basis is right", which is the one signal
+ * a count can never contain. Time is not evidence. A human is.
+ *
+ * ── WHY SUSPECT RUNS ARE NO LONGER EXCLUDED ──
+ *
+ * They never needed to be. A shrink-corrupted run's count is BELOW the mark by
+ * construction, so it cannot win a max — the exclusion was belt-and-braces that
+ * bought nothing and cost the dark-guard bug above.
+ *
+ * ── THE CASE THIS DOES NOT CATCH ALONE ──
+ *
+ * "Corruption only ever shrinks" is FALSE, and an earlier version of this file
+ * asserted it. A bad restore or migration that sets is_member_corporation = true
+ * broadly INFLATES the basis (200 -> 600). That run grows, so it is not suspect,
+ * so it enters the max and poisons the baseline upward — and every later correct
+ * run then flags against it. The ack is what clears that too: an operator
+ * confirms the correct 200-corp run and the floor resets. Without an ack there
+ * would be no way out, which is the strongest argument for having one.
  */
-export async function getBasisBaseline(
-	db: DbClient<typeof schema>,
-	options?: { now?: Date }
-): Promise<BasisBaseline> {
-	const now = options?.now ?? new Date()
-	const windowStart = new Date(now.getTime() - BASIS_BASELINE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+export async function getBasisBaseline(db: DbClient<typeof schema>): Promise<BasisBaseline> {
+	// The anchor: the most recently acknowledged run. Everything before it is
+	// history a human has already superseded.
+	const anchor = await db.query.serviceAccessAuditRuns.findFirst({
+		where: isNotNull(serviceAccessAuditRuns.basisAcknowledgedAt),
+		orderBy: desc(serviceAccessAuditRuns.basisAcknowledgedAt),
+		columns: { startedAt: true, basisAcknowledgedAt: true },
+	})
 
-	const candidates = await db.query.serviceAccessAuditRuns.findMany({
-		where: (runs, { and }) =>
-			and(
-				inArray(runs.status, [...BASELINE_STATUSES]),
-				gte(runs.startedAt, windowStart),
-				// A run that was itself flagged suspect is a poor reference: its basis
-				// is the one nobody has vouched for. Excluding it costs nothing,
-				// because a suspect run's count is by definition BELOW the high-water
-				// mark it was compared against, so it could not have won the max anyway.
-				sql`${runs.basisSuspect} = false`
-			),
+	// ORDER BY member_corp_count DESC LIMIT 1 *is* the max, computed by Postgres
+	// over one row rather than by dragging every run's corporation_ids array
+	// through the driver to reduce() in JS.
+	const best = await db.query.serviceAccessAuditRuns.findFirst({
+		where: anchor
+			? and(
+					inArray(serviceAccessAuditRuns.status, [...BASELINE_STATUSES]),
+					gte(serviceAccessAuditRuns.startedAt, anchor.startedAt)
+				)
+			: inArray(serviceAccessAuditRuns.status, [...BASELINE_STATUSES]),
+		orderBy: desc(serviceAccessAuditRuns.memberCorpCount),
 		columns: { memberCorpCount: true, memberCorporationIds: true },
 	})
 
-	if (candidates.length === 0) {
-		return { memberCorpCount: null, corporationIds: [] }
+	if (!best) {
+		// No scan has ever completed. Genuinely nothing to compare against — the
+		// only path to a null baseline, and it cannot be reached by corruption.
+		return { memberCorpCount: null, corporationIds: [], acknowledgedAt: null }
 	}
 
-	const best = candidates.reduce((winner, candidate) =>
-		candidate.memberCorpCount > winner.memberCorpCount ? candidate : winner
-	)
-
-	return { memberCorpCount: best.memberCorpCount, corporationIds: best.memberCorporationIds ?? [] }
+	return {
+		memberCorpCount: best.memberCorpCount,
+		corporationIds: best.memberCorporationIds ?? [],
+		acknowledgedAt: anchor?.basisAcknowledgedAt ?? null,
+	}
 }
 
 export interface BasisVerdictOk {
 	blocked: false
-	/** True when no baseline exists. The UI must surface the corp count
-	 * prominently — on this path nothing has validated it. */
+	/**
+	 * No scan has ever completed, so there is nothing to compare against. The UI
+	 * must surface the corp count prominently — on this path nothing has validated
+	 * it.
+	 *
+	 * Reachable ONLY on a genuinely empty history. It is deliberately NOT
+	 * reachable by corruption: the previous design could arrive here by aging its
+	 * only good run out of a trailing window, which silently reported a corrupt
+	 * basis as `basisSuspect: false`.
+	 */
 	bootstrap: boolean
-	/** The basis shrank against the recent high-water mark. INFORMATIONAL for a
-	 * scan; enforcement must refuse on it. */
+	/** The basis shrank against the high-water mark since the last acknowledged
+	 * run. INFORMATIONAL for a scan; ENFORCEMENT MUST REFUSE on it unless
+	 * acknowledged. */
 	basisSuspect: boolean
 	corporationIds: string[]
 	memberCorpCount: number
@@ -238,10 +293,12 @@ export function evaluateBasis(options: {
 		removedCorporationIds,
 		basisNote: suspect
 			? `The member-corporation basis shrank from ${baselineCount} to ${memberCorpCount} ` +
-				`(${((memberCorpCount / (baselineCount || 1)) * 100).toFixed(1)}% retained) versus the highest basis seen in the last ` +
-				`${BASIS_BASELINE_WINDOW_DAYS} days. ${removedCorporationIds.length} corporation(s) left the basis. ` +
-				`If you de-flagged them, this is expected and the scan below is correct. If you do not recognise them, ` +
-				`managed_corporations may be half-restored or mid-sync and THIS SCAN'S RESULTS ARE NOT TRUSTWORTHY. ` +
+				`(${((memberCorpCount / (baselineCount || 1)) * 100).toFixed(1)}% retained) versus the highest basis seen since the last ` +
+				`confirmed basis${baseline.acknowledgedAt ? '' : ' (none has ever been confirmed)'}. ` +
+				`${removedCorporationIds.length} corporation(s) left the basis. ` +
+				`If you de-flagged them, this is expected: confirm the basis and this run becomes the new reference. ` +
+				`If you do not recognise them, managed_corporations may be half-restored or mid-sync and ` +
+				`THIS SCAN'S RESULTS ARE NOT TRUSTWORTHY — fix the data and re-scan rather than confirming. ` +
 				`Enforcement will refuse to act on this run until the basis is confirmed.`
 			: null,
 	}

--- a/apps/core/src/routes/__tests__/services-audit.route.test.ts
+++ b/apps/core/src/routes/__tests__/services-audit.route.test.ts
@@ -347,3 +347,95 @@ describe('the enforcement surface does not exist yet', () => {
 		expect(createWorkflowMock).not.toHaveBeenCalled()
 	})
 })
+
+/**
+ * THE ACKNOWLEDGEMENT.
+ *
+ * This is the only thing that can lower the guard's bar, so its failure modes are
+ * the guard's failure modes. It exists because a count cannot tell "an operator
+ * de-flagged 13 corps" from "the table is half-restored" — only a human reading
+ * WHICH corps left can — and because a basis poisoned upward by a bad migration
+ * has no other way out.
+ */
+describe('POST /runs/:id/acknowledge-basis', () => {
+	/** A db whose conditional ack UPDATE matches `matched` rows. */
+	function makeAckDb(matched: number) {
+		const captured: { where?: unknown; set?: Record<string, unknown> } = {}
+		return {
+			captured,
+			db: {
+				update: vi.fn(() => ({
+					set: (values: Record<string, unknown>) => {
+						captured.set = values
+						return {
+							where: (clause: unknown) => {
+								captured.where = clause
+								return {
+									returning: async () =>
+										Array.from({ length: matched }, () => ({
+											id: RUN_ID,
+											memberCorpCount: 37,
+										})),
+								}
+							},
+						}
+					},
+				})),
+			},
+		}
+	}
+
+	function ack(db: unknown, body: unknown) {
+		return createApp(db).request(
+			`/api/services-audit/runs/${RUN_ID}/acknowledge-basis`,
+			{
+				method: 'POST',
+				body: JSON.stringify(body),
+				headers: { 'content-type': 'application/json' },
+			},
+			env
+		)
+	}
+
+	it('records who vouched, when, and why', async () => {
+		const { db, captured } = makeAckDb(1)
+		const res = await ack(db, { reason: 'We de-flagged the 13 corps that left last night.' })
+
+		expect(res.status).toBe(200)
+		expect(captured.set?.basisAcknowledgedByUserId).toBe('admin-1')
+		expect(captured.set?.basisAcknowledgedAt).toBeInstanceOf(Date)
+		expect(captured.set?.basisAcknowledgedReason).toContain('13 corps')
+	})
+
+	it('requires a reason of substance', async () => {
+		// "ok" is not a judgement anyone can audit later.
+		const { db } = makeAckDb(1)
+		expect((await ack(db, { reason: 'ok' })).status).toBe(400)
+		expect((await ack(db, {})).status).toBe(400)
+		// And it must not have written anything.
+		expect(db.update).not.toHaveBeenCalled()
+	})
+
+	it('404s when the conditional UPDATE matches nothing', async () => {
+		// Covers all three: unknown id, already acknowledged, and a blocked/failed
+		// run — whose basis is by definition the broken one and must never be
+		// vouchable. The condition lives in SQL, so two admins racing resolve in
+		// Postgres rather than in JS.
+		const { db } = makeAckDb(0)
+		const res = await ack(db, { reason: 'This basis looks correct to me, honest.' })
+		expect(res.status).toBe(404)
+	})
+
+	it('is idempotent by construction: a second ack matches no rows', async () => {
+		const { db } = makeAckDb(0)
+		const res = await ack(db, { reason: 'Confirming again, should not double-apply.' })
+		expect(res.status).toBe(404)
+	})
+
+	it('never touches a Mumble or Discord stub', async () => {
+		const { db } = makeAckDb(1)
+		await ack(db, { reason: 'Confirming the basis after a corp restructure.' })
+		expect(getStubMock).not.toHaveBeenCalled()
+		expect(getDiscordStubMock).not.toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/routes/services-audit.ts
+++ b/apps/core/src/routes/services-audit.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-import { and, asc, desc, eq, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, isNull, sql } from '@repo/db-utils'
 import { logger } from '@repo/hono-helpers'
 import { createWorkflow } from '@repo/workflow-utils'
 
@@ -29,6 +29,15 @@ const app = new Hono<App>()
 /** Non-terminal statuses: a run in one of these still holds the active lock. */
 const LIVE_STATUSES = ['scanning', 'enforcing'] as const
 
+/**
+ * Statuses whose scan actually completed, and are therefore the only ones whose
+ * basis is meaningful enough to confirm. Mirrors BASELINE_STATUSES in
+ * lib/service-eligibility-basis.ts — a run that cannot inform the baseline must
+ * not be acknowledgeable either, or acking it would be a no-op that looks like an
+ * action.
+ */
+const BASELINE_STATUSES = ['completed', 'awaiting_confirmation', 'completed_with_errors'] as const
+
 const ALL_REASONS: ServiceEligibilityReason[] = [
 	'member_corp',
 	'admin_exempt',
@@ -38,6 +47,11 @@ const ALL_REASONS: ServiceEligibilityReason[] = [
 	'unmanaged_corp',
 	'no_user_row',
 ]
+
+/** Required so the confirmation is a judgement someone signed, not a click. */
+const acknowledgeBasisSchema = z.object({
+	reason: z.string().min(10),
+})
 
 /** House style: local z.object + safeParse in the handler. There is ZERO
  * zValidator in apps/core/src — do not introduce it here. */
@@ -177,6 +191,8 @@ app.get('/runs', requireAuth(), requireAdmin(), async (c) => {
 				// must reach the list, not just the detail view — an operator scanning
 				// a list of runs has to see which ones not to believe.
 				basisSuspect: true,
+				// So the picker can distinguish "suspect" from "suspect but confirmed".
+				basisAcknowledgedAt: true,
 				errorMessage: true,
 				startedAt: true,
 				completedAt: true,
@@ -332,6 +348,95 @@ app.get('/runs/:id/rows', requireAuth(), requireAdmin(), async (c) => {
 	} catch (error) {
 		logger.error('[ServicesAudit] Failed to read audit rows', { runId, error: String(error) })
 		return c.json({ error: 'Failed to read audit rows' }, 500)
+	}
+})
+
+/**
+ * POST /services-audit/runs/:id/acknowledge-basis
+ *
+ * A human vouches for this run's member-corporation basis: "these corporations
+ * really did leave, and this basis is correct."
+ *
+ * THIS IS THE ONLY THING THAT CAN LOWER THE BAR, and it is the piece the guard is
+ * built around. A count cannot distinguish "an operator de-flagged 13 corps" from
+ * "the table is half-restored" — only a human reading WHICH corps left can.
+ * Acknowledging records that judgement, and the acknowledged run becomes the
+ * baseline anchor: later runs are compared against the highest basis seen since
+ * it, not against history before it.
+ *
+ * It also clears an upward-poisoned baseline. A bad migration that flags corps
+ * true inflates the basis (200 -> 600); that run is not suspect, so it enters the
+ * max, and every later CORRECT run flags against it. Confirming a correct run
+ * resets the floor. Without this there would be no way out.
+ *
+ * Deliberately requires a reason. "13 corps left" is only safe if someone can say
+ * which and why it was expected — and the note is what a future operator reads
+ * when deciding whether to trust this run.
+ */
+app.post('/runs/:id/acknowledge-basis', requireAuth(), requireAdmin(), async (c) => {
+	const runId = c.req.param('id')
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not available' }, 500)
+
+	const user = c.get('user')
+	if (!user) return c.json({ error: 'Unauthorized' }, 401)
+
+	const parsed = acknowledgeBasisSchema.safeParse(await c.req.json().catch(() => ({})))
+	if (!parsed.success) {
+		return c.json({ error: 'A reason of at least 10 characters is required' }, 400)
+	}
+
+	try {
+		// Conditional UPDATE, not read-then-write: two admins confirming at once
+		// resolve in Postgres, and a blocked run can never be confirmed (its basis
+		// is empty by definition — there is nothing to vouch for).
+		const acknowledged = await db
+			.update(serviceAccessAuditRuns)
+			.set({
+				basisAcknowledgedAt: new Date(),
+				basisAcknowledgedByUserId: user.id,
+				basisAcknowledgedReason: parsed.data.reason,
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(serviceAccessAuditRuns.id, runId),
+					isNull(serviceAccessAuditRuns.basisAcknowledgedAt),
+					sql`${serviceAccessAuditRuns.status} IN (${sql.join(
+						BASELINE_STATUSES.map((status) => sql`${status}`),
+						sql`, `
+					)})`
+				)
+			)
+			.returning({
+				id: serviceAccessAuditRuns.id,
+				memberCorpCount: serviceAccessAuditRuns.memberCorpCount,
+			})
+
+		if (acknowledged.length === 0) {
+			return c.json(
+				{
+					error:
+						'No un-acknowledged audit run with that id and a completed scan. A blocked or failed run cannot have its basis confirmed.',
+				},
+				404
+			)
+		}
+
+		logger.info('[ServicesAudit] Basis acknowledged', {
+			runId,
+			userId: user.id,
+			memberCorpCount: acknowledged[0].memberCorpCount,
+		})
+
+		return c.json({
+			runId,
+			basisAcknowledgedAt: new Date().toISOString(),
+			memberCorpCount: acknowledged[0].memberCorpCount,
+		})
+	} catch (error) {
+		logger.error('[ServicesAudit] Failed to acknowledge basis', { runId, error: String(error) })
+		return c.json({ error: 'Failed to acknowledge basis' }, 500)
 	}
 })
 

--- a/apps/core/src/workflows/__tests__/service-access-audit.workflow.test.ts
+++ b/apps/core/src/workflows/__tests__/service-access-audit.workflow.test.ts
@@ -103,22 +103,35 @@ function makeDb(options: {
 				),
 			},
 			serviceAccessAuditRuns: {
-				// getBasisBaseline takes the MAX over recent good runs, so it reads a
-				// list rather than the single latest row.
-				findMany: vi.fn(async () =>
-					options.lastGoodMemberCorpCount === null ||
-					options.lastGoodMemberCorpCount === undefined
-						? []
-						: [
-								{
-									memberCorpCount: options.lastGoodMemberCorpCount,
-									memberCorporationIds: Array.from(
-										{ length: options.lastGoodMemberCorpCount },
-										(_, i) => `baseline-corp-${i + 1}`
-									),
-								},
-							]
-				),
+				/**
+				 * getBasisBaseline issues TWO findFirst reads: the acknowledgement
+				 * anchor, then the high-water run since it (the max is `ORDER BY
+				 * member_corp_count DESC LIMIT 1`, computed by Postgres).
+				 *
+				 * These fixtures never acknowledge, so the anchor is always undefined
+				 * and the baseline searches all history — which is the scenario every
+				 * test below actually cares about.
+				 */
+				findFirst: vi.fn(async (opts: Record<string, unknown>) => {
+					// The anchor query is the one filtering on basisAcknowledgedAt.
+					const isAnchorQuery = 'columns' in opts &&
+						Boolean((opts.columns as Record<string, unknown> | undefined)?.basisAcknowledgedAt)
+					if (isAnchorQuery) return undefined
+
+					if (
+						options.lastGoodMemberCorpCount === null ||
+						options.lastGoodMemberCorpCount === undefined
+					) {
+						return undefined
+					}
+					return {
+						memberCorpCount: options.lastGoodMemberCorpCount,
+						memberCorporationIds: Array.from(
+							{ length: options.lastGoodMemberCorpCount },
+							(_, i) => `baseline-corp-${i + 1}`
+						),
+					}
+				}),
 			},
 		},
 		execute: vi.fn(async (query: unknown) => {

--- a/apps/ui/src/client/hooks/useServicesAudit.ts
+++ b/apps/ui/src/client/hooks/useServicesAudit.ts
@@ -126,6 +126,20 @@ export function useStartServicesAuditScan() {
  * finalize step may still overwrite the status. Harmless while the scan only
  * reads.
  */
+export function useAcknowledgeServicesAuditBasis() {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: ({ runId, reason }: { runId: string; reason: string }) =>
+			api.acknowledgeServicesAuditBasis(runId, reason),
+		onSuccess: (_data, { runId }) => {
+			// Both: acking changes the baseline every FUTURE run is judged against, so
+			// the list's suspect markers can change too, not just this run.
+			void queryClient.invalidateQueries({ queryKey: servicesAuditKeys.runs() })
+			void queryClient.invalidateQueries({ queryKey: servicesAuditKeys.run(runId) })
+		},
+	})
+}
+
 export function useCancelServicesAuditScan() {
 	const queryClient = useQueryClient()
 	return useMutation({

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -1354,6 +1354,11 @@ export interface ServicesAuditRunSummary {
 	 * looking at a list of runs has to see which ones not to believe.
 	 */
 	basisSuspect: boolean
+	/**
+	 * When a human confirmed this run's basis is correct. null = nobody has.
+	 * ENFORCEMENT MUST REFUSE to act on a run that is basisSuspect with this null.
+	 */
+	basisAcknowledgedAt: string | null
 	errorMessage: string | null
 	startedAt: string | null
 	completedAt: string | null
@@ -1387,6 +1392,8 @@ export interface ServicesAuditRunDetail extends ServicesAuditRunSummary {
 	basisRemovedCorporationIds: string[] | null
 	/** Operator-facing explanation of the diff; null unless basisSuspect. */
 	basisNote: string | null
+	basisAcknowledgedByUserId: string | null
+	basisAcknowledgedReason: string | null
 	/** Grouped by (reason, eligible) in SQL — NOT one "ineligible" total. */
 	reasonBreakdown: Array<{
 		reason: ServiceEligibilityReasonCode
@@ -3864,6 +3871,18 @@ export class ApiClient {
 
 	async startServicesAuditScan(): Promise<StartServicesAuditScanResponse> {
 		return this.post('/services-audit/runs')
+	}
+
+	/**
+	 * Vouch for a run's member-corporation basis. The acknowledged run becomes the
+	 * baseline anchor, so later runs are compared against it rather than against
+	 * unvouched history. Requires a reason: it is a judgement someone signs.
+	 */
+	async acknowledgeServicesAuditBasis(
+		runId: string,
+		reason: string
+	): Promise<{ runId: string; basisAcknowledgedAt: string; memberCorpCount: number }> {
+		return this.post(`/services-audit/runs/${runId}/acknowledge-basis`, { reason })
 	}
 
 	async cancelServicesAuditScan(runId: string): Promise<{ runId: string; status: string }> {

--- a/apps/ui/src/client/routes/admin/services-audit.tsx
+++ b/apps/ui/src/client/routes/admin/services-audit.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { LoadingInline, LoadingSpinner } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
 import { Select } from '@/components/ui/select'
@@ -14,6 +15,7 @@ import { useEntityNames } from '@/hooks/useEntityNames'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import {
 	isTerminalRunStatus,
+	useAcknowledgeServicesAuditBasis,
 	useCancelServicesAuditScan,
 	useServicesAuditRun,
 	useServicesAuditRunRows,
@@ -259,16 +261,32 @@ function BasisSuspectBanner({
 	corporationNames: Record<string, string>
 }) {
 	const removed = run.basisRemovedCorporationIds ?? []
+	const acknowledge = useAcknowledgeServicesAuditBasis()
+	const [reason, setReason] = useState('')
+	const acknowledged = run.basisAcknowledgedAt !== null
+
 	return (
-		<Card className="border-amber-500 bg-amber-500/10">
+		<Card
+			className={
+				acknowledged ? 'border-border' : 'border-amber-500 bg-amber-500/10'
+			}
+		>
 			<CardHeader>
-				<CardTitle className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+				<CardTitle
+					className={
+						acknowledged
+							? 'flex items-center gap-2'
+							: 'flex items-center gap-2 text-amber-700 dark:text-amber-400'
+					}
+				>
 					<ShieldAlert className="h-5 w-5" />
-					The member-corporation basis shrank — check this before trusting the numbers below
+					{acknowledged
+						? 'The basis shrank, and an administrator confirmed it is correct'
+						: 'The member-corporation basis shrank — check this before trusting the numbers below'}
 				</CardTitle>
 				<CardDescription>
 					{run.memberCorpCount} member corporation{run.memberCorpCount === 1 ? '' : 's'} now, versus
-					a high of {run.basisComparedToCount} in the last 30 days.
+					a high of {run.basisComparedToCount} since the last confirmed basis.
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-3">
@@ -292,6 +310,58 @@ function BasisSuspectBanner({
 							them? <code>managed_corporations</code> may be half-restored or mid-sync, and the
 							counts below are not trustworthy.
 						</p>
+					</div>
+				)}
+
+				{acknowledged ? (
+					<div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+						<p className="font-medium">
+							Basis confirmed {formatTimestamp(run.basisAcknowledgedAt)}
+						</p>
+						{run.basisAcknowledgedReason && (
+							<p className="mt-1 text-muted-foreground whitespace-pre-wrap">
+								“{run.basisAcknowledgedReason}”
+							</p>
+						)}
+						<p className="mt-2 text-xs text-muted-foreground">
+							Later scans are now compared against this basis rather than against the higher
+							figure above.
+						</p>
+					</div>
+				) : (
+					/*
+					 * Confirming is the ONLY thing that lowers the guard's bar, so it is
+					 * deliberately a typed judgement rather than a button. It also has to
+					 * exist: without it a legitimate de-flag would flag every future scan
+					 * forever, and an operator trained to ignore an amber banner is worse
+					 * than no banner.
+					 */
+					<div className="space-y-2 rounded-md border border-amber-500/50 p-3">
+						<label htmlFor="basis-ack-reason" className="text-sm font-medium">
+							Confirm this basis is correct
+						</label>
+						<p className="text-xs text-muted-foreground">
+							Only if you recognise the corporations above. If you don’t, fix the corporation
+							data and re-scan instead — confirming a broken basis is what tells enforcement to
+							trust it.
+						</p>
+						<Input
+							id="basis-ack-reason"
+							value={reason}
+							onChange={(event) => setReason(event.target.value)}
+							placeholder="Why is this basis correct? e.g. we de-flagged these 13 corps on 14 Jul"
+							disabled={acknowledge.isPending}
+						/>
+						{acknowledge.isError && (
+							<p className="text-xs text-destructive">{acknowledge.error.message}</p>
+						)}
+						<Button
+							variant="secondary"
+							disabled={reason.trim().length < 10 || acknowledge.isPending}
+							onClick={() => acknowledge.mutate({ runId: run.id, reason: reason.trim() })}
+						>
+							{acknowledge.isPending ? 'Confirming…' : 'Confirm basis'}
+						</Button>
 					</div>
 				)}
 			</CardContent>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Replaces the service-access-audit basis guard's trailing 30-day window and suspect-run exclusion with an explicit human acknowledgement. The previous design could silently go dark: once a corrupted basis aged out of the window (or if all candidate runs were flagged suspect and excluded), the baseline emptied out, fell back to "bootstrap", and reported `basisSuspect: false` on a corrupt basis — exactly the failure the guard exists to catch. The fix anchors the baseline on the highest member-corp count seen since the last *acknowledged* run, so only a human confirmation (not a timer) can lower the bar.

## Changes

- `apps/core/src/lib/service-eligibility-basis.ts`: `getBasisBaseline` now finds the most recently acknowledged run as an anchor, then takes `ORDER BY member_corp_count DESC LIMIT 1` since that anchor (or over all history if nothing has been acknowledged) — computed in Postgres instead of `findMany` + JS `reduce`. Removes the trailing window and the `basisSuspect = false` exclusion, both of which contributed to the dark-guard bug. `BasisBaseline` gains `acknowledgedAt`.
- `apps/core/src/db/schema.ts`: adds `basisAcknowledgedAt`, `basisAcknowledgedByUserId` (FK to `users`, `set null` on delete), and `basisAcknowledgedReason` to `serviceAccessAuditRuns`, plus supporting indexes and a relation.
- `apps/core/.migrations/0045_third_legion.sql`: generated migration for the new columns/indexes/FK (not applied).
- `apps/core/src/routes/services-audit.ts`: new `POST /runs/:id/acknowledge-basis` route — requires a reason (min 10 chars), performs a conditional `UPDATE` (only un-acknowledged runs in a baseline-eligible status), and returns the confirmed run's member-corp count. Also exposes `basisAcknowledgedAt` on the run summary.
- `apps/ui/src/client/lib/api.ts` / `useServicesAudit.ts`: adds `acknowledgeServicesAuditBasis` API call and `useAcknowledgeServicesAuditBasis` mutation hook that invalidates both the run list and run detail queries (acknowledging changes the baseline every future run is judged against).
- `apps/ui/src/client/routes/admin/services-audit.tsx`: the suspect-basis banner now shows a confirmation form (reason input + button) when unacknowledged, and a confirmed state (reason + timestamp) once acknowledged.

## Testing

- `apps/core/src/lib/__tests__/service-eligibility-basis.test.ts` rewritten: covers the anchor/search-boundary wiring, the shape of the Postgres query (`ORDER BY member_corp_count`, not `started_at`), and adds regression guards asserting `getBasisBaseline`'s body contains no date/window arithmetic and no `basisSuspect` filtering, plus a regression test reproducing the dark-guard scenario (all-suspect history still yields a real baseline, not a false bootstrap).
- `apps/core/src/routes/__tests__/services-audit.route.test.ts` and `apps/core/src/workflows/__tests__/service-access-audit.workflow.test.ts` updated for the schema/route changes.
- Per the commit message, full suite reported at 770 passing (up from 760), with 6 pre-existing unrelated failures.
<!-- claude:end -->