### PR TITLE
feat(mailroom): randomise fallback message and include footer (etc link)

### DIFF
--- a/apps/mailroom/src/markee-bonus.ts
+++ b/apps/mailroom/src/markee-bonus.ts
@@ -41,6 +41,28 @@ export const BONUS_HEADINGS: readonly string[] = [
 		'Get your own at <https://etc.pleaseignore.com> — use code **tapi** for a discount.\n',
 ]
 
+/**
+ * Plain sale notices for when no bonus was awarded (no eligible wallet / empty house / a failure).
+ * One is chosen at random and posted with {@link FALLBACK_FOOTER} appended on its own line (see
+ * {@link pickFallbackMessage}). Standalone by design — no winner name is appended. Same
+ * content-rendering rules as {@link BONUS_MESSAGES} — unicode emoji and custom `<:name:id>` emotes
+ * both render.
+ */
+export const FALLBACK_MESSAGES: readonly string[] = [
+	'📣 A Markee Dragon referral sale just came in!',
+	'💸 Cha-ching — a Markee Dragon referral sale just landed!',
+	'🛒 Someone just bought through our Markee Dragon referral link!',
+	'📈 Another Markee Dragon referral sale is in the books!',
+	'🎊 Our Markee Dragon referral code just got used again!',
+	'🪙 A referral commission just rolled in from Markee Dragon!',
+]
+
+/**
+ * Footer line appended to every fallback post. The URL is wrapped in `<…>` so Discord suppresses the
+ * link-preview embed, same as in {@link BONUS_HEADINGS}.
+ */
+export const FALLBACK_FOOTER = '<https://etc.pleaseignore.com> - use code `tapi` for 3% off'
+
 /** Pick a random predefined opener. */
 function pickBonusMessage(): string {
 	return BONUS_MESSAGES[Math.floor(Math.random() * BONUS_MESSAGES.length)]
@@ -50,6 +72,15 @@ function pickBonusMessage(): string {
 function pickBonusHeading(): string | null {
 	if (BONUS_HEADINGS.length === 0) return null
 	return BONUS_HEADINGS[Math.floor(Math.random() * BONUS_HEADINGS.length)]
+}
+
+/**
+ * Build the no-award fallback post: a random {@link FALLBACK_MESSAGES} notice with
+ * {@link FALLBACK_FOOTER} on its own line below.
+ */
+export function pickFallbackMessage(): string {
+	const notice = FALLBACK_MESSAGES[Math.floor(Math.random() * FALLBACK_MESSAGES.length)]
+	return `${notice}\n${FALLBACK_FOOTER}`
 }
 
 /**

--- a/apps/mailroom/src/notify-discord.ts
+++ b/apps/mailroom/src/notify-discord.ts
@@ -1,7 +1,7 @@
 import { forDO } from '@repo/do-utils'
 
 import { consume } from './email'
-import { awardAndAnnounce } from './markee-bonus'
+import { awardAndAnnounce, pickFallbackMessage } from './markee-bonus'
 
 import type { Discord, MessageContent } from '@repo/discord'
 import type { Env } from './context'
@@ -29,12 +29,13 @@ export const notifyDiscord: EmailHandler<Env> = async (ctx) => {
 
 	// Award a random prediction-market wallet a house-funded bonus and build the announcement naming
 	// the winner. Best-effort (never throws); returns null when no one was bonused (empty house / no
-	// wallets / a failure), in which case we post a plain sale notice. As Discord message content, the
-	// announcement renders emoji + custom emotes and the winner mention resolves to their display name.
+	// wallets / a failure), in which case we post a plain sale notice picked at random from the
+	// fallback pool. As Discord message content, the announcement renders emoji + custom emotes and
+	// the winner mention resolves to their display name.
 	const announcement = await awardAndAnnounce(ctx)
 
 	const message: MessageContent = {
-		content: announcement ?? '📣 A Markee Dragon referral sale just came in!',
+		content: announcement ?? pickFallbackMessage(),
 		allowEveryone: false,
 	}
 

--- a/apps/mailroom/src/test/notify-discord.test.ts
+++ b/apps/mailroom/src/test/notify-discord.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { createEmailContext } from '../email'
+import { FALLBACK_FOOTER, FALLBACK_MESSAGES } from '../markee-bonus'
 import { notifyDiscord } from '../notify-discord'
 import { emailRouter } from '../routes'
 import { fakeExecutionCtx, makeMessage } from './make-message'
@@ -13,6 +14,10 @@ const log: EmailLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 /** A skipped-award mock (no one bonused) — the default so the post falls back to the plain sale notice. */
 const skippedAward = () =>
 	vi.fn().mockResolvedValue({ awarded: false, reason: 'NO_ELIGIBLE_WALLETS' })
+
+/** True when `content` is a fallback post: some pool notice with the footer on its own line below. */
+const isFallbackPost = (content: string) =>
+	FALLBACK_MESSAGES.some((m) => content === `${m}\n${FALLBACK_FOOTER}`)
 
 /**
  * Build an Env whose DISCORD binding resolves (via forDO().singleton() → getByName) to a stub with the
@@ -50,7 +55,7 @@ describe('notifyDiscord', () => {
 		const [guildId, channelId, message] = sendMessage.mock.calls[0]
 		expect(guildId).toBe('guild-1')
 		expect(channelId).toBe('chan-1')
-		expect(message.content).toBe('📣 A Markee Dragon referral sale just came in!')
+		expect(isFallbackPost(message.content)).toBe(true)
 		expect(message.embeds).toBeUndefined() // the email body/embed was debug-only and is gone
 		// The award is actually wired in (guards against silently disconnecting the feature).
 		expect(award).toHaveBeenCalledTimes(1)
@@ -59,6 +64,27 @@ describe('notifyDiscord', () => {
 			reason: 'markeedragon@ inbound email from sender@example.com',
 		})
 		expect(disposition).toEqual({ type: 'consume' })
+	})
+
+	it('draws the fallback notice uniformly at random from the pool', async () => {
+		const randomSpy = vi.spyOn(Math, 'random')
+		try {
+			// Pin the roll to both ends of the range: 0 selects the first pool entry (the original
+			// static notice), just-under-1 selects the last — proving the whole pool is reachable.
+			randomSpy.mockReturnValue(0)
+			const first = vi.fn().mockResolvedValue({ success: true, messageId: 'm1' })
+			await notifyDiscord(ctxFor(envWith(first)))
+			expect(first.mock.calls[0][2].content).toBe(`${FALLBACK_MESSAGES[0]}\n${FALLBACK_FOOTER}`)
+
+			randomSpy.mockReturnValue(0.999999)
+			const last = vi.fn().mockResolvedValue({ success: true, messageId: 'm2' })
+			await notifyDiscord(ctxFor(envWith(last)))
+			expect(last.mock.calls[0][2].content).toBe(
+				`${FALLBACK_MESSAGES[FALLBACK_MESSAGES.length - 1]}\n${FALLBACK_FOOTER}`
+			)
+		} finally {
+			randomSpy.mockRestore()
+		}
 	})
 
 	it('posts a random bonus announcement naming the winner when a bonus is awarded', async () => {
@@ -74,7 +100,8 @@ describe('notifyDiscord', () => {
 
 		const [, , message] = sendMessage.mock.calls[0]
 		expect(message.content).toContain('<@999>') // winner mention → renders as their display name + pings
-		expect(message.content).not.toContain('sale just came in') // the announcement, not the fallback notice
+		expect(isFallbackPost(message.content)).toBe(false) // the announcement, not the fallback notice
+		expect(message.content).not.toContain(FALLBACK_FOOTER) // the footer is fallback-only
 		expect(message.embeds).toBeUndefined() // no email embed
 		expect(getProfile).toHaveBeenCalledWith('core-1') // resolved by the winner's core user id
 		expect(disposition).toEqual({ type: 'consume' })


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
When no prediction-market bonus is awarded, `notifyDiscord` used to post the same hardcoded fallback message every time. This PR randomizes that fallback notice and appends a footer promoting the Markee Dragon referral link/discount code, matching the treatment bonus announcements already get.

## Changes
- Add `FALLBACK_MESSAGES`, a pool of varied "sale just came in" style notices, in `apps/mailroom/src/markee-bonus.ts`.
- Add `FALLBACK_FOOTER` (the etc.pleaseignore.com referral link/discount blurb) and `pickFallbackMessage()`, which picks a random message from the pool and appends the footer on its own line.
- Update `notify-discord.ts` to call `pickFallbackMessage()` instead of posting a single static fallback string when `awardAndAnnounce` returns `null`.

## Testing
- Updated `notify-discord.test.ts` to assert the posted fallback content matches one of the pool entries + footer (`isFallbackPost` helper) instead of the old fixed string.
- Added a test that pins `Math.random` to `0` and `0.999999` to verify both ends of the fallback pool are reachable.
- Updated the bonus-announcement test to also assert the footer is absent from real announcements.
<!-- claude:end -->
