### PR TITLE
fix(auth): bind identity to server-side flow state

### DIFF
--- a/apps/core/src/db/schema.ts
+++ b/apps/core/src/db/schema.ts
@@ -314,8 +314,8 @@ export const oauthStates = pgTable(
 		userId: uuid('user_id').references(() => users.id, { onDelete: 'cascade' }),
 		/** Optional redirect URL after successful authentication */
 		redirectUrl: varchar('redirect_url', { length: 500 }),
-		/** Flow-specific context (e.g. mumble temp-op key/id for the guest SSO flow) */
-		metadata: jsonb('metadata').$type<TempopOAuthMetadata | null>(),
+		/** Flow-specific context (e.g. mumble temp-op key/id, or the character bound to a claim-main ticket) */
+		metadata: jsonb('metadata').$type<OAuthStateMetadata | null>(),
 		/** When this state was created */
 		createdAt: timestamp('created_at').defaultNow().notNull(),
 		/** When this state expires (15 minutes from creation) */
@@ -328,6 +328,26 @@ export interface TempopOAuthMetadata {
 	key: string
 	tempopId: string
 }
+
+/**
+ * Binds a claim-main ticket to the character EVE SSO just proved the caller controls.
+ *
+ * The claim endpoint reads the character from this row rather than from its request body:
+ * a caller can only ever claim the character they personally authenticated as, because the
+ * only way to obtain a ticket is to complete the SSO round-trip for that character.
+ */
+export interface ClaimMainOAuthMetadata {
+	characterId: string
+	characterName: string
+	/**
+	 * The owner hash observed when the ticket was minted. Re-checked at redemption so a
+	 * character transferred during the ticket's lifetime cannot have the new owner's hash
+	 * written onto the account the previous owner is in the middle of creating.
+	 */
+	characterOwnerHash: string
+}
+
+export type OAuthStateMetadata = TempopOAuthMetadata | ClaimMainOAuthMetadata
 
 /**
  * Managed Corporations table - Global corporation registry for admin management

--- a/apps/core/src/routes/__tests__/auth.identity-binding.test.ts
+++ b/apps/core/src/routes/__tests__/auth.identity-binding.test.ts
@@ -1,0 +1,617 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getStub } from '@repo/do-utils'
+
+import { createDb } from '../../db'
+import { waitUntilWithTelemetry } from '../../lib/background-task'
+import { ActivityService } from '../../services/activity.service'
+import { AuthService } from '../../services/auth.service'
+import { hydrateCharacterAffiliation } from '../../services/character-affiliation-hydration.service'
+import { reconcileUserCoreMembershipRoles } from '../../services/core-role-reconciliation.service'
+import { autoRegisterDirectorCorporation } from '../../services/corporation-auto-register.service'
+import { SessionService } from '../../services/session.service'
+import { CharacterAlreadyClaimedError, UserService } from '../../services/user.service'
+import authRoutes from '../auth'
+
+import type { ClaimMainOAuthMetadata } from '../../db/schema'
+
+vi.mock('../../db', () => ({ createDb: vi.fn() }))
+vi.mock('@repo/do-utils', () => ({ getStub: vi.fn() }))
+vi.mock('../../lib/background-task', () => ({ waitUntilWithTelemetry: vi.fn() }))
+vi.mock('../../lib/ip-tracking', () => ({
+	extractClientIp: vi.fn().mockReturnValue(null),
+	recordUserIpAddress: vi.fn(),
+}))
+vi.mock('../../services/activity.service', () => ({ ActivityService: vi.fn() }))
+vi.mock('../../services/auth.service', () => ({ AuthService: vi.fn() }))
+vi.mock('../../services/session.service', () => ({ SessionService: vi.fn() }))
+vi.mock('../../services/user.service', () => {
+	// CharacterAlreadyClaimedError stays a real class: the route discriminates on it with
+	// `instanceof`, so replacing it with a mock would make that branch untestable.
+	class CharacterAlreadyClaimedError extends Error {}
+	return { UserService: vi.fn(), CharacterAlreadyClaimedError }
+})
+vi.mock('../../services/character-affiliation-hydration.service', () => ({
+	hydrateCharacterAffiliation: vi.fn(),
+}))
+vi.mock('../../services/core-role-reconciliation.service', () => ({
+	reconcileUserCoreMembershipRoles: vi.fn(),
+}))
+vi.mock('../../services/corporation-auto-register.service', () => ({
+	autoRegisterDirectorCorporation: vi.fn(),
+}))
+vi.mock('../../services/director-health-recheck.service', () => ({
+	recheckDirectorHealthAfterTokenReauth: vi.fn(),
+}))
+vi.mock('../../services/mumble.service', () => ({ provisionTempopGuest: vi.fn() }))
+vi.mock('../../services/mumble-tempop.service', () => ({ storeCredentialHandoff: vi.fn() }))
+vi.mock('@repo/workflow-utils', () => ({ createWorkflow: vi.fn() }))
+
+const createDbMock = vi.mocked(createDb)
+const getStubMock = vi.mocked(getStub)
+
+const FUTURE = new Date('2099-01-01T00:00:00.000Z')
+const PAST = new Date('2000-01-01T00:00:00.000Z')
+
+const env = {
+	DATABASE_URL: 'postgres://test',
+	EVE_TOKEN_STORE: { binding: 'tokens' },
+	HR: { binding: 'hr' },
+	EVE_CHARACTER_DATA: { binding: 'chardata' },
+	EVE_CORPORATION_DATA: { binding: 'corpdata' },
+	GROUPS: { binding: 'groups' },
+	USER_REFRESH_WORKFLOW: { binding: 'wf' },
+} as any
+
+/**
+ * Route handlers reach for c.executionCtx when scheduling background work. Mocking
+ * waitUntilWithTelemetry is not enough: c.executionCtx is evaluated as an *argument* to it, so
+ * it must exist or Hono throws before the mock is ever consulted.
+ */
+function execCtx() {
+	return { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as any
+}
+
+function createApp() {
+	const app = new Hono<{ Bindings: any; Variables: any }>()
+	app.route('/api/auth', authRoutes)
+	return app
+}
+
+/** A db mock whose oauth_states lookup returns `oauthState`, recording writes. */
+function mockDb(oauthState: unknown) {
+	const deleteWhere = vi.fn().mockResolvedValue(undefined)
+	const updateWhere = vi.fn().mockResolvedValue(undefined)
+	const insertValues = vi.fn().mockResolvedValue(undefined)
+
+	createDbMock.mockReturnValue({
+		query: {
+			oauthStates: { findFirst: vi.fn().mockResolvedValue(oauthState) },
+			users: { findFirst: vi.fn().mockResolvedValue(null) },
+		},
+		delete: vi.fn(() => ({ where: deleteWhere })),
+		update: vi.fn(() => ({ set: vi.fn(() => ({ where: updateWhere })) })),
+		insert: vi.fn(() => ({ values: insertValues })),
+	} as any)
+
+	return { deleteWhere, insertValues }
+}
+
+const cleanHrStub = {
+	isCharacterBlacklisted: vi.fn().mockResolvedValue(false),
+	getBlacklistsForCharacter: vi.fn().mockResolvedValue([]),
+	isCharacterNameBlacklisted: vi.fn().mockResolvedValue(false),
+	getBlacklistsForCharacterName: vi.fn().mockResolvedValue([]),
+	isUserBlacklisted: vi.fn().mockResolvedValue(false),
+}
+
+function mockStubs(tokenStore: Record<string, unknown>) {
+	getStubMock.mockImplementation((binding: unknown) => {
+		if (binding === env.EVE_TOKEN_STORE) return tokenStore as any
+		if (binding === env.HR) return cleanHrStub as any
+		return {} as any
+	})
+}
+
+/**
+ * Drive GET /auth/callback. `cookie` defaults to matching `state` (the honest browser); pass
+ * it explicitly to model a browser that never started the flow.
+ */
+function callbackRequest(opts: { state?: string; cookie?: string } = {}) {
+	const state = 'state' in opts ? opts.state : 'state-1'
+	const cookie = 'cookie' in opts ? opts.cookie : state
+	const query = state === undefined ? 'code=code-1' : `code=code-1&state=${state}`
+	const headers: Record<string, string> = {}
+	if (cookie !== undefined) headers.Cookie = `oauth_state=${cookie}`
+
+	return createApp().request(`/api/auth/callback?${query}`, { headers }, env, execCtx())
+}
+
+function claimRequest(body: unknown) {
+	return createApp().request(
+		'/api/auth/claim-main',
+		{
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(body),
+		},
+		env,
+		execCtx()
+	)
+}
+
+function loginState() {
+	return {
+		state: 'state-1',
+		flowType: 'login',
+		userId: null,
+		redirectUrl: null,
+		metadata: null,
+		expiresAt: FUTURE,
+	}
+}
+
+function claimTicketRow(overrides: Record<string, unknown> = {}) {
+	return {
+		state: 'ticket-1',
+		flowType: 'claim-main',
+		userId: null,
+		redirectUrl: null,
+		metadata: {
+			characterId: 'char-1',
+			characterName: 'Pilot',
+			characterOwnerHash: 'HASH-1',
+		} satisfies ClaimMainOAuthMetadata,
+		expiresAt: FUTURE,
+		...overrides,
+	}
+}
+
+function tokenInfo(ownerHash: string) {
+	return {
+		characterId: 'char-1',
+		characterName: 'Pilot',
+		characterOwnerHash: ownerHash,
+		scopes: [],
+		isExpired: false,
+		hasRefreshToken: true,
+	}
+}
+
+function callbackResult(ownerHash: string) {
+	return {
+		success: true,
+		characterId: 'char-1',
+		characterInfo: {
+			characterId: 'char-1',
+			characterName: 'Pilot',
+			characterOwnerHash: ownerHash,
+			scopes: [],
+		},
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(waitUntilWithTelemetry).mockImplementation(() => undefined)
+	vi.mocked(ActivityService).mockImplementation(
+		() =>
+			({
+				logLogin: vi.fn(),
+				logLoginFailed: vi.fn(),
+				logCharacterLinked: vi.fn(),
+			}) as any
+	)
+	vi.mocked(SessionService).mockImplementation(
+		() => ({ invalidateAllUserSessions: vi.fn().mockResolvedValue(1) }) as any
+	)
+	vi.mocked(AuthService).mockImplementation(
+		() =>
+			({
+				createSession: vi.fn().mockResolvedValue({
+					id: 'session-1',
+					sessionToken: 'token-1',
+					createdAt: new Date(),
+				}),
+			}) as any
+	)
+	vi.mocked(autoRegisterDirectorCorporation).mockResolvedValue(undefined as any)
+	vi.mocked(reconcileUserCoreMembershipRoles).mockResolvedValue(undefined as any)
+	vi.mocked(hydrateCharacterAffiliation).mockResolvedValue(undefined as any)
+})
+
+/**
+ * Account pre-hijacking.
+ *
+ * Before: claim-main was unauthenticated AND took characterId from the request body, so any
+ * unauthenticated caller could name a character that had completed SSO but not yet been
+ * claimed and receive an account plus a 30-day session for it. The endpoint stays
+ * unauthenticated by necessity (the caller has no account yet); the fix is that the *object*
+ * it acts on now comes from a server-minted ticket rather than from the caller.
+ */
+describe('POST /api/auth/claim-main - authority comes from the ticket, not the body', () => {
+	it('ignores a characterId supplied in the request body and uses the ticket-bound one', async () => {
+		mockDb(
+			claimTicketRow({
+				metadata: {
+					characterId: 'attacker-char',
+					characterName: 'Attacker',
+					characterOwnerHash: 'HASH-A',
+				},
+			})
+		)
+
+		// Returning null short-circuits the route; we only care which id it asked about.
+		const getTokenInfo = vi.fn().mockResolvedValue(null)
+		mockStubs({ getTokenInfo })
+
+		// The victim's id is what the old code would have honoured.
+		const res = await claimRequest({ claimTicket: 'ticket-1', characterId: 'victim-char' })
+
+		expect(res.status).toBe(400)
+		expect(getTokenInfo).toHaveBeenCalledWith('attacker-char')
+		expect(getTokenInfo).not.toHaveBeenCalledWith('victim-char')
+	})
+
+	it('rejects a request with no ticket, without touching the token store', async () => {
+		mockDb(null)
+		const getTokenInfo = vi.fn()
+		mockStubs({ getTokenInfo })
+
+		const res = await claimRequest({ characterId: 'victim-char' })
+
+		expect(res.status).toBe(400)
+		expect(getTokenInfo).not.toHaveBeenCalled()
+	})
+
+	it('rejects an unknown ticket', async () => {
+		mockDb(null)
+		const getTokenInfo = vi.fn()
+		mockStubs({ getTokenInfo })
+
+		const res = await claimRequest({ claimTicket: 'no-such-ticket' })
+
+		expect(res.status).toBe(400)
+		expect(getTokenInfo).not.toHaveBeenCalled()
+	})
+
+	it('refuses to redeem a login state as a claim ticket, though both are oauth_states rows', async () => {
+		// Metadata is deliberately claim-shaped so ONLY the flowType guard can reject this.
+		mockDb(claimTicketRow({ state: 'login-state', flowType: 'login' }))
+		const getTokenInfo = vi.fn()
+		mockStubs({ getTokenInfo })
+
+		const res = await claimRequest({ claimTicket: 'login-state' })
+
+		expect(res.status).toBe(400)
+		expect(getTokenInfo).not.toHaveBeenCalled()
+	})
+
+	it('rejects an expired ticket and deletes it', async () => {
+		const { deleteWhere } = mockDb(claimTicketRow({ expiresAt: PAST }))
+		const getTokenInfo = vi.fn()
+		mockStubs({ getTokenInfo })
+
+		const res = await claimRequest({ claimTicket: 'ticket-1' })
+
+		expect(res.status).toBe(400)
+		expect(getTokenInfo).not.toHaveBeenCalled()
+		expect(deleteWhere).toHaveBeenCalled()
+	})
+
+	it('burns the ticket so it cannot be replayed', async () => {
+		const { deleteWhere } = mockDb(claimTicketRow())
+		mockStubs({ getTokenInfo: vi.fn().mockResolvedValue(null) })
+
+		await claimRequest({ claimTicket: 'ticket-1' })
+
+		expect(deleteWhere).toHaveBeenCalled()
+	})
+
+	it('refuses a ticket whose character changed hands before it was redeemed', async () => {
+		mockDb(claimTicketRow())
+		const createUser = vi.fn()
+		// The token store reflects the CURRENT owner, who is not who the ticket was minted for.
+		mockStubs({ getTokenInfo: vi.fn().mockResolvedValue(tokenInfo('HASH-2-NEW-OWNER')) })
+		vi.mocked(UserService).mockImplementation(() => ({ createUser }) as any)
+
+		const res = await claimRequest({ claimTicket: 'ticket-1' })
+
+		expect(res.status).toBe(400)
+		expect(createUser).not.toHaveBeenCalled()
+	})
+
+	it('answers 409 rather than 500 when the character was already claimed', async () => {
+		mockDb(claimTicketRow())
+		mockStubs({ getTokenInfo: vi.fn().mockResolvedValue(tokenInfo('HASH-1')) })
+		vi.mocked(UserService).mockImplementation(
+			() =>
+				({
+					createUser: vi
+						.fn()
+						.mockRejectedValue(new CharacterAlreadyClaimedError('User already exists')),
+				}) as any
+		)
+
+		const res = await claimRequest({ claimTicket: 'ticket-1' })
+
+		expect(res.status).toBe(409)
+	})
+
+	it('does not flatten an unexpected fault into a reassuring 409', async () => {
+		mockDb(claimTicketRow())
+		mockStubs({ getTokenInfo: vi.fn().mockResolvedValue(tokenInfo('HASH-1')) })
+		vi.mocked(UserService).mockImplementation(
+			() =>
+				({
+					// A database outage is not a lost race, and must stay loud.
+					createUser: vi.fn().mockRejectedValue(new Error('connection terminated')),
+				}) as any
+		)
+
+		const res = await claimRequest({ claimTicket: 'ticket-1' })
+
+		expect(res.status).toBe(500)
+	})
+})
+
+/**
+ * Login CSRF. The oauth_states row proves only that *a* flow was started — /auth/login and
+ * /auth/login/start are unauthenticated and hand a valid state to any caller — so the
+ * browser-bound cookie is the half that actually does the work.
+ */
+describe('GET /api/auth/callback - the state must belong to this browser', () => {
+	it('refuses an attacker-minted state replayed into a browser that never started a flow', async () => {
+		// The row is perfectly valid: the attacker really did call /auth/login/start.
+		mockDb(loginState())
+		const handleCallback = vi.fn()
+		mockStubs({ handleCallback })
+
+		const res = await callbackRequest({ state: 'state-1', cookie: undefined })
+
+		expect(res.status).toBe(400)
+		// Never exchange an attacker's code in a victim's browser.
+		expect(handleCallback).not.toHaveBeenCalled()
+	})
+
+	it('refuses when the cookie names a different flow than the query parameter', async () => {
+		mockDb(loginState())
+		const handleCallback = vi.fn()
+		mockStubs({ handleCallback })
+
+		const res = await callbackRequest({ state: 'state-1', cookie: 'a-different-state' })
+
+		expect(res.status).toBe(400)
+		expect(handleCallback).not.toHaveBeenCalled()
+	})
+
+	it('rejects a callback with no state at all, without exchanging the code', async () => {
+		mockDb(loginState())
+		const handleCallback = vi.fn()
+		mockStubs({ handleCallback })
+
+		const res = await callbackRequest({ state: undefined, cookie: undefined })
+
+		expect(res.status).toBe(400)
+		expect(handleCallback).not.toHaveBeenCalled()
+	})
+
+	it('rejects a state that was never issued', async () => {
+		mockDb(null)
+		const handleCallback = vi.fn()
+		mockStubs({ handleCallback })
+
+		const res = await callbackRequest({ state: 'forged-state' })
+
+		expect(res.status).toBe(400)
+		expect(handleCallback).not.toHaveBeenCalled()
+	})
+
+	it('rejects an expired state', async () => {
+		mockDb({ ...loginState(), expiresAt: PAST })
+		const handleCallback = vi.fn()
+		mockStubs({ handleCallback })
+
+		const res = await callbackRequest({ state: 'state-1' })
+
+		expect(res.status).toBe(400)
+		expect(handleCallback).not.toHaveBeenCalled()
+	})
+
+	it('refuses to redeem a claim-main ticket as a callback state', async () => {
+		mockDb(claimTicketRow())
+		const handleCallback = vi.fn()
+		mockStubs({ handleCallback })
+
+		const res = await callbackRequest({ state: 'ticket-1' })
+
+		expect(res.status).toBe(400)
+		expect(handleCallback).not.toHaveBeenCalled()
+	})
+
+	it('binds the state to the browser when a login flow starts', async () => {
+		mockDb(null)
+		mockStubs({
+			startLoginFlow: vi.fn().mockResolvedValue({
+				url: 'https://login.eveonline.com/authorize?state=state-xyz',
+				state: 'state-xyz',
+			}),
+		})
+
+		const res = await createApp().request(
+			'/api/auth/login/start',
+			{ method: 'POST' },
+			env,
+			execCtx()
+		)
+
+		expect(res.status).toBe(200)
+		const cookie = res.headers.get('set-cookie')
+		expect(cookie).toContain('oauth_state=state-xyz')
+		expect(cookie).toContain('HttpOnly')
+	})
+})
+
+/**
+ * The mint half of the claim flow. Without these, the ticket could name any character at all
+ * and every redeem-side test above would still pass.
+ */
+describe('GET /api/auth/callback - minting a claim ticket for a new user', () => {
+	function mockNewUser() {
+		mockStubs({ handleCallback: vi.fn().mockResolvedValue(callbackResult('HASH-1')) })
+		vi.mocked(UserService).mockImplementation(
+			() =>
+				({
+					// No account exists for this character yet.
+					getUserByCharacterId: vi.fn().mockResolvedValue(null),
+					getCharacterOwnership: vi.fn().mockResolvedValue(null),
+				}) as any
+		)
+	}
+
+	it('binds the ticket to the character SSO verified, not to anything client-supplied', async () => {
+		const { insertValues } = mockDb(loginState())
+		mockNewUser()
+
+		const res = await callbackRequest({ state: 'state-1' })
+		const body = (await res.json()) as { requiresClaimMain: boolean; claimTicket: string }
+
+		expect(res.status).toBe(200)
+		expect(body.requiresClaimMain).toBe(true)
+		expect(body.claimTicket).toEqual(expect.any(String))
+
+		expect(insertValues).toHaveBeenCalledWith(
+			expect.objectContaining({
+				state: body.claimTicket,
+				flowType: 'claim-main',
+				metadata: {
+					characterId: 'char-1',
+					characterName: 'Pilot',
+					characterOwnerHash: 'HASH-1',
+				},
+			})
+		)
+	})
+
+	it('gives the ticket a future expiry', async () => {
+		const { insertValues } = mockDb(loginState())
+		mockNewUser()
+
+		await callbackRequest({ state: 'state-1' })
+
+		const written = insertValues.mock.calls[0]?.[0] as { expiresAt: Date }
+		expect(written.expiresAt.getTime()).toBeGreaterThan(Date.now())
+	})
+})
+
+/**
+ * Character transfer detection. CharacterOwnerHash rotates when a character changes hands; it
+ * was written on every login and never compared, so a Bazaar sale handed the buyer the
+ * seller's entire account.
+ */
+describe('GET /api/auth/callback - character owner hash is enforced on login', () => {
+	it('refuses the login and kills existing sessions when the owner hash has rotated', async () => {
+		mockDb(loginState())
+		mockStubs({ handleCallback: vi.fn().mockResolvedValue(callbackResult('NEW-OWNER-HASH')) })
+
+		const invalidateAllUserSessions = vi.fn().mockResolvedValue(1)
+		vi.mocked(SessionService).mockImplementation(() => ({ invalidateAllUserSessions }) as any)
+
+		const logLoginFailed = vi.fn()
+		vi.mocked(ActivityService).mockImplementation(
+			() => ({ logLogin: vi.fn(), logLoginFailed }) as any
+		)
+
+		vi.mocked(UserService).mockImplementation(
+			() =>
+				({
+					getUserByCharacterId: vi.fn().mockResolvedValue({ id: 'seller-user', characters: [] }),
+					getCharacterOwnership: vi.fn().mockResolvedValue({
+						userId: 'seller-user',
+						characterOwnerHash: 'OLD-OWNER-HASH',
+					}),
+				}) as any
+		)
+
+		const res = await callbackRequest({ state: 'state-1' })
+
+		expect(res.status).toBe(403)
+		// The seller must not keep a live session on an account the buyer now controls.
+		expect(invalidateAllUserSessions).toHaveBeenCalledWith('seller-user')
+		expect(logLoginFailed).toHaveBeenCalled()
+		// Above all: no session may be minted for the new owner.
+		expect(res.headers.get('set-cookie')).not.toContain('session=')
+	})
+
+	it('allows the login when the owner hash still matches', async () => {
+		mockDb(loginState())
+		mockStubs({ handleCallback: vi.fn().mockResolvedValue(callbackResult('SAME-HASH')) })
+
+		vi.mocked(UserService).mockImplementation(
+			() =>
+				({
+					getUserByCharacterId: vi.fn().mockResolvedValue({ id: 'user-1', characters: [] }),
+					getCharacterOwnership: vi.fn().mockResolvedValue({
+						userId: 'user-1',
+						characterOwnerHash: 'SAME-HASH',
+					}),
+				}) as any
+		)
+
+		const res = await callbackRequest({ state: 'state-1' })
+
+		expect(res.status).toBe(200)
+		expect(res.headers.get('set-cookie')).toContain('session=')
+	})
+
+	it('adopts the real hash for a legacy-imported character instead of locking the user out', async () => {
+		// Legacy imports store a placeholder, never a CCP hash. Comparing it would refuse every
+		// migrated user on sight and wipe their sessions, with no self-service path back.
+		mockDb(loginState())
+		mockStubs({ handleCallback: vi.fn().mockResolvedValue(callbackResult('REAL-CCP-HASH')) })
+
+		const adoptCharacterOwnerHash = vi.fn().mockResolvedValue(undefined)
+		const invalidateAllUserSessions = vi.fn()
+		vi.mocked(SessionService).mockImplementation(() => ({ invalidateAllUserSessions }) as any)
+
+		vi.mocked(UserService).mockImplementation(
+			() =>
+				({
+					getUserByCharacterId: vi.fn().mockResolvedValue({ id: 'migrated-user', characters: [] }),
+					getCharacterOwnership: vi.fn().mockResolvedValue({
+						userId: 'migrated-user',
+						characterOwnerHash: 'legacy-import:42:esi_owner',
+					}),
+					adoptCharacterOwnerHash,
+				}) as any
+		)
+
+		const res = await callbackRequest({ state: 'state-1' })
+
+		expect(res.status).toBe(200)
+		expect(res.headers.get('set-cookie')).toContain('session=')
+		expect(adoptCharacterOwnerHash).toHaveBeenCalledWith('char-1', 'REAL-CCP-HASH')
+		expect(invalidateAllUserSessions).not.toHaveBeenCalled()
+	})
+})
+
+describe('POST /api/auth/link-character - removed', () => {
+	it('no longer exists, so a body-supplied characterId cannot absorb a character', async () => {
+		mockDb(null)
+		mockStubs({ getTokenInfo: vi.fn() })
+
+		const res = await createApp().request(
+			'/api/auth/link-character',
+			{
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ characterId: 'victim-char' }),
+			},
+			env,
+			execCtx()
+		)
+
+		expect(res.status).toBe(404)
+	})
+})

--- a/apps/core/src/routes/__tests__/auth.tempop-callback.test.ts
+++ b/apps/core/src/routes/__tests__/auth.tempop-callback.test.ts
@@ -109,7 +109,13 @@ describe('GET /api/auth/callback temp-op flow', () => {
 		storeCredentialHandoffMock.mockResolvedValue('handoff-1')
 
 		const app = createApp()
-		const res = await app.request('/api/auth/callback?code=code-1&state=state-1', {}, env)
+		// The callback requires the state to be bound to the browser that started the flow.
+		// The guest flow sets this cookie when it mints the state (mumble-tempop-public.ts).
+		const res = await app.request(
+			'/api/auth/callback?code=code-1&state=state-1',
+			{ headers: { Cookie: 'oauth_state=state-1' } },
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(res.headers.get('content-type')).toContain('application/json')

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -4,7 +4,7 @@ import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import { eq } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { assertEveCharacterId } from '@repo/eve-types'
-import { toErrorMessage } from '@repo/hono-helpers'
+import { captureException, toErrorMessage } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
 import { managedCorporations, mumbleTempops, oauthStates, userCharacters, users } from '../db/schema'
@@ -27,15 +27,19 @@ import { provisionTempopGuest } from '../services/mumble.service'
 import { storeCredentialHandoff } from '../services/mumble-tempop.service'
 import { autoRegisterDirectorCorporation } from '../services/corporation-auto-register.service'
 import { SessionService } from '../services/session.service'
-import { UserService } from '../services/user.service'
+import { CharacterAlreadyClaimedError, UserService } from '../services/user.service'
 
 import type { Context } from 'hono'
-import type { RequestMetadata } from '@repo/core'
+import type { RequestMetadata, UserProfileDTO } from '@repo/core'
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { BlacklistEntry, Hr } from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
-import type { TempopOAuthMetadata } from '../db/schema'
+import type {
+	ClaimMainOAuthMetadata,
+	OAuthStateMetadata,
+	TempopOAuthMetadata,
+} from '../db/schema'
 import type { App } from '../context'
 import { logger } from '@repo/hono-helpers'
 import { createWorkflow } from '@repo/workflow-utils'
@@ -49,6 +53,71 @@ const auth = new Hono<App>()
 
 export function shouldUseSecureSessionCookie(c: Context<App>): boolean {
 	return new URL(c.req.url).protocol === 'https:'
+}
+
+/**
+ * Flows that legitimately terminate at GET /auth/callback.
+ *
+ * oauth_states also holds 'legacy-auth' rows (redeemed at /auth/legacy-auth/callback) and
+ * 'claim-main' tickets (redeemed at /auth/claim-main). Each callback accepts only its own
+ * flow types so a state minted for one flow cannot be replayed against another.
+ */
+const CALLBACK_FLOW_TYPES = ['login', 'character', 'mumble-tempop'] as const
+type CallbackFlowType = (typeof CALLBACK_FLOW_TYPES)[number]
+
+function isCallbackFlowType(flowType: string): flowType is CallbackFlowType {
+	return (CALLBACK_FLOW_TYPES as readonly string[]).includes(flowType)
+}
+
+/** How long a claim-main ticket stays redeemable after SSO verifies the character. */
+const CLAIM_TICKET_TTL_MS = 15 * 60 * 1000
+
+/**
+ * Characters imported from legacy auth carry this placeholder instead of a CCP owner hash
+ * (see legacyImportCharacterLinks in ../durable-object.ts). The import is an admin assertion
+ * with no cryptographic proof of ownership, so the placeholder is not evidence of anything —
+ * it must never be compared against a real hash.
+ */
+const LEGACY_IMPORT_HASH_PREFIX = 'legacy-import:'
+
+const OAUTH_STATE_COOKIE = 'oauth_state'
+
+/**
+ * Deliberately outlives the 15-minute oauth_states row. If the cookie died first, an expired
+ * flow would be reported by the cookie check below instead of by the state-expiry check, which
+ * is the one that knows how to render a friendly per-flow error (the temp-op guest redirect).
+ */
+const OAUTH_STATE_COOKIE_TTL_SECONDS = 30 * 60
+
+/**
+ * Bind an in-flight OAuth state to the browser that started the flow.
+ *
+ * The oauth_states row proves *a* flow was started; it does not prove *this browser* started
+ * it, because /auth/login and /auth/login/start are unauthenticated and will hand a valid
+ * state to anyone who asks. This cookie is what supplies the missing half, and it is the
+ * actual login-CSRF defence — see the check in /auth/callback.
+ *
+ * SameSite=Lax is sufficient: EVE redirects the browser to the SPA's /auth/callback page,
+ * which then calls this API same-origin.
+ */
+export function setOAuthStateCookie(c: Context<App>, state: string): void {
+	setCookie(c, OAUTH_STATE_COOKIE, state, {
+		httpOnly: true,
+		secure: shouldUseSecureSessionCookie(c),
+		sameSite: 'Lax',
+		maxAge: OAUTH_STATE_COOKIE_TTL_SECONDS,
+		path: '/',
+	})
+}
+
+/** Narrow an oauth_states.metadata blob to the temp-op shape, or null if it is not one. */
+function getTempopMetadata(metadata: OAuthStateMetadata | null): TempopOAuthMetadata | null {
+	return metadata && 'key' in metadata ? metadata : null
+}
+
+/** Narrow an oauth_states.metadata blob to the claim-main shape, or null if it is not one. */
+function getClaimMainMetadata(metadata: OAuthStateMetadata | null): ClaimMainOAuthMetadata | null {
+	return metadata && 'characterId' in metadata ? metadata : null
 }
 
 interface AuthSessionPermissionView {
@@ -481,6 +550,10 @@ auth.get('/login', async (c) => {
 		expiresAt,
 	})
 
+	// Tie this state to the browser we are about to send to EVE, so only that browser can
+	// complete the flow.
+	setOAuthStateCookie(c, authUrl.state)
+
 	// Redirect user to EVE SSO
 	return c.redirect(authUrl.url)
 })
@@ -507,6 +580,8 @@ auth.post('/login/start', async (c) => {
 		redirectUrl: null,
 		expiresAt,
 	})
+
+	setOAuthStateCookie(c, authUrl.state)
 
 	return c.json({
 		authorizationUrl: authUrl.url,
@@ -539,6 +614,8 @@ auth.post('/character/start', requireAuth(), async (c) => {
 		expiresAt,
 	})
 
+	setOAuthStateCookie(c, authUrl.state)
+
 	return c.json({
 		authorizationUrl: authUrl.url,
 		state: authUrl.state,
@@ -559,6 +636,29 @@ auth.get('/callback', async (c) => {
 		return c.json({ error: 'Missing authorization code' }, 400)
 	}
 
+	if (!state) {
+		return c.json({ error: 'Missing state parameter' }, 400)
+	}
+
+	// SECURITY: this pair of checks is the login-CSRF defence, and BOTH halves are load-bearing.
+	//
+	// The oauth_states row (checked below) proves only that *a* flow was started — it is not
+	// evidence about *this* browser, because /auth/login and /auth/login/start are
+	// unauthenticated and hand a valid state to any caller. An attacker can therefore mint a
+	// state, complete SSO as their own character, and walk a victim through this endpoint with
+	// the attacker's code; every DB-side check would pass and the victim's browser would be
+	// left holding a 30-day session on the attacker's account.
+	//
+	// The cookie is what ties the state to the browser that started the flow. It is HttpOnly,
+	// so an attacker cannot plant their own state in the victim's browser. Note the EVE token
+	// store accepts `state` but uses it only as a log tag, so nothing downstream re-checks this.
+	const boundState = getCookie(c, OAUTH_STATE_COOKIE)
+	deleteCookie(c, OAUTH_STATE_COOKIE, { path: '/' })
+
+	if (!boundState || boundState !== state) {
+		return c.json({ error: 'OAuth state does not match this browser. Please try again.' }, 400)
+	}
+
 	const db = createDb(c.env.DATABASE_URL)
 	const eveTokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
 
@@ -566,46 +666,46 @@ auth.get('/callback', async (c) => {
 	const userService = new UserService(db)
 	const activityService = new ActivityService(db)
 
-	// Look up the flow type from the state parameter
-	let flowType: string | null = null
-	let stateUserId: string | null = null
-	let redirectUrl: string | null = null
-	let stateMetadata: TempopOAuthMetadata | null = null
+	const oauthState = await db.query.oauthStates.findFirst({
+		where: eq(oauthStates.state, state),
+	})
 
-	if (state) {
-		const oauthState = await db.query.oauthStates.findFirst({
-			where: eq(oauthStates.state, state),
-		})
-
-		if (oauthState) {
-			// Check if state has expired
-			if (new Date() > oauthState.expiresAt) {
-				await db.delete(oauthStates).where(eq(oauthStates.state, state))
-				// Guest temp-op flows render in the SPA, so surface a usable error
-				// on the landing page rather than a raw JSON response.
-				if (oauthState.flowType === 'mumble-tempop') {
-					const expiredKey =
-						typeof oauthState.metadata?.key === 'string' ? oauthState.metadata.key : ''
-					return c.redirect(`/tempop/${expiredKey}?error=expired`)
-				}
-				return c.json({ error: 'OAuth state has expired. Please try again.' }, 400)
-			}
-
-			flowType = oauthState.flowType
-			stateUserId = oauthState.userId
-			redirectUrl = oauthState.redirectUrl
-			stateMetadata = oauthState.metadata
-
-			// Delete the state after use (one-time use)
-			await db.delete(oauthStates).where(eq(oauthStates.state, state))
-		}
+	if (!oauthState) {
+		return c.json({ error: 'Invalid OAuth state' }, 400)
 	}
+
+	// Check if state has expired
+	if (new Date() > oauthState.expiresAt) {
+		await db.delete(oauthStates).where(eq(oauthStates.state, state))
+		// Guest temp-op flows render in the SPA, so surface a usable error
+		// on the landing page rather than a raw JSON response.
+		if (oauthState.flowType === 'mumble-tempop') {
+			const expiredKey = getTempopMetadata(oauthState.metadata)?.key ?? ''
+			return c.redirect(`/tempop/${expiredKey}?error=expired`)
+		}
+		return c.json({ error: 'OAuth state has expired. Please try again.' }, 400)
+	}
+
+	// Only flows that actually terminate here may be replayed here. This notably excludes
+	// 'claim-main' tickets, which live in the same table but are redeemable only at
+	// /auth/claim-main.
+	if (!isCallbackFlowType(oauthState.flowType)) {
+		return c.json({ error: 'Invalid flow type' }, 400)
+	}
+
+	const flowType = oauthState.flowType
+	const stateUserId = oauthState.userId
+	const redirectUrl = oauthState.redirectUrl
+	const stateMetadata = oauthState.metadata
+
+	// Delete the state after use (one-time use)
+	await db.delete(oauthStates).where(eq(oauthStates.state, state))
 
 	// Mumble temp-op guest flow: minimal publicData identity → ephemeral voice
 	// credentials. Handled separately because guests never carry full scopes and
 	// no token is persisted (handleCallback would reject and over-persist).
 	if (flowType === 'mumble-tempop') {
-		return handleMumbleTempopCallback(c, code, stateMetadata)
+		return handleMumbleTempopCallback(c, code, getTempopMetadata(stateMetadata))
 	}
 
 	// Handle callback with eve-token-store
@@ -769,6 +869,52 @@ auth.get('/callback', async (c) => {
 	const user = await userService.getUserByCharacterId(characterId)
 
 	if (user) {
+		// SECURITY: EVE rotates CharacterOwnerHash whenever a character changes hands (a
+		// Character Bazaar sale, or any transfer). It is the only evidence CCP gives us that
+		// the human behind this character is no longer the human who linked it, so a mismatch
+		// must never mint a session onto the previous owner's account — that would hand the
+		// buyer every alt, role and permission the seller had.
+		//
+		// This is checked before the blacklist and before anything else reads `user`, because
+		// a broken identity binding makes every other fact about that account meaningless.
+		// Fail closed: refuse both parties and let an admin decide, rather than silently
+		// migrating or destroying an account on the strength of one hash comparison.
+		const ownership = await userService.getCharacterOwnership(characterId)
+
+		if (ownership?.characterOwnerHash.startsWith(LEGACY_IMPORT_HASH_PREFIX)) {
+			// Legacy-imported links carry a placeholder, never a CCP hash, so there is nothing
+			// meaningful to compare against — the import asserted ownership without proving it.
+			// This SSO round-trip is the first real proof we have ever had for this character, so
+			// adopt its hash. Without this branch every migrated user is refused on sight and has
+			// their sessions wiped, with no self-service path back.
+			await userService.adoptCharacterOwnerHash(characterId, characterInfo.characterOwnerHash)
+			logger.info('[Auth] Adopted real owner hash for legacy-imported character', {
+				characterId,
+				userId: ownership.userId,
+			})
+		} else if (ownership && ownership.characterOwnerHash !== characterInfo.characterOwnerHash) {
+			const sessionService = new SessionService(db)
+			await sessionService.invalidateAllUserSessions(ownership.userId)
+			await activityService.logLoginFailed(
+				characterId,
+				'Character owner hash mismatch - character ownership has changed',
+				getRequestMetadata(c)
+			)
+			logger.warn('[Auth] Character owner hash mismatch, refusing login', {
+				characterId,
+				userId: ownership.userId,
+			})
+
+			return c.json(
+				{
+					error:
+						'This character has changed ownership since it was linked. ' +
+						'For security, access has been suspended. Please contact an administrator.',
+				},
+				403
+			)
+		}
+
 		// SECURITY: Check if character ID/name or user is blacklisted
 		const hrStub = getStub<Hr>(c.env.HR, 'default')
 		const charBlacklistTrigger = await findBlacklistedCharacterTrigger(
@@ -929,9 +1075,27 @@ auth.get('/callback', async (c) => {
 		return c.json({ error: 'Account suspended' }, 403)
 	}
 
-	// New user - return character info for claim-main flow
+	// New user - mint a single-use ticket bound to the character SSO just verified, and hand
+	// the client that instead of trusting it to tell us which character to claim. The
+	// characterInfo below is display data for the confirmation screen; nothing is authorized
+	// from it.
+	const claimTicket = crypto.randomUUID()
+	await db.insert(oauthStates).values({
+		state: claimTicket,
+		flowType: 'claim-main',
+		userId: null,
+		redirectUrl: redirectUrl || null,
+		expiresAt: new Date(Date.now() + CLAIM_TICKET_TTL_MS),
+		metadata: {
+			characterId,
+			characterName: characterInfo.characterName,
+			characterOwnerHash: characterInfo.characterOwnerHash,
+		} satisfies ClaimMainOAuthMetadata,
+	})
+
 	return c.json({
 		requiresClaimMain: true,
+		claimTicket,
 		characterInfo: {
 			characterOwnerHash: characterInfo.characterOwnerHash,
 			characterId: characterInfo.characterId,
@@ -944,16 +1108,24 @@ auth.get('/callback', async (c) => {
  * POST /auth/claim-main
  *
  * Claim a character as main and create root user account.
- * This should be called after a successful callback for a new user.
+ * This should be called after a successful callback for a new user, with the claim ticket
+ * that callback issued.
  *
- * Security: Character data comes from the token store, not from client input.
+ * SECURITY: this endpoint is deliberately unauthenticated — the caller has no account yet,
+ * which is the whole point of it. Authority therefore comes from the claim ticket, which is
+ * minted only by /auth/callback after EVE SSO proves the caller controls the character, and
+ * which names that character server-side. Never reintroduce a characterId (or any other
+ * object selector) read from the request body here: `getTokenInfo` resolves whatever id it
+ * is handed with no notion of who is asking, so a body-supplied id let any unauthenticated
+ * caller mint an account and a 30-day session for any character that had authenticated but
+ * not yet been claimed.
  */
 auth.post('/claim-main', async (c) => {
 	const body = await c.req.json()
-	const { characterId } = body
+	const { claimTicket } = body
 
-	if (!characterId) {
-		return c.json({ error: 'Missing characterId' }, 400)
+	if (!claimTicket || typeof claimTicket !== 'string') {
+		return c.json({ error: 'Missing claim ticket' }, 400)
 	}
 
 	const db = createDb(c.env.DATABASE_URL)
@@ -963,11 +1135,51 @@ auth.post('/claim-main', async (c) => {
 	const userService = new UserService(db)
 	const activityService = new ActivityService(db)
 
+	// Resolve which character is being claimed from the ticket, never from the request.
+	const ticket = await db.query.oauthStates.findFirst({
+		where: eq(oauthStates.state, claimTicket),
+	})
+
+	if (!ticket || ticket.flowType !== 'claim-main') {
+		return c.json({ error: 'Invalid or expired claim ticket. Please login again.' }, 400)
+	}
+
+	if (new Date() > ticket.expiresAt) {
+		await db.delete(oauthStates).where(eq(oauthStates.state, claimTicket))
+		return c.json({ error: 'Claim ticket has expired. Please login again.' }, 400)
+	}
+
+	const claimMetadata = getClaimMainMetadata(ticket.metadata)
+
+	if (!claimMetadata) {
+		return c.json({ error: 'Invalid claim ticket. Please login again.' }, 400)
+	}
+
+	// Burn the ticket before doing any work, so a failure below cannot leave a replayable
+	// ticket behind. The cost is that a retry needs a fresh SSO round-trip.
+	await db.delete(oauthStates).where(eq(oauthStates.state, claimTicket))
+
+	const characterId = claimMetadata.characterId
+
 	// Fetch verified character data from token store
 	const tokenInfo = await eveTokenStoreStub.getTokenInfo(characterId)
 
 	if (!tokenInfo) {
 		return c.json({ error: 'Character not authenticated. Please login first.' }, 400)
+	}
+
+	// SECURITY: the token store holds *current* state, so if the character changed hands
+	// between minting and redeeming this ticket, tokenInfo now describes the new owner. Pin it
+	// to what SSO verified when the ticket was issued, or we would stamp the buyer's hash onto
+	// the account the seller is creating and lock the seller out of it forever.
+	if (tokenInfo.characterOwnerHash !== claimMetadata.characterOwnerHash) {
+		logger.warn('[Auth] claim-main ticket owner hash no longer matches, refusing', {
+			characterId,
+		})
+		return c.json(
+			{ error: 'This character has changed ownership. Please login again.' },
+			400
+		)
 	}
 
 	// SECURITY: Check if character ID/name is blacklisted before creating user
@@ -984,11 +1196,36 @@ auth.post('/claim-main', async (c) => {
 	}
 
 	// Create user with verified data from token store (not from client)
-	const user = await userService.createUser({
-		characterOwnerHash: tokenInfo.characterOwnerHash,
-		characterId: tokenInfo.characterId,
-		characterName: tokenInfo.characterName,
-	})
+	let user: UserProfileDTO
+	try {
+		user = await userService.createUser({
+			characterOwnerHash: tokenInfo.characterOwnerHash,
+			characterId: tokenInfo.characterId,
+			characterName: tokenInfo.characterName,
+		})
+	} catch (error) {
+		// A lost race (double submit, stale tab) is not a server fault, so answer it rather than
+		// letting it surface as an unhandled 500 — which also made this endpoint a
+		// claimed/unclaimed oracle, since 400/500/200 were three distinguishable answers.
+		// Everything else IS a fault and must keep reaching Sentry rather than being flattened
+		// into a reassuring 409.
+		if (error instanceof CharacterAlreadyClaimedError) {
+			logger.warn('[Auth] claim-main lost a race for this character', {
+				characterId,
+				reason: toErrorMessage(error),
+			})
+			return c.json(
+				{ error: 'This character has already been claimed. Please login again.' },
+				409
+			)
+		}
+
+		captureException(error as Error, {
+			tags: { route: 'auth.claim-main', characterId },
+		})
+		throw error
+	}
+
 	await hydrateAndReconcileUserRoles(c, db, user.id, tokenInfo.characterId)
 
 	// Update token validity cache (token was just received from SSO)
@@ -1074,111 +1311,6 @@ auth.post('/claim-main', async (c) => {
 			mainCharacterId: user.mainCharacterId,
 		},
 		autoRegistration: autoRegResult,
-	})
-})
-
-/**
- * POST /auth/link-character
- *
- * Link an additional character to the authenticated user.
- * Requires authentication.
- *
- * Security: Character data comes from the token store, not from client input.
- */
-auth.post('/link-character', requireAuth(), async (c) => {
-	const user = c.get('user')!
-	const body = await c.req.json()
-	const { characterId } = body
-
-	if (!characterId) {
-		return c.json({ error: 'Missing characterId' }, 400)
-	}
-
-	const db = c.get('db') || createDb(c.env.DATABASE_URL)
-	const eveTokenStoreStub =
-		c.get('eveTokenStore') || getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
-
-	const userService = new UserService(db)
-	const activityService = new ActivityService(db)
-
-	// Fetch verified character data from token store
-	const tokenInfo = await eveTokenStoreStub.getTokenInfo(characterId)
-
-	if (!tokenInfo) {
-		return c.json(
-			{ error: 'Character not authenticated. Please complete character flow first.' },
-			400
-		)
-	}
-
-	// SECURITY: Check if character ID or name is blacklisted
-	const hrStub = getStub<Hr>(c.env.HR, 'default')
-	const charBlacklistTrigger = await findBlacklistedCharacterTrigger(
-		hrStub,
-		tokenInfo.characterId,
-		tokenInfo.characterName
-	)
-
-	if (charBlacklistTrigger) {
-		// Character is blacklisted - auto-blacklist the user
-		const userBlacklistEntry = await hrStub.createUserBlacklist({
-			userId: user.id,
-			discordUserId: user.discordUserId ?? undefined,
-			reason: `Auto-blacklisted: attempted to link blacklisted character ${tokenInfo.characterId}`,
-			blacklistedBy: charBlacklistTrigger.blacklistedBy,
-			triggeredBy: charBlacklistTrigger.id,
-			isAutoBlacklist: true,
-		})
-		await blacklistUserLinkedTargets(
-			db,
-			hrStub,
-			user.id,
-			charBlacklistTrigger.blacklistedBy,
-			userBlacklistEntry.id
-		)
-
-		// Invalidate all sessions for this user
-		const sessionService = new SessionService(db)
-		await sessionService.invalidateAllUserSessions(user.id)
-
-		return c.json({ error: 'Account suspended' }, 403)
-	}
-
-	// Link character with verified data from token store (not from client)
-	const linkedCharacter = await userService.linkCharacter({
-		userId: user.id,
-		characterOwnerHash: tokenInfo.characterOwnerHash,
-		characterId: tokenInfo.characterId,
-		characterName: tokenInfo.characterName,
-	})
-	await hydrateAndReconcileUserRoles(c, db, user.id, tokenInfo.characterId)
-
-	await activityService.logCharacterLinked(user.id, tokenInfo.characterId, getRequestMetadata(c))
-	triggerLegacyMigrationRecheck(c, user.id)
-
-	waitUntilWithTelemetry(
-		c.executionCtx,
-		'auth.link.refresh',
-		async () => {
-			await db
-				.update(users)
-				.set({ lastRefreshWorkflowAttempt: new Date() })
-				.where(eq(users.id, user.id))
-
-			await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
-				id: createUserRefreshWorkflowId('link', user.id),
-				params: { userId: user.id, refreshMode: 'event' },
-			})
-		},
-		{
-			userId: user.id,
-			characterId: tokenInfo.characterId,
-			source: 'link',
-		}
-	)
-
-	return c.json({
-		character: linkedCharacter,
 	})
 })
 

--- a/apps/core/src/routes/mumble-tempop-public.ts
+++ b/apps/core/src/routes/mumble-tempop-public.ts
@@ -7,6 +7,7 @@ import { MUMBLE_FEATURE_FLAG_KEY } from '@repo/features'
 import { createDb } from '../db'
 import { mumbleTempops, oauthStates } from '../db/schema'
 import { consumeCredentialHandoff, hashToken } from '../services/mumble-tempop.service'
+import { setOAuthStateCookie } from './auth'
 import { resolveFlag } from './flags'
 
 import type { EveTokenStore } from '@repo/eve-token-store'
@@ -115,6 +116,10 @@ publicMumbleTempopRoutes.post('/:key/start-sso', async (c) => {
 		metadata: { key, tempopId: tempop.id },
 		expiresAt: new Date(Date.now() + OAUTH_STATE_TTL_MS),
 	})
+
+	// This flow completes at /auth/callback, which requires the state to be bound to the
+	// browser that started it.
+	setOAuthStateCookie(c, state)
 
 	const eveTokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
 	const { url } = await eveTokenStoreStub.startPublicDataFlow(state)

--- a/apps/core/src/services/user.service.ts
+++ b/apps/core/src/services/user.service.ts
@@ -13,6 +13,19 @@ import type { createDb } from '../db'
 import { logger } from '@repo/hono-helpers'
 
 /**
+ * Thrown when a character cannot be claimed because it is already attached to an account.
+ *
+ * Distinct from a generic failure so callers can answer a losing race with a 409 while still
+ * letting real faults (a database outage, say) surface as 5xx and reach error reporting.
+ */
+export class CharacterAlreadyClaimedError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'CharacterAlreadyClaimedError'
+	}
+}
+
+/**
  * User Service
  *
  * Handles user CRUD operations, character linking, and user profile management.
@@ -32,7 +45,7 @@ export class UserService {
 		})
 
 		if (existingUser) {
-			throw new Error('User already exists with this character as main')
+			throw new CharacterAlreadyClaimedError('User already exists with this character as main')
 		}
 
 		// Check if character is already linked to another user
@@ -41,7 +54,7 @@ export class UserService {
 		})
 
 		if (existingCharacter) {
-			throw new Error('Character is already linked to another user')
+			throw new CharacterAlreadyClaimedError('Character is already linked to another user')
 		}
 
 		// Create user
@@ -104,6 +117,39 @@ export class UserService {
 		}
 
 		return this.getUserProfile(character.userId)
+	}
+
+	/**
+	 * Fetch the raw ownership record for a linked character.
+	 *
+	 * Deliberately does not go through getUserProfile(): that hides soft-deleted characters,
+	 * and a character that was unlinked and later transferred must still be recognisable as
+	 * transferred. Returns the stored owner hash so callers can compare it against the one
+	 * EVE SSO just handed us.
+	 */
+	async getCharacterOwnership(
+		characterId: string
+	): Promise<{ userId: string; characterOwnerHash: string } | null> {
+		const character = await this.db.query.userCharacters.findFirst({
+			where: eq(userCharacters.characterId, characterId),
+			columns: { userId: true, characterOwnerHash: true },
+		})
+
+		return character ?? null
+	}
+
+	/**
+	 * Record the real CCP owner hash for a character that does not have one yet.
+	 *
+	 * Only for adopting a placeholder written by an admin-driven import, where no real hash was
+	 * ever known. Callers must confirm the stored value is a placeholder first — overwriting a
+	 * genuine hash would erase the only evidence that a character changed hands.
+	 */
+	async adoptCharacterOwnerHash(characterId: string, characterOwnerHash: string): Promise<void> {
+		await this.db
+			.update(userCharacters)
+			.set({ characterOwnerHash, updatedAt: new Date() })
+			.where(eq(userCharacters.characterId, characterId))
 	}
 
 	/**

--- a/apps/ui/src/client/routes/auth-callback.tsx
+++ b/apps/ui/src/client/routes/auth-callback.tsx
@@ -11,6 +11,8 @@ interface CallbackResponse {
 		requiresClaimMain?: boolean
 	}
 	requiresClaimMain?: boolean
+	/** Single-use ticket naming the character SSO just verified; redeemed at /auth/claim-main. */
+	claimTicket?: string
 	characterInfo?: {
 		characterOwnerHash: string
 		characterId: number
@@ -50,13 +52,20 @@ export default function AuthCallbackPage() {
 				return
 			}
 
+			// The server requires a state parameter and rejects the callback without one, so
+			// surface a real error here rather than sending an empty string it will refuse.
+			if (!state) {
+				setError('No state parameter received')
+				return
+			}
+
 			// Mark as called before making the request
 			hasCalledCallback.current = true
 
 			try {
 				// Call the callback endpoint
 				const response = await apiClient.get<CallbackResponse>(
-					`/auth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state || '')}`
+					`/auth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`
 				)
 
 				if (response.characterLinked) {
@@ -65,11 +74,13 @@ export default function AuthCallbackPage() {
 					// and token state are reflected without waiting for stale cache expiry.
 					const destination = '/dashboard?tokenUpdated=1'
 					void navigate(destination)
-				} else if (response.requiresClaimMain && response.characterInfo) {
-					// New user - redirect to claim-main page
+				} else if (response.requiresClaimMain && response.characterInfo && response.claimTicket) {
+					// New user - redirect to claim-main page. characterInfo is for display; the
+					// ticket is the only thing that actually authorizes the claim.
 					void navigate('/claim-main', {
 						state: {
 							characterInfo: response.characterInfo,
+							claimTicket: response.claimTicket,
 						},
 					})
 				} else if (response.success) {

--- a/apps/ui/src/client/routes/claim-main.tsx
+++ b/apps/ui/src/client/routes/claim-main.tsx
@@ -29,8 +29,9 @@ export default function ClaimMainPage() {
 	const [error, setError] = useState<string | null>(null)
 
 	const characterInfo = location.state?.characterInfo as CharacterInfo | undefined
+	const claimTicket = location.state?.claimTicket as string | undefined
 
-	if (!characterInfo) {
+	if (!characterInfo || !claimTicket) {
 		return (
 			<div className="min-h-screen flex items-center justify-center">
 				<div className="text-center">
@@ -51,9 +52,10 @@ export default function ClaimMainPage() {
 		setError(null)
 
 		try {
-			// Only send characterId - server will fetch verified data from token store
+			// Send only the ticket. It names the character server-side, so the client never
+			// gets to choose which character is being claimed.
 			await apiClient.post<ClaimMainResponse>('/auth/claim-main', {
-				characterId: characterInfo.characterId,
+				claimTicket,
 			})
 
 			// Session cookie set by server, redirect to dashboard


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Hardens the EVE SSO flow so account identity is derived from server-minted, single-use flow state instead of from client-supplied request parameters, closing several account-takeover vectors: unauthenticated claim-main hijacking, login CSRF via state replay, and silent account takeover on character transfer (Bazaar sales).

## Changes
- **claim-main is now ticket-based**: `/auth/callback` mints a single-use `claim-main` ticket (bound server-side to the character SSO just verified) instead of returning a `characterId` the client echoes back; `/auth/claim-main` resolves the character from the ticket and ignores any `characterId` in the request body.
- **OAuth state is now browser-bound**: an `oauth_state` HttpOnly cookie is set whenever a flow starts (`/auth/login`, `/auth/login/start`, `/auth/character/start`, mumble temp-op SSO start) and is required to match the `state` query parameter on `/auth/callback`, preventing an attacker from replaying their own state into a victim's browser.
- **CharacterOwnerHash is now verified on login**: a mismatch between the stored and SSO-reported owner hash invalidates all sessions on the affected account and refuses the login (403) instead of silently minting a session for the new owner; legacy-imported characters (which carry a placeholder hash) instead adopt the real hash on first verified login.
- **`/auth/link-character` removed** as unused/redundant now that character binding flows through the hardened claim-main path.
- **claim-main race handling**: a new `CharacterAlreadyClaimedError` lets a lost race (double submit) answer with `409` instead of an unhandled `500`, while unexpected faults still propagate to Sentry via `captureException`.
- Schema: `oauthStates.metadata` widened from `TempopOAuthMetadata | null` to `OAuthStateMetadata` (`TempopOAuthMetadata | ClaimMainOAuthMetadata`) — a JSONB type widening only, no migration needed.
- UI (`auth-callback.tsx`, `claim-main.tsx`) updated to carry and submit the `claimTicket` instead of a raw `characterId`.

## Testing
Adds 22 regression tests in `apps/core/src/routes/__tests__/auth.identity-binding.test.ts` covering claim-ticket enforcement, state/cookie binding, owner-hash verification (including legacy-import adoption), the removed `/auth/link-character` endpoint, and claim-main race handling; the existing tempop callback test was updated to include the new required cookie. Per the commit message, 17 of the new tests fail against the previous implementation.
<!-- claude:end -->