### PR TITLE
correct sov vuln window details ux

### DIFF
--- a/apps/ui/src/client/lib/sovereignty-vulnerability-window.ts
+++ b/apps/ui/src/client/lib/sovereignty-vulnerability-window.ts
@@ -1,0 +1,78 @@
+export type SovereigntyVulnerabilityWindowLabel = 'Starts in' | 'Ends in' | 'Expired'
+
+export interface SovereigntyVulnerabilityWindowDisplay {
+	hasWindow: boolean
+	isActiveWindow: boolean
+	label: SovereigntyVulnerabilityWindowLabel
+	countdownTarget: string | null
+}
+
+function parseDateMs(value: string | null | undefined): number | null {
+	if (!value) {
+		return null
+	}
+
+	const time = new Date(value).getTime()
+	return Number.isFinite(time) ? time : null
+}
+
+export function getSovereigntyVulnerabilityWindowDisplay(input: {
+	vulnerabilityWindowStart?: string | null
+	vulnerabilityWindowEnd?: string | null
+	nowMs?: number
+}): SovereigntyVulnerabilityWindowDisplay {
+	const { vulnerabilityWindowStart, vulnerabilityWindowEnd } = input
+	const nowMs = input.nowMs ?? Date.now()
+	const startMs = parseDateMs(vulnerabilityWindowStart)
+	const endMs = parseDateMs(vulnerabilityWindowEnd)
+	const hasWindow = vulnerabilityWindowStart != null || vulnerabilityWindowEnd != null
+	const isActiveWindow =
+		startMs !== null && endMs !== null && nowMs >= startMs && nowMs < endMs
+
+	const isExpiredWindow =
+		(endMs !== null && nowMs > endMs) ||
+		(startMs !== null && endMs === null && nowMs > startMs)
+
+	if (isActiveWindow) {
+		return {
+			hasWindow,
+			isActiveWindow,
+			label: 'Ends in',
+			countdownTarget: vulnerabilityWindowEnd ?? vulnerabilityWindowStart ?? null,
+		}
+	}
+
+	if (isExpiredWindow) {
+		return {
+			hasWindow,
+			isActiveWindow,
+			label: 'Expired',
+			countdownTarget: null,
+		}
+	}
+
+	if (startMs !== null && nowMs < startMs) {
+		return {
+			hasWindow,
+			isActiveWindow,
+			label: 'Starts in',
+			countdownTarget: vulnerabilityWindowStart ?? vulnerabilityWindowEnd ?? null,
+		}
+	}
+
+	if (endMs !== null && nowMs < endMs) {
+		return {
+			hasWindow,
+			isActiveWindow,
+			label: 'Ends in',
+			countdownTarget: vulnerabilityWindowEnd ?? vulnerabilityWindowStart ?? null,
+		}
+	}
+
+	return {
+		hasWindow,
+		isActiveWindow,
+		label: 'Expired',
+		countdownTarget: null,
+	}
+}

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -62,6 +62,7 @@ import { api } from '@/lib/api'
 import { formatDateTimeLong } from '@/lib/date-utils'
 import { formatDurationMs } from '@/lib/duration-utils'
 import { allianceLogoUrl, typeIconUrl, typeImageUrl, typeRenderUrl } from '@/lib/eve-images'
+import { getSovereigntyVulnerabilityWindowDisplay } from '@/lib/sovereignty-vulnerability-window'
 import { stripLeadingContextName } from '@/lib/structure-name-utils'
 import toast from '@/lib/toast'
 
@@ -783,7 +784,13 @@ export default function StructuresDetailPage() {
 	const sovereigntyHub = structure?.sovereignty?.hub ?? null
 	const sovereigntyAllianceId = structure?.sovereignty?.allianceId ?? null
 	const sovereigntyAllianceName = structure?.sovereignty?.allianceName ?? null
+	const nowMs = Date.now()
 	const sovereigntyVulnerabilityState = getSovereigntyVulnerabilityState(structure?.sovereignty)
+	const sovereigntyVulnerabilityWindow = getSovereigntyVulnerabilityWindowDisplay({
+		vulnerabilityWindowStart: structure?.sovereignty?.vulnerabilityWindowStart ?? null,
+		vulnerabilityWindowEnd: structure?.sovereignty?.vulnerabilityWindowEnd ?? null,
+		nowMs,
+	})
 	const { data: sovereigntyStructures = [] } = useQuery({
 		queryKey: ['structures', 'sovereignty', corporationId],
 		queryFn: async () => {
@@ -1055,12 +1062,12 @@ export default function StructuresDetailPage() {
 									</div>
 								</div>
 								<div>
-									<div className="text-muted-foreground">
-										{hasSovereigntySummary ? (
-											'Theft Window'
-										) : isReinforced ? (
-											<Badge variant="destructive">Reinforced until</Badge>
-										) : (
+								<div className="text-muted-foreground">
+									{hasSovereigntySummary ? (
+										'Vulnerability Window'
+									) : isReinforced ? (
+										<Badge variant="destructive">Reinforced until</Badge>
+									) : (
 											'Next State'
 										)}
 									</div>
@@ -1096,6 +1103,22 @@ export default function StructuresDetailPage() {
 											'-'
 										)}
 									</div>
+									{hasSovereigntySummary &&
+									(structure.sovereignty?.vulnerabilityWindowStart ||
+										structure.sovereignty?.vulnerabilityWindowEnd) ? (
+										<div className="mt-1 text-xs text-muted-foreground">
+											{sovereigntyVulnerabilityWindow.label}{' '}
+											{sovereigntyVulnerabilityWindow.countdownTarget ? (
+												<DurationDisplay
+													endDate={sovereigntyVulnerabilityWindow.countdownTarget}
+													referenceTimeMs={nowMs}
+													maxUnits={2}
+													durationStyle="compact"
+													format="compact"
+												/>
+											) : null}
+										</div>
+									) : null}
 								</div>
 							</div>
 							<div className="flex flex-wrap gap-2 pt-2">

--- a/apps/ui/src/test/unit/sovereignty-vulnerability-window.test.ts
+++ b/apps/ui/src/test/unit/sovereignty-vulnerability-window.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSovereigntyVulnerabilityWindowDisplay } from '@/lib/sovereignty-vulnerability-window'
+
+describe('getSovereigntyVulnerabilityWindowDisplay', () => {
+	it('shows starts in before the window begins', () => {
+		const result = getSovereigntyVulnerabilityWindowDisplay({
+			vulnerabilityWindowStart: '2026-07-21T06:00:00.000Z',
+			vulnerabilityWindowEnd: '2026-07-21T08:00:00.000Z',
+			nowMs: new Date('2026-07-21T05:00:00.000Z').getTime(),
+		})
+
+		expect(result).toEqual({
+			hasWindow: true,
+			isActiveWindow: false,
+			label: 'Starts in',
+			countdownTarget: '2026-07-21T06:00:00.000Z',
+		})
+	})
+
+	it('shows ends in while the window is active', () => {
+		const result = getSovereigntyVulnerabilityWindowDisplay({
+			vulnerabilityWindowStart: '2026-07-21T06:00:00.000Z',
+			vulnerabilityWindowEnd: '2026-07-21T08:00:00.000Z',
+			nowMs: new Date('2026-07-21T07:00:00.000Z').getTime(),
+		})
+
+		expect(result).toEqual({
+			hasWindow: true,
+			isActiveWindow: true,
+			label: 'Ends in',
+			countdownTarget: '2026-07-21T08:00:00.000Z',
+		})
+	})
+
+	it('shows expired after the window has ended', () => {
+		const result = getSovereigntyVulnerabilityWindowDisplay({
+			vulnerabilityWindowStart: '2026-07-21T06:00:00.000Z',
+			vulnerabilityWindowEnd: '2026-07-21T08:00:00.000Z',
+			nowMs: new Date('2026-07-21T09:00:00.000Z').getTime(),
+		})
+
+		expect(result).toEqual({
+			hasWindow: true,
+			isActiveWindow: false,
+			label: 'Expired',
+			countdownTarget: null,
+		})
+	})
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the sovereignty structure detail page to correctly compute and display the vulnerability window (start/end/expired state) instead of a generic "Theft Window" label, via a new pure helper function.

## Changes
- Add `getSovereigntyVulnerabilityWindowDisplay` in `apps/ui/src/client/lib/sovereignty-vulnerability-window.ts`, which derives whether the window is upcoming, active, or expired and returns the appropriate label ("Starts in" / "Ends in" / "Expired") and countdown target.
- Update `structures-detail.tsx` to use this helper, rename the "Theft Window" label to "Vulnerability Window", and render a `DurationDisplay` countdown beneath it when a window start/end is present.

## Testing
- Added unit tests in `apps/ui/src/test/unit/sovereignty-vulnerability-window.test.ts` covering the "Starts in", "Ends in" (active), and "Expired" cases.
<!-- claude:end -->