### PR TITLE
fix the sov system shared cache more maybe

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -2939,10 +2939,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			where: eq(structureSovereigntySystems.corporationId, corporationId),
 			columns: {
 				systemId: true,
-				systemName: true,
 			},
 		})
-		const existingBySystemId = new Map(existingRows.map((row) => [row.systemId, row]))
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
 			systems.length > 0
 				? await universe.resolveSolarSystemsByIds([
@@ -2953,14 +2951,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			const claimedSince = parseDateOrNull(system.claimed_since) ?? null
 			const vulnerabilityWindowStart = parseDateOrNull(system.vulnerability_window?.start) ?? null
 			const vulnerabilityWindowEnd = parseDateOrNull(system.vulnerability_window?.end) ?? null
-			const existing = existingBySystemId.get(system.system_id) ?? null
 			const resolvedSystemName =
 				systemGeography[system.system_id]?.solarSystemName ?? system.system_name ?? null
 
 			return {
 				systemId: system.system_id,
 				corporationId,
-				systemName: resolvedSystemName ?? existing?.systemName ?? null,
+				systemName: resolvedSystemName,
 				claimType: system.claim_type,
 				allianceId: system.alliance_id ?? null,
 				corporationClaimantId: system.corporation_id ?? null,
@@ -3240,19 +3237,22 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			where: eq(structureSovereigntyHubs.corporationId, corporationId),
 			columns: {
 				structureId: true,
-				systemName: true,
-				name: true,
 			},
 		})
-		const existingByStructureId = new Map(existingRows.map((row) => [row.structureId, row]))
+		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
+		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
+			hubs.length > 0
+				? await universe.resolveSolarSystemsByIds([...new Set(hubs.map((hub) => hub.system_id))])
+				: {}
 		const values: SovereigntyHubInsertRow[] = hubs.map((hub) => {
-			const existing = existingByStructureId.get(hub.structure_id) ?? null
+			const resolvedSystemName =
+				systemGeography[hub.system_id]?.solarSystemName ?? hub.system_name ?? null
 			return {
 				structureId: hub.structure_id,
 				corporationId,
 				systemId: hub.system_id,
-				systemName: hub.system_name ?? existing?.systemName ?? null,
-				name: hub.name ?? existing?.name ?? null,
+				systemName: resolvedSystemName,
+				name: hub.name ?? null,
 				typeId: hub.type_id,
 				fuelAccessListId: hub.fuel_access_list_id ?? null,
 				controllerAllianceId: hub.controller_alliance_id ?? null,

--- a/apps/eve-corporation-data/src/scheduled.ts
+++ b/apps/eve-corporation-data/src/scheduled.ts
@@ -99,7 +99,7 @@ async function runScheduledRefresh(event: ScheduledEvent, env: Env): Promise<voi
 				count: sovereigntySystems.length,
 			})
 		} catch (error) {
-			logger.warn('[BackgroundRefresh] Failed to warm shared sovereignty systems cache', {
+			logger.error('[BackgroundRefresh] Failed to warm shared sovereignty systems cache', {
 				error: error instanceof Error ? error.message : String(error),
 			})
 		}

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -64,6 +64,9 @@ function makeDb() {
 	const structureMoonDrillsFindMany = vi
 		.fn()
 		.mockResolvedValue([{ structureId: 'stale-structure' }])
+	const structureSovereigntySystemsFindMany = vi
+		.fn()
+		.mockResolvedValue([{ systemId: 'stale-system', systemName: 'Stale Name' }])
 	const structureSovereigntyHubsFindMany = vi.fn().mockResolvedValue([])
 
 	return {
@@ -82,6 +85,9 @@ function makeDb() {
 			},
 			structureMoonDrills: {
 				findMany: structureMoonDrillsFindMany,
+			},
+			structureSovereigntySystems: {
+				findMany: structureSovereigntySystemsFindMany,
 			},
 			structureSovereigntyHubs: {
 				findMany: structureSovereigntyHubsFindMany,
@@ -259,6 +265,14 @@ describe('structure prune cleanup', () => {
 		const db = makeDb()
 		const instance = createDoInstance(db)
 
+		mocks.getStub.mockReturnValueOnce({
+			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({
+				'30000142': {
+					solarSystemName: 'Jita',
+				},
+			}),
+		} as never)
+
 		await instance.storeSovereigntyHubs('corp-1', [
 			{
 				structure_id: 'hub-1',
@@ -320,6 +334,109 @@ describe('structure prune cleanup', () => {
 			},
 		})
 		expect(db.delete).not.toHaveBeenCalled()
+	})
+
+	it('rebuilds sovereignty systems without preserving stale system names', async () => {
+		const db = makeDb()
+		db.query.structureSovereigntySystems.findMany = vi.fn().mockResolvedValue([
+			{
+				systemId: '30000142',
+				systemName: 'Stale Name',
+			},
+		])
+		const instance = createDoInstance(db)
+
+		mocks.getStub.mockReturnValueOnce({
+			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({
+				'30000142': {
+					solarSystemName: 'Jita',
+				},
+			}),
+		} as never)
+
+		await instance.storeSovereigntySystems('corp-1', [
+			{
+				system_id: '30000142',
+				claim_type: 'alliance',
+				alliance_id: '123456789',
+				corporation_id: '987654321',
+				claimed_since: '2026-07-12T19:36:46.834Z',
+				is_capital_system: false,
+				sovereignty_hub_structure_id: 'hub-1',
+				vulnerability_window: null,
+				activity_defense_multiplier: '1.0000',
+				military_level: 1,
+				industrial_level: 1,
+				strategic_level: 1,
+			},
+		])
+
+		expect(db._values).toHaveBeenCalled()
+		expect(db._values.mock.calls[0][0][0]).toMatchObject({
+			systemName: 'Jita',
+		})
+	})
+
+	it('rebuilds sovereignty hubs without preserving stale hub names', async () => {
+		const db = makeDb()
+		db.query.structureSovereigntyHubs.findMany = vi.fn().mockResolvedValue([
+			{
+				structureId: 'hub-1',
+				systemName: 'Stale Name',
+				name: 'Stale Hub',
+			},
+		])
+		const instance = createDoInstance(db)
+
+		mocks.getStub.mockReturnValueOnce({
+			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({
+				'30000142': {
+					solarSystemName: 'Jita',
+				},
+			}),
+		} as never)
+
+		await instance.storeSovereigntyHubs('corp-1', [
+			{
+				structure_id: 'hub-1',
+				corporation_id: 'corp-1',
+				system_id: '30000142',
+				system_name: null,
+				type_id: SOVEREIGNTY_HUB_TYPE_ID,
+				name: null,
+				fuel_access_list_id: null,
+				controller_alliance_id: null,
+				reagent_bay: {
+					last_updated: '2026-07-12T19:36:46.834Z',
+					reagents: [],
+				},
+				resources: {
+					power: { allocated: 0, available: 0 },
+					workforce: { allocated: 0, available: 0 },
+				},
+				upgrades: [],
+				vulnerability_window: null,
+				workforce_transport: {
+					configuration: {
+						import: {
+							sources: [{ solar_system_id: 30000142 }],
+						},
+					},
+					state: {
+						import: {
+							sources: [{ solar_system_id: 30000142, amount: 0 }],
+						},
+					},
+				},
+				raw: { detail: { id: 1 } },
+			} as never,
+		])
+
+		expect(db._values).toHaveBeenCalled()
+		expect(db._values.mock.calls[0][0][0]).toMatchObject({
+			systemName: 'Jita',
+			name: null,
+		})
 	})
 
 	it('preserves existing skyhook snapshots when upstream skyhooks cannot be synthesized', async () => {

--- a/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
@@ -33,13 +33,19 @@ describe('refreshSharedSovereigntySystems', () => {
 		const getSharedSovereigntySystemsSnapshotMock = vi.fn().mockResolvedValue([
 			{ system_id: '30000142' },
 		])
-		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue(
+			'lease-token'
+		)
 		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const clearSharedSovereigntySystemsMock = vi.fn()
 		const storeSharedSovereigntySystemsMock = vi.fn()
 
+		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.fetchSovereigntySystemsMock.mockResolvedValue([{ system_id: '30000142' }])
 		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
 			acquireSharedSovereigntySystemsRefreshLease:
 				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
 			releaseSharedSovereigntySystemsRefreshLease:
 				releaseSharedSovereigntySystemsRefreshLeaseMock,
 			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
@@ -48,12 +54,45 @@ describe('refreshSharedSovereigntySystems', () => {
 
 		const result = await refreshSharedSovereigntySystems({} as never)
 
-		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalled()
-		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
-		expect(mocks.fetchSovereigntySystemsMock).not.toHaveBeenCalled()
-		expect(storeSharedSovereigntySystemsMock).not.toHaveBeenCalled()
-		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
+		expect(getSharedSovereigntySystemsSnapshotMock).not.toHaveBeenCalled()
+		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(clearSharedSovereigntySystemsMock).toHaveBeenCalledWith()
+		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
+		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000142' }])
+		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
 		expect(result).toEqual([{ system_id: '30000142' }])
+	})
+
+	it('rebuilds the snapshot even if an existing snapshot is still fresh', async () => {
+		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const clearSharedSovereigntySystemsMock = vi.fn()
+		const storeSharedSovereigntySystemsMock = vi.fn()
+		const getSharedSovereigntySystemsSnapshotMock = vi.fn().mockResolvedValue([
+			{ system_id: '30000142' },
+		])
+		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue('lease-token')
+
+		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.fetchSovereigntySystemsMock.mockResolvedValue([{ system_id: '30000999' }])
+		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+			acquireSharedSovereigntySystemsRefreshLease:
+				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
+			releaseSharedSovereigntySystemsRefreshLease:
+				releaseSharedSovereigntySystemsRefreshLeaseMock,
+			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
+			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
+		})
+
+		const result = await refreshSharedSovereigntySystems({} as never)
+
+		expect(getSharedSovereigntySystemsSnapshotMock).not.toHaveBeenCalled()
+		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(clearSharedSovereigntySystemsMock).toHaveBeenCalledWith()
+		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
+		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000999' }])
+		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
+		expect(result).toEqual([{ system_id: '30000999' }])
 	})
 
 	it('uses the lease holder to refresh the snapshot and releases the lease afterward', async () => {
@@ -89,7 +128,6 @@ describe('refreshSharedSovereigntySystems', () => {
 		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000142' }])
 		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
 		expect(result).toEqual([{ system_id: '30000142' }])
-		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(1)
 		expect(clearSharedSovereigntySystemsMock.mock.invocationCallOrder[0]).toBeLessThan(
 			mocks.fetchSovereigntySystemsMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
 		)
@@ -125,5 +163,34 @@ describe('refreshSharedSovereigntySystems', () => {
 		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
 		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(2)
 		expect(result).toEqual([{ system_id: '30000142' }])
+	})
+
+	it('throws when it cannot produce a fresh snapshot after refresh attempts', async () => {
+		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const clearSharedSovereigntySystemsMock = vi.fn()
+		const storeSharedSovereigntySystemsMock = vi.fn()
+		const getSharedSovereigntySystemsSnapshotMock = vi.fn().mockResolvedValue(null)
+		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue(null)
+
+		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+			acquireSharedSovereigntySystemsRefreshLease:
+				acquireSharedSovereigntySystemsRefreshLeaseMock,
+			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
+			releaseSharedSovereigntySystemsRefreshLease:
+				releaseSharedSovereigntySystemsRefreshLeaseMock,
+			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
+			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
+		})
+
+		await expect(refreshSharedSovereigntySystems({} as never)).rejects.toThrow(
+			'Failed to refresh shared sovereignty systems snapshot'
+		)
+
+		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(clearSharedSovereigntySystemsMock).not.toHaveBeenCalled()
+		expect(mocks.fetchSovereigntySystemsMock).not.toHaveBeenCalled()
+		expect(storeSharedSovereigntySystemsMock).not.toHaveBeenCalled()
+		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
+		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(4)
 	})
 })

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -34,6 +34,16 @@ export interface SkyhookEnrichmentData {
 	skyhooks: CorporationSkyhooksData
 }
 
+function buildSovereigntyAllianceBySystemId(
+	sovereigntySystems: SovereigntySystemsData
+): Map<string, string | null> {
+	return new Map(
+		sovereigntySystems
+			.filter((system) => system.claim_type === 'alliance')
+			.map((system) => [system.system_id, system.alliance_id ?? null])
+	)
+}
+
 export async function fetchStructures(
 	env: Env,
 	corporationId: string,
@@ -95,11 +105,7 @@ export async function fetchSovereigntyEnrichment(
 			sovereigntySystems = await refreshSharedSovereigntySystems(env)
 		}
 
-		const allianceBySystemId = new Map(
-			sovereigntySystems
-				.filter((system) => system.claim_type === 'alliance' && system.alliance_id !== undefined)
-				.map((system) => [system.system_id, system.alliance_id ?? null])
-		)
+		const allianceBySystemId = buildSovereigntyAllianceBySystemId(sovereigntySystems)
 		const enrichedSovereigntyHubs = sovereigntyHubs.map((hub) => ({
 			...hub,
 			name: systemGeography[hub.system_id]?.solarSystemName ?? hub.name ?? null,

--- a/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
@@ -34,13 +34,6 @@ export async function refreshSharedSovereigntySystems(
 	env: Env
 ): Promise<EsiSovereigntySystem[]> {
 	const globalCorpData = getGlobalCorporationDataStub(env)
-	const freshSnapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
-		SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
-	)
-	if (freshSnapshot) {
-		return freshSnapshot
-	}
-
 	const leaseToken = await globalCorpData.acquireSharedSovereigntySystemsRefreshLease()
 
 	if (leaseToken) {
@@ -65,9 +58,12 @@ export async function refreshSharedSovereigntySystems(
 		await sleep(delayMs)
 	}
 
-	return (
-		(await globalCorpData.getSharedSovereigntySystemsSnapshot(
-			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
-		)) ?? []
+	const snapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
+		SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
 	)
+	if (snapshot) {
+		return snapshot
+	}
+
+	throw new Error('Failed to refresh shared sovereignty systems snapshot')
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes stale/incorrect sovereignty data by always resolving system and hub names fresh (instead of falling back to previously stored values), and makes the shared sovereignty-systems cache refresh always rebuild rather than trusting a cached snapshot that may already be wrong.

## Changes
- `storeSovereigntySystems`: stop preserving `systemName` from existing DB rows; always use the name resolved via the `Universe` stub (or the raw ESI value), removing the now-unused existing-rows lookup.
- `storeSovereigntyHubs`: resolve hub system names via `Universe.resolveSolarSystemsByIds` instead of falling back to previously stored `systemName`/`name` values, so stale names/hub names are no longer carried forward.
- `refreshSharedSovereigntySystems`: remove the early "return fresh cached snapshot" short-circuit so the lease-holder always fetches and rebuilds the shared snapshot; throw an error if a fresh snapshot still can't be produced after refresh attempts, instead of silently returning an empty array.
- `scheduled.ts`: log the background shared-sovereignty-cache warm failure at `error` level instead of `warn`.
- Extracted `buildSovereigntyAllianceBySystemId` helper in `workflows/steps/structures/index.ts` (same logic, dropped a redundant `alliance_id !== undefined` check).

## Testing
- Updated unit tests in `structure-prune-cleanup.test.ts` to cover that sovereignty systems/hubs are rebuilt with fresh names rather than stale ones.
- Updated `sovereignty-systems-cache.test.ts` to reflect the new always-refresh behavior, including a new test asserting the refresh throws when no fresh snapshot can be produced.
<!-- claude:end -->