### PR TITLE
fix sov enrichment fetching and adjust skyhook UX copy

### DIFF
--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -161,9 +161,7 @@ async function enrichStructureDetailTypeNames(
 ): Promise<StructureDetailResult> {
 	const sovereignty = structure.sovereignty ?? null
 	const sovereigntyHub = sovereignty?.hub ?? null
-	const allianceIds = sovereigntyHub?.controllerAllianceId
-		? [sovereigntyHub.controllerAllianceId]
-		: []
+	const allianceIds = sovereignty?.allianceId ? [sovereignty.allianceId] : []
 	const structureTypeIds = new Set<string>([
 		...(structure.inventoryBays?.flatMap((bay: StructureInventoryBay) =>
 			bay.items.map((item: StructureInventoryItem) => item.typeId)
@@ -187,14 +185,12 @@ async function enrichStructureDetailTypeNames(
 		const nextSovereignty = sovereignty
 			? {
 					...sovereignty,
-					hub: sovereigntyHub
-						? {
-								...sovereigntyHub,
-								controllerAllianceName: sovereigntyHub.controllerAllianceId
-									? (allianceNameMap.get(sovereigntyHub.controllerAllianceId) ?? null)
-									: null,
-							}
-						: sovereigntyHub,
+					allianceName: sovereignty.allianceId
+						? (allianceNameMap.get(sovereignty.allianceId) ??
+							sovereignty.allianceName ??
+							sovereignty.allianceId)
+						: null,
+					hub: sovereigntyHub,
 				}
 			: sovereignty
 
@@ -257,12 +253,14 @@ async function enrichStructureDetailTypeNames(
 		sovereignty: sovereignty
 			? {
 					...sovereignty,
+					allianceName: sovereignty.allianceId
+						? (allianceNameMap.get(sovereignty.allianceId) ??
+							sovereignty.allianceName ??
+							sovereignty.allianceId)
+						: null,
 					hub: sovereigntyHub
 						? {
 								...sovereigntyHub,
-							controllerAllianceName: sovereigntyHub.controllerAllianceId
-								? (allianceNameMap.get(sovereigntyHub.controllerAllianceId) ?? null)
-								: null,
 								reagentBay: sovereigntyHub.reagentBay
 									? {
 											...sovereigntyHub.reagentBay,

--- a/apps/eve-corporation-data/package.json
+++ b/apps/eve-corporation-data/package.json
@@ -16,6 +16,7 @@
 		"dev": "run-vite-dev",
 		"fix:workers-types": "run-wrangler-types",
 		"preview": "run-vite-preview",
+		"diagnose-sovereignty": "tsx ./src/scripts/diagnose-sovereignty.ts",
 		"query-killmails": "tsx ./src/scripts/query-killmails.ts",
 		"tail": "run-wrangler-tail",
 		"test": "run-vitest",

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -199,7 +199,9 @@ const NPC_CORPORATION_ID_MIN = 1_000_000
 const NPC_CORPORATION_ID_MAX = 1_999_999
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY = 'shared:sovereignty-systems:observed-at'
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX = 'shared:sovereignty-systems:row:'
-const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS = 300
+const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS = 60 * 60
+const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY = 'shared:sovereignty-systems:refresh-lease'
+const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS = 2 * 60
 const ORBITAL_SKYHOOK_TYPE_ID = '81080'
 const STRUCTURE_SNAPSHOT_BATCH_SIZE = 10
 const STRUCTURE_CLEANUP_BATCH_SIZE = 250
@@ -236,6 +238,11 @@ function parseNumberOrNull(value: unknown): number | null {
 type SkyhookStateRow = typeof structureSkyhooks.$inferSelect
 type SovereigntyHubInsertRow = typeof structureSovereigntyHubs.$inferInsert
 type SkyhookInsertRow = typeof structureSkyhooks.$inferInsert
+type SharedSovereigntySystemsRefreshLease = {
+	token: string
+	expiresAtMs: number
+	acquiredAtMs: number
+}
 type SkyhookStorageRow = {
 	structureId: string
 	corporationId: string
@@ -3054,6 +3061,44 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 	}
 
+	async acquireSharedSovereigntySystemsRefreshLease(
+		leaseSeconds = SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS
+	): Promise<string | null> {
+		const now = Date.now()
+		const lease: SharedSovereigntySystemsRefreshLease = {
+			token: crypto.randomUUID(),
+			acquiredAtMs: now,
+			expiresAtMs: now + leaseSeconds * 1000,
+		}
+		let acquired = false
+
+		await this.state.storage.transaction(async (txn) => {
+			const existing = await txn.get<SharedSovereigntySystemsRefreshLease>(
+				SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY
+			)
+			if (existing && existing.expiresAtMs > now) {
+				return
+			}
+
+			await txn.put(SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY, lease)
+			acquired = true
+		})
+
+		return acquired ? lease.token : null
+	}
+
+	async releaseSharedSovereigntySystemsRefreshLease(leaseToken: string): Promise<void> {
+		await this.state.storage.transaction(async (txn) => {
+			const existing = await txn.get<SharedSovereigntySystemsRefreshLease>(
+				SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY
+			)
+			if (!existing || existing.token !== leaseToken) {
+				return
+			}
+			await txn.delete(SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY)
+		})
+	}
+
 	/**
 	 * Get shared sovereignty system snapshots for the requested system IDs if they are still within TTL.
 	 */
@@ -3087,6 +3132,32 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			uniqueSystemIds.map((systemId) => `${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX}${systemId}`)
 		)
 
+		return [...rows.values()]
+	}
+
+	async getSharedSovereigntySystemsSnapshot(
+		maxAgeSeconds = SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS
+	): Promise<EsiSovereigntySystem[] | null> {
+		const observedAtRaw = await this.state.storage.get<string>(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
+		)
+		if (!observedAtRaw) {
+			return null
+		}
+
+		const observedAt = parseDateOrNull(observedAtRaw)
+		if (!observedAt) {
+			return null
+		}
+
+		const ageMs = Date.now() - observedAt.getTime()
+		if (ageMs > maxAgeSeconds * 1000) {
+			return null
+		}
+
+		const rows = await this.state.storage.list<EsiSovereigntySystem>({
+			prefix: SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX,
+		})
 		return [...rows.values()]
 	}
 

--- a/apps/eve-corporation-data/src/scripts/diagnose-sovereignty.ts
+++ b/apps/eve-corporation-data/src/scripts/diagnose-sovereignty.ts
@@ -1,0 +1,685 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_COMPATIBILITY_DATE = '2026-05-19'
+const EVE_OAUTH_METADATA_URL = 'https://login.eveonline.com/.well-known/oauth-authorization-server'
+const DIAGNOSTIC_ENV_PREFIX = 'DIAGNOSTIC' as const
+const REGION_10000023_ID = '10000023'
+const REGION_10000023_NAME = 'Pure Blind'
+const REGION_10000023_SYSTEM_IDS = new Set<string>([
+	'30001963',
+	'30001964',
+	'30001965',
+	'30001966',
+	'30001967',
+	'30001968',
+	'30001969',
+	'30001970',
+	'30001971',
+	'30001972',
+	'30001973',
+	'30001974',
+	'30001975',
+	'30001976',
+	'30001977',
+	'30001978',
+	'30001979',
+	'30001980',
+	'30001981',
+	'30001982',
+	'30001983',
+	'30001984',
+	'30001985',
+	'30001986',
+	'30001987',
+	'30001988',
+	'30001989',
+	'30001990',
+	'30001991',
+	'30001992',
+	'30001993',
+	'30001994',
+	'30001995',
+	'30001996',
+	'30001997',
+	'30001998',
+	'30001999',
+	'30002000',
+	'30002001',
+	'30002002',
+	'30002003',
+	'30002004',
+	'30002005',
+	'30002006',
+	'30002007',
+	'30002008',
+	'30002009',
+	'30002010',
+	'30002011',
+	'30002012',
+	'30002013',
+	'30002014',
+	'30002015',
+	'30002016',
+	'30002017',
+	'30002018',
+	'30002019',
+	'30002020',
+	'30002021',
+	'30002022',
+	'30002023',
+	'30002024',
+	'30002025',
+	'30002026',
+	'30002027',
+	'30002028',
+	'30002029',
+	'30002030',
+	'30002031',
+	'30002032',
+	'30002033',
+	'30002034',
+	'30002035',
+	'30002036',
+	'30002037',
+	'30002038',
+	'30002039',
+	'30002040',
+	'30002041',
+	'30002042',
+	'30002043',
+	'30002044',
+	'30002045',
+	'30002046',
+	'30002047',
+])
+
+type RawSovereigntySystem = {
+	solar_systems: Array<{
+		solar_system_id: number
+		claim?: {
+			alliance?: {
+				alliance_id: number
+				corporation_id: number
+				claimed_since: string
+				is_capital_system: boolean
+				sovereignty_hub: {
+					id: number
+					vulnerability_window?: {
+						start: string
+						end: string
+					}
+				}
+				development: {
+					activity_defense_multiplier: number
+					military_level: number
+					industrial_level: number
+					strategic_level: number
+				}
+			}
+			faction?: {
+				faction_id: number
+			}
+			unclaimed?: boolean
+		}
+	}>
+}
+
+type SovereigntyHubsListing = {
+	sovereignty_hubs: Array<{
+		id: number
+		solar_system_id: number
+	}>
+}
+
+type SovereigntyHubDetail = {
+	id: number
+	solar_system_id: number
+	controller_alliance_id?: number | null
+	fuel_access_list_id?: number | null
+	reagent_bay: {
+		last_updated: string
+		reagents: Array<{
+			type_id: number
+			amount: number
+			burning_per_hour: number
+			last_cycle: string
+		}>
+	}
+	resources: {
+		power: {
+			allocated: number
+			available: number
+		}
+		workforce: {
+			allocated: number
+			available: number
+		}
+	}
+	upgrades: Array<{
+		type_id: number
+		power_state: string
+	}>
+	vulnerability_window?: {
+		start: string
+		end: string
+	} | null
+	workforce_transport: unknown
+}
+
+type OAuthMetadata = {
+	token_endpoint: string
+}
+
+type AllianceDetail = {
+	creator_corporation_id: number
+	creator_id: number
+	date_founded: string
+	executor_corporation_id?: number
+	faction_id?: number
+	name: string
+	ticker: string
+}
+
+function loadEnvFile(): void {
+	const __dirname = dirname(fileURLToPath(import.meta.url))
+	const envPath = resolve(__dirname, '../../../../.env')
+
+	try {
+		const envContent = readFileSync(envPath, 'utf-8')
+		for (const line of envContent.split('\n')) {
+			const trimmed = line.trim()
+			if (!trimmed || trimmed.startsWith('#')) continue
+			const match = trimmed.match(/^([^=]+)=(.*)$/)
+			if (!match) continue
+
+			const key = match[1].trim()
+			let value = match[2].trim()
+			if (
+				(value.startsWith('"') && value.endsWith('"')) ||
+				(value.startsWith("'") && value.endsWith("'"))
+			) {
+				value = value.slice(1, -1)
+			} else {
+				const commentIndex = value.indexOf(' #')
+				if (commentIndex !== -1) {
+					value = value.slice(0, commentIndex).trimEnd()
+				}
+			}
+			process.env[key] = value
+		}
+	} catch {
+		// Optional local env file.
+	}
+}
+
+function parseArgs() {
+	const args = process.argv.slice(2)
+	let corporationId: string | undefined
+	let accessToken: string | undefined
+	let refreshToken: string | undefined
+	let clientId: string | undefined
+	let clientSecret: string | undefined
+	let baseUrl = 'https://esi.evetech.net'
+	let compatibilityDate = DEFAULT_COMPATIBILITY_DATE
+
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i]
+
+		if (arg === '--corp' || arg === '--corporation-id') {
+			corporationId = args[++i]
+		} else if (arg === '--access-token' || arg === '--token') {
+			accessToken = args[++i]
+		} else if (arg === '--refresh-token') {
+			refreshToken = args[++i]
+		} else if (arg === '--client-id') {
+			clientId = args[++i]
+		} else if (arg === '--client-secret') {
+			clientSecret = args[++i]
+		} else if (arg === '--base-url') {
+			baseUrl = args[++i] ?? baseUrl
+		} else if (arg === '--compatibility-date') {
+			compatibilityDate = args[++i] ?? compatibilityDate
+		} else if (arg === '--help' || arg === '-h') {
+			console.log('Usage: pnpm -F eve-corporation-data diagnose-sovereignty --corp <corporationId> [options]')
+			console.log('')
+			console.log('Options:')
+			console.log('  --corp, --corporation-id <id>   Corporation ID to inspect')
+			console.log('  --access-token <jwt>            Optional pre-minted access token override')
+			console.log('  --refresh-token <jwt>           Refresh token used to mint an access token')
+			console.log('  --client-id <id>                OAuth client ID for the refresh flow')
+			console.log('  --client-secret <secret>        OAuth client secret for the refresh flow')
+			console.log('  --base-url <url>                ESI base URL (default: https://esi.evetech.net)')
+			console.log('  --compatibility-date <YYYY-MM-DD>  Override ESI compatibility date')
+			console.log('')
+			console.log('Env defaults:')
+			console.log('  DIAGNOSTIC_EVE_SSO_REFRESH_TOKEN')
+			console.log('  DIAGNOSTIC_EVE_SSO_CLIENT_ID')
+			console.log('  DIAGNOSTIC_EVE_SSO_CLIENT_SECRET')
+			process.exit(0)
+		} else {
+			throw new Error(`Unknown argument: ${arg}`)
+		}
+	}
+
+	if (!corporationId) {
+		throw new Error('Missing required --corp/--corporation-id value')
+	}
+
+	return {
+		corporationId,
+		accessToken,
+		refreshToken,
+		clientId,
+		clientSecret,
+		baseUrl,
+		compatibilityDate,
+	}
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+	return baseUrl.replace(/\/+$/, '')
+}
+
+function getEnvValue(...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = process.env[key]?.trim()
+		if (value) {
+			return value
+		}
+	}
+	return undefined
+}
+
+async function fetchJson<T>(
+	url: string,
+	init: RequestInit,
+	label: string
+): Promise<{ data: T; headers: Headers; status: number }> {
+	const response = await fetch(url, init)
+	if (!response.ok) {
+		const body = await response.text()
+		throw new Error(`${label} failed: ${response.status} ${response.statusText} - ${body}`)
+	}
+
+	return {
+		data: (await response.json()) as T,
+		headers: response.headers,
+		status: response.status,
+	}
+}
+
+async function fetchOAuthMetadata() {
+	return await fetchJson<OAuthMetadata>(
+		EVE_OAUTH_METADATA_URL,
+		{
+			headers: {
+				'User-Agent': 'eve-corporation-data-diagnostics/1.0',
+				accept: 'application/json',
+			},
+		},
+		'GET /.well-known/oauth-authorization-server'
+	)
+}
+
+async function fetchSovereigntySystems(baseUrl: string, compatibilityDate: string) {
+	return await fetchJson<RawSovereigntySystem>(
+		`${baseUrl}/sovereignty/systems`,
+		{
+			headers: {
+				'User-Agent': 'eve-corporation-data-diagnostics/1.0',
+				'X-Compatibility-Date': compatibilityDate,
+			},
+		},
+		'GET /sovereignty/systems'
+	)
+}
+
+async function refreshAccessToken(input: {
+	clientId: string
+	clientSecret: string
+	refreshToken: string
+	tokenEndpoint: string
+}): Promise<string> {
+	const credentials = btoa(`${input.clientId}:${input.clientSecret}`)
+	const response = await fetch(input.tokenEndpoint, {
+		method: 'POST',
+		headers: {
+			Authorization: `Basic ${credentials}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+			Host: 'login.eveonline.com',
+			'User-Agent': 'eve-corporation-data-diagnostics/1.0',
+		},
+		body: new URLSearchParams({
+			grant_type: 'refresh_token',
+			refresh_token: input.refreshToken,
+		}),
+	})
+
+	if (!response.ok) {
+		const body = await response.text()
+		throw new Error(`Refresh token exchange failed: ${response.status} ${response.statusText} - ${body}`)
+	}
+
+	const tokenResponse = (await response.json()) as { access_token: string }
+	if (!tokenResponse.access_token) {
+		throw new Error('Refresh token exchange did not return an access token')
+	}
+
+	return tokenResponse.access_token
+}
+
+async function fetchSovereigntyHubs(
+	corporationId: string,
+	accessToken: string,
+	baseUrl: string,
+	compatibilityDate: string
+) {
+	const headers = {
+		Authorization: `Bearer ${accessToken}`,
+		'User-Agent': 'eve-corporation-data-diagnostics/1.0',
+		'X-Compatibility-Date': compatibilityDate,
+	}
+
+	const firstPage = await fetchJson<SovereigntyHubsListing>(
+		`${baseUrl}/corporations/${corporationId}/structures/sovereignty-hubs?page=1`,
+		{ headers },
+		'GET /corporations/{corporation_id}/structures/sovereignty-hubs?page=1'
+	)
+
+	const hubs = [...firstPage.data.sovereignty_hubs]
+	const totalPages = Number(firstPage.headers.get('X-Pages') ?? '1')
+
+	for (let page = 2; page <= totalPages; page += 1) {
+		const pageResult = await fetchJson<SovereigntyHubsListing>(
+			`${baseUrl}/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
+			{ headers },
+			`GET /corporations/{corporation_id}/structures/sovereignty-hubs?page=${page}`
+		)
+		hubs.push(...pageResult.data.sovereignty_hubs)
+	}
+
+	return {
+		pages: totalPages,
+		listing: hubs,
+	}
+}
+
+async function fetchSovereigntyHubDetails(
+	corporationId: string,
+	accessToken: string,
+	baseUrl: string,
+	compatibilityDate: string,
+	sovereigntyHubIds: number[]
+) {
+	const headers = {
+		Authorization: `Bearer ${accessToken}`,
+		'User-Agent': 'eve-corporation-data-diagnostics/1.0',
+		'X-Compatibility-Date': compatibilityDate,
+	}
+
+	const details = await Promise.all(
+		sovereigntyHubIds.map(async (hubId) => {
+			const result = await fetchJson<SovereigntyHubDetail>(
+				`${baseUrl}/corporations/${corporationId}/structures/sovereignty-hubs/${hubId}`,
+				{ headers },
+				`GET /corporations/{corporation_id}/structures/sovereignty-hubs/${hubId}`
+			)
+			return result.data
+		})
+	)
+
+	return details
+}
+
+async function fetchAllianceDetails(
+	baseUrl: string,
+	compatibilityDate: string,
+	allianceIds: number[]
+) {
+	const headers = {
+		'User-Agent': 'eve-corporation-data-diagnostics/1.0',
+		'X-Compatibility-Date': compatibilityDate,
+	}
+	const entries = await Promise.all(
+		allianceIds.map(async (allianceId) => {
+			try {
+				const result = await fetchJson<AllianceDetail>(
+					`${baseUrl}/alliances/${allianceId}`,
+					{ headers },
+					`GET /alliances/${allianceId}`
+				)
+				return [String(allianceId), result.data] as const
+			} catch (error) {
+				console.warn(
+					`Failed to resolve alliance ${allianceId}: ${error instanceof Error ? error.message : String(error)}`
+				)
+				return [String(allianceId), null] as const
+			}
+		})
+	)
+
+	return new Map(entries)
+}
+
+async function main(): Promise<void> {
+	loadEnvFile()
+	const {
+		corporationId,
+		accessToken,
+		refreshToken,
+		clientId,
+		clientSecret,
+		baseUrl,
+		compatibilityDate,
+	} = parseArgs()
+	const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+	const regionSystemIds = REGION_10000023_SYSTEM_IDS
+
+	let bearerToken =
+		accessToken ?? getEnvValue(`${DIAGNOSTIC_ENV_PREFIX}_EVE_SSO_ACCESS_TOKEN`)
+	if (!bearerToken) {
+		const oauthMetadata = await fetchOAuthMetadata()
+		const resolvedRefreshToken = refreshToken ?? getEnvValue(
+			`${DIAGNOSTIC_ENV_PREFIX}_EVE_SSO_REFRESH_TOKEN`
+		)
+		const resolvedClientId = clientId ?? getEnvValue(
+			`${DIAGNOSTIC_ENV_PREFIX}_EVE_SSO_CLIENT_ID`
+		)
+		const resolvedClientSecret = clientSecret ?? getEnvValue(
+			`${DIAGNOSTIC_ENV_PREFIX}_EVE_SSO_CLIENT_SECRET`
+		)
+
+		if (!resolvedRefreshToken) {
+			throw new Error(
+				'Missing access token and refresh token. Set DIAGNOSTIC_EVE_SSO_REFRESH_TOKEN (preferred) or pass --access-token.'
+			)
+		}
+		if (!resolvedClientId) {
+			throw new Error(
+				'Missing OAuth client ID. Set DIAGNOSTIC_EVE_SSO_CLIENT_ID (preferred) or pass --client-id.'
+			)
+		}
+		if (!resolvedClientSecret) {
+			throw new Error(
+				'Missing OAuth client secret. Set DIAGNOSTIC_EVE_SSO_CLIENT_SECRET (preferred) or pass --client-secret.'
+			)
+		}
+
+		bearerToken = await refreshAccessToken({
+			clientId: resolvedClientId,
+			clientSecret: resolvedClientSecret,
+			refreshToken: resolvedRefreshToken,
+			tokenEndpoint: oauthMetadata.data.token_endpoint,
+		})
+	}
+
+	const systemsResult = await fetchSovereigntySystems(normalizedBaseUrl, compatibilityDate)
+	const regionSystems = systemsResult.data.solar_systems.filter((system) =>
+		regionSystemIds.has(String(system.solar_system_id))
+	)
+	const systemById = new Map(regionSystems.map((system) => [String(system.solar_system_id), system] as const))
+
+	let hubsListing: Awaited<ReturnType<typeof fetchSovereigntyHubs>> | null = null
+	let hubDetails: SovereigntyHubDetail[] = []
+	let regionHubListing: SovereigntyHubsListing['sovereignty_hubs'] = []
+
+	if (bearerToken) {
+		hubsListing = await fetchSovereigntyHubs(
+			corporationId,
+			bearerToken,
+			normalizedBaseUrl,
+			compatibilityDate
+		)
+		const regionHubIds = hubsListing.listing
+			.filter((hub) => regionSystemIds.has(String(hub.solar_system_id)))
+			.map((hub) => hub.id)
+		regionHubListing = hubsListing.listing.filter((hub) =>
+			regionSystemIds.has(String(hub.solar_system_id))
+		)
+		hubDetails = await fetchSovereigntyHubDetails(
+			corporationId,
+			bearerToken,
+			normalizedBaseUrl,
+			compatibilityDate,
+			regionHubIds
+		)
+	}
+
+	const hubDetailsBySystemId = new Map(
+		hubDetails.map((detail) => [String(detail.solar_system_id), detail] as const)
+	)
+
+	const allianceIds = new Set<number>()
+	for (const system of regionSystems) {
+		const allianceId = system.claim?.alliance?.alliance_id
+		if (typeof allianceId === 'number') {
+			allianceIds.add(allianceId)
+		}
+	}
+	for (const hub of hubDetails) {
+		if (typeof hub.controller_alliance_id === 'number') {
+			allianceIds.add(hub.controller_alliance_id)
+		}
+	}
+
+	const allianceDetailsById = allianceIds.size > 0
+		? await fetchAllianceDetails(normalizedBaseUrl, compatibilityDate, [...allianceIds])
+		: new Map<string, AllianceDetail | null>()
+
+	const sovereigntySystemSummary = regionSystems.map((system) => {
+		const claim = system.claim
+		if (claim?.alliance) {
+			const allianceId = String(claim.alliance.alliance_id)
+			const alliance = allianceDetailsById.get(allianceId) ?? null
+			return {
+				systemId: String(system.solar_system_id),
+				claimType: 'alliance',
+				allianceId,
+				allianceName: alliance?.name ?? null,
+				allianceTicker: alliance?.ticker ?? null,
+				corporationId: String(claim.alliance.corporation_id),
+				sovereigntyHubId: String(claim.alliance.sovereignty_hub.id),
+			}
+		}
+
+		if (claim?.faction) {
+			return {
+				systemId: String(system.solar_system_id),
+				claimType: 'faction',
+				factionId: String(claim.faction.faction_id),
+			}
+		}
+
+			return {
+				systemId: String(system.solar_system_id),
+				claimType: 'unclaimed',
+			}
+	})
+
+	const hubComparison = regionHubListing.map((hub) => {
+			const detail = hubDetailsBySystemId.get(String(hub.solar_system_id))
+			const system = systemById.get(String(hub.solar_system_id))
+			const alliance = system?.claim?.alliance ?? null
+			const allianceId = alliance ? alliance.alliance_id : null
+			const systemAlliance = allianceId !== null ? allianceDetailsById.get(String(allianceId)) ?? null : null
+			const controllerAllianceId = detail?.controller_alliance_id ?? null
+			const controllerAlliance =
+				controllerAllianceId !== null
+					? allianceDetailsById.get(String(controllerAllianceId)) ?? null
+					: null
+
+			return {
+				structureId: String(hub.id),
+				systemId: String(hub.solar_system_id),
+				esiControllerAllianceId: detail?.controller_alliance_id ?? null,
+				esiControllerAllianceName: controllerAlliance?.name ?? null,
+				esiControllerAllianceTicker: controllerAlliance?.ticker ?? null,
+				esiAllianceIdFromSystems: allianceId !== null ? String(allianceId) : null,
+				esiAllianceNameFromSystems: systemAlliance?.name ?? null,
+				esiAllianceTickerFromSystems: systemAlliance?.ticker ?? null,
+				systemClaimType: system?.claim
+					? 'alliance' in system.claim
+						? 'alliance'
+						: 'faction' in system.claim
+							? 'faction'
+							: 'unclaimed'
+					: 'unknown',
+			}
+		})
+
+	const mismatches = hubComparison.filter(
+		(entry) => entry.esiControllerAllianceId !== entry.esiAllianceIdFromSystems
+	)
+
+	const output = {
+		fetchedAt: new Date().toISOString(),
+		corporationId,
+		regionFilter: {
+			regionId: REGION_10000023_ID,
+			regionName: REGION_10000023_NAME,
+			systemCount: regionSystemIds.size,
+		},
+		compatibilityDate,
+		baseUrl: normalizedBaseUrl,
+		systems: {
+			count: regionSystems.length,
+			headers: {
+				etag: systemsResult.headers.get('ETag'),
+				expires: systemsResult.headers.get('Expires'),
+				lastModified: systemsResult.headers.get('Last-Modified'),
+			},
+			raw: {
+				solar_systems: regionSystems,
+			},
+			summary: sovereigntySystemSummary,
+		},
+		sovereigntyHubs: hubsListing
+			? {
+					count: regionHubListing.length,
+					pages: hubsListing.pages,
+					rawListing: regionHubListing,
+					rawDetails: hubDetails,
+					alliances: [...allianceDetailsById.entries()].map(([allianceId, alliance]) => ({
+						allianceId,
+						allianceName: alliance?.name ?? null,
+						allianceTicker: alliance?.ticker ?? null,
+					})),
+					comparison: hubComparison,
+					mismatches,
+				}
+			: null,
+	}
+
+	process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+
+	if (mismatches.length > 0) {
+		process.stderr.write(`\nFound ${mismatches.length} controller alliance mismatches.\n`)
+	}
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error))
+	process.exit(1)
+})

--- a/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+	const fetchSovereigntySystemsMock = vi.fn()
+	const createTokenStoreMock = vi.fn()
+	const getGlobalCorporationDataStubMock = vi.fn()
+
+	return {
+		fetchSovereigntySystemsMock,
+		createTokenStoreMock,
+		getGlobalCorporationDataStubMock,
+	}
+})
+
+vi.mock('../../../services/esi-fetch', () => ({
+	fetchSovereigntySystems: (...args: unknown[]) => mocks.fetchSovereigntySystemsMock(...args),
+}))
+
+vi.mock('../../../workflows/utils/services', () => ({
+	createTokenStore: (...args: unknown[]) => mocks.createTokenStoreMock(...args),
+	getGlobalCorporationDataStub: (...args: unknown[]) =>
+		mocks.getGlobalCorporationDataStubMock(...args),
+}))
+
+import { refreshSharedSovereigntySystems } from '../../../workflows/utils/sovereignty-systems-cache'
+
+describe('refreshSharedSovereigntySystems', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('returns the fresh snapshot without acquiring a lease or fetching ESI', async () => {
+		const getSharedSovereigntySystemsSnapshotMock = vi.fn().mockResolvedValue([
+			{ system_id: '30000142' },
+		])
+		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const storeSharedSovereigntySystemsMock = vi.fn()
+
+		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+			acquireSharedSovereigntySystemsRefreshLease:
+				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			releaseSharedSovereigntySystemsRefreshLease:
+				releaseSharedSovereigntySystemsRefreshLeaseMock,
+			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
+			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
+		})
+
+		const result = await refreshSharedSovereigntySystems({} as never)
+
+		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalled()
+		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
+		expect(mocks.fetchSovereigntySystemsMock).not.toHaveBeenCalled()
+		expect(storeSharedSovereigntySystemsMock).not.toHaveBeenCalled()
+		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
+		expect(result).toEqual([{ system_id: '30000142' }])
+	})
+
+	it('uses the lease holder to refresh the snapshot and releases the lease afterward', async () => {
+		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const storeSharedSovereigntySystemsMock = vi.fn()
+		const getSharedSovereigntySystemsSnapshotMock = vi
+			.fn()
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce(null)
+		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi
+			.fn()
+			.mockResolvedValue('lease-token')
+
+		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.fetchSovereigntySystemsMock.mockResolvedValue([{ system_id: '30000142' }])
+		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+			acquireSharedSovereigntySystemsRefreshLease:
+				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			releaseSharedSovereigntySystemsRefreshLease:
+				releaseSharedSovereigntySystemsRefreshLeaseMock,
+			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
+			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
+		})
+
+		const result = await refreshSharedSovereigntySystems({} as never)
+
+		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(mocks.createTokenStoreMock).toHaveBeenCalledWith({})
+		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
+		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000142' }])
+		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
+		expect(result).toEqual([{ system_id: '30000142' }])
+		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(2)
+	})
+
+	it('falls back to the existing snapshot when another refresh already holds the lease', async () => {
+		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const storeSharedSovereigntySystemsMock = vi.fn()
+		const getSharedSovereigntySystemsSnapshotMock = vi
+			.fn()
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce([{ system_id: '30000142' }])
+		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue(null)
+
+		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+			acquireSharedSovereigntySystemsRefreshLease:
+				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			releaseSharedSovereigntySystemsRefreshLease:
+				releaseSharedSovereigntySystemsRefreshLeaseMock,
+			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
+			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
+		})
+
+		const result = await refreshSharedSovereigntySystems({} as never)
+
+		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(mocks.fetchSovereigntySystemsMock).not.toHaveBeenCalled()
+		expect(storeSharedSovereigntySystemsMock).not.toHaveBeenCalled()
+		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
+		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(2)
+		expect(result).toEqual([{ system_id: '30000142' }])
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -4,6 +4,7 @@ const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 const mocks = vi.hoisted(() => {
 	const fetchSovereigntyHubsMock = vi.fn()
 	const readSharedSovereigntySystemsByIdsMock = vi.fn()
+	const refreshSharedSovereigntySystemsMock = vi.fn()
 	const resolveSolarSystemsByIdsMock = vi.fn()
 	const getStubMock = vi.fn(() => ({
 		resolveSolarSystemsByIds: resolveSolarSystemsByIdsMock,
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => {
 	return {
 		fetchSovereigntyHubsMock,
 		readSharedSovereigntySystemsByIdsMock,
+		refreshSharedSovereigntySystemsMock,
 		resolveSolarSystemsByIdsMock,
 		getStubMock,
 		createTokenStoreMock,
@@ -35,6 +37,8 @@ vi.mock('../../../workflows/utils/services', () => ({
 vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
 	readSharedSovereigntySystemsByIds: (...args: unknown[]) =>
 		mocks.readSharedSovereigntySystemsByIdsMock(...args),
+	refreshSharedSovereigntySystems: (...args: unknown[]) =>
+		mocks.refreshSharedSovereigntySystemsMock(...args),
 }))
 
 import { fetchSovereigntyEnrichment } from '../../../workflows/steps/structures'
@@ -42,6 +46,23 @@ import { fetchSovereigntyEnrichment } from '../../../workflows/steps/structures'
 describe('fetchSovereigntyEnrichment', () => {
 	it('enriches sovereignty hub names from resolved solar systems before persistence', async () => {
 		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.readSharedSovereigntySystemsByIdsMock.mockResolvedValue([
+			{
+				system_id: '30000142',
+				claim_type: 'alliance',
+				alliance_id: '123456789',
+				corporation_id: '987654321',
+				claimed_since: '2026-07-12T19:36:46.834Z',
+				is_capital_system: false,
+				sovereignty_hub_structure_id: 'hub-1',
+				vulnerability_window: null,
+				activity_defense_multiplier: '1.0000',
+				military_level: 1,
+				industrial_level: 1,
+				strategic_level: 1,
+				raw: { claim: {} },
+			},
+		])
 		mocks.fetchSovereigntyHubsMock.mockResolvedValue([
 			{
 				structure_id: 'hub-1',
@@ -69,7 +90,6 @@ describe('fetchSovereigntyEnrichment', () => {
 				raw: { detail: { id: 1 } },
 			},
 		])
-		mocks.readSharedSovereigntySystemsByIdsMock.mockResolvedValue([])
 		mocks.resolveSolarSystemsByIdsMock.mockResolvedValue({
 			'30000142': {
 				solarSystemName: 'Jita',
@@ -85,11 +105,18 @@ describe('fetchSovereigntyEnrichment', () => {
 		)
 
 		expect(mocks.fetchSovereigntyHubsMock).toHaveBeenCalledWith({}, 'corp-1', 'character-1')
+		expect(mocks.readSharedSovereigntySystemsByIdsMock).toHaveBeenCalledWith(
+			{
+				UNIVERSE: {},
+			},
+			['30000142']
+		)
 		expect(mocks.getStubMock).toHaveBeenCalledWith({}, 'default')
 		expect(mocks.resolveSolarSystemsByIdsMock).toHaveBeenCalledWith(['30000142'])
 		expect(result?.sovereigntyHubs[0]).toMatchObject({
 			name: 'Jita',
 			system_name: 'Jita',
+			controller_alliance_id: '123456789',
 		})
 	})
 

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -8,7 +8,10 @@ import {
 	type StructureEnrichmentSyncTarget,
 } from '../../utils/structure-enrichment-auth'
 import { createTokenStore, getCorporationDataStub } from '../../utils/services'
-import { readSharedSovereigntySystemsByIds } from '../../utils/sovereignty-systems-cache'
+import {
+	readSharedSovereigntySystemsByIds,
+	refreshSharedSovereigntySystems,
+} from '../../utils/sovereignty-systems-cache'
 import type { Universe } from '@repo/universe'
 import type { SkyhookStoreResult } from '@repo/eve-corporation-data'
 
@@ -81,19 +84,19 @@ export async function fetchSovereigntyEnrichment(
 						[...new Set(sovereigntyHubs.map((hub) => hub.system_id))]
 					)
 				: {}
-		const sovereigntySystems = await readSharedSovereigntySystemsByIds(
+		let sovereigntySystems = await readSharedSovereigntySystemsByIds(
 			env,
 			sovereigntyHubs.map((hub) => hub.system_id)
 		)
 		if (!sovereigntySystems) {
-			logger.warn(
-				'[StructuresStep] Shared sovereignty snapshot missing or stale; skipping system enrichment',
-				{ corporationId }
-			)
+			logger.warn('[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache', {
+				corporationId,
+			})
+			sovereigntySystems = await refreshSharedSovereigntySystems(env)
 		}
 
 		const allianceBySystemId = new Map(
-			(sovereigntySystems ?? [])
+			sovereigntySystems
 				.filter((system) => system.claim_type === 'alliance' && system.alliance_id !== undefined)
 				.map((system) => [system.system_id, system.alliance_id ?? null])
 		)

--- a/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
@@ -4,7 +4,14 @@ import { createTokenStore, getGlobalCorporationDataStub } from './services'
 import type { EsiSovereigntySystem } from '@repo/eve-corporation-data'
 import type { Env } from '../../context'
 
-const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS = 300
+const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS = 60 * 60
+const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_RETRY_DELAYS_MS = [250, 500, 1000]
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms)
+	})
+}
 
 /**
  * Read the shared sovereignty snapshot subset for the requested system IDs if it is still fresh enough.
@@ -26,9 +33,47 @@ export async function readSharedSovereigntySystemsByIds(
 export async function refreshSharedSovereigntySystems(
 	env: Env
 ): Promise<EsiSovereigntySystem[]> {
-	const tokenStore = createTokenStore(env)
-	const sovereigntySystems = await esiFetch.fetchSovereigntySystems(tokenStore)
 	const globalCorpData = getGlobalCorporationDataStub(env)
-	await globalCorpData.storeSharedSovereigntySystems(sovereigntySystems)
-	return sovereigntySystems
+	const freshSnapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
+		SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+	)
+	if (freshSnapshot) {
+		return freshSnapshot
+	}
+
+	const leaseToken = await globalCorpData.acquireSharedSovereigntySystemsRefreshLease()
+
+	if (leaseToken) {
+		try {
+			const refreshedSnapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
+				SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+			)
+			if (refreshedSnapshot) {
+				return refreshedSnapshot
+			}
+
+			const tokenStore = createTokenStore(env)
+			const sovereigntySystems = await esiFetch.fetchSovereigntySystems(tokenStore)
+			await globalCorpData.storeSharedSovereigntySystems(sovereigntySystems)
+			return sovereigntySystems
+		} finally {
+			await globalCorpData.releaseSharedSovereigntySystemsRefreshLease(leaseToken)
+		}
+	}
+
+	for (const delayMs of SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_RETRY_DELAYS_MS) {
+		const snapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+		)
+		if (snapshot) {
+			return snapshot
+		}
+		await sleep(delayMs)
+	}
+
+	return (
+		(await globalCorpData.getSharedSovereigntySystemsSnapshot(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+		)) ?? []
+	)
 }

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -303,6 +303,7 @@ export interface StructureSovereigntyHubSummary {
 export interface StructureSovereigntySummary {
 	claimType: 'alliance' | 'faction' | 'unclaimed'
 	allianceId: string | null
+	allianceName?: string | null
 	corporationClaimantId: string | null
 	factionId: string | null
 	claimedSince: string | null

--- a/apps/ui/src/client/components/skyhook-state-badge.tsx
+++ b/apps/ui/src/client/components/skyhook-state-badge.tsx
@@ -1,0 +1,25 @@
+import { Badge } from '@/components/ui/badge'
+
+type SkyhookState = 'vulnerable' | 'invulnerable' | 'reinforced'
+
+function getSkyhookStateBadgeState(state: string): { label: string; variant: 'ghost' | 'success' | 'destructive' } {
+	switch (state.trim().toLowerCase() as SkyhookState) {
+		case 'reinforced':
+			return { label: 'Reinforced', variant: 'destructive' }
+		case 'invulnerable':
+			return { label: 'Invulnerable', variant: 'ghost' }
+		case 'vulnerable':
+		default:
+			return { label: 'Vulnerable', variant: 'success' }
+	}
+}
+
+export function SkyhookStateBadge({ state, className }: { state: string; className?: string }) {
+	const { label, variant } = getSkyhookStateBadgeState(state)
+
+	return (
+		<Badge variant={variant} className={className}>
+			{label}
+		</Badge>
+	)
+}

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -881,6 +881,7 @@ export interface StructureSovereigntyHubSummary {
 export interface StructureSovereigntySummary {
 	claimType: 'alliance' | 'faction' | 'unclaimed'
 	allianceId: string | null
+	allianceName?: string | null
 	corporationClaimantId: string | null
 	factionId: string | null
 	claimedSince: string | null

--- a/apps/ui/src/client/lib/skyhook-vulnerability-window.ts
+++ b/apps/ui/src/client/lib/skyhook-vulnerability-window.ts
@@ -1,4 +1,4 @@
-export type SkyhookVulnerabilityWindowLabel = 'Starts in' | 'Raidable for' | 'Ends in' | 'expired'
+export type SkyhookVulnerabilityWindowLabel = 'Starts in' | 'Raidable for' | 'Ends in' | 'Expired'
 
 export interface SkyhookVulnerabilityWindowDisplay {
 	hasWindow: boolean
@@ -52,7 +52,7 @@ export function getSkyhookVulnerabilityWindowDisplay(input: {
 		return {
 			hasWindow,
 			isActiveWindow,
-			label: 'expired',
+			label: 'Expired',
 			countdownTarget: null,
 		}
 	}

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -27,6 +27,7 @@ import {
 
 import { CorporationLogo } from '@/components/corporation-logo'
 import { StructureFuelUsageChart } from '@/components/structure-fuel-usage-chart'
+import { SkyhookStateBadge } from '@/components/skyhook-state-badge'
 import { StructureStateBadge } from '@/components/structure-state-badge'
 import { StructureSyncStatusBadge } from '@/components/structure-sync-status-badge'
 import { Badge } from '@/components/ui/badge'
@@ -780,6 +781,8 @@ export default function StructuresDetailPage() {
 	const moonDrill = structure?.moonDrill ?? null
 	const miningExtraction = structure?.miningExtraction ?? null
 	const sovereigntyHub = structure?.sovereignty?.hub ?? null
+	const sovereigntyAllianceId = structure?.sovereignty?.allianceId ?? null
+	const sovereigntyAllianceName = structure?.sovereignty?.allianceName ?? null
 	const sovereigntyVulnerabilityState = getSovereigntyVulnerabilityState(structure?.sovereignty)
 	const { data: sovereigntyStructures = [] } = useQuery({
 		queryKey: ['structures', 'sovereignty', corporationId],
@@ -956,15 +959,14 @@ export default function StructuresDetailPage() {
 									</div>
 									<div className="font-medium">
 										{hasSovereigntySummary
-											? sovereigntyHub?.controllerAllianceId ? (
+											? sovereigntyAllianceId ? (
 													<div className="flex items-center gap-2">
 														<AllianceLogo
-															allianceId={sovereigntyHub.controllerAllianceId}
-															allianceName={sovereigntyHub.controllerAllianceName}
+															allianceId={sovereigntyAllianceId}
+															allianceName={sovereigntyAllianceName}
 														/>
 														<span>
-															{sovereigntyHub.controllerAllianceName ??
-																sovereigntyHub.controllerAllianceId}
+															{sovereigntyAllianceName ?? sovereigntyAllianceId}
 														</span>
 													</div>
 												) : (
@@ -1052,7 +1054,7 @@ export default function StructuresDetailPage() {
 								</div>
 								<div>
 									<div className="text-muted-foreground">
-										{hasSovereigntySummary ? 'Vulnerability Window' : isReinforced ? 'Reinforced until' : 'Next State'}
+										{hasSovereigntySummary ? 'Theft Window' : isReinforced ? 'Reinforced until' : 'Next State'}
 									</div>
 									<div className="font-medium">
 										{hasSovereigntySummary ? (
@@ -1430,7 +1432,7 @@ export default function StructuresDetailPage() {
 							<div className="text-muted-foreground">State</div>
 							<div className="font-medium">
 								{structure.skyhook ? (
-									<StructureStateBadge state={structure.skyhook.state} />
+									<SkyhookStateBadge state={structure.skyhook.state} />
 								) : (
 									'-'
 								)}

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -27,6 +27,7 @@ import {
 
 import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { CorporationLogo } from '@/components/corporation-logo'
+import { SkyhookStateBadge } from '@/components/skyhook-state-badge'
 import { StructureSyncStatusBadge } from '@/components/structure-sync-status-badge'
 import { StructureStateBadge } from '@/components/structure-state-badge'
 import { DurationDisplay } from '@/components/ui/duration-display'
@@ -711,7 +712,7 @@ export default function StructuresPage() {
 			return (
 				<TableRow key={structure.structureId}>
 					<TableCell>
-						<StructureStateBadge state={structure.state} />
+						<SkyhookStateBadge state={structure.state} />
 					</TableCell>
 					<TableCell className="font-medium">
 						{structure.regionName ?? structure.regionId ?? '-'}
@@ -925,7 +926,7 @@ export default function StructuresPage() {
 					</TableCell>
 					<TableCell>{formatNullableNumber(structure.effectiveWorkforce)}</TableCell>
 					<TableCell>
-						<Badge variant={structure.isRaidable ? 'warning' : 'ghost'}>
+						<Badge variant={structure.isRaidable ? 'warning' : 'success'}>
 							{structure.isRaidable ? 'Yes' : 'No'}
 						</Badge>
 					</TableCell>
@@ -1741,7 +1742,7 @@ export default function StructuresPage() {
 												<SortableHead field="skyhookSurplusFullness" label="Fullness (Surplus)" />
 												<SortableHead field="workforce" label="Workforce" />
 												<SortableHead field="raidable" label="Raidable" />
-												<SortableHead field="theftVulnerabilityStart" label="Vulnerability Window" />
+												<SortableHead field="theftVulnerabilityStart" label="Theft Window" />
 												<SortableHead field="nextStateAt" label="Next State In" />
 												<SortableHead field="group" label="Group" />
 												<SortableHead field="syncStatus" label="Sync" />

--- a/apps/ui/src/test/unit/skyhook-vulnerability-window.test.ts
+++ b/apps/ui/src/test/unit/skyhook-vulnerability-window.test.ts
@@ -45,7 +45,7 @@ describe('getSkyhookVulnerabilityWindowDisplay', () => {
 		expect(afterWindow).toEqual({
 			hasWindow: true,
 			isActiveWindow: false,
-			label: 'expired',
+			label: 'Expired',
 			countdownTarget: null,
 		})
 	})
@@ -62,7 +62,7 @@ describe('getSkyhookVulnerabilityWindowDisplay', () => {
 		expect(result).toEqual({
 			hasWindow: true,
 			isActiveWindow: false,
-			label: 'expired',
+			label: 'Expired',
 			countdownTarget: null,
 		})
 	})

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -1315,12 +1315,30 @@ export interface EveCorporationData {
 	storeSharedSovereigntySystems(systems: EsiSovereigntySystem[]): Promise<void>
 
 	/**
+	 * Acquire a short-lived refresh lease for the shared sovereignty snapshot.
+	 * Returns a token when acquired, or null when another refresh is already in progress.
+	 */
+	acquireSharedSovereigntySystemsRefreshLease(
+		leaseSeconds?: number
+	): Promise<string | null>
+
+	/**
+	 * Release a previously acquired shared sovereignty refresh lease.
+	 */
+	releaseSharedSovereigntySystemsRefreshLease(leaseToken: string): Promise<void>
+
+	/**
 	 * Read a subset of the shared sovereignty system snapshot by system ID if it is still fresh.
 	 */
 	getSharedSovereigntySystemsByIds(
 		systemIds: string[],
 		maxAgeSeconds?: number
 	): Promise<EsiSovereigntySystem[] | null>
+
+	/**
+	 * Read the entire shared sovereignty system snapshot if it is still fresh.
+	 */
+	getSharedSovereigntySystemsSnapshot(maxAgeSeconds?: number): Promise<EsiSovereigntySystem[] | null>
 
 	/**
 	 * Get a cached sovereignty system snapshot if it is still fresh enough.

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -590,6 +590,7 @@ export interface StructureSovereigntyHubSummary {
 export interface StructureSovereigntySummary {
 	claimType: 'alliance' | 'faction' | 'unclaimed'
 	allianceId: string | null
+	allianceName?: string | null
 	corporationClaimantId: string | null
 	factionId: string | null
 	claimedSince: string | null


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes sovereignty structure enrichment to source the controlling alliance from the sovereignty claim (system-level) instead of the sovereignty hub's `controller_alliance_id`, which could be stale or mismatched, and hardens the shared sovereignty-systems cache against thundering-herd ESI refreshes. Also tweaks skyhook-related UI copy and badges.

## Changes
- **Sovereignty alliance source of truth**: `apps/core/src/routes/structures.ts` now derives `allianceId`/`allianceName` from `sovereignty.allianceId` (the system claim) rather than `sovereigntyHub.controllerAllianceId`; added `allianceName` to `StructureSovereigntySummary` in `packages/structures`, `apps/structures`, and the UI API types.
- **Shared sovereignty cache**: raised `SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS`/TTL from 5 minutes to 1 hour, and added a lease-based refresh mechanism (`acquireSharedSovereigntySystemsRefreshLease` / `releaseSharedSovereigntySystemsRefreshLease` / `getSharedSovereigntySystemsSnapshot` on `EveCorporationDataDO`) so only one caller refreshes from ESI while others poll the snapshot with retry/backoff.
- **Enrichment fallback**: `fetchSovereigntyEnrichment` now calls `refreshSharedSovereigntySystems` to rewarm the cache when the shared snapshot is missing/stale instead of just logging a warning and skipping enrichment.
- **Diagnostics**: added `apps/eve-corporation-data/src/scripts/diagnose-sovereignty.ts` (pnpm -F eve-corporation-data diagnose-sovereignty) to compare ESI /sovereignty/systems claims against corp sovereignty hub details for a region and surface controller-alliance mismatches.
- **UI copy/badges**: renamed "Vulnerability Window" to "Theft Window" in the structures list/detail pages, capitalized the "Expired" window label, introduced a dedicated SkyhookStateBadge component (used in place of StructureStateBadge for skyhooks), and changed the non-raidable badge variant from ghost to success.

## Testing
- Added apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts covering the fresh-snapshot, lease-acquired-refresh, and lease-contended fallback paths of refreshSharedSovereigntySystems.
- Updated structure-enrichment.test.ts to reflect alliance data coming from the shared sovereignty systems snapshot.
- Updated skyhook-vulnerability-window.test.ts for the "Expired" label capitalization change.
<!-- claude:end -->