### PR TITLE
fix(broadcasts): scrolling of broadcast text field on mobile

### DIFF
--- a/apps/ui/src/client/features/broadcasts/components/template-fields-editor.tsx
+++ b/apps/ui/src/client/features/broadcasts/components/template-fields-editor.tsx
@@ -110,6 +110,7 @@ export function TemplateFieldsEditor({
 						autoResizeTextarea(e.currentTarget)
 						onMessagePartsChange({ ...messageParts, prefix: e.target.value })
 					}}
+					onBlur={(e) => autoResizeTextarea(e.currentTarget, { forceShrink: true })}
 					rows={1}
 					placeholder="Optional text prepended before the template message"
 					className="resize-none overflow-hidden"
@@ -216,6 +217,7 @@ export function TemplateFieldsEditor({
 											autoResizeTextarea(e.currentTarget)
 											onUpdateTemplateField(field.name, e.target.value)
 										}}
+										onBlur={(e) => autoResizeTextarea(e.currentTarget, { forceShrink: true })}
 										rows={1}
 										required={field.required}
 										className="resize-none overflow-hidden"
@@ -244,6 +246,7 @@ export function TemplateFieldsEditor({
 						autoResizeTextarea(e.currentTarget)
 						onMessagePartsChange({ ...messageParts, suffix: e.target.value })
 					}}
+					onBlur={(e) => autoResizeTextarea(e.currentTarget, { forceShrink: true })}
 					rows={1}
 					placeholder="Optional text appended after the template message"
 					className="resize-none overflow-hidden"

--- a/apps/ui/src/client/features/broadcasts/utils.ts
+++ b/apps/ui/src/client/features/broadcasts/utils.ts
@@ -74,7 +74,29 @@ export function resolveFleetCommanderSelectionFromFields(args: {
 	}
 }
 
-export function autoResizeTextarea(element: HTMLTextAreaElement): void {
+interface AutoResizeTextareaOptions {
+	forceShrink?: boolean
+}
+
+function isCoarsePointerViewport(): boolean {
+	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+	return window.matchMedia('(pointer: coarse)').matches
+}
+
+export function autoResizeTextarea(
+	element: HTMLTextAreaElement,
+	options: AutoResizeTextareaOptions = {}
+): void {
+	const isFocused = typeof document !== 'undefined' && document.activeElement === element
+	if (isCoarsePointerViewport() && isFocused && !options.forceShrink) {
+		const currentHeight =
+			Number.parseFloat(element.style.height) || element.getBoundingClientRect().height
+		if (element.scrollHeight > currentHeight) {
+			element.style.height = `${element.scrollHeight}px`
+		}
+		return
+	}
+
 	element.style.height = '0px'
 	element.style.height = `${element.scrollHeight}px`
 }

--- a/apps/ui/src/test/unit/broadcast-textarea-utils.test.ts
+++ b/apps/ui/src/test/unit/broadcast-textarea-utils.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { autoResizeTextarea } from '@/features/broadcasts/utils'
+
+function makeTextarea({
+	height,
+	scrollHeight,
+}: {
+	height: string
+	scrollHeight: number
+}): { element: HTMLTextAreaElement; heightWrites: string[] } {
+	let currentHeight = height
+	const heightWrites: string[] = []
+	const style = {} as CSSStyleDeclaration
+	Object.defineProperty(style, 'height', {
+		get: () => currentHeight,
+		set: (value: string) => {
+			currentHeight = value
+			heightWrites.push(value)
+		},
+	})
+
+	const element = {
+		style,
+		scrollHeight,
+		getBoundingClientRect: () => ({ height: Number.parseFloat(currentHeight) }) as DOMRect,
+	} as HTMLTextAreaElement
+	return { element, heightWrites }
+}
+
+function stubFocusedMobileViewport(element: HTMLTextAreaElement): void {
+	vi.stubGlobal('document', { activeElement: element })
+	vi.stubGlobal('window', {
+		matchMedia: () => ({ matches: true }) as MediaQueryList,
+	})
+}
+
+function stubFocusedDesktopViewport(element: HTMLTextAreaElement): void {
+	vi.stubGlobal('document', { activeElement: element })
+	vi.stubGlobal('window', {
+		matchMedia: () => ({ matches: false }) as MediaQueryList,
+	})
+}
+
+describe('autoResizeTextarea', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('preserves desktop shrink behavior while focused', () => {
+		const { element, heightWrites } = makeTextarea({ height: '160px', scrollHeight: 64 })
+		stubFocusedDesktopViewport(element)
+
+		autoResizeTextarea(element)
+
+		expect(heightWrites).toEqual(['0px', '64px'])
+		expect(element.style.height).toBe('64px')
+	})
+
+	it('grows a focused mobile textarea without first collapsing it', () => {
+		const { element, heightWrites } = makeTextarea({ height: '40px', scrollHeight: 96 })
+		stubFocusedMobileViewport(element)
+
+		autoResizeTextarea(element)
+
+		expect(heightWrites).toEqual(['96px'])
+		expect(element.style.height).toBe('96px')
+	})
+
+	it('does not shrink a focused mobile textarea while the user is editing', () => {
+		const { element, heightWrites } = makeTextarea({ height: '160px', scrollHeight: 64 })
+		stubFocusedMobileViewport(element)
+
+		autoResizeTextarea(element)
+
+		expect(heightWrites).toEqual([])
+		expect(element.style.height).toBe('160px')
+	})
+
+	it('shrinks focused mobile textareas when forced after editing finishes', () => {
+		const { element, heightWrites } = makeTextarea({ height: '160px', scrollHeight: 64 })
+		stubFocusedMobileViewport(element)
+
+		autoResizeTextarea(element, { forceShrink: true })
+
+		expect(heightWrites).toEqual(['0px', '64px'])
+		expect(element.style.height).toBe('64px')
+	})
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the broadcast text field auto-resize behavior so it no longer fights the user's scrolling on mobile: while a textarea is focused on a coarse-pointer (touch) viewport, it now only grows to fit content instead of first collapsing to `0px` and re-expanding, which was causing the scroll position to jump.

## Changes
- `autoResizeTextarea` now detects coarse-pointer (touch) viewports via `matchMedia('(pointer: coarse)')` and, while the textarea is focused, only grows the element's height (never shrinks) unless a new `forceShrink` option is passed.
- Added `onBlur` handlers to the prefix, suffix, and template field textareas in `TemplateFieldsEditor` that call `autoResizeTextarea(element, { forceShrink: true })`, so the field still shrinks back down once editing ends.
- Desktop/non-touch behavior is unchanged (still collapses to `0px` then re-measures on every input).

## Testing
- Added unit tests in `apps/ui/src/test/unit/broadcast-textarea-utils.test.ts` covering: desktop shrink-while-focused behavior, mobile grow-without-collapsing, mobile not shrinking while focused, and forced shrink on blur.
<!-- claude:end -->