### PR TITLE
make the tokin validity alerts mehcanism abandon fatal scenarios instead of retry

### DIFF
--- a/apps/core/src/__tests__/token-invalid-alerts.delivery.test.ts
+++ b/apps/core/src/__tests__/token-invalid-alerts.delivery.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldRetryTokenInvalidationAlertDelivery } from '../lib/token-invalid-alerts'
+
+describe('token invalidation alert delivery retry policy', () => {
+	it('treats missing DM permissions as fatal', () => {
+		expect(
+			shouldRetryTokenInvalidationAlertDelivery({
+				error: 'Missing permissions to send DM to this user',
+				retryable: false,
+			})
+		).toBe(false)
+	})
+
+	it('treats other failures as retryable by default', () => {
+		expect(
+			shouldRetryTokenInvalidationAlertDelivery({
+				error: 'Discord API error: 500',
+			})
+		).toBe(true)
+	})
+})

--- a/apps/core/src/durable-object.ts
+++ b/apps/core/src/durable-object.ts
@@ -25,6 +25,7 @@ import {
 	TOKEN_INVALID_ALERT_COOLDOWN_MS,
 	TOKEN_INVALID_ALERT_RETRY_MS,
 	TOKEN_INVALID_ALERT_TTL_MS,
+	shouldRetryTokenInvalidationAlertDelivery,
 } from './lib/token-invalid-alerts'
 import {
 	validateAndSyncCharacterTokenValidityBatchTransitions,
@@ -2737,6 +2738,19 @@ export class CoreDO extends DurableObject<Env> implements Core {
 			const message = this.buildPendingTokenInvalidationMessage(invalidCharacterNames)
 			const result = await discordStub.sendDirectMessage(userId, message)
 			if (!result.success) {
+				if (!shouldRetryTokenInvalidationAlertDelivery(result)) {
+					await this.evictPendingTokenInvalidationAlert(
+						userId,
+						result.error ?? 'fatal Discord delivery failure'
+					)
+					failed++
+					this.logger.warn('[CoreDO] Dropped token invalidation alert due to fatal Discord delivery failure', {
+						userId,
+						error: result.error ?? 'Unknown Discord delivery error',
+					})
+					continue
+				}
+
 				const retryAfterMs =
 					typeof result.retryAfter === 'number' && result.retryAfter > 0
 						? result.retryAfter * 1000

--- a/apps/core/src/lib/token-invalid-alerts.ts
+++ b/apps/core/src/lib/token-invalid-alerts.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@repo/core'
-import type { DiscordEmbed, MessageContent } from '@repo/discord'
+import type { DiscordEmbed, MessageContent, SendMessageResult } from '@repo/discord'
 
 export const TOKEN_INVALID_ALERT_COOLDOWN_MS = 12 * 60 * 60 * 1000
 export const TOKEN_INVALID_ALERT_TTL_MS = 7 * 24 * 60 * 60 * 1000
@@ -11,6 +11,20 @@ export function didTokenTransitionFromValidToInvalid(
 	nextHasValidToken: boolean | null | undefined
 ): boolean {
 	return previousHasValidToken === true && nextHasValidToken === false
+}
+
+export function shouldRetryTokenInvalidationAlertDelivery(
+	result: Pick<SendMessageResult, 'error' | 'retryable'>
+): boolean {
+	if (result.retryable === false) {
+		return false
+	}
+
+	if (result.error === 'Missing permissions to send DM to this user') {
+		return false
+	}
+
+	return true
 }
 
 export async function queueTokenInvalidationAlertsForUser(

--- a/apps/discord/src/durable-object.ts
+++ b/apps/discord/src/durable-object.ts
@@ -1716,6 +1716,7 @@ export class DiscordDO extends DurableObject<Env> implements Discord {
 					return {
 						success: false,
 						error: 'Missing permissions to send DM to this user',
+						retryable: false,
 					}
 				}
 
@@ -1724,6 +1725,7 @@ export class DiscordDO extends DurableObject<Env> implements Discord {
 					return {
 						success: false,
 						error: 'DM channel not found',
+						retryable: false,
 					}
 				}
 

--- a/apps/discord/src/services/__tests__/discord-do.send-direct-message.test.ts
+++ b/apps/discord/src/services/__tests__/discord-do.send-direct-message.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('cloudflare:workers', () => ({
+	DurableObject: class {},
+}))
+
+import { DiscordDO } from '../../durable-object'
+import { DiscordAPIError } from '@repo/discord'
+
+describe('DiscordDO.sendDirectMessage', () => {
+	it('marks missing DM permissions as non-retryable', async () => {
+		const fakeClient = {
+			post: vi
+				.fn()
+				.mockResolvedValueOnce({ id: 'dm-channel-1' })
+				.mockRejectedValueOnce(new DiscordAPIError(403, { message: 'Missing permissions' })),
+		}
+
+		const fakeThis = {
+			getProfileByCoreUserId: vi.fn().mockResolvedValue({
+				userId: 'discord-user-1',
+				username: 'pilot',
+				discriminator: '1234',
+				scopes: ['identify'],
+			}),
+			createDiscordClient: vi.fn().mockReturnValue(fakeClient),
+		}
+
+		const result = await DiscordDO.prototype.sendDirectMessage.call(
+			fakeThis as never,
+			'core-user-1',
+			{
+				content: 'hello',
+			}
+		)
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Missing permissions to send DM to this user',
+			retryable: false,
+		})
+	})
+})

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -1047,6 +1047,8 @@ export default function StructuresDetailPage() {
 											<Badge variant={sovereigntyVulnerabilityState.variant}>
 												{sovereigntyVulnerabilityState.label}
 											</Badge>
+										) : structure.skyhook ? (
+											<SkyhookStateBadge state={structure.skyhook.state} />
 										) : (
 											<StructureStateBadge state={structure.state} />
 										)}

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -902,7 +902,7 @@ export default function StructuresPage() {
 			return (
 				<TableRow key={structure.structureId}>
 					<TableCell>
-						<StructureStateBadge state={structure.state} />
+						<SkyhookStateBadge state={structure.state} />
 					</TableCell>
 					<TableCell className="font-medium">
 						{structure.regionName ?? structure.regionId ?? '-'}

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -259,6 +259,8 @@ export interface SendMessageResult {
 	error?: string
 	/** Retry after seconds if rate limited */
 	retryAfter?: number
+	/** Whether the caller should retry this delivery */
+	retryable?: boolean
 }
 
 export interface DiscordGuildRoleDetail {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Stops the Discord token-invalidation alert delivery mechanism from endlessly retrying fatal, non-recoverable failures (e.g. the recipient has DMs disabled or no shared server), and instead abandons those alerts immediately. Also fixes two structure list/detail views to show the skyhook state badge instead of the generic structure state badge for skyhook structures.

## Changes
- Add `retryable?: boolean` to `SendMessageResult` (`packages/discord`) so delivery failures can be flagged as non-retryable.
- Mark "Missing permissions to send DM" and "DM channel not found" failures from `DiscordDO.sendDirectMessage` as `retryable: false`.
- Add `shouldRetryTokenInvalidationAlertDelivery` helper in `apps/core/src/lib/token-invalid-alerts.ts` that treats `retryable: false` results (and the missing-DM-permissions error specifically) as fatal.
- In `CoreDO`'s alert delivery loop, evict the pending alert and log a warning instead of scheduling a retry when a failure is deemed fatal.
- Fix `apps/ui` structures pages to render `SkyhookStateBadge` for skyhook structures instead of `StructureStateBadge` (structures list and structure detail views).

## Testing
- Added unit tests for `shouldRetryTokenInvalidationAlertDelivery` covering fatal vs. retryable outcomes.
- Added a test for `DiscordDO.sendDirectMessage` verifying missing DM permissions are returned as non-retryable.
<!-- claude:end -->