### PR TITLE
fix fleet tracking lifecycle

### DIFF
--- a/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
+++ b/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
@@ -102,6 +102,7 @@ describe('fleets tracking routes', () => {
 
 	let fleetsStub: {
 		startTrackingSession: ReturnType<typeof vi.fn>
+		stopTrackingSession: ReturnType<typeof vi.fn>
 		getCharacterFleetInformation: ReturnType<typeof vi.fn>
 		getActiveTrackingSessionByFleetId: ReturnType<typeof vi.fn>
 		getLatestTrackingSessionByFleetId: ReturnType<typeof vi.fn>
@@ -132,6 +133,7 @@ describe('fleets tracking routes', () => {
 
 		fleetsStub = {
 			startTrackingSession: vi.fn(),
+			stopTrackingSession: vi.fn(),
 			getCharacterFleetInformation: vi.fn(),
 			getActiveTrackingSessionByFleetId: vi.fn(),
 			getLatestTrackingSessionByFleetId: vi.fn(),
@@ -222,6 +224,79 @@ describe('fleets tracking routes', () => {
 			name: 'Op Fleet',
 			action: 'new',
 		})
+	})
+
+	it('treats already-ended tracking sessions as an idempotent delete', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:create' }] as any)
+		fleetsStub.getTrackingSession.mockResolvedValue({
+			id: 'session-ended',
+			name: 'Ended Fleet',
+			characterId: '1001',
+			currentCommanderCharacterId: '1001',
+			commanderCharacterIds: ['1001'],
+			startedByUserId: 'user-1',
+			fleetId: 'fleet-1',
+			status: 'ended',
+			startedAt: '2026-05-25T10:00:00.000Z',
+			endedAt: '2026-05-25T10:30:00.000Z',
+			endedReason: 'fleet_disbanded',
+			endedByUserId: null,
+			createdAt: '2026-05-25T10:00:00.000Z',
+			updatedAt: '2026-05-25T10:30:00.000Z',
+		} as any)
+		const app = createApp(makeUser())
+
+		const res = await app.request('/api/fleets/tracking/session-ended', { method: 'DELETE' }, env)
+
+		expect(res.status).toBe(200)
+		await expect(res.json()).resolves.toEqual({ ok: true, status: 'ended' })
+		expect(fleetsStub.stopTrackingSession).not.toHaveBeenCalled()
+	})
+
+	it('treats a stop race as success when the session is no longer active after a failure', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:create' }] as any)
+		fleetsStub.getTrackingSession
+			.mockResolvedValueOnce({
+				id: 'session-race',
+				name: 'Race Fleet',
+				characterId: '1001',
+				currentCommanderCharacterId: '1001',
+				commanderCharacterIds: ['1001'],
+				startedByUserId: 'user-1',
+				fleetId: 'fleet-1',
+				status: 'active',
+				startedAt: '2026-05-25T10:00:00.000Z',
+				endedAt: null,
+				endedReason: null,
+				endedByUserId: null,
+				createdAt: '2026-05-25T10:00:00.000Z',
+				updatedAt: '2026-05-25T10:00:00.000Z',
+			} as any)
+			.mockResolvedValueOnce({
+				id: 'session-race',
+				name: 'Race Fleet',
+				characterId: '1001',
+				currentCommanderCharacterId: '1001',
+				commanderCharacterIds: ['1001'],
+				startedByUserId: 'user-1',
+				fleetId: 'fleet-1',
+				status: 'ended',
+				startedAt: '2026-05-25T10:00:00.000Z',
+				endedAt: '2026-05-25T10:30:00.000Z',
+				endedReason: 'fleet_disbanded',
+				endedByUserId: null,
+				createdAt: '2026-05-25T10:00:00.000Z',
+				updatedAt: '2026-05-25T10:30:00.000Z',
+			} as any)
+		fleetsStub.stopTrackingSession.mockRejectedValueOnce(new Error('Failed query'))
+		const app = createApp(makeUser())
+
+		const res = await app.request('/api/fleets/tracking/session-race', { method: 'DELETE' }, env)
+
+		expect(res.status).toBe(200)
+		await expect(res.json()).resolves.toEqual({ ok: true, status: 'ended' })
+		expect(fleetsStub.stopTrackingSession).toHaveBeenCalledTimes(1)
+		expect(fleetsStub.getTrackingSession).toHaveBeenCalledTimes(2)
 	})
 
 	it('takes over an existing tracked fleet when requested', async () => {

--- a/apps/core/src/routes/fleets.ts
+++ b/apps/core/src/routes/fleets.ts
@@ -547,7 +547,7 @@ app.delete('/tracking/:sessionId', async (c) => {
 	const session = await fleetsStub.getTrackingSession(sessionId)
 	if (!session) return c.json({ error: 'Session not found' }, 404)
 	if (session.status !== 'active') {
-		return c.json({ error: 'Session is not active' }, 409)
+		return c.json({ ok: true, status: session.status })
 	}
 
 	const { isAdmin } = await resolveTrackingPerms(c)
@@ -569,6 +569,10 @@ app.delete('/tracking/:sessionId', async (c) => {
 			userId: user.id,
 			error: error instanceof Error ? error.message : String(error),
 		})
+		const refreshedSession = await fleetsStub.getTrackingSession(sessionId)
+		if (!refreshedSession || refreshedSession.status !== 'active') {
+			return c.json({ ok: true, status: refreshedSession?.status ?? 'ended' })
+		}
 		return c.json({ error: 'Failed to stop tracking session' }, 500)
 	}
 })

--- a/apps/fleets/.migrations/0011_hot_marvel_boy.sql
+++ b/apps/fleets/.migrations/0011_hot_marvel_boy.sql
@@ -1,0 +1,3 @@
+DROP INDEX "fleet_state_cache_ended_at_idx";--> statement-breakpoint
+ALTER TABLE "fleet_state_cache" DROP COLUMN "is_active";--> statement-breakpoint
+ALTER TABLE "fleet_state_cache" DROP COLUMN "ended_at";

--- a/apps/fleets/.migrations/meta/0011_snapshot.json
+++ b/apps/fleets/.migrations/meta/0011_snapshot.json
@@ -1,0 +1,1701 @@
+{
+  "id": "ff575241-a0fc-4b83-abe6-c8f2388422eb",
+  "prevId": "3aeb2aaa-b9ac-4859-805c-d1a6f2a5b6e3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.fleet_commander_access_anchors": {
+      "name": "fleet_commander_access_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commander_character_id": {
+          "name": "commander_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_commander_access_anchors_fleet_id_idx": {
+          "name": "fleet_commander_access_anchors_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_fleet_id_commander_character_id_unique": {
+          "name": "fleet_commander_access_anchors_fleet_id_commander_character_id_unique",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commander_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_tracking_session_id_idx": {
+          "name": "fleet_commander_access_anchors_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_commander_character_id_idx": {
+          "name": "fleet_commander_access_anchors_commander_character_id_idx",
+          "columns": [
+            {
+              "expression": "commander_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_last_seen_at_idx": {
+          "name": "fleet_commander_access_anchors_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_commander_access_anchors_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_commander_access_anchors_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_commander_access_anchors",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_commander_events": {
+      "name": "fleet_commander_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_commander_character_id": {
+          "name": "previous_commander_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commander_character_id": {
+          "name": "commander_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_commander_events_fleet_id_idx": {
+          "name": "fleet_commander_events_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_events_tracking_session_id_idx": {
+          "name": "fleet_commander_events_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_events_commander_character_id_idx": {
+          "name": "fleet_commander_events_commander_character_id_idx",
+          "columns": [
+            {
+              "expression": "commander_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_events_observed_at_idx": {
+          "name": "fleet_commander_events_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_commander_events_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_commander_events_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_commander_events",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_invitations": {
+      "name": "fleet_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_boss_id": {
+          "name": "fleet_boss_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "fleet_invitations_token_idx": {
+          "name": "fleet_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_invitations_expires_at_idx": {
+          "name": "fleet_invitations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_invitations_fleet_boss_id_idx": {
+          "name": "fleet_invitations_fleet_boss_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_boss_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fleet_invitations_token_unique": {
+          "name": "fleet_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_member_history": {
+      "name": "fleet_member_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wing_id": {
+          "name": "wing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_name": {
+          "name": "ship_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wing_name": {
+          "name": "wing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "squad_name": {
+          "name": "squad_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "fleet_member_history_fleet_id_idx": {
+          "name": "fleet_member_history_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_character_id_idx": {
+          "name": "fleet_member_history_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_event_type_idx": {
+          "name": "fleet_member_history_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_event_timestamp_idx": {
+          "name": "fleet_member_history_event_timestamp_idx",
+          "columns": [
+            {
+              "expression": "event_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_fleet_character_idx": {
+          "name": "fleet_member_history_fleet_character_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_corporation_id_idx": {
+          "name": "fleet_member_history_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_member_ship_events": {
+      "name": "fleet_member_ship_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_member_ship_events_session_character_started_idx": {
+          "name": "fleet_member_ship_events_session_character_started_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_ship_events_fleet_character_started_idx": {
+          "name": "fleet_member_ship_events_fleet_character_started_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_ship_events_event_timestamp_idx": {
+          "name": "fleet_member_ship_events_event_timestamp_idx",
+          "columns": [
+            {
+              "expression": "event_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_ship_events_ended_at_idx": {
+          "name": "fleet_member_ship_events_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_member_ship_events_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_member_ship_events_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_member_ship_events",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_memberships": {
+      "name": "fleet_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squad_member'"
+        }
+      },
+      "indexes": {
+        "fleet_memberships_character_id_idx": {
+          "name": "fleet_memberships_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_memberships_fleet_id_idx": {
+          "name": "fleet_memberships_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_memberships_invitation_id_idx": {
+          "name": "fleet_memberships_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_memberships_invitation_id_fleet_invitations_id_fk": {
+          "name": "fleet_memberships_invitation_id_fleet_invitations_id_fk",
+          "tableFrom": "fleet_memberships",
+          "tableTo": "fleet_invitations",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_state_cache": {
+      "name": "fleet_state_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_boss_id": {
+          "name": "fleet_boss_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "motd": {
+          "name": "motd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free_move": {
+          "name": "is_free_move",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_registered": {
+          "name": "is_registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_voice_enabled": {
+          "name": "is_voice_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "not_found": {
+          "name": "not_found",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "not_found_at": {
+          "name": "not_found_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_state_cache_fleet_id_idx": {
+          "name": "fleet_state_cache_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_state_cache_fleet_boss_id_idx": {
+          "name": "fleet_state_cache_fleet_boss_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_boss_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_state_cache_tracking_session_id_idx": {
+          "name": "fleet_state_cache_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_state_cache_last_checked_idx": {
+          "name": "fleet_state_cache_last_checked_idx",
+          "columns": [
+            {
+              "expression": "last_checked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_state_cache_not_found_idx": {
+          "name": "fleet_state_cache_not_found_idx",
+          "columns": [
+            {
+              "expression": "not_found",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_state_cache_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_state_cache_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_state_cache",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fleet_state_cache_fleet_id_unique": {
+          "name": "fleet_state_cache_fleet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "fleet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_summaries": {
+      "name": "fleet_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_boss_id": {
+          "name": "fleet_boss_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_member_count": {
+          "name": "peak_member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "final_member_count": {
+          "name": "final_member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "motd": {
+          "name": "motd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free_move": {
+          "name": "is_free_move",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_registered": {
+          "name": "is_registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_voice_enabled": {
+          "name": "is_voice_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_summaries_fleet_id_idx": {
+          "name": "fleet_summaries_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_fleet_boss_id_idx": {
+          "name": "fleet_summaries_fleet_boss_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_boss_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_tracking_session_id_idx": {
+          "name": "fleet_summaries_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_started_at_idx": {
+          "name": "fleet_summaries_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_ended_at_idx": {
+          "name": "fleet_summaries_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_fleet_boss_started_idx": {
+          "name": "fleet_summaries_fleet_boss_started_idx",
+          "columns": [
+            {
+              "expression": "fleet_boss_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_summaries_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_summaries_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_summaries",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_tracking_session_events": {
+      "name": "fleet_tracking_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_character_id": {
+          "name": "previous_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_tracking_session_events_fleet_id_idx": {
+          "name": "fleet_tracking_session_events_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_session_events_tracking_session_id_idx": {
+          "name": "fleet_tracking_session_events_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_session_events_character_id_idx": {
+          "name": "fleet_tracking_session_events_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_session_events_observed_at_idx": {
+          "name": "fleet_tracking_session_events_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_tracking_session_events_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_tracking_session_events_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_tracking_session_events",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_tracking_sessions": {
+      "name": "fleet_tracking_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_user_id": {
+          "name": "ended_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_tracking_sessions_character_id_idx": {
+          "name": "fleet_tracking_sessions_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_fleet_id_idx": {
+          "name": "fleet_tracking_sessions_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_started_by_user_id_idx": {
+          "name": "fleet_tracking_sessions_started_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "started_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_status_idx": {
+          "name": "fleet_tracking_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_started_at_idx": {
+          "name": "fleet_tracking_sessions_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/fleets/.migrations/meta/_journal.json
+++ b/apps/fleets/.migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1782568399721,
       "tag": "0010_mixed_purifiers",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1784521994428,
+      "tag": "0011_hot_marvel_boy",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/fleets/src/db/schema.ts
+++ b/apps/fleets/src/db/schema.ts
@@ -208,7 +208,6 @@ export const fleetStateCache = pgTable(
 		trackingSessionId: uuid('tracking_session_id').references(() => fleetTrackingSessions.id, {
 			onDelete: 'set null',
 		}),
-		isActive: boolean('is_active').default(true).notNull(),
 		memberCount: integer('member_count').default(0).notNull(),
 		motd: text('motd'),
 		isFreeMove: boolean('is_free_move').default(false).notNull(),
@@ -216,22 +215,20 @@ export const fleetStateCache = pgTable(
 		isVoiceEnabled: boolean('is_voice_enabled').default(false).notNull(),
 		notFound: boolean('not_found').default(false).notNull(),
 		notFoundAt: timestamp('not_found_at'),
-		endedAt: timestamp('ended_at'),
 		lastChecked: timestamp('last_checked').defaultNow().notNull(),
 		createdAt: timestamp('created_at').defaultNow().notNull(),
 		updatedAt: timestamp('updated_at').defaultNow().notNull(),
-	},
-	(table) => ({
-		fleetIdIdx: index('fleet_state_cache_fleet_id_idx').on(table.fleetId),
-		fleetBossIdIdx: index('fleet_state_cache_fleet_boss_id_idx').on(table.fleetBossId),
-		trackingSessionIdIdx: index('fleet_state_cache_tracking_session_id_idx').on(
-			table.trackingSessionId
-		),
-		lastCheckedIdx: index('fleet_state_cache_last_checked_idx').on(table.lastChecked),
-		notFoundIdx: index('fleet_state_cache_not_found_idx').on(table.notFound),
-		endedAtIdx: index('fleet_state_cache_ended_at_idx').on(table.endedAt),
-	})
-)
+		},
+		(table) => ({
+			fleetIdIdx: index('fleet_state_cache_fleet_id_idx').on(table.fleetId),
+			fleetBossIdIdx: index('fleet_state_cache_fleet_boss_id_idx').on(table.fleetBossId),
+			trackingSessionIdIdx: index('fleet_state_cache_tracking_session_id_idx').on(
+				table.trackingSessionId
+			),
+			lastCheckedIdx: index('fleet_state_cache_last_checked_idx').on(table.lastChecked),
+			notFoundIdx: index('fleet_state_cache_not_found_idx').on(table.notFound),
+		})
+	)
 
 /**
  * Fleet summaries table

--- a/apps/fleets/src/durable-object.ts
+++ b/apps/fleets/src/durable-object.ts
@@ -170,6 +170,15 @@ export class FleetsDO extends DurableObject implements Fleets {
 		})
 	}
 
+	private getEffectiveSessionStatus(
+		session: {
+			status: string
+			endedAt: Date | null
+		},
+	): TrackingSession['status'] {
+		return session.status === 'active' && session.endedAt === null ? 'active' : 'ended'
+	}
+
 	async getCharacterFleetInformation(characterId: EveCharacterId): Promise<FleetInformation> {
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 
@@ -308,7 +317,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.values({
 				fleetId,
 				fleetBossId,
-				isActive: true,
 				memberCount: 0,
 				motd: fleetData.motd || null,
 				isFreeMove: fleetData.is_free_move,
@@ -319,7 +327,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				target: fleetStateCache.fleetId,
 				set: {
 					fleetBossId,
-					isActive: true,
 					motd: fleetData.motd || null,
 					isFreeMove: fleetData.is_free_move,
 					isRegistered: fleetData.is_registered,
@@ -457,7 +464,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.values({
 					fleetId,
 					fleetBossId: characterId,
-					isActive: true,
 					memberCount: 0,
 					motd: fleetInfo.motd || null,
 					isFreeMove: fleetInfo.is_free_move,
@@ -470,7 +476,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.onConflictDoUpdate({
 					target: fleetStateCache.fleetId,
 					set: {
-						isActive: true,
 						motd: fleetInfo.motd || null,
 						isFreeMove: fleetInfo.is_free_move,
 						isRegistered: fleetInfo.is_registered,
@@ -494,25 +499,23 @@ export class FleetsDO extends DurableObject implements Fleets {
 				// Mark fleet as not found
 				await this.db
 					.insert(fleetStateCache)
-					.values({
-						fleetId,
-						fleetBossId: characterId,
-						isActive: false,
-						memberCount: 0,
+				.values({
+					fleetId,
+					fleetBossId: characterId,
+					memberCount: 0,
+					notFound: true,
+					notFoundAt: new Date(),
+					lastChecked: new Date(),
+				})
+				.onConflictDoUpdate({
+					target: fleetStateCache.fleetId,
+					set: {
 						notFound: true,
 						notFoundAt: new Date(),
 						lastChecked: new Date(),
-					})
-					.onConflictDoUpdate({
-						target: fleetStateCache.fleetId,
-						set: {
-							notFound: true,
-							notFoundAt: new Date(),
-							isActive: false,
-							lastChecked: new Date(),
-							updatedAt: new Date(),
-						},
-					})
+						updatedAt: new Date(),
+					},
+				})
 			}
 			throw error
 		}
@@ -780,7 +783,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 					return false
 				}
 			}
-			return cached.isActive
+			return !cached.notFound
 		}
 
 		// Check with ESI
@@ -818,7 +821,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.values({
 					fleetId,
 					fleetBossId: characterId,
-					isActive: true,
 					memberCount: 0,
 					motd: fleetInfo.motd || null,
 					isFreeMove: fleetInfo.is_free_move,
@@ -831,7 +833,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.onConflictDoUpdate({
 					target: fleetStateCache.fleetId,
 					set: {
-						isActive: true,
 						motd: fleetInfo.motd || null,
 						isFreeMove: fleetInfo.is_free_move,
 						isRegistered: fleetInfo.is_registered,
@@ -849,7 +850,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.values({
 					fleetId,
 					fleetBossId: characterId,
-					isActive: false,
 					memberCount: 0,
 					notFound: isNotFound,
 					notFoundAt: isNotFound ? new Date() : null,
@@ -858,7 +858,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.onConflictDoUpdate({
 					target: fleetStateCache.fleetId,
 					set: {
-						isActive: false,
 						notFound: isNotFound,
 						notFoundAt: isNotFound ? new Date() : null,
 						lastChecked: new Date(),
@@ -872,12 +871,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 	async getFleetCacheStatus(
 		fleetId: string
-	): Promise<{ isActive: boolean; notFound: boolean; endedAt: Date | null } | null> {
+	): Promise<{ notFound: boolean; notFoundAt: Date | null; lastChecked: Date } | null> {
 		const [cached] = await this.db
 			.select({
-				isActive: fleetStateCache.isActive,
 				notFound: fleetStateCache.notFound,
-				endedAt: fleetStateCache.endedAt,
+				notFoundAt: fleetStateCache.notFoundAt,
+				lastChecked: fleetStateCache.lastChecked,
 			})
 			.from(fleetStateCache)
 			.where(eq(fleetStateCache.fleetId, fleetId))
@@ -888,9 +887,9 @@ export class FleetsDO extends DurableObject implements Fleets {
 		}
 
 		return {
-			isActive: cached.isActive,
 			notFound: cached.notFound,
-			endedAt: cached.endedAt,
+			notFoundAt: cached.notFoundAt,
+			lastChecked: cached.lastChecked,
 		}
 	}
 
@@ -949,7 +948,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.values({
 					fleetId,
 					fleetBossId: characterId,
-					isActive: true,
 					memberCount: 0,
 					motd: fleetInfo.motd || null,
 					isFreeMove: fleetInfo.is_free_move,
@@ -962,7 +960,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				.onConflictDoUpdate({
 					target: fleetStateCache.fleetId,
 					set: {
-						isActive: true,
 						motd: fleetInfo.motd || null,
 						isFreeMove: fleetInfo.is_free_move,
 						isRegistered: fleetInfo.is_registered,
@@ -983,7 +980,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.values({
 				fleetId,
 				fleetBossId: characterId,
-				isActive: false,
 				memberCount: 0,
 				notFound: isNotFound,
 				notFoundAt: isNotFound ? new Date() : null,
@@ -992,7 +988,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.onConflictDoUpdate({
 				target: fleetStateCache.fleetId,
 				set: {
-					isActive: false,
 					notFound: isNotFound,
 					notFoundAt: isNotFound ? new Date() : null,
 					lastChecked: new Date(),
@@ -1074,9 +1069,11 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.select({
 				id: fleetTrackingSessions.id,
 				status: fleetTrackingSessions.status,
+				endedAt: fleetTrackingSessions.endedAt,
 				characterId: fleetTrackingSessions.characterId,
 			})
 			.from(fleetTrackingSessions)
+			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.fleetId, fleetId))
 			.orderBy(desc(fleetTrackingSessions.startedAt))
 			.limit(1)
@@ -1085,6 +1082,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 		let sessionId: string
 		let previousFleetBossCharacterId: string | null = null
 		let resumedExistingSession = false
+		const mostRecentStatus = mostRecentByFleet
+			? this.getEffectiveSessionStatus({
+					status: mostRecentByFleet.status,
+					endedAt: mostRecentByFleet.endedAt,
+				})
+			: null
 
 		if (action === 'take_over' && mostRecentByFleet) {
 			previousFleetBossCharacterId = mostRecentByFleet.characterId
@@ -1107,9 +1110,9 @@ export class FleetsDO extends DurableObject implements Fleets {
 			}
 
 			sessionId = resumed.id
-			resumedExistingSession = mostRecentByFleet.status === 'ended'
+			resumedExistingSession = mostRecentStatus === 'ended'
 
-			if (mostRecentByFleet.status === 'ended') {
+			if (mostRecentStatus === 'ended') {
 				await this.recordSessionLifecycleEvent({
 					fleetId,
 					trackingSessionId: sessionId,
@@ -1123,7 +1126,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 					.where(eq(fleetSummaries.trackingSessionId, sessionId))
 			}
 		} else {
-			if (action === 'new' && mostRecentByFleet?.status === 'active') {
+			if (action === 'new' && mostRecentStatus === 'active') {
 				throw new StartTrackingSessionError('fleet_session_active')
 			}
 
@@ -1206,16 +1209,33 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const { sessionId, endedReason, endedByUserId } = args
 
 		const [session] = await this.db
-			.select()
+			.select({
+				id: fleetTrackingSessions.id,
+				status: fleetTrackingSessions.status,
+				endedAt: fleetTrackingSessions.endedAt,
+				fleetId: fleetTrackingSessions.fleetId,
+			})
 			.from(fleetTrackingSessions)
+			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.id, sessionId))
 			.limit(1)
 
 		if (!session) {
-			throw new Error(`Session not found: ${sessionId}`)
+			logger.info('[FleetsDO stopTrackingSession] Session already missing; treating as closed', {
+				sessionId,
+			})
+			return
 		}
-		if (session.status !== 'active') {
-			throw new Error(`Session is not active: ${sessionId}`)
+		const effectiveStatus = this.getEffectiveSessionStatus({
+			status: session.status,
+			endedAt: session.endedAt,
+		})
+		if (effectiveStatus !== 'active') {
+			logger.info('[FleetsDO stopTrackingSession] Session already ended; treating as closed', {
+				sessionId,
+				status: effectiveStatus,
+			})
+			return
 		}
 		if (!session.fleetId) {
 			// Defensive — shouldn't happen because startTrackingSession only
@@ -1244,6 +1264,14 @@ export class FleetsDO extends DurableObject implements Fleets {
 			filter.fleetBossCharacterIds ?? filter.commanderCharacterIds ?? []
 
 		const conditions = []
+		const activeSessionCondition = and(
+			eq(fleetTrackingSessions.status, 'active'),
+			isNull(fleetTrackingSessions.endedAt)
+		)
+		const closedSessionCondition = and(
+			eq(fleetTrackingSessions.status, 'ended'),
+			isNotNull(fleetTrackingSessions.endedAt)
+		)
 		if (filter.characterId) {
 			conditions.push(eq(fleetTrackingSessions.characterId, filter.characterId))
 		}
@@ -1273,7 +1301,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 			conditions.push(or(...accessConditions))
 		}
 		if (filter.status) {
-			conditions.push(eq(fleetTrackingSessions.status, filter.status))
+			conditions.push(filter.status === 'active' ? activeSessionCondition : closedSessionCondition)
 		}
 		if (filter.from) {
 			conditions.push(gte(fleetTrackingSessions.startedAt, new Date(filter.from)))
@@ -1304,7 +1332,15 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 		return {
 			items: items.map((row) =>
-				this.serializeSession(row.session, row.currentCommanderCharacterId ?? null)
+				this.serializeSession(
+					row.session,
+					row.currentCommanderCharacterId ?? null,
+					[],
+					this.getEffectiveSessionStatus({
+						status: row.session.status,
+						endedAt: row.session.endedAt,
+					})
+				)
 			),
 			total,
 			limit,
@@ -1339,11 +1375,16 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const commanderCharacterIds = Array.from(
 			new Set(commanderRows.map((r) => r.commanderCharacterId))
 		)
+		const effectiveStatus = this.getEffectiveSessionStatus({
+			status: row.session.status,
+			endedAt: row.session.endedAt,
+		})
 
 		return this.serializeSession(
 			row.session,
 			row.currentCommanderCharacterId ?? null,
-			commanderCharacterIds
+			commanderCharacterIds,
+			effectiveStatus
 		)
 	}
 
@@ -1358,7 +1399,13 @@ export class FleetsDO extends DurableObject implements Fleets {
 			})
 			.from(fleetTrackingSessions)
 			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
-			.where(and(eq(fleetTrackingSessions.fleetId, fleetId), eq(fleetTrackingSessions.status, 'active')))
+			.where(
+				and(
+					eq(fleetTrackingSessions.fleetId, fleetId),
+					eq(fleetTrackingSessions.status, 'active'),
+					isNull(fleetTrackingSessions.endedAt)
+				)
+			)
 			.orderBy(desc(fleetTrackingSessions.startedAt))
 			.limit(1)
 		if (!row) return null
@@ -1373,11 +1420,16 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const commanderCharacterIds = Array.from(
 			new Set(commanderRows.map((r) => r.commanderCharacterId))
 		)
+		const effectiveStatus = this.getEffectiveSessionStatus({
+			status: row.session.status,
+			endedAt: row.session.endedAt,
+		})
 
 		return this.serializeSession(
 			row.session,
 			row.currentCommanderCharacterId ?? null,
-			commanderCharacterIds
+			commanderCharacterIds,
+			effectiveStatus
 		)
 	}
 
@@ -1407,11 +1459,16 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const commanderCharacterIds = Array.from(
 			new Set(commanderRows.map((r) => r.commanderCharacterId))
 		)
+		const effectiveStatus = this.getEffectiveSessionStatus({
+			status: row.session.status,
+			endedAt: row.session.endedAt,
+		})
 
 		return this.serializeSession(
 			row.session,
 			row.currentCommanderCharacterId ?? null,
-			commanderCharacterIds
+			commanderCharacterIds,
+			effectiveStatus
 		)
 	}
 
@@ -1421,18 +1478,25 @@ export class FleetsDO extends DurableObject implements Fleets {
 	 */
 	async getSessionLiveSnapshot(sessionId: string): Promise<SessionLiveSnapshot | null> {
 		const [session] = await this.db
-			.select({ fleetId: fleetTrackingSessions.fleetId })
+			.select({
+				fleetId: fleetTrackingSessions.fleetId,
+				status: fleetTrackingSessions.status,
+				endedAt: fleetTrackingSessions.endedAt,
+			})
 			.from(fleetTrackingSessions)
 			.where(eq(fleetTrackingSessions.id, sessionId))
 			.limit(1)
 		if (!session || !session.fleetId) return null
+		if (this.getEffectiveSessionStatus({ status: session.status, endedAt: session.endedAt }) !== 'active') {
+			return null
+		}
 
 		const [cache] = await this.db
 			.select()
 			.from(fleetStateCache)
 			.where(eq(fleetStateCache.fleetId, session.fleetId))
 			.limit(1)
-		if (!cache) return null
+		if (!cache || cache.notFound) return null
 
 		// Pull peak member count from the FleetMonitor DO's SQLite state.
 		let peakMemberCount = cache.memberCount
@@ -1745,14 +1809,13 @@ export class FleetsDO extends DurableObject implements Fleets {
 				characterId: fleetTrackingSessions.characterId,
 				startedAt: fleetTrackingSessions.startedAt,
 				endedAt: fleetTrackingSessions.endedAt,
-				status: fleetTrackingSessions.status,
 			})
 			.from(fleetTrackingSessions)
 			.where(
 				and(
 					lt(fleetTrackingSessions.startedAt, to),
 					or(
-						eq(fleetTrackingSessions.status, 'active'),
+						and(eq(fleetTrackingSessions.status, 'active'), isNull(fleetTrackingSessions.endedAt)),
 						and(isNotNull(fleetTrackingSessions.endedAt), gt(fleetTrackingSessions.endedAt, from))
 					)
 				)
@@ -1963,12 +2026,21 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.select({
 				fleetId: fleetTrackingSessions.fleetId,
 				status: fleetTrackingSessions.status,
+				endedAt: fleetTrackingSessions.endedAt,
 			})
 			.from(fleetTrackingSessions)
+			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.id, sessionId))
 			.limit(1)
 
-		if (!session?.fleetId || session.status !== 'active') {
+		const effectiveStatus = session
+			? this.getEffectiveSessionStatus({
+					status: session.status,
+					endedAt: session.endedAt,
+				})
+			: 'ended'
+
+		if (!session?.fleetId || effectiveStatus !== 'active') {
 			return []
 		}
 
@@ -2143,10 +2215,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.select({
 				id: fleetTrackingSessions.id,
 				status: fleetTrackingSessions.status,
+				endedAt: fleetTrackingSessions.endedAt,
 				fleetId: fleetTrackingSessions.fleetId,
 				characterId: fleetTrackingSessions.characterId,
 			})
 			.from(fleetTrackingSessions)
+			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.id, args.sessionId))
 			.limit(1)
 
@@ -2157,7 +2231,11 @@ export class FleetsDO extends DurableObject implements Fleets {
 				error: 'Session not found',
 			}))
 		}
-		if (session.status !== 'active') {
+		const effectiveStatus = this.getEffectiveSessionStatus({
+			status: session.status,
+			endedAt: session.endedAt,
+		})
+		if (effectiveStatus !== 'active') {
 			return uniqueMemberIds.map((characterId) => ({
 				characterId,
 				success: false,
@@ -2250,6 +2328,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.where(
 				and(
 					eq(fleetTrackingSessions.status, 'active'),
+					isNull(fleetTrackingSessions.endedAt),
 					gte(fleetTrackingSessions.startedAt, from),
 					lt(fleetTrackingSessions.startedAt, to)
 				)
@@ -2792,7 +2871,8 @@ export class FleetsDO extends DurableObject implements Fleets {
 	private serializeSession = (
 		row: typeof fleetTrackingSessions.$inferSelect,
 		currentFleetBossCharacterId: string | null,
-		fleetBossCharacterIds: string[] = []
+		fleetBossCharacterIds: string[] = [],
+		effectiveStatus?: TrackingSession['status']
 	): TrackingSession => ({
 		id: row.id,
 		name: row.name,
@@ -2805,7 +2885,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 		commanderCharacterIds: fleetBossCharacterIds,
 		startedByUserId: row.startedByUserId,
 		fleetId: row.fleetId,
-		status: row.status as TrackingSession['status'],
+		status: effectiveStatus ?? (row.status as TrackingSession['status']),
 		startedAt: row.startedAt.toISOString(),
 		endedAt: row.endedAt ? row.endedAt.toISOString() : null,
 		endedReason: (row.endedReason as TrackingSession['endedReason']) ?? null,
@@ -2874,216 +2954,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 	}
 
 	/**
-	 * Alarm handler - Watchdog for FleetMonitor instances
-	 * Checks all active FleetMonitor instances to ensure they're updating regularly
-	 * Runs every 2 minutes to detect stale monitors
-	 */
-	async alarm(): Promise<void> {
-		logger.info('[FleetsDO Watchdog] Starting FleetMonitor health check', {
-			timestamp: new Date().toISOString(),
-		})
-
-		try {
-			// Get all active fleets from cache (excluding not found fleets)
-			const activeFleets = await this.db
-				.select({
-					fleetId: fleetStateCache.fleetId,
-					fleetBossId: fleetStateCache.fleetBossId,
-					lastChecked: fleetStateCache.lastChecked,
-				})
-				.from(fleetStateCache)
-				.where(and(eq(fleetStateCache.notFound, false), eq(fleetStateCache.isActive, true)))
-
-			logger.info('[FleetsDO Watchdog] Found active fleets to check', {
-				count: activeFleets.length,
-			})
-
-			if (activeFleets.length === 0) {
-				logger.info('[FleetsDO Watchdog] No active fleets to monitor')
-				await this.scheduleNextWatchdog()
-				return
-			}
-
-			// Check each FleetMonitor instance
-			const now = Date.now()
-			const staleThreshold = 2 * 60 * 1000 // 2 minutes in milliseconds
-			const staleFleets: Array<{ fleetId: string; lastChecked: Date | null; ageMs: number }> = []
-			let recoveredCount = 0
-
-			for (const fleet of activeFleets) {
-				try {
-					// Get the FleetMonitor DO stub for this fleet
-					const fleetMonitorStub = getStub<FleetMonitor>(
-						this.env.FLEET_MONITOR,
-						`fleet-${fleet.fleetId}`
-					)
-
-					// Get the monitor's internal state
-					const monitorState = await fleetMonitorStub.getMonitorState()
-
-					if (!monitorState || !monitorState.isInitialized) {
-						logger.warn('[FleetsDO Watchdog] FleetMonitor not initialized', {
-							fleetId: fleet.fleetId,
-						})
-						const recovered = await this.recoverFleetMonitorSession(fleet.fleetId)
-						if (recovered) {
-							recoveredCount += 1
-						}
-						continue
-					}
-
-					// Check if lastChecked is stale
-					if (monitorState.lastChecked) {
-						const lastCheckedTime = new Date(monitorState.lastChecked).getTime()
-						const ageMs = now - lastCheckedTime
-
-						if (ageMs > staleThreshold) {
-							staleFleets.push({
-								fleetId: fleet.fleetId,
-								lastChecked: new Date(monitorState.lastChecked),
-								ageMs,
-							})
-
-							logger.error('[FleetsDO Watchdog] Stale FleetMonitor detected', {
-								fleetId: fleet.fleetId,
-								lastChecked: monitorState.lastChecked,
-								ageMs,
-								ageSeconds: Math.round(ageMs / 1000),
-								thresholdMs: staleThreshold,
-							})
-
-							const recovered = await this.recoverFleetMonitorSession(fleet.fleetId)
-							if (recovered) {
-								recoveredCount += 1
-							}
-						} else {
-							logger.debug('[FleetsDO Watchdog] FleetMonitor is healthy', {
-								fleetId: fleet.fleetId,
-								lastChecked: monitorState.lastChecked,
-								ageMs,
-								ageSeconds: Math.round(ageMs / 1000),
-							})
-						}
-					} else {
-						logger.warn('[FleetsDO Watchdog] FleetMonitor has no lastChecked timestamp', {
-							fleetId: fleet.fleetId,
-						})
-						const recovered = await this.recoverFleetMonitorSession(fleet.fleetId)
-						if (recovered) {
-							recoveredCount += 1
-						}
-					}
-				} catch (error) {
-					logger.error('[FleetsDO Watchdog] Failed to check FleetMonitor', {
-						fleetId: fleet.fleetId,
-						error: error instanceof Error ? error.message : String(error),
-					})
-				}
-			}
-
-			// Log summary
-			if (staleFleets.length > 0) {
-				logger.error('[FleetsDO Watchdog] Watchdog check completed with stale monitors', {
-					totalChecked: activeFleets.length,
-					staleCount: staleFleets.length,
-					recoveredCount,
-					staleFleets: staleFleets.map((f) => ({
-						fleetId: f.fleetId,
-						ageSeconds: Math.round(f.ageMs / 1000),
-					})),
-				})
-			} else {
-				logger.info('[FleetsDO Watchdog] All FleetMonitors are healthy', {
-					totalChecked: activeFleets.length,
-					recoveredCount,
-				})
-			}
-		} catch (error) {
-			logger.error('[FleetsDO Watchdog] Watchdog check failed', {
-				error: error instanceof Error ? error.message : String(error),
-				stack: error instanceof Error ? error.stack : undefined,
-			})
-		} finally {
-			// Always reschedule the watchdog
-			await this.scheduleNextWatchdog()
-		}
-	}
-
-	/**
-	 * Attempt to self-heal a FleetMonitor by re-initializing it from the active
-	 * tracking session for the fleet.
-	 */
-	private async recoverFleetMonitorSession(fleetId: string): Promise<boolean> {
-		try {
-			const [activeSession] = await this.db
-				.select({
-					id: fleetTrackingSessions.id,
-					characterId: fleetTrackingSessions.characterId,
-				})
-				.from(fleetTrackingSessions)
-				.where(
-					and(
-						eq(fleetTrackingSessions.fleetId, fleetId),
-						eq(fleetTrackingSessions.status, 'active')
-					)
-				)
-				.orderBy(desc(fleetTrackingSessions.startedAt))
-				.limit(1)
-
-			if (!activeSession) {
-				logger.warn('[FleetsDO Watchdog] Cannot recover monitor - no active session', {
-					fleetId,
-				})
-				return false
-			}
-
-			const fleetMonitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
-			await fleetMonitorStub.initializeMonitoring(
-				fleetId,
-				activeSession.characterId,
-				activeSession.id,
-				{ force: true }
-			)
-
-			logger.info('[FleetsDO Watchdog] Recovered FleetMonitor via forced re-initialize', {
-				fleetId,
-				sessionId: activeSession.id,
-				characterId: activeSession.characterId,
-			})
-			return true
-		} catch (error) {
-			logger.error('[FleetsDO Watchdog] Failed to recover FleetMonitor', {
-				fleetId,
-				error: error instanceof Error ? error.message : String(error),
-			})
-			return false
-		}
-	}
-
-	/**
-	 * Schedule the next watchdog alarm to run 2 minutes from now
-	 */
-	private async scheduleNextWatchdog(): Promise<void> {
-		const twoMinutes = 2 * 60 * 1000 // 2 minutes in milliseconds
-		const nextAlarmTime = Date.now() + twoMinutes
-
-		await this.state.storage.setAlarm(nextAlarmTime)
-
-		logger.debug('[FleetsDO Watchdog] Next watchdog scheduled', {
-			nextAlarmTime: new Date(nextAlarmTime).toISOString(),
-		})
-	}
-
-	/**
-	 * Start the watchdog (schedules the first alarm)
-	 * Can be called manually or will start automatically
-	 */
-	async startWatchdog(): Promise<void> {
-		logger.info('[FleetsDO Watchdog] Starting watchdog')
-		await this.scheduleNextWatchdog()
-	}
-
-	/**
 	 * Fetch handler for HTTP requests to the Durable Object
 	 */
 	async fetch(request: Request): Promise<Response> {
@@ -3100,17 +2970,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 			return new Response(null, {
 				status: 101,
 				webSocket: client,
-			})
-		}
-
-		// Start watchdog on first access if not already running
-		// This ensures the watchdog starts automatically
-		try {
-			await this.startWatchdog()
-		} catch (error) {
-			// Ignore errors if alarm is already scheduled
-			logger.debug('[FleetsDO] Watchdog may already be running', {
-				error: error instanceof Error ? error.message : String(error),
 			})
 		}
 

--- a/apps/fleets/src/fleet-monitor.ts
+++ b/apps/fleets/src/fleet-monitor.ts
@@ -163,7 +163,9 @@ async function syncFleetBossAccess(
  */
 export class FleetMonitorDO extends DurableObject {
 	private static readonly BASE_POLL_INTERVAL_MS = 10 * 1000
+	private static readonly MONITOR_STATE_TTL_MS = 24 * 60 * 60 * 1000
 	private db: ReturnType<typeof createDbClientWs<typeof schema>>
+	private finalizeSessionPromise: Promise<void> | null = null
 	// In-memory caches for ID to name mappings
 	private characterNameCache = new Map<string, string>()
 	private shipTypeNameCache = new Map<string, string>()
@@ -203,7 +205,7 @@ export class FleetMonitorDO extends DurableObject {
 			.toArray()
 
 		const currentVersion = versionResult.length > 0 ? versionResult[0].version : 0
-		const targetVersion = 4 // Current schema version
+		const targetVersion = 5 // Current schema version
 
 		// Run migrations if needed
 		if (currentVersion < targetVersion) {
@@ -228,7 +230,8 @@ export class FleetMonitorDO extends DurableObject {
 					fleet_id TEXT NOT NULL,
 					character_id TEXT NOT NULL,
 					is_initialized INTEGER DEFAULT 0,
-					last_checked TEXT
+					last_checked TEXT,
+					expires_at TEXT
 				)
 			`)
 
@@ -388,6 +391,48 @@ export class FleetMonitorDO extends DurableObject {
 			)
 		}
 
+		// Migration 4 -> 5: add TTL metadata so monitor_state can self-expire.
+		if (currentVersion < 5) {
+			try {
+				this.state.storage.sql.exec(`ALTER TABLE monitor_state ADD COLUMN expires_at TEXT`)
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				if (!message.includes('duplicate column')) {
+					logger.warn('[FleetMonitor] Could not add expires_at column', {
+						error: message,
+					})
+				}
+			}
+
+			// Backfill legacy rows so they participate in the TTL cleanup flow.
+			// If we have a last_checked timestamp, expire 24h after that check.
+			// Otherwise expire immediately so obsolete pre-TTL rows do not linger.
+			const legacyRows = this.state.storage.sql
+				.exec<{ last_checked: string | null; expires_at: string | null }>(
+					`SELECT last_checked, expires_at FROM monitor_state WHERE id = 1`
+				)
+				.toArray()
+			if (legacyRows.length > 0 && legacyRows[0].expires_at === null) {
+				const legacyRow = legacyRows[0]
+				const backfilledExpiresAt =
+					legacyRow.last_checked !== null
+						? new Date(new Date(legacyRow.last_checked).getTime() + FleetMonitorDO.MONITOR_STATE_TTL_MS).toISOString()
+						: new Date(Date.now() - 1000).toISOString()
+				this.state.storage.sql.exec(
+					`UPDATE monitor_state SET expires_at = ? WHERE id = 1`,
+					backfilledExpiresAt
+				)
+			}
+
+			this.state.storage.sql.exec(`
+				INSERT INTO schema_version (id, version)
+				VALUES (1, 5)
+				ON CONFLICT(id) DO UPDATE SET version = 5
+			`)
+
+			logger.info('[FleetMonitor] Migration 4 -> 5 completed (added expires_at)')
+		}
+
 		logger.info('[FleetMonitor] Schema migrations completed', {
 			finalVersion: targetVersion,
 		})
@@ -448,26 +493,29 @@ export class FleetMonitorDO extends DurableObject {
 			// Same — fine to ignore.
 		}
 
-		// Store initialization state in SQLite (peak starts at 0 — bumped on first tick)
-		const now = new Date().toISOString()
-		await this.state.storage.sql.exec(
-			`
-			INSERT INTO monitor_state (id, fleet_id, character_id, tracking_session_id, last_synced_fleet_boss_id, is_initialized, last_checked, peak_member_count)
-			VALUES (1, ?, ?, ?, NULL, 1, ?, 0)
-			ON CONFLICT(id) DO UPDATE SET
-				fleet_id = excluded.fleet_id,
-				character_id = excluded.character_id,
-				tracking_session_id = excluded.tracking_session_id,
-				last_synced_fleet_boss_id = excluded.last_synced_fleet_boss_id,
-				is_initialized = excluded.is_initialized,
-				last_checked = excluded.last_checked,
-				peak_member_count = 0
-		`,
+			// Store initialization state in SQLite (peak starts at 0 — bumped on first tick)
+			const now = new Date().toISOString()
+			const expiresAt = this.getMonitorStateExpiresAt(new Date()).toISOString()
+			await this.state.storage.sql.exec(
+				`
+				INSERT INTO monitor_state (id, fleet_id, character_id, tracking_session_id, last_synced_fleet_boss_id, is_initialized, last_checked, peak_member_count, expires_at)
+				VALUES (1, ?, ?, ?, NULL, 1, ?, 0, ?)
+				ON CONFLICT(id) DO UPDATE SET
+					fleet_id = excluded.fleet_id,
+					character_id = excluded.character_id,
+					tracking_session_id = excluded.tracking_session_id,
+					last_synced_fleet_boss_id = excluded.last_synced_fleet_boss_id,
+					is_initialized = excluded.is_initialized,
+					last_checked = excluded.last_checked,
+					peak_member_count = 0,
+					expires_at = excluded.expires_at
+			`,
 			fleetId,
 			characterId,
 			trackingSessionId,
-			now
-		)
+			now,
+			expiresAt
+			)
 
 		// Get initial fleet status to create baseline snapshot
 		try {
@@ -510,8 +558,9 @@ export class FleetMonitorDO extends DurableObject {
 					observedAt,
 				})
 				this.state.storage.sql.exec(
-					`UPDATE monitor_state SET last_synced_fleet_boss_id = ? WHERE id = 1`,
-					currentFleetBossId
+					`UPDATE monitor_state SET last_synced_fleet_boss_id = ?, expires_at = ? WHERE id = 1`,
+					currentFleetBossId,
+					this.getMonitorStateExpiresAtIso()
 				)
 				// Update fleet cache immediately to clear inactive/ended state
 				await this.db
@@ -520,7 +569,6 @@ export class FleetMonitorDO extends DurableObject {
 						fleetId,
 						fleetBossId: currentFleetBossId,
 						trackingSessionId,
-						isActive: true,
 						memberCount: initialStatus.memberCount,
 						motd: initialStatus.fleetInfo.motd || null,
 						isFreeMove: initialStatus.fleetInfo.is_free_move,
@@ -528,7 +576,6 @@ export class FleetMonitorDO extends DurableObject {
 						isVoiceEnabled: initialStatus.fleetInfo.is_voice_enabled,
 						notFound: false,
 						notFoundAt: null,
-						endedAt: null,
 						lastChecked: observedAt,
 					})
 					.onConflictDoUpdate({
@@ -536,7 +583,6 @@ export class FleetMonitorDO extends DurableObject {
 						set: {
 							fleetBossId: currentFleetBossId,
 							trackingSessionId,
-							isActive: true,
 							memberCount: initialStatus.memberCount,
 							motd: initialStatus.fleetInfo.motd || null,
 							isFreeMove: initialStatus.fleetInfo.is_free_move,
@@ -544,7 +590,6 @@ export class FleetMonitorDO extends DurableObject {
 							isVoiceEnabled: initialStatus.fleetInfo.is_voice_enabled,
 							notFound: false,
 							notFoundAt: null,
-							endedAt: null,
 							lastChecked: observedAt,
 							updatedAt: observedAt,
 						},
@@ -552,8 +597,9 @@ export class FleetMonitorDO extends DurableObject {
 
 				// Seed peak member count with the initial roster size
 				this.state.storage.sql.exec(
-					`UPDATE monitor_state SET peak_member_count = ? WHERE id = 1`,
-					initialStatus.memberCount
+					`UPDATE monitor_state SET peak_member_count = ?, expires_at = ? WHERE id = 1`,
+					initialStatus.memberCount,
+					this.getMonitorStateExpiresAtIso()
 				)
 
 				logger.info(`[FleetMonitor ${fleetId}] Updated fleet cache during initialization`, {
@@ -771,8 +817,9 @@ export class FleetMonitorDO extends DurableObject {
 				if (resolvedAccess.switchedToFleetBoss) {
 					accessCharacterId = resolvedAccess.accessCharacterId
 					await this.state.storage.sql.exec(
-						`UPDATE monitor_state SET character_id = ? WHERE id = 1`,
-						accessCharacterId
+						`UPDATE monitor_state SET character_id = ?, expires_at = ? WHERE id = 1`,
+						accessCharacterId,
+						this.getMonitorStateExpiresAtIso()
 					)
 					logger.info(`[FleetMonitor ${fleetId}] Rebound ESI source to live fleet boss`, {
 						fleetId,
@@ -927,11 +974,59 @@ export class FleetMonitorDO extends DurableObject {
 	}
 
 	/**
-	 * Get monitor state (RPC method for watchdog)
+	 * Get monitor state for diagnostics and liveness inspection.
 	 * @returns Monitor state including lastChecked timestamp, or null if not initialized
 	 */
 	async getMonitorState(): Promise<FleetMonitorState | null> {
 		return await this.getState()
+	}
+
+	private getMonitorStateExpiresAt(base = new Date()): Date {
+		return new Date(base.getTime() + FleetMonitorDO.MONITOR_STATE_TTL_MS)
+	}
+
+	private getMonitorStateExpiresAtIso(base = new Date()): string {
+		return this.getMonitorStateExpiresAt(base).toISOString()
+	}
+
+	private async clearMonitorStorage(fleetId: string): Promise<void> {
+		// Delete any pending alarms
+		try {
+			await this.state.storage.deleteAlarm()
+			logger.debug(`[FleetMonitor ${fleetId}] Alarm deleted`)
+		} catch (error) {
+			// Ignore if no alarm exists
+			logger.debug(`[FleetMonitor ${fleetId}] No alarm to delete`, {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+
+		// Delete all SQLite table data
+		this.state.storage.sql.exec(`DELETE FROM monitor_state WHERE id = 1`)
+
+		try {
+			this.state.storage.sql.exec(`DELETE FROM previous_members`)
+		} catch (error) {
+			logger.debug(`[FleetMonitor ${fleetId}] Could not delete previous_members`, {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+
+		try {
+			this.state.storage.sql.exec(`DELETE FROM error_tracking`)
+		} catch (error) {
+			logger.debug(`[FleetMonitor ${fleetId}] Could not delete error_tracking`, {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+
+		try {
+			this.state.storage.sql.exec(`DELETE FROM schema_version WHERE id = 1`)
+		} catch (error) {
+			logger.debug(`[FleetMonitor ${fleetId}] Could not delete schema_version`, {
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
 	}
 
 	/**
@@ -992,28 +1087,6 @@ export class FleetMonitorDO extends DurableObject {
 			peakMemberCount,
 		})
 
-		// Mark the cache row inactive so the UI flips from LIVE to ENDED immediately.
-		await this.db
-			.insert(fleetStateCache)
-			.values({
-				fleetId,
-				fleetBossId: currentFleetBossId,
-				trackingSessionId,
-				isActive: false,
-				memberCount: 0,
-				endedAt,
-				lastChecked: endedAt,
-			})
-			.onConflictDoUpdate({
-				target: fleetStateCache.fleetId,
-				set: {
-					isActive: false,
-					endedAt,
-					lastChecked: endedAt,
-					updatedAt: endedAt,
-				},
-			})
-
 		// Tear down the DO.
 		try {
 			await this.terminate()
@@ -1042,50 +1115,7 @@ export class FleetMonitorDO extends DurableObject {
 		})
 
 		try {
-			// Delete any pending alarms
-			try {
-				await this.state.storage.deleteAlarm()
-				logger.debug(`[FleetMonitor ${fleetId}] Alarm deleted`)
-			} catch (error) {
-				// Ignore if no alarm exists
-				logger.debug(`[FleetMonitor ${fleetId}] No alarm to delete`, {
-					error: error instanceof Error ? error.message : String(error),
-				})
-			}
-
-			// Delete all SQLite table data
-			// Delete monitor_state
-			this.state.storage.sql.exec(`DELETE FROM monitor_state WHERE id = 1`)
-
-			// Delete previous_members snapshot — if we don't, the next session
-			// tracked on the same fleetId will hit a PRIMARY KEY violation when
-			// trying to seed its initial roster.
-			try {
-				this.state.storage.sql.exec(`DELETE FROM previous_members`)
-			} catch (error) {
-				logger.debug(`[FleetMonitor ${fleetId}] Could not delete previous_members`, {
-					error: error instanceof Error ? error.message : String(error),
-				})
-			}
-
-			// Delete error_tracking — fresh slate for next session.
-			try {
-				this.state.storage.sql.exec(`DELETE FROM error_tracking`)
-			} catch (error) {
-				logger.debug(`[FleetMonitor ${fleetId}] Could not delete error_tracking`, {
-					error: error instanceof Error ? error.message : String(error),
-				})
-			}
-
-			// Delete schema_version (optional, but ensures clean state)
-			try {
-				this.state.storage.sql.exec(`DELETE FROM schema_version WHERE id = 1`)
-			} catch (error) {
-				// Ignore if table doesn't exist or error
-				logger.debug(`[FleetMonitor ${fleetId}] Could not delete schema_version`, {
-					error: error instanceof Error ? error.message : String(error),
-				})
-			}
+			await this.clearMonitorStorage(fleetId)
 
 			logger.info(`[FleetMonitor ${fleetId}] Storage deleted - DO can be garbage collected`, {
 				fleetId,
@@ -1107,7 +1137,7 @@ export class FleetMonitorDO extends DurableObject {
 		const result = this.state.storage.sql
 			.exec<FleetMonitorStateRow>(
 				`
-				SELECT fleet_id, character_id, tracking_session_id, last_synced_fleet_boss_id, is_initialized, last_checked, peak_member_count
+				SELECT fleet_id, character_id, tracking_session_id, last_synced_fleet_boss_id, is_initialized, last_checked, peak_member_count, expires_at
 				FROM monitor_state
 				WHERE id = 1
 			`
@@ -1119,6 +1149,16 @@ export class FleetMonitorDO extends DurableObject {
 		}
 
 		const row = result[0]
+		const expiresAtMs = row.expires_at ? new Date(row.expires_at).getTime() : null
+		if (expiresAtMs !== null && Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now()) {
+			logger.info('[FleetMonitor] Monitor state expired; clearing stale storage', {
+				fleetId: row.fleet_id,
+				expiresAt: row.expires_at,
+			})
+			await this.clearMonitorStorage(row.fleet_id)
+			return null
+		}
+
 		return {
 			fleetId: row.fleet_id,
 			characterId: row.character_id,
@@ -1127,6 +1167,7 @@ export class FleetMonitorDO extends DurableObject {
 			isInitialized: row.is_initialized === 1,
 			lastChecked: row.last_checked,
 			peakMemberCount: row.peak_member_count ?? 0,
+			expiresAt: row.expires_at,
 		}
 	}
 
@@ -1157,83 +1198,99 @@ export class FleetMonitorDO extends DurableObject {
 		endedByUserId: string | null
 		peakMemberCount: number
 	}): Promise<void> {
-		const {
-			fleetId,
-			fleetBossId,
-			trackingSessionId,
-			endedAt,
-			endedReason,
-			endedByUserId,
-			peakMemberCount,
-		} = args
-
-		try {
-			await this.db.insert(fleetTrackingSessionEvents).values({
-				fleetId,
-				trackingSessionId,
-				previousCharacterId: null,
-				characterId: fleetBossId,
-				eventType: 'ended',
-				observedAt: endedAt,
-				createdAt: endedAt,
-			})
-		} catch (error) {
-			logger.warn(`[FleetMonitor ${fleetId}] Failed to record session end event`, {
-				fleetId,
-				trackingSessionId,
-				error: error instanceof Error ? error.message : String(error),
-			})
+		if (this.finalizeSessionPromise) {
+			await this.finalizeSessionPromise
+			return
 		}
 
-		// 1. Close all open ship-event rows for this session.
-		try {
-			await this.db
-				.update(fleetMemberShipEvents)
-				.set({ endedAt })
-				.where(
-					and(
-						eq(fleetMemberShipEvents.trackingSessionId, trackingSessionId),
-						isNull(fleetMemberShipEvents.endedAt)
-					)
-				)
-		} catch (error) {
-			logger.error(`[FleetMonitor ${fleetId}] Failed to close ship-event rows on session end`, {
+		const finalizePromise = (async () => {
+			const {
 				fleetId,
+				fleetBossId,
 				trackingSessionId,
-				error: error instanceof Error ? error.message : String(error),
-			})
-		}
+				endedAt,
+				endedReason,
+				endedByUserId,
+				peakMemberCount,
+			} = args
 
-		// 2. Update the session row.
-		try {
-			await this.db
-				.update(fleetTrackingSessions)
-				.set({
-					status: 'ended',
-					endedAt,
-					endedReason,
-					endedByUserId,
-					updatedAt: endedAt,
+			try {
+				await this.db.insert(fleetTrackingSessionEvents).values({
+					fleetId,
+					trackingSessionId,
+					previousCharacterId: null,
+					characterId: fleetBossId,
+					eventType: 'ended',
+					observedAt: endedAt,
+					createdAt: endedAt,
 				})
-				.where(
-					and(
-						eq(fleetTrackingSessions.id, trackingSessionId),
-						eq(fleetTrackingSessions.status, 'active')
-					)
-				)
-		} catch (error) {
-			logger.error(`[FleetMonitor ${fleetId}] Failed to update session row on end`, {
-				fleetId,
-				trackingSessionId,
-				error: error instanceof Error ? error.message : String(error),
-			})
-		}
+			} catch (error) {
+				logger.warn(`[FleetMonitor ${fleetId}] Failed to record session end event`, {
+					fleetId,
+					trackingSessionId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
 
-		// 3. Archive the fleet summary.
-		await this.archiveFleetToSummary(fleetId, fleetBossId, endedAt, {
-			trackingSessionId,
-			peakMemberCount,
-		})
+			// 1. Close all open ship-event rows for this session.
+			try {
+				await this.db
+					.update(fleetMemberShipEvents)
+					.set({ endedAt })
+					.where(
+						and(
+							eq(fleetMemberShipEvents.trackingSessionId, trackingSessionId),
+							isNull(fleetMemberShipEvents.endedAt)
+						)
+					)
+			} catch (error) {
+				logger.error(`[FleetMonitor ${fleetId}] Failed to close ship-event rows on session end`, {
+					fleetId,
+					trackingSessionId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+
+			// 2. Update the session row.
+			try {
+				await this.db
+					.update(fleetTrackingSessions)
+					.set({
+						status: 'ended',
+						endedAt,
+						endedReason,
+						endedByUserId,
+						updatedAt: endedAt,
+					})
+					.where(
+						and(
+							eq(fleetTrackingSessions.id, trackingSessionId),
+							eq(fleetTrackingSessions.status, 'active')
+						)
+					)
+			} catch (error) {
+				logger.error(`[FleetMonitor ${fleetId}] Failed to update session row on end`, {
+					fleetId,
+					trackingSessionId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+
+			// 3. Archive the fleet summary.
+			await this.archiveFleetToSummary(fleetId, fleetBossId, endedAt, {
+				trackingSessionId,
+				peakMemberCount,
+			})
+		})()
+
+		this.finalizeSessionPromise = finalizePromise
+		try {
+			await finalizePromise
+		} finally {
+			if (this.finalizeSessionPromise === finalizePromise) {
+				this.finalizeSessionPromise = null
+			}
+		}
 	}
 
 	private async archiveFleetToSummary(
@@ -2165,8 +2222,9 @@ export class FleetMonitorDO extends DurableObject {
 				if (row) {
 					trackingSessionId = row.id
 					this.state.storage.sql.exec(
-						`UPDATE monitor_state SET tracking_session_id = ? WHERE id = 1`,
-						trackingSessionId
+						`UPDATE monitor_state SET tracking_session_id = ?, expires_at = ? WHERE id = 1`,
+						trackingSessionId,
+						this.getMonitorStateExpiresAtIso()
 					)
 					logger.info('[FleetMonitor] Recovered missing trackingSessionId from DB', {
 						fleetId,
@@ -2271,8 +2329,9 @@ export class FleetMonitorDO extends DurableObject {
 			// Update peak member count if exceeded
 			if (fleetStatus.memberCount > peakMemberCount) {
 				this.state.storage.sql.exec(
-					`UPDATE monitor_state SET peak_member_count = ? WHERE id = 1`,
-					fleetStatus.memberCount
+					`UPDATE monitor_state SET peak_member_count = ?, expires_at = ? WHERE id = 1`,
+					fleetStatus.memberCount,
+					this.getMonitorStateExpiresAtIso()
 				)
 			}
 
@@ -2289,38 +2348,23 @@ export class FleetMonitorDO extends DurableObject {
 			})
 			if (liveFleetBossId !== characterId) {
 				this.state.storage.sql.exec(
-					`UPDATE monitor_state SET character_id = ? WHERE id = 1`,
-					liveFleetBossId
+					`UPDATE monitor_state SET character_id = ?, expires_at = ? WHERE id = 1`,
+					liveFleetBossId,
+					this.getMonitorStateExpiresAtIso()
 				)
 				characterId = liveFleetBossId
 			}
 			this.state.storage.sql.exec(
-				`UPDATE monitor_state SET last_synced_fleet_boss_id = ? WHERE id = 1`,
-				liveFleetBossId
+				`UPDATE monitor_state SET last_synced_fleet_boss_id = ?, expires_at = ? WHERE id = 1`,
+				liveFleetBossId,
+				this.getMonitorStateExpiresAtIso()
 			)
-			await this.db
-				.insert(fleetStateCache)
-				.values({
-					fleetId,
-					fleetBossId: liveFleetBossId,
-					trackingSessionId,
-					isActive: true,
-					memberCount: fleetStatus.memberCount,
-					motd: fleetStatus.fleetInfo.motd || null,
-					isFreeMove: fleetStatus.fleetInfo.is_free_move,
-					isRegistered: fleetStatus.fleetInfo.is_registered,
-					isVoiceEnabled: fleetStatus.fleetInfo.is_voice_enabled,
-					notFound: false,
-					notFoundAt: null,
-					endedAt: null,
-					lastChecked: observedAt,
-				})
-				.onConflictDoUpdate({
-					target: fleetStateCache.fleetId,
-					set: {
+				await this.db
+					.insert(fleetStateCache)
+					.values({
+						fleetId,
 						fleetBossId: liveFleetBossId,
 						trackingSessionId,
-						isActive: true,
 						memberCount: fleetStatus.memberCount,
 						motd: fleetStatus.fleetInfo.motd || null,
 						isFreeMove: fleetStatus.fleetInfo.is_free_move,
@@ -2328,7 +2372,20 @@ export class FleetMonitorDO extends DurableObject {
 						isVoiceEnabled: fleetStatus.fleetInfo.is_voice_enabled,
 						notFound: false,
 						notFoundAt: null,
-						endedAt: null,
+						lastChecked: observedAt,
+					})
+				.onConflictDoUpdate({
+					target: fleetStateCache.fleetId,
+					set: {
+						fleetBossId: liveFleetBossId,
+						trackingSessionId,
+						memberCount: fleetStatus.memberCount,
+						motd: fleetStatus.fleetInfo.motd || null,
+						isFreeMove: fleetStatus.fleetInfo.is_free_move,
+						isRegistered: fleetStatus.fleetInfo.is_registered,
+						isVoiceEnabled: fleetStatus.fleetInfo.is_voice_enabled,
+						notFound: false,
+						notFoundAt: null,
 						lastChecked: observedAt,
 						updatedAt: observedAt,
 					},
@@ -2363,13 +2420,15 @@ export class FleetMonitorDO extends DurableObject {
 
 			// Update lastChecked timestamp after successful check
 			const now = new Date().toISOString()
+			const expiresAt = this.getMonitorStateExpiresAt(new Date()).toISOString()
 			await this.state.storage.sql.exec(
 				`
 			UPDATE monitor_state
-			SET last_checked = ?
+			SET last_checked = ?, expires_at = ?
 			WHERE id = 1
 		`,
-				now
+				now,
+				expiresAt
 			)
 
 			// Clear 404 error tracking on successful check (fleet is confirmed active)
@@ -2508,21 +2567,17 @@ export class FleetMonitorDO extends DurableObject {
 						.values({
 							fleetId,
 							fleetBossId: liveFleetBossId,
-							isActive: false,
 							memberCount: 0,
 							notFound: true,
 							notFoundAt: endedAt,
-							endedAt: endedAt,
 							lastChecked: endedAt,
 						})
 						.onConflictDoUpdate({
 							target: fleetStateCache.fleetId,
 							set: {
 								fleetBossId: liveFleetBossId,
-								isActive: false,
 								notFound: true,
 								notFoundAt: endedAt,
-								endedAt: endedAt,
 								lastChecked: endedAt,
 								updatedAt: endedAt,
 							},

--- a/apps/fleets/src/test/integration/api.test.ts
+++ b/apps/fleets/src/test/integration/api.test.ts
@@ -1,49 +1,105 @@
-import { createExecutionContext, env, waitOnExecutionContext } from 'cloudflare:test'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+	getStub: vi.fn(() => ({})),
+}))
+
+vi.mock('cloudflare:workers', () => ({
+	DurableObject: class {
+		constructor(
+			public state: DurableObjectState,
+			public env: unknown
+		) {}
+	},
+}))
+
+vi.mock('@repo/db-utils', () => ({
+	and: vi.fn(() => ({})),
+	asc: vi.fn(() => ({})),
+	desc: vi.fn(() => ({})),
+	eq: vi.fn(() => ({})),
+	gt: vi.fn(() => ({})),
+	gte: vi.fn(() => ({})),
+	inArray: vi.fn(() => ({})),
+	isNull: vi.fn(() => ({})),
+	isNotNull: vi.fn(() => ({})),
+	lt: vi.fn(() => ({})),
+	lte: vi.fn(() => ({})),
+	or: vi.fn(() => ({})),
+	sql: vi.fn(() => ({})),
+	createDbClient: vi.fn(() => ({})),
+	createDbClientWs: vi.fn(() => ({})),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: harness.getStub,
+}))
+
+vi.mock('@repo/hono-helpers', () => ({
+	logger: {
+		debug: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+		log: vi.fn(),
+		warn: vi.fn(),
+	},
+	withOnError: () => async (_err: Error, ctx: { json: (body: unknown, status: number) => Response }) =>
+		ctx.json({ success: false, error: { message: 'internal server error' } }, 500),
+	withNotFound: () =>
+		async (ctx: { json: (body: unknown, status: number) => Response }) =>
+			ctx.json({ success: false, error: { message: 'not found' } }, 404),
+	withWorkersLogger:
+		() =>
+		async (_ctx: unknown, next: () => Promise<Response>) =>
+			await next(),
+}))
 
 import worker from '../../index'
 
 import type { Env } from '../../context'
 
-// Type augmentation for test environment
-declare module 'cloudflare:test' {
-	interface ProvidedEnv extends Env {}
+function createEnv(): Env {
+	return {
+		DATABASE_URL: 'postgres://example',
+		NAME: 'fleets',
+		ENVIRONMENT: 'VITEST',
+		SENTRY_RELEASE: 'test',
+		LOG_LEVEL: 'warn',
+		FLEETS: {} as DurableObjectNamespace,
+		FLEET_MONITOR: {} as DurableObjectNamespace,
+		EVE_TOKEN_STORE: {} as DurableObjectNamespace,
+		EVE_CHARACTER_DATA: {} as DurableObjectNamespace,
+		EVE_CORPORATION_DATA: {} as DurableObjectNamespace,
+		UNIVERSE: {} as DurableObjectNamespace,
+		ESI_RATE_LIMITS: {} as KVNamespace,
+		EVE_SSO_CLIENT_ID: 'client-id',
+	}
 }
 
-describe('Fleets Worker', () => {
-	it('responds to root endpoint', async () => {
-		const request = new Request('http://example.com/')
-		const ctx = createExecutionContext()
-		const response = await worker.fetch(request, env as Env, ctx)
-		await waitOnExecutionContext(ctx)
-
-		expect(response.status).toBe(200)
-		const text = await response.text()
-		expect(text).toContain('EVE Online Fleet Manager')
-	})
-
-	it('redirects unauthenticated user on join page', async () => {
-		const request = new Request('http://example.com/join/test-token')
-		const ctx = createExecutionContext()
-		const response = await worker.fetch(request, env as Env, ctx)
-		await waitOnExecutionContext(ctx)
-
-		// Should redirect to login since no auth cookie
-		expect(response.status).toBe(302)
-		expect(response.headers.get('location')).toContain('/login')
-	})
+beforeEach(() => {
+	harness.getStub.mockReset()
+	harness.getStub.mockReturnValue({})
+	vi.clearAllMocks()
 })
 
-describe('Fleets Durable Object', () => {
-	it('can create a Durable Object instance', async () => {
-		// Skip this test if FLEETS is not available in test environment
-		// This is primarily for TypeScript checking
-		if (!env.FLEETS) {
-			console.log('FLEETS binding not available in test environment')
-			return
-		}
+describe('Fleets Worker', () => {
+	it('responds to the root endpoint', async () => {
+		const response = await worker.fetch(new Request('http://example.com/'), createEnv())
 
-		const id = env.FLEETS.idFromName(`test-${Date.now()}`)
-		expect(id).toBeDefined()
+		expect(response.status).toBe(200)
+		await expect(response.text()).resolves.toContain('Fleets Durable Object Worker')
+	})
+
+	it('returns a clear error when the fleet monitor stub is unavailable', async () => {
+		const response = await worker.fetch(
+			new Request('http://example.com/fleet-monitor/123/status'),
+			createEnv()
+		)
+
+		expect(response.status).toBe(500)
+		await expect(response.json()).resolves.toEqual({
+			error: 'Fleet monitor endpoint unavailable',
+		})
+		expect(harness.getStub).toHaveBeenCalledWith(expect.anything(), 'fleet-123')
 	})
 })

--- a/apps/fleets/src/test/unit/lifecycle.test.ts
+++ b/apps/fleets/src/test/unit/lifecycle.test.ts
@@ -1,0 +1,584 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+	currentDb: null as unknown,
+	stubs: new Map<string, unknown>(),
+	namespaceIds: new WeakMap<object, string>(),
+	namespaceSeq: 0,
+}))
+
+vi.mock('cloudflare:workers', () => {
+	class DurableObject {
+		constructor(
+			public state: DurableObjectState,
+			public env: unknown
+		) {}
+	}
+
+	return {
+		DurableObject,
+	}
+})
+
+vi.mock('@repo/db-utils', async () => {
+	return {
+		and: vi.fn(() => ({})),
+		asc: vi.fn(() => ({})),
+		desc: vi.fn(() => ({})),
+		eq: vi.fn(() => ({})),
+		gt: vi.fn(() => ({})),
+		gte: vi.fn(() => ({})),
+		inArray: vi.fn(() => ({})),
+		isNull: vi.fn(() => ({})),
+		isNotNull: vi.fn(() => ({})),
+		lt: vi.fn(() => ({})),
+		lte: vi.fn(() => ({})),
+		or: vi.fn(() => ({})),
+		sql: vi.fn(() => ({})),
+		createDbClient: vi.fn(() => harness.currentDb),
+		createDbClientWs: vi.fn(() => harness.currentDb),
+	}
+})
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn((namespace: object, id: string) => {
+		const nsKey = getNamespaceKey(namespace)
+		return harness.stubs.get(`${nsKey}:${id}`) ?? {}
+	}),
+}))
+
+vi.mock('@repo/hono-helpers', () => ({
+	logger: {
+		debug: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+		log: vi.fn(),
+		warn: vi.fn(),
+	},
+}))
+
+import {
+	fleetMemberShipEvents,
+	fleetSummaries,
+	fleetTrackingSessionEvents,
+	fleetTrackingSessions,
+} from '../../db/schema'
+import { FleetMonitorDO } from '../../fleet-monitor'
+import { FleetsDO } from '../../durable-object'
+
+function getNamespaceKey(namespace: object): string {
+	const existing = harness.namespaceIds.get(namespace)
+	if (existing) return existing
+
+	const key = `ns-${++harness.namespaceSeq}`
+	harness.namespaceIds.set(namespace, key)
+	return key
+}
+
+function registerStub(namespace: object, id: string, stub: unknown): void {
+	harness.stubs.set(`${getNamespaceKey(namespace)}:${id}`, stub)
+}
+
+function createDbMock(options: {
+	selectResults?: unknown[]
+	insertResults?: unknown[]
+	updateResults?: unknown[]
+	deleteResults?: unknown[]
+} = {}) {
+	const queues = {
+		select: [...(options.selectResults ?? [])],
+		insert: [...(options.insertResults ?? [])],
+		update: [...(options.updateResults ?? [])],
+		delete: [...(options.deleteResults ?? [])],
+	}
+
+	const captures = {
+		selects: [] as Array<Record<string, unknown>>,
+		inserts: [] as Array<Record<string, unknown>>,
+		updates: [] as Array<Record<string, unknown>>,
+		deletes: [] as Array<Record<string, unknown>>,
+	}
+
+	const makeChain = (queue: unknown[], capture: Record<string, unknown>) => {
+		const chain: any = {
+			from: (...args: unknown[]) => {
+				capture.from = args
+				return chain
+			},
+			leftJoin: (...args: unknown[]) => {
+				capture.leftJoin = args
+				return chain
+			},
+			where: (...args: unknown[]) => {
+				capture.where = args
+				return chain
+			},
+			orderBy: (...args: unknown[]) => {
+				capture.orderBy = args
+				return chain
+			},
+			limit: (...args: unknown[]) => {
+				capture.limit = args
+				return chain
+			},
+			offset: (...args: unknown[]) => {
+				capture.offset = args
+				return chain
+			},
+			groupBy: (...args: unknown[]) => {
+				capture.groupBy = args
+				return chain
+			},
+			values: (...args: unknown[]) => {
+				capture.values = args
+				return chain
+			},
+			set: (...args: unknown[]) => {
+				capture.set = args
+				return chain
+			},
+			returning: (...args: unknown[]) => {
+				capture.returning = args
+				return Promise.resolve(queue.shift())
+			},
+			onConflictDoUpdate: (...args: unknown[]) => {
+				capture.onConflictDoUpdate = args
+				return Promise.resolve(queue.shift())
+			},
+			then: (onFulfilled: ((value: unknown) => unknown) | null, onRejected: ((reason: unknown) => unknown) | null) =>
+				Promise.resolve(queue.shift()).then(onFulfilled, onRejected),
+		}
+
+		return chain
+	}
+
+	return {
+		select: vi.fn((selection: unknown) => {
+			const capture: Record<string, unknown> = { selection }
+			captures.selects.push(capture)
+			return makeChain(queues.select, capture)
+		}),
+		insert: vi.fn((table: unknown) => {
+			const capture: Record<string, unknown> = { table }
+			captures.inserts.push(capture)
+			return makeChain(queues.insert, capture)
+		}),
+		update: vi.fn((table: unknown) => {
+			const capture: Record<string, unknown> = { table }
+			captures.updates.push(capture)
+			return makeChain(queues.update, capture)
+		}),
+		delete: vi.fn((table: unknown) => {
+			const capture: Record<string, unknown> = { table }
+			captures.deletes.push(capture)
+			return makeChain(queues.delete, capture)
+		}),
+		captures,
+		queues,
+	}
+}
+
+function createBaseEnv() {
+	const FLEET_MONITOR = {} as DurableObjectNamespace
+	const EVE_TOKEN_STORE = {} as DurableObjectNamespace
+	const EVE_CHARACTER_DATA = {} as DurableObjectNamespace
+	const UNIVERSE = {} as DurableObjectNamespace
+	const ESI_RATE_LIMITS = {} as KVNamespace
+
+	return {
+		DATABASE_URL: 'postgres://example',
+		FLEET_MONITOR,
+		EVE_TOKEN_STORE,
+		EVE_CHARACTER_DATA,
+		UNIVERSE,
+		ESI_RATE_LIMITS,
+		EVE_SSO_CLIENT_ID: 'client-id',
+	}
+}
+
+function createFleetsDo(db: ReturnType<typeof createDbMock>) {
+	harness.currentDb = db
+	return new FleetsDO({} as DurableObjectState, createBaseEnv() as never)
+}
+
+function createFleetMonitorDo(db: ReturnType<typeof createDbMock>) {
+	harness.currentDb = db
+	const state = {
+		storage: {
+			sql: {
+				exec: vi.fn((query: string) => ({
+					toArray: () => (query.includes('SELECT version') ? [{ version: 5 }] : []),
+				})),
+			},
+			deleteAlarm: vi.fn().mockResolvedValue(undefined),
+			setAlarm: vi.fn().mockResolvedValue(undefined),
+		},
+	} as never
+
+	return new FleetMonitorDO(state, createBaseEnv() as never)
+}
+
+beforeEach(() => {
+	harness.currentDb = null
+	harness.stubs.clear()
+	harness.namespaceIds = new WeakMap<object, string>()
+	harness.namespaceSeq = 0
+	vi.clearAllMocks()
+})
+
+describe('fleet lifecycle management', () => {
+	it('starts a new tracking session and initializes the fleet monitor', async () => {
+		const db = createDbMock({
+			selectResults: [[]],
+			insertResults: [[{ id: 'session-1' }]],
+		})
+		const fleets = createFleetsDo(db)
+		const env = createBaseEnv()
+		const monitorStub = {
+			initializeMonitoring: vi.fn().mockResolvedValue(undefined),
+		}
+		registerStub(env.FLEET_MONITOR, 'fleet-123', monitorStub)
+
+		;(fleets as any).env = env
+		;(fleets as any).getCharacterFleetInformation = vi.fn().mockResolvedValue({
+			fleet_id: '123',
+			fleet_boss_id: '42',
+			role: 'squad_member',
+			squad_id: 1,
+			wing_id: 2,
+			lastUpdated: '2026-07-20T00:00:00.000Z',
+		})
+		;(fleets as any).recordSessionLifecycleEvent = vi.fn().mockResolvedValue(undefined)
+
+		const result = await fleets.startTrackingSession({
+			characterId: '42',
+			startedByUserId: 'user-1',
+			name: 'Alpha Fleet',
+		})
+
+		expect(result).toEqual({ sessionId: 'session-1' })
+		expect(db.captures.inserts[0]?.table).toBe(fleetTrackingSessions)
+		expect(db.captures.inserts[0]?.values).toEqual([
+			expect.objectContaining({
+				name: 'Alpha Fleet',
+				characterId: '42',
+				startedByUserId: 'user-1',
+				fleetId: '123',
+				status: 'active',
+			}),
+		])
+		expect(monitorStub.initializeMonitoring).toHaveBeenCalledWith('123', '42', 'session-1', {
+			force: true,
+			previousFleetBossCharacterId: null,
+			resumedExistingSession: false,
+		})
+		expect((fleets as any).recordSessionLifecycleEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				fleetId: '123',
+				trackingSessionId: 'session-1',
+				eventType: 'started',
+			})
+		)
+	})
+
+	it('takes over an ended session and records a resumed lifecycle event', async () => {
+		const db = createDbMock({
+			selectResults: [
+				[
+					{
+						id: 'session-1',
+						status: 'ended',
+						endedAt: new Date('2026-07-19T23:59:00.000Z'),
+						characterId: '41',
+					},
+				],
+			],
+			updateResults: [[{ id: 'session-1' }]],
+			deleteResults: [undefined],
+		})
+		const fleets = createFleetsDo(db)
+		const env = createBaseEnv()
+		const monitorStub = {
+			initializeMonitoring: vi.fn().mockResolvedValue(undefined),
+		}
+		registerStub(env.FLEET_MONITOR, 'fleet-123', monitorStub)
+		;(fleets as any).env = env
+		;(fleets as any).getCharacterFleetInformation = vi.fn().mockResolvedValue({
+			fleet_id: '123',
+			fleet_boss_id: '42',
+			role: 'squad_member',
+			squad_id: 1,
+			wing_id: 2,
+			lastUpdated: '2026-07-20T00:00:00.000Z',
+		})
+		;(fleets as any).recordSessionLifecycleEvent = vi.fn().mockResolvedValue(undefined)
+
+		const result = await fleets.startTrackingSession({
+			characterId: '42',
+			startedByUserId: 'user-1',
+			name: 'Alpha Fleet',
+			action: 'take_over',
+		})
+
+		expect(result).toEqual({ sessionId: 'session-1' })
+		expect(db.captures.updates[0]?.table).toBe(fleetTrackingSessions)
+		expect(db.captures.updates[0]?.set).toEqual([
+			expect.objectContaining({
+				name: 'Alpha Fleet',
+				characterId: '42',
+				status: 'active',
+				endedAt: null,
+				endedReason: null,
+				endedByUserId: null,
+			}),
+		])
+		expect(monitorStub.initializeMonitoring).toHaveBeenCalledWith('123', '42', 'session-1', {
+			force: true,
+			previousFleetBossCharacterId: '41',
+			resumedExistingSession: true,
+		})
+		expect((fleets as any).recordSessionLifecycleEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				fleetId: '123',
+				trackingSessionId: 'session-1',
+				eventType: 'resumed',
+				previousCharacterId: '41',
+			})
+		)
+		expect(db.captures.deletes[0]?.table).toBe(fleetSummaries)
+	})
+
+	it('rejects a new session when one is already active', async () => {
+		const db = createDbMock({
+			selectResults: [
+				[
+					{
+						id: 'session-1',
+						status: 'active',
+						endedAt: null,
+						characterId: '41',
+					},
+				],
+			],
+		})
+		const fleets = createFleetsDo(db)
+		const env = createBaseEnv()
+		registerStub(env.FLEET_MONITOR, 'fleet-123', {})
+		;(fleets as any).env = env
+		;(fleets as any).getCharacterFleetInformation = vi.fn().mockResolvedValue({
+			fleet_id: '123',
+			fleet_boss_id: '42',
+			role: 'squad_member',
+			squad_id: 1,
+			wing_id: 2,
+			lastUpdated: '2026-07-20T00:00:00.000Z',
+		})
+
+		await expect(
+			fleets.startTrackingSession({
+				characterId: '42',
+				startedByUserId: 'user-1',
+				name: 'Alpha Fleet',
+			})
+		).rejects.toMatchObject({ code: 'fleet_session_active' })
+		expect(db.captures.inserts).toHaveLength(0)
+	})
+
+	it('delegates stop requests only for active sessions', async () => {
+		const db = createDbMock({
+			selectResults: [
+				[
+					{
+						id: 'session-1',
+						status: 'active',
+						endedAt: null,
+						fleetId: '123',
+					},
+				],
+				[
+					{
+						id: 'session-2',
+						status: 'ended',
+						endedAt: new Date('2026-07-19T23:59:00.000Z'),
+						fleetId: '123',
+					},
+				],
+			],
+		})
+		const fleets = createFleetsDo(db)
+		const env = createBaseEnv()
+		const monitorStub = {
+			endSession: vi.fn().mockResolvedValue(undefined),
+		}
+		registerStub(env.FLEET_MONITOR, 'fleet-123', monitorStub)
+		;(fleets as any).env = env
+
+		await fleets.stopTrackingSession({
+			sessionId: 'session-1',
+			endedReason: 'user_stopped',
+			endedByUserId: 'user-1',
+		})
+
+		await fleets.stopTrackingSession({
+			sessionId: 'session-2',
+			endedReason: 'admin_stopped',
+			endedByUserId: 'user-2',
+		})
+
+		expect(monitorStub.endSession).toHaveBeenCalledTimes(1)
+		expect(monitorStub.endSession).toHaveBeenCalledWith({
+			sessionId: 'session-1',
+			endedReason: 'user_stopped',
+			endedByUserId: 'user-1',
+		})
+	})
+
+	it('treats live snapshot and member lookups as session-gated', async () => {
+		const activeSnapshotDb = createDbMock({
+			selectResults: [
+				[
+					{
+						fleetId: '123',
+						status: 'active',
+						endedAt: null,
+					},
+				],
+				[
+					{
+						id: 'cache-row',
+						fleetId: '123',
+						memberCount: 3,
+						motd: 'Test motd',
+						isFreeMove: true,
+						isRegistered: false,
+						isVoiceEnabled: true,
+						notFound: false,
+						notFoundAt: null,
+						lastChecked: new Date('2026-07-20T00:00:00.000Z'),
+						createdAt: new Date('2026-07-20T00:00:00.000Z'),
+						updatedAt: new Date('2026-07-20T00:00:00.000Z'),
+					},
+				],
+			],
+		})
+		const activeSnapshotDo = createFleetsDo(activeSnapshotDb)
+		const activeSnapshotEnv = createBaseEnv()
+		const monitorStub = {
+			getMonitorState: vi.fn().mockResolvedValue({ peakMemberCount: 8 }),
+		}
+		registerStub(activeSnapshotEnv.FLEET_MONITOR, 'fleet-123', monitorStub)
+		;(activeSnapshotDo as any).env = activeSnapshotEnv
+
+		await expect(activeSnapshotDo.getSessionLiveSnapshot('session-1')).resolves.toEqual({
+			fleetId: '123',
+			memberCount: 3,
+			peakMemberCount: 8,
+			motd: 'Test motd',
+			isFreeMove: true,
+			isRegistered: false,
+			isVoiceEnabled: true,
+			lastChecked: '2026-07-20T00:00:00.000Z',
+			updatedAt: '2026-07-20T00:00:00.000Z',
+		})
+		expect(monitorStub.getMonitorState).toHaveBeenCalledTimes(1)
+
+		const endedLocationsDb = createDbMock({
+			selectResults: [[{ fleetId: '123', status: 'ended', endedAt: new Date('2026-07-19T23:59:00.000Z') }]],
+		})
+		const endedLocationsDo = createFleetsDo(endedLocationsDb)
+		const endedLocationsEnv = createBaseEnv()
+		const liveMonitorStub = {
+			getFleetStatus: vi.fn().mockResolvedValue({ members: [] }),
+		}
+		registerStub(endedLocationsEnv.FLEET_MONITOR, 'fleet-123', liveMonitorStub)
+		;(endedLocationsDo as any).env = endedLocationsEnv
+
+		await expect(endedLocationsDo.getSessionLiveMemberLocations('session-2')).resolves.toEqual([])
+		expect(liveMonitorStub.getFleetStatus).not.toHaveBeenCalled()
+	})
+
+	it('treats inconsistent session rows as closed when stopping tracking', async () => {
+		const db = createDbMock({
+			selectResults: [
+				[
+					{
+						id: 'session-1',
+						status: 'active',
+						endedAt: new Date('2026-07-20T00:00:00.000Z'),
+						fleetId: '123',
+					},
+				],
+			],
+		})
+		const fleets = createFleetsDo(db)
+		const env = createBaseEnv()
+		const monitorStub = {
+			endSession: vi.fn().mockResolvedValue(undefined),
+		}
+		registerStub(env.FLEET_MONITOR, 'fleet-123', monitorStub)
+		;(fleets as any).env = env
+
+		await fleets.stopTrackingSession({
+			sessionId: 'session-1',
+			endedReason: 'user_stopped',
+			endedByUserId: 'user-1',
+		})
+
+		expect(monitorStub.endSession).not.toHaveBeenCalled()
+	})
+
+	it('finalizes a fleet monitor session once and ignores mismatches', async () => {
+		const db = createDbMock({
+			selectResults: [
+				[
+					{
+						id: 'cache-row',
+						fleetId: '123',
+						fleetBossId: '42',
+						memberCount: 4,
+						motd: 'Test motd',
+						isFreeMove: true,
+						isRegistered: false,
+						isVoiceEnabled: true,
+						notFound: false,
+						notFoundAt: null,
+						lastChecked: new Date('2026-07-20T00:00:00.000Z'),
+						createdAt: new Date('2026-07-20T00:00:00.000Z'),
+						updatedAt: new Date('2026-07-20T00:00:00.000Z'),
+					},
+				],
+				[],
+			],
+			insertResults: [undefined, undefined],
+			updateResults: [undefined, undefined],
+		})
+		const monitor = createFleetMonitorDo(db)
+		const finalize = (monitor as any).finalizeSession.bind(monitor)
+
+		await Promise.all([
+			finalize({
+				fleetId: '123',
+				fleetBossId: '42',
+				trackingSessionId: 'session-2',
+				endedAt: new Date('2026-07-20T00:01:00.000Z'),
+				endedReason: 'fleet_disbanded',
+				endedByUserId: null,
+				peakMemberCount: 7,
+			}),
+			finalize({
+				fleetId: '123',
+				fleetBossId: '42',
+				trackingSessionId: 'session-2',
+				endedAt: new Date('2026-07-20T00:01:00.000Z'),
+				endedReason: 'fleet_disbanded',
+				endedByUserId: null,
+				peakMemberCount: 7,
+			}),
+		])
+
+		expect(db.captures.inserts.filter((entry) => entry.table === fleetTrackingSessionEvents)).toHaveLength(1)
+		expect(db.captures.updates.filter((entry) => entry.table === fleetMemberShipEvents)).toHaveLength(1)
+		expect(db.captures.updates.filter((entry) => entry.table === fleetTrackingSessions)).toHaveLength(1)
+		expect(db.captures.inserts.filter((entry) => entry.table === fleetSummaries)).toHaveLength(1)
+	})
+})

--- a/apps/fleets/vitest.config.ts
+++ b/apps/fleets/vitest.config.ts
@@ -1,20 +1,8 @@
-import { defineWorkersProject } from '@cloudflare/vitest-pool-workers/config'
+import { defineConfig } from 'vitest/config'
 
-export default defineWorkersProject({
+export default defineConfig({
 	test: {
-		poolOptions: {
-			workers: {
-				wrangler: { configPath: `${__dirname}/wrangler.jsonc` },
-				miniflare: {
-					bindings: {
-						ENVIRONMENT: 'VITEST',
-						CORE_API_URL: 'https://pleaseignore.app',
-					},
-					durableObjects: {
-						FLEETS: 'Fleets',
-					},
-				},
-			},
-		},
+		environment: 'node',
+		include: ['src/test/**/*.test.ts'],
 	},
 })

--- a/packages/fleets/src/fleet-monitor.ts
+++ b/packages/fleets/src/fleet-monitor.ts
@@ -34,6 +34,7 @@ export interface FleetMonitorStateRow extends Record<string, string | number | n
 	is_initialized: number
 	last_checked: string | null
 	peak_member_count: number
+	expires_at: string | null
 }
 
 /**
@@ -48,6 +49,7 @@ export interface FleetMonitorState {
 	isInitialized: boolean
 	lastChecked: string | null
 	peakMemberCount: number
+	expiresAt: string | null
 }
 
 /**
@@ -93,7 +95,7 @@ export interface FleetMonitor extends DurableObject {
 	getFleetStatus(): Promise<FleetDetailsResponse | null>
 
 	/**
-	 * Get monitor state (for watchdog checks)
+	 * Get monitor state for diagnostics and liveness inspection.
 	 * @returns Monitor state including lastChecked timestamp, or null if not initialized
 	 */
 	getMonitorState(): Promise<FleetMonitorState | null>

--- a/packages/fleets/src/index.ts
+++ b/packages/fleets/src/index.ts
@@ -161,9 +161,9 @@ export interface Fleets extends DurableObject {
 	/**
 	 * Get fleet cache status from database
 	 * @param fleetId - ESI fleet ID
-	 * @returns Cache status with isActive, notFound, and endedAt, or null if not in cache
+	 * @returns Cache snapshot with notFound markers, or null if not in cache
 	 */
-	getFleetCacheStatus(fleetId: string): Promise<{ isActive: boolean; notFound: boolean; endedAt: Date | null } | null>
+	getFleetCacheStatus(fleetId: string): Promise<{ notFound: boolean; notFoundAt: Date | null; lastChecked: Date } | null>
 
 	/**
 	 * Get fleet registration status (is_registered) with cache-first approach


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes race conditions and inconsistent state in the fleet tracking session lifecycle: stopping a tracking session is now idempotent, "active" status is derived consistently instead of trusted from a separate boolean column, and `FleetMonitorDO` no longer double-runs session finalization or leaks stale state.

## Changes
- `DELETE /api/fleets/tracking/:sessionId` (`apps/core/src/routes/fleets.ts`) now returns `200 { ok: true, status }` for sessions that are already ended instead of a `409`, and re-checks session status after a `stopTrackingSession` failure to treat a race (session ended anyway) as success rather than a `500`.
- `FleetsDO` (`apps/fleets/src/durable-object.ts`):
  - Added `getEffectiveSessionStatus()` to derive "active" vs "ended" from `status` + `endedAt` together, and uses it everywhere a session's status is read (list/get/latest/active session lookups, live snapshot, member management).
  - `stopTrackingSession` no longer throws when the session is missing or already ended — it logs and returns, making it safe to call repeatedly.
  - Removed the `fleet_state_cache.is_active` / `ended_at` columns and the now-unused `fleet_state_cache_ended_at_idx` index in favor of the `notFound` flag and the session's own `status`/`endedAt`.
  - Removed the dead alarm-based watchdog (`alarm`, `recoverFleetMonitorSession`, `scheduleNextWatchdog`, `startWatchdog`) and its auto-start on first DO access.
- `FleetMonitorDO` (`apps/fleets/src/fleet-monitor.ts`):
  - Added a `finalizeSessionPromise` guard so concurrent/duplicate calls to end a session await the in-flight finalize instead of re-running it.
  - Added a TTL (`expires_at`, 24h, schema v4 → v5) to `monitor_state`, with self-expiry that clears stale monitor storage when read after expiry.
  - Extracted `clearMonitorStorage()` shared by the finalize and cleanup paths.
  - Stopped writing to the removed `is_active` / `ended_at` cache columns.
- Updated shared types in `packages/fleets/src/index.ts` and `packages/fleets/src/fleet-monitor.ts` (`getFleetCacheStatus` return shape, `FleetMonitorState`/`FleetMonitorStateRow` gain `expiresAt`/`expires_at`).
- Added migration `apps/fleets/.migrations/0011_hot_marvel_boy.sql` dropping the retired index/columns.
- `apps/fleets/vitest.config.ts` switched from the workers pool config to a plain Node `vitest` config.

## Testing
- Added route tests covering idempotent DELETE of an already-ended tracking session and a stop-race where `stopTrackingSession` fails but the session ended anyway (`apps/core/src/routes/__tests__/fleets.tracking.route.test.ts`).
- Added a new unit test suite for the DO lifecycle logic (`apps/fleets/src/test/unit/lifecycle.test.ts`) and updated integration tests (`apps/fleets/src/test/integration/api.test.ts`).
<!-- claude:end -->