### PR TITLE
fix(broadcasts): improve mobile support for broadcasts

### DIFF
--- a/apps/ui/src/client/components/ui/textarea.tsx
+++ b/apps/ui/src/client/components/ui/textarea.tsx
@@ -5,14 +5,15 @@ import { cn } from '@/lib/utils'
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-	({ className, ...props }, ref) => {
+	({ className, wrap = 'soft', ...props }, ref) => {
 		return (
 			<textarea
 				className={cn(
-					'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+					'flex min-h-[80px] w-full min-w-0 max-w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background overflow-x-hidden whitespace-pre-wrap break-words [overflow-wrap:anywhere] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
 					className
 				)}
 				ref={ref}
+				wrap={wrap}
 				{...props}
 			/>
 		)

--- a/apps/ui/src/client/features/broadcasts/components/broadcast-preview-pane.tsx
+++ b/apps/ui/src/client/features/broadcasts/components/broadcast-preview-pane.tsx
@@ -7,9 +7,9 @@ interface BroadcastPreviewPaneProps {
 
 export function BroadcastPreviewPane({ message }: BroadcastPreviewPaneProps) {
 	return (
-		<div className="[grid-area:preview] space-y-2 lg:self-stretch">
+		<div className="[grid-area:preview] min-w-0 max-w-full space-y-2 lg:self-stretch">
 			<Label className="text-sm font-medium">Preview</Label>
-			<div className="rounded-md border border-border bg-muted/20 p-3 text-sm overflow-y-auto min-h-[16rem] h-full">
+			<div className="h-full min-h-[16rem] max-w-full overflow-y-auto overflow-x-hidden rounded-md border border-border bg-muted/20 p-3 text-sm break-words [overflow-wrap:anywhere] [&_pre]:max-w-full [&_pre]:whitespace-pre-wrap [&_pre]:break-words">
 				{message.trim() ? (
 					renderDiscordContentValue(message, 'preview')
 				) : (

--- a/apps/ui/src/client/routes/broadcasts-new.tsx
+++ b/apps/ui/src/client/routes/broadcasts-new.tsx
@@ -650,10 +650,10 @@ export default function NewBroadcastPage() {
 						<CardDescription>Configure your broadcast message</CardDescription>
 					</CardHeader>
 					<CardContent>
-						<form onSubmit={handleSend} className="space-y-6">
-							<div className="grid gap-4 lg:grid-cols-3">
+						<form onSubmit={handleSend} className="min-w-0 space-y-6">
+							<div className="grid min-w-0 gap-4 lg:grid-cols-3">
 								{/* Target Selection */}
-								<div className="space-y-2">
+								<div className="min-w-0 space-y-2">
 									<Label htmlFor="target">Target *</Label>
 									<Select
 										inputId="target"
@@ -677,7 +677,7 @@ export default function NewBroadcastPage() {
 								</div>
 
 								{/* Template Selection */}
-								<div className="space-y-2">
+								<div className="min-w-0 space-y-2">
 									<Label htmlFor="template">Template</Label>
 									<Select
 										value={selectedTemplateId}
@@ -701,7 +701,7 @@ export default function NewBroadcastPage() {
 								</div>
 
 								{/* Mention Level Selection */}
-								<div className="space-y-2">
+								<div className="min-w-0 space-y-2">
 									<Label htmlFor="mentions">Mentions</Label>
 									<Select
 										inputId="mentions"
@@ -732,9 +732,9 @@ export default function NewBroadcastPage() {
 
 							{/* Custom Message or Template Fields */}
 							{selectedTemplateId === 'custom' ? (
-								<div className="grid gap-4 [grid-template-areas:'preview''form'] lg:[grid-template-areas:'form_preview'] lg:grid-cols-2 lg:items-stretch">
+								<div className="grid min-w-0 gap-4 [grid-template-areas:'preview''form'] lg:[grid-template-areas:'form_preview'] lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch">
 									<BroadcastPreviewPane message={customMessage} />
-									<div className="[grid-area:form] space-y-2">
+									<div className="[grid-area:form] min-w-0 space-y-2">
 										<Label htmlFor="message">Message *</Label>
 										<Textarea
 											id="message"
@@ -743,7 +743,7 @@ export default function NewBroadcastPage() {
 											rows={10}
 											placeholder="Enter your broadcast message..."
 											required
-											className="resize-none h-[16rem]"
+											className="h-[16rem] resize-none"
 										/>
 										<p className="text-xs text-muted-foreground">
 											Write your custom message. Supports Discord markdown formatting.
@@ -751,23 +751,23 @@ export default function NewBroadcastPage() {
 									</div>
 								</div>
 							) : selectedTemplate ? (
-								<div className="grid gap-4 [grid-template-areas:'preview''form'] lg:[grid-template-areas:'form_preview'] lg:grid-cols-2 lg:items-stretch">
+								<div className="grid min-w-0 gap-4 [grid-template-areas:'preview''form'] lg:[grid-template-areas:'form_preview'] lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch">
 									<BroadcastPreviewPane message={renderedOutboundMessage} />
-									<div className="[grid-area:form] space-y-4">
+									<div className="[grid-area:form] min-w-0 space-y-4">
 										<TemplateFieldsEditor
 											fields={selectedTemplate.fieldSchema}
 											templateFields={templateFields}
 											templateFieldSelections={templateFieldSelections}
 											doctrines={doctrines}
 											stagingSystems={stagingSystems}
-										userCharacters={user?.characters ?? []}
-										mainCharacterId={user?.mainCharacterId}
-										canCreateFleetTracking={canCreateFleetTracking}
-										messageParts={messageParts}
-										onMessagePartsChange={setMessageParts}
-										onUpdateTemplateField={updateTemplateField}
-										onUpdateTemplateFieldSelection={updateTemplateFieldSelection}
-									/>
+											userCharacters={user?.characters ?? []}
+											mainCharacterId={user?.mainCharacterId}
+											canCreateFleetTracking={canCreateFleetTracking}
+											messageParts={messageParts}
+											onMessagePartsChange={setMessageParts}
+											onUpdateTemplateField={updateTemplateField}
+											onUpdateTemplateFieldSelection={updateTemplateFieldSelection}
+										/>
 									</div>
 								</div>
 							) : null}
@@ -784,8 +784,14 @@ export default function NewBroadcastPage() {
 									Rendered length: {renderedOutboundLength}/{DISCORD_MESSAGE_MAX_LENGTH}
 								</span>
 							</div>
-							<div className="flex justify-end gap-3 pt-4">
-								<Button variant="cancel" type="button" onClick={() => navigate('/broadcasts')} disabled={isSubmitting}>
+							<div className="flex flex-col gap-3 pt-4 sm:flex-row sm:justify-end">
+								<Button
+									variant="cancel"
+									type="button"
+									onClick={() => navigate('/broadcasts')}
+									disabled={isSubmitting}
+									className="w-full sm:w-auto"
+								>
 									Cancel
 								</Button>
 								<Button
@@ -796,6 +802,7 @@ export default function NewBroadcastPage() {
 									loadingText="Saving..."
 									showIcon={false}
 									onClick={handleSaveAsDraft}
+									className="w-full sm:w-auto"
 								>
 									Save as Draft
 								</Button>
@@ -806,6 +813,7 @@ export default function NewBroadcastPage() {
 									loading={isSending}
 									loadingText="Sending..."
 									showIcon={false}
+									className="w-full sm:w-auto"
 								>
 									Send Broadcast
 								</Button>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Fixes broadcast composer layout issues on mobile where long, unbroken text (e.g. URLs or Discord markdown without spaces) could overflow its container and force horizontal scrolling.

## Changes

- `Textarea`: default to `wrap="soft"` and add `min-w-0`/`max-w-full`/`overflow-x-hidden`/`whitespace-pre-wrap`/`break-words` styling so long unbroken input wraps instead of overflowing.
- `BroadcastPreviewPane`: constrain the preview container width (`min-w-0`, `max-w-full`, `overflow-x-hidden`) and wrap long content, including `<pre>` blocks, instead of letting it overflow horizontally.
- `broadcasts-new.tsx`:
  - Add `min-w-0` throughout the form's grid/flex containers so children can shrink properly instead of forcing the page wider on small screens.
  - Change the message/preview grid from `grid-cols-2` to `grid-cols-[minmax(0,1fr)_minmax(0,1fr)]` so both panes can shrink below their content size.
  - Stack the Cancel/Save/Send buttons full-width in a column on mobile (`flex-col`) and back to a row on larger screens (`sm:flex-row`, `w-full sm:w-auto`).
  - Minor JSX indentation cleanup on `TemplateFieldsEditor` props.
<!-- claude:end -->
