### PR TITLE
optimize corp HR access check

### DIFF
--- a/apps/core/src/routes/__tests__/corporations.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporations.access.route.test.ts
@@ -1,0 +1,350 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getStub } from '@repo/do-utils'
+
+import { getCachedUserPermissions } from '../../lib/groups-cache'
+import corporationsRoutes from '../corporations'
+
+import type { SessionUser } from '../../context'
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn(),
+}))
+
+vi.mock('../../lib/groups-cache', () => ({
+	getCachedUserPermissions: vi.fn(),
+}))
+
+vi.mock('../../middleware/session', () => ({
+	requireAuth:
+		() =>
+			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+				await next()
+			},
+	requireAdmin:
+		() =>
+			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+				await next()
+			},
+}))
+
+const getStubMock = vi.mocked(getStub)
+const getCachedUserPermissionsMock = vi.mocked(getCachedUserPermissions)
+
+function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
+	return {
+		id: 'user-1',
+		mainCharacterId: '1001',
+		sessionId: 'session-1',
+		characters: [],
+		is_admin: false,
+		roles: [],
+		discordUserId: null,
+		...overrides,
+	}
+}
+
+function createApp(user: SessionUser, db: any) {
+	const app = new Hono<{
+		Bindings: any
+		Variables: {
+			user?: SessionUser
+			db?: any
+		}
+	}>()
+
+	app.use('*', async (c, next) => {
+		c.set('user', user)
+		c.set('db', db)
+		await next()
+	})
+
+	app.route('/api/corporations', corporationsRoutes)
+	return app
+}
+
+describe('corporations access route', () => {
+	const env = {
+		EVE_CHARACTER_DATA: { name: 'EVE_CHARACTER_DATA' },
+		EVE_CORPORATION_DATA: { name: 'EVE_CORPORATION_DATA' },
+		HR: { name: 'HR' },
+		DATABASE_URL: 'postgresql://test',
+	} as any
+
+	let dbStub: {
+		query: {
+			managedCorporations: {
+				findFirst: ReturnType<typeof vi.fn>
+			}
+			userCharacters: {
+				findMany: ReturnType<typeof vi.fn>
+			}
+		}
+	}
+	let charStub: {
+		getCharacterInfo: ReturnType<typeof vi.fn>
+	}
+	let hrStub: {
+		checkPermission: ReturnType<typeof vi.fn>
+	}
+	let corpStub: {
+		getCorporationInfo: ReturnType<typeof vi.fn>
+		getDirectors: ReturnType<typeof vi.fn>
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		dbStub = {
+			query: {
+				managedCorporations: {
+					findFirst: vi.fn().mockResolvedValue({
+						corporationId: '1001',
+						name: 'Alpha Corp',
+						ticker: 'ALP',
+						isMemberCorporation: true,
+						isAltCorp: false,
+						isSpecialPurpose: false,
+					}),
+				},
+				userCharacters: {
+					findMany: vi.fn().mockResolvedValue([
+						{
+							characterId: '1001',
+							characterName: 'Alpha Main',
+							corporationId: '1001',
+						},
+					]),
+				},
+			},
+		}
+		charStub = {
+			getCharacterInfo: vi.fn(),
+		}
+		hrStub = {
+			checkPermission: vi.fn().mockResolvedValue(false),
+		}
+		corpStub = {
+			getCorporationInfo: vi.fn().mockResolvedValue({ ceoId: '1001' } as any),
+			getDirectors: vi.fn().mockResolvedValue([]),
+		}
+		getCachedUserPermissionsMock.mockResolvedValue([])
+
+		getStubMock.mockImplementation((binding: unknown) => {
+			if (binding === env.EVE_CHARACTER_DATA) return charStub as any
+			if (binding === env.HR) return hrStub as any
+			if (binding === env.EVE_CORPORATION_DATA) return corpStub as any
+			throw new Error('Unexpected binding')
+		})
+	})
+
+	it('returns corp metadata and role without hitting the character fallback path', async () => {
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: true,
+			userRole: 'CEO',
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('returns admin access for site admins without probing corp leadership', async () => {
+		const app = createApp(makeUser({ is_admin: true }), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: true,
+			userRole: 'admin',
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
+		expect(corpStub.getCorporationInfo).not.toHaveBeenCalled()
+		expect(corpStub.getDirectors).not.toHaveBeenCalled()
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('returns director access when a persisted character is on the director list', async () => {
+		corpStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' } as any)
+		corpStub.getDirectors.mockResolvedValue([{ characterId: '1001' }] as any)
+
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: true,
+			userRole: 'Director',
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('returns HR admin access for member corporations', async () => {
+		corpStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' } as any)
+		corpStub.getDirectors.mockResolvedValue([] as any)
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{
+				characterId: '2001',
+				characterName: 'Alpha Other',
+				corporationId: '1001',
+			},
+		])
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		hrStub.checkPermission.mockResolvedValue(true)
+
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: true,
+			userRole: 'hr_admin',
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('returns HR reviewer access for member corporations', async () => {
+		corpStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' } as any)
+		corpStub.getDirectors.mockResolvedValue([] as any)
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{
+				characterId: '2001',
+				characterName: 'Alpha Other',
+				corporationId: '1001',
+			},
+		])
+		hrStub.checkPermission.mockImplementation(
+			async (_userId: string, _corporationId: string, requiredRole: string) =>
+				requiredRole === 'hr_viewer' || requiredRole === 'hr_reviewer'
+		)
+
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: true,
+			userRole: 'hr_reviewer',
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('returns HR viewer access for auditors on member corporations', async () => {
+		corpStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' } as any)
+		corpStub.getDirectors.mockResolvedValue([] as any)
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{
+				characterId: '2001',
+				characterName: 'Alpha Other',
+				corporationId: '1001',
+			},
+		])
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:hr:auditor' } as any])
+
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: true,
+			userRole: 'hr_viewer',
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+		expect(getCachedUserPermissionsMock).toHaveBeenCalledWith(env, 'user-1')
+	})
+
+	it('returns corp metadata even when access is denied', async () => {
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{
+				characterId: '2001',
+				characterName: 'Bravo Alt',
+				corporationId: '2001',
+			},
+		])
+		corpStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' } as any)
+
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: false,
+			userRole: null,
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('returns no corp access when the managed corporation row is missing', async () => {
+		dbStub.query.managedCorporations.findFirst.mockResolvedValueOnce(null)
+
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: false,
+			userRole: null,
+			corporation: null,
+		})
+		expect(corpStub.getCorporationInfo).not.toHaveBeenCalled()
+		expect(corpStub.getDirectors).not.toHaveBeenCalled()
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+})

--- a/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
+++ b/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
@@ -76,7 +76,7 @@ describe('users corporation access', () => {
 	let corpStub: {
 		getCorporationInfo: ReturnType<typeof vi.fn>
 		getDirectors: ReturnType<typeof vi.fn>
-		getCoreData: ReturnType<typeof vi.fn>
+		getMembers: ReturnType<typeof vi.fn>
 	}
 
 	beforeEach(() => {
@@ -141,9 +141,9 @@ describe('users corporation access', () => {
 			getCharacterInfo: vi.fn(),
 		}
 		corpStub = {
-			getCorporationInfo: vi.fn(),
-			getDirectors: vi.fn(),
-			getCoreData: vi.fn(),
+			getCorporationInfo: vi.fn().mockResolvedValue({ ceoId: '9999' } as any),
+			getDirectors: vi.fn().mockResolvedValue([]),
+			getMembers: vi.fn(),
 		}
 
 		getStubMock.mockImplementation((binding: unknown) => {
@@ -155,19 +155,41 @@ describe('users corporation access', () => {
 	})
 
 	it('returns only member corporation HR access for non-admin users', async () => {
-		dbStub.query.userCharacters.findMany.mockResolvedValue([
-			{ characterId: '2001', userId: 'user-a', status: 'active', hasValidToken: true },
-			{ characterId: '2002', userId: 'user-a', status: 'active', hasValidToken: true },
-			{ characterId: '2003', userId: 'user-b', status: 'active', hasValidToken: true },
+		dbStub.query.userCharacters.findMany
+			.mockResolvedValueOnce([
+				{
+					characterId: '2001',
+					characterName: 'Alpha One',
+					corporationId: '1001',
+					status: 'active',
+					hasValidToken: true,
+				},
+				{
+					characterId: '2002',
+					characterName: 'Alpha Two',
+					corporationId: '1001',
+					status: 'active',
+					hasValidToken: true,
+				},
+				{
+					characterId: '2003',
+					characterName: 'Bravo One',
+					corporationId: '2001',
+					status: 'active',
+					hasValidToken: true,
+				},
+			] as any)
+			.mockResolvedValueOnce([
+				{ characterId: '2001', userId: 'user-a', status: 'active', hasValidToken: true },
+				{ characterId: '2002', userId: 'user-a', status: 'active', hasValidToken: true },
+				{ characterId: '2003', userId: 'user-b', status: 'active', hasValidToken: true },
+			] as any)
+		corpStub.getMembers.mockResolvedValue([
+			{ characterId: '2001' },
+			{ characterId: '2002' },
+			{ characterId: '2003' },
+			{ characterId: '2004' },
 		] as any)
-		corpStub.getCoreData.mockResolvedValue({
-			members: [
-				{ characterId: '2001' },
-				{ characterId: '2002' },
-				{ characterId: '2003' },
-				{ characterId: '2004' },
-			],
-		} as any)
 
 		const app = createApp({ user: makeUser(), db: dbStub })
 		const res = await app.request('/api/users/corporation-access', {}, env)
@@ -195,5 +217,74 @@ describe('users corporation access', () => {
 		})
 		expect(hrStub.getUserHrCorporations).toHaveBeenCalledWith('user-1')
 		expect(hrStub.getUserRoles).toHaveBeenCalledWith('user-1')
+		expect(corpStub.getMembers).toHaveBeenCalledWith('1001')
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('returns all managed corporations for site admins without character lookups', async () => {
+		dbStub.query.userCharacters.findMany.mockResolvedValue([] as any)
+		corpStub.getMembers
+			.mockResolvedValueOnce([{ characterId: '1001' }] as any)
+			.mockResolvedValueOnce([{ characterId: '2001' }] as any)
+			.mockResolvedValueOnce([{ characterId: '3001' }] as any)
+
+		const app = createApp({ user: makeUser({ is_admin: true }), db: dbStub })
+		const res = await app.request('/api/users/corporation-access', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({
+			hasAccess: true,
+			corporations: [
+				{
+					corporationId: '1001',
+					name: 'Alpha Corp',
+					ticker: 'ALP',
+					userRole: 'admin',
+					characterId: null,
+					characterName: null,
+					isMemberCorporation: true,
+					isAltCorp: false,
+					isSpecialPurpose: false,
+					memberCount: 1,
+					linkedMemberCount: 0,
+					unlinkedMemberCount: 1,
+					validEsiKeyMemberCount: 0,
+				},
+				{
+					corporationId: '2001',
+					name: 'Bravo Corp',
+					ticker: 'BRV',
+					userRole: 'admin',
+					characterId: null,
+					characterName: null,
+					isMemberCorporation: false,
+					isAltCorp: true,
+					isSpecialPurpose: false,
+					memberCount: 1,
+					linkedMemberCount: 0,
+					unlinkedMemberCount: 1,
+					validEsiKeyMemberCount: 0,
+				},
+				{
+					corporationId: '3001',
+					name: 'Charlie Corp',
+					ticker: 'CHR',
+					userRole: 'admin',
+					characterId: null,
+					characterName: null,
+					isMemberCorporation: false,
+					isAltCorp: false,
+					isSpecialPurpose: true,
+					memberCount: 1,
+					linkedMemberCount: 0,
+					unlinkedMemberCount: 1,
+					validEsiKeyMemberCount: 0,
+				},
+			],
+		})
+		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+		expect(corpStub.getCorporationInfo).not.toHaveBeenCalled()
+		expect(corpStub.getDirectors).not.toHaveBeenCalled()
+		expect(corpStub.getMembers).toHaveBeenCalledTimes(3)
 	})
 })

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -55,6 +55,21 @@ type MemberCorpHrAccess = {
 	isMemberCorporation: boolean
 }
 
+type CorporationAccessScope = {
+	corporationId: string
+	name: string
+	ticker: string
+	isMemberCorporation: boolean
+	isAltCorp: boolean
+	isSpecialPurpose: boolean
+}
+
+type CorporationAccessScopeResponse = {
+	hasAccess: boolean
+	userRole: 'CEO' | 'Director' | 'admin' | 'hr_admin' | 'hr_reviewer' | 'hr_viewer' | null
+	corporation: CorporationAccessScope | null
+}
+
 async function hasMemberCorpHrPermission(
 	c: Context<App>,
 	userId: string,
@@ -99,6 +114,78 @@ async function resolveCorporationMembersAccess(
 		return isHrAdmin ? 'hr_admin' : isHrReviewer ? 'hr_reviewer' : 'hr_viewer'
 	}
 }
+
+/**
+ * GET /corporations/:corporationId/access
+ * Corp-scoped access check used by single-corporation screens.
+ * Returns the corporation metadata needed for page-level gating plus the access role.
+ */
+app.get('/:corporationId/access', requireAuth(), async (c) => {
+	const corporationId = c.req.param('corporationId')
+	const user = c.get('user')!
+	const db = c.get('db')
+
+	if (!db) {
+		return c.json({ error: 'Database not available' }, 500)
+	}
+
+	try {
+		const managedCorp = await db.query.managedCorporations.findFirst({
+			where: and(
+				eq(managedCorporations.corporationId, corporationId),
+				eq(managedCorporations.isActive, true)
+			),
+			columns: {
+				corporationId: true,
+				name: true,
+				ticker: true,
+				isMemberCorporation: true,
+				isAltCorp: true,
+				isSpecialPurpose: true,
+			},
+		})
+
+		if (!managedCorp) {
+			const response: CorporationAccessScopeResponse = {
+				hasAccess: false,
+				userRole: null,
+				corporation: null,
+			}
+			return c.json(response)
+		}
+
+		try {
+			const userRole = await resolveCorporationMembersAccess(c, corporationId, {
+				isMemberCorporation: managedCorp.isMemberCorporation,
+			})
+
+			const response: CorporationAccessScopeResponse = {
+				hasAccess: true,
+				userRole,
+				corporation: managedCorp,
+			}
+			return c.json(response)
+		} catch {
+			logger.info('[Corporations] Corp-scoped access denied', {
+				corporationId,
+				userId: user.id,
+			})
+			const response: CorporationAccessScopeResponse = {
+				hasAccess: false,
+				userRole: null,
+				corporation: managedCorp,
+			}
+			return c.json(response)
+		}
+	} catch (error) {
+		logger.error('[Corporations] Failed to resolve corp-scoped access', {
+			corporationId,
+			userId: user.id,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return c.json({ error: 'Failed to resolve corporation access' }, 500)
+	}
+})
 
 type CorporationMemberListItem = {
 	characterId: string

--- a/apps/core/src/routes/users.ts
+++ b/apps/core/src/routes/users.ts
@@ -404,6 +404,13 @@ users.get('/has-corporation-access', async (c) => {
 		// Get all user's characters
 		const characters = await db.query.userCharacters.findMany({
 			where: eq(userCharacters.userId, user.id),
+			columns: {
+				characterId: true,
+				characterName: true,
+				corporationId: true,
+				hasValidToken: true,
+				status: true,
+			},
 		})
 
 		if (!characters.length) {
@@ -575,33 +582,40 @@ users.get('/corporation-access', async (c) => {
 		}> = []
 
 		if (characters.length > 0 && managedCorps.length > 0) {
-			// OPTIMIZATION: First, fetch all character corporation IDs to reduce checks
+			// Prefer the corporation ID already cached on the user character row.
+			// Only fall back to the corporation-data worker for rows that are missing it.
 			const characterCorpMap = new Map<string, string>() // characterId -> corporationId
+			const missingCharacterIds: string[] = []
+			const charactersById = new Map(characters.map((character) => [character.characterId, character]))
 
-			logger.info('[Corporation Access] Fetching character corporation IDs...')
+			for (const character of characters) {
+				if (character.corporationId) {
+					characterCorpMap.set(character.characterId, character.corporationId)
+				} else {
+					missingCharacterIds.push(character.characterId)
+				}
+			}
 
-			// Create single character stub (reuse for all calls)
-			const charStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
+			if (missingCharacterIds.length > 0) {
+				logger.info('[Corporation Access] Fetching missing character corporation IDs', {
+					missingCount: missingCharacterIds.length,
+				})
 
-			// Fetch character data in parallel to get corporation IDs
-			const charDataPromises = characters.map(async (character) => {
 				try {
-					const charData = await charStub.getCharacterInfo(character.characterId)
-					if (charData?.corporationId) {
-						const corpId = String(charData.corporationId)
-						characterCorpMap.set(character.characterId, corpId)
-						return { characterId: character.characterId, corporationId: corpId }
+					const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, 'default')
+					const missingCorpMap = await corpStub.getCorporationIdsByCharacterIds(
+						missingCharacterIds
+					)
+
+					for (const [characterId, corporationId] of Object.entries(missingCorpMap)) {
+						characterCorpMap.set(characterId, corporationId)
 					}
 				} catch (error) {
-					logger.warn('[Corporation Access] Error fetching character data', {
-						characterId: character.characterId,
+					logger.warn('[Corporation Access] Error fetching missing character corporation IDs', {
 						error: error instanceof Error ? error.message : String(error),
 					})
 				}
-				return null
-			})
-
-			await Promise.all(charDataPromises)
+			}
 
 			logger.info('[Corporation Access] Character corporations mapped', {
 				mappedCount: characterCorpMap.size,
@@ -623,7 +637,7 @@ users.get('/corporation-access', async (c) => {
 				if (!charactersByCorpId.has(corpId)) {
 					charactersByCorpId.set(corpId, [])
 				}
-				const char = characters.find((c) => c.characterId === charId)
+				const char = charactersById.get(charId)
 				if (char) {
 					charactersByCorpId.get(corpId)!.push(char)
 				}
@@ -800,10 +814,10 @@ users.get('/corporation-access', async (c) => {
 			accessibleCorporations.map(async (corp) => {
 				try {
 					const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corp.corporationId)
-					const coreData = await corpStub.getCoreData(corp.corporationId)
+					const members = await corpStub.getMembers(corp.corporationId)
 					return {
 						corporationId: corp.corporationId,
-						members: coreData?.members ?? [],
+						members,
 					}
 				} catch (error) {
 					logger.warn('[Corporation Access] Failed to hydrate corporation stats', {

--- a/apps/ui/src/client/features/corporations/api.ts
+++ b/apps/ui/src/client/features/corporations/api.ts
@@ -5,7 +5,7 @@
  * functionality, including member lists and access control.
  */
 
-import { API_BASE_URL, apiClient } from '../../lib/api'
+import { API_BASE_URL, apiClient, type ManagedCorporation } from '../../lib/api'
 
 // ============================================================================
 // Type Definitions
@@ -243,6 +243,15 @@ export interface CorporationAccessResult {
 	}>
 }
 
+export interface CorporationScopedAccessResult {
+	hasAccess: boolean
+	userRole: 'CEO' | 'Director' | 'admin' | 'hr_admin' | 'hr_reviewer' | 'hr_viewer' | null
+	corporation: Pick<
+		ManagedCorporation,
+		'corporationId' | 'name' | 'ticker' | 'isMemberCorporation' | 'isAltCorp' | 'isSpecialPurpose'
+	> | null
+}
+
 /**
  * Quick access check result (for UI navigation)
  */
@@ -271,6 +280,14 @@ export const myCorporationsApi = {
 	 */
 	async checkAccess(): Promise<CorporationAccessResult> {
 		return apiClient.get('/users/corporation-access')
+	},
+
+	/**
+	 * Check access for a single corporation.
+	 * Used by corp-scoped screens and does not depend on query params.
+	 */
+	async getCorporationAccess(corporationId: string): Promise<CorporationScopedAccessResult> {
+		return apiClient.get(`/corporations/${encodeURIComponent(corporationId)}/access`)
 	},
 
 	/**

--- a/apps/ui/src/client/features/corporations/hooks.ts
+++ b/apps/ui/src/client/features/corporations/hooks.ts
@@ -16,6 +16,7 @@ import type {
 	CorporationMembersResponse,
 	CorporationUserSearchResult,
 	MyCorporation,
+	CorporationScopedAccessResult,
 } from './api'
 
 // ============================================================================
@@ -36,6 +37,7 @@ export const corporationKeys = {
 	userSearch: (corpId: string, query: { search?: string; limit?: number; offset?: number }) =>
 		[...corporationKeys.all, 'user-search', corpId, query] as const,
 	access: () => [...corporationKeys.all, 'access'] as const,
+	accessForCorporation: (corpId: string) => [...corporationKeys.all, 'access', corpId] as const,
 }
 
 // ============================================================================
@@ -281,22 +283,27 @@ export function useCorporationMemberStats(corporationId: string) {
 }
 
 /**
- * Hook to check if user can access a specific corporation
+ * Hook to check access for a specific corporation.
  */
 export function useCanAccessCorporation(corporationId: string) {
-	const { data: access, isLoading, isFetching } = useCorporationAccess()
+	const {
+		data: access,
+		isLoading,
+		isFetching,
+	} = useQuery<CorporationScopedAccessResult>({
+		queryKey: corporationKeys.accessForCorporation(corporationId),
+		queryFn: () => myCorporationsApi.getCorporationAccess(corporationId),
+		enabled: Boolean(corporationId),
+		staleTime: 1000 * 60 * 5,
+		gcTime: 1000 * 60 * 10,
+		meta: {
+			suppressErrorToast: true,
+		},
+	})
 
-	const canAccess = useMemo(() => {
-		if (!access) return false
-		return access.corporations.some((corp) => corp.corporationId === corporationId)
-	}, [access, corporationId])
-
-	const corporation = useMemo(() => {
-		if (!access) return undefined
-		return access.corporations.find((c) => c.corporationId === corporationId)
-	}, [access, corporationId])
-
-	const userRole = corporation?.userRole
+	const canAccess = access?.hasAccess ?? false
+	const corporation = access?.corporation ?? undefined
+	const userRole = access?.userRole ?? undefined
 
 	return { canAccess, userRole, corporation, isLoading, isFetching }
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Optimizes the corporate HR access check by avoiding redundant per-character ESI lookups and full corp core-data fetches, and adds a new corp-scoped access endpoint so single-corporation UI screens no longer need to fetch and filter the entire corporation-access list.

## Changes
- Add `GET /corporations/:corporationId/access` — a corp-scoped access check that looks up a single `managedCorporations` row and resolves the caller's role (`CEO`/`Director`/`admin`/`hr_admin`/`hr_reviewer`/`hr_viewer`) without needing the full accessible-corporations list.
- In `GET /users/corporation-access`, use the corporation ID already cached on the `userCharacters` row instead of always calling `EveCharacterData.getCharacterInfo` per character; only fall back to `EveCorporationData.getCorporationIdsByCharacterIds` for characters missing a cached corp ID.
- Replace `corpStub.getCoreData(...)` (which also fetches other core corp data) with the narrower `corpStub.getMembers(...)` when only member lists are needed for hydrating corporation stats.
- Add `useCanAccessCorporation` support for the new endpoint via `myCorporationsApi.getCorporationAccess` and a dedicated React Query key (`corporationKeys.accessForCorporation`), replacing the previous approach of deriving per-corp access from the bulk `useCorporationAccess()` result.

## Testing
- Added `apps/core/src/routes/__tests__/corporations.access.route.test.ts` covering the new `/corporations/:corporationId/access` endpoint (CEO, Director, admin, hr_admin, hr_reviewer, hr_viewer, access-denied, and missing-managed-corporation cases).
- Updated `apps/core/src/routes/__tests__/users.corporation-access.route.test.ts` to reflect the `getMembers` (formerly `getCoreData`) call and added a case verifying site admins get access to all managed corporations without character/corp lookups.
<!-- claude:end -->