### PR TITLE
fix issue with erroneous invalid token response for empty recent loss

### DIFF
--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -25,7 +25,7 @@ import {
 	srpRequests,
 } from './db/schema'
 import { buildEquippedByType } from './lib/equipment'
-import { SrpKillmailEsiClient } from './lib/killmail-esi'
+import { SrpKillmailEsiClient, SrpKillmailNotFoundError } from './lib/killmail-esi'
 import { computeSrpPayout } from './lib/payout'
 import {
 	doesRecentLossCacheCoverCutoff,
@@ -249,6 +249,24 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		)
 	}
 
+	private async writeRecentLossCache(
+		characterId: string,
+		losses: CharacterLossData[],
+		maxLossAgeDays: number
+	): Promise<void> {
+		const record: RecentLossCacheStorageRecord = {
+			losses: losses.map((loss) => ({
+				...loss,
+				killmailTime: loss.killmailTime.toISOString(),
+			})),
+			refreshedAtMs: Date.now(),
+			complete: true,
+			maxLossAgeDays,
+		}
+
+		await this.storage.put(this.buildRecentLossCacheKey(characterId), record)
+	}
+
 	private async selfHealRequestItemMetadata(request: any): Promise<void> {
 		const itemPrices: Array<{ typeId?: string; typeName?: string | null; [key: string]: unknown }> =
 			Array.isArray(request?.srpItemPrices) ? request.srpItemPrices : []
@@ -363,7 +381,15 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		let totalPages = 1
 
 		while (page <= totalPages) {
-			const pageResult = await this.killmailEsi.fetchCharacterKillmailPage(characterId, page)
+			let pageResult
+			try {
+				pageResult = await this.killmailEsi.fetchCharacterKillmailPage(characterId, page)
+			} catch (error) {
+				if (error instanceof SrpKillmailNotFoundError) {
+					break
+				}
+				throw error
+			}
 			totalPages = Math.max(1, pageResult.pages)
 			const selection = selectRecentKillmailsUntilKnown(pageResult.data, knownKillmailIds)
 			const pageLosses = await this.fetchLossDetailsForKillmails(characterId, selection.killmails)
@@ -972,6 +998,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			)
 
 			if (mergedCharacterLosses.length === 0) {
+				if (cached?.complete === true) {
+					continue
+				}
 				const tokenValidation = await tokenStore.validateToken(
 					character.characterId,
 					SRP_REQUIRED_KILLMAIL_SCOPES
@@ -1176,6 +1205,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 
 		const freshLosses = await this.fetchRecentLossesFromEsi(characterId, knownKillmailIds)
 		await this.persistRecentLossesToCharacterData(characterId, freshLosses, cacheCutoffMs)
+		await this.writeRecentLossCache(characterId, freshLosses.map((entry) => entry.loss), maxLossAgeDays)
 
 		return {
 			characterId,

--- a/apps/srp/src/lib/killmail-esi.ts
+++ b/apps/srp/src/lib/killmail-esi.ts
@@ -177,7 +177,7 @@ class SrpKillmailCache implements EsiCacheAdapter {
 	}
 }
 
-class SrpKillmailNotFoundError extends Error {
+export class SrpKillmailNotFoundError extends Error {
 	constructor(public readonly path: string) {
 		super(`Killmail not found for ${path}`)
 		this.name = 'SrpKillmailNotFoundError'

--- a/apps/srp/src/lib/recent-loss-cache.ts
+++ b/apps/srp/src/lib/recent-loss-cache.ts
@@ -43,8 +43,12 @@ export function doesRecentLossCacheCoverCutoff(
 	cutoffMs: number,
 	currentMaxLossAgeDays: number
 ): boolean {
-	if (!record || record.complete !== true || record.losses.length === 0) {
+	if (!record || record.complete !== true) {
 		return false
+	}
+
+	if (record.losses.length === 0) {
+		return true
 	}
 
 	if (!Number.isFinite(record.maxLossAgeDays) || record.maxLossAgeDays < currentMaxLossAgeDays) {

--- a/apps/srp/src/test/unit/recent-loss-cache.unit.test.ts
+++ b/apps/srp/src/test/unit/recent-loss-cache.unit.test.ts
@@ -94,6 +94,18 @@ describe('recent-loss cache helpers', () => {
 				30
 			)
 		).toBe(false)
+		expect(
+			doesRecentLossCacheCoverCutoff(
+				{
+					losses: [],
+					refreshedAtMs: Date.parse('2026-06-02T04:00:00.000Z'),
+					complete: true,
+					maxLossAgeDays: 30,
+				},
+				Date.parse('2026-05-01T00:00:00.000Z'),
+				30
+			)
+		).toBe(true)
 	})
 
 	it('invalidates cached recent losses when the configured max age increases', () => {

--- a/apps/srp/src/test/unit/recent-loss-refresh-flow.unit.test.ts
+++ b/apps/srp/src/test/unit/recent-loss-refresh-flow.unit.test.ts
@@ -43,7 +43,7 @@ describe('refreshRecentLossesForCharacter', () => {
 			complete: true,
 			maxLossAgeDays: 30,
 		})
-		srp.readMostRecentStoredLoss = vi.fn().mockResolvedValue(storedLoss)
+		srp.readMostRecentLoss = vi.fn().mockResolvedValue(storedLoss)
 		srp.fetchRecentLossesFromEsi = vi.fn().mockImplementation(async (_characterId: string, ids: Set<string>) => {
 			for (const id of ids) {
 				knownKillmailIds.add(id)
@@ -66,7 +66,7 @@ describe('refreshRecentLossesForCharacter', () => {
 			characterName: 'Character One',
 			success: true,
 		})
-		expect(srp.readMostRecentStoredLoss).toHaveBeenCalledWith('character-1')
+		expect(srp.readMostRecentLoss).toHaveBeenCalledWith('character-1')
 		expect(srp.fetchRecentLossesFromEsi).toHaveBeenCalledTimes(1)
 		expect(knownKillmailIds).toEqual(new Set(['200']))
 		expect(srp.persistRecentLossesToCharacterData).toHaveBeenCalledWith(
@@ -74,5 +74,32 @@ describe('refreshRecentLossesForCharacter', () => {
 			[{ loss: refreshedLoss, killmailData: { killmail_id: refreshedLoss.killmailId } }],
 			expect.any(Number)
 		)
+		expect(srp.writeRecentLossCache).toHaveBeenCalledWith('character-1', [refreshedLoss], 30)
+	})
+
+	it('treats an empty refresh as a successful complete cache write', async () => {
+		const srp = Object.create(SrpDO.prototype) as Record<string, any>
+
+		srp.readRecentLossCache = vi.fn().mockResolvedValue(null)
+		srp.readMostRecentLoss = vi.fn().mockResolvedValue(null)
+		srp.fetchRecentLossesFromEsi = vi.fn().mockResolvedValue([])
+		srp.persistRecentLossesToCharacterData = vi.fn().mockResolvedValue(undefined)
+		srp.writeRecentLossCache = vi.fn().mockResolvedValue(undefined)
+		srp.getConfig = vi.fn().mockResolvedValue({ maxLossAgeDays: 30 })
+
+		const result = await srp.refreshRecentLossesForCharacter(
+			'user-1',
+			'character-1',
+			'Character One',
+			30
+		)
+
+		expect(result).toEqual({
+			characterId: 'character-1',
+			characterName: 'Character One',
+			success: true,
+		})
+		expect(srp.persistRecentLossesToCharacterData).toHaveBeenCalledWith('character-1', [], expect.any(Number))
+		expect(srp.writeRecentLossCache).toHaveBeenCalledWith('character-1', [], 30)
 	})
 })


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a bug where the SRP recent-losses refresh incorrectly returned an "invalid token" error for characters with no recent losses, because an empty-but-complete cache was treated as not covering the requested cutoff and triggered an unnecessary token validation. Also makes killmail page fetching tolerate ESI 404 responses instead of throwing.

## Changes
- `doesRecentLossCacheCoverCutoff`: an empty `losses` array on a `complete: true` cache record is now treated as covering the cutoff, instead of always returning `false`.
- `SrpDO.refreshRecentLossesForCharacter`: skip token validation when merged losses are empty but the existing cache is already marked `complete`.
- Added `SrpDO.writeRecentLossCache` to persist a `complete` recent-loss cache record after a fresh ESI fetch, and call it after `persistRecentLossesToCharacterData`.
- `fetchCharacterKillmailPage` pagination loop now catches `SrpKillmailNotFoundError` (exported from `killmail-esi.ts`) and stops paging instead of letting the error propagate.
- Fixed test mocks/assertions referencing `readMostRecentStoredLoss` to use the actual method name `readMostRecentLoss`.

## Testing
- Updated `recent-loss-cache.unit.test.ts` with a case asserting an empty-but-complete cache record covers the cutoff.
- Updated `recent-loss-refresh-flow.unit.test.ts` with a case asserting an empty refresh still results in a successful, complete cache write via `writeRecentLossCache`.
<!-- claude:end -->