### PR TITLE
evict failed immunitas alerts rather than linger

### DIFF
--- a/apps/core/src/__tests__/immunitas-alerts.test.ts
+++ b/apps/core/src/__tests__/immunitas-alerts.test.ts
@@ -1,6 +1,30 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
 
-import { buildImmunitasAccessAlertMessage } from '../lib/immunitas-alerts'
+import { getStub } from '@repo/do-utils'
+import { CoreDO } from '../durable-object'
+import {
+	buildImmunitasAccessAlertMessage,
+	IMMUNITAS_ALERT_COOLDOWN_MS,
+	shouldRetryImmunitasAccessAlertDelivery,
+} from '../lib/immunitas-alerts'
+
+import type { Discord } from '@repo/discord'
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn(),
+}))
+
+const getStubMock = vi.mocked(getStub)
+
+function createDbMock() {
+	return {
+		query: {
+			users: {
+				findFirst: vi.fn(),
+			},
+		},
+	}
+}
 
 describe('immunitas alerts message builder', () => {
 	it('groups requestors by accessor user in the attempted by field', () => {
@@ -57,5 +81,132 @@ describe('immunitas alerts message builder', () => {
 			title: 'Unauthorized profile data access blocked',
 			color: 0xf59e0b,
 		})
+	})
+})
+
+describe('immunitas alert delivery retry policy', () => {
+	it('treats 401/403-style discord failures and missing permissions as fatal', () => {
+		expect(
+			shouldRetryImmunitasAccessAlertDelivery({
+				error: 'Discord API error: 401',
+			})
+		).toBe(false)
+		expect(
+			shouldRetryImmunitasAccessAlertDelivery({
+				error: 'Discord API error: 403',
+			})
+		).toBe(false)
+		expect(
+			shouldRetryImmunitasAccessAlertDelivery({
+				error: 'Missing permissions to send DM to this user',
+			})
+		).toBe(false)
+		expect(
+			shouldRetryImmunitasAccessAlertDelivery({
+				error: 'Discord API error: 500',
+			})
+		).toBe(true)
+	})
+})
+
+describe('CoreDO immunitas alert draining', () => {
+	const createState = () =>
+		({
+			storage: {
+				delete: vi.fn().mockResolvedValue(undefined),
+				put: vi.fn().mockResolvedValue(undefined),
+				deleteAlarm: vi.fn().mockResolvedValue(undefined),
+			},
+		}) as any
+
+	const createCore = (discordStub: { sendDirectMessage: ReturnType<typeof vi.fn> }) => {
+		const core = Object.create(CoreDO.prototype) as CoreDO
+		const db = createDbMock()
+		;(core as any).env = { DISCORD: {} as DurableObjectNamespace }
+		;(core as any).state = createState()
+		;(core as any).getDb = vi.fn().mockReturnValue(db)
+		;(core as any).scheduleImmunitasAccessAlertAlarm = vi.fn().mockResolvedValue(undefined)
+		;(core as any).pendingImmunitasAccessAlerts = new Map([
+			[
+				'core-user:fulcrum-report',
+				{
+					expiresAt: Date.now() + 60_000,
+					pendingTargetCharacterLabels: ['Target Pilot'],
+					pendingRequestorGroups: [
+						{
+							requestorUserId: 'requestor-1',
+							requestorLabels: ['Requester One'],
+							attemptCount: 1,
+						},
+					],
+					lastNotifiedAt: null,
+					nextEligibleAt: 0,
+					attemptCount: 1,
+					lastError: undefined,
+					source: 'test',
+					accessType: 'fulcrum-report' as const,
+					targetUserId: 'core-user',
+				},
+			],
+		])
+		getStubMock.mockImplementation((binding: unknown) => {
+			if (binding === (core as any).env.DISCORD) return discordStub as unknown as Discord
+			throw new Error('Unexpected binding')
+		})
+		return { core, db }
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('evicts the queue entry after a successful Discord send', async () => {
+		const discordStub = {
+			sendDirectMessage: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-1' }),
+		}
+		const { core, db } = createCore(discordStub)
+		db.query.users.findFirst.mockResolvedValue({ id: 'core-user', discordUserId: 'discord-user' })
+
+		const result = await (core as any).processPendingImmunitasAccessAlerts()
+
+		expect(result).toEqual({ processed: 1, sent: 1, failed: 0 })
+		const entry = (core as any).pendingImmunitasAccessAlerts.get('core-user:fulcrum-report')
+		expect(entry).toMatchObject({
+			pendingTargetCharacterLabels: [],
+			pendingRequestorGroups: [],
+			lastNotifiedAt: expect.any(Number),
+			attemptCount: 0,
+			lastError: undefined,
+		})
+		expect(entry.nextEligibleAt).toBeGreaterThanOrEqual(Date.now() + IMMUNITAS_ALERT_COOLDOWN_MS - 1000)
+		expect((core as any).state.storage.delete).not.toHaveBeenCalled()
+		expect((core as any).state.storage.put).toHaveBeenCalledWith(
+			expect.objectContaining({
+				'pending-immunitas:core-user:fulcrum-report': expect.objectContaining({
+					pendingTargetCharacterLabels: [],
+					pendingRequestorGroups: [],
+				}),
+			})
+		)
+	})
+
+	it('evicts the queue entry for fatal Discord failures instead of retrying', async () => {
+		const discordStub = {
+			sendDirectMessage: vi.fn().mockResolvedValue({
+				success: false,
+				error: 'Discord API error: 401',
+			}),
+		}
+		const { core, db } = createCore(discordStub)
+		db.query.users.findFirst.mockResolvedValue({ id: 'core-user', discordUserId: 'discord-user' })
+
+		const result = await (core as any).processPendingImmunitasAccessAlerts()
+
+		expect(result).toEqual({ processed: 1, sent: 0, failed: 1 })
+		expect((core as any).pendingImmunitasAccessAlerts.has('core-user:fulcrum-report')).toBe(false)
+		expect((core as any).state.storage.delete).toHaveBeenCalledWith(
+			'pending-immunitas:core-user:fulcrum-report'
+		)
+		expect((core as any).state.storage.put).not.toHaveBeenCalled()
 	})
 })

--- a/apps/core/src/durable-object.ts
+++ b/apps/core/src/durable-object.ts
@@ -18,6 +18,7 @@ import {
 	IMMUNITAS_ALERT_COOLDOWN_MS,
 	IMMUNITAS_ALERT_RETRY_MS,
 	IMMUNITAS_ALERT_TTL_MS,
+	shouldRetryImmunitasAccessAlertDelivery,
 } from './lib/immunitas-alerts'
 import { recordUserIpAddress } from './lib/ip-tracking'
 import {
@@ -2595,6 +2596,21 @@ export class CoreDO extends DurableObject<Env> implements Core {
 			})
 			const result = await discordStub.sendDirectMessage(entry.targetUserId, message)
 			if (!result.success) {
+				if (!shouldRetryImmunitasAccessAlertDelivery(result)) {
+					await this.evictPendingImmunitasAccessAlert(
+						queueKey,
+						result.error ?? 'fatal Discord delivery failure'
+					)
+					failed++
+					this.logger.warn('[CoreDO] Dropped immunitas access alert due to fatal Discord delivery failure', {
+						queueKey,
+						targetUserId: entry.targetUserId,
+						accessType: entry.accessType,
+						error: result.error ?? 'Unknown Discord delivery error',
+					})
+					continue
+				}
+
 				const retryAfterMs =
 					typeof result.retryAfter === 'number' && result.retryAfter > 0
 						? result.retryAfter * 1000

--- a/apps/core/src/lib/immunitas-alerts.ts
+++ b/apps/core/src/lib/immunitas-alerts.ts
@@ -1,9 +1,9 @@
 import type { Core } from '@repo/core'
-import type { DiscordEmbed, MessageContent } from '@repo/discord'
+import type { DiscordEmbed, MessageContent, SendMessageResult } from '@repo/discord'
 
 export const IMMUNITAS_ALERT_COOLDOWN_MS = 15 * 60 * 1000
 export const IMMUNITAS_ALERT_INITIAL_DELAY_MS = 30 * 1000
-export const IMMUNITAS_ALERT_TTL_MS = 7 * 24 * 60 * 60 * 1000
+export const IMMUNITAS_ALERT_TTL_MS = 60 * 60 * 1000
 export const IMMUNITAS_ALERT_RETRY_MS = 15 * 60 * 1000
 export const IMMUNITAS_ALERT_DRAIN_CRON = '0,15,30,45 * * * *'
 
@@ -12,6 +12,30 @@ export type ImmunitasAccessRequestorGroup = {
 	requestorUserId: string
 	requestorLabels: string[]
 	attemptCount: number
+}
+
+export function shouldRetryImmunitasAccessAlertDelivery(
+	result: Pick<SendMessageResult, 'error' | 'retryable'>
+): boolean {
+	if (result.retryable === false) {
+		return false
+	}
+
+	const error = result.error?.trim() ?? ''
+	if (!error) {
+		return true
+	}
+
+	if (
+		error === 'Missing permissions to send DM to this user' ||
+		error === 'DM channel not found' ||
+		error.startsWith('Discord API error: 401') ||
+		error.startsWith('Discord API error: 403')
+	) {
+		return false
+	}
+
+	return true
 }
 
 function formatLabelList(labels: string[], maxItems = 8): string {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes immunitas access alerts lingering in the retry queue when Discord delivery fails permanently (e.g. missing DM permissions or an unauthorized/forbidden response). These alerts now get evicted immediately instead of being retried until their TTL expires.

## Changes
- Add `shouldRetryImmunitasAccessAlertDelivery` in `apps/core/src/lib/immunitas-alerts.ts` to classify Discord send failures as fatal (401/403, missing DM permissions, DM channel not found, or explicit `retryable: false`) vs. retryable.
- In `CoreDO.processPendingImmunitasAccessAlerts` (`apps/core/src/durable-object.ts`), use this check to evict a pending alert entry via `evictPendingImmunitasAccessAlert` and log a warning when a Discord send fails fatally, rather than falling through to the normal retry/backoff path.
- Shorten `IMMUNITAS_ALERT_TTL_MS` from 7 days to 1 hour so any alerts that do remain queued (e.g. due to transient failures) don't linger for as long.

## Testing
- Added unit tests for `shouldRetryImmunitasAccessAlertDelivery` covering fatal (401/403, missing permissions) vs. retryable (500) Discord errors.
- Added `CoreDO` tests exercising `processPendingImmunitasAccessAlerts` for both a successful send (entry cleared and cooldown applied) and a fatal failure (entry evicted from memory and storage instead of retried).
<!-- claude:end -->
