### PR TITLE
feat(blocklist): renamed blacklist -> blocklist in webui

### DIFF
--- a/apps/ui/src/client/components/admin-nav.tsx
+++ b/apps/ui/src/client/components/admin-nav.tsx
@@ -166,7 +166,7 @@ export function AdminNav({ onNavigate }: AdminNavProps) {
 			icon: ShieldAlert,
 		},
 		{
-			label: 'Blacklist',
+			label: 'Blocklist',
 			href: '/admin/blacklist',
 			icon: ShieldBan,
 		},

--- a/apps/ui/src/client/features/applications/components/fulcrum-report-viewer.tsx
+++ b/apps/ui/src/client/features/applications/components/fulcrum-report-viewer.tsx
@@ -100,7 +100,7 @@ function LegacyDataSection({ data }: { data: unknown }) {
 								<h3 className="text-sm font-semibold">Legacy User {item.legacyAuthUserId}</h3>
 								<Badge variant="secondary">{item.status}</Badge>
 								{blacklistSignals.hasAnyBlacklistSignal ? (
-									<Badge variant="destructive">Blacklist Alert</Badge>
+									<Badge variant="destructive">Blocklist Alert</Badge>
 								) : null}
 							</div>
 

--- a/apps/ui/src/client/features/applications/components/report-sections/alerts-banner.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/alerts-banner.tsx
@@ -208,7 +208,7 @@ function LegacyAssociationDetails({
 						<div className="flex flex-wrap items-center gap-2">
 							<span className="font-medium">Legacy User {item.legacyAuthUserId}</span>
 							<Badge variant="secondary">{item.status}</Badge>
-							{hasBlacklistSignal ? <Badge variant="destructive">Blacklist Alert</Badge> : null}
+							{hasBlacklistSignal ? <Badge variant="destructive">Blocklist Alert</Badge> : null}
 						</div>
 						<div className="mt-1 text-xs text-muted-foreground">
 							{characterCount} character(s), {noteCount} note(s), {ipAddressCount} IP address(es)
@@ -242,7 +242,7 @@ function LegacyAssociationDetails({
 						) : null}
 						{alertType === 'legacy-blacklist-association' && matchedTargets.length > 0 ? (
 							<div className="mt-2 space-y-1.5">
-								<div className="text-xs font-semibold text-muted-foreground">Matched Blacklist Items</div>
+								<div className="text-xs font-semibold text-muted-foreground">Matched Blocklist Items</div>
 								<LegacyBlacklistTargetList targets={matchedTargets} alertItemId={item.id} />
 							</div>
 						) : null}

--- a/apps/ui/src/client/features/applications/components/report-sections/blacklist-highlighting-impl.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/blacklist-highlighting-impl.tsx
@@ -116,7 +116,7 @@ export function BlacklistHighlight({
 		>
 			<div className="space-y-2 text-xs">
 				<div className="font-semibold uppercase tracking-wide text-muted-foreground">
-					Blacklist context
+					Blocklist context
 				</div>
 				{contexts.length > 0 ? (
 					<ul className="space-y-1">

--- a/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
+++ b/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
@@ -201,7 +201,7 @@ export function ProfileCharactersSection({
 												)}
 												{character.isBlacklisted && (
 													<Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
-														Blacklisted
+														Blocklisted
 													</Badge>
 												)}
 											</>

--- a/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
@@ -491,7 +491,7 @@ export default function HrMemberProfile() {
 									{account.hasBlacklisted && (
 										<Badge variant="destructive" className="gap-1">
 											<ShieldAlert className="h-3 w-3" />
-											Blacklisted
+											Blocklisted
 										</Badge>
 									)}
 								</div>

--- a/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
+++ b/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
@@ -538,7 +538,7 @@ export default function CorporationMembersTable({
 											<Badge variant="special" icon={Heart}>Emeritus</Badge>
 										)}
 										{member.isBlacklisted && (
-											<Badge variant="destructive" icon={ShieldBan}>Blacklisted</Badge>
+											<Badge variant="destructive" icon={ShieldBan}>Blocklisted</Badge>
 										)}
 									</div>
 								</TableCell>

--- a/apps/ui/src/client/features/corporations/components/emeritus-confirmation-dialog.tsx
+++ b/apps/ui/src/client/features/corporations/components/emeritus-confirmation-dialog.tsx
@@ -96,7 +96,7 @@ export function EmeritusConfirmationDialog({
 								<li>This status is designed for characters whose owners have passed away</li>
 								<li>
 									<strong>Important:</strong> If the character logs in (in-game or to the app), they
-									should be immediately blacklisted
+									should be immediately blocklisted
 								</li>
 							</ul>
 						</div>

--- a/apps/ui/src/client/routes/admin/blacklist.tsx
+++ b/apps/ui/src/client/routes/admin/blacklist.tsx
@@ -57,12 +57,12 @@ const BLACKLIST_CREATE_TARGET_OPTIONS: SelectOption[] = [
 	{
 		value: 'character_id',
 		label: 'Character ID',
-		description: 'Block a specific EVE character and auto-blacklist linked users.',
+		description: 'Block a specific EVE character and auto-blocklist linked users.',
 	},
 	{
 		value: 'character_name',
 		label: 'Character Name',
-		description: 'Block a character name and auto-blacklist currently linked users.',
+		description: 'Block a character name and auto-blocklist currently linked users.',
 	},
 	{
 		value: 'discord_id',
@@ -83,12 +83,12 @@ const BLACKLIST_CREATE_FIELD_CONFIG: Record<
 	character_id: {
 		label: 'Character ID',
 		placeholder: 'Enter EVE character ID',
-		helperText: 'This will also auto-blacklist users currently linked to that character.',
+		helperText: 'This will also auto-blocklist users currently linked to that character.',
 	},
 	character_name: {
 		label: 'Character Name',
 		placeholder: 'Enter EVE character name',
-		helperText: 'This will auto-blacklist users currently linked to that character name.',
+		helperText: 'This will auto-blocklist users currently linked to that character name.',
 	},
 	discord_id: {
 		label: 'Discord ID',
@@ -98,7 +98,7 @@ const BLACKLIST_CREATE_FIELD_CONFIG: Record<
 }
 
 export default function BlacklistPage() {
-	usePageTitle('Blacklist Management')
+	usePageTitle('Blocklist Management')
 
 	const queryClient = useQueryClient()
 
@@ -200,19 +200,19 @@ export default function BlacklistPage() {
 			setAddDialogOpen(false)
 			resetAddForm()
 
-			let successMessage = `${TARGET_TYPE_LABELS[targetType]} blacklisted successfully.`
+			let successMessage = `${TARGET_TYPE_LABELS[targetType]} blocklisted successfully.`
 			if (targetType === 'user') {
 				const autoBlacklisted = result as {
 					autoBlacklisted: { characters: string[]; users: string[]; totalCount: number }
 				}
 				const cascadeMsg =
 					autoBlacklisted.autoBlacklisted.totalCount > 0
-						? ` Auto-blacklisted ${autoBlacklisted.autoBlacklisted.characters.length} character(s) and ${autoBlacklisted.autoBlacklisted.users.length} user(s).`
+						? ` Auto-blocklisted ${autoBlacklisted.autoBlacklisted.characters.length} character(s) and ${autoBlacklisted.autoBlacklisted.users.length} user(s).`
 						: ''
 				successMessage += cascadeMsg
 			} else if (targetType === 'character_id' || targetType === 'character_name') {
 				const characterResult = result as { autoBlacklistedCount: number }
-				successMessage += ` ${characterResult.autoBlacklistedCount} user(s) auto-blacklisted.`
+				successMessage += ` ${characterResult.autoBlacklistedCount} user(s) auto-blocklisted.`
 			}
 
 			setMessage({ type: 'success', text: successMessage })
@@ -221,7 +221,7 @@ export default function BlacklistPage() {
 		onError: (error: any) => {
 			setMessage({
 				type: 'error',
-				text: error.message || 'Failed to create blacklist entry',
+				text: error.message || 'Failed to create blocklist entry',
 			})
 			setTimeout(() => setMessage(null), 5000)
 		},
@@ -236,15 +236,15 @@ export default function BlacklistPage() {
 			setSelectedEntry(null)
 			const cascadeMsg =
 				result.removedCount > 1
-					? ` Also removed ${result.removedCount - 1} triggered blacklist(s).`
+					? ` Also removed ${result.removedCount - 1} triggered blocklist(s).`
 					: ''
-			setMessage({ type: 'success', text: `Blacklist entry removed successfully.${cascadeMsg}` })
+			setMessage({ type: 'success', text: `Blocklist entry removed successfully.${cascadeMsg}` })
 			setTimeout(() => setMessage(null), 5000)
 		},
 		onError: (error: any) => {
 			setMessage({
 				type: 'error',
-				text: error.message || 'Failed to remove blacklist entry',
+				text: error.message || 'Failed to remove blocklist entry',
 			})
 			setTimeout(() => setMessage(null), 5000)
 		},
@@ -306,14 +306,14 @@ export default function BlacklistPage() {
 			{/* Header */}
 			<div className="flex items-center justify-between">
 				<div>
-					<h1 className="text-3xl font-bold gradient-text">Blacklist Management</h1>
+					<h1 className="text-3xl font-bold gradient-text">Blocklist Management</h1>
 					<p className="text-muted-foreground mt-1">
-						Manage global blacklist for users and characters
+						Manage global blocklist for users and characters
 					</p>
 				</div>
 				<Button onClick={() => setAddDialogOpen(true)}>
 					<Plus className="h-4 w-4" />
-					Add to Blacklist
+					Add to Blocklist
 				</Button>
 			</div>
 
@@ -379,7 +379,7 @@ export default function BlacklistPage() {
 						</div>
 
 						<div className="space-y-2">
-							<Label htmlFor="autoBlacklist">Auto-Blacklist</Label>
+							<Label htmlFor="autoBlacklist">Auto-Blocklist</Label>
 							<Select
 								value={autoBlacklistFilter}
 								onValueChange={(v) => setAutoBlacklistFilter(v as 'all' | 'true' | 'false')}
@@ -422,7 +422,7 @@ export default function BlacklistPage() {
 				<CardHeader>
 					<div className="space-y-4">
 						<div>
-							<CardTitle>Blacklist Entries</CardTitle>
+							<CardTitle>Blocklist Entries</CardTitle>
 							<CardDescription>
 								{isLoading ? (
 									<Skeleton className="h-4 w-32" />
@@ -450,19 +450,19 @@ export default function BlacklistPage() {
 					) : error ? (
 						<div className="flex flex-col items-center justify-center py-8 text-center">
 							<AlertTriangle className="h-12 w-12 text-destructive mb-4" />
-							<h3 className="text-lg font-semibold">Error Loading Blacklist</h3>
+							<h3 className="text-lg font-semibold">Error Loading Blocklist</h3>
 							<p className="text-muted-foreground mt-1">
-								{error instanceof Error ? error.message : 'Failed to load blacklist entries'}
+								{error instanceof Error ? error.message : 'Failed to load blocklist entries'}
 							</p>
 						</div>
 					) : filteredData.length === 0 ? (
 						<div className="flex flex-col items-center justify-center py-8 text-center">
 							<ShieldBan className="h-12 w-12 text-muted-foreground mb-4" />
-							<h3 className="text-lg font-semibold">No Blacklist Entries</h3>
+							<h3 className="text-lg font-semibold">No Blocklist Entries</h3>
 							<p className="text-muted-foreground mt-1">
 								{hasActiveFilters
 									? 'No entries match your filters'
-									: 'No users or characters have been blacklisted yet'}
+									: 'No users or characters have been blocklisted yet'}
 							</p>
 							{!hasActiveFilters && (
 								<Button className="mt-4" onClick={() => setAddDialogOpen(true)}>
@@ -584,7 +584,7 @@ export default function BlacklistPage() {
 			>
 				<DialogContent>
 					<DialogHeader>
-						<DialogTitle>Add to Blacklist</DialogTitle>
+						<DialogTitle>Add to Blocklist</DialogTitle>
 						<DialogDescription>
 							Block a user account, character, or Discord account from accessing the platform
 						</DialogDescription>
@@ -623,7 +623,7 @@ export default function BlacklistPage() {
 								<Label htmlFor="reason">Reason</Label>
 								<Textarea
 									id="reason"
-									placeholder="Explain why this user/character is being blacklisted"
+									placeholder="Explain why this user/character is being blocklisted"
 									value={formData.reason}
 									onChange={(e) => setFormData({ ...formData, reason: e.target.value })}
 									rows={3}
@@ -647,7 +647,7 @@ export default function BlacklistPage() {
 								loading={createBlacklist.isPending}
 								loadingText="Adding..."
 							>
-								Add to Blacklist
+								Add to Blocklist
 							</Button>
 						</DialogFooter>
 					</form>
@@ -658,14 +658,14 @@ export default function BlacklistPage() {
 			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
 				<DialogContent>
 					<DialogHeader>
-						<DialogTitle>Remove from Blacklist</DialogTitle>
+						<DialogTitle>Remove from Blocklist</DialogTitle>
 						<DialogDescription>
 							Are you sure you want to remove this{' '}
-					{selectedEntry ? TARGET_TYPE_LABELS[selectedEntry.targetType] : ''} from the blacklist?
+					{selectedEntry ? TARGET_TYPE_LABELS[selectedEntry.targetType] : ''} from the blocklist?
 							{selectedEntry?.isAutoBlacklist && (
 								<span className="block mt-2 text-orange-500">
-									Warning: This is an auto-blacklist entry. The user may still be blocked if the
-									triggering character is still blacklisted.
+									Warning: This is an auto-blocklist entry. The user may still be blocked if the
+									triggering character is still blocklisted.
 								</span>
 							)}
 						</DialogDescription>
@@ -673,7 +673,7 @@ export default function BlacklistPage() {
 					<DialogFooter>
 						<Button variant="cancel" onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
 						<Button variant="destructive" onClick={handleDelete} loading={removeBlacklist.isPending}>
-							Remove from Blacklist
+							Remove from Blocklist
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/apps/ui/src/client/routes/admin/legacy-migration-detail.tsx
+++ b/apps/ui/src/client/routes/admin/legacy-migration-detail.tsx
@@ -578,7 +578,7 @@ export default function AdminLegacyMigrationDetailPage() {
 									{item.legacyAuthUserId}
 								</Badge>
 								<Badge variant={accountStatusVariant(item.status)}>{item.status}</Badge>
-								{conflictSummary.hasBlacklist ? <Badge variant="destructive">Blacklist</Badge> : null}
+								{conflictSummary.hasBlacklist ? <Badge variant="destructive">Blocklist</Badge> : null}
 								{conflictSummary.multiMatch ? <Badge variant="warning">Multi-match</Badge> : null}
 								{conflictSummary.crossUserCount > 0 ? (
 									<Badge variant="destructive">Cross-user ({conflictSummary.crossUserCount})</Badge>
@@ -589,16 +589,16 @@ export default function AdminLegacyMigrationDetailPage() {
 							{blacklistAlerts.hasAnyBlacklistSignal ? (
 								<Card className="border-destructive/60">
 									<CardHeader>
-										<CardTitle className="text-destructive">Blacklist Alerts</CardTitle>
+										<CardTitle className="text-destructive">Blocklist Alerts</CardTitle>
 									</CardHeader>
 									<CardContent className="space-y-2">
-										{blacklistAlerts.modernUserBlacklisted ? <Badge variant="destructive">Modern user is blacklisted</Badge> : null}
+										{blacklistAlerts.modernUserBlacklisted ? <Badge variant="destructive">Modern user is blocklisted</Badge> : null}
 										{blacklistAlerts.discordMatches.length > 0 ? (
-											<Badge variant="destructive">Discord ID blacklist match ({blacklistAlerts.discordMatches.length})</Badge>
+											<Badge variant="destructive">Discord ID blocklist match ({blacklistAlerts.discordMatches.length})</Badge>
 										) : null}
 										{blacklistAlerts.ipAssociatedMatches.length > 0 ? (
 											<Badge variant="destructive">
-												IP-associated blacklist matches ({blacklistAlerts.ipAssociatedMatches.length})
+												IP-associated blocklist matches ({blacklistAlerts.ipAssociatedMatches.length})
 											</Badge>
 										) : null}
 										{blacklistAlerts.matches.map((match) => (
@@ -810,7 +810,7 @@ export default function AdminLegacyMigrationDetailPage() {
 												}))
 											}
 										/>
-										<span className="text-sm">Apply blacklist to user</span>
+										<span className="text-sm">Apply blocklist to user</span>
 									</label>
 								) : null}
 								<label className="flex items-center gap-2 cursor-pointer">

--- a/apps/ui/src/client/routes/admin/legacy-migrations.tsx
+++ b/apps/ui/src/client/routes/admin/legacy-migrations.tsx
@@ -313,7 +313,7 @@ export default function AdminLegacyMigrationsPage() {
 												{crossUserCount > 0 ? (
 													<Badge variant="destructive">Cross-user ({crossUserCount})</Badge>
 												) : null}
-												{hasBlacklist ? <Badge variant="destructive">Blacklist</Badge> : null}
+												{hasBlacklist ? <Badge variant="destructive">Blocklist</Badge> : null}
 												{!hasMultiMatch && crossUserCount === 0 && !hasBlacklist ? (
 													<Badge variant="ghost">None</Badge>
 												) : null}

--- a/apps/ui/src/client/routes/admin/user-detail.tsx
+++ b/apps/ui/src/client/routes/admin/user-detail.tsx
@@ -462,7 +462,7 @@ export default function UserDetailPage() {
 		if (!blacklistReason.trim()) {
 			setMessage({
 				type: 'error',
-				text: 'Please provide a reason for blacklisting',
+				text: 'Please provide a reason for blocklisting',
 			})
 			setTimeout(() => setMessage(null), 3000)
 			return
@@ -474,13 +474,13 @@ export default function UserDetailPage() {
 			setBlacklistReason('')
 			setMessage({
 				type: 'success',
-				text: 'User has been blacklisted successfully',
+				text: 'User has been blocklisted successfully',
 			})
 			setTimeout(() => setMessage(null), 3000)
 		} catch (error) {
 			setMessage({
 				type: 'error',
-				text: error instanceof Error ? error.message : 'Failed to blacklist user',
+				text: error instanceof Error ? error.message : 'Failed to blocklist user',
 			})
 			setTimeout(() => setMessage(null), 5000)
 		}
@@ -494,13 +494,13 @@ export default function UserDetailPage() {
 			setRemoveBlacklistDialogOpen(false)
 			setMessage({
 				type: 'success',
-				text: 'User has been removed from blacklist',
+				text: 'User has been removed from blocklist',
 			})
 			setTimeout(() => setMessage(null), 3000)
 		} catch (error) {
 			setMessage({
 				type: 'error',
-				text: error instanceof Error ? error.message : 'Failed to remove blacklist',
+				text: error instanceof Error ? error.message : 'Failed to remove blocklist',
 			})
 			setTimeout(() => setMessage(null), 5000)
 		}
@@ -617,7 +617,7 @@ export default function UserDetailPage() {
 									{activeBlacklist && (
 										<Badge variant="destructive">
 											<ShieldBan className="h-3 w-3 mr-1" />
-											Blacklisted
+											Blocklisted
 										</Badge>
 									)}
 									{user.is_admin ? (
@@ -648,7 +648,7 @@ export default function UserDetailPage() {
 											onClick={() => setRemoveBlacklistDialogOpen(true)}
 											disabled={removeBlacklist.isPending}
 										>
-											Remove from Blacklist
+											Remove from Blocklist
 										</Button>
 									) : (
 										<Button variant="destructive"
@@ -673,7 +673,7 @@ export default function UserDetailPage() {
 														'0 1px 8px rgba(220, 38, 38, 1), 0 1px 3px rgba(248, 113, 113, 0.95)',
 												}}
 											>
-												💩 Blacklist User
+												💩 Blocklist User
 											</span>
 										</Button>
 									)}
@@ -854,7 +854,7 @@ export default function UserDetailPage() {
 										{activeDiscordBlacklist && (
 											<Badge variant="destructive" className="gap-1">
 												<ShieldBan className="h-3 w-3" />
-												Blacklisted
+												Blocklisted
 											</Badge>
 										)}
 									</div>
@@ -867,11 +867,11 @@ export default function UserDetailPage() {
 									<div className="flex items-start gap-2">
 										<ShieldBan className="h-4 w-4 text-destructive mt-0.5 flex-shrink-0" />
 										<div>
-											<p className="text-sm text-destructive font-medium">Discord Account Blacklisted</p>
+											<p className="text-sm text-destructive font-medium">Discord Account Blocklisted</p>
 											<p className="text-sm text-destructive/90 mt-1">
 												This Discord account is blocked from accessing the platform.
 												{activeDiscordBlacklist.isAutoBlacklist && (
-													<span> Auto-blocked due to associated user blacklist.</span>
+													<span> Auto-blocked due to associated user blocklist.</span>
 												)}
 											</p>
 										</div>
@@ -1043,8 +1043,8 @@ export default function UserDetailPage() {
 			{activeBlacklist && (
 				<Card className="border-red-500/20 bg-red-500/5">
 					<CardHeader>
-						<CardTitle className="text-red-500">Blacklist Status</CardTitle>
-						<CardDescription>This user has been blacklisted</CardDescription>
+						<CardTitle className="text-red-500">Blocklist Status</CardTitle>
+						<CardDescription>This user has been blocklisted</CardDescription>
 					</CardHeader>
 					<CardContent>
 						<div className="space-y-4">
@@ -1060,7 +1060,7 @@ export default function UserDetailPage() {
 
 							<div className="grid grid-cols-2 gap-4">
 								<div>
-									<div className="text-sm text-muted-foreground">Blacklisted On</div>
+									<div className="text-sm text-muted-foreground">Blocklisted On</div>
 									<div className="text-sm font-medium">
 										{formatDateTime(activeBlacklist.createdAt)}
 									</div>
@@ -1073,11 +1073,11 @@ export default function UserDetailPage() {
 									<div className="text-sm font-medium">
 										{activeBlacklist.isAutoBlacklist ? (
 											<Badge variant="default" className="bg-orange-500/20 text-orange-500">
-												Auto-Blacklisted
+												Auto-Blocklisted
 											</Badge>
 										) : (
 											<Badge variant="destructive">
-												Manual Blacklist
+												Manual Blocklist
 											</Badge>
 										)}
 									</div>
@@ -1090,7 +1090,7 @@ export default function UserDetailPage() {
 										<AlertTriangle className="h-4 w-4 text-orange-500 mt-0.5 flex-shrink-0" />
 										<div className="space-y-1">
 											<p className="text-sm text-orange-500 font-medium">
-												Automatically Blacklisted
+												Automatically Blocklisted
 											</p>
 											{triggeringEntry ? (
 												<p className="text-sm text-orange-500/90">
@@ -1098,20 +1098,20 @@ export default function UserDetailPage() {
 													<span className="font-medium">
 														{TARGET_TYPE_LABELS[triggeringEntry.targetType]}
 													</span>{' '}
-													blacklist on{' '}
+													blocklist on{' '}
 													<span className="font-mono">
 														{triggeringEntry.targetValue}
 													</span>
 													.{' '}
 													<Link to="/admin/blacklist" className="underline hover:text-orange-400">
-														View blacklist
+														View blocklist
 													</Link>
 												</p>
 											) : (
 												<p className="text-sm text-orange-500/90">
-													This user was automatically blacklisted due to a linked blacklist entry.{' '}
+													This user was automatically blocklisted due to a linked blocklist entry.{' '}
 													<Link to="/admin/blacklist" className="underline hover:text-orange-400">
-														View blacklist
+														View blocklist
 													</Link>
 												</p>
 											)}
@@ -1173,7 +1173,7 @@ export default function UserDetailPage() {
 														{character.isBlacklisted && (
 															<Badge variant="destructive">
 																<ShieldBan className="h-3 w-3 mr-1" />
-																Blacklisted
+																Blocklisted
 															</Badge>
 														)}
 													</div>
@@ -1668,9 +1668,9 @@ export default function UserDetailPage() {
 			<Dialog open={blacklistDialogOpen} onOpenChange={setBlacklistDialogOpen}>
 				<DialogContent>
 					<DialogHeader>
-						<DialogTitle>Blacklist User</DialogTitle>
+						<DialogTitle>Blocklist User</DialogTitle>
 						<DialogDescription>
-							Blacklist {primaryCharacterName}.
+							Blocklist {primaryCharacterName}.
 							This will immediately disable all services and prevent login. This action can be
 							reversed.
 						</DialogDescription>
@@ -1680,7 +1680,7 @@ export default function UserDetailPage() {
 							<Label htmlFor="blacklist-reason">Reason *</Label>
 							<Textarea
 								id="blacklist-reason"
-								placeholder="Enter the reason for blacklisting this user..."
+								placeholder="Enter the reason for blocklisting this user..."
 								value={blacklistReason}
 								onChange={(e) => setBlacklistReason(e.target.value)}
 								rows={4}
@@ -1703,11 +1703,11 @@ export default function UserDetailPage() {
 						<Button variant="destructive"
 							onClick={handleBlacklistConfirm}
 							loading={createBlacklist.isPending}
-							loadingText="Blacklisting..."
+							loadingText="Blocklisting..."
 							showIcon={false}
 						>
 							<ShieldBan className="h-4 w-4" />
-							Blacklist User
+							Blocklist User
 						</Button>
 					</DialogFooter>
 				</DialogContent>
@@ -1717,16 +1717,16 @@ export default function UserDetailPage() {
 			<Dialog open={removeBlacklistDialogOpen} onOpenChange={setRemoveBlacklistDialogOpen}>
 				<DialogContent>
 					<DialogHeader>
-						<DialogTitle>Remove from Blacklist</DialogTitle>
+						<DialogTitle>Remove from Blocklist</DialogTitle>
 						<DialogDescription>
 							Are you sure you want to remove{' '}
 							{primaryCharacterName} from the
-							blacklist? They will regain access to all services immediately.
+							blocklist? They will regain access to all services immediately.
 						</DialogDescription>
 					</DialogHeader>
 					{activeBlacklist && (
 						<div className="bg-muted/50 border rounded-lg p-3 my-2">
-							<p className="text-sm text-muted-foreground mb-1">Current blacklist reason:</p>
+							<p className="text-sm text-muted-foreground mb-1">Current blocklist reason:</p>
 							<p className="text-sm">{activeBlacklist.reason}</p>
 						</div>
 					)}
@@ -1744,7 +1744,7 @@ export default function UserDetailPage() {
 							showIcon={false}
 						>
 							<ShieldBan className="h-4 w-4" />
-							Remove from Blacklist
+							Remove from Blocklist
 						</Button>
 					</DialogFooter>
 				</DialogContent>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Renames the user-facing "Blacklist" terminology to "Blocklist" throughout the admin web UI. This is a display-text-only rename; underlying variable names, route paths (`/admin/blacklist`), props, and API fields are unchanged.

## Changes
- Admin nav label: "Blacklist" → "Blocklist" (`admin-nav.tsx`)
- Blacklist alert/status badges and card titles renamed to "Blocklist" across application/legacy-migration review views (`fulcrum-report-viewer.tsx`, `alerts-banner.tsx`, `blacklist-highlighting-impl.tsx`, `legacy-migration-detail.tsx`, `legacy-migrations.tsx`)
- "Blacklisted" character/user badges renamed to "Blocklisted" (`user-profile-sections.tsx`, `hr-member-profile.tsx`, `corporation-members-table.tsx`, `emeritus-confirmation-dialog.tsx`)
- Full admin Blacklist management page (`routes/admin/blacklist.tsx`) relabeled: page title, headings, form helper text, dialogs, buttons, and toast/success/error messages now say "Blocklist"/"blocklisted"
- User detail page (`routes/admin/user-detail.tsx`) relabeled: blacklist status card, badges, dialogs, buttons, and messages now say "Blocklist"/"blocklisted"

## Testing
No test changes included in this diff; this is a text-only rename with no logic changes.
<!-- claude:end -->