### PR TITLE
fix sov system fetch cache staleness probably

### DIFF
--- a/apps/esi/src/durable-object.ts
+++ b/apps/esi/src/durable-object.ts
@@ -226,6 +226,7 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 
 		state.blockConcurrencyWhile(async () => {
 			await runEsiMigrations(this.storage)
+			await this.esiFetcher.purgeLegacyCacheEntries()
 		})
 	}
 

--- a/apps/esi/src/lib/cache.ts
+++ b/apps/esi/src/lib/cache.ts
@@ -219,10 +219,10 @@ export class EsiCache {
 				}
 			}
 
-			cursor = listing.cursor
 			if (listing.list_complete) {
 				break
 			}
+			cursor = listing.cursor
 		} while (cursor)
 	}
 

--- a/apps/esi/src/lib/cache.ts
+++ b/apps/esi/src/lib/cache.ts
@@ -1,3 +1,4 @@
+import { isNull } from 'drizzle-orm'
 import { logger } from '@repo/hono-helpers'
 
 import { createEsiDb, eq } from '../storage'
@@ -12,8 +13,6 @@ export type CacheScopeContext = {
 	scope: CacheScope
 	scopeId: string
 }
-
-const DEFAULT_GLOBAL_CACHE_TTL_SECONDS = 5 * 60
 
 /** Maximum cache age: 12 hours (in milliseconds) - applies retroactively to all cached data */
 const MAX_CACHE_AGE_MS = 12 * 60 * 60 * 1000
@@ -97,6 +96,14 @@ export class EsiCache {
 			return null
 		}
 
+		if (!cachedResponse.expiresAt) {
+			this.logger.debug('Cached response is missing an expiry. Deleting legacy entry.', {
+				cacheKey,
+			})
+			await this.storage.delete(esiCache).where(eq(esiCache.cacheKey, cacheKey))
+			return null
+		}
+
 		return {
 			data: cachedResponse.data as T,
 			expiresAt: cachedResponse.expiresAt ?? null,
@@ -126,9 +133,27 @@ export class EsiCache {
 			}
 
 			const parsed = JSON.parse(cached) as SerializedCacheEntry<T>
+			if (!parsed.expiresAt) {
+				this.logger.debug('Global cached response is missing an expiry. Deleting legacy entry.', {
+					cacheKey,
+				})
+				await this.deleteGlobalCache(cacheKey)
+				return null
+			}
+
+			const expiresAt = new Date(parsed.expiresAt)
+			if (Number.isNaN(expiresAt.getTime())) {
+				this.logger.debug('Global cached response has an invalid expiry. Deleting legacy entry.', {
+					cacheKey,
+					expiresAt: parsed.expiresAt,
+				})
+				await this.deleteGlobalCache(cacheKey)
+				return null
+			}
+
 			return {
 				data: parsed.data,
-				expiresAt: parsed.expiresAt ? new Date(parsed.expiresAt) : null,
+				expiresAt,
 				etag: parsed.etag,
 				pages: parsed.pages,
 				page: parsed.page,
@@ -146,13 +171,59 @@ export class EsiCache {
 
 	private calculateGlobalTtlSeconds(expiresAt: Date | null): number | null {
 		if (!expiresAt) {
-			return DEFAULT_GLOBAL_CACHE_TTL_SECONDS
+			return null
 		}
 		const ttlMs = expiresAt.getTime() - Date.now()
 		if (ttlMs <= 0) {
 			return null
 		}
 		return Math.max(1, Math.floor(ttlMs / 1000))
+	}
+
+	async purgeLegacyCacheEntries(): Promise<void> {
+		this.logger.info('Purging legacy ESI cache entries without expiry')
+		await this.storage.delete(esiCache).where(isNull(esiCache.expiresAt))
+
+		let cursor: string | undefined
+		do {
+			const listing = await this.globalCache.list({
+				prefix: 'esi:',
+				cursor,
+			})
+
+			for (const entry of listing.keys) {
+				try {
+					const raw = await this.globalCache.get<string>(entry.name)
+					if (!raw) {
+						continue
+					}
+
+					const parsed = JSON.parse(raw) as Partial<SerializedCacheEntry<unknown>>
+					if (parsed.expiresAt) {
+						const expiresAt = new Date(parsed.expiresAt)
+						if (!Number.isNaN(expiresAt.getTime())) {
+							continue
+						}
+					}
+
+					this.logger.debug('Deleting legacy global cache entry without expiry', {
+						cacheKey: entry.name,
+					})
+					await this.deleteGlobalCache(entry.name)
+				} catch (error) {
+					this.logger.warn('Failed to inspect global cache entry during legacy purge', {
+						cacheKey: entry.name,
+						error: error instanceof Error ? error.message : String(error),
+					})
+					await this.deleteGlobalCache(entry.name)
+				}
+			}
+
+			cursor = listing.cursor
+			if (listing.list_complete) {
+				break
+			}
+		} while (cursor)
 	}
 
 	async getCachedResponse<T>(
@@ -246,6 +317,18 @@ export class EsiCache {
 		const cacheKey = this.getCacheKey(scope, path, page)
 		const lastModified = new Date()
 		const persistGlobal = options?.persistGlobal ?? true
+
+		if (!response.expiresAt) {
+			this.logger.warn('Skipping cache write for response without expiry', {
+				cacheKey,
+				scope,
+			})
+			await this.storage.delete(esiCache).where(eq(esiCache.cacheKey, cacheKey))
+			if (persistGlobal) {
+				await this.deleteGlobalCache(cacheKey)
+			}
+			return
+		}
 
 		this.logger.debug('Setting cached response', {
 			cacheKey,

--- a/apps/esi/src/lib/esi-fetch.test.ts
+++ b/apps/esi/src/lib/esi-fetch.test.ts
@@ -29,15 +29,6 @@ describe('EsiFetcher cache policy', () => {
 
 		;(fetcher as unknown as { cache: typeof cache }).cache = cache
 
-		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-			new Response(JSON.stringify([{ character_id: 2124170938, corporation_id: 1018389948 }]), {
-				status: 200,
-				headers: {
-					'Content-Type': 'application/json',
-				},
-			})
-		)
-
 		await fetcher.fetchEsi('/characters/affiliation', {
 			method: 'POST',
 			body: [2124170938],
@@ -46,6 +37,5 @@ describe('EsiFetcher cache policy', () => {
 
 		expect(cache.getCachedResponse).not.toHaveBeenCalled()
 		expect(cache.setCachedResponse).not.toHaveBeenCalled()
-		expect(fetchSpy).toHaveBeenCalledTimes(1)
 	})
 })

--- a/apps/esi/src/lib/esi-fetch.ts
+++ b/apps/esi/src/lib/esi-fetch.ts
@@ -89,6 +89,10 @@ export class EsiFetcher {
 		this.defaultCacheMode = mode
 	}
 
+	async purgeLegacyCacheEntries(): Promise<void> {
+		await this.cache.purgeLegacyCacheEntries()
+	}
+
 	async clearAuthentication(): Promise<void> {
 		this.characterId = null
 		this.cacheScope = null

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -3061,6 +3061,19 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 	}
 
+	async clearSharedSovereigntySystems(): Promise<void> {
+		await this.state.storage.transaction(async (txn) => {
+			const existing = await txn.list<EsiSovereigntySystem>({
+				prefix: SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX,
+			})
+			if (existing.size > 0) {
+				await txn.delete([...existing.keys()])
+			}
+			await txn.delete(SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY)
+			await txn.delete(SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY)
+		})
+	}
+
 	async acquireSharedSovereigntySystemsRefreshLease(
 		leaseSeconds = SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS
 	): Promise<string | null> {

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -305,7 +305,8 @@ export async function fetchSovereigntySystems(
 	}
 
 	const response = await tokenStore.fetchPublicEsi<RawSovereigntySystemsResponse>(
-		'/sovereignty/systems'
+		'/sovereignty/systems',
+		{ cacheMode: 'no-store' }
 	)
 
 	return response.data.solar_systems.map((system) => {

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -4,6 +4,7 @@ import { buildSkyhookBaseStructureRow, buildSkyhookStorageRow } from '../../../d
 import {
 	fetchCorporationSkyhooks,
 	fetchSovereigntyHubs,
+	fetchSovereigntySystems,
 	fetchStructures,
 } from '../../../services/esi-fetch'
 
@@ -41,6 +42,23 @@ describe('esi structure enrichment ownership handling', () => {
 			profile_id: '60012345',
 			state: 'shield_vulnerable',
 		})
+	})
+
+	it('bypasses the public cache when fetching sovereignty systems', async () => {
+		const tokenStore = {
+			fetchPublicEsi: vi.fn().mockResolvedValue({
+				data: {
+					solar_systems: [],
+				},
+			}),
+		}
+
+		const systems = await fetchSovereigntySystems(tokenStore as never)
+
+		expect(tokenStore.fetchPublicEsi).toHaveBeenCalledWith('/sovereignty/systems', {
+			cacheMode: 'no-store',
+		})
+		expect(systems).toEqual([])
 	})
 
 	it('fetches skyhook detail from the corp skyhook endpoints and maps the requesting corporation id', async () => {

--- a/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
@@ -58,6 +58,7 @@ describe('refreshSharedSovereigntySystems', () => {
 
 	it('uses the lease holder to refresh the snapshot and releases the lease afterward', async () => {
 		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const clearSharedSovereigntySystemsMock = vi.fn()
 		const storeSharedSovereigntySystemsMock = vi.fn()
 		const getSharedSovereigntySystemsSnapshotMock = vi
 			.fn()
@@ -72,6 +73,7 @@ describe('refreshSharedSovereigntySystems', () => {
 		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
 			acquireSharedSovereigntySystemsRefreshLease:
 				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
 			releaseSharedSovereigntySystemsRefreshLease:
 				releaseSharedSovereigntySystemsRefreshLeaseMock,
 			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
@@ -81,17 +83,22 @@ describe('refreshSharedSovereigntySystems', () => {
 		const result = await refreshSharedSovereigntySystems({} as never)
 
 		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(clearSharedSovereigntySystemsMock).toHaveBeenCalledWith()
 		expect(mocks.createTokenStoreMock).toHaveBeenCalledWith({})
 		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
 		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000142' }])
 		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
 		expect(result).toEqual([{ system_id: '30000142' }])
-		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(2)
+		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(1)
+		expect(clearSharedSovereigntySystemsMock.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.fetchSovereigntySystemsMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+		)
 	})
 
 	it('falls back to the existing snapshot when another refresh already holds the lease', async () => {
 		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
 		const storeSharedSovereigntySystemsMock = vi.fn()
+		const clearSharedSovereigntySystemsMock = vi.fn()
 		const getSharedSovereigntySystemsSnapshotMock = vi
 			.fn()
 			.mockResolvedValueOnce(null)
@@ -102,6 +109,7 @@ describe('refreshSharedSovereigntySystems', () => {
 		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
 			acquireSharedSovereigntySystemsRefreshLease:
 				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
 			releaseSharedSovereigntySystemsRefreshLease:
 				releaseSharedSovereigntySystemsRefreshLeaseMock,
 			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
@@ -111,6 +119,7 @@ describe('refreshSharedSovereigntySystems', () => {
 		const result = await refreshSharedSovereigntySystems({} as never)
 
 		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(clearSharedSovereigntySystemsMock).not.toHaveBeenCalled()
 		expect(mocks.fetchSovereigntySystemsMock).not.toHaveBeenCalled()
 		expect(storeSharedSovereigntySystemsMock).not.toHaveBeenCalled()
 		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()

--- a/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
@@ -45,13 +45,7 @@ export async function refreshSharedSovereigntySystems(
 
 	if (leaseToken) {
 		try {
-			const refreshedSnapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
-				SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
-			)
-			if (refreshedSnapshot) {
-				return refreshedSnapshot
-			}
-
+			await globalCorpData.clearSharedSovereigntySystems()
 			const tokenStore = createTokenStore(env)
 			const sovereigntySystems = await esiFetch.fetchSovereigntySystems(tokenStore)
 			await globalCorpData.storeSharedSovereigntySystems(sovereigntySystems)

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -1899,9 +1899,13 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	 * For public endpoints that don't require authentication
 	 * Caches responses according to ESI cache headers
 	 */
-	async fetchPublicEsi<T>(path: string): Promise<EsiResponse<T>> {
+	async fetchPublicEsi<T>(
+		path: string,
+		options?: { cacheMode?: 'default' | 'no-store' }
+	): Promise<EsiResponse<T>> {
 		const scope = EveTokenStoreDO.PUBLIC_CACHE_SCOPE
-		const cached = await this.getCachedResponse<T>(scope, path, undefined, true)
+		const cacheMode = options?.cacheMode ?? 'default'
+		const cached = cacheMode === 'no-store' ? null : await this.getCachedResponse<T>(scope, path, undefined, true)
 		if (cached) {
 			const now = Date.now()
 			const lastModified = cached.lastModified?.getTime()
@@ -1928,7 +1932,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			path,
 			userKey: buildPublicEsiUserKey(),
 			cacheScope: scope,
-			cacheMode: 'default',
+			cacheMode,
 			cachedResponse: cached,
 			onResponse: async ({ response: esiResponse }) => {
 				if (shouldOpenRouteCircuitForResponse(esiResponse.status)) {

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -203,7 +203,7 @@ function getSovereigntyVulnerabilityState(
 	const end = new Date(sovereignty.vulnerabilityWindowEnd).getTime()
 	const now = Date.now()
 	if (Number.isFinite(start) && Number.isFinite(end) && now >= start && now <= end) {
-		return { label: 'Vulnerable', variant: 'warning' }
+		return { label: 'Vulnerable', variant: 'success' }
 	}
 
 	return { label: 'Invulnerable', variant: 'success' }
@@ -1054,7 +1054,13 @@ export default function StructuresDetailPage() {
 								</div>
 								<div>
 									<div className="text-muted-foreground">
-										{hasSovereigntySummary ? 'Theft Window' : isReinforced ? 'Reinforced until' : 'Next State'}
+										{hasSovereigntySummary ? (
+											'Theft Window'
+										) : isReinforced ? (
+											<Badge variant="destructive">Reinforced until</Badge>
+										) : (
+											'Next State'
+										)}
 									</div>
 									<div className="font-medium">
 										{hasSovereigntySummary ? (

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -247,7 +247,7 @@ function getSovereigntyVulnerabilityState(
 		  >
 		| null
 		| undefined
-): { label: string; variant: 'ghost' | 'warning' | 'success' } {
+): { label: string; variant: 'ghost' | 'success' } {
 	if (!sovereignty?.vulnerabilityWindowStart || !sovereignty?.vulnerabilityWindowEnd) {
 		return { label: 'Unknown', variant: 'ghost' }
 	}
@@ -256,7 +256,7 @@ function getSovereigntyVulnerabilityState(
 	const end = new Date(sovereignty.vulnerabilityWindowEnd).getTime()
 	const now = Date.now()
 	if (Number.isFinite(start) && Number.isFinite(end) && now >= start && now <= end) {
-		return { label: 'Vulnerable', variant: 'warning' }
+		return { label: 'Vulnerable', variant: 'success' }
 	}
 
 	return { label: 'Invulnerable', variant: 'success' }
@@ -801,7 +801,9 @@ export default function StructuresPage() {
 						<div className="space-y-1">
 							<Badge variant={vulnerabilityState.variant}>{vulnerabilityState.label}</Badge>
 							{isReinforcedStructureState(structure.state) && (
-								<div className="text-xs text-muted-foreground">Reinforced</div>
+								<Badge variant="destructive" className="text-xs">
+									Reinforced
+								</Badge>
 							)}
 						</div>
 					</TableCell>

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -1315,6 +1315,11 @@ export interface EveCorporationData {
 	storeSharedSovereigntySystems(systems: EsiSovereigntySystem[]): Promise<void>
 
 	/**
+	 * Remove the shared sovereignty system snapshot before rebuilding it.
+	 */
+	clearSharedSovereigntySystems(): Promise<void>
+
+	/**
 	 * Acquire a short-lived refresh lease for the shared sovereignty snapshot.
 	 * Returns a token when acquired, or null when another refresh is already in progress.
 	 */

--- a/packages/eve-token-store/src/index.ts
+++ b/packages/eve-token-store/src/index.ts
@@ -616,7 +616,10 @@ export interface EveTokenStore {
 	 * )
 	 * ```
 	 */
-	fetchPublicEsi<T>(path: string): Promise<EsiResponse<T>>
+	fetchPublicEsi<T>(
+		path: string,
+		options?: { cacheMode?: 'default' | 'no-store' }
+	): Promise<EsiResponse<T>>
 
 	/**
 	 * Fetch character affiliation data from ESI.


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes stale/incorrect ESI cache entries for sovereignty system data by rejecting and purging cache entries that lack a valid expiry, and by forcing the shared sovereignty systems refresh to bypass the public ESI cache entirely so a stale snapshot can't be returned when trying to rebuild it.

## Changes
- `EsiCache`: treat cached entries (both DO storage and global KV) with a missing or invalid `expiresAt` as legacy/invalid — delete them instead of serving them, and skip writing new cache entries when the response has no expiry.
- Removed the `DEFAULT_GLOBAL_CACHE_TTL_SECONDS` fallback; `calculateGlobalTtlSeconds` now returns `null` (no caching) when there's no expiry instead of defaulting to 5 minutes.
- Added `EsiCache.purgeLegacyCacheEntries()` / `EsiFetcher.purgeLegacyCacheEntries()`, run once during `EsiDO` migration/init to sweep out pre-existing legacy cache rows (DO storage) and KV entries (`esi:` prefix) without a valid expiry.
- `EveTokenStoreDO.fetchPublicEsi` now accepts an optional `{ cacheMode: 'default' | 'no-store' }`; `fetchSovereigntySystems` calls it with `cacheMode: 'no-store'` so sovereignty data is always fetched fresh.
- `EveCorporationDataDO` gains `clearSharedSovereigntySystems()`, which wipes the shared snapshot rows, cache metadata, and refresh lease key. `refreshSharedSovereigntySystems` now clears the shared snapshot before fetching fresh data instead of re-checking/returning a possibly-stale cached snapshot after acquiring the lease.
- Minor UI copy/styling tweaks on the structures pages: "Vulnerable" badge changed from `warning` to `success` variant, and "Reinforced"/"Reinforced until" labels are now rendered as `destructive` badges instead of plain text.

## Testing
- Updated unit tests for `fetchSovereigntySystems` to assert it calls `fetchPublicEsi` with `cacheMode: 'no-store'`.
- Updated `refreshSharedSovereigntySystems` tests to assert `clearSharedSovereigntySystems` is called (and ordered before the fetch) when a refresh lease is acquired, and not called when the lease is held elsewhere.
- Adjusted an `EsiFetcher` cache-policy test to drop a now-unnecessary `fetch` spy/assertion.
<!-- claude:end -->