### PR TITLE
fix(broadcast): Fix mobile broadcast composer layout and suppress emp…

### DIFF
--- a/apps/ui/src/client/features/broadcasts/components/broadcast-preview-pane.tsx
+++ b/apps/ui/src/client/features/broadcasts/components/broadcast-preview-pane.tsx
@@ -7,7 +7,7 @@ interface BroadcastPreviewPaneProps {
 
 export function BroadcastPreviewPane({ message }: BroadcastPreviewPaneProps) {
 	return (
-		<div className="[grid-area:preview] min-w-0 max-w-full space-y-2 lg:self-stretch">
+		<div className="min-w-0 max-w-full space-y-2 lg:self-stretch">
 			<Label className="text-sm font-medium">Preview</Label>
 			<div className="h-full min-h-[16rem] max-w-full overflow-y-auto overflow-x-hidden rounded-md border border-border bg-muted/20 p-3 text-sm break-words [overflow-wrap:anywhere] [&_pre]:max-w-full [&_pre]:whitespace-pre-wrap [&_pre]:break-words">
 				{message.trim() ? (

--- a/apps/ui/src/client/hooks/useBroadcasts.ts
+++ b/apps/ui/src/client/hooks/useBroadcasts.ts
@@ -237,10 +237,11 @@ export function useBroadcasts(
 /**
  * Fetch a single broadcast by ID with full details
  */
-export function useBroadcast(id: string) {
+export function useBroadcast(id: string, enabled = true) {
 	return useQuery({
 		queryKey: broadcastKeys.broadcast(id),
 		queryFn: () => api.getBroadcast(id),
+		enabled: enabled && id.length > 0,
 		staleTime: 1000 * 30,
 	})
 }

--- a/apps/ui/src/client/routes/broadcasts-new.tsx
+++ b/apps/ui/src/client/routes/broadcasts-new.tsx
@@ -80,7 +80,7 @@ export default function NewBroadcastPage() {
 	const { user } = useAuth()
 	const { requestConfirmation, confirmationDialog } = useConfirmationDialog()
 	const { hasPermission, isAdmin } = useUserPermissions()
-	const { data: draftBroadcast, isLoading: draftLoading } = useBroadcast(draftId)
+	const { data: draftBroadcast, isLoading: draftLoading } = useBroadcast(draftId, isEditMode)
 
 	// Form state
 	const [selectedTargetId, setSelectedTargetId] = useState<string>('')
@@ -732,8 +732,8 @@ export default function NewBroadcastPage() {
 
 							{/* Custom Message or Template Fields */}
 							{selectedTemplateId === 'custom' ? (
-								<div className="grid min-w-0 gap-4 [grid-template-areas:'form''preview'] lg:[grid-template-areas:'form_preview'] lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch">
-									<div className="[grid-area:form] min-w-0 space-y-2">
+								<div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch">
+									<div className="min-w-0 space-y-2">
 										<Label htmlFor="message">Message *</Label>
 										<Textarea
 											id="message"
@@ -751,8 +751,8 @@ export default function NewBroadcastPage() {
 									<BroadcastPreviewPane message={customMessage} />
 								</div>
 							) : selectedTemplate ? (
-								<div className="grid min-w-0 gap-4 [grid-template-areas:'form''preview'] lg:[grid-template-areas:'form_preview'] lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch">
-									<div className="[grid-area:form] min-w-0 space-y-4">
+								<div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch">
+									<div className="min-w-0 space-y-4">
 										<TemplateFieldsEditor
 											fields={selectedTemplate.fieldSchema}
 											templateFields={templateFields}


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes two issues in the mobile broadcast composer: a layout bug where CSS grid-area utilities broke the responsive form/preview stacking on smaller screens, and an unnecessary network request that fetched an empty draft broadcast when creating a new (non-edit) broadcast.

## Changes
- `broadcast-preview-pane.tsx`: Removed the `[grid-area:preview]` utility class that was conflicting with the responsive grid layout.
- `broadcasts-new.tsx`: Removed the `[grid-template-areas:...]` and `[grid-area:form]` utility classes from both the custom-message and template grid containers, relying on the existing `grid-cols` responsive layout instead.
- `useBroadcasts.ts`: Added an `enabled` parameter (default `true`) to `useBroadcast`, so the query is skipped when disabled or when `id` is empty.
- `broadcasts-new.tsx`: Passed `isEditMode` as the new `enabled` argument to `useBroadcast`, so the draft broadcast query only fires when actually editing an existing draft.
<!-- claude:end -->