### PR TITLE
apply cooldown to all structures and only upsate when successful

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -896,6 +896,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async getCorporationsNeedingRefresh(): Promise<string[]> {
 		const tooOld = minutesAgo(20)
 		const assetsTooOld = minutesAgo(60)
+		const structuresTooOld = minutesAgo(60)
 
 		const configs = await this.getDb().query.corporationConfig.findMany({
 			where: and(eq(corporationConfig.includeInBackgroundRefresh, true)),
@@ -908,7 +909,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			{ field: 'walletJournalLastSync' as const, cutoff: tooOld },
 			{ field: 'walletTransactionsLastSync' as const, cutoff: tooOld },
 			{ field: 'assetsLastSync' as const, cutoff: assetsTooOld },
-			{ field: 'structuresLastSync' as const, cutoff: tooOld },
+			{ field: 'structuresLastSync' as const, cutoff: structuresTooOld },
 			{ field: 'ordersLastSync' as const, cutoff: tooOld },
 			{ field: 'contractsLastSync' as const, cutoff: tooOld },
 			{ field: 'industryJobsLastSync' as const, cutoff: tooOld },

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -290,6 +290,11 @@ describe('EveCorporationSyncWorkflow', () => {
 			},
 		])
 		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001', ['structure-1'])
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			['assets', 'structures']
+		)
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
@@ -454,6 +459,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		)
 		expect(selectDirectorMock).toHaveBeenCalledTimes(1)
 		expect(executedStepNames).toContain('store-structure-sovereignty-enrichment-failure')
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
@@ -617,7 +623,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
-	it('skips sovereignty and mining enrichment when the structure sync is within the cooldown window but still refreshes skyhooks', async () => {
+	it('skips structure enrichment work when the structure sync is within the cooldown window', async () => {
 		vi.clearAllMocks()
 		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
 		corpDataStub.getCorporationSyncConfig.mockResolvedValue({
@@ -689,13 +695,16 @@ describe('EveCorporationSyncWorkflow', () => {
 			trigger: 'cron',
 		})
 
+		expect(fetchStructuresMock).not.toHaveBeenCalled()
+		expect(storeStructuresMock).not.toHaveBeenCalled()
 		expect(fetchSovereigntyEnrichmentMock).not.toHaveBeenCalled()
-		expect(fetchSkyhookEnrichmentMock).toHaveBeenCalledTimes(1)
-		expect(storeSkyhookEnrichmentMock).toHaveBeenCalledTimes(1)
+		expect(fetchSkyhookEnrichmentMock).not.toHaveBeenCalled()
+		expect(storeSkyhookEnrichmentMock).not.toHaveBeenCalled()
 		expect(fetchMiningExtractionEnrichmentMock).not.toHaveBeenCalled()
 		expect(executedStepNames).not.toContain('store-structure-sovereignty-enrichment')
-		expect(executedStepNames).toContain('store-structure-skyhook-enrichment')
+		expect(executedStepNames).not.toContain('store-structure-skyhook-enrichment')
 		expect(executedStepNames).not.toContain('store-structure-mining-extraction-enrichment')
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets'])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -195,6 +195,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			const structureEnrichmentCooldownActive =
 				structureEnrichmentNextAllowedAt !== null &&
 				structureEnrichmentNextAllowedAt > workflowObservedAt
+			let structureSyncCompleted = false
 			const shouldSync = createShouldSyncPredicate(dataTypes, {
 				disabledDataTypes: structureAssetSyncEnabled ? [] : ['assets'],
 			})
@@ -688,10 +689,17 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			}
 
 			if (shouldSyncAuthenticated('structures')) {
+				if (structureEnrichmentCooldownActive) {
+					logger.info('[EveCorporationSyncWorkflow] Skipping structure sync due to cooldown', {
+						corporationId,
+						nextAllowedAt: structureEnrichmentNextAllowedAt?.toISOString() ?? null,
+					})
+				} else {
 				// Keep the structure refresh from blocking the asset projection refresh.
 				// The inventory path can fall back to the DB or refresh structures on its own.
 				let structures: Awaited<ReturnType<typeof fetchStructures>> | null = null
 				let miningCitadelStructureIds = new Set<string>()
+				let structureSyncHadFailure = false
 				try {
 					structures = await runDirectorStepWithFailover({
 						stepName: 'fetch-structures',
@@ -713,6 +721,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 							.map((structure) => String(structure.structure_id))
 					)
 				} catch (error) {
+					structureSyncHadFailure = true
 					logger.warn(
 						'[EveCorporationSyncWorkflow] Structure sync failed; continuing to asset sync',
 						{
@@ -780,6 +789,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 									}
 								)
 							}
+							structureSyncHadFailure = true
 						}
 
 						if (miningCitadelStructureIds.size > 0) {
@@ -813,6 +823,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 									)
 								}
 							} catch (error) {
+								structureSyncHadFailure = true
 								logger.warn(
 									'[EveCorporationSyncWorkflow] Mining extraction enrichment failed; continuing without it',
 									{
@@ -833,77 +844,83 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 								)
 							})
 						}
+
 					} else {
 						logger.info('[EveCorporationSyncWorkflow] Skipping structure enrichment due to cooldown', {
 							corporationId,
 							nextAllowedAt: structureEnrichmentNextAllowedAt?.toISOString() ?? null,
 						})
+						structureSyncHadFailure = true
 					}
 
-					try {
-						skyhookEnrichment = await runDirectorStepWithFailover({
-							stepName: 'fetch-structure-skyhook-enrichment',
-							timeout: '10 minutes',
-							requiredRoles: ['Director'],
-							run: (directorCharacterId) =>
-								fetchSkyhookEnrichment(this.env, corporationId, directorCharacterId),
-						})
-					} catch (error) {
-						if (error instanceof StructureEnrichmentScopeMismatchError) {
-							try {
-								await step.do(
-									'store-structure-skyhook-enrichment-failure',
-									{},
-									async () =>
-										await markStructureEnrichmentSyncFailure(
-											this.env,
+					if (!structureEnrichmentCooldownActive) {
+						try {
+							skyhookEnrichment = await runDirectorStepWithFailover({
+								stepName: 'fetch-structure-skyhook-enrichment',
+								timeout: '10 minutes',
+								requiredRoles: ['Director'],
+								run: (directorCharacterId) =>
+									fetchSkyhookEnrichment(this.env, corporationId, directorCharacterId),
+							})
+						} catch (error) {
+							structureSyncHadFailure = true
+							if (error instanceof StructureEnrichmentScopeMismatchError) {
+								try {
+									await step.do(
+										'store-structure-skyhook-enrichment-failure',
+										{},
+										async () =>
+											await markStructureEnrichmentSyncFailure(
+												this.env,
+												corporationId,
+												error.target,
+												error.message
+											)
+									)
+								} catch (markError) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Skyhook enrichment scope mismatch could not be persisted',
+										{
 											corporationId,
-											error.target,
-											error.message
-										)
-								)
-							} catch (markError) {
+											error: markError instanceof Error ? markError.message : String(markError),
+										}
+									)
+								}
 								logger.warn(
-									'[EveCorporationSyncWorkflow] Skyhook enrichment scope mismatch could not be persisted',
+									'[EveCorporationSyncWorkflow] Skyhook enrichment scope mismatch; marking sync failure',
 									{
 										corporationId,
-										error: markError instanceof Error ? markError.message : String(markError),
+										error: error.message,
+									}
+								)
+							} else {
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Skyhook enrichment failed; continuing without it',
+									{
+										corporationId,
+										error: error instanceof Error ? error.message : String(error),
 									}
 								)
 							}
-							logger.warn(
-								'[EveCorporationSyncWorkflow] Skyhook enrichment scope mismatch; marking sync failure',
-								{
-									corporationId,
-									error: error.message,
-								}
-							)
-						} else {
-							logger.warn(
-								'[EveCorporationSyncWorkflow] Skyhook enrichment failed; continuing without it',
-								{
-									corporationId,
-									error: error instanceof Error ? error.message : String(error),
+						}
+
+						if (skyhookEnrichment) {
+							const fetchedSkyhookEnrichment = skyhookEnrichment
+							skyhookStoreResult = await step.do(
+								'store-structure-skyhook-enrichment',
+								{},
+								async () => {
+									return await storeSkyhookEnrichment(
+										this.env,
+										corporationId,
+										fetchedSkyhookEnrichment
+									)
 								}
 							)
 						}
 					}
 
-					if (skyhookEnrichment) {
-						const fetchedSkyhookEnrichment = skyhookEnrichment
-						skyhookStoreResult = await step.do(
-							'store-structure-skyhook-enrichment',
-							{},
-							async () => {
-								return await storeSkyhookEnrichment(
-									this.env,
-									corporationId,
-									fetchedSkyhookEnrichment
-								)
-							}
-						)
-					}
-
+					structureSyncCompleted = !structureSyncHadFailure && !structureEnrichmentCooldownActive
 					structuresSync = {
 						dataType: 'structures' as const,
 						stats: {
@@ -916,6 +933,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 							miningExtractionsCount: miningExtractions?.length ?? 0,
 						},
 					}
+				}
 				}
 			}
 
@@ -1043,6 +1061,9 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			const stats: SyncStats = allSyncResults
 				.filter((result): result is NonNullable<typeof result> => result !== null)
 				.reduce((acc, result) => ({ ...acc, ...result.stats }), {} as SyncStats)
+			const syncedDataTypesForTimestamps = syncedDataTypes.filter(
+				(dataType) => dataType !== 'structures' || structureSyncCompleted
+			)
 
 			const walletJournalFetched = walletJournalSync?.stats.walletJournalFetchedCount ?? 0
 			const walletTransactionsFetched =
@@ -1080,7 +1101,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			})
 
 			await step.do('update-sync-timestamps', {}, () =>
-				updateSyncTimestamps(this.env, corporationId, syncedDataTypes)
+				updateSyncTimestamps(this.env, corporationId, syncedDataTypesForTimestamps)
 			)
 
 			await step.do('update-last-sync', {}, () => updateCoreLastSync(this.env, corporationId))


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Applies the structure-enrichment cooldown consistently to the entire structure sync (not just sovereignty/mining enrichment), and stops recording `structuresLastSync` as updated unless the structure sync actually completed successfully.

## Changes

- `getCorporationsNeedingRefresh`: give `structuresLastSync` its own 60-minute cutoff (`structuresTooOld`) instead of sharing the 20-minute default, matching the cadence used for assets.
- `sync-workflow.ts`: when the structure enrichment cooldown is active, skip the entire structures sync block (structure fetch, sovereignty enrichment, mining extraction enrichment, and skyhook enrichment) instead of only skipping sovereignty/mining enrichment while still running skyhook enrichment.
- Track a `structureSyncHadFailure` flag across structure fetch/enrichment steps and only mark the structures sync as completed (`structureSyncCompleted`) when nothing failed and the sync wasn't skipped due to cooldown.
- Filter `structures` out of the data types passed to `updateSyncTimestamps` unless `structureSyncCompleted` is true, so `structuresLastSync` is only bumped on a fully successful sync.

## Testing

- Updated unit tests in `sync-workflow.test.ts` to assert `updateSyncTimestamps` is called with the correct data types (including omitting `structures` on failure/cooldown), and that skyhook fetch/store are skipped during the cooldown window.
<!-- claude:end -->
