### PR TITLE
add pagination to recent losses and my losses tabs

### DIFF
--- a/apps/core/src/routes/__tests__/srp.route.test.ts
+++ b/apps/core/src/routes/__tests__/srp.route.test.ts
@@ -91,12 +91,18 @@ function createApp(user?: SessionUser, db?: any) {
 	return app
 }
 
-function makeSrpStub() {
-	return {
-		getConfig: vi.fn().mockResolvedValue({ maxLossAgeDays: 30 }),
-		getUserRequests: vi.fn().mockResolvedValue([]),
-		getRecentLosses: vi.fn().mockResolvedValue({ losses: [], failedCharacters: [] }),
-		getRecentLossRefreshStatus: vi.fn().mockResolvedValue({ status: null, cooldownUntil: null }),
+	function makeSrpStub() {
+		return {
+			getConfig: vi.fn().mockResolvedValue({ maxLossAgeDays: 30 }),
+			getUserRequests: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
+			getRecentLosses: vi.fn().mockResolvedValue({
+				losses: [],
+				failedCharacters: [],
+				total: 0,
+				limit: 0,
+				offset: 0,
+			}),
+			getRecentLossRefreshStatus: vi.fn().mockResolvedValue({ status: null, cooldownUntil: null }),
 		getRequest: vi.fn(),
 		getRequestsByStatus: vi.fn().mockResolvedValue({ requests: [], total: 0 }),
 		getPendingPayments: vi.fn().mockResolvedValue([]),
@@ -414,7 +420,13 @@ describe('srp routes - permissions', () => {
 		const response = await app.request('/api/srp/requests', {}, env)
 
 		expect(response.status).toBe(200)
-		expect(srpStub.getUserRequests).toHaveBeenCalledWith('request-list-user', 50, 0)
+		expect(await response.json()).toEqual({
+			requests: [],
+			total: 0,
+			limit: 50,
+			offset: 0,
+		})
+		expect(srpStub.getUserRequests).toHaveBeenCalledWith('request-list-user', 50, 0, undefined)
 	})
 
 	it('returns partial losses with failedCharacters when one character fetch fails', async () => {
@@ -465,20 +477,26 @@ describe('srp routes - permissions', () => {
 					message: 'Recent losses have not been refreshed yet. Use Refresh to fetch them.',
 				},
 			],
+			total: 1,
+			limit: 50,
+			offset: 0,
 		})
 
 		const response = await app.request('/api/srp/losses?daysBack=60', {}, env)
 		const body = await response.json<any>()
 
 		expect(response.status).toBe(200)
-		expect(srpStub.getRecentLosses).toHaveBeenCalledWith(
-			[
-				{ characterId: '7001', characterName: 'Pilot One' },
-				{ characterId: '7002', characterName: 'Pilot Two' },
-			],
-			'loss-user',
-			30
-		)
+			expect(srpStub.getRecentLosses).toHaveBeenCalledWith(
+				[
+					{ characterId: '7001', characterName: 'Pilot One' },
+					{ characterId: '7002', characterName: 'Pilot Two' },
+				],
+				'loss-user',
+				30,
+				true,
+				undefined,
+				undefined
+			)
 		expect(body.losses).toHaveLength(1)
 		expect(body.losses[0]).toMatchObject({
 			killmailId: '123',
@@ -553,20 +571,26 @@ describe('srp routes - permissions', () => {
 					message: 'ESI token is invalid or expired. Please re-authenticate this character.',
 				},
 			],
+			total: 1,
+			limit: 50,
+			offset: 0,
 		})
 
 		const response = await app.request('/api/srp/losses?daysBack=60', {}, env)
 		const body = await response.json<any>()
 
 		expect(response.status).toBe(200)
-		expect(srpStub.getRecentLosses).toHaveBeenCalledWith(
-			[
-				{ characterId: '7001', characterName: 'Pilot One' },
-				{ characterId: '7002', characterName: 'Pilot Two' },
-			],
-			'loss-user-invalid-token',
-			30
-		)
+			expect(srpStub.getRecentLosses).toHaveBeenCalledWith(
+				[
+					{ characterId: '7001', characterName: 'Pilot One' },
+					{ characterId: '7002', characterName: 'Pilot Two' },
+				],
+				'loss-user-invalid-token',
+				30,
+				true,
+				undefined,
+				undefined
+			)
 		expect(body.losses).toHaveLength(1)
 		expect(body.failedCharacters).toEqual([
 			{

--- a/apps/core/src/routes/admin.ts
+++ b/apps/core/src/routes/admin.ts
@@ -41,7 +41,7 @@ import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Groups } from '@repo/groups'
 import type { Hr } from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
-import type { Srp } from '@repo/srp'
+import type { SRPRequestResponse, Srp } from '@repo/srp'
 import type { App } from '../context'
 import thirdPartyAppsRoutes from './admin/third-party-apps'
 
@@ -170,10 +170,11 @@ async function rejectUnpaidSrpRequestsForBlacklistedUser(
 	const srpStub = getStub<Srp>(c.env.SRP, `admin-blacklist-${targetUserId}`)
 	const limit = 200
 	let offset = 0
-	const allRequests: Awaited<ReturnType<Srp['getUserRequests']>> = []
+	const allRequests: SRPRequestResponse[] = []
 
 	while (true) {
-		const batch = await srpStub.getUserRequests(targetUserId, limit, offset)
+		const batchResult = await srpStub.getUserRequests(targetUserId, limit, offset)
+		const batch = Array.isArray(batchResult) ? batchResult : batchResult.requests
 		if (batch.length === 0) break
 		allRequests.push(...batch)
 		if (batch.length < limit) break

--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -8,6 +8,7 @@ import {
 	CreateSRPPolicySchema,
 	CreateSRPRequestSchema,
 	EditCommentSchema,
+	REQUEST_STATUSES,
 	SRPReviewSubmissionSchema,
 	UpdateReviewStateSchema,
 	UpdateSRPConfigSchema,
@@ -22,6 +23,7 @@ import { waitUntilWithTelemetry } from '../lib/background-task'
 import { isExportArtifactExpired } from '../lib/export-retention'
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import { normalizeWorkflowStatus } from '../lib/workflow-status'
+import { validatePagination } from '../lib/validation'
 import { requireAllianceMember } from '../middleware/session'
 
 import type { Doctrines, FittingWithItems } from '@repo/doctrines'
@@ -32,6 +34,7 @@ import type {
 	SRPRequestResponse,
 	RecentLossRefreshCharacterInput,
 	RecentLossRefreshCoordinator,
+	RequestStatus,
 	Srp,
 } from '@repo/srp'
 import type { Universe } from '@repo/universe'
@@ -81,6 +84,25 @@ function getExecutionContextOrNull(c: { executionCtx?: ExecutionContext }): Exec
 	} catch {
 		return null
 	}
+}
+
+type UserRequestListResult = Awaited<ReturnType<Srp['getUserRequests']>>
+type NormalizedUserRequestListResult = {
+	requests: SRPRequestResponse[]
+	total: number
+}
+
+function normalizeUserRequestListResult(
+	result: UserRequestListResult | SRPRequestResponse[]
+): NormalizedUserRequestListResult {
+	if (Array.isArray(result)) {
+		return {
+			requests: result,
+			total: result.length,
+		}
+	}
+
+	return result
 }
 
 type SrpBackfillRefreshCandidate = {
@@ -733,6 +755,15 @@ srp.get('/losses', async (c) => {
 	const srpStub = getStub<Srp>(c.env.SRP, 'default')
 	const config = await srpStub.getConfig()
 	const configuredLookbackDays = config?.maxLossAgeDays ?? 30
+	const limitRaw = c.req.query('limit')
+	const offsetRaw = c.req.query('offset')
+	const pagination =
+		limitRaw !== undefined || offsetRaw !== undefined
+			? validatePagination(limitRaw, offsetRaw)
+			: null
+	if (pagination && !pagination.success) {
+		return c.json({ error: pagination.error }, pagination.status)
+	}
 
 	// Get all character IDs for the user
 	const characters = user.characters.map((char) => ({
@@ -741,10 +772,23 @@ srp.get('/losses', async (c) => {
 	}))
 
 	if (characters.length === 0) {
-		return c.json({ losses: [], failedCharacters: [] })
+		return c.json({
+			losses: [],
+			failedCharacters: [],
+			total: 0,
+			limit: 0,
+			offset: 0,
+		})
 	}
 
-	const result = await srpStub.getRecentLosses(characters, user.id, configuredLookbackDays)
+	const result = await srpStub.getRecentLosses(
+		characters,
+		user.id,
+		configuredLookbackDays,
+		true,
+		pagination?.data.limit,
+		pagination?.data.offset
+	)
 	const losses = result.losses
 		.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime())
 	const failedCharacters = result.failedCharacters
@@ -760,6 +804,9 @@ srp.get('/losses', async (c) => {
 	return c.json({
 		losses: lossesWithRegions,
 		failedCharacters,
+		total: result.total,
+		limit: result.limit,
+		offset: result.offset,
 	})
 })
 
@@ -970,13 +1017,26 @@ srp.post('/requests', async (c) => {
  */
 srp.get('/requests', async (c) => {
 	const user = c.get('user')!
-	const limit = c.req.query('limit') ? Number.parseInt(c.req.query('limit')!, 10) : 50
-	const offset = c.req.query('offset') ? Number.parseInt(c.req.query('offset')!, 10) : 0
+	const pagination = validatePagination(c.req.query('limit'), c.req.query('offset'))
+	if (!pagination.success) {
+		return c.json({ error: pagination.error }, pagination.status)
+	}
+	const statusQuery = c.req.query('status')?.trim()
+	if (statusQuery && !REQUEST_STATUSES.includes(statusQuery as RequestStatus)) {
+		return c.json({ error: 'Invalid status' }, 400)
+	}
 
 	const srpStub = getStub<Srp>(c.env.SRP, 'default')
-	const requestsRaw = await srpStub.getUserRequests(user.id, limit, offset)
+	const requestsRaw = normalizeUserRequestListResult(
+		await srpStub.getUserRequests(
+			user.id,
+			pagination.data.limit,
+			pagination.data.offset,
+			statusQuery ? (statusQuery as RequestStatus) : undefined
+		)
+	)
 	const withCharacterRoles = await hydrateRequestCharacterRoles(
-		requestsRaw as RequestWithCharacterRole[],
+		requestsRaw.requests as RequestWithCharacterRole[],
 		c.env.DATABASE_URL
 	)
 	const withSystemRegions = await enrichRequestsWithSystemRegions(withCharacterRoles, c.env)
@@ -984,9 +1044,9 @@ srp.get('/requests', async (c) => {
 
 	return c.json({
 		requests,
-		total: requests.length,
-		limit,
-		offset,
+		total: requestsRaw.total,
+		limit: pagination.data.limit,
+		offset: pagination.data.offset,
 	})
 })
 

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -898,15 +898,35 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	/**
 	 * Get all requests for a user
 	 */
-	async getUserRequests(userId: string, limit = 50, offset = 0): Promise<SRPRequestResponse[]> {
-		const requests = await this.db.query.srpRequests.findMany({
-			where: eq(srpRequests.userId, userId),
-			orderBy: desc(srpRequests.createdAt),
-			limit,
-			offset,
-		})
+	async getUserRequests(
+		userId: string,
+		limit = 50,
+		offset = 0,
+		status?: RequestStatus
+	): Promise<{ requests: SRPRequestResponse[]; total: number }> {
+		const conditions = [eq(srpRequests.userId, userId)]
+		if (status) {
+			conditions.push(eq(srpRequests.requestStatus, status))
+		}
 
-		return await Promise.all(requests.map((r) => this.formatRequest(r)))
+		const where = and(...conditions)
+		const [requests, countRows] = await Promise.all([
+			this.db.query.srpRequests.findMany({
+				where,
+				orderBy: desc(srpRequests.createdAt),
+				limit,
+				offset,
+			}),
+			this.db
+				.select({ count: sql<number>`count(*)::int` })
+				.from(srpRequests)
+				.where(where),
+		])
+
+		return {
+			requests: await Promise.all(requests.map((r) => this.formatRequest(r))),
+			total: countRows[0]?.count ?? 0,
+		}
 	}
 
 	// private async getLossesForCharacter(
@@ -924,7 +944,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		characters: RecentLossRefreshCharacterInput[],
 		userId: string,
 		daysBack = 30,
-		_excludeNonSrpEligible = true
+		_excludeNonSrpEligible = true,
+		limit?: number,
+		offset?: number
 	): Promise<RecentLossesResponse> {
 		const config = await this.getConfig()
 		const maxLossAgeDays = config?.maxLossAgeDays ?? daysBack
@@ -996,6 +1018,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		const mergedLosses = [...allLosses.values()]
 			.filter((loss) => new Date(loss.killmailTime).getTime() >= cutoffMs)
 			.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime())
+		const total = mergedLosses.length
+		const effectiveLimit = typeof limit === 'number' ? Math.max(1, limit) : total
+		const effectiveOffset = typeof offset === 'number' ? Math.max(0, offset) : 0
 
 		const shipTypeIds = [...new Set(mergedLosses.map((l) => String(l.shipTypeId)))]
 		const systemIds = [...new Set(mergedLosses.map((l) => String(l.solarSystemId)))]
@@ -1028,6 +1053,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			return {
 				losses: [],
 				failedCharacters,
+				total,
+				limit: effectiveLimit,
+				offset: effectiveOffset,
 			}
 		}
 
@@ -1076,8 +1104,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		}
 
 		// Annotate losses with SRP status and sort by time descending
-		return {
-			losses: mergedLosses
+		const annotatedLosses = mergedLosses
 				.filter((loss) => !dismissedKillmailIds.has(String(loss.killmailId)))
 				.filter((loss) => !legacyPaidKillmailIds.has(String(loss.killmailId)))
 				.filter((loss) => {
@@ -1106,8 +1133,14 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 						srpRequestStatus: request?.status,
 					}
 				})
-				.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime()),
+				.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime())
+
+		return {
+			losses: annotatedLosses.slice(effectiveOffset, effectiveOffset + effectiveLimit),
 			failedCharacters,
+			total: annotatedLosses.length,
+			limit: effectiveLimit,
+			offset: effectiveOffset,
 		}
 	}
 

--- a/apps/ui/src/client/components/user-search-pagination-controls.tsx
+++ b/apps/ui/src/client/components/user-search-pagination-controls.tsx
@@ -13,7 +13,8 @@ interface UserSearchPaginationControlsProps {
 	pageSizeOptions?: number[]
 	itemLabel?: string
 	nextButtonLoading?: boolean
-	summaryAction?: ReactNode
+	leadingAction?: ReactNode
+	trailingAction?: ReactNode
 }
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [25, 50, 100]
@@ -27,7 +28,8 @@ export function UserSearchPaginationControls({
 	pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
 	itemLabel = 'users',
 	nextButtonLoading = false,
-	summaryAction,
+	leadingAction,
+	trailingAction,
 }: UserSearchPaginationControlsProps) {
 	const totalPages = Math.ceil(totalCount / pageSize)
 	const start = totalCount === 0 ? 0 : (page - 1) * pageSize + 1
@@ -46,12 +48,9 @@ export function UserSearchPaginationControls({
 	return (
 		<div className="flex flex-wrap items-center justify-between gap-3">
 			<div className="flex items-center gap-2 text-sm text-muted-foreground">
-				<div>
-					{totalCount > 0
-						? `${start}-${end} of ${totalCount} ${itemLabel}`
-						: `0 ${itemLabel}`}
-				</div>
-				{summaryAction ? <div className="shrink-0">{summaryAction}</div> : null}
+				{leadingAction ? <div className="shrink-0">{leadingAction}</div> : null}
+				<div>{totalCount > 0 ? `${start}-${end} of ${totalCount} ${itemLabel}` : `0 ${itemLabel}`}</div>
+				{trailingAction ? <div className="shrink-0">{trailingAction}</div> : null}
 			</div>
 			<div className="flex flex-wrap items-center gap-2 justify-end">
 				<div className="flex items-center gap-2">

--- a/apps/ui/src/client/features/srp/components/CreateRequestForm.tsx
+++ b/apps/ui/src/client/features/srp/components/CreateRequestForm.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 
 import { useCreateRequest } from '../hooks'
+import type { RecentLossVictimItem } from '../types'
 import { getKillmailUrl } from '../utils'
 import { transformKillmailToCargoItems, transformKillmailToFittingItems } from '../utils/fitting'
 import { SRPFittingDisplay } from './SRPFittingDisplay'
@@ -48,28 +49,36 @@ interface CreateRequestFormProps {
 	shipTypeId: string
 	shipTypeName: string
 	lossDate: string
-	lossVictimItems?: Array<{
-		flag: number
-		item_type_id: string
-		quantity_destroyed?: number
-		quantity_dropped?: number
-		items?: Array<{
-			flag: number
-			item_type_id: string
-			quantity_destroyed?: number
-			quantity_dropped?: number
-			items?: never
-		}>
-	}>
+	lossVictimItems?: RecentLossVictimItem[]
 	preview: KillmailPreview | null
 	previewLoading: boolean
 }
 
 type NormalizedVictimItem = {
-	item_type_id: string
+	item_type_id: number
 	flag: number
 	quantity_destroyed?: number
 	quantity_dropped?: number
+	items?: NormalizedVictimItem[]
+}
+
+function normalizeVictimItems(items: RecentLossVictimItem[]): NormalizedVictimItem[] {
+	return items.map((item) => ({
+		item_type_id: Number(item.item_type_id),
+		flag: item.flag,
+		quantity_destroyed: item.quantity_destroyed,
+		quantity_dropped: item.quantity_dropped,
+		items: item.items?.length ? normalizeVictimItems(item.items) : undefined,
+	}))
+}
+
+function normalizePreviewVictimItems(items: KillmailPreview['victimItems']): NormalizedVictimItem[] {
+	return items.map((item) => ({
+		item_type_id: Number(item.typeId),
+		flag: item.flag,
+		quantity_destroyed: item.quantityDestroyed,
+		quantity_dropped: item.quantityDropped,
+	}))
 }
 
 export function CreateRequestForm({
@@ -91,27 +100,14 @@ export function CreateRequestForm({
 		defaultValues: { killmailId, killmailHash, characterId, contextText: '' },
 	})
 
-	const displayVictimItems: NormalizedVictimItem[] =
-		lossVictimItems?.map((i) => ({
-			item_type_id: i.item_type_id,
-			flag: i.flag,
-			quantity_destroyed: i.quantity_destroyed,
-			quantity_dropped: i.quantity_dropped,
-		})) ??
-		preview?.victimItems?.map((i) => ({
-			item_type_id: i.typeId,
-			flag: i.flag,
-			quantity_destroyed: i.quantityDestroyed,
-			quantity_dropped: i.quantityDropped,
-		})) ??
-		[]
+	const displayVictimItems =
+		lossVictimItems?.length
+			? normalizeVictimItems(lossVictimItems)
+			: preview?.victimItems?.length
+				? normalizePreviewVictimItems(preview.victimItems)
+				: []
 	const fittingItems = transformKillmailToFittingItems(
-		displayVictimItems.map((i) => ({
-			item_type_id: Number(i.item_type_id),
-			flag: i.flag,
-			quantity_destroyed: i.quantity_destroyed,
-			quantity_dropped: i.quantity_dropped,
-		})),
+		displayVictimItems,
 		preview?.itemPrices?.map((p) => ({
 			typeId: p.typeId,
 			price: p.unitPrice,
@@ -120,12 +116,7 @@ export function CreateRequestForm({
 		preview?.itemNames ?? {}
 	)
 	const cargoItems = transformKillmailToCargoItems(
-		displayVictimItems.map((i) => ({
-			item_type_id: Number(i.item_type_id),
-			flag: i.flag,
-			quantity_destroyed: i.quantity_destroyed,
-			quantity_dropped: i.quantity_dropped,
-		})),
+		displayVictimItems,
 		preview?.itemNames ?? {}
 	)
 

--- a/apps/ui/src/client/features/srp/components/LossTable.tsx
+++ b/apps/ui/src/client/features/srp/components/LossTable.tsx
@@ -28,11 +28,14 @@ import type { LossWithSRPStatus, RecentLossRefreshStatusRecord, SRPConfigRespons
 interface LossTableProps {
 	losses: LossWithSRPStatus[]
 	isLoading?: boolean
-	isRefreshing?: boolean
-	onRefresh?: () => void
 	config?: SRPConfigResponse | null
+	onDismissLoss?: (killmailId: string) => Promise<void> | void
+	dismissingKillmailId?: string | null
+}
+
+interface RecentLossesStatusAlertsProps {
 	refreshStatus?: RecentLossRefreshStatusRecord | null
-	refreshCooldownUntil?: string | null
+	refreshErrorMessage?: string | null
 	loadFailures?: Array<{
 		characterId: string
 		characterName: string
@@ -40,77 +43,17 @@ interface LossTableProps {
 		message?: string
 		error?: string
 	}>
-	onDismissLoss?: (killmailId: string) => Promise<void> | void
-	dismissingKillmailId?: string | null
 }
 
 export function LossTable({
 	losses,
 	isLoading,
-	isRefreshing,
-	onRefresh,
 	config,
-	refreshStatus,
-	refreshCooldownUntil,
-	loadFailures,
 	onDismissLoss,
 	dismissingKillmailId,
 }: LossTableProps) {
 	const { requestConfirmation, confirmationDialog } = useConfirmationDialog()
 	const maxLossAgeDays = config?.maxLossAgeDays ?? 30
-	const [nowMs, setNowMs] = useState(() => Date.now())
-	const [cooldownUntilMs, setCooldownUntilMs] = useState(() => {
-		if (typeof window === 'undefined') return 0
-		return readRefreshCooldownUntilMs(window.localStorage)
-	})
-
-	useEffect(() => {
-		if (cooldownUntilMs <= Date.now()) return
-		const intervalId = window.setInterval(() => setNowMs(Date.now()), 1000)
-		return () => window.clearInterval(intervalId)
-	}, [cooldownUntilMs])
-
-	useEffect(() => {
-		if (typeof window === 'undefined') return
-		persistRefreshCooldownUntilMs(window.localStorage, cooldownUntilMs)
-	}, [cooldownUntilMs])
-
-	useEffect(() => {
-		if (!refreshCooldownUntil) return
-		const serverCooldownUntilMs = Date.parse(refreshCooldownUntil)
-		if (!Number.isFinite(serverCooldownUntilMs)) return
-		setCooldownUntilMs((current) => {
-			const next = Math.max(current, serverCooldownUntilMs)
-			if (typeof window !== 'undefined') {
-				persistRefreshCooldownUntilMs(window.localStorage, next)
-			}
-			return next
-		})
-	}, [refreshCooldownUntil])
-
-	const cooldownRemainingMs = Math.max(0, cooldownUntilMs - nowMs)
-	const isCooldownActive = cooldownRemainingMs > 0
-	const isWorkflowRefreshing =
-		refreshStatus?.status === 'queued' || refreshStatus?.status === 'running'
-	const refreshDisabled = Boolean(isRefreshing || isCooldownActive || isWorkflowRefreshing)
-	const remainingSeconds = Math.ceil(cooldownRemainingMs / 1000)
-	const remainingMinutesPart = String(Math.floor(remainingSeconds / 60)).padStart(2, '0')
-	const remainingSecondsPart = String(remainingSeconds % 60).padStart(2, '0')
-
-	const handleRefreshClick = () => {
-		if (!onRefresh || refreshDisabled) return
-		const nextCooldownUntilMs = Date.now() + REFRESH_COOLDOWN_MS
-		if (typeof window !== 'undefined') {
-			// Persist immediately so a hard refresh right after click cannot bypass cooldown.
-			persistRefreshCooldownUntilMs(window.localStorage, nextCooldownUntilMs)
-		}
-		setCooldownUntilMs(nextCooldownUntilMs)
-		onRefresh()
-	}
-
-	const actionableLoadFailures =
-		loadFailures?.filter((failure) => failure.reason === 'invalid_token' || failure.reason === 'fetch_failed') ?? []
-	const hasLoadFailures = actionableLoadFailures.length > 0
 
 	if (isLoading) {
 		return (
@@ -131,116 +74,11 @@ export function LossTable({
 	return (
 		<div className="space-y-3">
 			{confirmationDialog}
-			{onRefresh && (
-				<div className="flex justify-end">
-					<Button
-						size="sm"
-						onClick={handleRefreshClick}
-						disabled={refreshDisabled}
-						title={
-							isCooldownActive
-								? `Refresh available in ${remainingMinutesPart}:${remainingSecondsPart}`
-								: isWorkflowRefreshing
-									? 'Recent loss refresh is already in progress'
-								: undefined
-						}
-					>
-						<RefreshCw
-							className={`mr-2 h-4 w-4 ${isRefreshing || isWorkflowRefreshing ? 'animate-spin' : ''}`}
-						/>
-						{isRefreshing
-							? 'Starting…'
-							: isWorkflowRefreshing
-								? `Fetching… ${refreshStatus.processedCharacters}/${refreshStatus.totalCharacters}`
-							: isCooldownActive
-								? `Refresh in ${remainingMinutesPart}:${remainingSecondsPart}`
-								: 'Refresh Losses'}
-					</Button>
-				</div>
-			)}
-
-			{isWorkflowRefreshing && (
-				<div className="rounded-md border border-sky-500/40 bg-sky-500/10 px-4 py-3 text-sm">
-					<p className="mb-1 font-medium text-sky-400">
-						Refreshing recent losses for {refreshStatus.processedCharacters}/{refreshStatus.totalCharacters}{' '}
-						characters
-					</p>
-					<p className="text-xs text-muted-foreground">
-						{refreshStatus.currentCharacterName
-							? `Currently fetching ${refreshStatus.currentCharacterName}.`
-							: 'Starting background refresh workflow.'}
-					</p>
-				</div>
-			)}
-
-			{refreshStatus?.status === 'completed' && (
-				<div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm">
-					<p className="mb-1 font-medium text-emerald-400">Recent losses refreshed</p>
-					<p className="text-xs text-muted-foreground">
-						{refreshStatus.successfulCharacters} characters refreshed, {refreshStatus.failedCharacters}{' '}
-						characters reported warnings.
-					</p>
-				</div>
-			)}
-
-			{refreshStatus?.status === 'failed' && (
-				<div className="rounded-md border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm">
-					<p className="mb-1 font-medium text-red-400">Recent loss refresh failed</p>
-					<p className="text-xs text-muted-foreground">{refreshStatus.lastError ?? 'Unknown error'}</p>
-				</div>
-			)}
-
-			{refreshStatus && refreshStatus.failures.length > 0 && (
-				<div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
-					<p className="mb-1 font-medium text-amber-400">Some characters could not be refreshed</p>
-					<ul className="space-y-0.5">
-						{refreshStatus.failures.map((failure) => (
-							<li key={failure.characterId} className="flex items-center gap-2 text-xs text-muted-foreground">
-								<span className="font-medium text-foreground">{failure.characterName}</span>
-								{failure.reason === 'invalid_token'
-									? '— token expired or invalid (re-auth required)'
-									: failure.reason === 'cache_incomplete'
-										? '— recent losses need a refresh to cover the full lookback window'
-										: failure.reason === 'cache_missing'
-											? '— recent losses have not been loaded yet'
-											: failure.error
-												? `— ${failure.error}`
-												: `— ${failure.message}`}
-							</li>
-						))}
-					</ul>
-				</div>
-			)}
-
-			{hasLoadFailures && (
-				<div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
-					<p className="mb-1 font-medium text-amber-400">
-						Some character losses could not be fetched
-					</p>
-					<ul className="space-y-0.5">
-						{actionableLoadFailures.map((failure) => (
-							<li
-								key={failure.characterId}
-								className="flex items-center gap-2 text-xs text-muted-foreground"
-							>
-								<span className="font-medium text-foreground">{failure.characterName}</span>
-								{failure.message
-									? `— ${failure.message}`
-									: failure.reason === 'invalid_token'
-										? '— ESI token is invalid or expired. Please re-authenticate this character.'
-											: '— Could not load losses right now. Please try again shortly.'}
-							</li>
-						))}
-					</ul>
-				</div>
-			)}
 
 			{losses.length === 0 ? (
 				<div className="rounded-lg border border-dashed p-8 text-center">
 					<p className="text-sm text-muted-foreground">
-						{hasLoadFailures
-							? 'No requestable losses loaded from available characters right now. Some character fetches failed above.'
-							: `No requestable losses found in the last ${maxLossAgeDays} days.`}
+						{`No requestable losses found in the last ${maxLossAgeDays} days.`}
 					</p>
 				</div>
 			) : (
@@ -389,5 +227,187 @@ export function LossTable({
 				</div>
 			)}
 		</div>
+	)
+}
+
+export function RecentLossesStatusAlerts({
+	refreshStatus,
+	refreshErrorMessage,
+	loadFailures,
+}: RecentLossesStatusAlertsProps) {
+	const actionableLoadFailures =
+		loadFailures?.filter((failure) => failure.reason === 'invalid_token' || failure.reason === 'fetch_failed') ?? []
+	const hasLoadFailures = actionableLoadFailures.length > 0
+	const isWorkflowRefreshing =
+		refreshStatus?.status === 'queued' || refreshStatus?.status === 'running'
+
+	if (!isWorkflowRefreshing && !refreshStatus && !refreshErrorMessage && !hasLoadFailures) {
+		return null
+	}
+
+	const warningBanner = isWorkflowRefreshing
+		? null
+		: refreshStatus?.status === 'failed'
+			? {
+					title: 'Recent loss refresh failed',
+					body: refreshStatus?.lastError ?? refreshErrorMessage ?? 'Unknown error',
+					className: 'border-red-500/40 bg-red-500/10 text-red-400',
+				}
+			: refreshErrorMessage
+				? {
+						title: 'Recent loss refresh failed',
+						body: refreshErrorMessage,
+						className: 'border-red-500/40 bg-red-500/10 text-red-400',
+					}
+				: hasLoadFailures
+					? {
+							title: 'Some character losses could not be fetched',
+							body: actionableLoadFailures,
+							className: 'border-amber-500/40 bg-amber-500/10 text-amber-400',
+						}
+					: null
+
+	return (
+		<div className="space-y-3">
+			{isWorkflowRefreshing ? (
+				<div className="rounded-md border border-sky-500/40 bg-sky-500/10 px-4 py-3 text-sm text-sky-400">
+					<p className="mb-1 font-medium">
+						Refreshing recent losses for {refreshStatus?.processedCharacters ?? 0}/{refreshStatus?.totalCharacters ?? 0}{' '}
+						characters
+					</p>
+					<p className="text-xs text-muted-foreground">
+						{refreshStatus?.currentCharacterName
+							? `Currently fetching ${refreshStatus.currentCharacterName}.`
+							: 'Starting background refresh workflow.'}
+					</p>
+				</div>
+			) : null}
+
+			{refreshStatus?.status === 'completed' ? (
+				<div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
+					<p className="mb-1 font-medium">Recent losses refreshed</p>
+					<p className="text-xs text-muted-foreground">
+						{refreshStatus?.successfulCharacters ?? 0} characters refreshed, {refreshStatus?.failedCharacters ?? 0}{' '}
+						characters reported warnings.
+					</p>
+				</div>
+			) : null}
+
+			{warningBanner ? (
+				<div className={`rounded-md border px-4 py-3 text-sm ${warningBanner.className}`}>
+					<p className="mb-1 font-medium">{warningBanner.title}</p>
+					{Array.isArray(warningBanner.body) ? (
+						<ul className="space-y-0.5">
+							{warningBanner.body.map((failure) => (
+								<li key={failure.characterId} className="flex items-center gap-2 text-xs text-muted-foreground">
+									<span className="font-medium text-foreground">{failure.characterName}</span>
+									{failure.message
+										? `— ${failure.message}`
+										: failure.reason === 'invalid_token'
+											? '— ESI token is invalid or expired. Please re-authenticate this character.'
+												: '— Could not load losses right now. Please try again shortly.'}
+								</li>
+							))}
+						</ul>
+					) : (
+						<p className="text-xs text-muted-foreground">{warningBanner.body}</p>
+					)}
+				</div>
+			) : null}
+		</div>
+	)
+}
+
+interface RecentLossRefreshButtonProps {
+	isRefreshing?: boolean
+	refreshStatus?: RecentLossRefreshStatusRecord | null
+	refreshCooldownUntil?: string | null
+	onRefresh?: () => void
+}
+
+export function RecentLossRefreshButton({
+	isRefreshing,
+	refreshStatus,
+	refreshCooldownUntil,
+	onRefresh,
+}: RecentLossRefreshButtonProps) {
+	const [nowMs, setNowMs] = useState(() => Date.now())
+	const [cooldownUntilMs, setCooldownUntilMs] = useState(() => {
+		if (typeof window === 'undefined') return 0
+		return readRefreshCooldownUntilMs(window.localStorage)
+	})
+
+	useEffect(() => {
+		if (cooldownUntilMs <= Date.now()) return
+		const intervalId = window.setInterval(() => setNowMs(Date.now()), 1000)
+		return () => window.clearInterval(intervalId)
+	}, [cooldownUntilMs])
+
+	useEffect(() => {
+		if (typeof window === 'undefined') return
+		persistRefreshCooldownUntilMs(window.localStorage, cooldownUntilMs)
+	}, [cooldownUntilMs])
+
+	useEffect(() => {
+		if (!refreshCooldownUntil) return
+		const serverCooldownUntilMs = Date.parse(refreshCooldownUntil)
+		if (!Number.isFinite(serverCooldownUntilMs)) return
+		setCooldownUntilMs((current) => {
+			const next = Math.max(current, serverCooldownUntilMs)
+			if (typeof window !== 'undefined') {
+				persistRefreshCooldownUntilMs(window.localStorage, next)
+			}
+			return next
+		})
+	}, [refreshCooldownUntil])
+
+	if (!onRefresh) return null
+
+	const cooldownRemainingMs = Math.max(0, cooldownUntilMs - nowMs)
+	const isCooldownActive = cooldownRemainingMs > 0
+	const isWorkflowRefreshing =
+		refreshStatus?.status === 'queued' || refreshStatus?.status === 'running'
+	const refreshDisabled = Boolean(isRefreshing || isCooldownActive || isWorkflowRefreshing)
+	const remainingSeconds = Math.ceil(cooldownRemainingMs / 1000)
+	const remainingMinutesPart = String(Math.floor(remainingSeconds / 60)).padStart(2, '0')
+	const remainingSecondsPart = String(remainingSeconds % 60).padStart(2, '0')
+
+	const handleRefreshClick = () => {
+		if (refreshDisabled) return
+		const nextCooldownUntilMs = Date.now() + REFRESH_COOLDOWN_MS
+		if (typeof window !== 'undefined') {
+			// Persist immediately so a hard refresh right after click cannot bypass cooldown.
+			persistRefreshCooldownUntilMs(window.localStorage, nextCooldownUntilMs)
+		}
+		setCooldownUntilMs(nextCooldownUntilMs)
+		onRefresh()
+	}
+
+	return (
+		<Button
+			size="sm"
+			className="whitespace-nowrap"
+			onClick={handleRefreshClick}
+			disabled={refreshDisabled}
+			title={
+				isCooldownActive
+					? `Refresh available in ${remainingMinutesPart}:${remainingSecondsPart}`
+					: isWorkflowRefreshing
+						? 'Recent loss refresh is already in progress'
+						: 'Refresh losses'
+			}
+		>
+			<RefreshCw
+				aria-hidden
+				className={`mr-2 h-4 w-4 ${isRefreshing || isWorkflowRefreshing ? 'animate-spin' : ''}`}
+			/>
+			{isRefreshing
+				? 'Starting…'
+				: isWorkflowRefreshing
+					? `Fetching… ${refreshStatus?.processedCharacters ?? 0}/${refreshStatus?.totalCharacters ?? 0}`
+					: isCooldownActive
+						? `Refresh in ${remainingMinutesPart}:${remainingSecondsPart}`
+						: 'Refresh Losses'}
+		</Button>
 	)
 }

--- a/apps/ui/src/client/features/srp/hooks.ts
+++ b/apps/ui/src/client/features/srp/hooks.ts
@@ -31,7 +31,9 @@ import {
 
 import type {
 	CommentVisibility,
+	RequestListResponse,
 	RequestStatus,
+	RecentLossesResponse,
 	SRPCommentResponse,
 	SRPConfigResponse,
 	SRPRequestResponse,
@@ -169,18 +171,28 @@ function adjustPendingPayoutTotalCaches(
 
 // ===== Query Hooks =====
 
-export function useRecentLosses() {
+export function useRecentLosses(
+	params: { limit?: number; offset?: number } = {},
+	options: { enabled?: boolean } = {}
+) {
 	const overlay = useLossRequestOverlaySnapshot()
-	const query = useQuery({
-		queryKey: srpKeys.losses(),
-		queryFn: () => api.getRecentLosses(),
+	const query = useQuery<RecentLossesResponse>({
+		queryKey: srpKeys.losses(params),
+		queryFn: () => api.getRecentLosses(params),
 		staleTime: 1000 * 60 * 5,
+		enabled: options.enabled ?? true,
 	})
 	useEffect(() => {
 		if (!query.data?.losses) return
 		reconcileOverlayFromServerLosses(query.data.losses)
 	}, [query.data])
-	const mergedData = useMemo(() => mergeLossesWithOverlay(query.data?.losses), [query.data, overlay])
+	const mergedData = useMemo(() => {
+		if (!query.data) return query.data
+		return {
+			...query.data,
+			losses: mergeLossesWithOverlay(query.data.losses ?? []),
+		}
+	}, [query.data, overlay])
 	return {
 		...query,
 		data: mergedData,
@@ -214,13 +226,15 @@ export function useRecentLossRefreshStatus() {
 }
 
 export function useMyRequests(
-	params: { limit?: number; offset?: number; status?: RequestStatus } = {}
+	params: { limit?: number; offset?: number; status?: RequestStatus } = {},
+	options: { enabled?: boolean } = {}
 ) {
 	const overlay = useLossRequestOverlaySnapshot()
-	const query = useQuery({
+	const query = useQuery<RequestListResponse>({
 		queryKey: srpKeys.myRequests(params),
 		queryFn: () => api.getMyRequests(params),
 		staleTime: 1000 * 60,
+		enabled: options.enabled ?? true,
 	})
 	const mergedData = useMemo(() => {
 		if (!query.data) return query.data

--- a/apps/ui/src/client/features/srp/query-keys.ts
+++ b/apps/ui/src/client/features/srp/query-keys.ts
@@ -4,7 +4,7 @@ export const srpKeys = {
 	all: ['srp'] as const,
 
 	// Losses
-	losses: () => [...srpKeys.all, 'losses'] as const,
+	losses: (params?: { limit?: number; offset?: number }) => [...srpKeys.all, 'losses', params] as const,
 	lossRefreshStatus: () => [...srpKeys.losses(), 'refresh-status'] as const,
 
 	// Requests

--- a/apps/ui/src/client/features/srp/routes/create.tsx
+++ b/apps/ui/src/client/features/srp/routes/create.tsx
@@ -17,7 +17,7 @@ export default function CreateRequest() {
 	const killmailHash = searchParams.get('killmailHash')
 
 	const { data: losses, isLoading: lossesLoading } = useRecentLosses()
-	const loss = losses?.find((l: any) => l.killmailId === killmailId)
+	const loss = losses?.losses?.find((l) => l.killmailId === killmailId)
 
 	const { data: preview, isLoading: previewLoading } = useKillmailPreview(
 		killmailId,

--- a/apps/ui/src/client/features/srp/routes/index.tsx
+++ b/apps/ui/src/client/features/srp/routes/index.tsx
@@ -1,10 +1,18 @@
+import { useEffect, useMemo, useState } from 'react'
+
 import { Card, CardContent } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { PageHeader } from '@/components/ui/page-header'
+import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { usePageTitle } from '@/hooks/usePageTitle'
 
-import { LossTable } from '../components/LossTable'
+import {
+	LossTable,
+	RecentLossRefreshButton,
+	RecentLossesStatusAlerts,
+} from '../components/LossTable'
 import { RequestTable } from '../components/RequestTable'
 import {
 	useDismissRecentLoss,
@@ -14,27 +22,135 @@ import {
 	useRefreshKillmails,
 	useSRPConfig,
 } from '../hooks'
+import {
+	setRecentLossesPage,
+	setRecentLossesPageSize,
+	setRecentLossesSnapshot,
+	useRecentLossesUiState,
+} from '../state/recent-losses-store'
+import {
+	setMyRequestsPage,
+	setMyRequestsPageSize,
+	setMyRequestsSnapshot,
+	useMyRequestsUiState,
+} from '../state/my-requests-store'
 
-import type { LossWithSRPStatus } from '../types'
+import type { LossWithSRPStatus, RecentLossesResponse } from '../types'
 
 export default function SRPIndex() {
 	usePageTitle('SRP')
 	const { data: config } = useSRPConfig()
+	const [activeTab, setActiveTab] = useState<'losses' | 'requests'>('losses')
+	const lossPage = useRecentLossesUiState((state) => state.page)
+	const lossPageSize = useRecentLossesUiState((state) => state.pageSize)
+	const requestPage = useMyRequestsUiState((state) => state.page)
+	const requestPageSize = useMyRequestsUiState((state) => state.pageSize)
 
 	const {
-		data: losses,
+		data: lossesData,
 		isLoading: lossesLoading,
+		isFetching: lossesFetching,
 		error: lossesError,
 		failedCharacters: loadFailures,
-	} = useRecentLosses()
+		refetch: refetchLosses,
+	} = useRecentLosses(
+		{
+			limit: lossPageSize,
+			offset: (lossPage - 1) * lossPageSize,
+		},
+		{
+			enabled: activeTab === 'losses',
+		}
+	)
+	const lossOffset = (lossPage - 1) * lossPageSize
+	const currentLossesData = useMemo<RecentLossesResponse | undefined>(() => {
+		if (!lossesData) return undefined
+		if (lossesData.limit !== lossPageSize || lossesData.offset !== lossOffset) return undefined
+		return {
+			...lossesData,
+			losses: lossesData.losses ?? [],
+			failedCharacters: lossesData.failedCharacters ?? [],
+		}
+	}, [lossesData, lossOffset, lossPageSize])
+	const cachedLossesData = useRecentLossesUiState(
+		(state) => state.pages[`${lossPageSize}:${lossOffset}`]
+	)
+	const effectiveLossesData = cachedLossesData ?? currentLossesData
+
+	useEffect(() => {
+		if (!currentLossesData) return
+		setRecentLossesSnapshot(lossPageSize, lossOffset, currentLossesData)
+	}, [currentLossesData, lossOffset, lossPageSize])
+
 	const refreshStatusQuery = useRecentLossRefreshStatus()
 	const refreshMutation = useRefreshKillmails()
 	const dismissLossMutation = useDismissRecentLoss()
 	const {
 		data: requestsData,
 		isLoading: requestsLoading,
+		isFetching: requestsFetching,
 		error: requestsError,
-	} = useMyRequests({ limit: 10 })
+	} = useMyRequests(
+		{
+			limit: requestPageSize,
+			offset: (requestPage - 1) * requestPageSize,
+		},
+		{
+			enabled: activeTab === 'requests',
+		}
+	)
+	const requestOffset = (requestPage - 1) * requestPageSize
+	const currentRequestsData =
+		requestsData?.limit === requestPageSize && requestsData.offset === requestOffset
+			? requestsData
+			: undefined
+	const cachedRequestsData = useMyRequestsUiState(
+		(state) => state.pages[`${requestPageSize}:${requestOffset}`]
+	)
+	const effectiveRequestsData = cachedRequestsData ?? currentRequestsData
+
+	useEffect(() => {
+		if (!currentRequestsData) return
+		setMyRequestsSnapshot(requestPageSize, requestOffset, currentRequestsData)
+	}, [currentRequestsData, requestOffset, requestPageSize])
+
+	const requestLoadError = !effectiveRequestsData ? requestsError : null
+	const requestGrid = effectiveRequestsData?.requests ?? []
+	const requestGridLoading = !effectiveRequestsData && requestsLoading
+	const requestGridRefreshing = Boolean(effectiveRequestsData) && requestsFetching
+	const lossLoadError = !effectiveLossesData ? lossesError : null
+	const lossGrid = effectiveLossesData?.losses ?? []
+	const lossGridLoading = !effectiveLossesData && lossesLoading
+	const lossGridRefreshing = Boolean(effectiveLossesData) && lossesFetching
+	const lossRefreshErrorMessage =
+		lossesError && effectiveLossesData
+			? lossesError instanceof Error
+				? lossesError.message
+				: 'Failed to refresh recent losses.'
+			: null
+	const lossRefreshAction = (
+		<RecentLossRefreshButton
+			isRefreshing={refreshMutation.isPending || lossesFetching}
+			onRefresh={() => refreshMutation.mutate()}
+			refreshStatus={refreshStatusQuery.data?.status ?? null}
+			refreshCooldownUntil={refreshStatusQuery.data?.cooldownUntil ?? null}
+		/>
+	)
+	const lossPaginationControls = (
+		<div className="mb-3 rounded-md border p-3">
+			<UserSearchPaginationControls
+				totalCount={effectiveLossesData?.total ?? 0}
+				page={lossPage}
+				pageSize={lossPageSize}
+				onPageChange={setRecentLossesPage}
+				onPageSizeChange={setRecentLossesPageSize}
+				itemLabel="losses"
+				nextButtonLoading={lossesFetching}
+				pageSizeOptions={[10, 25, 50]}
+				leadingAction={lossRefreshAction}
+			/>
+		</div>
+	)
 
 	return (
 		<Container>
@@ -45,58 +161,117 @@ export default function SRPIndex() {
 
 			<Card className="mt-section">
 				<CardContent className="p-0">
-				<Tabs defaultValue="losses">
-					<TabsList className="w-full rounded-b-none border-b">
-						<TabsTrigger value="losses">Recent Losses</TabsTrigger>
-						<TabsTrigger value="requests">My Requests</TabsTrigger>
-					</TabsList>
+					<Tabs
+						value={activeTab}
+						onValueChange={(value) => setActiveTab(value as 'losses' | 'requests')}
+					>
+						<TabsList className="w-full rounded-b-none border-b">
+							<TabsTrigger value="losses">Recent Losses</TabsTrigger>
+							<TabsTrigger value="requests">My Requests</TabsTrigger>
+						</TabsList>
 
-					<div className="p-4">
-						<TabsContent value="losses" className="mt-0 space-y-4">
-							{lossesError && !lossesLoading ? (
-								<div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-center">
-									<p className="text-sm text-red-500">Failed to load losses</p>
-									<p className="text-xs text-muted-foreground">
-										{lossesError instanceof Error ? lossesError.message : 'Unknown error'}
-									</p>
-								</div>
-							) : (
-							<LossTable
-									losses={(losses || []) as LossWithSRPStatus[]}
-									isLoading={lossesLoading}
-									isRefreshing={refreshMutation.isPending}
-									onRefresh={() => refreshMutation.mutate()}
-									config={config}
-									refreshStatus={refreshStatusQuery.data?.status ?? null}
-									refreshCooldownUntil={refreshStatusQuery.data?.cooldownUntil ?? null}
-									loadFailures={loadFailures}
-									onDismissLoss={async (killmailId) => {
-										await dismissLossMutation.mutateAsync({ killmailId })
-									}}
-									dismissingKillmailId={
-										dismissLossMutation.isPending
-											? dismissLossMutation.variables?.killmailId ?? null
-											: null
-									}
-								/>
-							)}
-						</TabsContent>
+						<div className="p-4">
+							<TabsContent value="losses" className="mt-0 space-y-4">
+								{lossLoadError && !lossGridLoading ? (
+									<div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-center">
+										<p className="text-sm text-red-500">Failed to load losses</p>
+										<p className="text-xs text-muted-foreground">
+											{lossLoadError instanceof Error ? lossLoadError.message : 'Unknown error'}
+										</p>
+									</div>
+								) : (
+									<>
+										<RecentLossesStatusAlerts
+											refreshStatus={refreshStatusQuery.data?.status ?? null}
+											refreshErrorMessage={lossRefreshErrorMessage}
+											loadFailures={effectiveLossesData?.failedCharacters ?? loadFailures}
+										/>
+										<TableRefreshFrame
+											isRefreshing={lossGridRefreshing || refreshMutation.isPending}
+											refreshMessage="Refreshing recent losses..."
+											onRetry={() => void refetchLosses()}
+											retryDisabled={lossesFetching}
+										>
+											{lossPaginationControls}
+											{!effectiveLossesData && lossGridLoading ? (
+												<LossTable
+													losses={[]}
+													isLoading
+													config={config}
+													onDismissLoss={async (killmailId) => {
+														await dismissLossMutation.mutateAsync({ killmailId })
+													}}
+													dismissingKillmailId={
+														dismissLossMutation.isPending
+															? dismissLossMutation.variables?.killmailId ?? null
+															: null
+													}
+												/>
+											) : (
+												<LossTable
+													losses={(lossGrid || []) as LossWithSRPStatus[]}
+													isLoading={false}
+													config={config}
+													onDismissLoss={async (killmailId) => {
+														await dismissLossMutation.mutateAsync({ killmailId })
+													}}
+													dismissingKillmailId={
+														dismissLossMutation.isPending
+															? dismissLossMutation.variables?.killmailId ?? null
+															: null
+													}
+												/>
+											)}
+										</TableRefreshFrame>
+									</>
+								)}
+							</TabsContent>
 
-						<TabsContent value="requests" className="mt-0 space-y-4">
-							{requestsError && !requestsLoading ? (
-								<div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-center">
-									<p className="text-sm text-red-500">Failed to load requests</p>
-									<p className="text-xs text-muted-foreground">
-										{requestsError instanceof Error ? requestsError.message : 'Unknown error'}
-									</p>
-								</div>
-							) : (
-								<RequestTable requests={requestsData?.requests || []} isLoading={requestsLoading} />
-							)}
-						</TabsContent>
-
-					</div>
-				</Tabs>
+							<TabsContent value="requests" className="mt-0 space-y-4">
+								{requestLoadError && !requestGridLoading ? (
+									<div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-center">
+										<p className="text-sm text-red-500">Failed to load requests</p>
+										<p className="text-xs text-muted-foreground">
+											{requestLoadError instanceof Error ? requestLoadError.message : 'Unknown error'}
+										</p>
+									</div>
+								) : !effectiveRequestsData && requestGridLoading ? (
+									<div className="rounded-lg border border-muted p-6 text-center">
+										<div className="mx-auto flex w-fit items-center gap-2 rounded-full border border-muted bg-muted/20 px-3 py-1.5 text-sm text-muted-foreground">
+											<span className="h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground/40 border-t-transparent" />
+											<span>Loading requests...</span>
+										</div>
+									</div>
+								) : (
+									<TableRefreshFrame
+										isRefreshing={requestGridRefreshing}
+										refreshMessage="Refreshing requests..."
+										errorMessage={
+											requestsError && effectiveRequestsData
+												? requestsError instanceof Error
+													? requestsError.message
+													: 'Failed to refresh requests.'
+												: null
+										}
+									>
+										<div className="mb-3 rounded-md border p-3">
+											<UserSearchPaginationControls
+												totalCount={effectiveRequestsData?.total ?? 0}
+												page={requestPage}
+												pageSize={requestPageSize}
+												onPageChange={setMyRequestsPage}
+												onPageSizeChange={setMyRequestsPageSize}
+												itemLabel="requests"
+												nextButtonLoading={requestsFetching}
+												pageSizeOptions={[10, 25, 50]}
+											/>
+										</div>
+										<RequestTable requests={requestGrid} isLoading={false} />
+									</TableRefreshFrame>
+								)}
+							</TabsContent>
+						</div>
+					</Tabs>
 				</CardContent>
 			</Card>
 		</Container>

--- a/apps/ui/src/client/features/srp/routes/review.tsx
+++ b/apps/ui/src/client/features/srp/routes/review.tsx
@@ -559,7 +559,7 @@ function ReviewTabContent({
 						pageSizeOptions={[10, 25, 50, 100]}
 						itemLabel="requests"
 						nextButtonLoading={isFetching}
-						summaryAction={actionButtons}
+						trailingAction={actionButtons}
 					/>
 				</div>
 				<div className="rounded-md border">

--- a/apps/ui/src/client/features/srp/state/my-requests-store.ts
+++ b/apps/ui/src/client/features/srp/state/my-requests-store.ts
@@ -1,0 +1,20 @@
+import type { RequestListResponse } from '../types'
+import { createPaginatedSnapshotStore } from './paginated-snapshot-store'
+
+const myRequestsStore = createPaginatedSnapshotStore<RequestListResponse>({
+	defaultPageSize: 10,
+	maxPageSize: 50,
+})
+
+export const setMyRequestsPage = myRequestsStore.setPage
+export const setMyRequestsPageSize = myRequestsStore.setPageSize
+export const setMyRequestsSnapshot = myRequestsStore.setSnapshot
+export const useMyRequestsUiState = myRequestsStore.useUiState
+
+export function getMyRequestsSnapshot(pageSize: number, offset: number): RequestListResponse | undefined {
+	return myRequestsStore.getSnapshot(pageSize, offset)
+}
+
+export function __resetMyRequestsStoreForTests(): void {
+	myRequestsStore.reset()
+}

--- a/apps/ui/src/client/features/srp/state/paginated-snapshot-store.ts
+++ b/apps/ui/src/client/features/srp/state/paginated-snapshot-store.ts
@@ -1,0 +1,90 @@
+import { createStore } from '@tanstack/store'
+import { useSyncExternalStore } from 'react'
+
+export interface PaginatedSnapshotStoreState<TSnapshot> {
+	page: number
+	pageSize: number
+	pages: Record<string, TSnapshot>
+}
+
+interface CreatePaginatedSnapshotStoreOptions {
+	defaultPageSize?: number
+	maxPageSize?: number
+}
+
+export function createPaginatedSnapshotStore<TSnapshot>(
+	options: CreatePaginatedSnapshotStoreOptions = {}
+) {
+	const defaultPageSize = options.defaultPageSize ?? 10
+	const maxPageSize = options.maxPageSize ?? 50
+	const store = createStore<PaginatedSnapshotStoreState<TSnapshot>>({
+		page: 1,
+		pageSize: defaultPageSize,
+		pages: {},
+	})
+
+	function getPageKey(pageSize: number, offset: number): string {
+		return `${pageSize}:${offset}`
+	}
+
+	function setPage(page: number): void {
+		store.setState((state) => ({
+			...state,
+			page: Math.max(1, page),
+		}))
+	}
+
+	function setPageSize(pageSize: number): void {
+		store.setState((state) => ({
+			...state,
+			pageSize: Math.min(maxPageSize, Math.max(1, pageSize)),
+			page: 1,
+		}))
+	}
+
+	function setSnapshot(pageSize: number, offset: number, data: TSnapshot): void {
+		const key = getPageKey(pageSize, offset)
+		store.setState((state) => {
+			if (state.pages[key] === data) return state
+			return {
+				...state,
+				pages: {
+					...state.pages,
+					[key]: data,
+				},
+			}
+		})
+	}
+
+	function getSnapshot(pageSize: number, offset: number): TSnapshot | undefined {
+		return store.state.pages[getPageKey(pageSize, offset)]
+	}
+
+	function useUiState<TSelected>(
+		selector: (state: PaginatedSnapshotStoreState<TSnapshot>) => TSelected
+	): TSelected {
+		return useSyncExternalStore(
+			(listener) => store.subscribe(listener).unsubscribe,
+			() => selector(store.state),
+			() => selector(store.state)
+		)
+	}
+
+	function reset(): void {
+		store.setState(() => ({
+			page: 1,
+			pageSize: defaultPageSize,
+			pages: {},
+		}))
+	}
+
+	return {
+		getPageKey,
+		getSnapshot,
+		reset,
+		setPage,
+		setPageSize,
+		setSnapshot,
+		useUiState,
+	}
+}

--- a/apps/ui/src/client/features/srp/state/recent-losses-store.ts
+++ b/apps/ui/src/client/features/srp/state/recent-losses-store.ts
@@ -1,0 +1,16 @@
+import type { RecentLossesResponse } from '../types'
+import { createPaginatedSnapshotStore } from './paginated-snapshot-store'
+
+const recentLossesStore = createPaginatedSnapshotStore<RecentLossesResponse>({
+	defaultPageSize: 10,
+	maxPageSize: 50,
+})
+
+export const setRecentLossesPage = recentLossesStore.setPage
+export const setRecentLossesPageSize = recentLossesStore.setPageSize
+export const setRecentLossesSnapshot = recentLossesStore.setSnapshot
+export const useRecentLossesUiState = recentLossesStore.useUiState
+
+export function __resetRecentLossesStoreForTests(): void {
+	recentLossesStore.reset()
+}

--- a/apps/ui/src/client/features/srp/types.ts
+++ b/apps/ui/src/client/features/srp/types.ts
@@ -11,6 +11,8 @@ export type {
 	RecentLossRefreshCharacterFailure,
 	RecentLossRefreshStatusRecord,
 	RecentLossRefreshStatusResponse,
+	RecentLossesResponse,
+	RecentLossVictimItem,
 	SRPCommentResponse,
 	SRPConfigResponse,
 	SRPHistoryResponse,

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -37,7 +37,11 @@ import type {
 	StructureSovereigntyTransportState,
 } from '@repo/structures'
 import type { TrackingSession } from '../features/fleet-tracking/types'
-import type { SRPRecentLossRefreshBackfillResponse } from '../features/srp/types'
+import type {
+	RecentLossesResponse,
+	RequestListResponse,
+	SRPRecentLossRefreshBackfillResponse,
+} from '../features/srp/types'
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 const API_REQUEST_TIMEOUT_MS = 30_000
@@ -4536,44 +4540,12 @@ export class ApiClient {
 	/**
 	 * Get recent losses for all user's characters with SRP status
 	 */
-	async getRecentLosses(): Promise<{
-		losses: Array<{
-			killmailId: string
-			killmailHash: string
-			killmailTime: string
-			shipTypeId: string
-			shipTypeName?: string
-			totalValue: string
-			solarSystemId: string
-			solarSystemName?: string
-			victimCharacterId: string
-			victimCharacterName?: string
-			victimItems?: Array<{
-				flag: number
-				item_type_id: string
-				quantity_destroyed?: number
-				quantity_dropped?: number
-				items?: Array<{
-					flag: number
-					item_type_id: string
-					quantity_destroyed?: number
-					quantity_dropped?: number
-					items?: never
-				}>
-			}>
-			hasSRPRequest: boolean
-			srpRequestId?: string
-			srpRequestStatus?: string
-		}>
-		failedCharacters: Array<{
-			characterId: string
-			characterName: string
-			reason: 'invalid_token' | 'cache_missing' | 'cache_incomplete' | 'fetch_failed'
-			message?: string
-			error?: string
-		}>
-	}> {
-		return this.get('/srp/losses')
+	async getRecentLosses(params?: { limit?: number; offset?: number }): Promise<RecentLossesResponse> {
+		const searchParams = new URLSearchParams()
+		if (params?.limit !== undefined) searchParams.set('limit', String(params.limit))
+		if (params?.offset !== undefined) searchParams.set('offset', String(params.offset))
+		const query = searchParams.toString()
+		return this.get(`/srp/losses${query ? `?${query}` : ''}`)
 	}
 
 	async dismissRecentLoss(killmailId: string): Promise<{ success: true }> {
@@ -4604,12 +4576,7 @@ export class ApiClient {
 	/**
 	 * Get user's own SRP requests (paginated)
 	 */
-	async getMyRequests(params?: { limit?: number; offset?: number; status?: string }): Promise<{
-		requests: any[]
-		total: number
-		limit: number
-		offset: number
-	}> {
+	async getMyRequests(params?: { limit?: number; offset?: number; status?: string }): Promise<RequestListResponse> {
 		const searchParams = new URLSearchParams()
 		if (params?.limit) searchParams.set('limit', String(params.limit))
 		if (params?.offset) searchParams.set('offset', String(params.offset))

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -1627,7 +1627,7 @@ export default function StructuresPage() {
 								pageSizeOptions={[25, 50, 100]}
 								itemLabel="structures"
 								nextButtonLoading={isFetching}
-								summaryAction={refreshButton}
+								trailingAction={refreshButton}
 							/>
 						</div>
 						<TableRefreshFrame

--- a/packages/srp/src/index.ts
+++ b/packages/srp/src/index.ts
@@ -37,6 +37,9 @@ export interface RecentLossRefreshCharacterFailure {
 export interface RecentLossesResponse {
 	losses: LossWithSRPStatus[]
 	failedCharacters: RecentLossRefreshCharacterFailure[]
+	total: number
+	limit: number
+	offset: number
 }
 
 export interface RecentLossVictimItem {
@@ -137,12 +140,19 @@ export interface Srp {
 	): Promise<SRPRequestResponse>
 	getRequest(requestId: string, userId: string): Promise<SRPRequestResponse | null>
 	getPublicRequestSummary(requestId: string): Promise<SRPPublicRequestSummaryResponse | null>
-	getUserRequests(userId: string, limit?: number, offset?: number): Promise<SRPRequestResponse[]>
+	getUserRequests(
+		userId: string,
+		limit?: number,
+		offset?: number,
+		status?: RequestStatus
+	): Promise<SRPRequestListResponse>
 	getRecentLosses(
 		characters: RecentLossRefreshCharacterInput[],
 		userId: string,
 		daysBack?: number,
-		excludeNonSrpEligible?: boolean
+		excludeNonSrpEligible?: boolean,
+		limit?: number,
+		offset?: number
 	): Promise<RecentLossesResponse>
 	dismissLoss(userId: string, killmailId: string): Promise<void>
 	refreshRecentLossesForCharacter(
@@ -576,6 +586,11 @@ export interface SRPRequestResponse {
 	// Populated relations
 	comments?: SRPCommentResponse[]
 	history?: SRPHistoryResponse[]
+}
+
+export interface SRPRequestListResponse {
+	requests: SRPRequestResponse[]
+	total: number
 }
 
 /**


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds pagination to the SRP "Recent Losses" and "My Losses" (My Requests) tabs, replacing the old client-only refresh/loss list with server-side paged data, cached per-page snapshots, and reworked status/refresh UI.

## Changes
- `apps/srp` durable object: `getUserRequests` now returns `{ requests, total }` (with optional `status` filter) and `getRecentLosses` accepts `limit`/`offset` and returns `total`/`limit`/`offset` alongside the sliced `losses`.
- `apps/core` SRP routes: `/api/srp/losses` and `/api/srp/requests` validate and forward `limit`/`offset` (and `status`) via a new shared `validatePagination` helper, and return pagination metadata in the response; `admin.ts` updated to handle the new `getUserRequests` shape.
- `packages/srp`: `Srp` interface and response types (`RecentLossesResponse`, new `SRPRequestListResponse`) updated to include `total`/`limit`/`offset`.
- `apps/ui` SRP feature:
  - New `paginated-snapshot-store` (Tanstack Store-based) with per-tab stores (`recent-losses-store`, `my-requests-store`) to keep the previous page's data visible while a new page loads.
  - `SRPIndex` route reworked to page both tabs independently, only fetch the active tab's data, and render pagination controls (`UserSearchPaginationControls`) for losses and requests.
  - `LossTable` split: refresh button (`RecentLossRefreshButton`) and status/error banners (`RecentLossesStatusAlerts`) extracted into standalone components so they can be rendered outside the table itself.
  - `UserSearchPaginationControls` renamed `summaryAction` prop to `leadingAction`/`trailingAction` (updated in `review.tsx` and `structures.tsx` call sites).
  - `useRecentLosses`/`useMyRequests` hooks accept pagination params and an `enabled` option; query keys include the params.
  - `CreateRequestForm` victim-item normalization cleaned up using shared `RecentLossVictimItem` type.

## Testing
- Updated `apps/core/src/routes/__tests__/srp.route.test.ts` to match the new paginated response shapes and updated stub call assertions for `getUserRequests`/`getRecentLosses`.
<!-- claude:end -->