### PR TITLE
Fix/fulcrum visibility

### DIFF
--- a/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
@@ -67,8 +67,9 @@ function makeFulcrumStub() {
 		createCharacterReport: vi.fn().mockResolvedValue('report-1'),
 		createBulkCharacterReports: vi.fn().mockResolvedValue({ batchId: 'batch-1' }),
 		getReportStatus: vi.fn(),
-		getSectionManifest: vi.fn(),
-		getSectionData: vi.fn(),
+		getReportSections: vi.fn(),
+		getReportSectionData: vi.fn(),
+		fetchMailContent: vi.fn(),
 	}
 }
 
@@ -274,6 +275,99 @@ describe('fulcrum route access matrix', () => {
 		expect(fulcrumStub.listReports).toHaveBeenCalledWith({ characterId: '3001' }, 50)
 		const body = (await res.json()) as Array<{ characterId: string; hasValidToken?: boolean | null }>
 		expect(body[0]).toMatchObject({ characterId: '3001', hasValidToken: true })
+	})
+
+	it('allows site admins to read completed report sections without HR role checks', async () => {
+		hrStub.getUserRoles.mockResolvedValue([])
+		hrStub.checkPermission.mockResolvedValue(false)
+		fulcrumStub.getReportStatus.mockResolvedValue({
+			reportId: 'report-1',
+			status: 'completed',
+			requestorCorporationId: '1001',
+		} as any)
+		fulcrumStub.getReportSections.mockResolvedValue({
+			sections: ['public-info'],
+		} as any)
+
+		const app = createApp(makeUser({ is_admin: true }))
+		const res = await app.request('/api/fulcrum/reports/report-1/sections', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ sections: ['public-info'] })
+		expect(hrStub.checkPermission).not.toHaveBeenCalled()
+		expect(fulcrumStub.getReportSections).toHaveBeenCalledWith('report-1')
+	})
+
+	it('denies unauthorized report section access before revealing readiness state', async () => {
+		hrStub.getUserRoles.mockResolvedValue([])
+		hrStub.checkPermission.mockResolvedValue(false)
+		fulcrumStub.getReportStatus.mockResolvedValue({
+			reportId: 'report-1',
+			status: 'pending',
+			requestorCorporationId: '1001',
+		} as any)
+
+		const app = createApp(makeUser())
+		const res = await app.request('/api/fulcrum/reports/report-1/sections', {}, env)
+
+		expect(res.status).toBe(403)
+		expect(await res.json()).toEqual({ error: 'HR role required' })
+		expect(fulcrumStub.getReportSections).not.toHaveBeenCalled()
+		expect(hrStub.checkPermission).toHaveBeenCalledWith('user-1', '1001', 'hr_viewer')
+	})
+
+	it('allows hr_viewer staff to read completed report section data', async () => {
+		hrStub.getUserRoles.mockResolvedValue([
+			{
+				id: 'role-1',
+				corporationId: '1001',
+				userId: 'user-1',
+				characterId: 'user-1',
+				characterName: 'Main Pilot',
+				role: 'hr_viewer',
+				grantedBy: 'granted-by',
+				grantedAt: new Date(),
+				expiresAt: null,
+				isActive: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		] as any)
+		hrStub.checkPermission.mockResolvedValue(true)
+		fulcrumStub.getReportStatus.mockResolvedValue({
+			reportId: 'report-1',
+			status: 'completed',
+			requestorCorporationId: '1001',
+		} as any)
+		fulcrumStub.getReportSectionData.mockResolvedValue({
+			rows: [{ section: 'public-info' }],
+		} as any)
+
+		const app = createApp(makeUser())
+		const res = await app.request('/api/fulcrum/reports/report-1/sections/public-info', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ rows: [{ section: 'public-info' }] })
+		expect(hrStub.checkPermission).toHaveBeenCalledWith('user-1', '1001', 'hr_viewer')
+		expect(fulcrumStub.getReportSectionData).toHaveBeenCalledWith('report-1', 'public-info')
+	})
+
+	it('denies unauthorized mail content access before revealing readiness state', async () => {
+		hrStub.getUserRoles.mockResolvedValue([])
+		hrStub.checkPermission.mockResolvedValue(false)
+		fulcrumStub.getReportStatus.mockResolvedValue({
+			reportId: 'report-1',
+			status: 'pending',
+			requestorCorporationId: '1001',
+		} as any)
+
+		const app = createApp(makeUser())
+		const res = await app.request('/api/fulcrum/reports/report-1/mails/mail-1/content', {}, env)
+
+		expect(res.status).toBe(403)
+		expect(await res.json()).toEqual({ error: 'HR role required' })
+		expect(fulcrumStub.fetchMailContent).not.toHaveBeenCalled()
+		expect(hrStub.checkPermission).toHaveBeenCalledWith('user-1', '1001', 'hr_viewer')
 	})
 
 	it('denies character report listing when backend access scope does not exist', async () => {

--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -1030,10 +1030,6 @@ app.get('/reports/:reportId/sections', requireAuth(), async (c) => {
 			return c.json({ error: 'Report not found' }, 404)
 		}
 
-		if (report.status !== 'completed') {
-			return c.json({ error: 'Report not ready', status: report.status }, 400)
-		}
-
 		if (!(await isHrAuditorUser(c, user))) {
 			const hr = getHrStub(c)
 			const hasPermission = await hr.checkPermission(
@@ -1044,6 +1040,10 @@ app.get('/reports/:reportId/sections', requireAuth(), async (c) => {
 			if (!hasPermission) {
 				return c.json({ error: 'HR role required' }, 403)
 			}
+		}
+
+		if (report.status !== 'completed') {
+			return c.json({ error: 'Report not ready', status: report.status }, 400)
 		}
 
 		const manifest = await fulcrum.getReportSections(reportId)
@@ -1083,10 +1083,6 @@ app.get('/reports/:reportId/sections/:section', requireAuth(), async (c) => {
 			return c.json({ error: 'Report not found' }, 404)
 		}
 
-		if (report.status !== 'completed') {
-			return c.json({ error: 'Report not ready', status: report.status }, 400)
-		}
-
 		if (!(await isHrAuditorUser(c, user))) {
 			const hr = getHrStub(c)
 			const hasPermission = await hr.checkPermission(
@@ -1097,6 +1093,10 @@ app.get('/reports/:reportId/sections/:section', requireAuth(), async (c) => {
 			if (!hasPermission) {
 				return c.json({ error: 'HR role required' }, 403)
 			}
+		}
+
+		if (report.status !== 'completed') {
+			return c.json({ error: 'Report not ready', status: report.status }, 400)
 		}
 
 		const data = await fulcrum.getReportSectionData(reportId, section)
@@ -1131,10 +1131,6 @@ app.get('/reports/:reportId/mails/:mailId/content', requireAuth(), async (c) => 
 			return c.json({ error: 'Report not found' }, 404)
 		}
 
-		if (report.status !== 'completed') {
-			return c.json({ error: 'Report not ready', status: report.status }, 400)
-		}
-
 		if (!(await isHrAuditorUser(c, user))) {
 			const hr = getHrStub(c)
 			const hasPermission = await hr.checkPermission(
@@ -1145,6 +1141,10 @@ app.get('/reports/:reportId/mails/:mailId/content', requireAuth(), async (c) => 
 			if (!hasPermission) {
 				return c.json({ error: 'HR role required' }, 403)
 			}
+		}
+
+		if (report.status !== 'completed') {
+			return c.json({ error: 'Report not ready', status: report.status }, 400)
 		}
 
 		const body = await fulcrum.fetchMailContent(reportId, mailId)

--- a/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
@@ -60,6 +60,7 @@ import {
 	useMessageCount,
 	useRecommendations,
 } from '../hooks'
+import { canViewFulcrumTab } from '../utils/fulcrum-access'
 import { FORBIDDEN_PRIVATE_DATA_MESSAGE } from '../utils/private-data'
 
 // ============================================================================
@@ -142,6 +143,11 @@ export default function HrApplicationReview() {
 		!!application &&
 		canViewCorporationApplications &&
 		(user?.is_admin === true || isAuditor || isMemberCorporation || OPEN_APPLICATION_STATUSES.includes(application.status))
+	const canShowFulcrumTab = canViewFulcrumTab({
+		applicationStatus: application?.status,
+		currentRole: permission?.currentRole,
+		isAdmin: user?.is_admin === true,
+	})
 
 	// Fetch selected HR note for edit/delete
 	const { data: selectedNote } = useHRNote(selectedNoteId)
@@ -519,7 +525,7 @@ export default function HrApplicationReview() {
 					>
 						Prior Apps
 					</TabsTrigger>
-					{permission?.currentRole && ['hr_admin', 'hr_reviewer'].includes(permission.currentRole) && application && OPEN_APPLICATION_STATUSES.includes(application.status) && (
+					{canShowFulcrumTab && (
 						<TabsTrigger
 							value="fulcrum"
 							className={reviewTabTriggerClassName}
@@ -816,7 +822,7 @@ export default function HrApplicationReview() {
 				</TabsContent>
 
 				{/* Fulcrum (Character Reports) Tab */}
-				{permission?.currentRole && ['hr_admin', 'hr_reviewer'].includes(permission.currentRole) && application && OPEN_APPLICATION_STATUSES.includes(application.status) && (
+				{canShowFulcrumTab && (
 					<TabsContent value="fulcrum">
 						<Card>
 							<CardHeader>

--- a/apps/ui/src/client/features/applications/utils/fulcrum-access.ts
+++ b/apps/ui/src/client/features/applications/utils/fulcrum-access.ts
@@ -1,0 +1,26 @@
+import { OPEN_APPLICATION_STATUSES } from '../constants'
+
+import type { ApplicationStatus } from '../api'
+import type { HrRoleType } from '../../hr/api'
+
+type FulcrumAccessInput = {
+	applicationStatus?: ApplicationStatus | null
+	currentRole?: HrRoleType | null
+	isAdmin: boolean
+}
+
+export function canViewFulcrumTab({
+	applicationStatus,
+	currentRole,
+	isAdmin,
+}: FulcrumAccessInput): boolean {
+	if (!applicationStatus || !OPEN_APPLICATION_STATUSES.includes(applicationStatus)) {
+		return false
+	}
+
+	if (isAdmin) {
+		return true
+	}
+
+	return currentRole === 'hr_admin' || currentRole === 'hr_reviewer'
+}

--- a/apps/ui/src/test/unit/features/applications/fulcrum-access.unit.test.ts
+++ b/apps/ui/src/test/unit/features/applications/fulcrum-access.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { canViewFulcrumTab } from '@/features/applications/utils/fulcrum-access'
+
+describe('canViewFulcrumTab', () => {
+	it('allows site admins to see the tab for open applications', () => {
+		expect(
+			canViewFulcrumTab({
+				applicationStatus: 'pending',
+				isAdmin: true,
+			})
+		).toBe(true)
+	})
+
+	it('allows hr reviewer and hr admin roles for open applications', () => {
+		expect(
+			canViewFulcrumTab({
+				applicationStatus: 'under_review',
+				currentRole: 'hr_reviewer',
+				isAdmin: false,
+			})
+		).toBe(true)
+
+		expect(
+			canViewFulcrumTab({
+				applicationStatus: 'accepted',
+				currentRole: 'hr_admin',
+				isAdmin: false,
+			})
+		).toBe(true)
+	})
+
+	it('hides the tab for closed applications regardless of role', () => {
+		expect(
+			canViewFulcrumTab({
+				applicationStatus: 'completed',
+				currentRole: 'hr_admin',
+				isAdmin: true,
+			})
+		).toBe(false)
+	})
+
+	it('hides the tab for open applications when the user lacks access', () => {
+		expect(
+			canViewFulcrumTab({
+				applicationStatus: 'pending',
+				currentRole: 'hr_viewer',
+				isAdmin: false,
+			})
+		).toBe(false)
+	})
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes two Fulcrum access-control bugs: an information-disclosure side channel in the report sections/mail API, and an overly-restrictive visibility check for the Fulcrum tab on the HR application review page that hid it from site admins.

## Changes
- In `apps/core/src/routes/fulcrum.ts`, reordered the `report.status !== 'completed'` check to run **after** the HR auditor/permission check for the sections, section-data, and mail-content routes, so an unauthorized caller gets `403` instead of learning the report's readiness state via a `400` response first.
- Extracted the Fulcrum tab visibility logic into a new `canViewFulcrumTab` helper (`apps/ui/src/client/features/applications/utils/fulcrum-access.ts`), which also grants access to site admins in addition to `hr_admin`/`hr_reviewer` roles, and used it in `hr-application-review.tsx` for both the tab trigger and tab content.
- Updated route tests (`fulcrum.access.route.test.ts`) with mocks for `getReportSections`, `getReportSectionData`, and `fetchMailContent`, plus new cases covering admin bypass and pre-authorization denial for report sections and mail content.
- Added unit tests for `canViewFulcrumTab` covering admin access, `hr_reviewer`/`hr_admin` access, closed applications, and users lacking access.

## Testing
- Added/updated Vitest coverage: `apps/core/src/routes/__tests__/fulcrum.access.route.test.ts` and `apps/ui/src/test/unit/features/applications/fulcrum-access.unit.test.ts`.
<!-- claude:end -->
