### PR TITLE
fix issue with character re-auth token validity update

### DIFF
--- a/apps/core/src/routes/__tests__/auth.identity-binding.test.ts
+++ b/apps/core/src/routes/__tests__/auth.identity-binding.test.ts
@@ -95,7 +95,7 @@ function mockDb(oauthState: unknown) {
 		insert: vi.fn(() => ({ values: insertValues })),
 	} as any)
 
-	return { deleteWhere, insertValues }
+	return { deleteWhere, updateWhere, insertValues }
 }
 
 const cleanHrStub = {
@@ -563,6 +563,62 @@ describe('GET /api/auth/callback - character owner hash is enforced on login', (
 
 		expect(res.status).toBe(200)
 		expect(res.headers.get('set-cookie')).toContain('session=')
+	})
+
+	it('marks an already-linked character token valid when it is reauthorized', async () => {
+		const { updateWhere } = mockDb({
+			state: 'state-1',
+			flowType: 'character',
+			userId: 'user-1',
+			redirectUrl: null,
+			metadata: null,
+			expiresAt: FUTURE,
+		})
+		mockStubs({ handleCallback: vi.fn().mockResolvedValue(callbackResult('SAME-HASH')) })
+
+		vi.mocked(UserService).mockImplementation(
+			() =>
+				({
+					getUserById: vi.fn().mockResolvedValue({
+						id: 'user-1',
+						characters: [
+							{
+								characterId: 'char-1',
+								characterName: 'Pilot',
+								hasValidToken: false,
+							},
+						],
+					}),
+					getUserByCharacterId: vi.fn().mockResolvedValue({
+						id: 'user-1',
+						characters: [
+							{
+								characterId: 'char-1',
+								characterName: 'Pilot',
+								hasValidToken: false,
+							},
+						],
+					}),
+					getCharacterOwnership: vi.fn().mockResolvedValue({
+						userId: 'user-1',
+						characterOwnerHash: 'SAME-HASH',
+					}),
+				}) as any
+		)
+
+		const res = await callbackRequest({ state: 'state-1' })
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toMatchObject({
+			characterLinked: true,
+			tokenUpdated: true,
+			character: {
+				characterId: 'char-1',
+				characterName: 'Pilot',
+				hasValidToken: true,
+			},
+		})
+		expect(updateWhere).toHaveBeenCalled()
 	})
 
 	it('adopts the real hash for a legacy-imported character instead of locking the user out', async () => {

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -740,12 +740,23 @@ auth.get('/callback', async (c) => {
 		if (existingUser) {
 			if (existingUser.id === stateUserId) {
 				await hydrateAndReconcileUserRoles(c, db, stateUserId, characterId)
-				// Character already linked to this user - token has been updated, just return success
 				const existingCharacter = user.characters.find((char) => char.characterId === characterId)
+				await db
+					.update(userCharacters)
+					.set({ hasValidToken: true, updatedAt: new Date() })
+					.where(eq(userCharacters.characterId, characterId))
+				triggerDirectorHealthRecheckAfterTokenReauth(
+					c,
+					db,
+					characterId,
+					characterInfo.characterName
+				)
+
+				// Character already linked to this user - token has been updated, just return success
 				return c.json({
 					characterLinked: true,
 					tokenUpdated: true,
-					character: existingCharacter,
+					character: existingCharacter ? { ...existingCharacter, hasValidToken: true } : existingCharacter,
 				})
 			} else {
 				return c.json({ error: 'Character is already linked to another account' }, 400)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

When a user re-authorizes a character that's already linked to their account, the callback returned success but never actually updated the character's `hasValidToken` flag in the database or in the response payload — so the UI kept showing the character as having an invalid token even though re-auth had just succeeded.

## Changes

- In `apps/core/src/routes/auth.ts`, the "character already linked to this user" branch of `GET /api/auth/callback` now updates `userCharacters.hasValidToken` to `true` (and `updatedAt`) for the character, triggers a director health recheck via `triggerDirectorHealthRecheckAfterTokenReauth`, and returns the character in the response with `hasValidToken: true` reflected.
- Added `updateWhere` to the test `mockDb` helper so tests can assert on the update call.

## Testing

- Added a test in `apps/core/src/routes/__tests__/auth.identity-binding.test.ts` covering re-authorization of an already-linked character, asserting `tokenUpdated: true`, `character.hasValidToken: true`, and that `updateWhere` was called.
<!-- claude:end -->