### PR TITLE
Fix/move monitor state to do

### DIFF
--- a/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
+++ b/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
@@ -664,13 +664,22 @@ describe('fleets tracking routes', () => {
 			startedByUserId: 'other-user',
 			characterId: '1001',
 		})
-		fleetsStub.getSessionLiveSnapshot.mockResolvedValue({ memberCount: 5 })
+		fleetsStub.getSessionLiveSnapshot.mockResolvedValue({
+			state: 'ready',
+			message: null,
+			snapshot: { memberCount: 5 } as any,
+		})
 
 		const app = createApp(makeUser({ id: 'user-1' }))
 		const res = await app.request('/api/fleets/tracking/s1/live', {}, env)
 
 		expect(res.status).toBe(200)
 		expect(fleetsStub.getSessionLiveSnapshot).toHaveBeenCalledWith('s1')
+		await expect(res.json()).resolves.toMatchObject({
+			state: 'ready',
+			message: null,
+			snapshot: { memberCount: 5 },
+		})
 	})
 
 	it('allows active owner live detail access', async () => {
@@ -681,13 +690,22 @@ describe('fleets tracking routes', () => {
 			startedByUserId: 'user-1',
 			characterId: '1001',
 		})
-		fleetsStub.getSessionLiveSnapshot.mockResolvedValue({ memberCount: 10 })
+		fleetsStub.getSessionLiveSnapshot.mockResolvedValue({
+			state: 'ready',
+			message: null,
+			snapshot: { memberCount: 10 } as any,
+		})
 
 		const app = createApp(makeUser({ id: 'user-1' }))
 		const res = await app.request('/api/fleets/tracking/s-active/live', {}, env)
 
 		expect(res.status).toBe(200)
 		expect(fleetsStub.getSessionLiveSnapshot).toHaveBeenCalledWith('s-active')
+		await expect(res.json()).resolves.toMatchObject({
+			state: 'ready',
+			message: null,
+			snapshot: { memberCount: 10 },
+		})
 	})
 
 	it('returns live member locations for detailed viewers without mutating ship events', async () => {

--- a/apps/core/src/routes/fleets.ts
+++ b/apps/core/src/routes/fleets.ts
@@ -818,7 +818,8 @@ app.get('/tracking/:sessionId', async (c) => {
 
 /**
  * GET /fleets/tracking/:sessionId/live
- * Live snapshot from fleet_state_cache. Useful while the session is active.
+ * Live snapshot from the FleetMonitor DO plus a status envelope explaining
+ * whether the snapshot is ready, inactive, or temporarily unavailable.
  */
 app.get('/tracking/:sessionId/live', async (c) => {
 	const result = await resolveSessionAccess(c, c.req.param('sessionId'))
@@ -828,9 +829,8 @@ app.get('/tracking/:sessionId/live', async (c) => {
 	}
 
 	const fleetsStub = getStub<Fleets>(c.env.FLEETS, 'default')
-	const snapshot = await fleetsStub.getSessionLiveSnapshot(c.req.param('sessionId'))
-	if (!snapshot) return c.json({ snapshot: null })
-	return c.json({ snapshot })
+	const liveSnapshot = await fleetsStub.getSessionLiveSnapshot(c.req.param('sessionId'))
+	return c.json(liveSnapshot)
 })
 
 /**

--- a/apps/fleets/.migrations/0012_cute_sabretooth.sql
+++ b/apps/fleets/.migrations/0012_cute_sabretooth.sql
@@ -1,0 +1,1 @@
+DROP TABLE "fleet_state_cache" CASCADE;

--- a/apps/fleets/.migrations/meta/0012_snapshot.json
+++ b/apps/fleets/.migrations/meta/0012_snapshot.json
@@ -1,0 +1,1497 @@
+{
+  "id": "d1ef86b9-961f-4f19-9a1e-6914cdb2c4a6",
+  "prevId": "ff575241-a0fc-4b83-abe6-c8f2388422eb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.fleet_commander_access_anchors": {
+      "name": "fleet_commander_access_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commander_character_id": {
+          "name": "commander_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_commander_access_anchors_fleet_id_idx": {
+          "name": "fleet_commander_access_anchors_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_fleet_id_commander_character_id_unique": {
+          "name": "fleet_commander_access_anchors_fleet_id_commander_character_id_unique",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commander_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_tracking_session_id_idx": {
+          "name": "fleet_commander_access_anchors_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_commander_character_id_idx": {
+          "name": "fleet_commander_access_anchors_commander_character_id_idx",
+          "columns": [
+            {
+              "expression": "commander_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_access_anchors_last_seen_at_idx": {
+          "name": "fleet_commander_access_anchors_last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_commander_access_anchors_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_commander_access_anchors_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_commander_access_anchors",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_commander_events": {
+      "name": "fleet_commander_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_commander_character_id": {
+          "name": "previous_commander_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commander_character_id": {
+          "name": "commander_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_commander_events_fleet_id_idx": {
+          "name": "fleet_commander_events_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_events_tracking_session_id_idx": {
+          "name": "fleet_commander_events_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_events_commander_character_id_idx": {
+          "name": "fleet_commander_events_commander_character_id_idx",
+          "columns": [
+            {
+              "expression": "commander_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_commander_events_observed_at_idx": {
+          "name": "fleet_commander_events_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_commander_events_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_commander_events_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_commander_events",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_invitations": {
+      "name": "fleet_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_boss_id": {
+          "name": "fleet_boss_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uses_count": {
+          "name": "uses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "fleet_invitations_token_idx": {
+          "name": "fleet_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_invitations_expires_at_idx": {
+          "name": "fleet_invitations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_invitations_fleet_boss_id_idx": {
+          "name": "fleet_invitations_fleet_boss_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_boss_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fleet_invitations_token_unique": {
+          "name": "fleet_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_member_history": {
+      "name": "fleet_member_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "squad_id": {
+          "name": "squad_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wing_id": {
+          "name": "wing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_name": {
+          "name": "ship_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wing_name": {
+          "name": "wing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "squad_name": {
+          "name": "squad_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "fleet_member_history_fleet_id_idx": {
+          "name": "fleet_member_history_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_character_id_idx": {
+          "name": "fleet_member_history_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_event_type_idx": {
+          "name": "fleet_member_history_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_event_timestamp_idx": {
+          "name": "fleet_member_history_event_timestamp_idx",
+          "columns": [
+            {
+              "expression": "event_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_fleet_character_idx": {
+          "name": "fleet_member_history_fleet_character_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_history_corporation_id_idx": {
+          "name": "fleet_member_history_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_member_ship_events": {
+      "name": "fleet_member_ship_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_member_ship_events_session_character_started_idx": {
+          "name": "fleet_member_ship_events_session_character_started_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_ship_events_fleet_character_started_idx": {
+          "name": "fleet_member_ship_events_fleet_character_started_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_ship_events_event_timestamp_idx": {
+          "name": "fleet_member_ship_events_event_timestamp_idx",
+          "columns": [
+            {
+              "expression": "event_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_member_ship_events_ended_at_idx": {
+          "name": "fleet_member_ship_events_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_member_ship_events_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_member_ship_events_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_member_ship_events",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_memberships": {
+      "name": "fleet_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'squad_member'"
+        }
+      },
+      "indexes": {
+        "fleet_memberships_character_id_idx": {
+          "name": "fleet_memberships_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_memberships_fleet_id_idx": {
+          "name": "fleet_memberships_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_memberships_invitation_id_idx": {
+          "name": "fleet_memberships_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_memberships_invitation_id_fleet_invitations_id_fk": {
+          "name": "fleet_memberships_invitation_id_fleet_invitations_id_fk",
+          "tableFrom": "fleet_memberships",
+          "tableTo": "fleet_invitations",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_summaries": {
+      "name": "fleet_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_boss_id": {
+          "name": "fleet_boss_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_member_count": {
+          "name": "peak_member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "final_member_count": {
+          "name": "final_member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "motd": {
+          "name": "motd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free_move": {
+          "name": "is_free_move",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_registered": {
+          "name": "is_registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_voice_enabled": {
+          "name": "is_voice_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_summaries_fleet_id_idx": {
+          "name": "fleet_summaries_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_fleet_boss_id_idx": {
+          "name": "fleet_summaries_fleet_boss_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_boss_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_tracking_session_id_idx": {
+          "name": "fleet_summaries_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_started_at_idx": {
+          "name": "fleet_summaries_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_ended_at_idx": {
+          "name": "fleet_summaries_ended_at_idx",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_summaries_fleet_boss_started_idx": {
+          "name": "fleet_summaries_fleet_boss_started_idx",
+          "columns": [
+            {
+              "expression": "fleet_boss_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_summaries_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_summaries_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_summaries",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_tracking_session_events": {
+      "name": "fleet_tracking_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_session_id": {
+          "name": "tracking_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_character_id": {
+          "name": "previous_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_tracking_session_events_fleet_id_idx": {
+          "name": "fleet_tracking_session_events_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_session_events_tracking_session_id_idx": {
+          "name": "fleet_tracking_session_events_tracking_session_id_idx",
+          "columns": [
+            {
+              "expression": "tracking_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_session_events_character_id_idx": {
+          "name": "fleet_tracking_session_events_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_session_events_observed_at_idx": {
+          "name": "fleet_tracking_session_events_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fleet_tracking_session_events_tracking_session_id_fleet_tracking_sessions_id_fk": {
+          "name": "fleet_tracking_session_events_tracking_session_id_fleet_tracking_sessions_id_fk",
+          "tableFrom": "fleet_tracking_session_events",
+          "tableTo": "fleet_tracking_sessions",
+          "columnsFrom": [
+            "tracking_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleet_tracking_sessions": {
+      "name": "fleet_tracking_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_user_id": {
+          "name": "ended_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fleet_tracking_sessions_character_id_idx": {
+          "name": "fleet_tracking_sessions_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_fleet_id_idx": {
+          "name": "fleet_tracking_sessions_fleet_id_idx",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_started_by_user_id_idx": {
+          "name": "fleet_tracking_sessions_started_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "started_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_status_idx": {
+          "name": "fleet_tracking_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fleet_tracking_sessions_started_at_idx": {
+          "name": "fleet_tracking_sessions_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/fleets/.migrations/meta/_journal.json
+++ b/apps/fleets/.migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1784521994428,
       "tag": "0011_hot_marvel_boy",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1784702105721,
+      "tag": "0012_cute_sabretooth",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/fleets/src/db/schema.ts
+++ b/apps/fleets/src/db/schema.ts
@@ -192,47 +192,8 @@ export const fleetCommanderAccessAnchors = pgTable(
 )
 
 /**
- * Fleet state cache table
- *
- * Live snapshot of an actively-tracked fleet, upserted each tick by the
- * FleetMonitor DO. Holds the current state from ESI plus a back-reference
- * to the tracking session.
- */
-export const fleetStateCache = pgTable(
-	'fleet_state_cache',
-	{
-		id: uuid('id').defaultRandom().primaryKey(),
-		fleetId: text('fleet_id').notNull().unique(),
-		fleetBossId: text('fleet_boss_id').notNull(),
-		/** The tracking session this cache row belongs to */
-		trackingSessionId: uuid('tracking_session_id').references(() => fleetTrackingSessions.id, {
-			onDelete: 'set null',
-		}),
-		memberCount: integer('member_count').default(0).notNull(),
-		motd: text('motd'),
-		isFreeMove: boolean('is_free_move').default(false).notNull(),
-		isRegistered: boolean('is_registered').default(false).notNull(),
-		isVoiceEnabled: boolean('is_voice_enabled').default(false).notNull(),
-		notFound: boolean('not_found').default(false).notNull(),
-		notFoundAt: timestamp('not_found_at'),
-		lastChecked: timestamp('last_checked').defaultNow().notNull(),
-		createdAt: timestamp('created_at').defaultNow().notNull(),
-		updatedAt: timestamp('updated_at').defaultNow().notNull(),
-		},
-		(table) => ({
-			fleetIdIdx: index('fleet_state_cache_fleet_id_idx').on(table.fleetId),
-			fleetBossIdIdx: index('fleet_state_cache_fleet_boss_id_idx').on(table.fleetBossId),
-			trackingSessionIdIdx: index('fleet_state_cache_tracking_session_id_idx').on(
-				table.trackingSessionId
-			),
-			lastCheckedIdx: index('fleet_state_cache_last_checked_idx').on(table.lastChecked),
-			notFoundIdx: index('fleet_state_cache_not_found_idx').on(table.notFound),
-		})
-	)
-
-/**
  * Fleet summaries table
- * Stores historical fleet data before deletion from fleet_state_cache
+ * Stores historical fleet data after a fleet session ends.
  * This allows us to maintain a permanent record of past fleets
  */
 export const fleetSummaries = pgTable(
@@ -370,7 +331,6 @@ export const schema = {
 	fleetTrackingSessions,
 	fleetCommanderEvents,
 	fleetCommanderAccessAnchors,
-	fleetStateCache,
 	fleetSummaries,
 	fleetMemberHistory,
 	fleetMemberShipEvents,

--- a/apps/fleets/src/durable-object.ts
+++ b/apps/fleets/src/durable-object.ts
@@ -39,7 +39,7 @@ import {
 	CorpRollupRow,
 	SessionCurrentMemberRow,
 	SessionLiveMemberLocation,
-	SessionLiveSnapshot,
+	SessionLiveSnapshotResult,
 	SessionMemberShipHistoryRow,
 	SessionRosterRow,
 	SessionSummary,
@@ -65,7 +65,6 @@ import {
 	fleetMemberships,
 	fleetMemberShipEvents,
 	fleetTrackingSessionEvents,
-	fleetStateCache,
 	fleetSummaries,
 	fleetTrackingSessions,
 	schema,
@@ -168,6 +167,49 @@ export class FleetsDO extends DurableObject implements Fleets {
 			observedAt,
 			createdAt: observedAt,
 		})
+	}
+
+	private async getMonitorStateForFleet(
+		fleetId: string
+	): Promise<import('@repo/fleets').FleetMonitorState | null> {
+		try {
+			const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
+			const state = await monitorStub.getMonitorState()
+			if (!state || state.fleetId !== fleetId || !state.isInitialized) {
+				return null
+			}
+			return state
+		} catch (error) {
+			logger.warn('[FleetsDO] Failed to read FleetMonitor state', {
+				fleetId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+			return null
+		}
+	}
+
+	private async getLatestCommanderBySessionIds(
+		sessionIds: string[]
+	): Promise<Map<string, string>> {
+		if (sessionIds.length === 0) return new Map()
+
+		const rows = await this.db
+			.select({
+				trackingSessionId: fleetCommanderEvents.trackingSessionId,
+				commanderCharacterId: fleetCommanderEvents.commanderCharacterId,
+			})
+			.from(fleetCommanderEvents)
+			.where(inArray(fleetCommanderEvents.trackingSessionId, sessionIds))
+			.orderBy(desc(fleetCommanderEvents.observedAt))
+
+		const latestBySession = new Map<string, string>()
+		for (const row of rows) {
+			if (!row.trackingSessionId) continue
+			if (!latestBySession.has(row.trackingSessionId)) {
+				latestBySession.set(row.trackingSessionId, row.commanderCharacterId)
+			}
+		}
+		return latestBySession
 	}
 
 	private getEffectiveSessionStatus(
@@ -311,31 +353,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 			})
 			.returning()
 
-		// Update fleet cache
-		await this.db
-			.insert(fleetStateCache)
-			.values({
-				fleetId,
-				fleetBossId,
-				memberCount: 0,
-				motd: fleetData.motd || null,
-				isFreeMove: fleetData.is_free_move,
-				isRegistered: fleetData.is_registered,
-				isVoiceEnabled: fleetData.is_voice_enabled,
-			})
-			.onConflictDoUpdate({
-				target: fleetStateCache.fleetId,
-				set: {
-					fleetBossId,
-					motd: fleetData.motd || null,
-					isFreeMove: fleetData.is_free_move,
-					isRegistered: fleetData.is_registered,
-					isVoiceEnabled: fleetData.is_voice_enabled,
-					lastChecked: new Date(),
-					updatedAt: new Date(),
-				},
-			})
-
 		return {
 			token,
 			url: `https://pleaseignore.app/fleets/join/${token}`,
@@ -428,27 +445,28 @@ export class FleetsDO extends DurableObject implements Fleets {
 	}
 
 	async getFleetDetails(fleetId: string, characterId: string): Promise<FleetDetailsResponse> {
-		// Check if fleet is marked as not found in cache
-		const [cached] = await this.db
-			.select()
-			.from(fleetStateCache)
-			.where(eq(fleetStateCache.fleetId, fleetId))
-			.limit(1)
-
-		if (cached?.notFound && cached.notFoundAt) {
-			const notFoundAge = Date.now() - cached.notFoundAt.getTime()
+		const liveMonitorState = await this.getMonitorStateForFleet(fleetId)
+		if (liveMonitorState?.notFound && liveMonitorState.notFoundAt) {
+			const notFoundAge = Date.now() - new Date(liveMonitorState.notFoundAt).getTime()
 			const twentyFourHours = 24 * 60 * 60 * 1000
 			if (notFoundAge < twentyFourHours) {
 				logger.log(
-					`[Fleet ${fleetId}] Marked as 404, skipping ESI query (age: ${Math.round(notFoundAge / 1000 / 60)} minutes)`
+					`[Fleet ${fleetId}] Marked as 404 in monitor state, skipping ESI query (age: ${Math.round(notFoundAge / 1000 / 60)} minutes)`
 				)
 				throw new Error('Fleet not found (404)')
 			}
 		}
 
+		if (liveMonitorState) {
+			const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
+			const liveStatus = await monitorStub.getFleetStatus()
+			if (liveStatus) {
+				return liveStatus
+			}
+		}
+
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 
-		// Fetch fleet info
 		let fleetInfo: EsiGetFleetInformation
 		try {
 			const fleetResponse = await tokenStore.fetchEsi<EsiGetFleetInformation>(
@@ -457,70 +475,10 @@ export class FleetsDO extends DurableObject implements Fleets {
 				LIVE_FLEET_ESI_OPTIONS
 			)
 			fleetInfo = esiGetFleetInformationSchema.parse(fleetResponse.data)
-
-			// Update cache with all fleet properties
-			await this.db
-				.insert(fleetStateCache)
-				.values({
-					fleetId,
-					fleetBossId: characterId,
-					memberCount: 0,
-					motd: fleetInfo.motd || null,
-					isFreeMove: fleetInfo.is_free_move,
-					isRegistered: fleetInfo.is_registered,
-					isVoiceEnabled: fleetInfo.is_voice_enabled,
-					notFound: false,
-					notFoundAt: null,
-					lastChecked: new Date(),
-				})
-				.onConflictDoUpdate({
-					target: fleetStateCache.fleetId,
-					set: {
-						motd: fleetInfo.motd || null,
-						isFreeMove: fleetInfo.is_free_move,
-						isRegistered: fleetInfo.is_registered,
-						isVoiceEnabled: fleetInfo.is_voice_enabled,
-						notFound: false,
-						notFoundAt: null,
-						lastChecked: new Date(),
-						updatedAt: new Date(),
-					},
-				})
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error)
-			// Check if it's a 404 error
-			if (
-				errorMessage.includes('404') ||
-				errorMessage.includes('Not found') ||
-				errorMessage.includes('Not Found')
-			) {
-				logger.log(`[Fleet ${fleetId}] Received 404 from ESI, marking as not found`)
-
-				// Mark fleet as not found
-				await this.db
-					.insert(fleetStateCache)
-				.values({
-					fleetId,
-					fleetBossId: characterId,
-					memberCount: 0,
-					notFound: true,
-					notFoundAt: new Date(),
-					lastChecked: new Date(),
-				})
-				.onConflictDoUpdate({
-					target: fleetStateCache.fleetId,
-					set: {
-						notFound: true,
-						notFoundAt: new Date(),
-						lastChecked: new Date(),
-						updatedAt: new Date(),
-					},
-				})
-			}
 			throw error
 		}
 
-		// Fetch fleet members
 		let members: EsiGetFleetMembers | undefined
 		let memberCount = 0
 		try {
@@ -529,30 +487,13 @@ export class FleetsDO extends DurableObject implements Fleets {
 				characterId,
 				LIVE_FLEET_ESI_OPTIONS
 			)
-
-			// Debug logging to see raw ESI response
-			logger.log(
-				'[Fleet Members] Raw ESI response sample (first member):',
-				JSON.stringify(membersResponse.data[0], null, 2)
-			)
-			logger.log(
-				'[Fleet Members] First member station_id type:',
-				typeof membersResponse.data[0]?.station_id
-			)
-			logger.log(
-				'[Fleet Members] First member station_id value:',
-				membersResponse.data[0]?.station_id
-			)
-
 			members = esiGetFleetMembersSchema.parse(membersResponse.data)
 			memberCount = members.length
 		} catch (error) {
-			// Members fetch failed, but continue
 			logger.error('[Fleet Members] Failed to parse or fetch:', error)
 			members = undefined
 		}
 
-		// Get fleet boss name
 		const characterStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, characterId)
 		const characterInfo = await characterStub.getCharacterInfo(characterId)
 
@@ -758,39 +699,33 @@ export class FleetsDO extends DurableObject implements Fleets {
 	}
 
 	async isFleetActive(fleetId: string, characterId: string): Promise<boolean> {
-		// Check cache first
-		const [cached] = await this.db
-			.select()
-			.from(fleetStateCache)
-			.where(
-				and(
-					eq(fleetStateCache.fleetId, fleetId),
-					// Cache valid for 4 minutes 30 seconds (to eliminate race conditions)
-					gt(fleetStateCache.lastChecked, new Date(Date.now() - (4 * 60 + 30) * 1000))
+		const monitorState = await this.getMonitorStateForFleet(fleetId)
+		if (monitorState?.notFound && monitorState.notFoundAt) {
+			const notFoundAge = Date.now() - new Date(monitorState.notFoundAt).getTime()
+			const twentyFourHours = 24 * 60 * 60 * 1000
+			if (notFoundAge < twentyFourHours) {
+				logger.log(
+					`[Fleet ${fleetId}] Marked as 404 in monitor state, skipping ESI query (age: ${Math.round(notFoundAge / 1000 / 60)} minutes)`
 				)
-			)
-			.limit(1)
-
-		if (cached) {
-			// If fleet was marked as not found within last 24 hours, don't query ESI again
-			if (cached.notFound && cached.notFoundAt) {
-				const notFoundAge = Date.now() - cached.notFoundAt.getTime()
-				const twentyFourHours = 24 * 60 * 60 * 1000
-				if (notFoundAge < twentyFourHours) {
-					logger.log(
-						`[Fleet ${fleetId}] Marked as 404, skipping ESI query (age: ${Math.round(notFoundAge / 1000 / 60)} minutes)`
-					)
-					return false
-				}
+				return false
 			}
-			return !cached.notFound
+		}
+
+		if (monitorState) {
+			try {
+				const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
+				return (await monitorStub.getFleetStatus()) !== null
+			} catch (error) {
+				logger.warn('[FleetsDO] Fleet monitor lookup failed while checking active state', {
+					fleetId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
 		}
 
 		// Check with ESI
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		let isActive = false
-		let isNotFound = false
-		let fleetInfo: EsiGetFleetInformation | null = null
 		try {
 			const fleetResponse = await tokenStore.fetchEsi<EsiGetFleetInformation>(
 				`/fleets/${fleetId}/`,
@@ -798,7 +733,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				LIVE_FLEET_ESI_OPTIONS
 			)
 			// Validate the response to ensure it's valid fleet data
-			fleetInfo = esiGetFleetInformationSchema.parse(fleetResponse.data)
+			esiGetFleetInformationSchema.parse(fleetResponse.data)
 			isActive = true
 		} catch (error) {
 			// Check if it's a 404 error
@@ -809,61 +744,8 @@ export class FleetsDO extends DurableObject implements Fleets {
 				errorMessage.includes('Not Found')
 			) {
 				logger.log(`[Fleet ${fleetId}] Received 404 from ESI, marking as not found`)
-				isNotFound = true
 			}
 			isActive = false
-		}
-
-		// Update cache with all fleet properties
-		if (fleetInfo) {
-			await this.db
-				.insert(fleetStateCache)
-				.values({
-					fleetId,
-					fleetBossId: characterId,
-					memberCount: 0,
-					motd: fleetInfo.motd || null,
-					isFreeMove: fleetInfo.is_free_move,
-					isRegistered: fleetInfo.is_registered,
-					isVoiceEnabled: fleetInfo.is_voice_enabled,
-					notFound: false,
-					notFoundAt: null,
-					lastChecked: new Date(),
-				})
-				.onConflictDoUpdate({
-					target: fleetStateCache.fleetId,
-					set: {
-						motd: fleetInfo.motd || null,
-						isFreeMove: fleetInfo.is_free_move,
-						isRegistered: fleetInfo.is_registered,
-						isVoiceEnabled: fleetInfo.is_voice_enabled,
-						notFound: false,
-						notFoundAt: null,
-						lastChecked: new Date(),
-						updatedAt: new Date(),
-					},
-				})
-		} else {
-			// Fleet not found or error - update cache with not found status
-			await this.db
-				.insert(fleetStateCache)
-				.values({
-					fleetId,
-					fleetBossId: characterId,
-					memberCount: 0,
-					notFound: isNotFound,
-					notFoundAt: isNotFound ? new Date() : null,
-					lastChecked: new Date(),
-				})
-				.onConflictDoUpdate({
-					target: fleetStateCache.fleetId,
-					set: {
-						notFound: isNotFound,
-						notFoundAt: isNotFound ? new Date() : null,
-						lastChecked: new Date(),
-						updatedAt: new Date(),
-					},
-				})
 		}
 
 		return isActive
@@ -872,53 +754,37 @@ export class FleetsDO extends DurableObject implements Fleets {
 	async getFleetCacheStatus(
 		fleetId: string
 	): Promise<{ notFound: boolean; notFoundAt: Date | null; lastChecked: Date } | null> {
-		const [cached] = await this.db
-			.select({
-				notFound: fleetStateCache.notFound,
-				notFoundAt: fleetStateCache.notFoundAt,
-				lastChecked: fleetStateCache.lastChecked,
-			})
-			.from(fleetStateCache)
-			.where(eq(fleetStateCache.fleetId, fleetId))
-			.limit(1)
-
-		if (!cached) {
+		const state = await this.getMonitorStateForFleet(fleetId)
+		if (!state) {
 			return null
 		}
 
 		return {
-			notFound: cached.notFound,
-			notFoundAt: cached.notFoundAt,
-			lastChecked: cached.lastChecked,
+			notFound: state.notFound,
+			notFoundAt: state.notFoundAt ? new Date(state.notFoundAt) : null,
+			lastChecked: new Date(state.lastChecked ?? new Date().toISOString()),
 		}
 	}
 
 	async getFleetIsRegistered(fleetId: string, characterId: string): Promise<boolean> {
-		// Check cache first with 4 minutes 30 seconds validity (same as isFleetActive)
-		const [cached] = await this.db
-			.select({
-				isRegistered: fleetStateCache.isRegistered,
-				lastChecked: fleetStateCache.lastChecked,
-			})
-			.from(fleetStateCache)
-			.where(
-				and(
-					eq(fleetStateCache.fleetId, fleetId),
-					// Cache valid for 4 minutes 30 seconds (to eliminate race conditions)
-					gt(fleetStateCache.lastChecked, new Date(Date.now() - (4 * 60 + 30) * 1000))
-				)
-			)
-			.limit(1)
-
-		if (cached) {
-			// Use cached value if fresh
-			return cached.isRegistered
+		const monitorState = await this.getMonitorStateForFleet(fleetId)
+		if (monitorState) {
+			try {
+				const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
+				const liveStatus = await monitorStub.getFleetStatus()
+				if (liveStatus) {
+					return liveStatus.fleetInfo.is_registered
+				}
+			} catch (error) {
+				logger.warn('[FleetsDO] Fleet monitor lookup failed while checking registration', {
+					fleetId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
 		}
 
-		// Cache is missing or stale, fetch from ESI
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		let fleetInfo: EsiGetFleetInformation | null = null
-		let isNotFound = false
 
 		try {
 			const fleetResponse = await tokenStore.fetchEsi<EsiGetFleetInformation>(
@@ -928,72 +794,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 			)
 			fleetInfo = esiGetFleetInformationSchema.parse(fleetResponse.data)
 		} catch (error) {
-			// Check if it's a 404 error
-			const errorMessage = error instanceof Error ? error.message : String(error)
-			if (
-				errorMessage.includes('404') ||
-				errorMessage.includes('Not found') ||
-				errorMessage.includes('Not Found')
-			) {
-				isNotFound = true
-			}
-			// If fleet not found, return false for isRegistered
 			fleetInfo = null
 		}
 
-		// Update cache with all fleet properties
 		if (fleetInfo) {
-			await this.db
-				.insert(fleetStateCache)
-				.values({
-					fleetId,
-					fleetBossId: characterId,
-					memberCount: 0,
-					motd: fleetInfo.motd || null,
-					isFreeMove: fleetInfo.is_free_move,
-					isRegistered: fleetInfo.is_registered,
-					isVoiceEnabled: fleetInfo.is_voice_enabled,
-					notFound: false,
-					notFoundAt: null,
-					lastChecked: new Date(),
-				})
-				.onConflictDoUpdate({
-					target: fleetStateCache.fleetId,
-					set: {
-						motd: fleetInfo.motd || null,
-						isFreeMove: fleetInfo.is_free_move,
-						isRegistered: fleetInfo.is_registered,
-						isVoiceEnabled: fleetInfo.is_voice_enabled,
-						notFound: false,
-						notFoundAt: null,
-						lastChecked: new Date(),
-						updatedAt: new Date(),
-					},
-				})
-
 			return fleetInfo.is_registered
 		}
-
-		// Fleet not found or error - update cache with not found status
-		await this.db
-			.insert(fleetStateCache)
-			.values({
-				fleetId,
-				fleetBossId: characterId,
-				memberCount: 0,
-				notFound: isNotFound,
-				notFoundAt: isNotFound ? new Date() : null,
-				lastChecked: new Date(),
-			})
-			.onConflictDoUpdate({
-				target: fleetStateCache.fleetId,
-				set: {
-					notFound: isNotFound,
-					notFoundAt: isNotFound ? new Date() : null,
-					lastChecked: new Date(),
-					updatedAt: new Date(),
-				},
-			})
 
 		return false
 	}
@@ -1073,7 +879,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				characterId: fleetTrackingSessions.characterId,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.fleetId, fleetId))
 			.orderBy(desc(fleetTrackingSessions.startedAt))
 			.limit(1)
@@ -1216,7 +1021,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				fleetId: fleetTrackingSessions.fleetId,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.id, sessionId))
 			.limit(1)
 
@@ -1281,7 +1085,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 		}
 		if (fleetBossCharacterIds.length > 0) {
 			const commanderMatches = or(
-				inArray(fleetStateCache.fleetBossId, fleetBossCharacterIds),
 				sql<boolean>`exists (
 					select 1
 					from fleet_commander_access_anchors
@@ -1314,10 +1117,8 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const items = await this.db
 			.select({
 				session: fleetTrackingSessions,
-				currentCommanderCharacterId: fleetStateCache.fleetBossId,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(where)
 			.orderBy(desc(fleetTrackingSessions.startedAt))
 			.limit(limit)
@@ -1326,15 +1127,15 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const totalResult = await this.db
 			.select({ count: sql<number>`count(*)::int` })
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(where)
 		const total = totalResult[0]?.count ?? 0
+		const commanderMap = await this.getLatestCommanderBySessionIds(items.map((row) => row.session.id))
 
 		return {
 			items: items.map((row) =>
 				this.serializeSession(
 					row.session,
-					row.currentCommanderCharacterId ?? null,
+					commanderMap.get(row.session.id) ?? null,
 					[],
 					this.getEffectiveSessionStatus({
 						status: row.session.status,
@@ -1355,26 +1156,15 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const [row] = await this.db
 			.select({
 				session: fleetTrackingSessions,
-				currentCommanderCharacterId: fleetStateCache.fleetBossId,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.id, sessionId))
 			.limit(1)
 		if (!row) return null
 
-		const commanderRows = row.session.fleetId
-			? await this.db
-				.select({
-					commanderCharacterId: fleetCommanderAccessAnchors.commanderCharacterId,
-				})
-				.from(fleetCommanderAccessAnchors)
-				.where(eq(fleetCommanderAccessAnchors.fleetId, row.session.fleetId))
-				.orderBy(asc(fleetCommanderAccessAnchors.firstSeenAt))
+		const commanderCharacterIds = row.session.fleetId
+			? Array.from((await this.getLatestCommanderBySessionIds([row.session.id])).values())
 			: []
-		const commanderCharacterIds = Array.from(
-			new Set(commanderRows.map((r) => r.commanderCharacterId))
-		)
 		const effectiveStatus = this.getEffectiveSessionStatus({
 			status: row.session.status,
 			endedAt: row.session.endedAt,
@@ -1382,7 +1172,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 		return this.serializeSession(
 			row.session,
-			row.currentCommanderCharacterId ?? null,
+			commanderCharacterIds[0] ?? null,
 			commanderCharacterIds,
 			effectiveStatus
 		)
@@ -1395,10 +1185,8 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const [row] = await this.db
 			.select({
 				session: fleetTrackingSessions,
-				currentCommanderCharacterId: fleetStateCache.fleetBossId,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(
 				and(
 					eq(fleetTrackingSessions.fleetId, fleetId),
@@ -1410,15 +1198,8 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.limit(1)
 		if (!row) return null
 
-		const commanderRows = await this.db
-			.select({
-				commanderCharacterId: fleetCommanderAccessAnchors.commanderCharacterId,
-			})
-			.from(fleetCommanderAccessAnchors)
-			.where(eq(fleetCommanderAccessAnchors.fleetId, fleetId))
-			.orderBy(asc(fleetCommanderAccessAnchors.firstSeenAt))
 		const commanderCharacterIds = Array.from(
-			new Set(commanderRows.map((r) => r.commanderCharacterId))
+			(await this.getLatestCommanderBySessionIds([row.session.id])).values()
 		)
 		const effectiveStatus = this.getEffectiveSessionStatus({
 			status: row.session.status,
@@ -1427,7 +1208,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 		return this.serializeSession(
 			row.session,
-			row.currentCommanderCharacterId ?? null,
+			commanderCharacterIds[0] ?? null,
 			commanderCharacterIds,
 			effectiveStatus
 		)
@@ -1440,24 +1221,15 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const [row] = await this.db
 			.select({
 				session: fleetTrackingSessions,
-				currentCommanderCharacterId: fleetStateCache.fleetBossId,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.fleetId, fleetId))
 			.orderBy(desc(fleetTrackingSessions.startedAt))
 			.limit(1)
 		if (!row) return null
 
-		const commanderRows = await this.db
-			.select({
-				commanderCharacterId: fleetCommanderAccessAnchors.commanderCharacterId,
-			})
-			.from(fleetCommanderAccessAnchors)
-			.where(eq(fleetCommanderAccessAnchors.fleetId, fleetId))
-			.orderBy(asc(fleetCommanderAccessAnchors.firstSeenAt))
 		const commanderCharacterIds = Array.from(
-			new Set(commanderRows.map((r) => r.commanderCharacterId))
+			(await this.getLatestCommanderBySessionIds([row.session.id])).values()
 		)
 		const effectiveStatus = this.getEffectiveSessionStatus({
 			status: row.session.status,
@@ -1466,17 +1238,18 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 		return this.serializeSession(
 			row.session,
-			row.currentCommanderCharacterId ?? null,
+			commanderCharacterIds[0] ?? null,
 			commanderCharacterIds,
 			effectiveStatus
 		)
 	}
 
 	/**
-	 * Get the live snapshot (last cache row) for an active session's fleet.
-	 * Returns null if the session has not started ticking yet.
+	 * Get the live snapshot from the FleetMonitor DO for an active session's fleet.
+	 * Returns a status envelope so callers can distinguish a ready snapshot
+	 * from an inactive session or a monitor read failure.
 	 */
-	async getSessionLiveSnapshot(sessionId: string): Promise<SessionLiveSnapshot | null> {
+	async getSessionLiveSnapshot(sessionId: string): Promise<SessionLiveSnapshotResult> {
 		const [session] = await this.db
 			.select({
 				fleetId: fleetTrackingSessions.fleetId,
@@ -1486,46 +1259,92 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.from(fleetTrackingSessions)
 			.where(eq(fleetTrackingSessions.id, sessionId))
 			.limit(1)
-		if (!session || !session.fleetId) return null
-		if (this.getEffectiveSessionStatus({ status: session.status, endedAt: session.endedAt }) !== 'active') {
-			return null
+		if (!session || !session.fleetId) {
+			return {
+				state: 'inactive',
+				message: 'This fleet tracking session is no longer active.',
+				snapshot: null,
+			}
 		}
-
-		const [cache] = await this.db
-			.select()
-			.from(fleetStateCache)
-			.where(eq(fleetStateCache.fleetId, session.fleetId))
-			.limit(1)
-		if (!cache || cache.notFound) return null
-
-		// Pull peak member count from the FleetMonitor DO's SQLite state.
-		let peakMemberCount = cache.memberCount
+		if (this.getEffectiveSessionStatus({ status: session.status, endedAt: session.endedAt }) !== 'active') {
+			return {
+				state: 'inactive',
+				message: 'This fleet tracking session is no longer active.',
+				snapshot: null,
+			}
+		}
 		try {
-			const monitorStub = getStub<FleetMonitor>(
-				this.env.FLEET_MONITOR,
-				`fleet-${session.fleetId}`
-			)
-			const state = await monitorStub.getMonitorState()
-			if (state && typeof state.peakMemberCount === 'number') {
-				peakMemberCount = Math.max(state.peakMemberCount, cache.memberCount)
+			const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${session.fleetId}`)
+			const [status, monitorState] = await Promise.all([
+				monitorStub.getFleetStatus(),
+				monitorStub.getMonitorState(),
+			])
+			if (!status) {
+				return {
+					state: 'unavailable',
+					message:
+						'The latest live fleet snapshot could not be read. The fleet may have ended or the monitor may still be recovering.',
+					snapshot: null,
+				}
+			}
+			if (monitorState?.notFound) {
+				return {
+					state: 'unavailable',
+					message:
+						'The tracked fleet could not be found, so the latest live snapshot is unavailable.',
+					snapshot: null,
+				}
+			}
+
+			const peakMemberCount = Math.max(monitorState?.peakMemberCount ?? 0, status.memberCount)
+			const lastChecked = monitorState?.lastChecked ?? new Date().toISOString()
+
+			return {
+				state: 'ready',
+				message: null,
+				snapshot: {
+					fleetId: session.fleetId,
+					memberCount: status.memberCount,
+					peakMemberCount,
+					motd: status.fleetInfo.motd || null,
+					isFreeMove: status.fleetInfo.is_free_move,
+					isRegistered: status.fleetInfo.is_registered,
+					isVoiceEnabled: status.fleetInfo.is_voice_enabled,
+					lastChecked,
+					updatedAt: lastChecked,
+				},
 			}
 		} catch (error) {
-			logger.warn('[FleetsDO] Could not read FleetMonitor state for peak', {
-				fleetId: session.fleetId,
-				error: error instanceof Error ? error.message : String(error),
-			})
-		}
+			const message = error instanceof Error ? error.message : String(error)
+			if (
+				message.includes('ESI request failed: 404') ||
+				message.includes('404 Not Found') ||
+				message.includes('not found')
+			) {
+				logger.warn('[FleetsDO] Live snapshot unavailable because fleet no longer exists', {
+					sessionId,
+					fleetId: session.fleetId,
+					error: message,
+				})
+				return {
+					state: 'unavailable',
+					message:
+						'The latest live fleet snapshot could not be read. The fleet may have ended or the monitor may still be recovering.',
+					snapshot: null,
+				}
+			}
 
-		return {
-			fleetId: cache.fleetId,
-			memberCount: cache.memberCount,
-			peakMemberCount,
-			motd: cache.motd,
-			isFreeMove: cache.isFreeMove,
-			isRegistered: cache.isRegistered,
-			isVoiceEnabled: cache.isVoiceEnabled,
-			lastChecked: cache.lastChecked.toISOString(),
-			updatedAt: cache.updatedAt.toISOString(),
+			logger.warn('[FleetsDO] Failed to read live snapshot from FleetMonitor', {
+				sessionId,
+				fleetId: session.fleetId,
+				error: message,
+			})
+			return {
+				state: 'unavailable',
+				message:
+					'The latest live fleet snapshot could not be read. The fleet may have ended or the monitor may still be recovering.',
+				snapshot: null,
+			}
 		}
 	}
 
@@ -2029,7 +1848,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				endedAt: fleetTrackingSessions.endedAt,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.id, sessionId))
 			.limit(1)
 
@@ -2220,7 +2038,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 				characterId: fleetTrackingSessions.characterId,
 			})
 			.from(fleetTrackingSessions)
-			.leftJoin(fleetStateCache, eq(fleetTrackingSessions.fleetId, fleetStateCache.fleetId))
 			.where(eq(fleetTrackingSessions.id, args.sessionId))
 			.limit(1)
 

--- a/apps/fleets/src/fleet-monitor.ts
+++ b/apps/fleets/src/fleet-monitor.ts
@@ -24,7 +24,6 @@ import {
 	fleetCommanderAccessAnchors,
 	fleetCommanderEvents,
 	fleetTrackingSessionEvents,
-	fleetStateCache,
 	fleetSummaries,
 	fleetTrackingSessions,
 	schema,
@@ -159,7 +158,7 @@ async function syncFleetBossAccess(
  * - Alarm handler for periodic fleet status updates (10s baseline cadence, header-aware)
  * - WebSocket hibernation API for real-time updates
  * - SQLite-backed state for instance-specific data (fleetId, characterId)
- * - PostgreSQL for cross-instance data (fleetStateCache)
+ * - Persistent SQLite-backed live state and historical fleet/session tables
  */
 export class FleetMonitorDO extends DurableObject {
 	private static readonly BASE_POLL_INTERVAL_MS = 10 * 1000
@@ -205,7 +204,7 @@ export class FleetMonitorDO extends DurableObject {
 			.toArray()
 
 		const currentVersion = versionResult.length > 0 ? versionResult[0].version : 0
-		const targetVersion = 5 // Current schema version
+		const targetVersion = 6 // Current schema version
 
 		// Run migrations if needed
 		if (currentVersion < targetVersion) {
@@ -365,7 +364,7 @@ export class FleetMonitorDO extends DurableObject {
 		}
 
 		// Migration 3 -> 4: Persist the last synced boss separately so boss-change
-		// detection does not depend on cache rows that other helpers can rewrite.
+		// detection does not depend on state rows that other helpers can rewrite.
 		if (currentVersion < 4) {
 			try {
 				this.state.storage.sql.exec(
@@ -433,6 +432,39 @@ export class FleetMonitorDO extends DurableObject {
 			logger.info('[FleetMonitor] Migration 4 -> 5 completed (added expires_at)')
 		}
 
+		// Migration 5 -> 6: store the live fleet snapshot directly in monitor_state
+		// so the FleetMonitor DO owns the live-state cache instead of Postgres.
+		if (currentVersion < 6) {
+			const addColumn = (sqlStatement: string, columnName: string) => {
+				try {
+					this.state.storage.sql.exec(sqlStatement)
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error)
+					if (!message.includes('duplicate column')) {
+						logger.warn(`[FleetMonitor] Could not add ${columnName} column`, {
+							error: message,
+						})
+					}
+				}
+			}
+
+			addColumn(`ALTER TABLE monitor_state ADD COLUMN member_count INTEGER NOT NULL DEFAULT 0`, 'member_count')
+			addColumn(`ALTER TABLE monitor_state ADD COLUMN motd TEXT`, 'motd')
+			addColumn(`ALTER TABLE monitor_state ADD COLUMN is_free_move INTEGER NOT NULL DEFAULT 0`, 'is_free_move')
+			addColumn(`ALTER TABLE monitor_state ADD COLUMN is_registered INTEGER NOT NULL DEFAULT 0`, 'is_registered')
+			addColumn(`ALTER TABLE monitor_state ADD COLUMN is_voice_enabled INTEGER NOT NULL DEFAULT 0`, 'is_voice_enabled')
+			addColumn(`ALTER TABLE monitor_state ADD COLUMN not_found INTEGER NOT NULL DEFAULT 0`, 'not_found')
+			addColumn(`ALTER TABLE monitor_state ADD COLUMN not_found_at TEXT`, 'not_found_at')
+
+			this.state.storage.sql.exec(`
+				INSERT INTO schema_version (id, version)
+				VALUES (1, 6)
+				ON CONFLICT(id) DO UPDATE SET version = 6
+			`)
+
+			logger.info('[FleetMonitor] Migration 5 -> 6 completed (added live snapshot fields)')
+		}
+
 		logger.info('[FleetMonitor] Schema migrations completed', {
 			finalVersion: targetVersion,
 		})
@@ -493,29 +525,16 @@ export class FleetMonitorDO extends DurableObject {
 			// Same — fine to ignore.
 		}
 
-			// Store initialization state in SQLite (peak starts at 0 — bumped on first tick)
-			const now = new Date().toISOString()
-			const expiresAt = this.getMonitorStateExpiresAt(new Date()).toISOString()
-			await this.state.storage.sql.exec(
-				`
-				INSERT INTO monitor_state (id, fleet_id, character_id, tracking_session_id, last_synced_fleet_boss_id, is_initialized, last_checked, peak_member_count, expires_at)
-				VALUES (1, ?, ?, ?, NULL, 1, ?, 0, ?)
-				ON CONFLICT(id) DO UPDATE SET
-					fleet_id = excluded.fleet_id,
-					character_id = excluded.character_id,
-					tracking_session_id = excluded.tracking_session_id,
-					last_synced_fleet_boss_id = excluded.last_synced_fleet_boss_id,
-					is_initialized = excluded.is_initialized,
-					last_checked = excluded.last_checked,
-					peak_member_count = 0,
-					expires_at = excluded.expires_at
-			`,
+		// Store initialization state in SQLite (peak starts at 0 — bumped on first tick)
+		const now = new Date()
+		await this.persistMonitorState({
 			fleetId,
 			characterId,
 			trackingSessionId,
-			now,
-			expiresAt
-			)
+			lastSyncedFleetBossId: null,
+			lastChecked: now,
+			peakMemberCount: 0,
+		})
 
 		// Get initial fleet status to create baseline snapshot
 		try {
@@ -557,52 +576,23 @@ export class FleetMonitorDO extends DurableObject {
 					currentFleetBossCharacterId: currentFleetBossId,
 					observedAt,
 				})
-				this.state.storage.sql.exec(
-					`UPDATE monitor_state SET last_synced_fleet_boss_id = ?, expires_at = ? WHERE id = 1`,
-					currentFleetBossId,
-					this.getMonitorStateExpiresAtIso()
-				)
-				// Update fleet cache immediately to clear inactive/ended state
-				await this.db
-					.insert(fleetStateCache)
-					.values({
-						fleetId,
-						fleetBossId: currentFleetBossId,
-						trackingSessionId,
-						memberCount: initialStatus.memberCount,
-						motd: initialStatus.fleetInfo.motd || null,
-						isFreeMove: initialStatus.fleetInfo.is_free_move,
-						isRegistered: initialStatus.fleetInfo.is_registered,
-						isVoiceEnabled: initialStatus.fleetInfo.is_voice_enabled,
-						notFound: false,
-						notFoundAt: null,
-						lastChecked: observedAt,
-					})
-					.onConflictDoUpdate({
-						target: fleetStateCache.fleetId,
-						set: {
-							fleetBossId: currentFleetBossId,
-							trackingSessionId,
-							memberCount: initialStatus.memberCount,
-							motd: initialStatus.fleetInfo.motd || null,
-							isFreeMove: initialStatus.fleetInfo.is_free_move,
-							isRegistered: initialStatus.fleetInfo.is_registered,
-							isVoiceEnabled: initialStatus.fleetInfo.is_voice_enabled,
-							notFound: false,
-							notFoundAt: null,
-							lastChecked: observedAt,
-							updatedAt: observedAt,
-						},
-					})
+				await this.persistMonitorState({
+					fleetId,
+					characterId: currentFleetBossId,
+					trackingSessionId,
+					lastSyncedFleetBossId: currentFleetBossId,
+					lastChecked: observedAt,
+					peakMemberCount: initialStatus.memberCount,
+					memberCount: initialStatus.memberCount,
+					motd: initialStatus.fleetInfo.motd || null,
+					isFreeMove: initialStatus.fleetInfo.is_free_move,
+					isRegistered: initialStatus.fleetInfo.is_registered,
+					isVoiceEnabled: initialStatus.fleetInfo.is_voice_enabled,
+					notFound: false,
+					notFoundAt: null,
+				})
 
-				// Seed peak member count with the initial roster size
-				this.state.storage.sql.exec(
-					`UPDATE monitor_state SET peak_member_count = ?, expires_at = ? WHERE id = 1`,
-					initialStatus.memberCount,
-					this.getMonitorStateExpiresAtIso()
-				)
-
-				logger.info(`[FleetMonitor ${fleetId}] Updated fleet cache during initialization`, {
+				logger.info(`[FleetMonitor ${fleetId}] Updated monitor state during initialization`, {
 					fleetId,
 					memberCount: initialStatus.memberCount,
 				})
@@ -981,6 +971,91 @@ export class FleetMonitorDO extends DurableObject {
 		return await this.getState()
 	}
 
+	private async persistMonitorState(args: {
+		fleetId: string
+		characterId: string
+		trackingSessionId: string | null
+		lastSyncedFleetBossId: string | null
+		lastChecked: Date
+		peakMemberCount?: number
+		memberCount?: number
+		motd?: string | null
+		isFreeMove?: boolean
+		isRegistered?: boolean
+		isVoiceEnabled?: boolean
+		notFound?: boolean
+		notFoundAt?: Date | null
+	}): Promise<void> {
+		const {
+			fleetId,
+			characterId,
+			trackingSessionId,
+			lastSyncedFleetBossId,
+			lastChecked,
+			peakMemberCount = 0,
+			memberCount = 0,
+			motd = null,
+			isFreeMove = false,
+			isRegistered = false,
+			isVoiceEnabled = false,
+			notFound = false,
+			notFoundAt = null,
+		} = args
+		await this.state.storage.sql.exec(
+			`
+			INSERT INTO monitor_state (
+				id,
+				fleet_id,
+				character_id,
+				tracking_session_id,
+				last_synced_fleet_boss_id,
+				is_initialized,
+				last_checked,
+				peak_member_count,
+				expires_at,
+				member_count,
+				motd,
+				is_free_move,
+				is_registered,
+				is_voice_enabled,
+				not_found,
+				not_found_at
+			)
+			VALUES (1, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				fleet_id = excluded.fleet_id,
+				character_id = excluded.character_id,
+				tracking_session_id = excluded.tracking_session_id,
+				last_synced_fleet_boss_id = excluded.last_synced_fleet_boss_id,
+				is_initialized = excluded.is_initialized,
+				last_checked = excluded.last_checked,
+				peak_member_count = excluded.peak_member_count,
+				expires_at = excluded.expires_at,
+				member_count = excluded.member_count,
+				motd = excluded.motd,
+				is_free_move = excluded.is_free_move,
+				is_registered = excluded.is_registered,
+				is_voice_enabled = excluded.is_voice_enabled,
+				not_found = excluded.not_found,
+				not_found_at = excluded.not_found_at
+		`,
+			fleetId,
+			characterId,
+			trackingSessionId,
+			lastSyncedFleetBossId,
+			lastChecked.toISOString(),
+			peakMemberCount,
+			this.getMonitorStateExpiresAt(lastChecked).toISOString(),
+			memberCount,
+			motd,
+			isFreeMove ? 1 : 0,
+			isRegistered ? 1 : 0,
+			isVoiceEnabled ? 1 : 0,
+			notFound ? 1 : 0,
+			notFoundAt ? notFoundAt.toISOString() : null
+		)
+	}
+
 	private getMonitorStateExpiresAt(base = new Date()): Date {
 		return new Date(base.getTime() + FleetMonitorDO.MONITOR_STATE_TTL_MS)
 	}
@@ -1070,12 +1145,7 @@ export class FleetMonitorDO extends DurableObject {
 		}
 
 		const endedAt = new Date()
-		const [cachedState] = await this.db
-			.select({ fleetBossId: fleetStateCache.fleetBossId })
-			.from(fleetStateCache)
-			.where(eq(fleetStateCache.fleetId, fleetId))
-			.limit(1)
-		const currentFleetBossId = cachedState?.fleetBossId ?? characterId
+		const currentFleetBossId = state.lastSyncedFleetBossId ?? characterId
 
 		await this.finalizeSession({
 			fleetId,
@@ -1137,7 +1207,7 @@ export class FleetMonitorDO extends DurableObject {
 		const result = this.state.storage.sql
 			.exec<FleetMonitorStateRow>(
 				`
-				SELECT fleet_id, character_id, tracking_session_id, last_synced_fleet_boss_id, is_initialized, last_checked, peak_member_count, expires_at
+				SELECT fleet_id, character_id, tracking_session_id, last_synced_fleet_boss_id, is_initialized, last_checked, peak_member_count, expires_at, member_count, motd, is_free_move, is_registered, is_voice_enabled, not_found, not_found_at
 				FROM monitor_state
 				WHERE id = 1
 			`
@@ -1168,17 +1238,16 @@ export class FleetMonitorDO extends DurableObject {
 			lastChecked: row.last_checked,
 			peakMemberCount: row.peak_member_count ?? 0,
 			expiresAt: row.expires_at,
+			memberCount: row.member_count ?? 0,
+			motd: row.motd,
+			isFreeMove: row.is_free_move === 1,
+			isRegistered: row.is_registered === 1,
+			isVoiceEnabled: row.is_voice_enabled === 1,
+			notFound: row.not_found === 1,
+			notFoundAt: row.not_found_at,
 		}
 	}
 
-	/**
-	 * Archive a fleet to fleet_summaries before deletion from fleet_state_cache
-	 * Uses createdAt from fleet_state_cache as startedAt (for existing fleets)
-	 *
-	 * @param fleetId - Fleet ID to archive
-	 * @param characterId - Fleet boss character ID
-	 * @param endedAt - When the fleet ended
-	 */
 	/**
 	 * Finalize a tracking session: close all open ship-event rows, mark the session
 	 * row ended, and archive the fleet to fleet_summaries with the real peak member count.
@@ -1303,24 +1372,16 @@ export class FleetMonitorDO extends DurableObject {
 		}
 	): Promise<void> {
 		try {
-			// Get current fleet state from cache
-			const [cached] = await this.db
-				.select()
-				.from(fleetStateCache)
-				.where(eq(fleetStateCache.fleetId, fleetId))
-				.limit(1)
-
-			if (!cached) {
-				logger.warn(`[FleetMonitor ${fleetId}] No cache entry found to archive`, {
+			const state = await this.getState()
+			if (!state) {
+				logger.warn(`[FleetMonitor ${fleetId}] No monitor state found to archive`, {
 					fleetId,
 					fleetBossId,
 				})
 				return
 			}
 
-			// Use createdAt as startedAt (for existing fleets when migration runs)
-			// For new fleets, this will be accurate
-			const startedAt = cached.createdAt || new Date()
+			const startedAt = state.lastChecked ? new Date(state.lastChecked) : new Date()
 
 			// Calculate duration in minutes
 			const durationMs = endedAt.getTime() - startedAt.getTime()
@@ -1328,8 +1389,8 @@ export class FleetMonitorDO extends DurableObject {
 
 			// Prefer the real peak from the monitor's SQLite, falling back to the
 			// last-known cached member count for the legacy/pre-session path.
-			const peakMemberCount = options?.peakMemberCount ?? cached.memberCount
-			const finalMemberCount = cached.memberCount
+			const peakMemberCount = options?.peakMemberCount ?? state.peakMemberCount ?? state.memberCount
+			const finalMemberCount = state.memberCount
 
 			// Check if summary already exists (idempotent)
 			const [existing] = await this.db
@@ -1354,10 +1415,10 @@ export class FleetMonitorDO extends DurableObject {
 				endedAt,
 				peakMemberCount,
 				finalMemberCount,
-				motd: cached.motd || null,
-				isFreeMove: cached.isFreeMove,
-				isRegistered: cached.isRegistered,
-				isVoiceEnabled: cached.isVoiceEnabled,
+				motd: state.motd || null,
+				isFreeMove: state.isFreeMove,
+				isRegistered: state.isRegistered,
+				isVoiceEnabled: state.isVoiceEnabled,
 				durationMinutes,
 			})
 
@@ -2244,9 +2305,54 @@ export class FleetMonitorDO extends DurableObject {
 				'[FleetMonitor] Alarm triggered but no tracking session is associated, stopping',
 				{ fleetId, characterId }
 			)
-			// Reschedule anyway so the DO keeps trying — DB row may appear if a
-			// new session is started for this fleet.
-			await this.scheduleNextAlarm()
+			await this.clearMonitorStorage(fleetId)
+			return
+		}
+
+		const [sessionRow] = await this.db
+			.select({
+				id: fleetTrackingSessions.id,
+				status: fleetTrackingSessions.status,
+				endedAt: fleetTrackingSessions.endedAt,
+				endedReason: fleetTrackingSessions.endedReason,
+				endedByUserId: fleetTrackingSessions.endedByUserId,
+				fleetId: fleetTrackingSessions.fleetId,
+			})
+			.from(fleetTrackingSessions)
+			.where(eq(fleetTrackingSessions.id, trackingSessionId))
+			.limit(1)
+
+		if (!sessionRow || sessionRow.fleetId !== fleetId) {
+			logger.warn('[FleetMonitor] Tracking session missing or mismatched; clearing monitor state', {
+				fleetId,
+				trackingSessionId,
+			})
+			await this.clearMonitorStorage(fleetId)
+			return
+		}
+
+		const effectiveSessionStatus = sessionRow.status === 'active' && !sessionRow.endedAt ? 'active' : 'ended'
+		if (effectiveSessionStatus !== 'active') {
+			logger.info('[FleetMonitor] Session is no longer active; finalizing and stopping monitor', {
+				fleetId,
+				trackingSessionId,
+				sessionStatus: effectiveSessionStatus,
+			})
+			await this.finalizeSession({
+				fleetId,
+				fleetBossId: characterId,
+				trackingSessionId,
+				endedAt: sessionRow.endedAt ?? new Date(),
+				endedReason: (sessionRow.endedReason as
+					| 'user_stopped'
+					| 'admin_stopped'
+					| 'fleet_disbanded'
+					| 'esi_error'
+					| 'token_expired') ?? 'fleet_disbanded',
+				endedByUserId: sessionRow.endedByUserId ?? null,
+				peakMemberCount,
+			})
+			await this.clearMonitorStorage(fleetId)
 			return
 		}
 
@@ -2337,7 +2443,7 @@ export class FleetMonitorDO extends DurableObject {
 
 			const observedAt = new Date()
 			const previousFleetBossCharacterId = lastKnownFleetBossId
-			// Update fleet cache in PostgreSQL (cross-instance data)
+			// Persist the live monitor snapshot in Durable Object storage.
 			const liveFleetBossId = fleetStatus.fleetBossId ?? characterId
 			await syncFleetBossAccess(this.db, {
 				fleetId,
@@ -2347,49 +2453,23 @@ export class FleetMonitorDO extends DurableObject {
 				observedAt,
 			})
 			if (liveFleetBossId !== characterId) {
-				this.state.storage.sql.exec(
-					`UPDATE monitor_state SET character_id = ?, expires_at = ? WHERE id = 1`,
-					liveFleetBossId,
-					this.getMonitorStateExpiresAtIso()
-				)
 				characterId = liveFleetBossId
 			}
-			this.state.storage.sql.exec(
-				`UPDATE monitor_state SET last_synced_fleet_boss_id = ?, expires_at = ? WHERE id = 1`,
-				liveFleetBossId,
-				this.getMonitorStateExpiresAtIso()
-			)
-				await this.db
-					.insert(fleetStateCache)
-					.values({
-						fleetId,
-						fleetBossId: liveFleetBossId,
-						trackingSessionId,
-						memberCount: fleetStatus.memberCount,
-						motd: fleetStatus.fleetInfo.motd || null,
-						isFreeMove: fleetStatus.fleetInfo.is_free_move,
-						isRegistered: fleetStatus.fleetInfo.is_registered,
-						isVoiceEnabled: fleetStatus.fleetInfo.is_voice_enabled,
-						notFound: false,
-						notFoundAt: null,
-						lastChecked: observedAt,
-					})
-				.onConflictDoUpdate({
-					target: fleetStateCache.fleetId,
-					set: {
-						fleetBossId: liveFleetBossId,
-						trackingSessionId,
-						memberCount: fleetStatus.memberCount,
-						motd: fleetStatus.fleetInfo.motd || null,
-						isFreeMove: fleetStatus.fleetInfo.is_free_move,
-						isRegistered: fleetStatus.fleetInfo.is_registered,
-						isVoiceEnabled: fleetStatus.fleetInfo.is_voice_enabled,
-						notFound: false,
-						notFoundAt: null,
-						lastChecked: observedAt,
-						updatedAt: observedAt,
-					},
-				})
+			await this.persistMonitorState({
+				fleetId,
+				characterId: liveFleetBossId,
+				trackingSessionId,
+				lastSyncedFleetBossId: liveFleetBossId,
+				lastChecked: observedAt,
+				peakMemberCount,
+				memberCount: fleetStatus.memberCount,
+				motd: fleetStatus.fleetInfo.motd || null,
+				isFreeMove: fleetStatus.fleetInfo.is_free_move,
+				isRegistered: fleetStatus.fleetInfo.is_registered,
+				isVoiceEnabled: fleetStatus.fleetInfo.is_voice_enabled,
+				notFound: false,
+				notFoundAt: null,
+			})
 
 			// Broadcast update to connected WebSocket clients
 			const connections = this.ctx.getWebSockets()
@@ -2542,7 +2622,7 @@ export class FleetMonitorDO extends DurableObject {
 						}
 					)
 
-					// Mark fleet as not found in PostgreSQL cache
+					// Mark fleet as not found in monitor state and stop tracking.
 					const endedAt = new Date()
 					const liveFleetBossId = lastKnownFleetBossId
 
@@ -2562,26 +2642,17 @@ export class FleetMonitorDO extends DurableObject {
 						await this.archiveFleetToSummary(fleetId, liveFleetBossId, endedAt)
 					}
 
-					await this.db
-						.insert(fleetStateCache)
-						.values({
-							fleetId,
-							fleetBossId: liveFleetBossId,
-							memberCount: 0,
-							notFound: true,
-							notFoundAt: endedAt,
-							lastChecked: endedAt,
-						})
-						.onConflictDoUpdate({
-							target: fleetStateCache.fleetId,
-							set: {
-								fleetBossId: liveFleetBossId,
-								notFound: true,
-								notFoundAt: endedAt,
-								lastChecked: endedAt,
-								updatedAt: endedAt,
-							},
-						})
+					await this.persistMonitorState({
+						fleetId,
+						characterId: liveFleetBossId,
+						trackingSessionId,
+						lastSyncedFleetBossId: liveFleetBossId,
+						lastChecked: endedAt,
+						peakMemberCount,
+						memberCount: 0,
+						notFound: true,
+						notFoundAt: endedAt,
+					})
 
 					// Clean up old error tracking data (keep last 24 hours)
 					const cleanupTime = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()

--- a/apps/fleets/src/index.ts
+++ b/apps/fleets/src/index.ts
@@ -1,13 +1,16 @@
 import { Hono } from 'hono'
 
+import { and, eq, isNotNull, lt } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import { withNotFound, withOnError, withWorkersLogger } from '@repo/hono-helpers'
+import { logger, withNotFound, withOnError, withWorkersLogger } from '@repo/hono-helpers'
 
+import { createDb } from './db'
+import { fleetCommanderAccessAnchors, fleetSummaries, fleetTrackingSessions } from './db/schema'
 import { FleetsDO } from './durable-object'
 import { FleetMonitorDO } from './fleet-monitor'
 
 import type { FleetMonitor } from '@repo/fleets'
-import type { App } from './context'
+import type { App, Env } from './context'
 
 const app = new Hono<App>()
 	.use(
@@ -18,15 +21,11 @@ const app = new Hono<App>()
 				release: c.env.SENTRY_RELEASE,
 			})(c, next)
 	)
-
 	.onError(withOnError())
 	.notFound(withNotFound())
-
 	.get('/', async (c) => {
 		return c.text('Fleets Durable Object Worker')
 	})
-
-	// Fleet Monitor WebSocket endpoint
 	.get('/fleet-monitor/:fleetId/ws', async (c) => {
 		const fleetId = c.req.param('fleetId')
 
@@ -39,24 +38,18 @@ const app = new Hono<App>()
 			)
 		}
 
-			// Get the FleetMonitor DO stub for this fleet
-			// DO ID format: 'fleet-${fleetId}'
-			const fleetMonitorStub = getStub<FleetMonitor>(c.env.FLEET_MONITOR, `fleet-${fleetId}`)
-			if (!fleetMonitorStub.fetch) {
-				return c.json(
-					{
-						error: 'Fleet monitor endpoint unavailable',
-					},
-					500
-				)
-			}
+		const fleetMonitorStub = getStub<FleetMonitor>(c.env.FLEET_MONITOR, `fleet-${fleetId}`)
+		if (!fleetMonitorStub.fetch) {
+			return c.json(
+				{
+					error: 'Fleet monitor endpoint unavailable',
+				},
+				500
+			)
+		}
 
-			// Forward the request to the Durable Object for WebSocket upgrade
-			// The DO will handle the WebSocket protocol from here
-			return fleetMonitorStub.fetch(c.req.raw)
+		return fleetMonitorStub.fetch(c.req.raw)
 	})
-
-	// Fleet Monitor status endpoint (HTTP GET)
 	.get('/fleet-monitor/:fleetId/status', async (c) => {
 		const fleetId = c.req.param('fleetId')
 
@@ -69,20 +62,18 @@ const app = new Hono<App>()
 			)
 		}
 
-			try {
-				// Get the FleetMonitor DO stub for this fleet
-				const fleetMonitorStub = getStub<FleetMonitor>(c.env.FLEET_MONITOR, `fleet-${fleetId}`)
-				if (!fleetMonitorStub.fetch) {
-					return c.json(
-						{
-							error: 'Fleet monitor endpoint unavailable',
-						},
-						500
-					)
-				}
+		try {
+			const fleetMonitorStub = getStub<FleetMonitor>(c.env.FLEET_MONITOR, `fleet-${fleetId}`)
+			if (!fleetMonitorStub.fetch) {
+				return c.json(
+					{
+						error: 'Fleet monitor endpoint unavailable',
+					},
+					500
+				)
+			}
 
-				// Forward the request to the Durable Object
-				return fleetMonitorStub.fetch(c.req.raw)
+			return fleetMonitorStub.fetch(c.req.raw)
 		} catch (error) {
 			return c.json(
 				{
@@ -94,11 +85,96 @@ const app = new Hono<App>()
 		}
 	})
 
-// Export default worker (fetch only; manual tracking replaced the cron-based monitoring)
-export default {
-	fetch: app.fetch.bind(app),
+export async function sweepStaleFleetMonitors(
+	env: Env
+): Promise<{ scanned: number; terminated: number }> {
+	const db = createDb(env.DATABASE_URL)
+	const cutoff = new Date(Date.now() - 6 * 60 * 60 * 1000)
+
+	const activeRows = await db
+		.selectDistinct({
+			fleetId: fleetTrackingSessions.fleetId,
+		})
+		.from(fleetTrackingSessions)
+		.where(and(isNotNull(fleetTrackingSessions.fleetId), eq(fleetTrackingSessions.status, 'active')))
+
+	const activeFleetIds = new Set(
+		activeRows
+			.map((row) => row.fleetId)
+			.filter((fleetId): fleetId is string => fleetId !== null)
+	)
+
+	const endedRows = await db
+		.selectDistinct({
+			fleetId: fleetTrackingSessions.fleetId,
+		})
+		.from(fleetTrackingSessions)
+		.where(
+			and(
+				isNotNull(fleetTrackingSessions.fleetId),
+				eq(fleetTrackingSessions.status, 'ended'),
+				isNotNull(fleetTrackingSessions.endedAt),
+				lt(fleetTrackingSessions.endedAt, cutoff)
+			)
+		)
+
+	const commanderAnchorRows = await db
+		.selectDistinct({
+			fleetId: fleetCommanderAccessAnchors.fleetId,
+		})
+		.from(fleetCommanderAccessAnchors)
+		.where(isNotNull(fleetCommanderAccessAnchors.fleetId))
+
+	const summaryRows = await db
+		.selectDistinct({
+			fleetId: fleetSummaries.fleetId,
+		})
+		.from(fleetSummaries)
+		.where(isNotNull(fleetSummaries.fleetId))
+
+	const candidateFleetIds = new Set<string>()
+	for (const row of [...endedRows, ...commanderAnchorRows, ...summaryRows]) {
+		if (row.fleetId) candidateFleetIds.add(row.fleetId)
+	}
+
+	const staleFleetIds = Array.from(candidateFleetIds).filter((fleetId) => !activeFleetIds.has(fleetId))
+
+	let terminated = 0
+	for (const fleetId of staleFleetIds) {
+		try {
+			const monitorStub = getStub<FleetMonitor>(env.FLEET_MONITOR, `fleet-${fleetId}`)
+			const state = await monitorStub.getMonitorState()
+			if (!state) continue
+
+			await monitorStub.terminate()
+			terminated += 1
+		} catch (error) {
+			logger.warn('[Fleets:Scheduled] Failed to sweep FleetMonitor', {
+				fleetId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	return {
+		scanned: staleFleetIds.length,
+		terminated,
+	}
 }
 
-// Export the Durable Object classes
+export default {
+	fetch: app.fetch.bind(app),
+	async scheduled(event: ScheduledEvent, env: Env): Promise<void> {
+		if (event.cron !== '0 */6 * * *') {
+			return
+		}
+
+		const result = await sweepStaleFleetMonitors(env)
+		if (result.scanned > 0 || result.terminated > 0) {
+			logger.info('[Fleets:Scheduled] Swept stale fleet monitors', result)
+		}
+	},
+}
+
 export { FleetsDO as Fleets }
 export { FleetMonitorDO as FleetMonitor }

--- a/apps/fleets/src/test/unit/lifecycle.test.ts
+++ b/apps/fleets/src/test/unit/lifecycle.test.ts
@@ -55,6 +55,9 @@ vi.mock('@repo/hono-helpers', () => ({
 		log: vi.fn(),
 		warn: vi.fn(),
 	},
+	withNotFound: vi.fn(() => vi.fn()),
+	withOnError: vi.fn(() => vi.fn()),
+	withWorkersLogger: vi.fn(() => vi.fn((_c: unknown, next: () => Promise<void>) => next())),
 }))
 
 import {
@@ -63,6 +66,7 @@ import {
 	fleetTrackingSessionEvents,
 	fleetTrackingSessions,
 } from '../../db/schema'
+import { sweepStaleFleetMonitors } from '../../index'
 import { FleetMonitorDO } from '../../fleet-monitor'
 import { FleetsDO } from '../../durable-object'
 
@@ -155,6 +159,11 @@ function createDbMock(options: {
 	return {
 		select: vi.fn((selection: unknown) => {
 			const capture: Record<string, unknown> = { selection }
+			captures.selects.push(capture)
+			return makeChain(queues.select, capture)
+		}),
+		selectDistinct: vi.fn((selection: unknown) => {
+			const capture: Record<string, unknown> = { selection, distinct: true }
 			captures.selects.push(capture)
 			return makeChain(queues.select, capture)
 		}),
@@ -464,21 +473,35 @@ describe('fleet lifecycle management', () => {
 		const activeSnapshotDo = createFleetsDo(activeSnapshotDb)
 		const activeSnapshotEnv = createBaseEnv()
 		const monitorStub = {
-			getMonitorState: vi.fn().mockResolvedValue({ peakMemberCount: 8 }),
+			getFleetStatus: vi.fn().mockResolvedValue({
+				fleetInfo: {
+					motd: 'Test motd',
+					is_free_move: true,
+					is_registered: false,
+					is_voice_enabled: true,
+				},
+				memberCount: 3,
+				members: [],
+			}),
+			getMonitorState: vi.fn().mockResolvedValue({ peakMemberCount: 8, lastChecked: '2026-07-20T00:00:00.000Z' }),
 		}
 		registerStub(activeSnapshotEnv.FLEET_MONITOR, 'fleet-123', monitorStub)
 		;(activeSnapshotDo as any).env = activeSnapshotEnv
 
 		await expect(activeSnapshotDo.getSessionLiveSnapshot('session-1')).resolves.toEqual({
-			fleetId: '123',
-			memberCount: 3,
-			peakMemberCount: 8,
-			motd: 'Test motd',
-			isFreeMove: true,
-			isRegistered: false,
-			isVoiceEnabled: true,
-			lastChecked: '2026-07-20T00:00:00.000Z',
-			updatedAt: '2026-07-20T00:00:00.000Z',
+			state: 'ready',
+			message: null,
+			snapshot: {
+				fleetId: '123',
+				memberCount: 3,
+				peakMemberCount: 8,
+				motd: 'Test motd',
+				isFreeMove: true,
+				isRegistered: false,
+				isVoiceEnabled: true,
+				lastChecked: '2026-07-20T00:00:00.000Z',
+				updatedAt: '2026-07-20T00:00:00.000Z',
+			},
 		})
 		expect(monitorStub.getMonitorState).toHaveBeenCalledTimes(1)
 
@@ -495,6 +518,57 @@ describe('fleet lifecycle management', () => {
 
 		await expect(endedLocationsDo.getSessionLiveMemberLocations('session-2')).resolves.toEqual([])
 		expect(liveMonitorStub.getFleetStatus).not.toHaveBeenCalled()
+	})
+
+	it('returns null instead of throwing when the live snapshot monitor hits a fleet 404', async () => {
+		const liveSnapshotDb = createDbMock({
+			selectResults: [
+				[
+					{
+						fleetId: '123',
+						status: 'active',
+						endedAt: null,
+					},
+				],
+			],
+		})
+		const liveSnapshotDo = createFleetsDo(liveSnapshotDb)
+		const liveSnapshotEnv = createBaseEnv()
+		const monitorStub = {
+			getFleetStatus: vi.fn().mockRejectedValue(
+				new Error(
+					'ESI request failed: 404 Not Found - {"error":"The fleet does not exist or you don\'t have access to it!"}'
+				)
+			),
+			getMonitorState: vi.fn().mockResolvedValue({
+				fleetId: '123',
+				characterId: '42',
+				trackingSessionId: 'session-1',
+				lastSyncedFleetBossId: '42',
+				isInitialized: true,
+				lastChecked: '2026-07-22T00:00:00.000Z',
+				peakMemberCount: 8,
+				expiresAt: '2026-07-23T00:00:00.000Z',
+				memberCount: 3,
+				motd: null,
+				isFreeMove: false,
+				isRegistered: false,
+				isVoiceEnabled: false,
+				notFound: false,
+				notFoundAt: null,
+			}),
+		}
+		registerStub(liveSnapshotEnv.FLEET_MONITOR, 'fleet-123', monitorStub)
+		;(liveSnapshotDo as any).env = liveSnapshotEnv
+
+		await expect(liveSnapshotDo.getSessionLiveSnapshot('session-1')).resolves.toEqual({
+			state: 'unavailable',
+			message:
+				'The latest live fleet snapshot could not be read. The fleet may have ended or the monitor may still be recovering.',
+			snapshot: null,
+		})
+		expect(monitorStub.getFleetStatus).toHaveBeenCalledTimes(1)
+		expect(monitorStub.getMonitorState).toHaveBeenCalledTimes(1)
 	})
 
 	it('treats inconsistent session rows as closed when stopping tracking', async () => {
@@ -530,29 +604,40 @@ describe('fleet lifecycle management', () => {
 	it('finalizes a fleet monitor session once and ignores mismatches', async () => {
 		const db = createDbMock({
 			selectResults: [
-				[
-					{
-						id: 'cache-row',
-						fleetId: '123',
-						fleetBossId: '42',
-						memberCount: 4,
-						motd: 'Test motd',
-						isFreeMove: true,
-						isRegistered: false,
-						isVoiceEnabled: true,
-						notFound: false,
-						notFoundAt: null,
-						lastChecked: new Date('2026-07-20T00:00:00.000Z'),
-						createdAt: new Date('2026-07-20T00:00:00.000Z'),
-						updatedAt: new Date('2026-07-20T00:00:00.000Z'),
-					},
-				],
+				[],
 				[],
 			],
 			insertResults: [undefined, undefined],
 			updateResults: [undefined, undefined],
 		})
 		const monitor = createFleetMonitorDo(db)
+		;(monitor as any).state.storage.sql.exec = vi.fn((query: string) => ({
+			toArray: () => {
+				if (query.includes('SELECT version')) return [{ version: 6 }]
+				if (query.includes('FROM monitor_state')) {
+					return [
+						{
+							fleet_id: '123',
+							character_id: '42',
+							tracking_session_id: 'session-2',
+							last_synced_fleet_boss_id: '42',
+							is_initialized: 1,
+							last_checked: '2026-07-20T00:00:00.000Z',
+							peak_member_count: 4,
+							expires_at: '2026-07-23T00:00:00.000Z',
+							member_count: 4,
+							motd: 'Test motd',
+							is_free_move: 1,
+							is_registered: 0,
+							is_voice_enabled: 1,
+							not_found: 0,
+							not_found_at: null,
+						},
+					]
+				}
+				return []
+			},
+		}))
 		const finalize = (monitor as any).finalizeSession.bind(monitor)
 
 		await Promise.all([
@@ -580,5 +665,95 @@ describe('fleet lifecycle management', () => {
 		expect(db.captures.updates.filter((entry) => entry.table === fleetMemberShipEvents)).toHaveLength(1)
 		expect(db.captures.updates.filter((entry) => entry.table === fleetTrackingSessions)).toHaveLength(1)
 		expect(db.captures.inserts.filter((entry) => entry.table === fleetSummaries)).toHaveLength(1)
+	})
+
+	it('sweeps stale fleet monitors discovered through ended sessions and historical fleet refs', async () => {
+		const db = createDbMock({
+			selectResults: [
+				[{ fleetId: '100' }],
+				[{ fleetId: '200' }, { fleetId: '300' }],
+				[{ fleetId: '400' }],
+				[{ fleetId: '500' }],
+			],
+		})
+		const env = createBaseEnv()
+		;(env as any).DATABASE_URL = 'postgres://example'
+		harness.currentDb = db
+
+		const terminated200 = vi.fn().mockResolvedValue(undefined)
+		const terminated400 = vi.fn().mockResolvedValue(undefined)
+		const terminated500 = vi.fn().mockResolvedValue(undefined)
+		registerStub(env.FLEET_MONITOR, 'fleet-200', {
+			getMonitorState: vi.fn().mockResolvedValue({
+				fleetId: '200',
+				characterId: '42',
+				trackingSessionId: 'session-200',
+				lastSyncedFleetBossId: '42',
+				isInitialized: true,
+				lastChecked: '2026-07-22T00:00:00.000Z',
+				peakMemberCount: 4,
+				expiresAt: '2026-07-23T00:00:00.000Z',
+				memberCount: 2,
+				motd: null,
+				isFreeMove: false,
+				isRegistered: false,
+				isVoiceEnabled: false,
+				notFound: false,
+				notFoundAt: null,
+			}),
+			terminate: terminated200,
+		})
+		registerStub(env.FLEET_MONITOR, 'fleet-300', {
+			getMonitorState: vi.fn().mockResolvedValue(null),
+			terminate: vi.fn(),
+		})
+		registerStub(env.FLEET_MONITOR, 'fleet-400', {
+			getMonitorState: vi.fn().mockResolvedValue({
+				fleetId: '400',
+				characterId: '99',
+				trackingSessionId: null,
+				lastSyncedFleetBossId: '99',
+				isInitialized: true,
+				lastChecked: '2026-07-22T00:00:00.000Z',
+				peakMemberCount: 1,
+				expiresAt: '2026-07-23T00:00:00.000Z',
+				memberCount: 1,
+				motd: null,
+				isFreeMove: false,
+				isRegistered: false,
+				isVoiceEnabled: false,
+				notFound: false,
+				notFoundAt: null,
+			}),
+			terminate: terminated400,
+		})
+		registerStub(env.FLEET_MONITOR, 'fleet-500', {
+			getMonitorState: vi.fn().mockResolvedValue({
+				fleetId: '500',
+				characterId: '88',
+				trackingSessionId: 'session-500',
+				lastSyncedFleetBossId: '88',
+				isInitialized: true,
+				lastChecked: '2026-07-22T00:00:00.000Z',
+				peakMemberCount: 3,
+				expiresAt: '2026-07-23T00:00:00.000Z',
+				memberCount: 1,
+				motd: null,
+				isFreeMove: false,
+				isRegistered: false,
+				isVoiceEnabled: false,
+				notFound: false,
+				notFoundAt: null,
+			}),
+			terminate: terminated500,
+		})
+
+		await expect(sweepStaleFleetMonitors(env as never)).resolves.toEqual({
+			scanned: 4,
+			terminated: 3,
+		})
+		expect(terminated200).toHaveBeenCalledTimes(1)
+		expect(terminated400).toHaveBeenCalledTimes(1)
+		expect(terminated500).toHaveBeenCalledTimes(1)
 	})
 })

--- a/apps/fleets/wrangler.jsonc
+++ b/apps/fleets/wrangler.jsonc
@@ -62,5 +62,8 @@
 			"tag": "v2",
 			"new_sqlite_classes": ["FleetMonitor"]
 		}
-	]
+	],
+	"triggers": {
+		"crons": ["0 */6 * * *"]
+	}
 }

--- a/apps/ui/src/client/features/fleet-tracking/api.ts
+++ b/apps/ui/src/client/features/fleet-tracking/api.ts
@@ -9,7 +9,6 @@ import type {
 	SessionCommanderHistoryResponse,
 	SessionRosterResponse,
 	SessionLiveMemberLocation,
-	SessionLiveSnapshot,
 	SessionMemberShipHistoryResponse,
 	SessionSummary,
 	SessionTimelineResult,
@@ -21,6 +20,7 @@ import type {
 	TrackingSessionListResult,
 	UserStatsResponse,
 	SessionBroadcastLink,
+	SessionLiveSnapshotResult,
 } from './types'
 
 function buildQuery(params: Record<string, string | number | undefined>): string {
@@ -92,7 +92,7 @@ export const fleetTrackingApi = {
 					: null,
 			})),
 
-	getLiveSnapshot: (sessionId: string): Promise<{ snapshot: SessionLiveSnapshot | null }> =>
+	getLiveSnapshot: (sessionId: string): Promise<SessionLiveSnapshotResult> =>
 		apiClient.get(`/fleets/tracking/${encodeURIComponent(sessionId)}/live`),
 
 	getCurrentMembers: (sessionId: string): Promise<SessionCurrentMembersResponse> =>

--- a/apps/ui/src/client/features/fleet-tracking/routes/tracking-session-detail.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/tracking-session-detail.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Clock, Lock, Square } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Clock, Lock, Square } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 
@@ -450,6 +450,18 @@ function DetailView({
 
 	return (
 		<div className="space-y-6">
+			{liveResp && liveResp.state !== 'ready' && (
+				<div className="rounded-lg border border-warning/40 bg-warning/10 p-4">
+					<div className="flex items-start gap-3">
+						<AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-warning" />
+						<div className="space-y-1 text-sm">
+							<p className="font-medium text-warning">Live fleet snapshot unavailable</p>
+							<p className="text-muted-foreground">{liveResp.message}</p>
+						</div>
+					</div>
+				</div>
+			)}
+
 			{stats.length > 0 && <SessionStatsGrid stats={stats} />}
 			{(isLive || broadcastLink) && (
 				<div className="grid gap-4 lg:grid-cols-2">

--- a/apps/ui/src/client/features/fleet-tracking/routes/tracking-session-detail.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/tracking-session-detail.tsx
@@ -450,7 +450,7 @@ function DetailView({
 
 	return (
 		<div className="space-y-6">
-			{liveResp && liveResp.state !== 'ready' && (
+			{isLive && liveResp && liveResp.state !== 'ready' && (
 				<div className="rounded-lg border border-warning/40 bg-warning/10 p-4">
 					<div className="flex items-start gap-3">
 						<AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-warning" />

--- a/apps/ui/src/client/features/fleet-tracking/types.ts
+++ b/apps/ui/src/client/features/fleet-tracking/types.ts
@@ -64,6 +64,14 @@ export interface SessionLiveSnapshot {
 	updatedAt: string
 }
 
+export type SessionLiveSnapshotState = 'ready' | 'inactive' | 'unavailable'
+
+export interface SessionLiveSnapshotResult {
+	state: SessionLiveSnapshotState
+	message: string | null
+	snapshot: SessionLiveSnapshot | null
+}
+
 export interface SessionTimelineRow {
 	id: string
 	characterId: string

--- a/packages/fleets/src/fleet-monitor.ts
+++ b/packages/fleets/src/fleet-monitor.ts
@@ -35,6 +35,13 @@ export interface FleetMonitorStateRow extends Record<string, string | number | n
 	last_checked: string | null
 	peak_member_count: number
 	expires_at: string | null
+	member_count: number
+	motd: string | null
+	is_free_move: number
+	is_registered: number
+	is_voice_enabled: number
+	not_found: number
+	not_found_at: string | null
 }
 
 /**
@@ -50,6 +57,13 @@ export interface FleetMonitorState {
 	lastChecked: string | null
 	peakMemberCount: number
 	expiresAt: string | null
+	memberCount: number
+	motd: string | null
+	isFreeMove: boolean
+	isRegistered: boolean
+	isVoiceEnabled: boolean
+	notFound: boolean
+	notFoundAt: string | null
 }
 
 /**

--- a/packages/fleets/src/index.ts
+++ b/packages/fleets/src/index.ts
@@ -219,9 +219,10 @@ export interface Fleets extends DurableObject {
 
 	/**
 	 * Get the live cache snapshot for a session's fleet.
-	 * Returns null if the session has not started ticking yet.
+	 * Returns a status envelope so callers can distinguish a ready snapshot
+	 * from an inactive session or a monitor read failure.
 	 */
-	getSessionLiveSnapshot(sessionId: string): Promise<SessionLiveSnapshot | null>
+	getSessionLiveSnapshot(sessionId: string): Promise<SessionLiveSnapshotResult>
 
 	/**
 	 * Get the join/leave event log for a session, paginated.
@@ -442,6 +443,14 @@ export interface SessionLiveSnapshot {
 	isVoiceEnabled: boolean
 	lastChecked: string
 	updatedAt: string
+}
+
+export type SessionLiveSnapshotState = 'ready' | 'inactive' | 'unavailable'
+
+export interface SessionLiveSnapshotResult {
+	state: SessionLiveSnapshotState
+	message: string | null
+	snapshot: SessionLiveSnapshot | null
 }
 
 export interface SessionTimelineRow {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Moves live fleet state (member count, MOTD, flags, not-found tracking) out of the Postgres `fleet_state_cache` table and into the `FleetMonitor` Durable Object's own SQLite storage, since that DO is already the single source of truth for a fleet's live status. This removes a cross-service Postgres write on every poll tick and drops the now-unused table.

## Changes
- `FleetMonitorDO`: adds a schema migration (v5 -> v6) that adds live-snapshot columns (`member_count`, `motd`, `is_free_move`, `is_registered`, `is_voice_enabled`, `not_found`, `not_found_at`) to `monitor_state`, and a `persistMonitorState` helper that replaces all the old `fleetStateCache` upserts.
- `FleetMonitorDO` alarm handler now re-checks the tracking session's status each tick and finalizes/stops the monitor if the session is no longer active, instead of blindly rescheduling.
- `FleetsDO`: `getFleetDetails`, `isFleetActive`, `getFleetCacheStatus`, `getFleetIsRegistered`, and commander-lookup queries now read from the `FleetMonitor` DO (via new `getMonitorStateForFleet`/`getLatestCommanderBySessionIds` helpers) instead of joining/querying `fleet_state_cache`.
- `getSessionLiveSnapshot` now returns a `SessionLiveSnapshotResult` envelope (`{ state: 'ready' | 'inactive' | 'unavailable', message, snapshot }`) instead of `snapshot | null`, so callers can distinguish "session inactive" from "monitor read failed" (e.g. fleet no longer exists via ESI 404).
- `apps/core/src/routes/fleets.ts`: `/tracking/:sessionId/live` now forwards the full envelope instead of wrapping/nulling the snapshot.
- UI (`tracking-session-detail.tsx`): shows a warning banner with the envelope's `message` when `state !== 'ready'`, but only while the session is live (hidden once the session has ended).
- `apps/fleets`: adds a `scheduled` cron handler (`0 */6 * * *`) that sweeps stale `FleetMonitor` DOs (fleets no longer actively tracked but with historical DB references) and terminates them; `wrangler.jsonc` registers the cron trigger.
- Drops the `fleet_state_cache` table from the schema and generates migration `0012_cute_sabretooth.sql` (`DROP TABLE "fleet_state_cache" CASCADE`).
- Updates `@repo/fleets` (`packages/fleets`) types (`FleetMonitorState`, `FleetMonitorStateRow`, `SessionLiveSnapshotResult`) to match.

## Testing
- Updated `apps/core/src/routes/__tests__/fleets.tracking.route.test.ts` to assert the new envelope shape returned by `/live`.
- Updated `apps/fleets/src/test/unit/lifecycle.test.ts` with cases for the ready/unavailable envelope states, the v6 migration/monitor_state shape, and a new test covering `sweepStaleFleetMonitors`.
<!-- claude:end -->
