### PR TITLE
refactor HR application character data and fulcrum UX access checks

### DIFF
--- a/apps/core/src/lib/character-access.ts
+++ b/apps/core/src/lib/character-access.ts
@@ -93,6 +93,10 @@ export function canViewCharacterPrivateDetails(access: CharacterAccessContext): 
 	return canViewCharacterSharedDetails(access)
 }
 
+export function canAccessCharacterPrivateData(access: CharacterAccessContext): boolean {
+	return canViewCharacterPrivateDetails(access) && !shouldBlockCharacterPrivateAccess(access)
+}
+
 export function shouldBlockCharacterPrivateAccess(
 	access: Pick<CharacterAccessContext, 'isActualOwner' | 'targetOwner'>
 ): boolean {

--- a/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
+++ b/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
@@ -233,6 +233,7 @@ describe('character detail access for HR page viewers', () => {
 		expect(res.status).toBe(200)
 		const body = (await res.json()) as any
 		expect(body.viewedAsHrViewer).toBe(true)
+		expect(body.canViewPrivateData).toBe(true)
 		expect(body.public.skills).toBeUndefined()
 		expect(body.private).toBeUndefined()
 	})

--- a/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
@@ -276,6 +276,57 @@ describe('fulcrum route access matrix', () => {
 		expect(body[0]).toMatchObject({ characterId: '3001', hasValidToken: true })
 	})
 
+	it('denies character report listing when backend access scope does not exist', async () => {
+		dbStub.query.userCharacters.findFirst.mockResolvedValue({
+			userId: 'target-1',
+			characterName: 'Alt Pilot',
+		} as any)
+
+		const app = createApp(makeUser(), dbStub)
+		const res = await app.request('/api/fulcrum/characters/3001/reports', {}, env)
+
+		expect(res.status).toBe(403)
+		expect(await res.json()).toEqual({
+			error: 'HR staff access requires a shared corporation or an open application',
+		})
+		expect(hrStub.listApplications).toHaveBeenCalledWith(
+			{ userId: 'target-1' },
+			'user-1',
+			{
+				isAdmin: false,
+				isAuditor: false,
+			}
+		)
+		expect(coreStub.getUserCorporations).toHaveBeenCalledWith('target-1')
+	})
+
+	it('allows character report listing without corporationId when the target has an open application', async () => {
+		dbStub.query.userCharacters.findFirst.mockResolvedValue({
+			userId: 'target-1',
+			characterName: 'Alt Pilot',
+		} as any)
+		hrStub.listApplications.mockResolvedValue([
+			{
+				id: 'app-1',
+				userId: 'target-1',
+				characterId: '3001',
+				characterName: 'Alt Pilot',
+				corporationId: '2001',
+				status: 'accepted',
+			},
+		] as any)
+		hrStub.checkPermission.mockImplementation(async (_userId, corporationId, role) => {
+			return corporationId === '2001' && role === 'hr_reviewer'
+		})
+
+		const app = createApp(makeUser(), dbStub)
+		const res = await app.request('/api/fulcrum/characters/3001/reports', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(hrStub.checkPermission).toHaveBeenCalledWith('user-1', '2001', 'hr_reviewer')
+		expect(fulcrumStub.listReports).toHaveBeenCalledWith({ characterId: '3001' }, 50)
+	})
+
 	it('blocks report creation for immunitas targets and queues an alert', async () => {
 		dbStub.query.userCharacters.findFirst.mockResolvedValue({
 			userId: 'target-user',

--- a/apps/core/src/routes/characters.ts
+++ b/apps/core/src/routes/characters.ts
@@ -8,7 +8,7 @@ import { logger } from '@repo/hono-helpers'
 import { userCharacters } from '../db/schema'
 import { waitUntilWithTelemetry } from '../lib/background-task'
 import {
-	canViewCharacterPrivateDetails,
+	canAccessCharacterPrivateData,
 	resolveCharacterAccessContext,
 	shouldBlockCharacterPrivateAccess,
 } from '../lib/character-access'
@@ -348,7 +348,7 @@ app.get('/:characterId/private', requireAuth(), async (c) => {
 			return c.json({ error: 'You do not have permission to view this character' }, 403)
 		}
 
-		const canViewSensitiveData = canViewCharacterPrivateDetails(access)
+		const canViewSensitiveData = canAccessCharacterPrivateData(access)
 
 		if (!canViewSensitiveData) {
 			return c.json({ error: 'You do not have permission to view this character' }, 403)
@@ -378,6 +378,7 @@ app.get('/:characterId/private', requireAuth(), async (c) => {
 			viewedAsCeoOrDirector: access.viewedAsCeoOrDirector,
 			viewedAsHrViewer: access.viewedAsHrViewer,
 			viewerRole: access.viewerRole,
+			canViewPrivateData: canAccessCharacterPrivateData(access),
 			skills: enrichedSkills,
 			allSkills,
 		}
@@ -622,6 +623,7 @@ app.get('/:characterId', requireAuth(), async (c) => {
 			viewedAsCeoOrDirector: access.viewedAsCeoOrDirector,
 			viewedAsHrViewer: access.viewedAsHrViewer,
 			viewerRole: access.viewerRole,
+			canViewPrivateData: canAccessCharacterPrivateData(access),
 			public: {
 				info: {
 					...info,

--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -143,6 +143,13 @@ type FulcrumReportAccessResolution = {
 	error: 'open_application_required' | 'unauthorized' | null
 }
 
+type FulcrumCharacterReportRow = {
+	characterId: string
+	reports: Awaited<ReturnType<Fulcrum['listReports']>>
+	role: 'CEO' | 'Director' | 'Member' | null
+	activityStatus: 'active' | 'inactive' | 'unknown' | null
+}
+
 async function resolveSharedFulcrumCorporationForTargetUser(
 	c: Context<App>,
 	hr: Hr,
@@ -216,6 +223,93 @@ async function resolveFulcrumReportAccessForTargetUser(
 		corporationId: null,
 		error: 'unauthorized',
 	}
+}
+
+async function buildFulcrumCharacterReportRows(
+	c: Context<App>,
+	userId: string,
+	characters: Array<{
+		characterId: string
+		corporationId?: string | null
+	}>
+): Promise<FulcrumCharacterReportRow[]> {
+	const corporationSnapshotCache = new Map<
+		string,
+		Promise<{
+			ceoId: string | null
+			directorIds: Set<string>
+			lastLogonByCharacterId: Map<string, Date | null>
+		}>
+	>()
+
+	const getCorporationSnapshot = async (corpId: string) => {
+		if (!corporationSnapshotCache.has(corpId)) {
+			const snapshotPromise = (async () => {
+				const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corpId)
+				const [corpInfo, directors, memberTracking] = await Promise.all([
+					corpStub.getCorporationInfo(corpId),
+					corpStub.getDirectors(corpId),
+					corpStub.getMemberTracking(corpId),
+				])
+
+				return {
+					ceoId: corpInfo ? String(corpInfo.ceoId) : null,
+					directorIds: new Set(directors.map((d) => d.characterId)),
+					lastLogonByCharacterId: new Map(
+						memberTracking.map((tracking) => [tracking.characterId, tracking.logonDate])
+					),
+				}
+			})()
+			corporationSnapshotCache.set(corpId, snapshotPromise)
+		}
+		return corporationSnapshotCache.get(corpId)!
+	}
+
+	const fulcrum = getFulcrumStub(c)
+	return await Promise.all(
+		characters.map(async (char) => {
+			let reports: Awaited<ReturnType<Fulcrum['listReports']>> = []
+			try {
+				reports = await fulcrum.listReports({ characterId: char.characterId }, 50)
+			} catch (error) {
+				logger.warn('[Fulcrum] Failed to list reports for character while building user data', {
+					userId,
+					characterId: char.characterId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+
+			let role: 'CEO' | 'Director' | 'Member' | null = null
+			let activityStatus: 'active' | 'inactive' | 'unknown' | null = null
+
+			if (char.corporationId) {
+				const snapshot = await getCorporationSnapshot(String(char.corporationId))
+				if (snapshot.ceoId === char.characterId) {
+					role = 'CEO'
+				} else if (snapshot.directorIds.has(char.characterId)) {
+					role = 'Director'
+				} else {
+					role = 'Member'
+				}
+
+				const lastLogon = snapshot.lastLogonByCharacterId.get(char.characterId)
+				if (!lastLogon) {
+					activityStatus = 'unknown'
+				} else {
+					const activeThresholdMs = 7 * MS_PER_DAY
+					activityStatus =
+						new Date().getTime() - lastLogon.getTime() < activeThresholdMs ? 'active' : 'inactive'
+				}
+			}
+
+			return {
+				characterId: char.characterId,
+				reports,
+				role,
+				activityStatus,
+			}
+		})
+	)
 }
 
 async function resolveFallbackFulcrumCorporationId(
@@ -336,94 +430,24 @@ app.get('/users/:userId/characters', requireAuth(), async (c) => {
 			// do not rely on it for authorization decisions.
 		}
 
-		// Get all linked characters from Core DO
 		const core = getCoreStub(c)
 		const characters = await core.getUserCharacters(userId, false)
-		const corporationSnapshotCache = new Map<
-			string,
-			Promise<{
-				ceoId: string | null
-				directorIds: Set<string>
-				lastLogonByCharacterId: Map<string, Date | null>
-			}>
-		>()
-
-		const getCorporationSnapshot = async (corpId: string) => {
-			if (!corporationSnapshotCache.has(corpId)) {
-				const snapshotPromise = (async () => {
-					const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corpId)
-					const [corpInfo, directors, memberTracking] = await Promise.all([
-						corpStub.getCorporationInfo(corpId),
-						corpStub.getDirectors(corpId),
-						corpStub.getMemberTracking(corpId),
-					])
-
-					return {
-						ceoId: corpInfo ? String(corpInfo.ceoId) : null,
-						directorIds: new Set(directors.map((d) => d.characterId)),
-						lastLogonByCharacterId: new Map(
-							memberTracking.map((tracking) => [tracking.characterId, tracking.logonDate])
-						),
-					}
-				})()
-				corporationSnapshotCache.set(corpId, snapshotPromise)
+		const reportRows = await buildFulcrumCharacterReportRows(c, userId, characters)
+		const results = reportRows.map((row, index) => {
+			const char = characters[index]
+			return {
+				characterId: char.characterId,
+				characterName: char.characterName,
+				corporationId: char.corporationId ?? null,
+				corporationName: char.corporationName ?? null,
+				allianceId: char.allianceId ?? null,
+				allianceName: char.allianceName ?? null,
+				hasValidToken: char.hasValidToken,
+				role: row.role,
+				activityStatus: row.activityStatus,
+				reports: row.reports,
 			}
-			return corporationSnapshotCache.get(corpId)!
-		}
-
-		// For each character, fetch their Fulcrum reports
-		const fulcrum = getFulcrumStub(c)
-		const results = await Promise.all(
-			characters.map(async (char) => {
-				let reports: Awaited<ReturnType<Fulcrum['listReports']>> = []
-				try {
-					reports = await fulcrum.listReports({ characterId: char.characterId }, 50)
-				} catch (error) {
-					logger.warn('[Fulcrum] Failed to list reports for character while building user list', {
-						userId,
-						characterId: char.characterId,
-						error: error instanceof Error ? error.message : String(error),
-					})
-				}
-				let role: 'CEO' | 'Director' | 'Member' | null = null
-				let activityStatus: 'active' | 'inactive' | 'unknown' | null = null
-
-				if (char.corporationId) {
-					const snapshot = await getCorporationSnapshot(String(char.corporationId))
-					if (snapshot.ceoId === char.characterId) {
-						role = 'CEO'
-					} else if (snapshot.directorIds.has(char.characterId)) {
-						role = 'Director'
-					} else {
-						role = 'Member'
-					}
-
-					const lastLogon = snapshot.lastLogonByCharacterId.get(char.characterId)
-					if (!lastLogon) {
-						activityStatus = 'unknown'
-					} else {
-						const activeThresholdMs = 7 * MS_PER_DAY
-						activityStatus =
-							new Date().getTime() - lastLogon.getTime() < activeThresholdMs
-								? 'active'
-								: 'inactive'
-					}
-				}
-
-				return {
-					characterId: char.characterId,
-					characterName: char.characterName,
-					corporationId: char.corporationId ?? null,
-					corporationName: char.corporationName ?? null,
-					allianceId: char.allianceId ?? null,
-					allianceName: char.allianceName ?? null,
-					hasValidToken: char.hasValidToken,
-					role,
-					activityStatus,
-					reports,
-				}
-			}),
-		)
+		})
 
 		return c.json(results)
 	} catch (error) {
@@ -433,6 +457,49 @@ app.get('/users/:userId/characters', requireAuth(), async (c) => {
 		})
 		return c.json(
 			{ error: error instanceof Error ? error.message : 'Failed to list characters' },
+			500,
+		)
+	}
+})
+
+/**
+ * GET /api/fulcrum/users/:userId/reports
+ * List report metadata for all linked characters on a user.
+ */
+app.get('/users/:userId/reports', requireAuth(), async (c) => {
+	const user = c.get('user')!
+	const userId = c.req.param('userId')
+	const corporationId = c.req.query('corporationId')
+
+	try {
+		const auditor = await isHrAuditorUser(c, user)
+
+		if (!auditor) {
+			const hr = getHrStub(c)
+			const accessResolution = await resolveFulcrumReportAccessForTargetUser(c, hr, user, userId)
+			if (!accessResolution.corporationId) {
+				return c.json(
+					{ error: 'HR staff access requires a shared corporation or an open application' },
+					403,
+				)
+			}
+		} else if (corporationId) {
+			// Keep the old query parameter accepted for auditor-driven callers, but
+			// do not rely on it for authorization decisions.
+		}
+
+		const core = getCoreStub(c)
+		const characters = await core.getUserCharacters(userId, false)
+		const reportRows = await buildFulcrumCharacterReportRows(c, userId, characters)
+
+		return c.json(reportRows)
+	} catch (error) {
+		logger.error('[Fulcrum] Failed to list user character reports', {
+			userId,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return c.json(
+			{ error: error instanceof Error ? error.message : 'Failed to list character reports' },
 			500,
 		)
 	}
@@ -450,23 +517,44 @@ app.get('/users/:userId/characters', requireAuth(), async (c) => {
 app.get('/characters/:characterId/reports', requireAuth(), async (c) => {
 	const user = c.get('user')!
 	const characterId = c.req.param('characterId')
-	const corporationId = c.req.query('corporationId')
 
 	try {
-		const auditor = await isHrAuditorUser(c, user)
-
-		// Require corporationId for scoping permission checks unless auditor
-		if (!corporationId && !auditor) {
-			return c.json({ error: 'corporationId query parameter is required' }, 400)
+		const db = c.get('db')
+		if (!db) {
+			return c.json({ error: 'Database not available' }, 500)
 		}
 
-		// Check HR permission for the corporation (auditors bypass)
-		if (!auditor && corporationId) {
+		const auditor = await isHrAuditorUser(c, user)
+
+		if (!auditor) {
 			const hr = getHrStub(c)
-			const hasPermission = await hr.checkPermission(user.id, corporationId, 'hr_viewer')
-			if (!hasPermission) {
-				return c.json({ error: 'HR role required' }, 403)
+			const target = await getImmunitasReportTarget(c, db, characterId)
+			if (!target) {
+				return c.json({ error: 'Fulcrum reports are not allowed for this character' }, 403)
 			}
+			const accessResolution = await resolveFulcrumReportAccessForTargetUser(
+				c,
+				hr,
+				user,
+				target.userId
+			)
+			if (accessResolution.corporationId) {
+				// Access is established by the backend user/corp resolution.
+			} else if (accessResolution.error === 'open_application_required') {
+				return c.json(
+					{ error: 'An open application is required to view Fulcrum reports for this user' },
+					403,
+				)
+			} else {
+				return c.json(
+					{ error: 'HR staff access requires a shared corporation or an open application' },
+					403,
+				)
+			}
+		}
+
+		if (auditor) {
+			// Auditors bypass HR scope checks.
 		}
 
 		const fulcrum = getFulcrumStub(c)

--- a/apps/core/src/routes/hr.ts
+++ b/apps/core/src/routes/hr.ts
@@ -2418,6 +2418,36 @@ app.get('/audit/users/:userId/ip-history', requireAuth(), async (c) => {
 })
 
 /**
+ * GET /api/hr/users/:userId/characters
+ * Return HR-owned character summary data for profile pages and application ESI overlays.
+ */
+app.get('/users/:userId/characters', requireAuth(), async (c) => {
+	const user = c.get('user')!
+	if (!user.is_admin && !(await hasAnyHrAccess(c))) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	const targetUserId = c.req.param('userId')
+
+	try {
+		const core = getCoreStub(c)
+		const characters = await core.getUserCharacters(targetUserId, false)
+
+		return c.json(characters)
+	} catch (error) {
+		logger.error('[HR] Failed to get user characters', {
+			userId: user.id,
+			targetUserId,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return c.json(
+			{ error: error instanceof Error ? error.message : 'Failed to get user characters' },
+			500
+		)
+	}
+})
+
+/**
  * GET /api/hr/audit/ip-history/:ipAddressHash/matches
  * Hashed-only user matches for a shared IP hash.
  */

--- a/apps/ui/src/client/features/applications/api.ts
+++ b/apps/ui/src/client/features/applications/api.ts
@@ -731,7 +731,8 @@ export interface CharacterReportMetadata {
 }
 
 /**
- * A character with their associated Fulcrum reports
+ * A character with their associated Fulcrum reports and identity fields.
+ * Legacy list endpoint payload retained for compatibility in older callers.
  */
 export interface FulcrumCharacterData {
 	characterId: string
@@ -741,6 +742,17 @@ export interface FulcrumCharacterData {
 	allianceId?: string | null
 	allianceName?: string | null
 	hasValidToken?: boolean | null
+	role?: 'CEO' | 'Director' | 'Member' | null
+	activityStatus?: 'active' | 'inactive' | 'unknown' | null
+	reports: CharacterReportMetadata[]
+}
+
+/**
+ * A character's Fulcrum report metadata without identity fields.
+ * This is the preferred payload for report-only consumers.
+ */
+export interface FulcrumCharacterReportData {
+	characterId: string
 	role?: 'CEO' | 'Director' | 'Member' | null
 	activityStatus?: 'active' | 'inactive' | 'unknown' | null
 	reports: CharacterReportMetadata[]
@@ -791,7 +803,8 @@ export interface ReportManifest {
  */
 export const fulcrumApi = {
 	/**
-	 * Get all linked characters for a user with their Fulcrum reports
+	 * Get all linked characters for a user with their Fulcrum reports and identity fields.
+	 * Legacy endpoint, retained for compatibility.
 	 */
 	async getUserCharactersWithReports(
 		userId: string,
@@ -803,15 +816,17 @@ export const fulcrumApi = {
 	},
 
 	/**
+	 * Get all linked characters for a user with Fulcrum report metadata only.
+	 */
+	async getUserCharacterReports(userId: string): Promise<FulcrumCharacterReportData[]> {
+		return apiClient.get(`/fulcrum/users/${userId}/reports`)
+	},
+
+	/**
 	 * List reports for a character
 	 */
-	async getCharacterReports(
-		characterId: string,
-		corporationId: string,
-	): Promise<CharacterReportMetadata[]> {
-		return apiClient.get(
-			`/fulcrum/characters/${characterId}/reports?corporationId=${encodeURIComponent(corporationId)}`,
-		)
+	async getCharacterReports(characterId: string): Promise<CharacterReportMetadata[]> {
+		return apiClient.get(`/fulcrum/characters/${characterId}/reports`)
 	},
 
 	/**

--- a/apps/ui/src/client/features/applications/components/character-identity-summary.tsx
+++ b/apps/ui/src/client/features/applications/components/character-identity-summary.tsx
@@ -15,7 +15,6 @@ interface CharacterSpWalletLineProps {
 	skillPoints: number | null | undefined
 	walletBalance: string | null | undefined
 	isLoading?: boolean
-	unavailableReason?: string | null
 	className?: string
 }
 

--- a/apps/ui/src/client/features/applications/components/fulcrum-panel.tsx
+++ b/apps/ui/src/client/features/applications/components/fulcrum-panel.tsx
@@ -8,7 +8,7 @@
 
 import { formatDistanceToNow } from 'date-fns'
 import { AlertCircle, Clock, ExternalLink, FileText, Loader2, RefreshCw, Users } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 
 import { Badge } from '@/components/ui/badge'
@@ -26,9 +26,14 @@ import { LoadingSpinner } from '@/components/ui/loading'
 import { Separator } from '@/components/ui/separator'
 import { CharacterIdentitySummary } from './character-identity-summary'
 
-import { useApplicationFulcrum, useRequestFulcrumReport, useRequestFulcrumReportBatch } from '../hooks'
+import {
+	useFulcrumUserReports,
+	useHrUserCharacters,
+	useRequestFulcrumReport,
+	useRequestFulcrumReportBatch,
+} from '../hooks'
 
-import type { CharacterReportMetadata, FulcrumCharacterData } from '../api'
+import type { CharacterReportMetadata } from '../api'
 
 const SEND_DM_PREF_KEY = 'fulcrum:scan-all:send-dm'
 
@@ -76,7 +81,7 @@ function canRequestNewReport(reports: CharacterReportMetadata[]): boolean {
 // ============================================================================
 
 interface CharacterReportCardProps {
-	character: FulcrumCharacterData
+	character: PanelCharacterRow
 	onRequest: () => void
 	getReportTarget: (reportId: string, characterName: string) => {
 		pathname: string
@@ -93,6 +98,19 @@ interface CharacterReportCardProps {
 	isRequesting: boolean
 	requestingCharacterId: string | null
 	canRequest: boolean
+}
+
+interface PanelCharacterRow {
+	characterId: string
+	characterName: string
+	corporationId: string | null
+	corporationName: string | null
+	allianceId: string | null
+	allianceName: string | null
+	hasValidToken: boolean | null
+	role: 'CEO' | 'Director' | 'Member' | null
+	activityStatus: 'active' | 'inactive' | 'unknown' | null
+	reports: CharacterReportMetadata[]
 }
 
 function CharacterReportCard({
@@ -201,7 +219,8 @@ interface FulcrumPanelProps {
 	applicationId?: string
 	mainCharacterId?: string
 	altCharacterIds?: string[]
-	canRequestCharacterReport?: (character: FulcrumCharacterData) => boolean
+	canRequestCharacterReport?: (character: PanelCharacterRow) => boolean
+	enabled?: boolean
 }
 
 export function FulcrumPanel({
@@ -211,15 +230,53 @@ export function FulcrumPanel({
 	mainCharacterId,
 	altCharacterIds = [],
 	canRequestCharacterReport,
+	enabled = true,
 }: FulcrumPanelProps) {
 	const { corporationId: routeCorporationId } = useParams<{ corporationId: string }>()
-	const { data: characters, isLoading, error } = useApplicationFulcrum(userId, corporationId)
+	const { data: reportCharacters = [], isLoading, error } = useFulcrumUserReports(userId, enabled)
+	const { data: hrCharacters = [] } = useHrUserCharacters(userId, {
+		enabled: !!userId && enabled,
+	})
+	const hrCharacterById = useMemo(
+		() => new Map(hrCharacters.map((character) => [character.characterId, character])),
+		[hrCharacters]
+	)
+	const reportCharacterById = useMemo(
+		() => new Map(reportCharacters.map((character) => [character.characterId, character])),
+		[reportCharacters]
+	)
+	const characters = useMemo<PanelCharacterRow[]>(() => {
+		const combinedCharacterIds = new Set<string>([
+			...reportCharacters.map((character) => character.characterId),
+			...hrCharacters.map((character) => character.characterId),
+		])
+		return [...combinedCharacterIds].map((characterId) => {
+			const reportCharacter = reportCharacterById.get(characterId)
+			const hrCharacter = hrCharacterById.get(characterId)
+			return {
+				characterId,
+				characterName: hrCharacter?.characterName ?? characterId,
+				corporationId: hrCharacter?.corporationId ?? null,
+				corporationName: hrCharacter?.corporationName ?? null,
+				allianceId: hrCharacter?.allianceId ?? null,
+				allianceName: hrCharacter?.allianceName ?? null,
+				hasValidToken: hrCharacter?.hasValidToken ?? null,
+				role: reportCharacter?.role ?? null,
+				activityStatus: reportCharacter?.activityStatus ?? null,
+				reports: reportCharacter?.reports ?? [],
+			}
+		})
+	}, [hrCharacterById, hrCharacters, reportCharacterById, reportCharacters])
 	const requestReport = useRequestFulcrumReport()
 	const requestReportBatch = useRequestFulcrumReportBatch()
 	const [sendDmForScanRequests, setSendDmForScanRequests] = useState(getInitialSendDmPreference)
 	const [scanAllDialogOpen, setScanAllDialogOpen] = useState(false)
-	const [scanSingleDialogCharacter, setScanSingleDialogCharacter] = useState<FulcrumCharacterData | null>(null)
+	const [scanSingleDialogCharacter, setScanSingleDialogCharacter] = useState<PanelCharacterRow | null>(null)
 	const [isRequestingAll, setIsRequestingAll] = useState(false)
+
+	if (!enabled) {
+		return null
+	}
 
 	const persistSendDmPreference = (enabled: boolean) => {
 		if (typeof window !== 'undefined') {
@@ -286,7 +343,7 @@ export function FulcrumPanel({
 		)
 	}
 
-	if (!characters || characters.length === 0) {
+	if (characters.length === 0) {
 		return (
 			<p className="text-center text-muted-foreground py-8">
 				No linked characters found for this applicant
@@ -327,7 +384,7 @@ export function FulcrumPanel({
 		}
 	}
 
-	const handleOpenSingleDialog = (character: FulcrumCharacterData) => {
+	const handleOpenSingleDialog = (character: PanelCharacterRow) => {
 		if (
 			isRequestingAll ||
 			requestReport.isPending ||
@@ -365,7 +422,7 @@ export function FulcrumPanel({
 		? characters.filter((c) => !applicationCharacterIds.has(c.characterId))
 		: characters
 
-	const renderCharacterCards = (chars: FulcrumCharacterData[]) =>
+	const renderCharacterCards = (chars: PanelCharacterRow[]) =>
 		chars.map((character) => (
 			<CharacterReportCard
 				key={character.characterId}

--- a/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
+++ b/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
@@ -69,6 +69,7 @@ function resolveEsiBadge(character: SharedProfileCharacter) {
 export function ProfileCharactersSection({
 	characters,
 	fulcrumLoading = false,
+	showFulcrumReports = true,
 	showViewDetailsButton = false,
 	isScanAllVisible = false,
 	isScanningAll = false,
@@ -85,6 +86,7 @@ export function ProfileCharactersSection({
 }: {
 	characters: SharedProfileCharacter[]
 	fulcrumLoading?: boolean
+	showFulcrumReports?: boolean
 	showViewDetailsButton?: boolean
 	isScanAllVisible?: boolean
 	isScanningAll?: boolean
@@ -107,7 +109,7 @@ export function ProfileCharactersSection({
 						<Users className="h-4 w-4" />
 						Characters ({characters.length})
 					</CardTitle>
-					{isScanAllVisible && (
+						{showFulcrumReports && isScanAllVisible && (
 						<Button
 							variant="ghost"
 							size="sm"
@@ -121,7 +123,7 @@ export function ProfileCharactersSection({
 				</div>
 			</CardHeader>
 			<CardContent>
-				{fulcrumLoading ? (
+				{showFulcrumReports && fulcrumLoading ? (
 					<div className="flex justify-center py-6">
 						<LoadingSpinner size="sm" />
 					</div>
@@ -205,92 +207,94 @@ export function ProfileCharactersSection({
 											</>
 										}
 									/>
-									<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-										{character.joinDate && (
-											<span>
-												Joined{' '}
-												{formatDistanceToNow(new Date(character.joinDate), { addSuffix: true })}
-											</span>
-										)}
-										{character.joinDate && character.lastLogin && <span>•</span>}
-										{character.lastLogin && (
-											<span title="Last active is based on the most recent ESI member-tracking login timestamp.">
-												Last active{' '}
-												{formatDistanceToNow(new Date(character.lastLogin), { addSuffix: true })}
-											</span>
-										)}
-									</div>
-									<div className="flex items-center gap-2">
-										<div
-											className={cn(
-												'flex min-w-0 flex-1 items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs',
-												character.latestReport?.status === 'completed' &&
-													character.corporationId &&
-													'cursor-pointer transition-colors hover:bg-muted/50'
+										<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+											{character.joinDate && (
+												<span>
+													Joined{' '}
+													{formatDistanceToNow(new Date(character.joinDate), { addSuffix: true })}
+												</span>
 											)}
-											onClick={() => onViewReport(character)}
-										>
-											<Scan className="h-3 w-3 shrink-0 text-muted-foreground" />
-											<span className="shrink-0 font-medium text-muted-foreground">
-												Fulcrum Report
-											</span>
-											<span className="shrink-0 text-muted-foreground">·</span>
-											{character.latestReport ? (
-												character.latestReport.status === 'completed' ? (
-													<>
-														<span className="truncate text-foreground">
-															View latest report (
-															{formatDistanceToNow(new Date(character.latestReport.createdAt), {
-																addSuffix: true,
-															})}
-															)
-														</span>
-														<ExternalLink className="ml-auto h-3 w-3 shrink-0 text-muted-foreground" />
-													</>
-												) : character.latestReport.status === 'pending' ||
-												  character.latestReport.status === 'processing' ? (
-													<span className="truncate text-muted-foreground">
-														Processing... (
-														{formatDistanceToNow(new Date(character.latestReport.createdAt), {
-															addSuffix: true,
-														})}
-														)
-													</span>
-												) : (
-													<span className="truncate text-muted-foreground">
-														Failed (
-														{formatDistanceToNow(new Date(character.latestReport.createdAt), {
-															addSuffix: true,
-														})}
-														)
-													</span>
-												)
-											) : (
-												<span className="truncate text-muted-foreground">No report yet</span>
+											{character.joinDate && character.lastLogin && <span>•</span>}
+											{character.lastLogin && (
+												<span title="Last active is based on the most recent ESI member-tracking login timestamp.">
+													Last active{' '}
+													{formatDistanceToNow(new Date(character.lastLogin), { addSuffix: true })}
+												</span>
 											)}
 										</div>
+										{showFulcrumReports && (
+											<div className="flex items-center gap-2">
+												<div
+													className={cn(
+														'flex min-w-0 flex-1 items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs',
+														character.latestReport?.status === 'completed' &&
+															character.corporationId &&
+															'cursor-pointer transition-colors hover:bg-muted/50'
+													)}
+													onClick={() => onViewReport(character)}
+												>
+													<Scan className="h-3 w-3 shrink-0 text-muted-foreground" />
+													<span className="shrink-0 font-medium text-muted-foreground">
+														Fulcrum Report
+													</span>
+													<span className="shrink-0 text-muted-foreground">·</span>
+													{character.latestReport ? (
+														character.latestReport.status === 'completed' ? (
+															<>
+																<span className="truncate text-foreground">
+																	View latest report (
+																	{formatDistanceToNow(new Date(character.latestReport.createdAt), {
+																		addSuffix: true,
+																	})}
+																	)
+																</span>
+																<ExternalLink className="ml-auto h-3 w-3 shrink-0 text-muted-foreground" />
+															</>
+														) : character.latestReport.status === 'pending' ||
+														  character.latestReport.status === 'processing' ? (
+															<span className="truncate text-muted-foreground">
+																Processing... (
+																{formatDistanceToNow(new Date(character.latestReport.createdAt), {
+																	addSuffix: true,
+																})}
+																)
+															</span>
+														) : (
+															<span className="truncate text-muted-foreground">
+																Failed (
+																{formatDistanceToNow(new Date(character.latestReport.createdAt), {
+																	addSuffix: true,
+																})}
+																)
+															</span>
+														)
+													) : (
+														<span className="truncate text-muted-foreground">No report yet</span>
+													)}
+												</div>
 
-										<Button
-											variant={character.latestReport ? 'ghost' : 'primary'}
-											size="sm"
-											disabled={
-												!canRequestReports ||
-												!canRequestCharacter ||
-												!character.corporationId ||
-												character.hasPendingReport ||
-												isScanPending
-											}
-											onClick={() => onScan(character)}
-										>
-											{isScanPending ? (
-												<Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-											) : (
-												<Scan className="mr-1.5 h-3.5 w-3.5" />
-											)}
-											{isScanPending ? 'Requesting...' : 'Scan'}
-										</Button>
+												<Button
+													variant={character.latestReport ? 'ghost' : 'primary'}
+													size="sm"
+													disabled={
+														!canRequestReports ||
+														!canRequestCharacter ||
+														!character.corporationId ||
+														character.hasPendingReport ||
+														isScanPending
+													}
+													onClick={() => onScan(character)}
+												>
+													{isScanPending ? (
+														<Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+													) : (
+														<Scan className="mr-1.5 h-3.5 w-3.5" />
+													)}
+													{isScanPending ? 'Requesting...' : 'Scan'}
+												</Button>
+											</div>
+										)}
 									</div>
-								</div>
 							)
 						})}
 					</div>

--- a/apps/ui/src/client/features/applications/constants.ts
+++ b/apps/ui/src/client/features/applications/constants.ts
@@ -3,6 +3,9 @@ import type { ApplicationStatus, ReportSectionName } from './api'
 /** Application statuses where the application is still being actively processed */
 export const ACTIVE_APPLICATION_STATUSES: ApplicationStatus[] = ['pending', 'under_review']
 
+/** Application statuses where private application data access should still be treated as open */
+export const OPEN_APPLICATION_STATUSES: ApplicationStatus[] = ['pending', 'under_review', 'accepted']
+
 // ============================================================================
 // Fulcrum Report Section Metadata
 // ============================================================================

--- a/apps/ui/src/client/features/applications/hooks.ts
+++ b/apps/ui/src/client/features/applications/hooks.ts
@@ -7,8 +7,8 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
+import { apiClient } from '@/lib/api'
 import { applicationsApi, fulcrumApi } from './api'
-import { auditorUserKeys } from '@/hooks/useAuditorUsers'
 import { useApiMutation } from '@/hooks/useApiMutation'
 
 import type {
@@ -33,6 +33,7 @@ import type {
 	ReportManifest,
 	ReportRequestSource,
 	ReportSectionName,
+	FulcrumCharacterReportData,
 	SendMessageRequest,
 	SubmitApplicationRequest,
 	UpsertApplicationStaffNoteRequest,
@@ -73,8 +74,10 @@ export const applicationKeys = {
 	// Fulcrum (Character Reports)
 	fulcrumUserCharacters: (userId: string, corporationId: string) =>
 		[...applicationKeys.all, 'fulcrum', 'user-characters', userId, corporationId] as const,
-	fulcrumCharacterReports: (characterId: string, corporationId: string) =>
-		[...applicationKeys.all, 'fulcrum', 'character', characterId, corporationId] as const,
+	fulcrumUserReports: (userId: string) =>
+		[...applicationKeys.all, 'fulcrum', 'user-reports', userId] as const,
+	fulcrumCharacterReports: (characterId: string) =>
+		[...applicationKeys.all, 'fulcrum', 'character', characterId] as const,
 	fulcrumReportSections: (reportId: string) =>
 		[...applicationKeys.all, 'fulcrum-report', reportId, 'sections'] as const,
 	fulcrumReportSection: (reportId: string, section: ReportSectionName) =>
@@ -88,6 +91,22 @@ export const applicationKeys = {
 		[...applicationKeys.all, 'character-history', characterId] as const,
 	userHistory: (userId: string) =>
 		[...applicationKeys.all, 'user-history', userId] as const,
+}
+
+export const hrUserKeys = {
+	all: ['hr', 'users'] as const,
+	characters: (userId: string) => [...hrUserKeys.all, userId, 'characters'] as const,
+}
+
+export interface HrUserCharacterData {
+	characterId: string
+	characterName: string
+	hasValidToken: boolean
+	isDeleted: boolean
+	corporationId?: string | null
+	corporationName?: string | null
+	allianceId?: string | null
+	allianceName?: string | null
 }
 
 // ============================================================================
@@ -248,6 +267,20 @@ export function useApplicationForRecommender(applicationId: string, options?: { 
 		staleTime: 1000 * 60, // 1 minute
 		gcTime: 1000 * 60 * 3, // 3 minutes
 		enabled: options?.enabled ?? !!applicationId,
+	})
+}
+
+
+export function useHrUserCharacters(userId: string, options?: { enabled?: boolean }) {
+	return useQuery<HrUserCharacterData[]>({
+		queryKey: hrUserKeys.characters(userId),
+		queryFn: () => apiClient.get(`/hr/users/${userId}/characters`),
+		staleTime: 1000 * 30,
+		gcTime: 1000 * 60 * 3,
+		enabled: options?.enabled ?? !!userId,
+		meta: {
+			suppressErrorToast: true,
+		},
 	})
 }
 
@@ -981,16 +1014,43 @@ export function useApplicationFulcrum(userId: string, corporationId: string, ena
 	})
 }
 
+export function useFulcrumUserReports(
+	userId: string,
+	options?: boolean | { enabled?: boolean; suppressErrorToast?: boolean }
+) {
+	const enabled = typeof options === 'boolean' ? options : options?.enabled ?? true
+	const suppressErrorToast =
+		typeof options === 'boolean' ? true : options?.suppressErrorToast ?? true
+
+	return useQuery<FulcrumCharacterReportData[]>({
+		queryKey: applicationKeys.fulcrumUserReports(userId),
+		queryFn: () => fulcrumApi.getUserCharacterReports(userId),
+		staleTime: 1000 * 30,
+		gcTime: 1000 * 60 * 3,
+		enabled: !!userId && enabled,
+		refetchInterval: (query) => {
+			const data = query.state.data
+			const hasInProgress = data?.some((ch) =>
+				ch.reports.some((r) => r.status === 'pending' || r.status === 'processing'),
+			)
+			return hasInProgress ? 10_000 : false
+		},
+		meta: {
+			suppressErrorToast,
+		},
+	})
+}
+
 /**
  * Hook to fetch Fulcrum reports for a specific character
  */
-export function useCharacterReports(characterId: string, corporationId: string, enabled = true) {
+export function useCharacterReports(characterId: string, enabled = true) {
 	return useQuery<CharacterReportMetadata[]>({
-		queryKey: applicationKeys.fulcrumCharacterReports(characterId, corporationId),
-		queryFn: () => fulcrumApi.getCharacterReports(characterId, corporationId),
+		queryKey: applicationKeys.fulcrumCharacterReports(characterId),
+		queryFn: () => fulcrumApi.getCharacterReports(characterId),
 		staleTime: 1000 * 30,
 		gcTime: 1000 * 60 * 3,
-		enabled: !!characterId && !!corporationId && enabled,
+		enabled: !!characterId && enabled,
 		refetchInterval: (query) => {
 			const data = query.state.data
 			const hasInProgress = data?.some((r) => r.status === 'pending' || r.status === 'processing')
@@ -1037,6 +1097,19 @@ export function useRequestFulcrumReport() {
 				createdAt: new Date().toISOString(),
 				updatedAt: new Date().toISOString(),
 			}
+			const applyOptimisticPendingToReportRows = (old: FulcrumCharacterReportData[] | undefined) =>
+				old?.map((character) =>
+					character.characterId !== characterId
+						? character
+						: {
+							...character,
+							reports: character.reports.some(
+								(report) => report.status === 'pending' || report.status === 'processing',
+							)
+								? character.reports
+								: [optimisticPendingReport, ...character.reports],
+						},
+				)
 
 			queryClient.setQueryData<FulcrumCharacterData[]>(
 				applicationKeys.fulcrumUserCharacters(userId, corporationId),
@@ -1052,33 +1125,23 @@ export function useRequestFulcrumReport() {
 									? character.reports
 									: [optimisticPendingReport, ...character.reports],
 							},
-					),
+						),
+			)
+			queryClient.setQueryData<FulcrumCharacterReportData[]>(
+				applicationKeys.fulcrumUserReports(userId),
+				applyOptimisticPendingToReportRows,
 			)
 
-			queryClient.setQueryData<FulcrumCharacterData[]>(auditorUserKeys.fulcrum(userId), (old) =>
-				old?.map((character) =>
-					character.characterId !== characterId
-						? character
-						: {
-							...character,
-							reports: character.reports.some(
-								(report) => report.status === 'pending' || report.status === 'processing',
-							)
-								? character.reports
-								: [optimisticPendingReport, ...character.reports],
-						},
-				),
-			)
 		},
 		onSettled: (_, __, variables) => {
 			queryClient.invalidateQueries({
-				queryKey: applicationKeys.fulcrumCharacterReports(
-					variables.characterId,
-					variables.corporationId,
-				),
+				queryKey: applicationKeys.fulcrumCharacterReports(variables.characterId),
 			})
 			// Also invalidate user-characters query if userId is provided
 			if (variables.userId) {
+				queryClient.invalidateQueries({
+					queryKey: applicationKeys.fulcrumUserReports(variables.userId),
+				})
 				queryClient.invalidateQueries({
 					queryKey: applicationKeys.fulcrumUserCharacters(
 						variables.userId,
@@ -1141,23 +1204,52 @@ export function useRequestFulcrumReportBatch() {
 						reports: [optimisticPendingReport, ...character.reports],
 					}
 				})
+			const applyOptimisticPendingToReportRows = (old: FulcrumCharacterReportData[] | undefined) =>
+				old?.map((character) => {
+					if (!characterIds.includes(character.characterId)) return character
+					if (
+						character.reports.some(
+							(report) => report.status === 'pending' || report.status === 'processing',
+						)
+					) {
+						return character
+					}
+					const optimisticPendingReport: CharacterReportMetadata = {
+						id: `pending-local-${character.characterId}-${Date.now()}`,
+						characterId: character.characterId,
+						status: 'pending',
+						requestorUserId: '',
+						requestorCorporationId: corporationId,
+						requestSource: 'hr',
+						retentionDays: 7,
+						createdAt: now,
+						updatedAt: now,
+					}
+					return {
+						...character,
+						reports: [optimisticPendingReport, ...character.reports],
+					}
+				})
 
 			queryClient.setQueryData<FulcrumCharacterData[]>(
 				applicationKeys.fulcrumUserCharacters(userId, corporationId),
 				applyOptimisticPendingToCharacters,
 			)
-			queryClient.setQueryData<FulcrumCharacterData[]>(
-				auditorUserKeys.fulcrum(userId),
-				applyOptimisticPendingToCharacters,
+			queryClient.setQueryData<FulcrumCharacterReportData[]>(
+				applicationKeys.fulcrumUserReports(userId),
+				applyOptimisticPendingToReportRows,
 			)
 		},
 		onSettled: (_, __, variables) => {
 			for (const characterId of variables.characterIds) {
 				queryClient.invalidateQueries({
-					queryKey: applicationKeys.fulcrumCharacterReports(characterId, variables.corporationId),
+					queryKey: applicationKeys.fulcrumCharacterReports(characterId),
 				})
 			}
 			if (variables.userId) {
+				queryClient.invalidateQueries({
+					queryKey: applicationKeys.fulcrumUserReports(variables.userId),
+				})
 				queryClient.invalidateQueries({
 					queryKey: applicationKeys.fulcrumUserCharacters(
 						variables.userId,

--- a/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
@@ -6,9 +6,8 @@
  * Requires HR Viewer role minimum.
  */
 
-import { useQueries } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
-import { ArrowLeft, Briefcase, Lock } from 'lucide-react'
+import { AlertCircle, ArrowLeft, Briefcase, Lock } from 'lucide-react'
 import { useState } from 'react'
 import toast from '@/lib/toast'
 import { Link, Navigate, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
@@ -31,11 +30,9 @@ import { useConfirmationDialog } from '@/hooks/useConfirmationDialog'
 import { useEntityNames } from '@/hooks/useEntityNames'
 import { useMessage } from '@/hooks/useMessage'
 import { usePageTitle } from '@/hooks/usePageTitle'
-import { apiClient } from '@/lib/api'
 
 import { useHrPermissionCheck } from '../../hr/hooks'
 import { useCanAccessCorporation } from '../../corporations/hooks'
-import { ACTIVE_APPLICATION_STATUSES } from '../constants'
 import { AccessDeniedCard } from '../components/access-denied-card'
 import { AddHRNoteDialog } from '../components/add-hr-note-dialog'
 import { ApplicationActionPanel } from '../components/application-action-panel'
@@ -51,17 +48,19 @@ import { MessagesPanel } from '../components/messages-panel'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { RecommendationList } from '../components/recommendation-list'
+import { OPEN_APPLICATION_STATUSES } from '../constants'
 import {
 	useApplication,
-	useApplicationFulcrum,
 	useApplicationActivity,
 	useApplicationStaffNotes,
 	useDeleteHRNote,
 	useHRNotes,
 	useHRNote,
+	useHrUserCharacters,
 	useMessageCount,
 	useRecommendations,
 } from '../hooks'
+import { FORBIDDEN_PRIVATE_DATA_MESSAGE } from '../utils/private-data'
 
 // ============================================================================
 // Component
@@ -133,11 +132,16 @@ export default function HrApplicationReview() {
 		}
 	)
 	const globalUserNotesCount = globalUserNotes.length
-	const { data: fulcrumCharacters = [] } = useApplicationFulcrum(
+	const { data: hrCharacters = [] } = useHrUserCharacters(
 		application?.userId ?? '',
-		corporationId ?? '',
-		!!application?.userId && !!corporationId && canViewCorporationApplications,
+		{
+			enabled: !!application?.userId && canViewCorporationApplications,
+		},
 	)
+	const canViewApplicationPrivateData =
+		!!application &&
+		canViewCorporationApplications &&
+		(user?.is_admin === true || isAuditor || isMemberCorporation || OPEN_APPLICATION_STATUSES.includes(application.status))
 
 	// Fetch selected HR note for edit/delete
 	const { data: selectedNote } = useHRNote(selectedNoteId)
@@ -166,32 +170,23 @@ export default function HrApplicationReview() {
 			toast.error('Failed to copy character name')
 		}
 	}
-	const spQueries = useQueries({
-		queries: allCharacterIds.map((charId) => ({
-			queryKey: ['character', charId, 'hr-review-private'],
-			queryFn: () => apiClient.getCharacterPrivateDetail(charId),
-			meta: {
-				suppressErrorToast: true,
-			},
-			enabled: !!application && canViewCorporationApplications,
-			staleTime: 5 * 60 * 1000,
-		})),
-	})
 	const spByCharacterId: Record<string, number | null> = {}
 	const walletByCharacterId: Record<string, string | null> = {}
 	const metricsLoadingByCharacterId: Record<string, boolean> = {}
 	for (let i = 0; i < allCharacterIds.length; i++) {
-		const query = spQueries[i]
-		spByCharacterId[allCharacterIds[i]] = query?.data?.skills?.totalSp ?? null
-		walletByCharacterId[allCharacterIds[i]] = query?.data?.private?.wallet?.balance ?? null
-		metricsLoadingByCharacterId[allCharacterIds[i]] =
-			(query?.isPending ?? false) && query?.data == null
+		spByCharacterId[allCharacterIds[i]] = null
+		walletByCharacterId[allCharacterIds[i]] = null
+		metricsLoadingByCharacterId[allCharacterIds[i]] = false
 	}
+	const privateDataUnavailableMessage = !canViewApplicationPrivateData ? FORBIDDEN_PRIVATE_DATA_MESSAGE : null
+	const hrCharacterTokenStateById = new Map(
+		hrCharacters.map((character) => [character.characterId, character.hasValidToken])
+	)
+	const hrCharacterById = new Map(hrCharacters.map((character) => [character.characterId, character]))
 	const esiStateByCharacterId: Record<string, boolean | null> = {}
-	for (const character of fulcrumCharacters) {
-		esiStateByCharacterId[character.characterId] = character.hasValidToken ?? null
+	for (const characterId of allCharacterIds) {
+		esiStateByCharacterId[characterId] = hrCharacterTokenStateById.get(characterId) ?? null
 	}
-	const fulcrumCharacterById = new Map(fulcrumCharacters.map((character) => [character.characterId, character]))
 
 	// Set page title
 	usePageTitle(
@@ -524,7 +519,7 @@ export default function HrApplicationReview() {
 					>
 						Prior Apps
 					</TabsTrigger>
-					{permission?.currentRole && ['hr_admin', 'hr_reviewer'].includes(permission.currentRole) && application && ACTIVE_APPLICATION_STATUSES.includes(application.status) && (
+					{permission?.currentRole && ['hr_admin', 'hr_reviewer'].includes(permission.currentRole) && application && OPEN_APPLICATION_STATUSES.includes(application.status) && (
 						<TabsTrigger
 							value="fulcrum"
 							className={reviewTabTriggerClassName}
@@ -601,6 +596,19 @@ export default function HrApplicationReview() {
 
 				{/* Alt Characters Tab */}
 				<TabsContent value="alts" className="space-y-6">
+					{privateDataUnavailableMessage && (
+						<div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+							<div className="flex items-start gap-3">
+								<AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+								<div className="space-y-1">
+									<p className="font-medium">Private ESI data is hidden for some characters</p>
+									<p className="text-sm text-amber-800 dark:text-amber-200">
+										{privateDataUnavailableMessage}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
 					{/* Main Character */}
 					<Card>
 						<CardHeader>
@@ -615,10 +623,10 @@ export default function HrApplicationReview() {
 							characterId={application.characterId}
 							characterName={application.characterName}
 							hasValidToken={esiStateByCharacterId[application.characterId]}
-							corporationId={fulcrumCharacterById.get(application.characterId)?.corporationId ?? null}
-							corporationName={fulcrumCharacterById.get(application.characterId)?.corporationName ?? null}
-							allianceId={fulcrumCharacterById.get(application.characterId)?.allianceId ?? null}
-							allianceName={fulcrumCharacterById.get(application.characterId)?.allianceName ?? null}
+							corporationId={hrCharacterById.get(application.characterId)?.corporationId ?? null}
+							corporationName={hrCharacterById.get(application.characterId)?.corporationName ?? null}
+							allianceId={hrCharacterById.get(application.characterId)?.allianceId ?? null}
+							allianceName={hrCharacterById.get(application.characterId)?.allianceName ?? null}
 							skillPoints={spByCharacterId[application.characterId]}
 							walletBalance={walletByCharacterId[application.characterId]}
 							isMetricsLoading={metricsLoadingByCharacterId[application.characterId]}
@@ -652,19 +660,19 @@ export default function HrApplicationReview() {
 							characterId={charId}
 							characterName={altCharacterNames[charId] ?? charId}
 							hasValidToken={esiStateByCharacterId[charId]}
-												corporationId={fulcrumCharacterById.get(charId)?.corporationId ?? null}
-												corporationName={fulcrumCharacterById.get(charId)?.corporationName ?? null}
-												allianceId={fulcrumCharacterById.get(charId)?.allianceId ?? null}
-												allianceName={fulcrumCharacterById.get(charId)?.allianceName ?? null}
-												skillPoints={spByCharacterId[charId]}
-												walletBalance={walletByCharacterId[charId]}
-												isMetricsLoading={metricsLoadingByCharacterId[charId]}
-												enableCopyName
-												isNameCopied={copiedCharacterIds.has(charId)}
-												onCopyName={() =>
-													void markCharacterNameCopied(charId, altCharacterNames[charId] ?? charId)
-												}
-											/>
+							corporationId={hrCharacterById.get(charId)?.corporationId ?? null}
+							corporationName={hrCharacterById.get(charId)?.corporationName ?? null}
+							allianceId={hrCharacterById.get(charId)?.allianceId ?? null}
+							allianceName={hrCharacterById.get(charId)?.allianceName ?? null}
+							skillPoints={spByCharacterId[charId]}
+							walletBalance={walletByCharacterId[charId]}
+							isMetricsLoading={metricsLoadingByCharacterId[charId]}
+							enableCopyName
+							isNameCopied={copiedCharacterIds.has(charId)}
+							onCopyName={() =>
+								void markCharacterNameCopied(charId, altCharacterNames[charId] ?? charId)
+							}
+						/>
 										</div>
 									))}
 								</div>
@@ -808,7 +816,7 @@ export default function HrApplicationReview() {
 				</TabsContent>
 
 				{/* Fulcrum (Character Reports) Tab */}
-				{permission?.currentRole && ['hr_admin', 'hr_reviewer'].includes(permission.currentRole) && application && ACTIVE_APPLICATION_STATUSES.includes(application.status) && (
+				{permission?.currentRole && ['hr_admin', 'hr_reviewer'].includes(permission.currentRole) && application && OPEN_APPLICATION_STATUSES.includes(application.status) && (
 					<TabsContent value="fulcrum">
 						<Card>
 							<CardHeader>
@@ -824,6 +832,7 @@ export default function HrApplicationReview() {
 									applicationId={applicationId!}
 									mainCharacterId={application.characterId}
 									altCharacterIds={altCharacterIds}
+									enabled={OPEN_APPLICATION_STATUSES.includes(application.status)}
 									canRequestCharacterReport={(character) =>
 										user?.is_admin || character.role !== 'CEO'
 									}

--- a/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
@@ -34,17 +34,22 @@ import {
 	FulcrumSingleScanDialog,
 	useFulcrumScanDmPreference,
 } from '../components/fulcrum-scan-dialogs'
-import { useApplications, useHRNotes, useRequestFulcrumReport, useRequestFulcrumReportBatch } from '../hooks'
+import {
+	useApplications,
+	useHRNotes,
+	useFulcrumUserReports,
+	useHrUserCharacters,
+	useRequestFulcrumReport,
+	useRequestFulcrumReportBatch,
+} from '../hooks'
 import { getPrivateDataUnavailableMessage } from '../utils/private-data'
 import {
-	auditorUserKeys,
-	useAuditorFulcrum,
 	useAuditorUser,
 	useAuditorUserIpHistory,
 } from '../../../hooks/useAuditorUsers'
 import { myCorporationsApi } from '../../corporations/api'
 
-import type { CharacterReportMetadata, FulcrumCharacterData } from '../api'
+import type { CharacterReportMetadata, FulcrumCharacterReportData } from '../api'
 
 interface AuditorProfileNavigationState {
 	source?: 'applications' | 'members'
@@ -67,7 +72,7 @@ interface AuditorCharacterRow {
 	hasPendingReport: boolean
 }
 
-function getLatestReport(character: FulcrumCharacterData): CharacterReportMetadata | null {
+function getLatestReport(character: FulcrumCharacterReportData): CharacterReportMetadata | null {
 	if (character.reports.length === 0) return null
 	return character.reports.reduce((latest, report) =>
 		new Date(report.createdAt) > new Date(latest.createdAt) ? report : latest
@@ -94,7 +99,21 @@ export default function HrAuditorUserProfilePage() {
 	} = useFulcrumScanDmPreference()
 
 	const { data: userDetails, isLoading: userLoading } = useAuditorUser(userId ?? '')
-	const { data: fulcrumCharacters, isLoading: fulcrumLoading } = useAuditorFulcrum(userId ?? '', !!userId)
+	const { data: hrCharacters = [], isLoading: hrLoading } = useHrUserCharacters(userId ?? '', {
+		enabled: !!userId,
+	})
+	const { data: reportCharacters = [], isLoading: fulcrumLoading } = useFulcrumUserReports(
+		userId ?? '',
+		!!userId
+	)
+	const hrCharacterById = useMemo(
+		() => new Map(hrCharacters.map((character) => [character.characterId, character])),
+		[hrCharacters]
+	)
+	const reportCharacterById = useMemo(
+		() => new Map(reportCharacters.map((character) => [character.characterId, character])),
+		[reportCharacters]
+	)
 	const { data: notes, isLoading: notesLoading } = useHRNotes(
 		userId ? { subjectUserId: userId } : undefined
 	)
@@ -140,26 +159,34 @@ export default function HrAuditorUserProfilePage() {
 	const rows = useMemo<AuditorCharacterRow[]>(() => {
 		if (!userDetails) return []
 
-		const fulcrumMap = new Map((fulcrumCharacters ?? []).map((c) => [c.characterId, c]))
-		return userDetails.characters
-			.map((character) => {
-				const fulcrum = fulcrumMap.get(character.characterId)
-				const latestReport = fulcrum ? getLatestReport(fulcrum) : null
+		const userCharacterById = new Map(userDetails.characters.map((character) => [character.characterId, character]))
+		const allCharacterIds = new Set<string>([
+			...userDetails.characters.map((character) => character.characterId),
+			...hrCharacters.map((character) => character.characterId),
+		])
+
+		return [...allCharacterIds]
+			.map((characterId) => {
+				const userCharacter = userCharacterById.get(characterId)
+				const hrCharacter = hrCharacterById.get(characterId)
+				const reportCharacter = reportCharacterById.get(characterId)
+				const latestReport = reportCharacter ? getLatestReport(reportCharacter) : null
 				const hasPendingReport =
-					fulcrum?.reports.some((r) => r.status === 'pending' || r.status === 'processing') ?? false
+					reportCharacter?.reports.some((r) => r.status === 'pending' || r.status === 'processing') ?? false
+
 				return {
-					characterId: character.characterId,
-					characterName: character.characterName,
-					isPrimary: character.is_primary,
-					corporationId: fulcrum?.corporationId ?? null,
-					corporationName: fulcrum?.corporationName ?? null,
-					allianceId: fulcrum?.allianceId ?? null,
-					allianceName: fulcrum?.allianceName ?? null,
-					role: fulcrum?.role ?? null,
-					activityStatus: fulcrum?.activityStatus ?? null,
+					characterId,
+					characterName: userCharacter?.characterName ?? hrCharacter?.characterName ?? characterId,
+					isPrimary: userCharacter?.is_primary ?? characterId === userDetails.mainCharacterId,
+					corporationId: hrCharacter?.corporationId ?? null,
+					corporationName: hrCharacter?.corporationName ?? null,
+					allianceId: hrCharacter?.allianceId ?? null,
+					allianceName: hrCharacter?.allianceName ?? null,
+					role: reportCharacter?.role ?? null,
+					activityStatus: reportCharacter?.activityStatus ?? null,
 					latestReport,
 					hasPendingReport,
-					hasValidToken: fulcrum?.hasValidToken ?? null,
+					hasValidToken: userCharacter?.hasValidToken ?? hrCharacter?.hasValidToken ?? null,
 				}
 			})
 			.sort((a, b) => {
@@ -167,7 +194,7 @@ export default function HrAuditorUserProfilePage() {
 				if (!a.isPrimary && b.isPrimary) return 1
 				return a.characterName.localeCompare(b.characterName)
 			})
-	}, [fulcrumCharacters, userDetails])
+	}, [hrCharacterById, hrCharacters, reportCharacterById, userDetails])
 
 	const characterDetailQueries = useQueries({
 		queries: rows.map((character) => ({
@@ -237,7 +264,7 @@ export default function HrAuditorUserProfilePage() {
 		return <Navigate to="/login" replace />
 	}
 
-	if (authLoading || userLoading) {
+	if ((authLoading || userLoading || hrLoading || fulcrumLoading) && rows.length === 0) {
 		return (
 			<Container>
 				<div className="flex items-center justify-center min-h-[320px]">
@@ -300,9 +327,6 @@ export default function HrAuditorUserProfilePage() {
 			},
 			{
 				onSettled: () => {
-					void queryClient.invalidateQueries({
-						queryKey: auditorUserKeys.fulcrum(userId),
-					})
 					setRequestingCharacterId(null)
 				},
 			}
@@ -371,9 +395,6 @@ export default function HrAuditorUserProfilePage() {
 				}
 			}
 		} finally {
-			void queryClient.invalidateQueries({
-				queryKey: auditorUserKeys.fulcrum(userId),
-			})
 			setIsScanningAll(false)
 		}
 	}
@@ -505,7 +526,7 @@ export default function HrAuditorUserProfilePage() {
 							locationSystem: memberMetaByCharacterId.get(character.characterId)?.locationSystem,
 							locationRegion: memberMetaByCharacterId.get(character.characterId)?.locationRegion,
 						}))}
-						fulcrumLoading={fulcrumLoading}
+						fulcrumLoading={fulcrumLoading && rows.length === 0}
 						showViewDetailsButton
 						isScanAllVisible
 						isScanningAll={isScanningAll}

--- a/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
@@ -55,14 +55,16 @@ import {
 	useFulcrumScanDmPreference,
 } from '../components/fulcrum-scan-dialogs'
 import {
-	useApplicationFulcrum,
 	useApplications,
 	useHRNotes,
 	useRequestFulcrumReport,
 	useRequestFulcrumReportBatch,
+	useFulcrumUserReports,
+	useHrUserCharacters,
 } from '../hooks'
 import type { CorporationMember } from '../../corporations/api'
-import type { FulcrumCharacterData } from '../api'
+import type { FulcrumCharacterReportData } from '../api'
+import { getPrivateDataUnavailableMessage } from '../utils/private-data'
 
 // ============================================================================
 // Types & Sub-Components
@@ -74,26 +76,37 @@ interface UnifiedCharacter {
 	isInCorp: boolean
 	role?: 'CEO' | 'Director' | 'Member' | null
 	member?: CorporationMember
-	fulcrum?: FulcrumCharacterData
+	hr?: {
+		characterId: string
+		characterName: string
+		hasValidToken: boolean
+		corporationId?: string | null
+		corporationName?: string | null
+		allianceId?: string | null
+		allianceName?: string | null
+	}
+	report?: FulcrumCharacterReportData
 }
 
 
 // Test compatibility helper retained after section-component extraction.
 export function resolveEsiBadgeState({
 	member,
-	fulcrum,
+	hr,
 	isInCorp,
 }: {
 	member?: CorporationMember
-	fulcrum?: FulcrumCharacterData
+	hr?: {
+		hasValidToken?: boolean | null
+	}
 	isInCorp: boolean
 }): {
 	show: boolean
 	label: 'ESI Valid' | 'ESI Invalid' | 'ESI Unknown'
 	variant: 'success' | 'destructive' | 'warning'
 } {
-	const tokenState = member?.hasValidToken ?? fulcrum?.hasValidToken ?? null
-	const show = Boolean(member?.hasAuthAccount) || (!isInCorp && !!fulcrum)
+	const tokenState = member?.hasValidToken ?? hr?.hasValidToken ?? null
+	const show = Boolean(member?.hasAuthAccount) || (!!hr && !isInCorp)
 	const shared = getEsiStatusBadgeState({
 		hasAuthAccount: show,
 		hasValidToken: tokenState,
@@ -156,10 +169,11 @@ export default function HrMemberProfile() {
 		(isAdmin || isAuditor) && authUserId ? { subjectUserId: authUserId } : undefined,
 	)
 
-	// Fulcrum data is visible to the current HR scope; report creation is gated separately below.
-	const { data: fulcrumCharacters, isLoading: fulcrumLoading } = useApplicationFulcrum(
+	const { data: hrCharacters = [] } = useHrUserCharacters(authUserId ?? '', {
+		enabled: account?.isLinked && !!authUserId,
+	})
+	const { data: reportCharacters = [], isLoading: fulcrumLoading } = useFulcrumUserReports(
 		authUserId ?? '',
-		corporationId ?? '',
 		account?.isLinked && !!authUserId,
 	)
 
@@ -177,35 +191,42 @@ export default function HrMemberProfile() {
 			(a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
 		)
 	}, [applications])
+	const reportCharacterById = useMemo(
+		() => new Map((reportCharacters ?? []).map((character) => [character.characterId, character])),
+		[reportCharacters]
+	)
+	const hrCharacterById = useMemo(
+		() => new Map(hrCharacters.map((character) => [character.characterId, character])),
+		[hrCharacters]
+	)
 	// Build a unified character list: in-corp members first, then external alts
 	const unifiedCharacters = useMemo(() => {
 		if (!account) return []
-		const fulcrumByCharId = new Map(
-			(fulcrumCharacters ?? []).map((fc) => [fc.characterId, fc]),
-		)
 		const corpCharIds = new Set(account.characters.map((c) => c.characterId))
 
-		// In-corp characters, enriched with fulcrum data when available
+		// In-corp characters, enriched with HR/report data when available
 		const inCorp: UnifiedCharacter[] = account.characters.map((m) => ({
 			characterId: m.characterId,
 			characterName: m.characterName,
 			isInCorp: true,
 			member: m,
-			fulcrum: fulcrumByCharId.get(m.characterId),
+			hr: hrCharacterById.get(m.characterId),
+			report: reportCharacterById.get(m.characterId),
 		}))
 
-		// External characters (on other corps) from fulcrum data
-		const external: UnifiedCharacter[] = (fulcrumCharacters ?? [])
-			.filter((fc) => !corpCharIds.has(fc.characterId))
-			.map((fc) => ({
-				characterId: fc.characterId,
-				characterName: fc.characterName,
-				isInCorp: fc.corporationId === corporationId,
-				fulcrum: fc,
+		// External characters come from HR-linked characters, with report metadata joined in.
+		const external: UnifiedCharacter[] = hrCharacters
+			.filter((character) => !corpCharIds.has(character.characterId))
+			.map((character) => ({
+				characterId: character.characterId,
+				characterName: character.characterName,
+				isInCorp: false,
+				hr: character,
+				report: reportCharacterById.get(character.characterId),
 			}))
 
 		return [...inCorp, ...external]
-	}, [account, fulcrumCharacters])
+	}, [account, hrCharacters, hrCharacterById, reportCharacterById])
 	const characterDetailQueries = useQueries({
 		queries: unifiedCharacters.map((character) => ({
 			queryKey: ['character', character.characterId, 'hr-member-profile-private'],
@@ -220,6 +241,7 @@ export default function HrMemberProfile() {
 	const spByCharacterId = new Map<string, number | null>()
 	const walletByCharacterId = new Map<string, string | null>()
 	const metricsLoadingByCharacterId = new Map<string, boolean>()
+	const privateDataUnavailableNoteByCharacterId = new Map<string, string | null>()
 	unifiedCharacters.forEach((character, index) => {
 		const query = characterDetailQueries[index]
 		const detail = query?.data
@@ -229,7 +251,13 @@ export default function HrMemberProfile() {
 			character.characterId,
 			(query?.isPending ?? false) && detail == null
 		)
+		privateDataUnavailableNoteByCharacterId.set(
+			character.characterId,
+			getPrivateDataUnavailableMessage(query?.error)
+		)
 	})
+	const privateDataUnavailableMessage =
+		[...privateDataUnavailableNoteByCharacterId.values()].find((note) => Boolean(note)) ?? null
 
 	const totalCharacters = unifiedCharacters.length
 	const inCorpCharacterCount = useMemo(() => {
@@ -244,11 +272,11 @@ export default function HrMemberProfile() {
 		() =>
 			unifiedCharacters.filter((character) => {
 				const hasPending =
-					character.fulcrum?.reports.some(
+					character.report?.reports.some(
 						(report) => report.status === 'pending' || report.status === 'processing'
 					) ?? false
 				return (
-					Boolean(character.fulcrum?.corporationId) &&
+					Boolean(character.member?.corporationId ?? character.hr?.corporationId) &&
 					!hasPending &&
 					((user?.is_admin || isAuditor) || character.role !== 'CEO')
 				)
@@ -269,7 +297,7 @@ export default function HrMemberProfile() {
 		try {
 			const groups = new Map<string, string[]>()
 			for (const character of scanEligibleCharacters) {
-				const groupCorporationId = character.fulcrum?.corporationId
+				const groupCorporationId = character.member?.corporationId ?? character.hr?.corporationId
 				if (!groupCorporationId) continue
 				const existing = groups.get(groupCorporationId)
 				if (existing) {
@@ -546,17 +574,30 @@ export default function HrMemberProfile() {
 
 				{/* ── Main Content ── */}
 				<div className="space-y-6">
+					{privateDataUnavailableMessage && (
+						<div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+							<div className="flex items-start gap-3">
+								<ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+								<div className="space-y-1">
+									<p className="font-medium">Private ESI data is hidden for some characters</p>
+									<p className="text-sm text-amber-800 dark:text-amber-200">
+										{privateDataUnavailableMessage}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
 					<ProfileCharactersSection
 						characters={unifiedCharacters.map((char) => ({
 							characterId: char.characterId,
 							characterName: char.characterName,
-							hasValidToken: char.member?.hasValidToken ?? char.fulcrum?.hasValidToken ?? null,
-							corporationId: char.member?.corporationId ?? char.fulcrum?.corporationId ?? null,
-							corporationName: char.member?.corporationName ?? char.fulcrum?.corporationName ?? null,
-							allianceId: char.member?.allianceId ?? char.fulcrum?.allianceId ?? null,
-							allianceName: char.member?.allianceName ?? char.fulcrum?.allianceName ?? null,
-							role: char.member?.role ?? char.fulcrum?.role ?? null,
-							activityStatus: char.member?.activityStatus ?? char.fulcrum?.activityStatus ?? null,
+							hasValidToken: char.member?.hasValidToken ?? char.hr?.hasValidToken ?? null,
+							corporationId: char.member?.corporationId ?? char.hr?.corporationId ?? null,
+							corporationName: char.member?.corporationName ?? char.hr?.corporationName ?? null,
+							allianceId: char.member?.allianceId ?? char.hr?.allianceId ?? null,
+							allianceName: char.member?.allianceName ?? char.hr?.allianceName ?? null,
+							role: char.member?.role ?? char.report?.role ?? null,
+							activityStatus: char.member?.activityStatus ?? char.report?.activityStatus ?? null,
 							isExternal: !char.isInCorp,
 							isBlacklisted: char.member?.isBlacklisted,
 							lastLogin: char.member?.lastLogin,
@@ -564,9 +605,9 @@ export default function HrMemberProfile() {
 							skillPoints: spByCharacterId.get(char.characterId),
 							walletBalance: walletByCharacterId.get(char.characterId),
 							isMetricsLoading: metricsLoadingByCharacterId.get(char.characterId),
-							latestReport: char.fulcrum?.reports[0] ?? null,
+							latestReport: char.report?.reports[0] ?? null,
 							hasPendingReport:
-								char.fulcrum?.reports.some((r) => r.status === 'pending' || r.status === 'processing') ??
+								char.report?.reports.some((r) => r.status === 'pending' || r.status === 'processing') ??
 								false,
 						}))}
 						fulcrumLoading={

--- a/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
@@ -24,13 +24,18 @@ import {
 	UserProfileStatusBadge,
 	UserProfileStatsSeparator,
 } from '../components/user-profile-page-shell'
-import { useRequestFulcrumReport, useRequestFulcrumReportBatch } from '../hooks'
+import {
+	useHrUserCharacters,
+	useFulcrumUserReports,
+	useRequestFulcrumReport,
+	useRequestFulcrumReportBatch,
+} from '../hooks'
 import { getPrivateDataUnavailableMessage } from '../utils/private-data'
 import {
 	applicationsApi,
 	type Application,
 	type CharacterReportMetadata,
-	type FulcrumCharacterData,
+	type FulcrumCharacterReportData,
 } from '../api'
 
 interface ReviewerProfileNavigationState {
@@ -54,7 +59,7 @@ interface ReviewerCharacterRow {
 	hasPendingReport: boolean
 }
 
-function getLatestReport(character: FulcrumCharacterData): CharacterReportMetadata | null {
+function getLatestReport(character: FulcrumCharacterReportData): CharacterReportMetadata | null {
 	if (character.reports.length === 0) return null
 	return character.reports.reduce((latest, report) =>
 		new Date(report.createdAt) > new Date(latest.createdAt) ? report : latest
@@ -103,24 +108,28 @@ export default function HrUserProfilePage() {
 		},
 	})
 
-	const fulcrumQuery = useQuery<FulcrumCharacterData[]>({
-		queryKey: ['hr', 'user-profile', userId, 'fulcrum'],
-		queryFn: () => apiClient.get(`/fulcrum/users/${userId}/characters`),
+	const characterQuery = useHrUserCharacters(userId ?? '', {
 		enabled: !!userId,
-		retry: false,
-		staleTime: 1000 * 30,
-		gcTime: 1000 * 60 * 3,
-		refetchInterval: (query) => {
-			const data = query.state.data
-			const hasInProgress = data?.some((ch) =>
-				ch.reports.some((r) => r.status === 'pending' || r.status === 'processing')
-			)
-			return hasInProgress ? 10_000 : false
-		},
-		meta: {
-			suppressErrorToast: true,
-		},
 	})
+
+	const {
+		data: reportCharacters = [],
+		isLoading: reportLoading,
+		isSuccess: reportLoaded,
+		error: reportError,
+	} = useFulcrumUserReports(userId ?? '', { enabled: !!userId })
+	const reportCharacterById = useMemo(
+		() => new Map(reportCharacters.map((character) => [character.characterId, character])),
+		[reportCharacters]
+	)
+	const reportAccessDenied = isForbiddenError(reportError)
+	const fulcrumAccessDeniedMessage = reportAccessDenied
+		? 'Fulcrum data is hidden because this user does not have an open application or shared corporation access.'
+		: null
+	const fulcrumUnavailableMessage =
+		reportError && !reportAccessDenied ? 'Fulcrum data is unavailable right now.' : null
+	const canViewFulcrumReports = reportLoaded
+	const canRequestFulcrumReports = canViewFulcrumReports && (accessibleCorporations?.length ?? 0) > 0
 
 	const sortedApplications = useMemo(() => {
 		if (!applicationsQuery.data) return []
@@ -130,13 +139,14 @@ export default function HrUserProfilePage() {
 	}, [applicationsQuery.data])
 
 	const rows = useMemo<ReviewerCharacterRow[]>(() => {
-		if (!fulcrumQuery.data) return []
+		if (!characterQuery.data) return []
 
-		return fulcrumQuery.data
+		return characterQuery.data
 			.map((character, index) => {
-				const latestReport = getLatestReport(character)
+				const report = reportCharacterById.get(character.characterId)
+				const latestReport = report ? getLatestReport(report) : null
 				const hasPendingReport =
-					character.reports.some((report) => report.status === 'pending' || report.status === 'processing')
+					report?.reports.some((entry) => entry.status === 'pending' || entry.status === 'processing') ?? false
 				const isPrimary = index === 0 || sortedApplications[0]?.characterId === character.characterId
 
 				return {
@@ -147,9 +157,9 @@ export default function HrUserProfilePage() {
 					corporationName: character.corporationName ?? null,
 					allianceId: character.allianceId ?? null,
 					allianceName: character.allianceName ?? null,
-					role: character.role ?? null,
-					activityStatus: character.activityStatus ?? null,
-					hasValidToken: character.hasValidToken ?? null,
+					role: report?.role ?? null,
+					activityStatus: report?.activityStatus ?? null,
+					hasValidToken: character.hasValidToken,
 					latestReport,
 					hasPendingReport,
 				}
@@ -159,7 +169,7 @@ export default function HrUserProfilePage() {
 				if (!a.isPrimary && b.isPrimary) return 1
 				return a.characterName.localeCompare(b.characterName)
 			})
-	}, [fulcrumQuery.data, sortedApplications])
+	}, [characterQuery.data, reportCharacterById, sortedApplications])
 
 	const characterDetailQueries = useQueries({
 		queries: rows.map((character) => ({
@@ -200,7 +210,6 @@ export default function HrUserProfilePage() {
 
 	usePageTitle(accountName ? `${accountName} | HR User Details` : 'HR User Details')
 
-	const canRequestFulcrumReports = (accessibleCorporations?.length ?? 0) > 0
 	const canRequestCharacterReport = (character: { corporationId?: string | null }) =>
 		Boolean(character.corporationId)
 	const scanEligibleCharacters = rows.filter(
@@ -225,7 +234,7 @@ export default function HrUserProfilePage() {
 		)
 	}
 
-	if (isForbiddenError(fulcrumQuery.error) && !fulcrumQuery.data) {
+	if (isForbiddenError(characterQuery.error) && !characterQuery.data) {
 		return (
 			<UserProfilePageShell
 				rootLabel="Users"
@@ -249,7 +258,7 @@ export default function HrUserProfilePage() {
 		)
 	}
 
-	if (fulcrumQuery.isLoading && rows.length === 0) {
+	if (characterQuery.isLoading && rows.length === 0) {
 		return <div className="flex items-center justify-center min-h-[400px]"><LoadingSpinner size="lg" /></div>
 	}
 
@@ -360,11 +369,6 @@ export default function HrUserProfilePage() {
 			userId={userId}
 			mainCharacterId={mainCharacter?.characterId}
 			mainCharacterName={mainCharacter?.characterName}
-			sidebarBadges={
-				<UserProfileStatusBadge variant={canRequestFulcrumReports ? 'success' : 'secondary'}>
-					{canRequestFulcrumReports ? 'HR Accessible' : 'HR Unavailable'}
-				</UserProfileStatusBadge>
-			}
 			sidebarStats={
 				<>
 					<UserProfileStatRow label="Characters" value={rows.length} />
@@ -391,6 +395,32 @@ export default function HrUserProfilePage() {
 							</div>
 						</div>
 					)}
+					{fulcrumAccessDeniedMessage && (
+						<div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+							<div className="flex items-start gap-3">
+								<AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+								<div className="space-y-1">
+									<p className="font-medium">Fulcrum reports are hidden for this user</p>
+									<p className="text-sm text-amber-800 dark:text-amber-200">
+										{fulcrumAccessDeniedMessage}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
+					{fulcrumUnavailableMessage && (
+						<div className="rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sky-900 dark:border-sky-800 dark:bg-sky-950 dark:text-sky-100">
+							<div className="flex items-start gap-3">
+								<AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+								<div className="space-y-1">
+									<p className="font-medium">Fulcrum data is temporarily unavailable</p>
+									<p className="text-sm text-sky-800 dark:text-sky-200">
+										{fulcrumUnavailableMessage}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
 					<ProfileCharactersSection
 						characters={rows.map((character) => ({
 							characterId: character.characterId,
@@ -410,7 +440,8 @@ export default function HrUserProfilePage() {
 							isMetricsLoading: metricsLoadingByCharacterId.get(character.characterId),
 							privateDataUnavailableNote: privateDataUnavailableNoteByCharacterId.get(character.characterId),
 						}))}
-						fulcrumLoading={fulcrumQuery.isLoading && rows.length === 0}
+						fulcrumLoading={canViewFulcrumReports && reportLoading && rows.length === 0}
+						showFulcrumReports={canViewFulcrumReports}
 						showViewDetailsButton
 						isScanAllVisible
 						isScanningAll={isScanningAll}
@@ -477,22 +508,26 @@ export default function HrUserProfilePage() {
 						}
 					/>
 
-			<FulcrumBulkScanDialog
-				open={scanAllDialogOpen}
-				onOpenChange={setScanAllDialogOpen}
-				eligibleCount={scanEligibleCharacters.length}
-				sendDmForScanRequests={sendDmForScanRequests}
-				setSendDmForScanRequests={setSendDmForScanRequests}
-				onConfirm={handleConfirmScanAll}
-			/>
-			<FulcrumSingleScanDialog
-				open={singleScanDialogCharacter !== null}
-				onOpenChange={(open) => !open && setSingleScanDialogCharacter(null)}
-				characterName={singleScanDialogCharacter?.characterName ?? 'Character'}
-				sendDmForScanRequests={sendDmForScanRequests}
-				setSendDmForScanRequests={setSendDmForScanRequests}
-				onConfirm={handleConfirmSingleScan}
-			/>
+				{canViewFulcrumReports && (
+					<>
+						<FulcrumBulkScanDialog
+							open={scanAllDialogOpen}
+							onOpenChange={setScanAllDialogOpen}
+							eligibleCount={scanEligibleCharacters.length}
+							sendDmForScanRequests={sendDmForScanRequests}
+							setSendDmForScanRequests={setSendDmForScanRequests}
+							onConfirm={handleConfirmScanAll}
+						/>
+						<FulcrumSingleScanDialog
+							open={singleScanDialogCharacter !== null}
+							onOpenChange={(open) => !open && setSingleScanDialogCharacter(null)}
+							characterName={singleScanDialogCharacter?.characterName ?? 'Character'}
+							sendDmForScanRequests={sendDmForScanRequests}
+							setSendDmForScanRequests={setSendDmForScanRequests}
+							onConfirm={handleConfirmSingleScan}
+						/>
+					</>
+				)}
 		</UserProfilePageShell>
 	)
 }

--- a/apps/ui/src/client/features/applications/utils/private-data.ts
+++ b/apps/ui/src/client/features/applications/utils/private-data.ts
@@ -1,7 +1,7 @@
-const FORBIDDEN_PRIVATE_DATA_MESSAGE =
+export const FORBIDDEN_PRIVATE_DATA_MESSAGE =
 	'Private ESI data is hidden because this user does not have an open application or shared corporation access for this character.'
 
-const GENERIC_PRIVATE_DATA_MESSAGE = 'Private ESI data is unavailable right now.'
+export const GENERIC_PRIVATE_DATA_MESSAGE = 'Private ESI data is unavailable right now.'
 
 function isForbiddenError(error: unknown): boolean {
 	return Boolean(

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -2887,6 +2887,7 @@ export class ApiClient {
 		viewedAsCeoOrDirector: boolean
 		viewedAsHrViewer: boolean
 		viewerRole: 'CEO' | 'Director' | null
+		canViewPrivateData: boolean
 		public: {
 			info: any
 			corporationHistory: any[]

--- a/apps/ui/src/test/unit/features/applications/hr-member-profile-esi-badge.unit.test.ts
+++ b/apps/ui/src/test/unit/features/applications/hr-member-profile-esi-badge.unit.test.ts
@@ -54,7 +54,7 @@ describe('resolveEsiBadgeState', () => {
 	it('shows badge for external character and uses fulcrum token validity', () => {
 		const result = resolveEsiBadgeState({
 			isInCorp: false,
-			fulcrum: {
+			hr: {
 				hasValidToken: false,
 			} as any,
 		})
@@ -79,4 +79,3 @@ describe('resolveEsiBadgeState', () => {
 		expect(result.label).toBe('ESI Unknown')
 	})
 })
-


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Decouples Fulcrum report data from HR-owned character identity data (corp/alliance/ESI token) so each can be fetched, cached, and access-gated independently, and tightens the character-report access checks that previously relied on a client-supplied `corporationId`.

## Changes
- Add `canAccessCharacterPrivateData` (combines `canViewCharacterPrivateDetails` + `shouldBlockCharacterPrivateAccess`) and expose it as `canViewPrivateData` on the character detail/private API responses (`apps/core/src/lib/character-access.ts`, `apps/core/src/routes/characters.ts`).
- `apps/core/src/routes/fulcrum.ts`:
  - Extract report/role/activity building into a shared `buildFulcrumCharacterReportRows` helper, reused by the existing `/users/:userId/characters` route and a new `GET /users/:userId/reports` endpoint (report metadata only, no identity fields).
  - `GET /characters/:characterId/reports` no longer requires a `corporationId` query param; access is now resolved server-side via `resolveFulcrumReportAccessForTargetUser` (shared corporation or open application), closing a gap where callers could bypass scoping by omitting/forging the query param.
- Add `GET /api/hr/users/:userId/characters` (`apps/core/src/routes/hr.ts`) returning HR-owned character identity/summary data independent of Fulcrum access.
- UI: replace the combined `useApplicationFulcrum`/`useAuditorFulcrum` hooks with separate `useHrUserCharacters` (identity) and `useFulcrumUserReports` (report metadata) hooks, updating `fulcrum-panel.tsx`, `hr-application-review.tsx`, `hr-auditor-user-profile.tsx`, `hr-member-profile.tsx`, and `hr-user-profile.tsx` accordingly.
- Replace `ACTIVE_APPLICATION_STATUSES` with a new `OPEN_APPLICATION_STATUSES` (adds `accepted`) for gating the Fulcrum tab and private-data visibility in `hr-application-review.tsx`; add a `canViewApplicationPrivateData` check and warning banner shown when private ESI data is hidden.
- Drop the unused `unavailableReason` prop from `CharacterIdentitySummary`.

## Testing
- Updated/added coverage in `characters.hr-auditor.route.test.ts`, `fulcrum.access.route.test.ts` (new cases for denied/allowed character report listing without a `corporationId`), and `hr-member-profile-esi-badge.unit.test.ts`.
<!-- claude:end -->