### PR TITLE
keep user profile detaisl access open to HR users until applicaton is

### DIFF
--- a/apps/core/src/lib/character-access.ts
+++ b/apps/core/src/lib/character-access.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
+import { isOpenApplicationStatus } from '@repo/hr'
 
 import { userCharacters, users } from '../db/schema'
 import { hasHrAuditorPermission } from './hr-access'
@@ -105,17 +106,17 @@ async function resolveSharedCorporationCandidates(
 ): Promise<SharedCorporationCandidate[]> {
 	const core = getStub<CoreRpc>(c.env.CORE, 'default')
 	const hr = getStub<Hr>(c.env.HR, 'default')
-	const [viewerCorporations, targetCorporations, pendingApplications, underReviewApplications] = await Promise.all([
+	const [viewerCorporations, targetCorporations, targetApplications] = await Promise.all([
 		core.getUserCorporations(user.id),
 		core.getUserCorporations(targetOwner.userId),
-		hr.listApplications({ userId: targetOwner.userId, status: 'pending' }, user.id, {
-			isAdmin: user.is_admin,
-			isAuditor: false,
-		}),
-		hr.listApplications({ userId: targetOwner.userId, status: 'under_review' }, user.id, {
-			isAdmin: user.is_admin,
-			isAuditor: false,
-		}),
+		hr.listApplications(
+			{ userId: targetOwner.userId },
+			user.id,
+			{
+				isAdmin: user.is_admin,
+				isAuditor: false,
+			}
+		),
 	])
 
 	const candidateCorporationIds = new Map<string, SharedCorporationCandidate>()
@@ -130,7 +131,8 @@ async function resolveSharedCorporationCandidates(
 		})
 	}
 
-	for (const application of [...pendingApplications, ...underReviewApplications]) {
+	for (const application of targetApplications) {
+		if (!isOpenApplicationStatus(application.status)) continue
 		if (!candidateCorporationIds.has(application.corporationId)) {
 			candidateCorporationIds.set(application.corporationId, {
 				corporationId: application.corporationId,

--- a/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
+++ b/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
@@ -291,7 +291,7 @@ describe('character detail access for HR page viewers', () => {
 		hoisted.core.getUserCorporations.mockResolvedValue([])
 		hoisted.hr.listApplications.mockImplementation(async (_filters: any, _userId: string, access: any) => {
 			if (access.isAdmin || access.isAuditor) return []
-			return [{ corporationId: '2001', status: 'pending' }]
+			return [{ corporationId: '2001', status: 'accepted' }]
 		})
 		hoisted.hr.checkPermission.mockResolvedValue(true)
 

--- a/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
@@ -233,7 +233,7 @@ describe('fulcrum route access matrix', () => {
 				characterId: '3001',
 				characterName: 'Alt Pilot',
 				corporationId: '2001',
-				status: 'under_review',
+				status: 'accepted',
 			},
 		] as any)
 		hrStub.checkPermission.mockImplementation(async (_userId, corporationId, role) => {
@@ -624,7 +624,7 @@ describe('fulcrum route access matrix', () => {
 							characterId: '3001',
 							characterName: 'Target Pilot',
 							applicationText: 'app',
-							status: 'under_review',
+							status: 'accepted',
 							reviewedBy: null,
 							reviewedByCharacterName: null,
 							reviewedAt: null,
@@ -1304,7 +1304,7 @@ describe('fulcrum route access matrix', () => {
 							characterId: '3001',
 							characterName: 'Alt Pilot',
 							applicationText: 'app',
-							status: 'under_review',
+							status: 'accepted',
 							reviewedBy: null,
 							reviewedByCharacterName: null,
 							reviewedAt: null,

--- a/apps/core/src/routes/characters.ts
+++ b/apps/core/src/routes/characters.ts
@@ -297,7 +297,7 @@ app.post('/ownership', requireAuth(), async (c) => {
  * Fetch private profile data and skills for intentional profile-detail hydration only.
  * This route shares the same visibility matrix as the overview route, with the
  * additional immunitas gate for non-owner access. The backend derives HR scope
- * from viewer/target corp attachments and active applications; no frontend corp
+ * from viewer/target corp attachments and open applications; no frontend corp
  * scope is accepted. It is the only character profile route that queues
  * profile-data immunitas access alerts.
  */

--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -15,7 +15,7 @@ import type { Core } from '@repo/core'
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { Fulcrum, ReportRequestSource, ReportSectionName } from '@repo/fulcrum'
-import { ACTIVE_APPLICATION_STATUSES } from '@repo/hr'
+import { isOpenApplicationStatus } from '@repo/hr'
 import type { Hr } from '@repo/hr'
 import type { App } from '../context'
 import type { SessionUser } from '../context'
@@ -116,7 +116,7 @@ async function resolveApplicationFulcrumCorporationForTargetUser(
 			continue
 		}
 		sawPermission = true
-		if (ACTIVE_APPLICATION_STATUSES.includes(application.status)) {
+		if (isOpenApplicationStatus(application.status)) {
 			sawOpenApplication = true
 			return {
 				corporationId: application.corporationId,

--- a/apps/ui/src/client/features/applications/components/character-identity-summary.tsx
+++ b/apps/ui/src/client/features/applications/components/character-identity-summary.tsx
@@ -15,6 +15,7 @@ interface CharacterSpWalletLineProps {
 	skillPoints: number | null | undefined
 	walletBalance: string | null | undefined
 	isLoading?: boolean
+	unavailableReason?: string | null
 	className?: string
 }
 
@@ -31,6 +32,7 @@ interface CharacterIdentitySummaryProps {
 	walletBalance?: string | null | undefined
 	showMetrics?: boolean
 	isMetricsLoading?: boolean
+	privateDataUnavailableNote?: string | null
 	portraitSize?: 'sm' | 'md' | 'lg' | 'xl' | 'auto'
 	nameBadges?: ReactNode
 	enableCopyName?: boolean

--- a/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
+++ b/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
@@ -43,6 +43,7 @@ export interface SharedProfileCharacter {
 	skillPoints?: number | null
 	walletBalance?: string | null
 	isMetricsLoading?: boolean
+	privateDataUnavailableNote?: string | null
 	isExternal?: boolean
 	latestReport?: CharacterReportMetadata | null
 	hasPendingReport?: boolean
@@ -145,7 +146,7 @@ export function ProfileCharactersSection({
 											</Button>
 										</div>
 									)}
-							<CharacterIdentitySummary
+									<CharacterIdentitySummary
 								characterId={character.characterId}
 								characterName={character.characterName}
 								hasValidToken={character.hasValidToken}

--- a/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
@@ -1,6 +1,6 @@
 import { useQueries, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
-import { Scan, Shield, Users } from 'lucide-react'
+import { AlertCircle, Scan, Shield, Users } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { Navigate, Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 
@@ -35,6 +35,7 @@ import {
 	useFulcrumScanDmPreference,
 } from '../components/fulcrum-scan-dialogs'
 import { useApplications, useHRNotes, useRequestFulcrumReport, useRequestFulcrumReportBatch } from '../hooks'
+import { getPrivateDataUnavailableMessage } from '../utils/private-data'
 import {
 	auditorUserKeys,
 	useAuditorFulcrum,
@@ -214,6 +215,7 @@ export default function HrAuditorUserProfilePage() {
 	const spByCharacterId = new Map<string, number | null>()
 	const walletByCharacterId = new Map<string, string | null>()
 	const metricsLoadingByCharacterId = new Map<string, boolean>()
+	const privateDataUnavailableNoteByCharacterId = new Map<string, string | null>()
 	rows.forEach((character, index) => {
 		const query = characterDetailQueries[index]
 		const detail = query?.data
@@ -223,7 +225,13 @@ export default function HrAuditorUserProfilePage() {
 			character.characterId,
 			!!character.corporationId && (query?.isPending ?? false) && detail == null
 		)
+		privateDataUnavailableNoteByCharacterId.set(
+			character.characterId,
+			getPrivateDataUnavailableMessage(query?.error)
+		)
 	})
+	const privateDataUnavailableMessage =
+		[...privateDataUnavailableNoteByCharacterId.values()].find((note) => Boolean(note)) ?? null
 
 	if (!authLoading && !isAuthenticated) {
 		return <Navigate to="/login" replace />
@@ -458,9 +466,22 @@ export default function HrAuditorUserProfilePage() {
 					</Link>
 				</Button>
 			}
-		>
+			>
 			<>
 				<div className="space-y-6">
+					{privateDataUnavailableMessage && (
+						<div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+							<div className="flex items-start gap-3">
+								<AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+								<div className="space-y-1">
+									<p className="font-medium">Private ESI data is hidden for some characters</p>
+									<p className="text-sm text-amber-800 dark:text-amber-200">
+										{privateDataUnavailableMessage}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
 					<ProfileCharactersSection
 						characters={rows.map((character) => ({
 							characterId: character.characterId,
@@ -478,6 +499,7 @@ export default function HrAuditorUserProfilePage() {
 							skillPoints: spByCharacterId.get(character.characterId),
 							walletBalance: walletByCharacterId.get(character.characterId),
 							isMetricsLoading: metricsLoadingByCharacterId.get(character.characterId),
+							privateDataUnavailableNote: privateDataUnavailableNoteByCharacterId.get(character.characterId),
 							joinDate: memberMetaByCharacterId.get(character.characterId)?.joinDate,
 							lastLogin: memberMetaByCharacterId.get(character.characterId)?.lastLogin,
 							locationSystem: memberMetaByCharacterId.get(character.characterId)?.locationSystem,

--- a/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useQueries } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
 import { Navigate, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { AlertCircle } from 'lucide-react'
 
 import { LoadingSpinner } from '@/components/ui/loading'
 import { useAuth } from '@/hooks/useAuth'
@@ -24,6 +25,7 @@ import {
 	UserProfileStatsSeparator,
 } from '../components/user-profile-page-shell'
 import { useRequestFulcrumReport, useRequestFulcrumReportBatch } from '../hooks'
+import { getPrivateDataUnavailableMessage } from '../utils/private-data'
 import {
 	applicationsApi,
 	type Application,
@@ -175,6 +177,7 @@ export default function HrUserProfilePage() {
 	const spByCharacterId = new Map<string, number | null>()
 	const walletByCharacterId = new Map<string, string | null>()
 	const metricsLoadingByCharacterId = new Map<string, boolean>()
+	const privateDataUnavailableNoteByCharacterId = new Map<string, string | null>()
 	rows.forEach((character, index) => {
 		const query = characterDetailQueries[index]
 		const detail = query?.data
@@ -184,7 +187,13 @@ export default function HrUserProfilePage() {
 			character.characterId,
 			(query?.isPending ?? false) && detail == null
 		)
+		privateDataUnavailableNoteByCharacterId.set(
+			character.characterId,
+			getPrivateDataUnavailableMessage(query?.error)
+		)
 	})
+	const privateDataUnavailableMessage =
+		[...privateDataUnavailableNoteByCharacterId.values()].find((note) => Boolean(note)) ?? null
 
 	const accountName =
 		sortedApplications[0]?.characterName ?? rows.find((row) => row.isPrimary)?.characterName ?? rows[0]?.characterName ?? userId ?? 'Unknown'
@@ -369,6 +378,19 @@ export default function HrUserProfilePage() {
 				</>
 			}
 		>
+					{privateDataUnavailableMessage && (
+						<div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+							<div className="flex items-start gap-3">
+								<AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+								<div className="space-y-1">
+									<p className="font-medium">Private ESI data is hidden for some characters</p>
+									<p className="text-sm text-amber-800 dark:text-amber-200">
+										{privateDataUnavailableMessage}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
 					<ProfileCharactersSection
 						characters={rows.map((character) => ({
 							characterId: character.characterId,
@@ -386,6 +408,7 @@ export default function HrUserProfilePage() {
 							skillPoints: spByCharacterId.get(character.characterId),
 							walletBalance: walletByCharacterId.get(character.characterId),
 							isMetricsLoading: metricsLoadingByCharacterId.get(character.characterId),
+							privateDataUnavailableNote: privateDataUnavailableNoteByCharacterId.get(character.characterId),
 						}))}
 						fulcrumLoading={fulcrumQuery.isLoading && rows.length === 0}
 						showViewDetailsButton

--- a/apps/ui/src/client/features/applications/utils/private-data.ts
+++ b/apps/ui/src/client/features/applications/utils/private-data.ts
@@ -1,0 +1,18 @@
+const FORBIDDEN_PRIVATE_DATA_MESSAGE =
+	'Private ESI data is hidden because this user does not have an open application or shared corporation access for this character.'
+
+const GENERIC_PRIVATE_DATA_MESSAGE = 'Private ESI data is unavailable right now.'
+
+function isForbiddenError(error: unknown): boolean {
+	return Boolean(
+		error &&
+			typeof error === 'object' &&
+			'status' in error &&
+			(error as { status?: number }).status === 403
+	)
+}
+
+export function getPrivateDataUnavailableMessage(error: unknown): string | null {
+	if (!error) return null
+	return isForbiddenError(error) ? FORBIDDEN_PRIVATE_DATA_MESSAGE : GENERIC_PRIVATE_DATA_MESSAGE
+}

--- a/apps/ui/src/test/unit/features/applications/private-data.unit.test.ts
+++ b/apps/ui/src/test/unit/features/applications/private-data.unit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPrivateDataUnavailableMessage } from '../../../../client/features/applications/utils/private-data'
+
+describe('getPrivateDataUnavailableMessage', () => {
+	it('returns null when no error is present', () => {
+		expect(getPrivateDataUnavailableMessage(null)).toBeNull()
+		expect(getPrivateDataUnavailableMessage(undefined)).toBeNull()
+	})
+
+	it('returns the access explanation for forbidden responses', () => {
+		expect(getPrivateDataUnavailableMessage({ status: 403 })).toBe(
+			'Private ESI data is hidden because this user does not have an open application or shared corporation access for this character.'
+		)
+	})
+
+	it('returns the generic explanation for other failures', () => {
+		expect(getPrivateDataUnavailableMessage({ status: 500 })).toBe(
+			'Private ESI data is unavailable right now.'
+		)
+	})
+})

--- a/docs/hr-permissions-matrix.md
+++ b/docs/hr-permissions-matrix.md
@@ -1,6 +1,6 @@
 # HR Permissions Matrix
 
-Last updated: 2026-06-21
+Last updated: 2026-07-17
 
 Scope notes:
 - Corporation-scoped unless explicitly marked global.
@@ -69,10 +69,10 @@ Scope notes:
 
 | Scenario | HR Reviewer | HR Admin | HR Auditor | Site Admin | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Target user has an active application (`pending` / `under_review`) in a corp where the requester has HR permission | ✅ | ✅ | ✅ | ✅ | The allowance is user-scoped and applies to all of that user's characters. |
-| No active application, but the target user has any character in a corp shared with the requester | ✅ | ✅ | ✅ | ✅ | The fallback is also user-scoped; the requested character does not need to be in the shared corp. |
+| Target user has an open application (`pending` / `under_review` / `accepted`) in a corp where the requester has HR permission | ✅ | ✅ | ✅ | ✅ | The allowance is user-scoped and applies to all of that user's characters. |
+| No open application, but the target user has any character in a corp shared with the requester | ✅ | ✅ | ✅ | ✅ | The fallback is also user-scoped; the requested character does not need to be in the shared corp. |
 | Target is a member-corp CEO | ❌ | ❌ | ✅ | ✅ | CEO gating supersedes the normal HR allowance path. |
-| No active application and no shared corp | ❌ | ❌ | ✅ | ✅ | Auditors and site admins bypass the corp-match requirement; HR staff do not. |
+| No open application and no shared corp | ❌ | ❌ | ✅ | ✅ | Auditors and site admins bypass the corp-match requirement; HR staff do not. |
 
 ## API Access Matrix (Core routes)
 
@@ -94,7 +94,7 @@ Scope notes:
 | `POST /api/corporations/:corpId/members/refresh` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | `PATCH /api/corporations/:corpId/members/:charId/status` (emeritus/active) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
-\* `HR Viewer` access depends on application state constraints from HR service logic (viewer-only corp access is restricted to active review states where enforced).
+\* `HR Viewer` access depends on application state constraints from HR service logic (viewer-only corp access is restricted to open application states where enforced).
 
 ## UI Action Matrix (by surface)
 

--- a/packages/hr/src/index.ts
+++ b/packages/hr/src/index.ts
@@ -22,6 +22,13 @@ export const APPLICATION_STATUSES = [
 /** Application statuses where the application is still being actively processed */
 export const ACTIVE_APPLICATION_STATUSES: readonly ApplicationStatus[] = ['pending', 'under_review']
 
+/** Application statuses where access should still be treated as open */
+export const OPEN_APPLICATION_STATUSES: readonly ApplicationStatus[] = [
+	'pending',
+	'under_review',
+	'accepted',
+]
+
 /**
  * Application status type
  */
@@ -39,6 +46,13 @@ export function isApplicationStatus(value: string): value is ApplicationStatus {
  */
 export function isActiveApplicationStatus(status: string): boolean {
 	return ACTIVE_APPLICATION_STATUSES.includes(status as ApplicationStatus)
+}
+
+/**
+ * Check if an application status is considered open for access gating
+ */
+export function isOpenApplicationStatus(status: string): boolean {
+	return OPEN_APPLICATION_STATUSES.includes(status as ApplicationStatus)
 }
 
 export interface HrAccessState {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Extends HR staff access to a target user's profile so it stays open through the `accepted` application status (not just `pending`/`under_review`), and restores visibility of ESI-derived badges/metrics with an explanatory banner when private profile details are hidden for some characters.

## Changes
- Add `OPEN_APPLICATION_STATUSES` (`pending`, `under_review`, `accepted`) and `isOpenApplicationStatus()` to `@repo/hr`, alongside the existing `ACTIVE_APPLICATION_STATUSES`/`isActiveApplicationStatus()`.
- Update `apps/core/src/lib/character-access.ts` to fetch all of a target user's applications in one call (instead of separate `pending`/`under_review` queries) and filter with `isOpenApplicationStatus()`.
- Update `apps/core/src/routes/fulcrum.ts` to use `isOpenApplicationStatus()` instead of `ACTIVE_APPLICATION_STATUSES.includes(...)`.
- Update the doc comment in `apps/core/src/routes/characters.ts` and `docs/hr-permissions-matrix.md` to reflect "open" (rather than "active") application states, including the `accepted` status.
- Add `getPrivateDataUnavailableMessage()` (`apps/ui/.../utils/private-data.ts`) to derive a user-facing explanation from a character-detail query error (distinguishing 403/forbidden from generic failures).
- Wire the new message into `hr-user-profile.tsx` and `hr-auditor-user-profile.tsx`: compute a per-character `privateDataUnavailableNote`, pass it through `ProfileCharactersSection`/`CharacterIdentitySummary`, and render an amber banner ("Private ESI data is hidden for some characters") when any character's detail fetch is forbidden or fails.

## Testing
- Updated existing unit/integration tests (`characters.hr-auditor.route.test.ts`, `fulcrum.access.route.test.ts`) to assert access remains granted when the application status is `accepted`.
- Added `private-data.unit.test.ts` covering `getPrivateDataUnavailableMessage()` for no-error, 403, and generic-error cases.
<!-- claude:end -->