### PR TITLE
ci: only run check/test/deploy when code actually changed

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -41,44 +41,16 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
       - name: Check for non-doc changes
         id: filter
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          # Empty on merge_group; the script then fails safe to running everything.
           PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-
-          # merge_group has no PR and cannot be path-filtered by GitHub — always run
-          # the full check on the exact commit that is about to land.
-          if [ -z "${PR:-}" ]; then
-            echo 'Not a pull_request event — running full checks.'
-            echo 'code=true' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          files="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')"
-
-          # Anything left after dropping the ignorable paths means real code changed.
-          # A mixed doc+code PR therefore still runs, same as paths-ignore did.
-          code="$(printf '%s\n' "$files" | grep -Ev \
-            -e '\.md$' \
-            -e '^docs/' \
-            -e '^\.changeset/' \
-            -e '^\.vscode/' \
-            -e '^\.cursor/' \
-            -e '^\.claude/' \
-            -e '^\.editorconfig$' \
-            || true)"
-
-          if [ -n "$code" ]; then
-            echo 'Code changed — running checks.'
-            echo 'code=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'Only docs/config changed — skipping checks.'
-            echo 'code=false' >> "$GITHUB_OUTPUT"
-          fi
+        run: node scripts/ci/detect-code-changes.mjs
 
   check:
     name: Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,35 @@ env:
   FORCE_COLOR: 1
 
 jobs:
+  # Skip the check/test/deploy pipeline when a push only touched docs or config.
+  # Shares scripts/ci/detect-code-changes.mjs with branches.yml so the ignore
+  # list is defined in exactly one place.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+      - name: Check for non-doc changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: node scripts/ci/detect-code-changes.mjs
+
   test-and-deploy:
     name: Test and Deploy
+    needs: changes
+    # Fail safe: only an explicit 'false' skips. An empty output (changes job
+    # errored) still deploys rather than silently skipping a real code change.
+    if: needs.changes.outputs.code != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency: ${{ github.workflow }}
@@ -47,7 +74,9 @@ jobs:
     # test-and-deploy fails, which is exactly when we most want the alert.
     name: Notify Discord
     needs: test-and-deploy
-    if: always()
+    # Fire on success and failure, but stay silent when the deploy was skipped
+    # (docs-only push) — there's nothing to announce.
+    if: always() && needs.test-and-deploy.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,6 +19,10 @@ export default [
 		rules: {
 			'@typescript-eslint/no-floating-promises': 'off',
 			'no-undef': 'off',
+			// These scripts run directly via `node`, never as a turbo task, so their
+			// CI env vars (GITHUB_OUTPUT, the change-detection inputs) don't belong
+			// in turbo.json — declaring them there would needlessly bust build caches.
+			'turbo/no-undeclared-env-vars': 'off',
 		},
 	},
 	{

--- a/scripts/ci/detect-code-changes.mjs
+++ b/scripts/ci/detect-code-changes.mjs
@@ -1,0 +1,96 @@
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+
+/**
+ * Decide whether a PR or push touched anything that needs check/test/deploy.
+ *
+ * Shared by both CI workflows so the ignore list lives in exactly one place:
+ *  - branches.yml (pull_request / merge_group) — gates the "Check" job
+ *  - release.yml  (push to main)               — gates test-and-deploy
+ *
+ * Writes `code=true|false` to $GITHUB_OUTPUT.
+ *
+ * FAIL-SAFE: any ambiguity (no file list, API error, truncated diff) resolves to
+ * `code=true`. Running checks we didn't strictly need is cheap; silently skipping
+ * CI on a real code change is not.
+ */
+
+// Paths that never affect a built or deployed worker. A change confined to these
+// skips the pipeline; a mixed doc+code change still runs.
+const IGNORE_PATTERNS = [
+	/\.md$/,
+	/^docs\//,
+	/^\.changeset\//,
+	/^\.github\//, // workflows, issue templates, CODEOWNERS — not app code
+	/^\.vscode\//,
+	/^\.cursor\//,
+	/^\.claude\//,
+	/^\.editorconfig$/,
+]
+
+const ZERO_SHA = '0000000000000000000000000000000000000000'
+
+/** Run `gh api`, paginating, and return one filename per line. */
+function ghApiFilenames(path, jqFilter) {
+	const out = execFileSync('gh', ['api', '--paginate', path, '--jq', jqFilter], {
+		encoding: 'utf8',
+		maxBuffer: 32 * 1024 * 1024,
+	})
+	return out.split('\n').filter(Boolean)
+}
+
+/**
+ * @returns {string[] | null} changed filenames, or null when the file set can't be
+ * determined reliably (caller then fails safe to running everything).
+ */
+function listChangedFiles() {
+	const { REPO, PR, BEFORE, AFTER } = process.env
+
+	// pull_request event: GitHub knows the PR's exact file set.
+	if (PR) {
+		return ghApiFilenames(`repos/${REPO}/pulls/${PR}/files`, '.[].filename')
+	}
+
+	// push event: compare the pushed range. The compare API needs no local git
+	// history, so it works with the default shallow checkout (fetch-depth: 1).
+	if (BEFORE && AFTER && BEFORE !== ZERO_SHA) {
+		return ghApiFilenames(`repos/${REPO}/compare/${BEFORE}...${AFTER}`, '.files[].filename')
+	}
+
+	// merge_group, first push to a branch (before = zeros), or missing inputs:
+	// no dependable file list, so run the full pipeline.
+	return null
+}
+
+function main() {
+	const output = process.env.GITHUB_OUTPUT
+	let code = true // fail-safe default
+
+	try {
+		const files = listChangedFiles()
+		if (files === null) {
+			console.log('No reliable changed-file list — running full checks.')
+		} else {
+			const changedCode = files.filter((f) => !IGNORE_PATTERNS.some((re) => re.test(f)))
+			if (changedCode.length > 0) {
+				console.log(`Code changed (${changedCode.length} file(s)) — running checks.`)
+				code = true
+			} else {
+				console.log('Only docs/config changed — skipping checks.')
+				code = false
+			}
+		}
+	} catch (err) {
+		console.error(`Change detection failed, running full checks to be safe: ${err.message}`)
+		code = true
+	}
+
+	if (output) {
+		appendFileSync(output, `code=${code}\n`)
+	} else {
+		// Local invocation: print the decision so the script is runnable by hand.
+		console.log(`code=${code}`)
+	}
+}
+
+main()


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Extracts the "did this touch real code" decision used by CI into a single shared script, `scripts/ci/detect-code-changes.mjs`, so `branches.yml` (PRs) and `release.yml` (pushes to main) use identical logic instead of each maintaining their own ignore list. `release.yml`'s deploy step is now gated the same way, and `.github/` itself is added to the ignore list so workflow-only changes no longer trigger the full check/test/deploy suite.

## Changes
- Add `scripts/ci/detect-code-changes.mjs`: determines changed files via the PR files API (`pull_request`) or the compare API (`push`), filters out doc/config paths, and writes `code=true|false` to `$GITHUB_OUTPUT`. Fails safe to `code=true` on any ambiguity (no PR/push info, API error, `merge_group` event).
- `branches.yml`: replace the inline bash filter with a checkout step + call to the shared script.
- `release.yml`: add a new `changes` job that runs the shared script, gate `test-and-deploy` on `needs.changes.outputs.code != 'false'`, and skip the Discord notify job when the deploy itself was skipped (`needs.test-and-deploy.result != 'skipped'`).
- Add `.github/` to the ignore-pattern list (previously only `.md`, `docs/`, `.changeset/`, `.vscode/`, `.cursor/`, `.claude/`, `.editorconfig`).
- `eslint.config.ts`: disable `turbo/no-undeclared-env-vars` for these scripts, since they run directly via `node` rather than as turbo tasks.

## Testing
No automated tests included; verification is via the workflow runs themselves once merged (branches.yml on this PR, release.yml on the next push to main).
<!-- claude:end -->
