### PR TITLE
fix(mobile): improve viewport rendering for users on mobile

### DIFF
--- a/apps/ui/src/client/components/admin-nav.tsx
+++ b/apps/ui/src/client/components/admin-nav.tsx
@@ -190,7 +190,7 @@ export function AdminNav({ onNavigate }: AdminNavProps) {
 				<p className="text-xs text-muted-foreground mt-1">System Management</p>
 			</div>
 
-			<div className="flex-1 p-4 space-y-1 overflow-y-auto">
+			<div className="flex-1 p-4 space-y-1 overflow-y-auto overscroll-contain">
 				{navItems.map((item) => {
 					const childActive = (item.children ?? []).some((child) =>
 						isRouteActive(location.pathname, child.href)

--- a/apps/ui/src/client/components/layout.tsx
+++ b/apps/ui/src/client/components/layout.tsx
@@ -103,7 +103,7 @@ export default function Layout() {
 			{/* Sidebar */}
 			<aside
 				className={`
-					fixed top-0 left-0 h-screen w-64 z-50
+					fixed top-0 left-0 h-dvh w-64 z-50
 					border-r border-border/50
 					bg-background/52 backdrop-blur-sm
 					transition-transform duration-300 ease-in-out

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -574,7 +574,7 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 			</div>
 
 			{/* Navigation Items */}
-			<nav className="flex-1 p-4 space-y-1 overflow-y-auto">
+			<nav className="flex-1 p-4 space-y-1 overflow-y-auto overscroll-contain">
 				{navItems.map((item) => {
 					const childActive = (item.children ?? []).some(
 						(child) =>

--- a/apps/ui/src/client/components/user-search-pagination-controls.tsx
+++ b/apps/ui/src/client/components/user-search-pagination-controls.tsx
@@ -44,7 +44,7 @@ export function UserSearchPaginationControls({
 	)
 
 	return (
-		<div className="flex items-center justify-between gap-3">
+		<div className="flex flex-wrap items-center justify-between gap-3">
 			<div className="flex items-center gap-2 text-sm text-muted-foreground">
 				<div>
 					{totalCount > 0
@@ -53,7 +53,7 @@ export function UserSearchPaginationControls({
 				</div>
 				{summaryAction ? <div className="shrink-0">{summaryAction}</div> : null}
 			</div>
-			<div className="flex items-center gap-2 justify-end">
+			<div className="flex flex-wrap items-center gap-2 justify-end">
 				<div className="flex items-center gap-2">
 					<span className="text-sm text-muted-foreground">Per page:</span>
 					<Select

--- a/apps/ui/src/client/routes/admin/layout.tsx
+++ b/apps/ui/src/client/routes/admin/layout.tsx
@@ -82,7 +82,7 @@ function AdminLayoutContent() {
 			{/* Sidebar */}
 			<aside
 				className={cn(
-					'fixed lg:sticky top-0 left-0 h-screen w-64 z-50 border-r border-border/50 bg-background/52 backdrop-blur-sm transition-transform duration-300 ease-in-out',
+					'fixed lg:sticky top-0 left-0 h-dvh w-64 z-50 border-r border-border/50 bg-background/52 backdrop-blur-sm transition-transform duration-300 ease-in-out',
 					sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
 				)}
 			>
@@ -90,7 +90,7 @@ function AdminLayoutContent() {
 			</aside>
 
 			{/* Main Content Area */}
-			<div className="relative z-10 flex-1 flex flex-col min-w-0 overflow-auto">
+			<div className="relative z-10 flex-1 flex flex-col min-w-0">
 				{/* Top Bar (Mobile) */}
 				<header className="sticky top-0 z-30 lg:hidden border-b border-border/30 bg-background/95 backdrop-blur-sm shadow-sm">
 					<div className="flex items-center justify-between">
@@ -110,10 +110,10 @@ function AdminLayoutContent() {
 				{/* Header with Breadcrumbs (kept as requested) */}
 				<header className="border-b border-border/30 bg-background/72 z-20 shadow-[0_4px_20px_rgba(0,0,0,0.3)] flex-shrink-0 backdrop-blur-sm">
 					<div className="px-4 md:px-6 lg:px-8 py-4">
-						<div className="flex items-center justify-between gap-4">
+						<div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
 							<h1 className="text-2xl font-bold gradient-text">Admin Panel</h1>
 
-							<nav className="flex items-center gap-2 text-sm" aria-label="Breadcrumb">
+							<nav className="flex flex-wrap items-center gap-2 text-sm" aria-label="Breadcrumb">
 								{breadcrumbs.map((crumb, index) => (
 									<Fragment key={crumb.path}>
 										{index > 0 && <ChevronRight className="h-4 w-4 text-muted-foreground" />}
@@ -136,7 +136,7 @@ function AdminLayoutContent() {
 					</div>
 				</header>
 
-				<main className="flex-1 relative z-10 p-4 md:p-6 lg:p-8">
+				<main className="flex-1 relative z-10 p-4 md:p-6 lg:p-8 overflow-x-hidden">
 					<div className="w-full mx-auto max-w-[120rem]">
 						<Outlet />
 					</div>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes mobile viewport rendering issues in the UI's admin/sidebar layouts, addressing incorrect sidebar height and content overflow/wrapping problems on mobile browsers.

## Changes
- Use `h-dvh` instead of `h-screen` for the sidebar in `layout.tsx` and `admin/layout.tsx` so it accounts for mobile browser dynamic viewport chrome (address bar, etc.)
- Add `overscroll-contain` to the scrollable nav lists in `admin-nav.tsx` and `sidebar-nav.tsx` to prevent scroll chaining to the page body
- Allow the admin header/breadcrumbs and pagination controls to wrap (`flex-wrap`) instead of forcing a single row, avoiding horizontal overflow on narrow screens
- Move `overflow-auto` from the admin content wrapper to `overflow-x-hidden` on `<main>` to stop unwanted horizontal scrolling while still allowing normal content flow
