### PR TITLE
fix corp contracts duplicates and freight leaderboard

### DIFF
--- a/apps/core/src/routes/__tests__/freight-leaderboard-period.test.ts
+++ b/apps/core/src/routes/__tests__/freight-leaderboard-period.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveFreightLeaderboardWindow } from '../freight-leaderboard-period'
+
+describe('resolveFreightLeaderboardWindow', () => {
+	it('defaults to all time when no period is provided', () => {
+		const window = resolveFreightLeaderboardWindow(undefined, new Date('2026-07-17T12:34:56Z'))
+
+		expect(window.since).toBeUndefined()
+		expect(window.before).toBeUndefined()
+	})
+
+	it('maps the 30d alias to the current month', () => {
+		const window = resolveFreightLeaderboardWindow('30d', new Date('2026-07-17T12:34:56Z'))
+
+		expect(window.since?.toISOString()).toBe('2026-07-01T00:00:00.000Z')
+		expect(window.before).toBeUndefined()
+	})
+
+	it('returns a bounded range for the previous month', () => {
+		const window = resolveFreightLeaderboardWindow('previous-month', new Date('2026-07-17T12:34:56Z'))
+
+		expect(window.since?.toISOString()).toBe('2026-06-01T00:00:00.000Z')
+		expect(window.before?.toISOString()).toBe('2026-07-01T00:00:00.000Z')
+	})
+
+	it('returns no bounds for all time', () => {
+		const window = resolveFreightLeaderboardWindow('all', new Date('2026-07-17T12:34:56Z'))
+
+		expect(window.since).toBeUndefined()
+		expect(window.before).toBeUndefined()
+	})
+})

--- a/apps/core/src/routes/freight-leaderboard-period.ts
+++ b/apps/core/src/routes/freight-leaderboard-period.ts
@@ -1,0 +1,39 @@
+export type FreightLeaderboardPeriod = 'month' | 'previous-month' | 'all'
+
+export interface FreightLeaderboardWindow {
+	since?: Date
+	before?: Date
+}
+
+function startOfUtcMonth(date: Date): Date {
+	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1))
+}
+
+function addUtcMonths(date: Date, months: number): Date {
+	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1))
+}
+
+export function resolveFreightLeaderboardWindow(
+	period: string | undefined,
+	now = new Date()
+): FreightLeaderboardWindow {
+	const normalizedPeriod = period === '30d' ? 'month' : period
+	const currentMonthStart = startOfUtcMonth(now)
+
+	switch (normalizedPeriod) {
+		case 'previous-month': {
+			const previousMonthStart = addUtcMonths(currentMonthStart, -1)
+			return {
+				since: previousMonthStart,
+				before: currentMonthStart,
+			}
+		}
+		case 'month':
+			return { since: currentMonthStart }
+		case 'all':
+		case undefined:
+			return {}
+		default:
+			return {}
+	}
+}

--- a/apps/core/src/routes/freight.ts
+++ b/apps/core/src/routes/freight.ts
@@ -18,9 +18,12 @@ import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { Freight } from '@repo/freight'
 import type { App } from '../context'
 import type { CorporationContractSortBy } from '@repo/eve-corporation-data'
+import {
+	resolveFreightLeaderboardWindow,
+	type FreightLeaderboardPeriod,
+} from './freight-leaderboard-period'
 
 const FREIGHT_MANAGER_URN = 'urn:freight:manager'
-const MS_PER_DAY = 86_400_000
 
 /**
  * Hardcoded TEST Alliance Please Ignore alliance ID
@@ -537,9 +540,9 @@ app.get('/leaderboard', requireAuth(), requireAllianceMember(), async (c) => {
 			'alliance-queries'
 		)
 
-		const period = c.req.query('period')
-		const since = period === '30d' ? new Date(Date.now() - 30 * MS_PER_DAY) : undefined
-		const leaderboard = await corpDataStub.getCourierLeaderboard(ALLIANCE_ID, since)
+		const period = c.req.query('period') as FreightLeaderboardPeriod | '30d' | undefined
+		const window = resolveFreightLeaderboardWindow(period)
+		const leaderboard = await corpDataStub.getCourierLeaderboard(ALLIANCE_ID, window)
 
 		// Resolve acceptor names
 		const idsToResolve = leaderboard.entries.map((entry) => entry.acceptorId)

--- a/apps/eve-corporation-data/.migrations/0026_shiny_revanche.sql
+++ b/apps/eve-corporation-data/.migrations/0026_shiny_revanche.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "corporation_contracts" DROP CONSTRAINT "corporation_contracts_corporation_id_contract_id_unique";--> statement-breakpoint
+ALTER TABLE "corporation_contracts" DROP CONSTRAINT "corporation_contracts_corporation_id_corporation_config_corporation_id_fk";
+--> statement-breakpoint
+CREATE INDEX "corporation_contracts_leaderboard_all_time_idx" ON "corporation_contracts" USING btree ("assignee_id","type","status","acceptor_id");--> statement-breakpoint
+CREATE INDEX "corporation_contracts_leaderboard_period_idx" ON "corporation_contracts" USING btree ("assignee_id","type","status","date_completed","acceptor_id");--> statement-breakpoint
+ALTER TABLE "corporation_contracts" DROP COLUMN "corporation_id";--> statement-breakpoint
+ALTER TABLE "corporation_contracts" ADD CONSTRAINT "corporation_contracts_contract_id_unique" UNIQUE("contract_id");

--- a/apps/eve-corporation-data/.migrations/meta/0026_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0026_snapshot.json
@@ -1,0 +1,3566 @@
+{
+  "id": "fe1b492b-2c68-425b-a93f-008cf15ffed0",
+  "prevId": "602080f3-7c33-464f-a885-d65cf6f070ca",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_corporation_roles": {
+      "name": "character_corporation_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_at_hq": {
+          "name": "roles_at_hq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_base": {
+          "name": "roles_at_base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_other": {
+          "name": "roles_at_other",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "character_corporation_roles",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_corporation_roles_corporation_id_character_id_unique": {
+          "name": "character_corporation_roles_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_assets": {
+      "name": "corporation_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_blueprint_copy": {
+          "name": "is_blueprint_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_assets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_assets_corporation_id_item_id_unique": {
+          "name": "corporation_assets_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_config": {
+      "name": "corporation_config",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "corporation_type": {
+          "name": "corporation_type",
+          "type": "corporation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "members_last_sync": {
+          "name": "members_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_tracking_last_sync": {
+          "name": "member_tracking_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets_last_sync": {
+          "name": "wallets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_journal_last_sync": {
+          "name": "wallet_journal_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_transactions_last_sync": {
+          "name": "wallet_transactions_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assets_last_sync": {
+          "name": "assets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structures_last_sync": {
+          "name": "structures_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_last_sync": {
+          "name": "orders_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contracts_last_sync": {
+          "name": "contracts_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_jobs_last_sync": {
+          "name": "industry_jobs_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killmails_last_sync": {
+          "name": "killmails_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_config_include_in_background_refresh_idx": {
+          "name": "corporation_config_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_include_in_structure_asset_sync_idx": {
+          "name": "corporation_config_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_corporation_type_idx": {
+          "name": "corporation_config_corporation_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_member_tracking_last_sync_idx": {
+          "name": "corporation_config_member_tracking_last_sync_idx",
+          "columns": [
+            {
+              "expression": "member_tracking_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallets_last_sync_idx": {
+          "name": "corporation_config_wallets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_assets_last_sync_idx": {
+          "name": "corporation_config_assets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "assets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_structures_last_sync_idx": {
+          "name": "corporation_config_structures_last_sync_idx",
+          "columns": [
+            {
+              "expression": "structures_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_orders_last_sync_idx": {
+          "name": "corporation_config_orders_last_sync_idx",
+          "columns": [
+            {
+              "expression": "orders_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_contracts_last_sync_idx": {
+          "name": "corporation_config_contracts_last_sync_idx",
+          "columns": [
+            {
+              "expression": "contracts_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_industry_jobs_last_sync_idx": {
+          "name": "corporation_config_industry_jobs_last_sync_idx",
+          "columns": [
+            {
+              "expression": "industry_jobs_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_killmails_last_sync_idx": {
+          "name": "corporation_config_killmails_last_sync_idx",
+          "columns": [
+            {
+              "expression": "killmails_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_members_last_sync_idx": {
+          "name": "corporation_config_members_last_sync_idx",
+          "columns": [
+            {
+              "expression": "members_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_transactions_last_sync_idx": {
+          "name": "corporation_config_wallet_transactions_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_transactions_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_journal_last_sync_idx": {
+          "name": "corporation_config_wallet_journal_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_journal_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_contracts": {
+      "name": "corporation_contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptor_id": {
+          "name": "acceptor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyout": {
+          "name": "buyout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collateral": {
+          "name": "collateral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_accepted": {
+          "name": "date_accepted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_expired": {
+          "name": "date_expired",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_to_complete": {
+          "name": "days_to_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_location_id": {
+          "name": "end_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_corporation": {
+          "name": "for_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_corporation_id": {
+          "name": "issuer_corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward": {
+          "name": "reward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_location_id": {
+          "name": "start_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_contracts_leaderboard_all_time_idx": {
+          "name": "corporation_contracts_leaderboard_all_time_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_contracts_leaderboard_period_idx": {
+          "name": "corporation_contracts_leaderboard_period_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_contracts_contract_id_unique": {
+          "name": "corporation_contracts_contract_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contract_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_directors": {
+      "name": "corporation_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_healthy": {
+          "name": "is_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permanent_failure_at": {
+          "name": "permanent_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_directors_corp_healthy_idx": {
+          "name": "corporation_directors_corp_healthy_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_healthy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_next_retry_idx": {
+          "name": "corporation_directors_corp_next_retry_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_permanent_failure_idx": {
+          "name": "corporation_directors_corp_permanent_failure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permanent_failure_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_last_used_idx": {
+          "name": "corporation_directors_last_used_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_directors",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_directors_corporation_id_character_id_unique": {
+          "name": "corporation_directors_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_industry_jobs": {
+      "name": "corporation_industry_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_id": {
+          "name": "installer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_type_id": {
+          "name": "blueprint_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_location_id": {
+          "name": "blueprint_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_location_id": {
+          "name": "output_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs": {
+          "name": "runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_runs": {
+          "name": "licensed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_type_id": {
+          "name": "product_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_date": {
+          "name": "pause_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_character_id": {
+          "name": "completed_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successful_runs": {
+          "name": "successful_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_industry_jobs",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_industry_jobs_corporation_id_job_id_unique": {
+          "name": "corporation_industry_jobs_corporation_id_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_killmails": {
+      "name": "corporation_killmails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_id": {
+          "name": "killmail_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_hash": {
+          "name": "killmail_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_time": {
+          "name": "killmail_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_killmails",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_killmails_corporation_id_killmail_id_unique": {
+          "name": "corporation_killmails_corporation_id_killmail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "killmail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_member_tracking": {
+      "name": "corporation_member_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoff_date": {
+          "name": "logoff_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logon_date": {
+          "name": "logon_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_member_tracking",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_member_tracking_corporation_id_character_id_unique": {
+          "name": "corporation_member_tracking_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_members": {
+      "name": "corporation_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_members_character_id_idx": {
+          "name": "corporation_members_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_members",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_members_corporation_id_character_id_unique": {
+          "name": "corporation_members_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_orders": {
+      "name": "corporation_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escrow": {
+          "name": "escrow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_buy_order": {
+          "name": "is_buy_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issued": {
+          "name": "issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_volume": {
+          "name": "min_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_remain": {
+          "name": "volume_remain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_total": {
+          "name": "volume_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_division": {
+          "name": "wallet_division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_orders",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_orders_corporation_id_order_id_unique": {
+          "name": "corporation_orders_corporation_id_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_public_info": {
+      "name": "corporation_public_info",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ceo_id": {
+          "name": "ceo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_founded": {
+          "name": "date_founded",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_station_id": {
+          "name": "home_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "war_eligible": {
+          "name": "war_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory": {
+      "name": "corporation_structure_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_corp_structure_idx": {
+          "name": "corporation_structure_inventory_corp_structure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+          "name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structure_inventory_corporation_id_item_id_unique": {
+          "name": "corporation_structure_inventory_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structures": {
+      "name": "corporation_structures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_expires": {
+          "name": "fuel_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_amount": {
+          "name": "fuel_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refilled_at": {
+          "name": "last_refilled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_apply": {
+          "name": "next_reinforce_apply",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_hour": {
+          "name": "next_reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforce_hour": {
+          "name": "reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_timer_end": {
+          "name": "state_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_timer_start": {
+          "name": "state_timer_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unanchors_at": {
+          "name": "unanchors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_power": {
+          "name": "low_power",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structures",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structures_structure_id_unique": {
+          "name": "corporation_structures_structure_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "structure_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_journal": {
+      "name": "corporation_wallet_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id_type": {
+          "name": "context_id_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_receiver_id": {
+          "name": "tax_receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_journal",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+          "name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "journal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_transactions": {
+      "name": "corporation_wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy": {
+          "name": "is_buy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "journal_ref_id": {
+          "name": "journal_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_transactions",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+          "name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallets": {
+      "name": "corporation_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallets_corporation_id_division_unique": {
+          "name": "corporation_wallets_corporation_id_division_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_fuel_log": {
+      "name": "structure_fuel_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_block_units": {
+          "name": "fuel_block_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_fuel_log_corp_structure_observed_idx": {
+          "name": "structure_fuel_log_corp_structure_observed_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_mining_citadel_extractions": {
+      "name": "structure_mining_citadel_extractions",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_start_time": {
+          "name": "extraction_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_arrival_time": {
+          "name": "chunk_arrival_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "natural_decay_time": {
+          "name": "natural_decay_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_mining_citadel_extractions_corporation_id_idx": {
+          "name": "structure_mining_citadel_extractions_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_citadel_extractions_last_synced_at_idx": {
+          "name": "structure_mining_citadel_extractions_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_drills": {
+      "name": "structure_moon_drills",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_drills_corporation_id_idx": {
+          "name": "structure_moon_drills_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_drills_last_synced_at_idx": {
+          "name": "structure_moon_drills_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_geographies": {
+      "name": "structure_moon_geographies",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_name": {
+          "name": "moon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_geographies_corporation_id_idx": {
+          "name": "structure_moon_geographies_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_moon_id_idx": {
+          "name": "structure_moon_geographies_moon_id_idx",
+          "columns": [
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_planet_id_idx": {
+          "name": "structure_moon_geographies_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_system_id_idx": {
+          "name": "structure_moon_geographies_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_last_synced_at_idx": {
+          "name": "structure_moon_geographies_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhooks": {
+      "name": "structure_skyhooks",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "effective_workforce": {
+          "name": "effective_workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagents": {
+          "name": "reagents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reinforcement_timer_end": {
+          "name": "reinforcement_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_start": {
+          "name": "theft_vulnerability_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_end": {
+          "name": "theft_vulnerability_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_raidable": {
+          "name": "is_raidable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "becomes_raidable_at": {
+          "name": "becomes_raidable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerable_at": {
+          "name": "vulnerable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhooks_corporation_id_idx": {
+          "name": "structure_skyhooks_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_planet_id_idx": {
+          "name": "structure_skyhooks_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_system_id_idx": {
+          "name": "structure_skyhooks_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_type_id_idx": {
+          "name": "structure_skyhooks_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_is_raidable_idx": {
+          "name": "structure_skyhooks_is_raidable_idx",
+          "columns": [
+            {
+              "expression": "is_raidable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_last_synced_at_idx": {
+          "name": "structure_skyhooks_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_hubs": {
+      "name": "structure_sovereignty_hubs",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_access_list_id": {
+          "name": "fuel_access_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_id": {
+          "name": "controller_alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay_last_updated": {
+          "name": "reagent_bay_last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay": {
+          "name": "reagent_bay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+        },
+        "upgrades": {
+          "name": "upgrades",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_transport": {
+          "name": "workforce_transport",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_hubs_corporation_id_idx": {
+          "name": "structure_sovereignty_hubs_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_system_id_idx": {
+          "name": "structure_sovereignty_hubs_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_type_id_idx": {
+          "name": "structure_sovereignty_hubs_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_last_synced_at_idx": {
+          "name": "structure_sovereignty_hubs_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_hubs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_systems": {
+      "name": "structure_sovereignty_systems",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_claimant_id": {
+          "name": "corporation_claimant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_since": {
+          "name": "claimed_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sovereignty_hub_structure_id": {
+          "name": "sovereignty_hub_structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capital_system": {
+          "name": "is_capital_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_defense_multiplier": {
+          "name": "activity_defense_multiplier",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "military_level": {
+          "name": "military_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industrial_level": {
+          "name": "industrial_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategic_level": {
+          "name": "strategic_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_systems_corporation_id_idx": {
+          "name": "structure_sovereignty_systems_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_alliance_id_idx": {
+          "name": "structure_sovereignty_systems_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+          "name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+          "columns": [
+            {
+              "expression": "sovereignty_hub_structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_last_synced_at_idx": {
+          "name": "structure_sovereignty_systems_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_systems",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.corporation_type": {
+      "name": "corporation_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "alt",
+        "special_purpose",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/eve-corporation-data/.migrations/meta/_journal.json
+++ b/apps/eve-corporation-data/.migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1784112964441,
       "tag": "0025_mysterious_lady_mastermind",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1784260492391,
+      "tag": "0026_shiny_revanche",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/eve-corporation-data/src/db/schema.ts
+++ b/apps/eve-corporation-data/src/db/schema.ts
@@ -499,9 +499,6 @@ export const corporationContracts = pgTable(
 	'corporation_contracts',
 	{
 		id: uuid('id').defaultRandom().primaryKey(),
-		corporationId: text('corporation_id')
-			.notNull()
-			.references(() => corporationConfig.corporationId),
 		contractId: text('contract_id').notNull(),
 		acceptorId: text('acceptor_id'),
 		assigneeId: text('assignee_id').notNull(),
@@ -526,7 +523,22 @@ export const corporationContracts = pgTable(
 		volume: text('volume'),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
-	(table) => [unique().on(table.corporationId, table.contractId)]
+	(table) => [
+		unique().on(table.contractId),
+		index('corporation_contracts_leaderboard_all_time_idx').on(
+			table.assigneeId,
+			table.type,
+			table.status,
+			table.acceptorId
+		),
+		index('corporation_contracts_leaderboard_period_idx').on(
+			table.assigneeId,
+			table.type,
+			table.status,
+			table.dateCompleted,
+			table.acceptorId
+		),
+	]
 )
 
 /**

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -1,6 +1,20 @@
 import { DurableObject } from 'cloudflare:workers'
 
-import { and, asc, desc, eq, gt, gte, inArray, lte, notInArray, sql } from '@repo/db-utils'
+import {
+	and,
+	asc,
+	desc,
+	eq,
+	gt,
+	gte,
+	inArray,
+	isNotNull,
+	lt,
+	lte,
+	notInArray,
+	or,
+	sql,
+} from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { parseDateOrNull } from '@repo/worker-utils'
@@ -562,7 +576,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): CorporationContractData {
 		return {
 			id: row.id,
-			corporationId: row.corporationId,
 			contractId: row.contractId,
 			acceptorId: row.acceptorId,
 			assigneeId: row.assigneeId,
@@ -2735,49 +2748,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 * Store contracts (workflow-friendly)
 	 */
 	async storeContracts(corporationId: string, contracts: any[]): Promise<void> {
-		const BATCH_SIZE = 20
-		for (let i = 0; i < contracts.length; i += BATCH_SIZE) {
-			const batch = contracts.slice(i, i + BATCH_SIZE)
-			const valuesToInsert = batch.map((contract) => ({
-				corporationId: String(corporationId),
-				contractId: contract.contract_id,
-				acceptorId: contract.acceptor_id || null,
-				assigneeId: contract.assignee_id,
-				availability: contract.availability,
-				buyout: contract.buyout?.toString() || null,
-				collateral: contract.collateral?.toString() || null,
-				dateAccepted: contract.date_accepted ? new Date(contract.date_accepted) : null,
-				dateCompleted: contract.date_completed ? new Date(contract.date_completed) : null,
-				dateExpired: new Date(contract.date_expired),
-				dateIssued: new Date(contract.date_issued),
-				daysToComplete: contract.days_to_complete ?? null,
-				endLocationId: contract.end_location_id || null,
-				forCorporation: contract.for_corporation,
-				issuerCorporationId: contract.issuer_corporation_id,
-				issuerId: contract.issuer_id,
-				price: contract.price?.toString() || null,
-				reward: contract.reward?.toString() || null,
-				startLocationId: contract.start_location_id || null,
-				status: contract.status,
-				title: contract.title || null,
-				type: contract.type,
-				volume: contract.volume?.toString() || null,
-				updatedAt: new Date(),
-			}))
-
-			await this.getDb()
-				.insert(corporationContracts)
-				.values(valuesToInsert)
-				.onConflictDoUpdate({
-					target: [corporationContracts.corporationId, corporationContracts.contractId],
-					set: {
-						status: sql`excluded.status`,
-						dateAccepted: sql`excluded.date_accepted`,
-						dateCompleted: sql`excluded.date_completed`,
-						updatedAt: sql`excluded.updated_at`,
-					},
-				})
-		}
+		await this.replaceContractsSnapshot(corporationId, contracts as EsiCorporationContract[])
 	}
 
 	/**
@@ -4431,16 +4402,22 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			corporationId,
 			characterId
 		)
+		await this.replaceContractsSnapshot(corporationId, contracts)
+	}
 
-		// Batch insert to prevent timeouts
-		const BATCH_SIZE = 20 // Contracts have many fields, use smaller batch
-		for (let i = 0; i < contracts.length; i += BATCH_SIZE) {
-			const batch = contracts.slice(i, i + BATCH_SIZE)
+	private async replaceContractsSnapshot(
+		_corporationId: string,
+		contracts: EsiCorporationContract[]
+	): Promise<void> {
+		const normalizedContracts = this.dedupeContractsByContractId(contracts)
+		const BATCH_SIZE = 20
+
+		for (let i = 0; i < normalizedContracts.length; i += BATCH_SIZE) {
+			const batch = normalizedContracts.slice(i, i + BATCH_SIZE)
 			const valuesToInsert = batch.map((contract) => ({
-				corporationId: String(corporationId),
-				contractId: contract.contract_id,
-				acceptorId: contract.acceptor_id || null,
-				assigneeId: contract.assignee_id,
+				contractId: String(contract.contract_id),
+				acceptorId: contract.acceptor_id?.toString() || null,
+				assigneeId: contract.assignee_id.toString(),
 				availability: contract.availability,
 				buyout: contract.buyout?.toString() || null,
 				collateral: contract.collateral?.toString() || null,
@@ -4449,13 +4426,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				dateExpired: new Date(contract.date_expired),
 				dateIssued: new Date(contract.date_issued),
 				daysToComplete: contract.days_to_complete ?? null,
-				endLocationId: contract.end_location_id || null,
+				endLocationId: contract.end_location_id?.toString() || null,
 				forCorporation: contract.for_corporation,
-				issuerCorporationId: contract.issuer_corporation_id,
-				issuerId: contract.issuer_id,
+				issuerCorporationId: contract.issuer_corporation_id.toString(),
+				issuerId: contract.issuer_id.toString(),
 				price: contract.price?.toString() || null,
 				reward: contract.reward?.toString() || null,
-				startLocationId: contract.start_location_id || null,
+				startLocationId: contract.start_location_id?.toString() || null,
 				status: contract.status,
 				title: contract.title || null,
 				type: contract.type,
@@ -4467,15 +4444,25 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				.insert(corporationContracts)
 				.values(valuesToInsert)
 				.onConflictDoUpdate({
-					target: [corporationContracts.corporationId, corporationContracts.contractId],
+					target: [corporationContracts.contractId],
 					set: {
-						status: sql`excluded.status`,
+						acceptorId: sql`excluded.acceptor_id`,
 						dateAccepted: sql`excluded.date_accepted`,
 						dateCompleted: sql`excluded.date_completed`,
+						status: sql`excluded.status`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})
 		}
+	}
+
+	private dedupeContractsByContractId(contracts: EsiCorporationContract[]): EsiCorporationContract[] {
+		const byContractId = new Map<string, EsiCorporationContract>()
+		for (const contract of contracts) {
+			byContractId.set(String(contract.contract_id), contract)
+		}
+
+		return [...byContractId.values()]
 	}
 
 	/**
@@ -5843,20 +5830,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 * Get corporation contracts
 	 */
 	async getContracts(corporationId: string, status?: string): Promise<CorporationContractData[]> {
+		const baseWhere = or(
+			eq(corporationContracts.assigneeId, corporationId),
+			eq(corporationContracts.issuerId, corporationId)
+		)
+
 		const results = status
 			? await this.getDb().query.corporationContracts.findMany({
-					where: and(
-						eq(corporationContracts.corporationId, corporationId),
-						eq(corporationContracts.status, status)
-					),
+					where: and(baseWhere, eq(corporationContracts.status, status)),
 				})
 			: await this.getDb().query.corporationContracts.findMany({
-					where: eq(corporationContracts.corporationId, corporationId),
+					where: baseWhere,
 				})
 
 		return results.map((r) => ({
 			id: r.id,
-			corporationId: r.corporationId,
 			contractId: r.contractId,
 			acceptorId: r.acceptorId,
 			assigneeId: r.assigneeId,
@@ -5953,17 +5941,27 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	/**
 	 * Get leaderboard for completed courier contracts assigned to an alliance
 	 */
-	async getCourierLeaderboard(allianceId: string, since?: Date): Promise<CourierLeaderboard> {
+	async getCourierLeaderboard(
+		allianceId: string,
+		options?: {
+			since?: Date
+			before?: Date
+		}
+	): Promise<CourierLeaderboard> {
 		const conditions: SQL[] = [
 			eq(corporationContracts.assigneeId, allianceId),
 			eq(corporationContracts.type, 'courier'),
 			eq(corporationContracts.status, 'finished'),
+			isNotNull(corporationContracts.acceptorId),
 		]
-		if (since) {
-			conditions.push(gt(corporationContracts.dateCompleted, since))
+		if (options?.since) {
+			conditions.push(gte(corporationContracts.dateCompleted, options.since))
+		}
+		if (options?.before) {
+			conditions.push(lt(corporationContracts.dateCompleted, options.before))
 		}
 
-		const distinct = this.getDb()
+		const distinctContracts = this.getDb()
 			.selectDistinctOn([corporationContracts.contractId], {
 				contractId: corporationContracts.contractId,
 				acceptorId: corporationContracts.acceptorId,
@@ -5977,28 +5975,28 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		const results = await this.getDb()
 			.select({
-				acceptorId: distinct.acceptorId,
+				acceptorId: distinctContracts.acceptorId,
 				contractsCompleted: sql<number>`count(*)`.as('contracts_completed'),
-				totalVolume: sql<number>`coalesce(sum(cast(${distinct.volume} as numeric)), 0)`.as(
+				totalVolume: sql<number>`coalesce(sum(cast(${distinctContracts.volume} as numeric)), 0)`.as(
 					'total_volume'
 				),
-				totalReward: sql<number>`coalesce(sum(cast(${distinct.reward} as numeric)), 0)`.as(
+				totalReward: sql<number>`coalesce(sum(cast(${distinctContracts.reward} as numeric)), 0)`.as(
 					'total_reward'
 				),
-				oldestContract: sql<Date | null>`min(${distinct.dateCompleted})`.as('oldest_contract'),
+				oldestContract: sql<Date | null>`min(${distinctContracts.dateCompleted})`.as(
+					'oldest_contract'
+				),
 			})
-			.from(distinct)
-			.groupBy(distinct.acceptorId)
+			.from(distinctContracts)
+			.groupBy(distinctContracts.acceptorId)
 			.orderBy(sql`count(*) desc`)
 
-		const entries = results
-			.filter((r) => r.acceptorId !== null)
-			.map((r) => ({
-				acceptorId: r.acceptorId!,
-				contractsCompleted: Number(r.contractsCompleted),
-				totalVolume: Number(r.totalVolume),
-				totalReward: Number(r.totalReward),
-			}))
+		const entries = results.map((r) => ({
+			acceptorId: r.acceptorId!,
+			contractsCompleted: Number(r.contractsCompleted),
+			totalVolume: Number(r.totalVolume),
+			totalReward: Number(r.totalReward),
+		}))
 
 		const oldestContractDate = results.reduce<Date | null>((min, r) => {
 			if (!r.oldestContract) return min

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -16,7 +16,7 @@ import {
 	sql,
 } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import { logger } from '@repo/hono-helpers'
+import { logger, TimeCache } from '@repo/hono-helpers'
 import { parseDateOrNull } from '@repo/worker-utils'
 import { retryWithBackoff } from '@repo/workflow-utils'
 import { getStructureTabForTypeId } from '@repo/structures'
@@ -484,6 +484,7 @@ function hoursBetween(start: Date, end: Date): number {
  */
 export class EveCorporationDataDO extends DurableObject<Env> implements EveCorporationData {
 	private readonly DIRECTORS_CACHE_TTL = 30 * 60 // 30 minutes in seconds (KV expirationTtl)
+	private readonly courierLeaderboardCache = new TimeCache<CourierLeaderboard>(5 * 60 * 1000)
 
 	private isNpcCorporationId(corporationId: string): boolean {
 		const parsed = Number(corporationId)
@@ -4454,6 +4455,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					},
 				})
 		}
+
+		this.courierLeaderboardCache.clear()
 	}
 
 	private dedupeContractsByContractId(contracts: EsiCorporationContract[]): EsiCorporationContract[] {
@@ -4463,6 +4466,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		return [...byContractId.values()]
+	}
+
+	private getCourierLeaderboardCacheKey(
+		allianceId: string,
+		options?: {
+			since?: Date
+			before?: Date
+		}
+	): string {
+		return [
+			'alliance',
+			allianceId,
+			options?.since?.toISOString() ?? 'all',
+			options?.before?.toISOString() ?? 'all',
+		].join(':')
 	}
 
 	/**
@@ -5948,63 +5966,66 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			before?: Date
 		}
 	): Promise<CourierLeaderboard> {
-		const conditions: SQL[] = [
-			eq(corporationContracts.assigneeId, allianceId),
-			eq(corporationContracts.type, 'courier'),
-			eq(corporationContracts.status, 'finished'),
-			isNotNull(corporationContracts.acceptorId),
-		]
-		if (options?.since) {
-			conditions.push(gte(corporationContracts.dateCompleted, options.since))
-		}
-		if (options?.before) {
-			conditions.push(lt(corporationContracts.dateCompleted, options.before))
-		}
+		const cacheKey = this.getCourierLeaderboardCacheKey(allianceId, options)
+		return this.courierLeaderboardCache.getOrSet(cacheKey, async () => {
+			const conditions: SQL[] = [
+				eq(corporationContracts.assigneeId, allianceId),
+				eq(corporationContracts.type, 'courier'),
+				eq(corporationContracts.status, 'finished'),
+				isNotNull(corporationContracts.acceptorId),
+			]
+			if (options?.since) {
+				conditions.push(gte(corporationContracts.dateCompleted, options.since))
+			}
+			if (options?.before) {
+				conditions.push(lt(corporationContracts.dateCompleted, options.before))
+			}
 
-		const distinctContracts = this.getDb()
-			.selectDistinctOn([corporationContracts.contractId], {
-				contractId: corporationContracts.contractId,
-				acceptorId: corporationContracts.acceptorId,
-				volume: corporationContracts.volume,
-				reward: corporationContracts.reward,
-				dateCompleted: corporationContracts.dateCompleted,
-			})
-			.from(corporationContracts)
-			.where(and(...conditions))
-			.as('distinct_contracts')
+			const distinctContracts = this.getDb()
+				.selectDistinctOn([corporationContracts.contractId], {
+					contractId: corporationContracts.contractId,
+					acceptorId: corporationContracts.acceptorId,
+					volume: corporationContracts.volume,
+					reward: corporationContracts.reward,
+					dateCompleted: corporationContracts.dateCompleted,
+				})
+				.from(corporationContracts)
+				.where(and(...conditions))
+				.as('distinct_contracts')
 
-		const results = await this.getDb()
-			.select({
-				acceptorId: distinctContracts.acceptorId,
-				contractsCompleted: sql<number>`count(*)`.as('contracts_completed'),
-				totalVolume: sql<number>`coalesce(sum(cast(${distinctContracts.volume} as numeric)), 0)`.as(
-					'total_volume'
-				),
-				totalReward: sql<number>`coalesce(sum(cast(${distinctContracts.reward} as numeric)), 0)`.as(
-					'total_reward'
-				),
-				oldestContract: sql<Date | null>`min(${distinctContracts.dateCompleted})`.as(
-					'oldest_contract'
-				),
-			})
-			.from(distinctContracts)
-			.groupBy(distinctContracts.acceptorId)
-			.orderBy(sql`count(*) desc`)
+			const results = await this.getDb()
+				.select({
+					acceptorId: distinctContracts.acceptorId,
+					contractsCompleted: sql<number>`count(*)`.as('contracts_completed'),
+					totalVolume: sql<number>`coalesce(sum(cast(${distinctContracts.volume} as numeric)), 0)`.as(
+						'total_volume'
+					),
+					totalReward: sql<number>`coalesce(sum(cast(${distinctContracts.reward} as numeric)), 0)`.as(
+						'total_reward'
+					),
+					oldestContract: sql<Date | null>`min(${distinctContracts.dateCompleted})`.as(
+						'oldest_contract'
+					),
+				})
+				.from(distinctContracts)
+				.groupBy(distinctContracts.acceptorId)
+				.orderBy(sql`count(*) desc`)
 
-		const entries = results.map((r) => ({
-			acceptorId: r.acceptorId!,
-			contractsCompleted: Number(r.contractsCompleted),
-			totalVolume: Number(r.totalVolume),
-			totalReward: Number(r.totalReward),
-		}))
+			const entries = results.map((r) => ({
+				acceptorId: r.acceptorId!,
+				contractsCompleted: Number(r.contractsCompleted),
+				totalVolume: Number(r.totalVolume),
+				totalReward: Number(r.totalReward),
+			}))
 
-		const oldestContractDate = results.reduce<Date | null>((min, r) => {
-			if (!r.oldestContract) return min
-			const d = new Date(r.oldestContract)
-			return min === null || d < min ? d : min
-		}, null)
+			const oldestContractDate = results.reduce<Date | null>((min, r) => {
+				if (!r.oldestContract) return min
+				const d = new Date(r.oldestContract)
+				return min === null || d < min ? d : min
+			}, null)
 
-		return { entries, oldestContractDate }
+			return { entries, oldestContractDate }
+		})
 	}
 
 	/**

--- a/apps/eve-corporation-data/src/test/unit/services/contracts-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/contracts-storage.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { corporationContracts } from '../../../db/schema'
+import { EveCorporationDataDO } from '../../../durable-object'
+
+function createDoInstance(db: any) {
+	const instance = new EveCorporationDataDO(
+		{} as DurableObjectState,
+		{
+			DATABASE_URL: 'postgres://example',
+			UNIVERSE: {} as never,
+			EVE_TOKEN_STORE: {} as never,
+		} as never
+	)
+
+	;(instance as any).getDb = () => db
+
+	return instance
+}
+
+describe('contract storage', () => {
+	it('stores contracts keyed by contract id only', async () => {
+		const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
+		const values = vi.fn(() => ({ onConflictDoUpdate }))
+		const insert = vi.fn(() => ({ values }))
+		const db = { insert }
+		const instance = createDoInstance(db)
+
+		await instance.storeContracts('123', [
+			{
+				contract_id: '987',
+				acceptor_id: '222',
+				assignee_id: '333',
+				availability: 'alliance',
+				buyout: 10,
+				collateral: 20,
+				date_accepted: '2026-07-16T12:00:00Z',
+				date_completed: null,
+				date_expired: '2026-07-20T12:00:00Z',
+				date_issued: '2026-07-15T12:00:00Z',
+				days_to_complete: 7,
+				end_location_id: '444',
+				for_corporation: true,
+				issuer_corporation_id: '555',
+				issuer_id: '666',
+				price: 30,
+				reward: 40,
+				start_location_id: '777',
+				status: 'outstanding',
+				title: 'Contract One',
+				type: 'courier',
+				volume: 50,
+			},
+			{
+				contract_id: '987',
+				acceptor_id: '222',
+				assignee_id: '333',
+				availability: 'alliance',
+				buyout: 10,
+				collateral: 20,
+				date_accepted: '2026-07-16T12:00:00Z',
+				date_completed: '2026-07-16T13:00:00Z',
+				date_expired: '2026-07-20T12:00:00Z',
+				date_issued: '2026-07-15T12:00:00Z',
+				days_to_complete: 7,
+				end_location_id: '444',
+				for_corporation: true,
+				issuer_corporation_id: '555',
+				issuer_id: '666',
+				price: 30,
+				reward: 40,
+				start_location_id: '777',
+				status: 'finished',
+				title: 'Contract One',
+				type: 'courier',
+				volume: 50,
+			},
+		])
+
+		expect(insert).toHaveBeenCalledWith(corporationContracts)
+		expect(values).toHaveBeenCalledTimes(1)
+
+		const rows = (values.mock.calls[0] as unknown as [Array<Record<string, unknown>>])[0]
+		expect(rows).toHaveLength(1)
+		expect(rows[0]).not.toHaveProperty('corporationId')
+		expect(rows[0]).toMatchObject({
+			contractId: '987',
+			acceptorId: '222',
+			assigneeId: '333',
+			status: 'finished',
+		})
+
+		expect(onConflictDoUpdate).toHaveBeenCalledTimes(1)
+		expect(onConflictDoUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				target: [corporationContracts.contractId],
+			})
+		)
+	})
+
+	it('keeps the corporation context on reads without storing it in the table', async () => {
+		const findMany = vi.fn().mockResolvedValue([
+			{
+				id: 'row-1',
+				contractId: '987',
+				acceptorId: '222',
+				assigneeId: '333',
+				availability: 'alliance',
+				buyout: '10',
+				collateral: '20',
+				dateAccepted: null,
+				dateCompleted: null,
+				dateExpired: new Date('2026-07-20T12:00:00Z'),
+				dateIssued: new Date('2026-07-15T12:00:00Z'),
+				daysToComplete: 7,
+				endLocationId: '444',
+				forCorporation: true,
+				issuerCorporationId: '555',
+				issuerId: '666',
+				price: '30',
+				reward: '40',
+				startLocationId: '777',
+				status: 'outstanding',
+				title: 'Contract One',
+				type: 'courier',
+				volume: '50',
+				updatedAt: new Date('2026-07-16T14:00:00Z'),
+			},
+		])
+		const db = {
+			query: {
+				corporationContracts: {
+					findMany,
+				},
+			},
+		}
+		const instance = createDoInstance(db)
+
+		const results = await instance.getContracts('123')
+
+		expect(findMany).toHaveBeenCalledTimes(1)
+		expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.anything() }))
+		expect(results).toEqual([
+			expect.objectContaining({
+				contractId: '987',
+				status: 'outstanding',
+			}),
+		])
+	})
+})

--- a/apps/ui/src/client/features/freight/routes/leaderboard.tsx
+++ b/apps/ui/src/client/features/freight/routes/leaderboard.tsx
@@ -13,8 +13,7 @@ import {
 } from '@/components/ui/table'
 import { useFreightLeaderboard } from '@/hooks/useFreightContracts'
 import { usePageTitle } from '@/hooks/usePageTitle'
-
-import { formatNumber } from '../utils'
+import type { FreightLeaderboardPeriod } from '@/lib/freight-api'
 
 function getRankDisplay(rank: number): React.ReactNode {
     switch (rank) {
@@ -32,7 +31,7 @@ function getRankDisplay(rank: number): React.ReactNode {
 export default function FreightLeaderboardPage() {
     usePageTitle('Freight Leaderboard')
 
-    const [period, setPeriod] = useState<'30d' | 'all'>('30d')
+    const [period, setPeriod] = useState<FreightLeaderboardPeriod>('month')
     const { data: entries, isLoading } = useFreightLeaderboard(period)
 
     const byContracts = useMemo(
@@ -57,26 +56,32 @@ export default function FreightLeaderboardPage() {
 
     const isEmpty = !entries || entries.entries.length === 0
 
-    const oldestDate = entries?.oldestContractDate
-        ? new Date(entries.oldestContractDate).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
-        : null
+    const periodLabel =
+        period === 'month' ? 'Current month' : period === 'previous-month' ? 'Previous month' : 'All time'
+    const formatWholeNumber = (value: string | number): string =>
+        new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(
+            typeof value === 'string' ? Number(value) : value
+        )
 
     return (
         <Container size="wide">
             <div className="mb-section md:mb-10 flex items-end justify-between gap-4">
                 <div>
                     <h1 className="text-3xl font-bold gradient-text">Freight Leaderboard</h1>
-                    <p className="text-muted-foreground mt-1">
-                        Top haulers by completed courier contracts
-                        {oldestDate && <span className="ml-2 text-xs">· since {oldestDate}</span>}
-                    </p>
+                    <p className="text-muted-foreground mt-1">Top haulers by completed courier contracts · {periodLabel}</p>
                 </div>
                 <div className="flex rounded-md border overflow-hidden shrink-0">
                     <button
-                        onClick={() => setPeriod('30d')}
-                        className={`px-4 py-1.5 text-sm font-medium transition-colors ${period === '30d' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted'}`}
+                        onClick={() => setPeriod('month')}
+                        className={`px-4 py-1.5 text-sm font-medium transition-colors ${period === 'month' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted'}`}
                     >
-                        Last 30 Days
+                        Current Month
+                    </button>
+                    <button
+                        onClick={() => setPeriod('previous-month')}
+                        className={`px-4 py-1.5 text-sm font-medium transition-colors ${period === 'previous-month' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted'}`}
+                    >
+                        Previous Month
                     </button>
                     <button
                         onClick={() => setPeriod('all')}
@@ -180,7 +185,7 @@ export default function FreightLeaderboardPage() {
                                                     {entry.acceptorName ?? entry.acceptorId}
                                                 </TableCell>
                                                 <TableCell className="text-right font-mono">
-                                                    {formatNumber(entry.totalVolume)}
+                                                    {formatWholeNumber(entry.totalVolume)}
                                                 </TableCell>
                                             </TableRow>
                                         ))}

--- a/apps/ui/src/client/hooks/useFreightContracts.ts
+++ b/apps/ui/src/client/hooks/useFreightContracts.ts
@@ -4,6 +4,7 @@ import { freightApi } from '@/lib/freight-api'
 import toast from '@/lib/toast'
 
 import type {
+	FreightLeaderboardPeriod,
 	FreightContractSortDirection,
 	FreightContractSortKey,
 } from '@/lib/freight-api'
@@ -60,7 +61,7 @@ export function useOpenContractInGame() {
 /**
  * Fetch courier contract leaderboard
  */
-export function useFreightLeaderboard(period?: '30d' | 'all') {
+export function useFreightLeaderboard(period?: FreightLeaderboardPeriod) {
 	return useQuery({
 		queryKey: [...freightContractKeys.leaderboard(), period],
 		queryFn: () => freightApi.getLeaderboard(period),

--- a/apps/ui/src/client/lib/freight-api.ts
+++ b/apps/ui/src/client/lib/freight-api.ts
@@ -14,6 +14,8 @@ import type {
 
 const FREIGHT_API_BASE = '/freight'
 
+export type FreightLeaderboardPeriod = 'month' | 'previous-month' | 'all'
+
 /**
  * Enriched contract data returned by the API (with resolved names)
  */
@@ -176,7 +178,7 @@ export class FreightApiClient extends ApiClient {
 	/**
 	 * Get courier contract leaderboard
 	 */
-	async getLeaderboard(period?: '30d' | 'all'): Promise<FreightLeaderboard> {
+	async getLeaderboard(period?: FreightLeaderboardPeriod): Promise<FreightLeaderboard> {
 		const params = period && period !== 'all' ? `?period=${period}` : ''
 		return this.get(`${FREIGHT_API_BASE}/leaderboard${params}`)
 	}

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -727,7 +727,6 @@ export interface CorporationOrderData {
  */
 export interface CorporationContractData {
 	id: string
-	corporationId: string
 	contractId: string
 	acceptorId: string | null
 	assigneeId: string
@@ -1698,9 +1697,16 @@ export interface EveCorporationData {
 	/**
 	 * Get leaderboard for completed courier contracts assigned to an alliance
 	 * @param allianceId - The alliance ID
+	 * @param options - Optional date window filters
 	 * @returns Leaderboard entries sorted by contracts completed descending
 	 */
-	getCourierLeaderboard(allianceId: string, since?: Date): Promise<CourierLeaderboard>
+	getCourierLeaderboard(
+		allianceId: string,
+		options?: {
+			since?: Date
+			before?: Date
+		}
+	): Promise<CourierLeaderboard>
 
 	/**
 	 * Get corporation industry jobs


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes duplicate courier contract rows caused by corporation-scoped storage, reworks the freight leaderboard to support month/previous-month/all-time filtering instead of a fixed "last 30 days" window, and adds a 5-minute in-memory cache for leaderboard queries.

## Changes
- `corporation_contracts` is now keyed globally by `contract_id` instead of `(corporation_id, contract_id)`: dropped the `corporation_id` column/FK and the old composite unique constraint, added a unique constraint on `contract_id` alone, plus two new composite indexes (`assignee_id, type, status, acceptor_id` and `...,date_completed,acceptor_id`) to support leaderboard queries.
- `storeContracts`/contract-sync now dedupe incoming ESI contracts by `contract_id` before upserting (`replaceContractsSnapshot` + `dedupeContractsByContractId`), and `getContracts` filters by `assignee_id`/`issuer_id` instead of the removed `corporation_id`.
- `getCourierLeaderboard` now takes an `{ since, before }` options object (instead of a single `since` date), excludes contracts with a null `acceptor_id`, and uses `gte`/`lt` for bounded date ranges.
- Added `resolveFreightLeaderboardWindow` (`apps/core/src/routes/freight-leaderboard-period.ts`) to map a `period` query param (`month` | `previous-month` | `all`, with `30d` treated as an alias for `month`) to a concrete date window.
- Added a 5-minute `TimeCache<CourierLeaderboard>` (`courierLeaderboardCache`) inside `EveCorporationDataDO`, keyed by alliance ID and the resolved `since`/`before` window; the cache is cleared whenever contracts are written via `replaceContractsSnapshot`.
- Updated the UI leaderboard page/hooks/API client (`freight-api.ts`, `useFreightContracts.ts`, `leaderboard.tsx`) to use the new `FreightLeaderboardPeriod` type and month/previous-month/all toggle buttons.
- Regenerated Drizzle migration `0026_shiny_revanche.sql` and its snapshot/journal metadata for the schema change.

## Testing
- Added unit tests for `resolveFreightLeaderboardWindow` covering the default, `30d` alias, `previous-month`, and `all` cases.
- Added unit tests for contract storage covering deduping contracts by `contract_id` on write and filtering on read without the removed `corporationId` field.
<!-- claude:end -->
