### PR TITLE
fix(moons): caching improvements

### DIFF
--- a/apps/core/src/routes/__tests__/moon-scan.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/moon-scan.access.route.test.ts
@@ -54,6 +54,8 @@ function makeScan(status: MoonScan['status'], submittedBy: string | null = '7777
 	return {
 		id: 'scan-1',
 		moonId: '40161739',
+		regionId: '10000002',
+		solarSystemId: '30000142',
 		submittedBy,
 		submittedAt: '2026-05-01T00:00:00.000Z',
 		status,
@@ -98,6 +100,8 @@ describe('moon-scan access matrix', () => {
 			getLeaderboard: vi.fn(),
 			getScan: vi.fn(),
 			getScanSummary: vi.fn(),
+			getScannedMoonCountsByRegionIds: vi.fn().mockResolvedValue([]),
+			getVerifiedMoonCountsByRegionIds: vi.fn().mockResolvedValue([]),
 			getScans: vi.fn(),
 			resolveCharacterNames: vi.fn(),
 			rejectScans: vi.fn(),
@@ -120,7 +124,12 @@ describe('moon-scan access matrix', () => {
 
 	it('allows moon viewers to read regions', async () => {
 		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:moons:view' }] as any)
-		moonScanStub.getScanSummary.mockResolvedValue({ scannedMoonIds: [], verifiedMoonIds: [] })
+		moonScanStub.getScannedMoonCountsByRegionIds.mockResolvedValue([
+			{ regionId: '10000002', scannedCount: 9 },
+		])
+		moonScanStub.getVerifiedMoonCountsByRegionIds.mockResolvedValue([
+			{ regionId: '10000002', verifiedCount: 7 },
+		])
 		universeStub.resolveRegionsByIds.mockImplementation(async (ids: string[]) =>
 			Object.fromEntries(ids.map((id) => [id, { regionId: id, regionName: `Region ${id}` }]))
 		)
@@ -133,8 +142,13 @@ describe('moon-scan access matrix', () => {
 		const res = await app.request('/api/moon-scan/moons/regions', {}, env)
 
 		expect(res.status).toBe(200)
-		const body = await res.json() as { regions: Array<{ regionId: string }> }
+		const body = await res.json() as { regions: Array<{ regionId: string; verifiedCount: number }> }
 		expect(body.regions.length).toBeGreaterThan(0)
+		expect(body.regions.find((region) => region.regionId === '10000002')?.verifiedCount).toBe(7)
+		expect(moonScanStub.getVerifiedMoonCountsByRegionIds).toHaveBeenCalledWith(expect.any(Array))
+		expect(moonScanStub.getScannedMoonCountsByRegionIds).toHaveBeenCalledWith(expect.any(Array))
+		expect(moonScanStub.getScanSummary).not.toHaveBeenCalled()
+		expect(universeStub.getMoonRegionIds).not.toHaveBeenCalled()
 	})
 
 	it('denies submitters from reading regions', async () => {

--- a/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
+++ b/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
@@ -159,6 +159,7 @@ describe('moon-scan profitability and batching behavior', () => {
 		}
 
 		marketsStub = {
+			getMarketDataRevisionAtTime: vi.fn().mockResolvedValue('revision-1'),
 			getBatchMarketDataAtTime: vi.fn().mockResolvedValue({ prices: [] }),
 		}
 		const storedExports = new Map<string, { text: string; fileName: string }>()
@@ -252,7 +253,7 @@ describe('moon-scan profitability and batching behavior', () => {
 		expect(body.moons.find((m) => m.moonId === 'moon-2')?.composition).toBeNull()
 	})
 
-	it('pages verified moons through the summary read model before computing profitability', async () => {
+	it('uses the database-backed page query for both pagination and profitability sorting', async () => {
 		moonScanStub.getVerifiedMoonPage.mockResolvedValue({
 			items: [
 				{
@@ -266,6 +267,8 @@ describe('moon-scan profitability and batching behavior', () => {
 					constellationName: 'Kimotoro',
 					securityStatus: '0.5',
 					highestRarity: 'R64',
+					metenoxProfit: '12345',
+					tataraProfit: '67890',
 				},
 			],
 			total: 1,
@@ -302,12 +305,18 @@ describe('moon-scan profitability and batching behavior', () => {
 		}
 
 		expect(res.status).toBe(200)
-		expect(moonScanStub.getVerifiedMoonPage).toHaveBeenCalled()
-		expect(moonScanStub.getVerifiedCompositions).toHaveBeenCalledWith(['moon-1'])
+		expect(moonScanStub.getVerifiedMoonPage).toHaveBeenCalledWith(expect.objectContaining({
+		profitability: expect.objectContaining({
+			defaultCycleDays: 1,
+			prices: expect.any(Array),
+		}),
+	}))
+	expect(moonScanStub.getVerifiedCompositions).not.toHaveBeenCalled()
 		expect(universeStub.resolveStaticMoonsByIds).not.toHaveBeenCalled()
 		expect(body.total).toBe(1)
 		expect(body.items).toHaveLength(1)
 		expect(body.items[0]?.moonId).toBe('moon-1')
+		expect(body.items[0]?.metenoxProfit).toBe('12345')
 	})
 
 	it('applies fuel and magmatic override prices in single-moon profitability', async () => {

--- a/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
+++ b/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
@@ -103,6 +103,8 @@ describe('moon-scan profitability and batching behavior', () => {
 				constellations: [],
 			}),
 			getVerifiedMoonSummaryIds: vi.fn().mockResolvedValue([]),
+			getScannedMoonCountsByRegionIds: vi.fn().mockResolvedValue([]),
+			getVerifiedMoonCountsByRegionIds: vi.fn().mockResolvedValue([]),
 			upsertVerifiedMoonSummaries: vi.fn().mockResolvedValue(undefined),
 			getScans: vi.fn().mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 50 }),
 			resolveCharacterNames: vi.fn().mockResolvedValue({}),

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -13,6 +13,7 @@ import {
 	getOreVolume,
 	parseMoonScanTsv,
 	type PaginatedScanQueue,
+	type MoonScan,
 	type MoonScanDO,
 	type ScanQueueEntry,
 	type MoonProfitability,
@@ -70,6 +71,7 @@ const MAX_SCAN_RAW_BYTES = 1_000_000
 // ─── Caches ──────────────────────────────────────────────────────────────────
 
 const permissionCache = new TimeCache<boolean>(15_000)
+const verifiedMoonSummaryBackfillCache = new TimeCache<boolean>(5 * 60_000)
 const VERIFIED_MOON_SUMMARY_BACKFILL_BATCH_SIZE = 250
 const VERIFIED_MOONS_EXPORT_PAGE_SIZE = 100
 const VERIFIED_MOONS_EXPORT_BUCKET_PREFIX = 'moon-scan/verified-moons-exports'
@@ -82,6 +84,7 @@ export type VerifiedMoonsExportQuery = Pick<
 // Minerals that Metenox does NOT output (only moon goo materials)
 const MINERAL_TYPE_IDS = new Set(['35', '36'])
 const ALLOWED_MOON_SCAN_ORE_TYPE_IDS = new Set<string>([...MOON_ORE_TYPE_IDS, ...MOON_GOO_TYPE_IDS])
+const ALL_MOON_SCAN_PRICING_TYPE_IDS = [...new Set([...MOON_ORE_TYPE_IDS, ...MOON_GOO_TYPE_IDS])]
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -177,6 +180,67 @@ function getExecutionContextOrNull(c: { executionCtx?: ExecutionContext }): Exec
 	}
 }
 
+function scanToVerifiedComposition(scan: MoonScan): VerifiedComposition | null {
+	if (scan.status !== 'verified' || !scan.verifiedAt) return null
+	return {
+		moonId: scan.moonId,
+		sourceScanId: scan.id,
+		verifiedAt: scan.verifiedAt,
+		verifiedBy: scan.verifiedBy,
+		ores: scan.ores,
+	}
+}
+
+async function upsertVerifiedMoonSummariesForScans(
+	moonScan: MoonScanDO,
+	universe: Universe,
+	scans: MoonScan[]
+): Promise<void> {
+	const compositions = scans
+		.map(scanToVerifiedComposition)
+		.filter((composition): composition is VerifiedComposition => composition !== null)
+	if (compositions.length === 0) return
+
+	const summaryRecords = await buildVerifiedMoonSummaryRecords(compositions, universe)
+	await moonScan.upsertVerifiedMoonSummaries(summaryRecords)
+}
+
+function queueVerifiedMoonSummaryUpsert(
+	c: { executionCtx?: ExecutionContext },
+	moonScan: MoonScanDO,
+	universe: Universe,
+	scans: MoonScan[]
+): void {
+	const task = upsertVerifiedMoonSummariesForScans(moonScan, universe, scans).catch((error) => {
+		logger.warn('[moon-scan] failed to upsert verified moon summaries from write path', { error })
+	})
+	const executionCtx = getExecutionContextOrNull(c)
+	if (executionCtx) {
+		executionCtx.waitUntil(task)
+	} else {
+		void task
+	}
+}
+
+async function backfillMissingVerifiedMoonSummaries(
+	moonScan: MoonScanDO,
+	universe: Universe
+): Promise<void> {
+	const [scanSummary, summaryMoonIds] = await Promise.all([
+		moonScan.getScanSummary(),
+		moonScan.getVerifiedMoonSummaryIds(),
+	])
+	const summaryMoonIdSet = new Set(summaryMoonIds)
+	const missingMoonIds = scanSummary.verifiedMoonIds.filter((moonId) => !summaryMoonIdSet.has(moonId))
+	if (missingMoonIds.length === 0) return
+
+	for (const missingMoonIdChunk of chunkArray(missingMoonIds, VERIFIED_MOON_SUMMARY_BACKFILL_BATCH_SIZE)) {
+		const missingCompositions = await moonScan.getVerifiedCompositions(missingMoonIdChunk)
+		const summaryRecords = await buildVerifiedMoonSummaryRecords(missingCompositions, universe)
+		await moonScan.upsertVerifiedMoonSummaries(summaryRecords)
+	}
+}
+
 export function getVerifiedMoonsExportBucket(env: App['Bindings']): R2Bucket {
 	return env.MOON_SCAN_EXPORTS
 }
@@ -241,6 +305,14 @@ export async function writeVerifiedMoonsExportToBucket(args: {
 			sortBy: 'moonName',
 			sortDir: 'asc',
 		})
+		const exportPricingInputs = firstPage.total > 0
+			? await getMoonPricingInputsForOreTypeIds(
+				args.env,
+				args.universe,
+				args.moonScan,
+				ALL_MOON_SCAN_PRICING_TYPE_IDS
+			)
+			: undefined
 		const totalPages = Math.max(1, Math.ceil(firstPage.total / VERIFIED_MOONS_EXPORT_PAGE_SIZE))
 		for (let page = 1; page <= totalPages; page += 1) {
 			const pageData =
@@ -261,6 +333,7 @@ export async function writeVerifiedMoonsExportToBucket(args: {
 				universe: args.universe,
 				env: args.env,
 				summaries: pageData.items,
+				pricingInputs: exportPricingInputs,
 			})
 			for (const entry of pageEntries) {
 				for (const row of buildMoonExportRows(entry)) {
@@ -412,10 +485,22 @@ async function getMoonPricingInputs(
 	compositions: VerifiedComposition[],
 ): Promise<MoonPricingInputs> {
 	const oreTypeIds = [...new Set(compositions.flatMap((composition) => composition.ores.map((ore) => ore.oreTypeId)))]
+	return getMoonPricingInputsForOreTypeIds(env, universe, moonScan, oreTypeIds)
+}
+
+async function getMoonPricingInputsForOreTypeIds(
+	env: App['Bindings'],
+	universe: Universe,
+	moonScan: MoonScanDO,
+	oreTypeIds: string[],
+): Promise<MoonPricingInputs> {
+	const uniqueOreTypeIds = [...new Set(oreTypeIds)]
 	const [settings, profiles, typeMaterialsMap] = await Promise.all([
 		moonScan.getExtractionSettings(),
 		moonScan.getStructureProfiles(),
-		universe.getTypeMaterials(oreTypeIds),
+		uniqueOreTypeIds.length > 0
+			? universe.getTypeMaterials(uniqueOreTypeIds)
+			: Promise.resolve({} as Record<string, Array<{ materialTypeId: string; quantity: number }>>),
 	])
 
 	const materialTypeIds = [
@@ -423,12 +508,13 @@ async function getMoonPricingInputs(
 			Object.values(typeMaterialsMap).flatMap((materials) => materials.map((material) => material.materialTypeId))
 		),
 	]
-	const typeIdsForNames = [...new Set([...oreTypeIds, ...materialTypeIds])]
+	const typeIdsForNames = [...new Set([...uniqueOreTypeIds, ...materialTypeIds])]
+	const priceTypeIds = [...new Set([...materialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID])]
 	const markets = getMarketsStub(env)
 	const [priceResponse, typeNamesMap] = await Promise.all([
 		markets.getBatchMarketDataAtTime({
 			regionId: createEveRegionId('universe'),
-			typeIds: [...materialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID].map(createEveTypeId),
+			typeIds: priceTypeIds.map(createEveTypeId),
 			atTime: new Date(),
 		}),
 		typeIdsForNames.length > 0
@@ -516,12 +602,13 @@ async function buildMoonExportEntriesForPage(args: {
 		securityStatus: string | null
 		highestRarity: string | null
 	}>
+	pricingInputs?: MoonPricingInputs
 }): Promise<MoonExportEntry[]> {
 	if (args.summaries.length === 0) return []
 
 	const compositions = await args.moonScan.getVerifiedCompositions(args.summaries.map((summary) => summary.moonId))
 	const compositionMap = new Map(compositions.map((composition) => [composition.moonId, composition]))
-	const inputs = await getMoonPricingInputs(args.env, args.universe, args.moonScan, compositions)
+	const inputs = args.pricingInputs ?? await getMoonPricingInputs(args.env, args.universe, args.moonScan, compositions)
 
 	return args.summaries.map((summary) => {
 		const composition = compositionMap.get(summary.moonId)
@@ -815,19 +902,10 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 	if (!usesProfitSort) {
 		let summary: Awaited<ReturnType<MoonScanDO['getVerifiedMoonPage']>> | null = null
 		try {
-			const [scanSummary, summaryMoonIds] = await Promise.all([
-				moonScan.getScanSummary(),
-				moonScan.getVerifiedMoonSummaryIds(),
-			])
-			const summaryMoonIdSet = new Set(summaryMoonIds)
-			const missingMoonIds = scanSummary.verifiedMoonIds.filter((moonId) => !summaryMoonIdSet.has(moonId))
-			if (missingMoonIds.length > 0) {
-				for (const missingMoonIdChunk of chunkArray(missingMoonIds, VERIFIED_MOON_SUMMARY_BACKFILL_BATCH_SIZE)) {
-					const missingCompositions = await moonScan.getVerifiedCompositions(missingMoonIdChunk)
-					const summaryRecords = await buildVerifiedMoonSummaryRecords(missingCompositions, universe)
-					await moonScan.upsertVerifiedMoonSummaries(summaryRecords)
-				}
-			}
+			await verifiedMoonSummaryBackfillCache.getOrSet('default', async () => {
+				await backfillMissingVerifiedMoonSummaries(moonScan, universe)
+				return true
+			})
 
 			summary = await moonScan.getVerifiedMoonPage({
 				...query.data,
@@ -1520,7 +1598,8 @@ moonScanRoutes.post('/scans/submit', async (c) => {
 
 	// Batch-resolve system security statuses and filter ineligible systems
 	const systemIds = [...new Set(parseResult.scans.map((s) => s.solarSystemId))]
-	const systemsById = await getUniverseStub(c.env).resolveSolarSystemsByIds(systemIds)
+	const universe = getUniverseStub(c.env)
+	const systemsById = await universe.resolveSolarSystemsByIds(systemIds)
 
 	const eligibleScans = parseResult.scans.filter((scan) => {
 		const system = systemsById[scan.solarSystemId]
@@ -1556,6 +1635,9 @@ moonScanRoutes.post('/scans/submit', async (c) => {
 		primaryChar?.characterId ?? null,
 		canValidate
 	)
+	if (canValidate) {
+		queueVerifiedMoonSummaryUpsert(c, moonScan, universe, submittedScans)
+	}
 
 	const rejected = parseResult.scans.length - scansWithOnlyAllowedOreTypes.length
 
@@ -1649,7 +1731,9 @@ moonScanRoutes.post('/scans/queue/verify-all', async (c) => {
 	const verifiedBy = primaryChar?.characterId ?? user.id
 
 	const moonScan = getMoonScanStub(c.env)
+	const universe = getUniverseStub(c.env)
 	const scans = await moonScan.verifyScans(body.data.scanIds, verifiedBy, null)
+	queueVerifiedMoonSummaryUpsert(c, moonScan, universe, scans)
 	return c.json(scans)
 })
 
@@ -1720,7 +1804,9 @@ moonScanRoutes.post('/scans/:id/verify', async (c) => {
 	const verifiedBy = primaryChar?.characterId ?? user.id
 
 	const moonScan = getMoonScanStub(c.env)
+	const universe = getUniverseStub(c.env)
 	const scan = await moonScan.verifyScan(c.req.param('id'), verifiedBy, body.data.notes ?? null)
+	queueVerifiedMoonSummaryUpsert(c, moonScan, universe, [scan])
 	return c.json(scan)
 })
 

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -17,6 +17,7 @@ import {
 	type MoonScanDO,
 	type ScanQueueEntry,
 	type MoonProfitability,
+	type MoonProfitabilityQueryInputs,
 	type OreRarity,
 	type OreWithProfitability,
 	type VerifiedMoonSummaryRecord,
@@ -71,8 +72,9 @@ const MAX_SCAN_RAW_BYTES = 1_000_000
 // ─── Caches ──────────────────────────────────────────────────────────────────
 
 const permissionCache = new TimeCache<boolean>(15_000)
-const MOON_PRICING_INPUTS_CACHE_TTL_MS = 60_000
-const VERIFIED_MOONS_RESPONSE_CACHE_TTL_MS = 30_000
+const MOON_PRICING_REVISION_CACHE_TTL_MS = 60_000
+const MOON_PRICING_INPUTS_CACHE_TTL_MS = 60 * 60_000
+const VERIFIED_MOONS_RESPONSE_CACHE_TTL_MS = 10 * 60_000
 const MOON_REGIONS_RESPONSE_CACHE_TTL_MS = 5 * 60_000
 const MOON_REGION_RESPONSE_CACHE_TTL_MS = 60_000
 const MOON_SYSTEM_RESPONSE_CACHE_TTL_MS = 60_000
@@ -364,6 +366,8 @@ type MoonPricingInputs = {
 	typeMaterialsMap: Record<string, Array<{ materialTypeId: string; quantity: number }>>
 	priceMap: Record<string, number>
 	typeNamesMap: Record<string, { typeName: string } | null>
+	oreVolumes: Record<string, number>
+	pricingSnapshotDate: string | null
 }
 
 type VerifiedMoonsListItem = {
@@ -388,6 +392,7 @@ type VerifiedMoonsListResponse = {
 	pageSize: number
 	constellations: Array<{ constellationId: string; constellationName: string }>
 	updatedAt: string
+	pricingSnapshotDate: string | null
 }
 
 type MoonRegionsResponse = {
@@ -436,6 +441,7 @@ type MoonSystemResponse = {
 type MoonLeaderboardResponse = Awaited<ReturnType<MoonScanDO['getLeaderboard']>>
 
 const moonPricingInputsCache = new TimeCache<MoonPricingInputs>(MOON_PRICING_INPUTS_CACHE_TTL_MS, 100)
+const moonPricingRevisionCache = new TimeCache<string | null>(MOON_PRICING_REVISION_CACHE_TTL_MS, 2)
 const verifiedMoonsResponseCache = new TimeCache<VerifiedMoonsListResponse>(
 	VERIFIED_MOONS_RESPONSE_CACHE_TTL_MS,
 	200
@@ -616,6 +622,7 @@ function getMoonProfitabilityInputsFromComposition(
 			ores: compositionOres,
 			structures,
 			updatedAt: new Date().toISOString(),
+			pricingSnapshotDate: inputs.pricingSnapshotDate,
 		}
 	} catch (error) {
 		logger.error('[moon-scan] failed to build profitability from cached inputs', { error })
@@ -633,12 +640,26 @@ function clearMoonScanReadCaches(): void {
 
 function clearMoonScanPricingCaches(): void {
 	moonPricingInputsCache.clear()
+	moonPricingRevisionCache.clear()
 	clearMoonScanReadCaches()
 }
 
-function buildMoonPricingInputsCacheKey(oreTypeIds: string[]): string {
+function buildMoonPricingInputsCacheKey(oreTypeIds: string[], pricingRevision: string | null): string {
 	const sortedOreTypeIds = [...new Set(oreTypeIds)].sort((a, b) => Number(a) - Number(b))
-	return `moon-pricing-inputs:${sortedOreTypeIds.join(',')}`
+	return `moon-pricing-inputs:${pricingRevision ?? 'none'}:${sortedOreTypeIds.join(',')}`
+}
+
+async function getMoonPricingRevision(env: App['Bindings']): Promise<string | null> {
+	return moonPricingRevisionCache.getOrSet('moon-pricing-revision:universe', () =>
+		getMarketsStub(env).getMarketDataRevisionAtTime({
+			regionId: createEveRegionId('universe'),
+			atTime: new Date(),
+		})
+	)
+}
+
+function getPricingSnapshotDate(pricingRevision: string | null): string | null {
+	return pricingRevision?.split(':', 1)[0] ?? null
 }
 
 function getMoonProfitValuesFromComposition(
@@ -693,6 +714,26 @@ function getMoonProfitValuesFromComposition(
 	}
 }
 
+function toMoonProfitabilityQueryInputs(inputs: MoonPricingInputs): MoonProfitabilityQueryInputs {
+	return {
+		...inputs.settings,
+		profiles: inputs.profiles.map((profile) => ({
+			id: profile.id,
+			baseVolumePerHr: profile.baseVolumePerHr,
+			rigBonus: profile.rigBonus,
+			fuelPerHr: profile.fuelPerHr,
+			magmaticGasPerHr: profile.magmaticGasPerHr,
+			nullsecModifier: profile.nullsecModifier,
+			isPassive: profile.isPassive,
+		})),
+		typeMaterials: Object.entries(inputs.typeMaterialsMap).flatMap(([oreTypeId, materials]) =>
+			materials.map((material) => ({ ...material, oreTypeId }))
+		),
+		oreVolumes: inputs.oreVolumes,
+		prices: Object.entries(inputs.priceMap).map(([typeId, price]) => ({ typeId, price })),
+	}
+}
+
 async function getMoonPricingInputs(
 	env: App['Bindings'],
 	universe: Universe,
@@ -708,9 +749,13 @@ async function getMoonPricingInputsForOreTypeIds(
 	universe: Universe,
 	moonScan: MoonScanDO,
 	oreTypeIds: string[],
+	pricingRevision?: string | null,
 ): Promise<MoonPricingInputs> {
 	const uniqueOreTypeIds = [...new Set(oreTypeIds)]
-	return moonPricingInputsCache.getOrSet(buildMoonPricingInputsCacheKey(uniqueOreTypeIds), async () => {
+	const effectivePricingRevision = pricingRevision ?? await getMoonPricingRevision(env)
+	return moonPricingInputsCache.getOrSet(
+		buildMoonPricingInputsCacheKey(uniqueOreTypeIds, effectivePricingRevision),
+		async () => {
 		const [settings, profiles, typeMaterialsMap] = await Promise.all([
 			moonScan.getExtractionSettings(),
 			moonScan.getStructureProfiles(),
@@ -749,8 +794,11 @@ async function getMoonPricingInputsForOreTypeIds(
 			typeMaterialsMap,
 			priceMap,
 			typeNamesMap,
+			oreVolumes: Object.fromEntries(uniqueOreTypeIds.map((typeId) => [typeId, getOreVolume(typeId)])),
+			pricingSnapshotDate: getPricingSnapshotDate(effectivePricingRevision),
 		}
-	})
+		}
+	)
 }
 
 function buildMoonExportRows(entry: MoonExportEntry): Array<Array<string | number | boolean | null | undefined>> {
@@ -887,7 +935,10 @@ const VerifiedMoonsQuerySchema = z.object({
 	sortDir: z.enum(['asc', 'desc']).default('asc'),
 })
 
-function buildVerifiedMoonsResponseCacheKey(query: z.infer<typeof VerifiedMoonsQuerySchema>): string {
+function buildVerifiedMoonsResponseCacheKey(
+	query: z.infer<typeof VerifiedMoonsQuerySchema>,
+	pricingRevision: string | null,
+): string {
 	const rarities = query.rarity ? [...query.rarity].sort().join(',') : ''
 	return [
 		'verified-moons',
@@ -899,6 +950,7 @@ function buildVerifiedMoonsResponseCacheKey(query: z.infer<typeof VerifiedMoonsQ
 		query.search ?? '',
 		query.sortBy,
 		query.sortDir,
+		pricingRevision ?? 'none',
 	].join('|')
 }
 
@@ -1131,252 +1183,36 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 
 	const moonScan = getMoonScanStub(c.env)
 	const universe = getUniverseStub(c.env)
-	const usesProfitSort = query.data.sortBy === 'metenoxProfit' || query.data.sortBy === 'tataraProfit'
-	const verifiedMoonsResponseCacheKey = buildVerifiedMoonsResponseCacheKey(query.data)
+	const pricingRevision = await getMoonPricingRevision(c.env)
+	const verifiedMoonsResponseCacheKey = buildVerifiedMoonsResponseCacheKey(query.data, pricingRevision)
 	const cachedResponse = verifiedMoonsResponseCache.get(verifiedMoonsResponseCacheKey)
 	if (cachedResponse) return c.json(cachedResponse)
 
-	if (!usesProfitSort) {
-		let summary: Awaited<ReturnType<MoonScanDO['getVerifiedMoonPage']>> | null = null
-		try {
-			summary = await moonScan.getVerifiedMoonPage({
-				...query.data,
-				sortBy: query.data.sortBy as VerifiedMoonsSortBy,
-			})
-		} catch (error) {
-			logger.warn('Falling back to legacy verified-moons hydration', {
-				error,
-				sortBy: query.data.sortBy,
-			})
-		}
-
-		if (summary) {
-			if (summary.items.length === 0) {
-				const response: VerifiedMoonsListResponse = {
-					items: [],
-					total: summary.total,
-					page: summary.page,
-					pageSize: summary.pageSize,
-					constellations: summary.constellations,
-					updatedAt: new Date().toISOString(),
-				}
-				verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
-				return c.json(response)
-			}
-
-			const pageMoonIds = summary.items.map((item) => item.moonId)
-			const compositions = await moonScan.getVerifiedCompositions(pageMoonIds)
-			const pricingInputs = await getMoonPricingInputs(c.env, universe, moonScan, compositions)
-
-			const compositionMap = new Map(compositions.map((composition) => [composition.moonId, composition]))
-			const items = summary.items.map((item) => {
-				const composition = compositionMap.get(item.moonId)
-				if (!composition) {
-					return {
-						...item,
-						metenoxProfit: null,
-						tataraProfit: null,
-					}
-				}
-				return {
-					...item,
-					...getMoonProfitValuesFromComposition(composition, pricingInputs),
-				}
-			})
-
-			const response: VerifiedMoonsListResponse = {
-				items,
-				total: summary.total,
-				page: summary.page,
-				pageSize: summary.pageSize,
-				constellations: summary.constellations,
-				updatedAt: new Date().toISOString(),
-			}
-			verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
-			return c.json(response)
-		}
-	}
-
-	// Get all verified moon IDs
-	const summary = await moonScan.getScanSummary()
-	const verifiedMoonIds = summary.verifiedMoonIds
-	if (verifiedMoonIds.length === 0) {
-		const response: VerifiedMoonsListResponse = {
-			items: [],
-			total: 0,
-			page: query.data.page,
-			pageSize: query.data.pageSize,
-			constellations: [],
-			updatedAt: new Date().toISOString(),
-		}
-		verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
-		return c.json(response)
-	}
-
-	// Bulk-load compositions and moon static data before the legacy in-memory sort fallback.
-	const [compositions, moonsById] = await Promise.all([
-		moonScan.getVerifiedCompositions(verifiedMoonIds),
-		universe.resolveStaticMoonsByIds(verifiedMoonIds),
-	])
-	const pricingInputsPromise = getMoonPricingInputs(c.env, universe, moonScan, compositions)
-
-	// Resolve system IDs and fetch system info + moon→region mapping
-	const systemIds = [...new Set(
-		Object.values(moonsById)
-			.filter((m): m is NonNullable<typeof m> => m !== null)
-			.map((m) => m.solarSystemId)
-	)]
-	const [systemsById, moonRegionMap] = await Promise.all([
-		universe.resolveSolarSystemsByIds(systemIds),
-		universe.getMoonRegionIds(verifiedMoonIds),
-	])
-
-	// Resolve region names
-	const regionIds = [...new Set(Object.values(moonRegionMap).filter((id): id is string => !!id))]
-	const regionsById = regionIds.length > 0 ? await universe.resolveRegionsByIds(regionIds) : {}
-
-	// Resolve constellation names (each system already carries constellationId)
-	const constellationIds = [
-		...new Set(
-			Object.values(systemsById)
-				.filter((s): s is NonNullable<typeof s> => s !== null)
-				.map((s) => s.constellationId)
-				.filter((id): id is string => !!id)
-		),
-	]
-	const constellationsById = constellationIds.length > 0
-		? await universe.resolveConstellationsByIds(constellationIds)
-		: {}
-	const pricingInputs = await pricingInputsPromise
-
-	const moons = compositions.map((comp) => {
-		const moon = moonsById[comp.moonId]
-		if (!moon) return null
-
-		const system = systemsById[moon.solarSystemId]
-		const regionId = moonRegionMap[comp.moonId] ?? null
-		const region = regionId ? regionsById[regionId] : null
-		const constellationId = system?.constellationId ?? null
-		const constellation = constellationId ? constellationsById[constellationId] : null
-
-		const highestRarity = comp.ores.reduce<OreRarity | null>((best, ore) => {
-			const r = ORE_TYPE_RARITY[ore.oreTypeId]
-			if (!r) return best
-			if (!best) return r
-			return (RARITY_ORDER[r] ?? 0) > (RARITY_ORDER[best] ?? 0) ? r : best
-		}, null)
-
-		return {
-			moonId: comp.moonId,
-			moonName: moon.moonName,
-			solarSystemId: moon.solarSystemId,
-			solarSystemName: system?.solarSystemName ?? moon.solarSystemId,
-			regionId: regionId ?? '',
-			regionName: region?.regionName ?? regionId ?? '',
-			constellationId: constellationId ?? '',
-			constellationName: constellation?.constellationName ?? constellationId ?? '',
-			securityStatus: system?.securityStatus ?? null,
-			highestRarity,
-			...getMoonProfitValuesFromComposition(comp, pricingInputs),
-		}
-	}).filter((m): m is NonNullable<typeof m> => m !== null)
-
-	let filtered = moons
-	if (query.data.regionId) {
-		filtered = filtered.filter((m) => m.regionId === query.data.regionId)
-	}
-	// Unique constellations within the region-filter (drives the cascading dropdown).
-	const constellationsForFilter = new Map<string, { constellationId: string; constellationName: string }>()
-	for (const m of filtered) {
-		if (m.constellationId && !constellationsForFilter.has(m.constellationId)) {
-			constellationsForFilter.set(m.constellationId, {
-				constellationId: m.constellationId,
-				constellationName: m.constellationName,
-			})
-		}
-	}
-	const constellationsSummary = [...constellationsForFilter.values()].sort((a, b) =>
-		a.constellationName.localeCompare(b.constellationName)
+	const pricingInputs = await getMoonPricingInputsForOreTypeIds(
+		c.env,
+		universe,
+		moonScan,
+		ALL_MOON_SCAN_PRICING_TYPE_IDS,
+		pricingRevision,
 	)
-	if (query.data.constellationId) {
-		filtered = filtered.filter((m) => m.constellationId === query.data.constellationId)
-	}
-	if (query.data.rarity && query.data.rarity.length > 0) {
-		const rarities = new Set<string>(query.data.rarity)
-		filtered = filtered.filter((m) => m.highestRarity !== null && rarities.has(m.highestRarity))
-	}
-	if (query.data.search) {
-		const q = query.data.search.toLowerCase()
-		filtered = filtered.filter(
-			(m) => m.moonName.toLowerCase().includes(q) || m.solarSystemName.toLowerCase().includes(q)
-		)
-	}
-
-	const { sortBy, sortDir } = query.data
-	const direction = sortDir === 'asc' ? 1 : -1
-	const rarityRank = (rarity: string | null): number => {
-		if (!rarity) return -1
-		return RARITY_ORDER[rarity as OreRarity] ?? -1
-	}
-	const parseNum = (value: string | null): number | null => {
-		if (value == null) return null
-		const n = Number.parseFloat(value)
-		return Number.isFinite(n) ? n : null
-	}
-	filtered = [...filtered].sort((a, b) => {
-		let cmp = 0
-		switch (sortBy) {
-			case 'moonName':
-				cmp = a.moonName.localeCompare(b.moonName)
-				break
-			case 'solarSystemName':
-				cmp = a.solarSystemName.localeCompare(b.solarSystemName)
-				break
-			case 'regionName':
-				cmp = a.regionName.localeCompare(b.regionName)
-				break
-			case 'securityStatus': {
-				const av = parseSecurityStatus(a.securityStatus)
-				const bv = parseSecurityStatus(b.securityStatus)
-				cmp = av === bv ? 0 : av === null ? 1 : bv === null ? -1 : av - bv
-				break
-			}
-			case 'highestRarity': {
-				const av = rarityRank(a.highestRarity)
-				const bv = rarityRank(b.highestRarity)
-				cmp = av - bv
-				break
-			}
-			case 'metenoxProfit': {
-				const av = parseNum(a.metenoxProfit)
-				const bv = parseNum(b.metenoxProfit)
-				cmp = av === bv ? 0 : av === null ? 1 : bv === null ? -1 : av - bv
-				break
-			}
-			case 'tataraProfit': {
-				const av = parseNum(a.tataraProfit)
-				const bv = parseNum(b.tataraProfit)
-				cmp = av === bv ? 0 : av === null ? 1 : bv === null ? -1 : av - bv
-				break
-			}
-		}
-		if (cmp !== 0) return cmp * direction
-		return a.moonName.localeCompare(b.moonName)
+	const summary = await moonScan.getVerifiedMoonPage({
+		...query.data,
+		sortBy: query.data.sortBy as VerifiedMoonsSortBy,
+		profitability: toMoonProfitabilityQueryInputs(pricingInputs),
 	})
 
-	const total = filtered.length
-	const page = query.data.page
-	const pageSize = query.data.pageSize
-	const start = (page - 1) * pageSize
-	const items = filtered.slice(start, start + pageSize)
-
 	const response: VerifiedMoonsListResponse = {
-		items,
-		total,
-		page,
-		pageSize,
-		constellations: constellationsSummary,
+		items: summary.items.map((item) => ({
+			...item,
+			metenoxProfit: item.metenoxProfit ?? null,
+			tataraProfit: item.tataraProfit ?? null,
+		})),
+		total: summary.total,
+		page: summary.page,
+		pageSize: summary.pageSize,
+		constellations: summary.constellations,
 		updatedAt: new Date().toISOString(),
+		pricingSnapshotDate: pricingInputs.pricingSnapshotDate,
 	}
 	verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
 	return c.json(response)

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -72,6 +72,8 @@ const MAX_SCAN_RAW_BYTES = 1_000_000
 
 const permissionCache = new TimeCache<boolean>(15_000)
 const verifiedMoonSummaryBackfillCache = new TimeCache<boolean>(5 * 60_000)
+const MOON_PRICING_INPUTS_CACHE_TTL_MS = 60_000
+const VERIFIED_MOONS_RESPONSE_CACHE_TTL_MS = 30_000
 const VERIFIED_MOON_SUMMARY_BACKFILL_BATCH_SIZE = 250
 const VERIFIED_MOONS_EXPORT_PAGE_SIZE = 100
 const VERIFIED_MOONS_EXPORT_BUCKET_PREFIX = 'moon-scan/verified-moons-exports'
@@ -359,6 +361,36 @@ type MoonPricingInputs = {
 	typeNamesMap: Record<string, { typeName: string } | null>
 }
 
+type VerifiedMoonsListItem = {
+	moonId: string
+	moonName: string
+	solarSystemId: string
+	solarSystemName: string
+	regionId: string
+	regionName: string
+	constellationId: string
+	constellationName: string
+	securityStatus: string | null
+	highestRarity: OreRarity | null
+	metenoxProfit: string | null
+	tataraProfit: string | null
+}
+
+type VerifiedMoonsListResponse = {
+	items: VerifiedMoonsListItem[]
+	total: number
+	page: number
+	pageSize: number
+	constellations: Array<{ constellationId: string; constellationName: string }>
+	updatedAt: string
+}
+
+const moonPricingInputsCache = new TimeCache<MoonPricingInputs>(MOON_PRICING_INPUTS_CACHE_TTL_MS, 100)
+const verifiedMoonsResponseCache = new TimeCache<VerifiedMoonsListResponse>(
+	VERIFIED_MOONS_RESPONSE_CACHE_TTL_MS,
+	200
+)
+
 type MoonExportEntry = {
 	moon: {
 		moonId: string
@@ -478,6 +510,73 @@ function getMoonProfitabilityInputsFromComposition(
 	}
 }
 
+function clearMoonScanReadCaches(): void {
+	verifiedMoonSummaryBackfillCache.clear()
+	verifiedMoonsResponseCache.clear()
+}
+
+function clearMoonScanPricingCaches(): void {
+	moonPricingInputsCache.clear()
+	clearMoonScanReadCaches()
+}
+
+function buildMoonPricingInputsCacheKey(oreTypeIds: string[]): string {
+	const sortedOreTypeIds = [...new Set(oreTypeIds)].sort((a, b) => Number(a) - Number(b))
+	return `moon-pricing-inputs:${sortedOreTypeIds.join(',')}`
+}
+
+function getMoonProfitValuesFromComposition(
+	composition: VerifiedComposition,
+	inputs: MoonPricingInputs,
+): Pick<VerifiedMoonsListItem, 'metenoxProfit' | 'tataraProfit'> {
+	const reprocessingYield = parseFloat(inputs.settings.defaultReprocessingYield)
+	const cycleDays = inputs.settings.defaultCycleDays
+	let metenoxProfit: number | null = null
+	let tataraProfit: number | null = null
+
+	for (const profile of inputs.profiles) {
+		const baseRate = parseFloat(profile.baseVolumePerHr) * (1 + parseFloat(profile.rigBonus))
+		const fuelPerHr = parseFloat(profile.fuelPerHr)
+		const magmaticGasPerHr = profile.magmaticGasPerHr ? parseFloat(profile.magmaticGasPerHr) : 0
+		const cycleHours = cycleDays * 24
+		const totalVolume = profile.isPassive
+			? baseRate * parseFloat(profile.nullsecModifier) * cycleHours
+			: baseRate * cycleHours
+		const fuelUnits = fuelPerHr * cycleHours
+		const magmaticGasUnits = profile.isPassive ? magmaticGasPerHr * cycleHours : 0
+
+		let grossIsk = 0
+		for (const ore of composition.ores) {
+			const liveMaterials = inputs.typeMaterialsMap[ore.oreTypeId] ?? []
+			const fraction = parseFloat(ore.quantity)
+			const oreUnits = (totalVolume * fraction) / getOreVolume(ore.oreTypeId)
+			for (const material of liveMaterials) {
+				if (profile.isPassive && MINERAL_TYPE_IDS.has(material.materialTypeId)) continue
+				const rawUnits = Math.floor(oreUnits / 100) * material.quantity * reprocessingYield
+				grossIsk += Math.floor(rawUnits) * (inputs.priceMap[material.materialTypeId] ?? 0)
+			}
+		}
+
+		const fuelCost = fuelUnits * resolveEffectivePrice(
+			inputs.settings.fuelBlockPriceOverride,
+			inputs.priceMap[FUEL_BLOCK_TYPE_ID] ?? 0
+		)
+		const magmaticGasCost = magmaticGasUnits * resolveEffectivePrice(
+			inputs.settings.magmaticGasPriceOverride,
+			inputs.priceMap[MAGMATIC_GAS_TYPE_ID] ?? 0
+		)
+		const profit = Math.round(grossIsk - fuelCost - magmaticGasCost)
+
+		if (profile.id === 'metenox') metenoxProfit = profit
+		else if (profile.id === 'tatara') tataraProfit = profit
+	}
+
+	return {
+		metenoxProfit: metenoxProfit !== null ? String(metenoxProfit) : null,
+		tataraProfit: tataraProfit !== null ? String(tataraProfit) : null,
+	}
+}
+
 async function getMoonPricingInputs(
 	env: App['Bindings'],
 	universe: Universe,
@@ -495,45 +594,47 @@ async function getMoonPricingInputsForOreTypeIds(
 	oreTypeIds: string[],
 ): Promise<MoonPricingInputs> {
 	const uniqueOreTypeIds = [...new Set(oreTypeIds)]
-	const [settings, profiles, typeMaterialsMap] = await Promise.all([
-		moonScan.getExtractionSettings(),
-		moonScan.getStructureProfiles(),
-		uniqueOreTypeIds.length > 0
-			? universe.getTypeMaterials(uniqueOreTypeIds)
-			: Promise.resolve({} as Record<string, Array<{ materialTypeId: string; quantity: number }>>),
-	])
+	return moonPricingInputsCache.getOrSet(buildMoonPricingInputsCacheKey(uniqueOreTypeIds), async () => {
+		const [settings, profiles, typeMaterialsMap] = await Promise.all([
+			moonScan.getExtractionSettings(),
+			moonScan.getStructureProfiles(),
+			uniqueOreTypeIds.length > 0
+				? universe.getTypeMaterials(uniqueOreTypeIds)
+				: Promise.resolve({} as Record<string, Array<{ materialTypeId: string; quantity: number }>>),
+		])
 
-	const materialTypeIds = [
-		...new Set(
-			Object.values(typeMaterialsMap).flatMap((materials) => materials.map((material) => material.materialTypeId))
-		),
-	]
-	const typeIdsForNames = [...new Set([...uniqueOreTypeIds, ...materialTypeIds])]
-	const priceTypeIds = [...new Set([...materialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID])]
-	const markets = getMarketsStub(env)
-	const [priceResponse, typeNamesMap] = await Promise.all([
-		markets.getBatchMarketDataAtTime({
-			regionId: createEveRegionId('universe'),
-			typeIds: priceTypeIds.map(createEveTypeId),
-			atTime: new Date(),
-		}),
-		typeIdsForNames.length > 0
-			? universe.resolveTypeNamesByIds(typeIdsForNames)
-			: Promise.resolve({} as Record<string, { typeName: string } | null>),
-	])
+		const materialTypeIds = [
+			...new Set(
+				Object.values(typeMaterialsMap).flatMap((materials) => materials.map((material) => material.materialTypeId))
+			),
+		]
+		const typeIdsForNames = [...new Set([...uniqueOreTypeIds, ...materialTypeIds])]
+		const priceTypeIds = [...new Set([...materialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID])]
+		const markets = getMarketsStub(env)
+		const [priceResponse, typeNamesMap] = await Promise.all([
+			markets.getBatchMarketDataAtTime({
+				regionId: createEveRegionId('universe'),
+				typeIds: priceTypeIds.map(createEveTypeId),
+				atTime: new Date(),
+			}),
+			typeIdsForNames.length > 0
+				? universe.resolveTypeNamesByIds(typeIdsForNames)
+				: Promise.resolve({} as Record<string, { typeName: string } | null>),
+		])
 
-	const priceMap: Record<string, number> = {}
-	for (const price of priceResponse.prices) {
-		if (price.bestSellPrice) priceMap[price.typeId] = parseFloat(price.bestSellPrice)
-	}
+		const priceMap: Record<string, number> = {}
+		for (const price of priceResponse.prices) {
+			if (price.bestSellPrice) priceMap[price.typeId] = parseFloat(price.bestSellPrice)
+		}
 
-	return {
-		settings,
-		profiles,
-		typeMaterialsMap,
-		priceMap,
-		typeNamesMap,
-	}
+		return {
+			settings,
+			profiles,
+			typeMaterialsMap,
+			priceMap,
+			typeNamesMap,
+		}
+	})
 }
 
 function buildMoonExportRows(entry: MoonExportEntry): Array<Array<string | number | boolean | null | undefined>> {
@@ -669,6 +770,21 @@ const VerifiedMoonsQuerySchema = z.object({
 		.default('moonName'),
 	sortDir: z.enum(['asc', 'desc']).default('asc'),
 })
+
+function buildVerifiedMoonsResponseCacheKey(query: z.infer<typeof VerifiedMoonsQuerySchema>): string {
+	const rarities = query.rarity ? [...query.rarity].sort().join(',') : ''
+	return [
+		'verified-moons',
+		query.page,
+		query.pageSize,
+		query.regionId ?? '',
+		query.constellationId ?? '',
+		rarities,
+		query.search ?? '',
+		query.sortBy,
+		query.sortDir,
+	].join('|')
+}
 
 const ExtractionSettingsSchema = z.object({
 	defaultReprocessingYield: z.string().optional(),
@@ -898,6 +1014,9 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 	const moonScan = getMoonScanStub(c.env)
 	const universe = getUniverseStub(c.env)
 	const usesProfitSort = query.data.sortBy === 'metenoxProfit' || query.data.sortBy === 'tataraProfit'
+	const verifiedMoonsResponseCacheKey = buildVerifiedMoonsResponseCacheKey(query.data)
+	const cachedResponse = verifiedMoonsResponseCache.get(verifiedMoonsResponseCacheKey)
+	if (cachedResponse) return c.json(cachedResponse)
 
 	if (!usesProfitSort) {
 		let summary: Awaited<ReturnType<MoonScanDO['getVerifiedMoonPage']>> | null = null
@@ -920,91 +1039,21 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 
 		if (summary) {
 			if (summary.items.length === 0) {
-				return c.json({
+				const response: VerifiedMoonsListResponse = {
 					items: [],
 					total: summary.total,
 					page: summary.page,
 					pageSize: summary.pageSize,
 					constellations: summary.constellations,
 					updatedAt: new Date().toISOString(),
-				})
+				}
+				verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
+				return c.json(response)
 			}
 
 			const pageMoonIds = summary.items.map((item) => item.moonId)
-			const [compositions, settings, profiles] = await Promise.all([
-				moonScan.getVerifiedCompositions(pageMoonIds),
-				moonScan.getExtractionSettings(),
-				moonScan.getStructureProfiles(),
-			])
-
-			// Collect all unique ore type IDs across the current page for typeMaterials lookup
-			const allOreTypeIds = [...new Set(compositions.flatMap((c) => c.ores.map((o) => o.oreTypeId)))]
-
-			// Fetch live typeMaterials first, then price all discovered materials + consumables.
-			const markets = getMarketsStub(c.env)
-			const typeMaterialsMap = await universe.getTypeMaterials(allOreTypeIds)
-			const allMaterialTypeIds = [...new Set(
-				Object.values(typeMaterialsMap).flatMap((materials) => materials.map((material) => material.materialTypeId))
-			)]
-			const priceResponse = await markets.getBatchMarketDataAtTime({
-				regionId: createEveRegionId('universe'),
-				typeIds: [...allMaterialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID].map(createEveTypeId),
-				atTime: new Date(),
-			})
-			const priceMap: Record<string, number> = {}
-			for (const p of priceResponse.prices) {
-				if (p.bestSellPrice) priceMap[p.typeId] = parseFloat(p.bestSellPrice)
-			}
-
-			const fuelBlockPrice = resolveEffectivePrice(
-				settings.fuelBlockPriceOverride,
-				priceMap[FUEL_BLOCK_TYPE_ID] ?? 0
-			)
-			const magmaticGasPrice = resolveEffectivePrice(
-				settings.magmaticGasPriceOverride,
-				priceMap[MAGMATIC_GAS_TYPE_ID] ?? 0
-			)
-			const reprocessingYield = parseFloat(settings.defaultReprocessingYield)
-			const cycleDays = settings.defaultCycleDays
-
-			function computeMoonProfit(composition: typeof compositions[number]) {
-				let metenoxProfit: number | null = null
-				let tataraProfit: number | null = null
-
-				for (const profile of profiles) {
-					const baseRate = parseFloat(profile.baseVolumePerHr) * (1 + parseFloat(profile.rigBonus))
-					const fuelPerHr = parseFloat(profile.fuelPerHr)
-					const magmaticGasPerHr = profile.magmaticGasPerHr ? parseFloat(profile.magmaticGasPerHr) : 0
-					const cycleHours = cycleDays * 24
-					const totalVolume = profile.isPassive
-						? baseRate * parseFloat(profile.nullsecModifier) * cycleHours
-						: baseRate * cycleHours
-					const fuelUnits = fuelPerHr * cycleHours
-					const magmaticGasUnits = profile.isPassive ? magmaticGasPerHr * cycleHours : 0
-
-					let grossIsk = 0
-					for (const ore of composition.ores) {
-						const liveMaterials = typeMaterialsMap[ore.oreTypeId] ?? []
-						const fraction = parseFloat(ore.quantity)
-						const oreVolumeM3 = totalVolume * fraction
-						const oreUnits = oreVolumeM3 / getOreVolume(ore.oreTypeId)
-						for (const mat of liveMaterials) {
-							if (profile.isPassive && MINERAL_TYPE_IDS.has(mat.materialTypeId)) continue
-							const rawUnits = Math.floor(oreUnits / 100) * mat.quantity * reprocessingYield
-							grossIsk += Math.floor(rawUnits) * (priceMap[mat.materialTypeId] ?? 0)
-						}
-					}
-
-					const fuelCost = fuelUnits * fuelBlockPrice
-					const magmaticGasCost = magmaticGasUnits * magmaticGasPrice
-					const profit = Math.round(grossIsk - fuelCost - magmaticGasCost)
-
-					if (profile.id === 'metenox') metenoxProfit = profit
-					else if (profile.id === 'tatara') tataraProfit = profit
-				}
-
-				return { metenoxProfit, tataraProfit }
-			}
+			const compositions = await moonScan.getVerifiedCompositions(pageMoonIds)
+			const pricingInputs = await getMoonPricingInputs(c.env, universe, moonScan, compositions)
 
 			const compositionMap = new Map(compositions.map((composition) => [composition.moonId, composition]))
 			const items = summary.items.map((item) => {
@@ -1016,22 +1065,22 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 						tataraProfit: null,
 					}
 				}
-				const { metenoxProfit, tataraProfit } = computeMoonProfit(composition)
 				return {
 					...item,
-					metenoxProfit: metenoxProfit !== null ? String(metenoxProfit) : null,
-					tataraProfit: tataraProfit !== null ? String(tataraProfit) : null,
+					...getMoonProfitValuesFromComposition(composition, pricingInputs),
 				}
 			})
 
-			return c.json({
+			const response: VerifiedMoonsListResponse = {
 				items,
 				total: summary.total,
 				page: summary.page,
 				pageSize: summary.pageSize,
 				constellations: summary.constellations,
 				updatedAt: new Date().toISOString(),
-			})
+			}
+			verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
+			return c.json(response)
 		}
 	}
 
@@ -1039,22 +1088,24 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 	const summary = await moonScan.getScanSummary()
 	const verifiedMoonIds = summary.verifiedMoonIds
 	if (verifiedMoonIds.length === 0) {
-		return c.json({
+		const response: VerifiedMoonsListResponse = {
 			items: [],
 			total: 0,
 			page: query.data.page,
 			pageSize: query.data.pageSize,
+			constellations: [],
 			updatedAt: new Date().toISOString(),
-		})
+		}
+		verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
+		return c.json(response)
 	}
 
-	// Bulk-load compositions, moon static data, and settings+prices in parallel
-	const [compositions, moonsById, settings, profiles] = await Promise.all([
+	// Bulk-load compositions and moon static data before the legacy in-memory sort fallback.
+	const [compositions, moonsById] = await Promise.all([
 		moonScan.getVerifiedCompositions(verifiedMoonIds),
 		universe.resolveStaticMoonsByIds(verifiedMoonIds),
-		moonScan.getExtractionSettings(),
-		moonScan.getStructureProfiles(),
 	])
+	const pricingInputsPromise = getMoonPricingInputs(c.env, universe, moonScan, compositions)
 
 	// Resolve system IDs and fetch system info + moon→region mapping
 	const systemIds = [...new Set(
@@ -1083,77 +1134,7 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 	const constellationsById = constellationIds.length > 0
 		? await universe.resolveConstellationsByIds(constellationIds)
 		: {}
-
-	// Collect all unique ore type IDs across all compositions for typeMaterials lookup
-	const allOreTypeIds = [...new Set(compositions.flatMap((c) => c.ores.map((o) => o.oreTypeId)))]
-
-	// Fetch live typeMaterials first, then price all discovered materials + consumables.
-	const markets = getMarketsStub(c.env)
-	const typeMaterialsMap = await universe.getTypeMaterials(allOreTypeIds)
-	const allMaterialTypeIds = [...new Set(
-		Object.values(typeMaterialsMap).flatMap((materials) => materials.map((material) => material.materialTypeId))
-	)]
-	const priceResponse = await markets.getBatchMarketDataAtTime({
-		regionId: createEveRegionId('universe'),
-		typeIds: [...allMaterialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID].map(createEveTypeId),
-		atTime: new Date(),
-	})
-	const priceMap: Record<string, number> = {}
-	for (const p of priceResponse.prices) {
-		if (p.bestSellPrice) priceMap[p.typeId] = parseFloat(p.bestSellPrice)
-	}
-
-	const fuelBlockPrice = resolveEffectivePrice(
-		settings.fuelBlockPriceOverride,
-		priceMap[FUEL_BLOCK_TYPE_ID] ?? 0
-	)
-	const magmaticGasPrice = resolveEffectivePrice(
-		settings.magmaticGasPriceOverride,
-		priceMap[MAGMATIC_GAS_TYPE_ID] ?? 0
-	)
-	const reprocessingYield = parseFloat(settings.defaultReprocessingYield)
-	const cycleDays = settings.defaultCycleDays
-
-
-
-	function computeMoonProfit(composition: typeof compositions[number]) {
-		let metenoxProfit: number | null = null
-		let tataraProfit: number | null = null
-
-		for (const profile of profiles) {
-			const baseRate = parseFloat(profile.baseVolumePerHr) * (1 + parseFloat(profile.rigBonus))
-			const fuelPerHr = parseFloat(profile.fuelPerHr)
-			const magmaticGasPerHr = profile.magmaticGasPerHr ? parseFloat(profile.magmaticGasPerHr) : 0
-			const cycleHours = cycleDays * 24
-			const totalVolume = profile.isPassive
-				? baseRate * parseFloat(profile.nullsecModifier) * cycleHours
-				: baseRate * cycleHours
-			const fuelUnits = fuelPerHr * cycleHours
-			const magmaticGasUnits = profile.isPassive ? magmaticGasPerHr * cycleHours : 0
-
-			let grossIsk = 0
-			for (const ore of composition.ores) {
-				const liveMaterials = typeMaterialsMap[ore.oreTypeId] ?? []
-				const fraction = parseFloat(ore.quantity)
-				const oreVolumeM3 = totalVolume * fraction
-				const oreUnits = oreVolumeM3 / getOreVolume(ore.oreTypeId)
-				for (const mat of liveMaterials) {
-					if (profile.isPassive && MINERAL_TYPE_IDS.has(mat.materialTypeId)) continue
-					const rawUnits = Math.floor(oreUnits / 100) * mat.quantity * reprocessingYield
-					grossIsk += Math.floor(rawUnits) * (priceMap[mat.materialTypeId] ?? 0)
-				}
-			}
-
-			const fuelCost = fuelUnits * fuelBlockPrice
-			const magmaticGasCost = magmaticGasUnits * magmaticGasPrice
-			const profit = Math.round(grossIsk - fuelCost - magmaticGasCost)
-
-			if (profile.id === 'metenox') metenoxProfit = profit
-			else if (profile.id === 'tatara') tataraProfit = profit
-		}
-
-		return { metenoxProfit, tataraProfit }
-	}
+	const pricingInputs = await pricingInputsPromise
 
 	const moons = compositions.map((comp) => {
 		const moon = moonsById[comp.moonId]
@@ -1165,14 +1146,12 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 		const constellationId = system?.constellationId ?? null
 		const constellation = constellationId ? constellationsById[constellationId] : null
 
-		const highestRarity = comp.ores.reduce<string | null>((best, ore) => {
+		const highestRarity = comp.ores.reduce<OreRarity | null>((best, ore) => {
 			const r = ORE_TYPE_RARITY[ore.oreTypeId]
 			if (!r) return best
 			if (!best) return r
-			return (RARITY_ORDER[r] ?? 0) > (RARITY_ORDER[best as OreRarity] ?? 0) ? r : best
+			return (RARITY_ORDER[r] ?? 0) > (RARITY_ORDER[best] ?? 0) ? r : best
 		}, null)
-
-		const { metenoxProfit, tataraProfit } = computeMoonProfit(comp)
 
 		return {
 			moonId: comp.moonId,
@@ -1185,8 +1164,7 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 			constellationName: constellation?.constellationName ?? constellationId ?? '',
 			securityStatus: system?.securityStatus ?? null,
 			highestRarity,
-			metenoxProfit: metenoxProfit !== null ? String(metenoxProfit) : null,
-			tataraProfit: tataraProfit !== null ? String(tataraProfit) : null,
+			...getMoonProfitValuesFromComposition(comp, pricingInputs),
 		}
 	}).filter((m): m is NonNullable<typeof m> => m !== null)
 
@@ -1279,14 +1257,16 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 	const start = (page - 1) * pageSize
 	const items = filtered.slice(start, start + pageSize)
 
-	return c.json({
+	const response: VerifiedMoonsListResponse = {
 		items,
 		total,
 		page,
 		pageSize,
 		constellations: constellationsSummary,
 		updatedAt: new Date().toISOString(),
-	})
+	}
+	verifiedMoonsResponseCache.set(verifiedMoonsResponseCacheKey, response)
+	return c.json(response)
 })
 
 moonScanRoutes.post('/moons/verified/export', async (c) => {
@@ -1636,6 +1616,7 @@ moonScanRoutes.post('/scans/submit', async (c) => {
 		canValidate
 	)
 	if (canValidate) {
+		clearMoonScanReadCaches()
 		queueVerifiedMoonSummaryUpsert(c, moonScan, universe, submittedScans)
 	}
 
@@ -1733,6 +1714,7 @@ moonScanRoutes.post('/scans/queue/verify-all', async (c) => {
 	const moonScan = getMoonScanStub(c.env)
 	const universe = getUniverseStub(c.env)
 	const scans = await moonScan.verifyScans(body.data.scanIds, verifiedBy, null)
+	clearMoonScanReadCaches()
 	queueVerifiedMoonSummaryUpsert(c, moonScan, universe, scans)
 	return c.json(scans)
 })
@@ -1751,6 +1733,7 @@ moonScanRoutes.post('/scans/queue/reject-all', async (c) => {
 
 	const moonScan = getMoonScanStub(c.env)
 	const scans = await moonScan.rejectScans(body.data.scanIds, verifiedBy, null)
+	clearMoonScanReadCaches()
 	return c.json(scans)
 })
 
@@ -1806,6 +1789,7 @@ moonScanRoutes.post('/scans/:id/verify', async (c) => {
 	const moonScan = getMoonScanStub(c.env)
 	const universe = getUniverseStub(c.env)
 	const scan = await moonScan.verifyScan(c.req.param('id'), verifiedBy, body.data.notes ?? null)
+	clearMoonScanReadCaches()
 	queueVerifiedMoonSummaryUpsert(c, moonScan, universe, [scan])
 	return c.json(scan)
 })
@@ -1826,6 +1810,7 @@ moonScanRoutes.post('/scans/:id/reject', async (c) => {
 
 	const moonScan = getMoonScanStub(c.env)
 	const scan = await moonScan.rejectScan(c.req.param('id'), verifiedBy, body.data.notes ?? null)
+	clearMoonScanReadCaches()
 	return c.json(scan)
 })
 
@@ -1875,6 +1860,7 @@ moonScanRoutes.post('/admin/settings', async (c) => {
 
 	const moonScan = getMoonScanStub(c.env)
 	const updated = await moonScan.updateExtractionSettings(body.data)
+	clearMoonScanPricingCaches()
 	return c.json(updated)
 })
 
@@ -1894,6 +1880,7 @@ moonScanRoutes.post('/admin/settings/profiles/:id', async (c) => {
 
 	const moonScan = getMoonScanStub(c.env)
 	const updated = await moonScan.updateStructureProfile(id as 'tatara' | 'metenox', body.data)
+	clearMoonScanPricingCaches()
 	return c.json(updated)
 })
 

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 
 import { getStub } from '@repo/do-utils'
-import { TimeCache } from '@repo/hono-helpers'
+import { logger, TimeCache } from '@repo/hono-helpers'
 import {
 	FUEL_BLOCK_TYPE_ID,
 	MAGMATIC_GAS_TYPE_ID,
@@ -35,7 +35,6 @@ import { createEveRegionId, createEveTypeId } from '@repo/eve-types'
 import type { Markets } from '@repo/markets'
 import type { Universe } from '@repo/universe'
 import type { App } from '../context'
-import { logger } from '@repo/hono-helpers'
 import { createWorkflow } from '@repo/workflow-utils'
 
 // ─── Permission URNs ─────────────────────────────────────────────────────────
@@ -71,9 +70,12 @@ const MAX_SCAN_RAW_BYTES = 1_000_000
 // ─── Caches ──────────────────────────────────────────────────────────────────
 
 const permissionCache = new TimeCache<boolean>(15_000)
-const verifiedMoonSummaryBackfillCache = new TimeCache<boolean>(5 * 60_000)
 const MOON_PRICING_INPUTS_CACHE_TTL_MS = 60_000
 const VERIFIED_MOONS_RESPONSE_CACHE_TTL_MS = 30_000
+const MOON_REGIONS_RESPONSE_CACHE_TTL_MS = 5 * 60_000
+const MOON_REGION_RESPONSE_CACHE_TTL_MS = 60_000
+const MOON_SYSTEM_RESPONSE_CACHE_TTL_MS = 60_000
+const MOON_LEADERBOARD_CACHE_TTL_MS = 60_000
 const VERIFIED_MOON_SUMMARY_BACKFILL_BATCH_SIZE = 250
 const VERIFIED_MOONS_EXPORT_PAGE_SIZE = 100
 const VERIFIED_MOONS_EXPORT_BUCKET_PREFIX = 'moon-scan/verified-moons-exports'
@@ -385,11 +387,58 @@ type VerifiedMoonsListResponse = {
 	updatedAt: string
 }
 
+type MoonRegionsResponse = {
+	regions: Array<{
+		regionId: string
+		regionName: string
+		systemCount: number
+		moonCount: number
+		scannedCount: number
+		verifiedCount: number
+	}>
+	connections: Awaited<ReturnType<Universe['getRegionConnections']>>
+}
+
+type MoonRegionResponse = {
+	regionId: string
+	systems: Array<{
+		solarSystemId: string
+		solarSystemName: string
+		securityStatus: string | null
+		moonCount: number
+		scannedCount: number
+		verifiedCount: number
+	}>
+	jumpLinks: Array<{ from: string; to: string }>
+	borderRegions: Awaited<ReturnType<Universe['getRegionsBySystemIds']>>
+}
+
+type MoonSystemResponse = {
+	system: {
+		solarSystemId: string
+		solarSystemName: string
+		securityStatus: string | null
+	}
+	moons: Array<{
+		moonId: string
+		moonName: string
+		hasScans: boolean
+		isVerified: boolean
+		composition: VerifiedComposition | null
+	}>
+}
+
+type MoonLeaderboardResponse = Awaited<ReturnType<MoonScanDO['getLeaderboard']>>
+
 const moonPricingInputsCache = new TimeCache<MoonPricingInputs>(MOON_PRICING_INPUTS_CACHE_TTL_MS, 100)
 const verifiedMoonsResponseCache = new TimeCache<VerifiedMoonsListResponse>(
 	VERIFIED_MOONS_RESPONSE_CACHE_TTL_MS,
 	200
 )
+const moonRegionsResponseCache = new TimeCache<MoonRegionsResponse>(MOON_REGIONS_RESPONSE_CACHE_TTL_MS, 10)
+const moonRegionResponseCache = new TimeCache<MoonRegionResponse>(MOON_REGION_RESPONSE_CACHE_TTL_MS, 100)
+const moonSystemResponseCache = new TimeCache<MoonSystemResponse>(MOON_SYSTEM_RESPONSE_CACHE_TTL_MS, 500)
+const moonLeaderboardCache = new TimeCache<MoonLeaderboardResponse>(MOON_LEADERBOARD_CACHE_TTL_MS, 10)
 
 type MoonExportEntry = {
 	moon: {
@@ -511,8 +560,11 @@ function getMoonProfitabilityInputsFromComposition(
 }
 
 function clearMoonScanReadCaches(): void {
-	verifiedMoonSummaryBackfillCache.clear()
 	verifiedMoonsResponseCache.clear()
+	moonRegionsResponseCache.clear()
+	moonRegionResponseCache.clear()
+	moonSystemResponseCache.clear()
+	moonLeaderboardCache.clear()
 }
 
 function clearMoonScanPricingCaches(): void {
@@ -818,6 +870,9 @@ moonScanRoutes.get('/moons/regions', async (c) => {
 		return c.json({ error: 'Forbidden' }, 403)
 	}
 
+	const cachedResponse = moonRegionsResponseCache.get('k-space')
+	if (cachedResponse) return c.json(cachedResponse)
+
 	const universe = getUniverseStub(c.env)
 	const moonScan = getMoonScanStub(c.env)
 	const K_SPACE_REGIONS = getKSpaceRegionIds()
@@ -858,7 +913,9 @@ moonScanRoutes.get('/moons/regions', async (c) => {
 			verifiedCount: verifiedByRegion.get(r.regionId) ?? 0,
 		}))
 
-	return c.json({ regions, connections })
+	const response: MoonRegionsResponse = { regions, connections }
+	moonRegionsResponseCache.set('k-space', response)
+	return c.json(response)
 })
 
 // ─── Region detail (for SVG map) ─────────────────────────────────────────────
@@ -872,15 +929,14 @@ moonScanRoutes.get('/moons/region/:regionId', async (c) => {
 	const regionId = c.req.param('regionId')
 	if (!isKSpaceRegion(regionId)) return c.json({ error: 'Region not in k-space' }, 400)
 
+	const cachedResponse = moonRegionResponseCache.get(regionId)
+	if (cachedResponse) return c.json(cachedResponse)
+
 	const universe = getUniverseStub(c.env)
 	const moonScan = getMoonScanStub(c.env)
 
 	// Get all systems and stargates for the region
 	const systems = await universe.getSystemsByRegionId(regionId)
-
-	const eligibleSystemIds = systems
-		.filter((s) => isMoonMiningEligibleSecurity(s.securityStatus))
-		.map((s) => s.solarSystemId)
 
 	const [stargates, moonsBySystem] = await Promise.all([
 		universe.getStargatesBySystemIds(systems.map((s) => s.solarSystemId)),
@@ -925,7 +981,7 @@ moonScanRoutes.get('/moons/region/:regionId', async (c) => {
 		systemMoonCoverage.set(systemId, { total, verified })
 	}
 
-	return c.json({
+	const response: MoonRegionResponse = {
 		regionId,
 		systems: systems.map((s) => ({
 				solarSystemId: s.solarSystemId,
@@ -937,7 +993,9 @@ moonScanRoutes.get('/moons/region/:regionId', async (c) => {
 			})),
 		jumpLinks,
 		borderRegions,
-	})
+	}
+	moonRegionResponseCache.set(regionId, response)
+	return c.json(response)
 })
 
 // ─── System detail ───────────────────────────────────────────────────────────
@@ -949,6 +1007,9 @@ moonScanRoutes.get('/moons/system/:systemId', async (c) => {
 	}
 
 	const systemId = c.req.param('systemId')
+	const cachedResponse = moonSystemResponseCache.get(systemId)
+	if (cachedResponse) return c.json(cachedResponse)
+
 	const universe = getUniverseStub(c.env)
 	const moonScan = getMoonScanStub(c.env)
 
@@ -973,7 +1034,7 @@ moonScanRoutes.get('/moons/system/:systemId', async (c) => {
 			.map((v) => [v.moonId, v])
 	)
 
-	return c.json({
+	const response: MoonSystemResponse = {
 		system: {
 			solarSystemId: system.solarSystemId,
 			solarSystemName: system.solarSystemName,
@@ -986,7 +1047,9 @@ moonScanRoutes.get('/moons/system/:systemId', async (c) => {
 			isVerified: compositionMap.get(m.moonId)?.isVerified ?? false,
 			composition: verifiedCompMap.get(m.moonId) ?? null,
 		})),
-	})
+	}
+	moonSystemResponseCache.set(systemId, response)
+	return c.json(response)
 })
 
 // ─── Verified moons list ─────────────────────────────────────────────────────
@@ -1021,11 +1084,6 @@ moonScanRoutes.get('/moons/verified', async (c) => {
 	if (!usesProfitSort) {
 		let summary: Awaited<ReturnType<MoonScanDO['getVerifiedMoonPage']>> | null = null
 		try {
-			await verifiedMoonSummaryBackfillCache.getOrSet('default', async () => {
-				await backfillMissingVerifiedMoonSummaries(moonScan, universe)
-				return true
-			})
-
 			summary = await moonScan.getVerifiedMoonPage({
 				...query.data,
 				sortBy: query.data.sortBy as VerifiedMoonsSortBy,
@@ -1615,8 +1673,8 @@ moonScanRoutes.post('/scans/submit', async (c) => {
 		primaryChar?.characterId ?? null,
 		canValidate
 	)
+	clearMoonScanReadCaches()
 	if (canValidate) {
-		clearMoonScanReadCaches()
 		queueVerifiedMoonSummaryUpsert(c, moonScan, universe, submittedScans)
 	}
 
@@ -1827,8 +1885,13 @@ moonScanRoutes.get('/leaderboard', async (c) => {
 		return c.json({ error: 'Invalid window (all|7d|30d)' }, 400)
 	}
 
+	const cacheKey = `leaderboard:${window}`
+	const cachedResponse = moonLeaderboardCache.get(cacheKey)
+	if (cachedResponse) return c.json(cachedResponse)
+
 	const moonScan = getMoonScanStub(c.env)
 	const entries = await moonScan.getLeaderboard(window)
+	moonLeaderboardCache.set(cacheKey, entries)
 	return c.json(entries)
 })
 
@@ -1882,6 +1945,33 @@ moonScanRoutes.post('/admin/settings/profiles/:id', async (c) => {
 	const updated = await moonScan.updateStructureProfile(id as 'tatara' | 'metenox', body.data)
 	clearMoonScanPricingCaches()
 	return c.json(updated)
+})
+
+moonScanRoutes.post('/admin/verified-moon-summaries/backfill', async (c) => {
+	const user = c.get('user')!
+	if (!await hasMoonPerm(c.env, user.id, MOON_URNS.admin, user.is_admin)) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	clearMoonScanReadCaches()
+	const moonScan = getMoonScanStub(c.env)
+	const universe = getUniverseStub(c.env)
+	const task = backfillMissingVerifiedMoonSummaries(moonScan, universe)
+		.then(() => {
+			clearMoonScanReadCaches()
+		})
+		.catch((error) => {
+			logger.error('[moon-scan] failed to backfill verified moon summaries', { error })
+		})
+
+	const executionCtx = getExecutionContextOrNull(c)
+	if (executionCtx) {
+		executionCtx.waitUntil(task)
+		return c.json({ status: 'queued' }, 202)
+	}
+
+	await task
+	return c.json({ status: 'completed' })
 })
 
 export { moonScanRoutes }

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -23,6 +23,7 @@ import {
 	type VerifiedMoonsSortBy,
 	type StructureProfitability,
 	type VerifiedComposition,
+	type ScanLocation,
 } from '@repo/moon-scan'
 import { buildCsvLine, createR2MultipartTextWriter } from '@repo/worker-utils'
 
@@ -33,7 +34,7 @@ import { requireAllianceMember } from '../middleware/session'
 
 import { createEveRegionId, createEveTypeId } from '@repo/eve-types'
 import type { Markets } from '@repo/markets'
-import type { Universe } from '@repo/universe'
+import type { Universe, UniverseSolarSystem } from '@repo/universe'
 import type { App } from '../context'
 import { createWorkflow } from '@repo/workflow-utils'
 
@@ -76,6 +77,8 @@ const MOON_REGIONS_RESPONSE_CACHE_TTL_MS = 5 * 60_000
 const MOON_REGION_RESPONSE_CACHE_TTL_MS = 60_000
 const MOON_SYSTEM_RESPONSE_CACHE_TTL_MS = 60_000
 const MOON_LEADERBOARD_CACHE_TTL_MS = 60_000
+const MOON_SYSTEM_LOCATION_CACHE_TTL_MS = 24 * 60 * 60_000
+const MOON_SYSTEM_LOCATION_CACHE_MAX_SIZE = 10_000
 const VERIFIED_MOON_SUMMARY_BACKFILL_BATCH_SIZE = 250
 const VERIFIED_MOONS_EXPORT_PAGE_SIZE = 100
 const VERIFIED_MOONS_EXPORT_BUCKET_PREFIX = 'moon-scan/verified-moons-exports'
@@ -399,6 +402,8 @@ type MoonRegionsResponse = {
 	connections: Awaited<ReturnType<Universe['getRegionConnections']>>
 }
 
+type VerifiedMoonRegionCount = Awaited<ReturnType<MoonScanDO['getVerifiedMoonCountsByRegionIds']>>[number]
+
 type MoonRegionResponse = {
 	regionId: string
 	systems: Array<{
@@ -439,6 +444,65 @@ const moonRegionsResponseCache = new TimeCache<MoonRegionsResponse>(MOON_REGIONS
 const moonRegionResponseCache = new TimeCache<MoonRegionResponse>(MOON_REGION_RESPONSE_CACHE_TTL_MS, 100)
 const moonSystemResponseCache = new TimeCache<MoonSystemResponse>(MOON_SYSTEM_RESPONSE_CACHE_TTL_MS, 500)
 const moonLeaderboardCache = new TimeCache<MoonLeaderboardResponse>(MOON_LEADERBOARD_CACHE_TTL_MS, 10)
+const moonSystemLocationCache = new TimeCache<UniverseSolarSystem | null>(
+	MOON_SYSTEM_LOCATION_CACHE_TTL_MS,
+	MOON_SYSTEM_LOCATION_CACHE_MAX_SIZE
+)
+
+async function resolveSolarSystemsWithCache(
+	universe: Universe,
+	systemIds: string[],
+): Promise<Record<string, UniverseSolarSystem | null>> {
+	const uniqueSystemIds = [...new Set(systemIds)]
+	if (uniqueSystemIds.length === 0) return {}
+
+	const resolved: Record<string, UniverseSolarSystem | null> = {}
+	const missingSystemIds: string[] = []
+	for (const systemId of uniqueSystemIds) {
+		const cached = moonSystemLocationCache.get(`moon-system:${systemId}`)
+		if (cached === undefined) missingSystemIds.push(systemId)
+		else resolved[systemId] = cached
+	}
+
+	if (missingSystemIds.length > 0) {
+		const fetched = await universe.resolveSolarSystemsByIds(missingSystemIds)
+		for (const systemId of missingSystemIds) {
+			const system = fetched[systemId] ?? null
+			moonSystemLocationCache.set(`moon-system:${systemId}`, system)
+			resolved[systemId] = system
+		}
+	}
+
+	return resolved
+}
+
+const SCAN_LOCATION_BACKFILL_BATCH_SIZE = 250
+
+async function backfillScanLocations(moonScan: MoonScanDO, universe: Universe): Promise<void> {
+	let afterMoonId: string | undefined
+
+	for (;;) {
+		const moonIds = await moonScan.getUnlocatedScannedMoonIds(SCAN_LOCATION_BACKFILL_BATCH_SIZE, afterMoonId)
+		if (moonIds.length === 0) return
+
+		const moonsById = await universe.resolveStaticMoonsByIds(moonIds)
+		const systemIds = moonIds
+			.map((moonId) => moonsById[moonId]?.solarSystemId)
+			.filter((systemId): systemId is string => Boolean(systemId))
+		const systemsById = await resolveSolarSystemsWithCache(universe, systemIds)
+		const locations: ScanLocation[] = []
+
+		for (const moonId of moonIds) {
+			const moon = moonsById[moonId]
+			const system = moon ? systemsById[moon.solarSystemId] : null
+			if (!moon || !system) continue
+			locations.push({ moonId, regionId: system.regionId, solarSystemId: moon.solarSystemId })
+		}
+
+		if (locations.length > 0) await moonScan.backfillScanLocations(locations)
+		afterMoonId = moonIds[moonIds.length - 1]
+	}
+}
 
 type MoonExportEntry = {
 	moon: {
@@ -877,29 +941,20 @@ moonScanRoutes.get('/moons/regions', async (c) => {
 	const moonScan = getMoonScanStub(c.env)
 	const K_SPACE_REGIONS = getKSpaceRegionIds()
 
-	const [regionData, regionStats, scanSummary, connections] = await Promise.all([
+	const [regionData, regionStats, scannedRegionCounts, verifiedRegionCounts, connections] = await Promise.all([
 		universe.resolveRegionsByIds(K_SPACE_REGIONS),
 		universe.getRegionStats(K_SPACE_REGIONS),
-		moonScan.getScanSummary(),
+		moonScan.getScannedMoonCountsByRegionIds(K_SPACE_REGIONS),
+		moonScan.getVerifiedMoonCountsByRegionIds(K_SPACE_REGIONS),
 		universe.getRegionConnections(K_SPACE_REGIONS),
 	])
 
-	// Map scanned/verified moon IDs back to their regions
-	const allScanMoonIds = [...new Set([...scanSummary.scannedMoonIds, ...scanSummary.verifiedMoonIds])]
-	const moonRegionMap = allScanMoonIds.length > 0
-		? await universe.getMoonRegionIds(allScanMoonIds)
-		: {}
-
-	const scannedByRegion = new Map<string, number>()
-	const verifiedByRegion = new Map<string, number>()
-	for (const moonId of scanSummary.scannedMoonIds) {
-		const regionId = moonRegionMap[moonId]
-		if (regionId) scannedByRegion.set(regionId, (scannedByRegion.get(regionId) ?? 0) + 1)
-	}
-	for (const moonId of scanSummary.verifiedMoonIds) {
-		const regionId = moonRegionMap[moonId]
-		if (regionId) verifiedByRegion.set(regionId, (verifiedByRegion.get(regionId) ?? 0) + 1)
-	}
+	const scannedByRegion = new Map(
+		scannedRegionCounts.map((entry) => [entry.regionId, entry.scannedCount])
+	)
+	const verifiedByRegion = new Map<string, VerifiedMoonRegionCount['verifiedCount']>(
+		verifiedRegionCounts.map((entry) => [entry.regionId, entry.verifiedCount])
+	)
 
 	const regions = K_SPACE_REGIONS
 		.map((regionId) => regionData[regionId])
@@ -1599,9 +1654,7 @@ moonScanRoutes.post('/scans/parse', async (c) => {
 
 	// Annotate each scan with sec status eligibility
 	const systemIds = [...new Set(parseResult.scans.map((s) => s.solarSystemId))]
-	const systemsById = systemIds.length > 0
-		? await getUniverseStub(c.env).resolveSolarSystemsByIds(systemIds)
-		: {}
+	const systemsById = await resolveSolarSystemsWithCache(getUniverseStub(c.env), systemIds)
 
 	const annotated = parseResult.scans.map((scan) => {
 		const system = systemsById[scan.solarSystemId]
@@ -1637,7 +1690,7 @@ moonScanRoutes.post('/scans/submit', async (c) => {
 	// Batch-resolve system security statuses and filter ineligible systems
 	const systemIds = [...new Set(parseResult.scans.map((s) => s.solarSystemId))]
 	const universe = getUniverseStub(c.env)
-	const systemsById = await universe.resolveSolarSystemsByIds(systemIds)
+	const systemsById = await resolveSolarSystemsWithCache(universe, systemIds)
 
 	const eligibleScans = parseResult.scans.filter((scan) => {
 		const system = systemsById[scan.solarSystemId]
@@ -1668,6 +1721,8 @@ moonScanRoutes.post('/scans/submit', async (c) => {
 	const submittedScans = await moonScan.submitScans(
 		scansWithOnlyAllowedOreTypes.map((s) => ({
 			moonId: s.moonId,
+			regionId: systemsById[s.solarSystemId]!.regionId,
+			solarSystemId: s.solarSystemId,
 			ores: s.ores.map((o) => ({ oreTypeId: o.oreTypeId, quantity: o.quantity })),
 		})),
 		primaryChar?.characterId ?? null,
@@ -1945,6 +2000,29 @@ moonScanRoutes.post('/admin/settings/profiles/:id', async (c) => {
 	const updated = await moonScan.updateStructureProfile(id as 'tatara' | 'metenox', body.data)
 	clearMoonScanPricingCaches()
 	return c.json(updated)
+})
+
+moonScanRoutes.post('/admin/scan-locations/backfill', async (c) => {
+	const user = c.get('user')!
+	if (!await hasMoonPerm(c.env, user.id, MOON_URNS.admin, user.is_admin)) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	const moonScan = getMoonScanStub(c.env)
+	const universe = getUniverseStub(c.env)
+	const task = backfillScanLocations(moonScan, universe).catch((error) => {
+		logger.error('[moon-scan] failed to backfill scan locations', { error })
+		throw error
+	})
+
+	const executionCtx = getExecutionContextOrNull(c)
+	if (executionCtx) {
+		executionCtx.waitUntil(task)
+		return c.json({ status: 'queued' }, 202)
+	}
+
+	await task
+	return c.json({ status: 'completed' })
 })
 
 moonScanRoutes.post('/admin/verified-moon-summaries/backfill', async (c) => {

--- a/apps/markets/src/durable-object.ts
+++ b/apps/markets/src/durable-object.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from 'cloudflare:workers'
 
+import { max } from 'drizzle-orm'
 import { and, desc, eq, gt, inArray, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { GetRegionMarketDataResponseObjectSchema } from '@repo/markets'
@@ -577,6 +578,39 @@ export class MarketsDO extends DurableObject<Env, {}> implements Markets {
 			prices,
 			missingTypeIds: uniqueTypeIds.filter((id) => !foundTypeIds.has(id)),
 		}
+	}
+
+	async getMarketDataRevisionAtTime(
+		input: Pick<import('@repo/markets').GetBatchMarketDataAtTimeInput, 'regionId' | 'atTime'>
+	): Promise<string | null> {
+		const targetDate = input.atTime.toISOString().slice(0, 10)
+		const [nearestDay] = await this.db
+			.select({ priceDate: marketDailyPrices.priceDate })
+			.from(marketDailyPrices)
+			.where(
+				and(
+					eq(marketDailyPrices.locationId, input.regionId),
+					sql`${marketDailyPrices.priceDate} <= ${targetDate}::date`
+				)
+			)
+			.orderBy(sql`${marketDailyPrices.priceDate} DESC`)
+			.limit(1)
+
+		if (!nearestDay) return null
+
+		const [revision] = await this.db
+			.select({ updatedAt: max(marketDailyPrices.updatedAt) })
+			.from(marketDailyPrices)
+			.where(
+				and(
+					eq(marketDailyPrices.locationId, input.regionId),
+					eq(marketDailyPrices.priceDate, nearestDay.priceDate)
+				)
+			)
+
+		return revision?.updatedAt
+			? `${nearestDay.priceDate}:${revision.updatedAt.toISOString()}`
+			: null
 	}
 
 	// ========================================================================

--- a/apps/moon-scan/.migrations/0002_ancient_medusa.sql
+++ b/apps/moon-scan/.migrations/0002_ancient_medusa.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "moon_scans" ADD COLUMN "region_id" text;--> statement-breakpoint
+ALTER TABLE "moon_scans" ADD COLUMN "solar_system_id" text;--> statement-breakpoint
+CREATE INDEX "moon_scans_region_moon_idx" ON "moon_scans" USING btree ("region_id","moon_id");

--- a/apps/moon-scan/.migrations/meta/0002_snapshot.json
+++ b/apps/moon-scan/.migrations/meta/0002_snapshot.json
@@ -1,0 +1,719 @@
+{
+  "id": "ee8992f3-93c7-4606-8954-29f3a5fc0e54",
+  "prevId": "a77a7cb6-38ce-4f81-9ce3-e67cd851c6a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.moon_character_name_cache": {
+      "name": "moon_character_name_cache",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moon_extraction_settings": {
+      "name": "moon_extraction_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "default_reprocessing_yield": {
+          "name": "default_reprocessing_yield",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.80'"
+        },
+        "default_cycle_days": {
+          "name": "default_cycle_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "fuel_block_price_override": {
+          "name": "fuel_block_price_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "magmatic_gas_price_override": {
+          "name": "magmatic_gas_price_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moon_scan_ores": {
+      "name": "moon_scan_ores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ore_type_id": {
+          "name": "ore_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "moon_scan_ores_scan_id_idx": {
+          "name": "moon_scan_ores_scan_id_idx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moon_scan_ores_scan_id_moon_scans_id_fk": {
+          "name": "moon_scan_ores_scan_id_moon_scans_id_fk",
+          "tableFrom": "moon_scan_ores",
+          "tableTo": "moon_scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moon_scan_ores_unique": {
+          "name": "moon_scan_ores_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scan_id",
+            "ore_type_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moon_scans": {
+      "name": "moon_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "moon_scan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "moon_scan_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "moon_scans_moon_id_idx": {
+          "name": "moon_scans_moon_id_idx",
+          "columns": [
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_scans_region_moon_idx": {
+          "name": "moon_scans_region_moon_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_scans_submitted_by_idx": {
+          "name": "moon_scans_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_scans_status_idx": {
+          "name": "moon_scans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_scans_submitted_at_idx": {
+          "name": "moon_scans_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moon_structure_profiles": {
+      "name": "moon_structure_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base_volume_per_hr": {
+          "name": "base_volume_per_hr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rig_bonus": {
+          "name": "rig_bonus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_per_hr": {
+          "name": "fuel_per_hr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "magmatic_gas_per_hr": {
+          "name": "magmatic_gas_per_hr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_cycle_days": {
+          "name": "min_cycle_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_cycle_days": {
+          "name": "max_cycle_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_passive": {
+          "name": "is_passive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lowsec_modifier": {
+          "name": "lowsec_modifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.5'"
+        },
+        "nullsec_modifier": {
+          "name": "nullsec_modifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moon_verified_compositions": {
+      "name": "moon_verified_compositions",
+      "schema": "",
+      "columns": {
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_scan_id": {
+          "name": "source_scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moon_verified_compositions_source_scan_id_moon_scans_id_fk": {
+          "name": "moon_verified_compositions_source_scan_id_moon_scans_id_fk",
+          "tableFrom": "moon_verified_compositions",
+          "tableTo": "moon_scans",
+          "columnsFrom": [
+            "source_scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moon_verified_moon_summaries": {
+      "name": "moon_verified_moon_summaries",
+      "schema": "",
+      "columns": {
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_scan_id": {
+          "name": "source_scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moon_name": {
+          "name": "moon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solar_system_name": {
+          "name": "solar_system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constellation_id": {
+          "name": "constellation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constellation_name": {
+          "name": "constellation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_status": {
+          "name": "security_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highest_rarity": {
+          "name": "highest_rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "moon_verified_moon_summaries_source_scan_id_idx": {
+          "name": "moon_verified_moon_summaries_source_scan_id_idx",
+          "columns": [
+            {
+              "expression": "source_scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_verified_moon_summaries_verified_at_idx": {
+          "name": "moon_verified_moon_summaries_verified_at_idx",
+          "columns": [
+            {
+              "expression": "verified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_verified_moon_summaries_region_id_idx": {
+          "name": "moon_verified_moon_summaries_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_verified_moon_summaries_constellation_id_idx": {
+          "name": "moon_verified_moon_summaries_constellation_id_idx",
+          "columns": [
+            {
+              "expression": "constellation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_verified_moon_summaries_moon_name_idx": {
+          "name": "moon_verified_moon_summaries_moon_name_idx",
+          "columns": [
+            {
+              "expression": "moon_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_verified_moon_summaries_solar_system_name_idx": {
+          "name": "moon_verified_moon_summaries_solar_system_name_idx",
+          "columns": [
+            {
+              "expression": "solar_system_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_verified_moon_summaries_highest_rarity_idx": {
+          "name": "moon_verified_moon_summaries_highest_rarity_idx",
+          "columns": [
+            {
+              "expression": "highest_rarity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moon_verified_moon_summaries_security_status_idx": {
+          "name": "moon_verified_moon_summaries_security_status_idx",
+          "columns": [
+            {
+              "expression": "security_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moon_verified_moon_summaries_source_scan_id_moon_scans_id_fk": {
+          "name": "moon_verified_moon_summaries_source_scan_id_moon_scans_id_fk",
+          "tableFrom": "moon_verified_moon_summaries",
+          "tableTo": "moon_scans",
+          "columnsFrom": [
+            "source_scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.moon_scan_source": {
+      "name": "moon_scan_source",
+      "schema": "public",
+      "values": [
+        "user",
+        "system"
+      ]
+    },
+    "public.moon_scan_status": {
+      "name": "moon_scan_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/moon-scan/.migrations/meta/_journal.json
+++ b/apps/moon-scan/.migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783286618443,
       "tag": "0001_wandering_bloodstorm",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784964393566,
+      "tag": "0002_ancient_medusa",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/moon-scan/src/db/schema.ts
+++ b/apps/moon-scan/src/db/schema.ts
@@ -6,6 +6,8 @@ export const moonScanSourceEnum = pgEnum('moon_scan_source', ['user', 'system'])
 export const moonScans = pgTable('moon_scans', {
 	id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
 	moonId: text('moon_id').notNull(),
+	regionId: text('region_id'),
+	solarSystemId: text('solar_system_id'),
 	submittedBy: text('submitted_by'),
 	submittedAt: timestamp('submitted_at', { withTimezone: true }).defaultNow().notNull(),
 	status: moonScanStatusEnum('status').default('pending').notNull(),
@@ -15,6 +17,7 @@ export const moonScans = pgTable('moon_scans', {
 	notes: text('notes'),
 }, (t) => [
 	index('moon_scans_moon_id_idx').on(t.moonId),
+	index('moon_scans_region_moon_idx').on(t.regionId, t.moonId),
 	index('moon_scans_submitted_by_idx').on(t.submittedBy),
 	index('moon_scans_status_idx').on(t.status),
 	index('moon_scans_submitted_at_idx').on(t.submittedAt),

--- a/apps/moon-scan/src/durable-object.ts
+++ b/apps/moon-scan/src/durable-object.ts
@@ -11,6 +11,7 @@ import {
 	ilike,
 	inArray,
 	isNotNull,
+	isNull,
 	or,
 	sql,
 } from '@repo/db-utils'
@@ -37,11 +38,14 @@ import type {
 	OreRarity,
 	PaginatedScans,
 	ScanFilters,
+	ScanLocation,
+	ScannedMoonRegionCount,
 	StructureProfile,
 	StructureType,
 	SubmitScanInput,
 	VerifiedComposition,
 	VerifiedMoonPage,
+	VerifiedMoonRegionCount,
 	VerifiedMoonSummaryRecord,
 	VerifiedMoonsSortBy,
 } from '@repo/moon-scan'
@@ -104,6 +108,8 @@ export class MoonScanDO extends DurableObject<Env> implements IMoonScanDO {
 				.insert(moonScans)
 				.values({
 					moonId: scan.moonId,
+					regionId: scan.regionId,
+					solarSystemId: scan.solarSystemId,
 					submittedBy,
 					status: autoVerify ? 'verified' : 'pending',
 					source: 'user',
@@ -409,10 +415,21 @@ export class MoonScanDO extends DurableObject<Env> implements IMoonScanDO {
 		})()
 
 		const rows = await this.db
-			.select()
+			.select({
+				moonId: verifiedMoonSummaries.moonId,
+				moonName: verifiedMoonSummaries.moonName,
+				solarSystemId: verifiedMoonSummaries.solarSystemId,
+				solarSystemName: verifiedMoonSummaries.solarSystemName,
+				regionId: verifiedMoonSummaries.regionId,
+				regionName: verifiedMoonSummaries.regionName,
+				constellationId: verifiedMoonSummaries.constellationId,
+				constellationName: verifiedMoonSummaries.constellationName,
+				securityStatus: verifiedMoonSummaries.securityStatus,
+				highestRarity: verifiedMoonSummaries.highestRarity,
+			})
 			.from(verifiedMoonSummaries)
 			.where(where)
-			.orderBy(...orderByColumns, asc(verifiedMoonSummaries.moonName))
+			.orderBy(...orderByColumns, asc(verifiedMoonSummaries.moonName), asc(verifiedMoonSummaries.moonId))
 			.limit(filters.pageSize)
 			.offset(offset)
 
@@ -437,6 +454,25 @@ export class MoonScanDO extends DurableObject<Env> implements IMoonScanDO {
 				constellationName: row.constellationName,
 			})),
 		}
+	}
+
+	async getVerifiedMoonCountsByRegionIds(regionIds: string[]): Promise<VerifiedMoonRegionCount[]> {
+		const uniqueRegionIds = [...new Set(regionIds)]
+		if (uniqueRegionIds.length === 0) return []
+
+		const rows = await this.db
+			.select({
+				regionId: verifiedMoonSummaries.regionId,
+				verifiedCount: count(verifiedMoonSummaries.moonId),
+			})
+			.from(verifiedMoonSummaries)
+			.where(inArray(verifiedMoonSummaries.regionId, uniqueRegionIds))
+			.groupBy(verifiedMoonSummaries.regionId)
+
+		return rows.map((row) => ({
+			regionId: row.regionId,
+			verifiedCount: Number(row.verifiedCount),
+		}))
 	}
 
 	async getVerifiedMoonSummaryIds(): Promise<string[]> {
@@ -534,6 +570,59 @@ export class MoonScanDO extends DurableObject<Env> implements IMoonScanDO {
 		return {
 			scannedMoonIds: scanned.map((r) => r.moonId),
 			verifiedMoonIds: verified.map((r) => r.moonId),
+		}
+	}
+
+	async getScannedMoonCountsByRegionIds(regionIds: string[]): Promise<ScannedMoonRegionCount[]> {
+		const uniqueRegionIds = [...new Set(regionIds)]
+		if (uniqueRegionIds.length === 0) return []
+
+		const rows = await this.db
+			.select({
+				regionId: moonScans.regionId,
+				scannedCount: sql<number>`count(distinct ${moonScans.moonId})`,
+			})
+			.from(moonScans)
+			.where(and(isNotNull(moonScans.regionId), inArray(moonScans.regionId, uniqueRegionIds)))
+			.groupBy(moonScans.regionId)
+
+		return rows.map((row) => ({
+			regionId: row.regionId as string,
+			scannedCount: Number(row.scannedCount),
+		}))
+	}
+
+	async getUnlocatedScannedMoonIds(limit: number, afterMoonId?: string): Promise<string[]> {
+		const conditions = [isNull(moonScans.regionId)]
+		if (afterMoonId) conditions.push(sql`${moonScans.moonId} > ${afterMoonId}`)
+
+		const rows = await this.db
+			.selectDistinct({ moonId: moonScans.moonId })
+			.from(moonScans)
+			.where(and(...conditions))
+			.orderBy(asc(moonScans.moonId))
+			.limit(Math.min(Math.max(limit, 1), 500))
+
+		return rows.map((row) => row.moonId)
+	}
+
+	async backfillScanLocations(locations: ScanLocation[]): Promise<void> {
+		const grouped = new Map<string, string[]>()
+		for (const location of locations) {
+			const key = `${location.regionId}:${location.solarSystemId}`
+			const moonIds = grouped.get(key) ?? []
+			moonIds.push(location.moonId)
+			grouped.set(key, moonIds)
+		}
+
+		for (const [key, moonIds] of grouped) {
+			const separator = key.indexOf(':')
+			const regionId = key.slice(0, separator)
+			const solarSystemId = key.slice(separator + 1)
+			await this.db
+				.update(moonScans)
+				.set({ regionId, solarSystemId })
+				.where(and(isNull(moonScans.regionId), inArray(moonScans.moonId, moonIds)))
 		}
 	}
 
@@ -672,6 +761,8 @@ export class MoonScanDO extends DurableObject<Env> implements IMoonScanDO {
 		return {
 			id: row.id,
 			moonId: row.moonId,
+			regionId: row.regionId,
+			solarSystemId: row.solarSystemId,
 			submittedBy: row.submittedBy,
 			submittedAt: row.submittedAt.toISOString(),
 			status: row.status,

--- a/apps/moon-scan/src/durable-object.ts
+++ b/apps/moon-scan/src/durable-object.ts
@@ -15,6 +15,8 @@ import {
 	or,
 	sql,
 } from '@repo/db-utils'
+import { FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID } from '@repo/moon-scan'
+import { logger } from '@repo/hono-helpers'
 
 import { createDb } from './db'
 import {
@@ -32,6 +34,7 @@ import type {
 	ExtractionSettings,
 	LeaderboardEntry,
 	LeaderboardWindow,
+	MoonProfitabilityQueryInputs,
 	MoonCoverageStat,
 	MoonScan,
 	MoonScanDO as IMoonScanDO,
@@ -51,7 +54,6 @@ import type {
 } from '@repo/moon-scan'
 import type { DbClient } from './db'
 import type { Env } from './context'
-import { logger } from '@repo/hono-helpers'
 
 const BATCH_SIZE = 500
 
@@ -334,6 +336,7 @@ export class MoonScanDO extends DurableObject<Env> implements IMoonScanDO {
 		search?: string
 		sortBy: VerifiedMoonsSortBy
 		sortDir: 'asc' | 'desc'
+		profitability?: MoonProfitabilityQueryInputs
 	}): Promise<VerifiedMoonPage> {
 		const offset = (filters.page - 1) * filters.pageSize
 		const conditions = []
@@ -384,6 +387,170 @@ export class MoonScanDO extends DurableObject<Env> implements IMoonScanDO {
 				})
 				.from(verifiedMoonSummaries)
 				.orderBy(asc(verifiedMoonSummaries.constellationName))
+
+		if (filters.profitability) {
+			// Keep the small pricing context as query parameters so compositions stay in SQL.
+			const inputs = filters.profitability
+			const materialRows = inputs.typeMaterials.map((material) => ({
+				ore_type_id: material.oreTypeId,
+				material_type_id: material.materialTypeId,
+				quantity: material.quantity,
+				ore_volume: inputs.oreVolumes[material.oreTypeId] ?? 1,
+			}))
+			const profileRows = inputs.profiles.map((profile) => ({
+				id: profile.id,
+				base_volume_per_hr: profile.baseVolumePerHr,
+				rig_bonus: profile.rigBonus,
+				fuel_per_hr: profile.fuelPerHr,
+				magmatic_gas_per_hr: profile.magmaticGasPerHr,
+				nullsec_modifier: profile.nullsecModifier,
+				is_passive: profile.isPassive,
+			}))
+			const priceRows = inputs.prices.map((price) => ({
+				type_id: price.typeId,
+				price: price.price,
+			}))
+			const orderColumn = filters.sortBy === 'metenoxProfit'
+				? 'metenox_profit'
+				: filters.sortBy === 'tataraProfit'
+					? 'tatara_profit'
+					: filters.sortBy === 'moonName'
+						? 'moon_name'
+						: filters.sortBy === 'solarSystemName'
+							? 'solar_system_name'
+							: filters.sortBy === 'regionName'
+								? 'region_name'
+								: filters.sortBy === 'securityStatus'
+									? 'security_status_value'
+									: 'rarity_order'
+			const direction = filters.sortDir === 'asc' ? 'asc' : 'desc'
+			const orderSql = sql.raw(
+				`${orderColumn} ${direction} nulls last, moon_name asc, moon_id asc`
+			)
+			const rawConditions = []
+			if (filters.regionId) rawConditions.push(sql`s.region_id = ${filters.regionId}`)
+			if (filters.constellationId) rawConditions.push(sql`s.constellation_id = ${filters.constellationId}`)
+			if (filters.rarity && filters.rarity.length > 0) {
+				rawConditions.push(
+					sql`s.highest_rarity in (${sql.join(filters.rarity.map((rarity) => sql`${rarity}`), sql`, `)})`
+				)
+			}
+			if (filters.search) {
+				const search = `%${filters.search.trim()}%`
+				rawConditions.push(sql`(s.moon_name ilike ${search} or s.solar_system_name ilike ${search})`)
+			}
+			const rawWhere = rawConditions.length > 0
+				? sql`where ${sql.join(rawConditions, sql` and `)}`
+				: sql``
+			const pricingSql = sql`
+				with pricing_settings as (
+					select
+						${inputs.defaultReprocessingYield}::numeric as reprocessing_yield,
+						${inputs.defaultCycleDays}::numeric as cycle_days,
+						${inputs.fuelBlockPriceOverride}::numeric as fuel_override,
+						${inputs.magmaticGasPriceOverride}::numeric as gas_override
+				), pricing_profiles as (
+					select * from jsonb_to_recordset(${JSON.stringify(profileRows)}::jsonb) as p(
+						id text, base_volume_per_hr numeric, rig_bonus numeric, fuel_per_hr numeric,
+						magmatic_gas_per_hr numeric, nullsec_modifier numeric, is_passive boolean
+					)
+				), pricing_materials as (
+					select * from jsonb_to_recordset(${JSON.stringify(materialRows)}::jsonb) as m(
+						ore_type_id text, material_type_id text, quantity numeric, ore_volume numeric
+					)
+				), pricing_prices as (
+					select * from jsonb_to_recordset(${JSON.stringify(priceRows)}::jsonb) as p(
+						type_id text, price numeric
+					)
+				), gross_values as (
+					select vc.moon_id, p.id as structure_type,
+						sum(
+							floor(
+								floor(
+									(
+										p.base_volume_per_hr * (1 + p.rig_bonus) * s.cycle_days * 24 *
+										case when p.is_passive then p.nullsec_modifier else 1 end *
+										o.quantity::numeric / m.ore_volume / 100
+										) * m.quantity * s.reprocessing_yield
+								) * coalesce(pr.price, 0)
+						)) as gross_isk
+					from ${verifiedCompositions} vc
+					join ${moonScanOres} o on o.scan_id = vc.source_scan_id
+					join pricing_materials m on m.ore_type_id = o.ore_type_id
+					cross join pricing_profiles p
+					cross join pricing_settings s
+					left join pricing_prices pr on pr.type_id = m.material_type_id
+					where not (p.is_passive and m.material_type_id in ('35', '36'))
+					group by vc.moon_id, p.id
+				), profit_values as (
+					select
+						g.moon_id,
+						g.structure_type,
+						round(
+							g.gross_isk -
+							(
+								p.fuel_per_hr * s.cycle_days * 24 *
+								case when s.fuel_override > 0 then s.fuel_override else coalesce(fuel.price, 0) end
+							) -
+							(
+								case when p.is_passive then coalesce(p.magmatic_gas_per_hr, 0) * s.cycle_days * 24 else 0 end *
+								case when s.gas_override > 0 then s.gas_override else coalesce(gas.price, 0) end
+							)
+						) as profit
+					from gross_values g
+					join pricing_profiles p on p.id = g.structure_type
+					cross join pricing_settings s
+					left join pricing_prices fuel on fuel.type_id = ${FUEL_BLOCK_TYPE_ID}
+					left join pricing_prices gas on gas.type_id = ${MAGMATIC_GAS_TYPE_ID}
+				)
+				select
+					s.moon_id as moon_id,
+					s.moon_name as moon_name,
+					s.solar_system_id as solar_system_id,
+					s.solar_system_name as solar_system_name,
+					s.region_id as region_id,
+					s.region_name as region_name,
+					s.constellation_id as constellation_id,
+					s.constellation_name as constellation_name,
+					s.security_status as security_status,
+					s.highest_rarity as highest_rarity,
+					case s.highest_rarity when 'R4' then 1 when 'R8' then 2 when 'R16' then 3 when 'R32' then 4 when 'R64' then 5 else -1 end as rarity_order,
+					case when s.security_status ~ '^[+-]?[0-9]+([.][0-9]+)?$' then s.security_status::double precision else null end as security_status_value,
+					max(case when pv.structure_type = 'metenox' then pv.profit end) as metenox_profit,
+					max(case when pv.structure_type = 'tatara' then pv.profit end) as tatara_profit
+				from ${verifiedMoonSummaries} s
+				left join profit_values pv on pv.moon_id = s.moon_id
+				${rawWhere}
+				group by s.moon_id, s.moon_name, s.solar_system_id, s.solar_system_name, s.region_id,
+					s.region_name, s.constellation_id, s.constellation_name, s.security_status, s.highest_rarity
+				order by ${orderSql}
+				limit ${filters.pageSize} offset ${offset}
+			`
+			const rows = await this.db.execute(pricingSql)
+			return {
+				items: rows.rows.map((row) => ({
+					moonId: String(row.moon_id),
+					moonName: String(row.moon_name),
+					solarSystemId: String(row.solar_system_id),
+					solarSystemName: String(row.solar_system_name),
+					regionId: String(row.region_id),
+					regionName: String(row.region_name),
+					constellationId: String(row.constellation_id),
+					constellationName: String(row.constellation_name),
+					securityStatus: row.security_status == null ? null : String(row.security_status),
+					highestRarity: row.highest_rarity as OreRarity | null,
+					metenoxProfit: row.metenox_profit == null ? null : String(row.metenox_profit),
+					tataraProfit: row.tatara_profit == null ? null : String(row.tatara_profit),
+				})),
+				total,
+				page: filters.page,
+				pageSize: filters.pageSize,
+				constellations: constellations.map((row) => ({
+					constellationId: row.constellationId,
+					constellationName: row.constellationName,
+				})),
+			}
+		}
 
 		const rarityOrderExpr = sql<number>`case ${verifiedMoonSummaries.highestRarity}
 			when 'R4' then 1

--- a/apps/ui/src/client/components/ui/eve-time-display.tsx
+++ b/apps/ui/src/client/components/ui/eve-time-display.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react'
 
-import { formatDateTimeWithZone, formatUtcDateTime } from '@/lib/date-utils'
+import { formatDate, formatDateTimeWithZone, formatUtcDateTime } from '@/lib/date-utils'
 import { cn } from '@/lib/utils'
 
 import { Popover, PopoverAnchor, PopoverContent } from './popover'
@@ -8,10 +8,14 @@ import { Popover, PopoverAnchor, PopoverContent } from './popover'
 interface EveTimeDisplayProps {
 	dateStr: string
 	className?: string
-	format?: 'full' | 'compact' | 'window'
+	format?: 'full' | 'compact' | 'date' | 'window'
 }
 
-function formatEveDateTime(dateStr: string, format: 'full' | 'compact' | 'window'): string {
+function formatEveDateTime(dateStr: string, format: 'full' | 'compact' | 'date' | 'window'): string {
+	if (format === 'date') {
+		return `${formatDate(dateStr)} EVE`
+	}
+
 	if (format === 'compact') {
 		const formatted = formatUtcDateTime(dateStr, true)
 		return `${formatted} EVE`

--- a/apps/ui/src/client/features/moon-scan/routes/moon.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/moon.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Container } from '@/components/ui/container'
+import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { PageHeader } from '@/components/ui/page-header'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -206,7 +207,15 @@ function StructurePanel({ structure }: { structure: StructureProfitability }) {
 	)
 }
 
-function ProfitabilityCard({ structures, updatedAt }: { structures: StructureProfitability[]; updatedAt: string }) {
+function ProfitabilityCard({
+	structures,
+	updatedAt,
+	pricingSnapshotDate,
+}: {
+	structures: StructureProfitability[]
+	updatedAt: string
+	pricingSnapshotDate: string | null
+}) {
 	const ORDER = ['metenox', 'tatara']
 	const visible = ORDER
 		.map((id) => structures.find((s) => s.structureType === id))
@@ -219,7 +228,22 @@ function ProfitabilityCard({ structures, updatedAt }: { structures: StructurePro
 				{visible.map((s) => <StructurePanel key={s.structureType} structure={s} />)}
 			</div>
 			<div className="border-t px-4 py-2 text-xs text-muted-foreground">
-				Updated {new Date(updatedAt).toUTCString().replace(':00 GMT', ' UTC')}
+				<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+					<span>Calculated:</span>
+					<EveTimeDisplay dateStr={updatedAt} />
+				</div>
+				<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+					<span>Pricing Source: Global Daily Average</span>
+					<span aria-hidden="true">•</span>
+					<span className="flex items-center gap-1">
+						Snapshot:
+						{pricingSnapshotDate ? (
+							<EveTimeDisplay dateStr={`${pricingSnapshotDate}T00:00:00Z`} format="date" />
+						) : (
+							<span>Unavailable</span>
+						)}
+					</span>
+				</div>
 			</div>
 		</div>
 	)
@@ -340,7 +364,11 @@ export default function MoonPage() {
 			{/* Profitability panel */}
 			{!isLoading && profitability && (
 				<div className="mb-6">
-					<ProfitabilityCard structures={profitability.structures} updatedAt={profitability.updatedAt} />
+					<ProfitabilityCard
+						structures={profitability.structures}
+						updatedAt={profitability.updatedAt}
+						pricingSnapshotDate={profitability.pricingSnapshotDate ?? null}
+					/>
 				</div>
 			)}
 

--- a/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
@@ -7,6 +7,7 @@ import { UserSearchPaginationControls } from '@/components/user-search-paginatio
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
+import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { HoverPopover } from '@/components/ui/hover-popover'
 import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
@@ -370,7 +371,6 @@ export default function ScannedMoonsPage() {
 					</div>
 				}
 			/>
-
 			{error && (
 				<div className="mt-4 rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-sm text-red-500">
 					Failed to load moon data
@@ -477,17 +477,15 @@ export default function ScannedMoonsPage() {
 					))}
 				</div>
 
-				{!isLoading && data && (
-					<span className="flex items-center gap-2 text-xs text-muted-foreground">
-						{isFetching && (
-							<span
-								className="inline-block h-2 w-2 animate-pulse rounded-full bg-primary"
-								aria-label="Updating"
-							/>
-						)}
-						{data.items.length} shown • {data.total} total
+			{!isLoading && data?.pricingSnapshotDate && (
+				<span className="ml-auto flex items-center gap-x-2 text-xs text-muted-foreground">
+					<span>Pricing Source: Global Daily Average</span>
+					<span aria-hidden="true">•</span>
+					<span className="flex items-center gap-1">
+						Snapshot: <EveTimeDisplay dateStr={`${data.pricingSnapshotDate}T00:00:00Z`} format="date" />
 					</span>
-				)}
+				</span>
+			)}
 			</div>
 
 			<Card className="mt-4 overflow-hidden">

--- a/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
@@ -21,6 +21,7 @@ import {
 	TableRow,
 } from '@/components/ui/table'
 import { TableRefreshFrame } from '@/components/table-refresh-frame'
+import { useDebounce } from '@/hooks/useDebounce'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { formatISK } from '@/lib/format-utils'
 import toast from '@/lib/toast'
@@ -38,6 +39,7 @@ import { parseSecurityStatus, securityStatusTextClass } from '../security-status
 import type { OreRarity, ScannedMoonEntry } from '../types'
 
 const RARITY_VALUES: readonly OreRarity[] = ['R4', 'R8', 'R16', 'R32', 'R64']
+const EXPORT_STATUS_POLL_INTERVALS_MS = [5_000, 10_000, 15_000, 30_000] as const
 type SortBy =
 	| 'moonName'
 	| 'solarSystemName'
@@ -118,6 +120,7 @@ export default function ScannedMoonsPage() {
 	const [collapsedConstellations, setCollapsedConstellations] = useState<Set<string>>(new Set())
 	const [pendingExport, setPendingExport] = useState<{ workflowInstanceId: string; fileName: string } | null>(null)
 	const [isExporting, setIsExporting] = useState(false)
+	const debouncedSearch = useDebounce(search, 400)
 
 	const exportStatusQuery = useQuery({
 		queryKey: ['moon-scan', 'verified-moons', 'export-status', pendingExport?.workflowInstanceId ?? null],
@@ -125,7 +128,10 @@ export default function ScannedMoonsPage() {
 		enabled: Boolean(pendingExport?.workflowInstanceId),
 		refetchInterval: (query) => {
 			const status = query.state.data?.status
-			return status === 'queued' || status === 'running' ? 5000 : false
+			if (status !== 'queued' && status !== 'running') return false
+			return EXPORT_STATUS_POLL_INTERVALS_MS[
+				Math.min(query.state.dataUpdateCount, EXPORT_STATUS_POLL_INTERVALS_MS.length - 1)
+			]
 		},
 		refetchOnWindowFocus: false,
 	})
@@ -174,7 +180,7 @@ export default function ScannedMoonsPage() {
 		regionId: regionFilter,
 		constellationId: constellationFilter,
 		rarities: selectedRarities,
-		search,
+		search: debouncedSearch,
 		sortBy,
 		sortDir,
 	}, canView)

--- a/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
@@ -39,7 +39,6 @@ import { parseSecurityStatus, securityStatusTextClass } from '../security-status
 import type { OreRarity, ScannedMoonEntry } from '../types'
 
 const RARITY_VALUES: readonly OreRarity[] = ['R4', 'R8', 'R16', 'R32', 'R64']
-const EXPORT_STATUS_POLL_INTERVALS_MS = [5_000, 10_000, 15_000, 30_000] as const
 type SortBy =
 	| 'moonName'
 	| 'solarSystemName'
@@ -128,10 +127,7 @@ export default function ScannedMoonsPage() {
 		enabled: Boolean(pendingExport?.workflowInstanceId),
 		refetchInterval: (query) => {
 			const status = query.state.data?.status
-			if (status !== 'queued' && status !== 'running') return false
-			return EXPORT_STATUS_POLL_INTERVALS_MS[
-				Math.min(query.state.dataUpdateCount, EXPORT_STATUS_POLL_INTERVALS_MS.length - 1)
-			]
+			return status === 'queued' || status === 'running' ? 5000 : false
 		},
 		refetchOnWindowFocus: false,
 	})

--- a/apps/ui/src/client/features/moon-scan/types.ts
+++ b/apps/ui/src/client/features/moon-scan/types.ts
@@ -192,6 +192,7 @@ export interface MoonProfitability {
 	ores: OreWithProfitability[]
 	structures: StructureProfitability[]
 	updatedAt: string
+	pricingSnapshotDate: string | null
 }
 
 export interface MoonDetail {
@@ -229,6 +230,7 @@ export interface ScannedMoonsResponse {
 	pageSize: number
 	constellations: ConstellationSummary[]
 	updatedAt: string
+	pricingSnapshotDate: string | null
 }
 
 // Scan submission

--- a/docs/CACHING_IMPROVEMENTS.md
+++ b/docs/CACHING_IMPROVEMENTS.md
@@ -1,0 +1,535 @@
+# Neon Data Transfer Investigation
+
+## 1. Executive summary
+
+Recent code changes could plausibly have increased Neon PostgreSQL data transfer. The strongest evidence points to application-level behavior rather than a Neon driver or infrastructure regression: several recent features repeatedly fetch broad database result sets without a shared Worker, edge, or query-result cache.
+
+Top suspected causes:
+
+| Rank | Suspect | Confidence | Summary |
+| ---: | ------- | ---------- | ------- |
+| 1 | Structures list and overview queries | High | Recent structures changes expanded tabbed views and summaries. Current code loads all visible structures and related fuel history before pagination, with no shared server-side cache. |
+| 2 | Fleet tracking active-session polling | Medium-high | Active fleet detail pages poll several protected endpoints every 5s or 15s. Each request also pays global auth/session DB overhead, and timeline data is read broadly before slicing. |
+| 3 | New background/admin workloads | Medium | Prediction-market reconciliation now runs every 5 minutes, and service access audit can scan all users when triggered. These are bounded, but new within the investigation window. |
+
+Most important next action: compare Neon top queries by calls, rows returned, and transfer with Cloudflare route counts for `/api/structures`, `/api/fleets/tracking/*`, prediction-market cron execution, and service-access-audit workflow runs across the deploy window.
+
+No application code, configuration, migrations, lock files, or infrastructure files were modified during the investigation before this report was written.
+
+## 2. Architecture summary
+
+This repository is a Cloudflare Workers monorepo using TypeScript, Hono, pnpm workspaces, Turborepo, Drizzle ORM, and Neon PostgreSQL.
+
+The primary execution model is multiple Cloudflare Worker services under `apps/*`. The main API gateway is `apps/core`, with Hono routes mounted from `src/index.ts`. The UI Worker serves the React SPA and proxies API-like flows to core. The repo also uses Durable Objects, Workflows, Queues, Cron Triggers, KV, R2, and service bindings.
+
+Neon access is centralized through `@repo/db-utils`. Most request-path database clients use Neon HTTP via `neon(databaseUrl)` and Drizzle in [`packages/db-utils/src/client.ts`](/Users/mcp/projects/auth-next/packages/db-utils/src/client.ts:14). Some Durable Objects use Neon WebSocket `Pool` clients via [`packages/db-utils/src/client.ts`](/Users/mcp/projects/auth-next/packages/db-utils/src/client.ts:40). I found no Hyperdrive integration and no primary Prisma, Kysely, or direct `pg` application access pattern.
+
+Database queries originate from:
+
+- Hono request handlers in core and service workers.
+- Global auth/session middleware in core.
+- Durable Object RPC methods.
+- Workflows, scheduled handlers, and background reconciliation jobs.
+- Queue-related and sync-oriented services.
+
+Existing caching mechanisms include:
+
+- Browser-local React Query caches in the UI.
+- Process-local `TimeCache` instances, for example group/permission caches in [`apps/core/src/lib/groups-cache.ts`](/Users/mcp/projects/auth-next/apps/core/src/lib/groups-cache.ts:21) and fleet stats in [`apps/core/src/routes/fleets.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/fleets.ts:1177).
+- Cloudflare Cache API helper code in [`packages/hono-helpers/src/middleware/withCache.ts`](/Users/mcp/projects/auth-next/packages/hono-helpers/src/middleware/withCache.ts:7), but it is not broadly applied to the high-risk structures or fleet detail paths.
+- Static asset caching in the UI Worker. HTML is served with no-cache semantics, while hashed assets are immutable.
+
+The existing process-local caches are not durable and are not shared across Worker isolates, regions, or deployments.
+
+## 3. Investigation period and Git history
+
+Exact investigation period: `2026-06-21` through `2026-07-21` inclusive.
+
+Commands used included:
+
+```bash
+git log --since="2026-06-21 00:00:00" --until="2026-07-21 23:59:59" --date=iso --stat
+git log --since="2026-06-21 00:00:00" --until="2026-07-21 23:59:59" --date=iso --name-status
+git log --since="2026-06-21 00:00:00" --until="2026-07-21 23:59:59" --date=iso --oneline --decorate
+git log --merges --since="2026-06-21 00:00:00" --until="2026-07-21 23:59:59" --date=iso --oneline --decorate
+```
+
+Code discovery was performed first through `codebase-memory-mcp`, including repository indexing and graph-based searches. Targeted read-only shell commands were then used for Git history, diffs, line-numbered evidence, configuration checks, and literal searches.
+
+No merge commits were present in the investigation period.
+
+Relevant commits selected for detailed review:
+
+| Commit | Area | Why selected |
+| ------ | ---- | ------------ |
+| `592d1830` | Structures | Adjusted structure cooldown/update behavior. |
+| `dd47a73b` | Structures, eve-corp-data | Touched structure services, workflows, and migrations. |
+| `05a37a6b` | Structures | Large refactor aligning structures data model and UI with current behavior. |
+| `fced9cc6` | Structures | Added structure sync cooldown behavior. |
+| `5a7658fc` | Structures | Split structure tabs and expanded tab-specific access paths. |
+| `402de771` | Fleet tracking | Added boss handoff and tracking stats behavior. |
+| `ca6993bd` | Fleet tracking | Added live location tracking and polling surface. |
+| `a12254f0` | Fleet tracking | Fixed tracking lifecycle and added migration. |
+| `6e75f2aa` | Prediction markets | Introduced prediction-market application and schema. |
+| `86bc80d3` | Prediction markets | Added forum-post reconciliation from core cron. |
+| `03f3d046` | Service audit | Added read-only services access audit workflow, routes, UI, and migrations. |
+| `c70792d1` | Navigation | Added DB-backed sidebar external links. |
+| `5b5bbd14` | SRP | Added pagination to recent losses and my losses. |
+| `aebda737` | SRP | Refactored SRP workflows and data storage. |
+
+Dependency and lock-file changes were reviewed. I did not find evidence of a recent Neon/Drizzle driver update that would itself explain increased data transfer. The relevant current dependencies are `@neondatabase/serverless 1.0.2` and `drizzle-orm 0.44.7`.
+
+## 4. Database-access inventory
+
+| Location | Trigger | Query purpose | Frequency | Result size risk | Cache present | Recently changed |
+| -------- | ------- | ------------- | --------: | ---------------- | ------------- | ---------------- |
+| [`apps/core/src/middleware/session.ts`](/Users/mcp/projects/auth-next/apps/core/src/middleware/session.ts:26) | Every authenticated core request | Validate session, load profile, roles, blacklist status, record IP | Every authenticated API hit | Medium | Short process-local role/group caches only | Mostly old |
+| [`apps/core/src/services/auth.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/auth.service.ts:70) | Session middleware | Session lookup and `lastActivityAt` update | Every valid authenticated API hit | Low per request, high at scale | None | Mostly old |
+| [`apps/core/src/services/user.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/user.service.ts:159) | Session middleware | User, characters, preferences | Every authenticated API hit | Medium | None found | Mostly old |
+| [`apps/core/src/lib/ip-tracking.ts`](/Users/mcp/projects/auth-next/apps/core/src/lib/ip-tracking.ts:77) | Session middleware background task | User IP insert/upsert | Every authenticated API hit with IP context | Low per request, write-amplified at scale | Throttled update condition, but still sends upsert | Mostly old |
+| [`apps/core/src/routes/navigation-links.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/navigation-links.ts:27) | Sidebar render | Enabled external navigation links | Per browser cache window | Low | Browser React Query only | Yes, `c70792d1` |
+| [`apps/structures/src/services/structures.service.ts`](/Users/mcp/projects/auth-next/apps/structures/src/services/structures.service.ts:2426) | Structures pages/API | Visible structures, configs, corp names | Page load and tab refresh | High | Browser React Query only | Yes |
+| [`apps/structures/src/services/structures.service.ts`](/Users/mcp/projects/auth-next/apps/structures/src/services/structures.service.ts:2339) | Structures overview/list summaries | Fuel history samples for visible structures | Per overview/list call | High | None found | Yes |
+| [`apps/core/src/routes/structures.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/structures.ts:756) | `/api/structures/overview` | Structure overview metrics | Page load and 30s stale refresh | High | None found | Yes |
+| [`apps/core/src/routes/fleets.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/fleets.ts:823) | Active fleet detail | Live snapshot, current members, timeline, locations | 5s and 15s polling | Medium-high | None for live/detail | Yes |
+| [`apps/fleets/src/durable-object.ts`](/Users/mcp/projects/auth-next/apps/fleets/src/durable-object.ts:1537) | Fleet timeline route | Member history, lifecycle, boss, ship timeline | 5s while page is active | High | None found | Yes |
+| [`apps/core/src/services/discord-market-reconcile.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/discord-market-reconcile.service.ts:87) | Core cron | Prediction-market Discord reconciliation | Every 5 minutes per active environment | Medium | None found | Yes, `86bc80d3` |
+| [`apps/prediction-markets/src/services/shared.ts`](/Users/mcp/projects/auth-next/apps/prediction-markets/src/services/shared.ts:36) | Prediction-market reads/reconcile | Market detail and outcomes | Per market detail | Medium | None found | Yes |
+| [`apps/core/src/workflows/service-access-audit.workflow.ts`](/Users/mcp/projects/auth-next/apps/core/src/workflows/service-access-audit.workflow.ts:251) | Admin-started workflow | Full user eligibility scan and audit row writes | On demand | High if repeated | Results persisted as audit run rows | Yes, `03f3d046` |
+| [`apps/srp/src/durable-object.ts`](/Users/mcp/projects/auth-next/apps/srp/src/durable-object.ts:969) | SRP losses page | Recent losses, SRP state, optional wallet journal scan | User page load, 5m client stale | Medium-high | DO storage and client cache | Yes |
+
+## 5. Findings ranked by likely impact
+
+### Finding 1: Structures endpoints fetch broad result sets without shared caching
+
+Severity: high.
+Confidence: high for the code mechanism, medium-high for production impact pending metrics.
+
+Relevant commits: `5a7658fc`, `05a37a6b`, `dd47a73b`, `592d1830`.
+
+Before the recent structures work, the feature was narrower and less tab-heavy. After the changes, the structures UI and routes expose richer overview and tabbed data, while the service layer currently loads broad visible datasets before reducing the response.
+
+Evidence:
+
+- `loadVisibleStructureContexts` reads all matching `corporationStructures` rows without SQL-side page limits in [`structures.service.ts`](/Users/mcp/projects/auth-next/apps/structures/src/services/structures.service.ts:2480).
+- Structure list functions sort and slice after building visible structures in memory, for example [`structures.service.ts`](/Users/mcp/projects/auth-next/apps/structures/src/services/structures.service.ts:2737).
+- `buildStructureSummary` loads fuel history for all returned structure IDs through [`structures.service.ts`](/Users/mcp/projects/auth-next/apps/structures/src/services/structures.service.ts:2327).
+- `loadFuelHistorySamplesByStructure` reads all `structureFuelLog` rows for the structure ID set, with no visible time or sample bound, in [`structures.service.ts`](/Users/mcp/projects/auth-next/apps/structures/src/services/structures.service.ts:2348).
+- Overview metrics call the same broad context path in [`structures.service.ts`](/Users/mcp/projects/auth-next/apps/structures/src/services/structures.service.ts:2765).
+- The core overview route has no Cache API or cache-control layer in [`structures.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/structures.ts:756).
+
+Mechanism that increases transfer:
+
+- Rows returned: high, because full visible structure sets and fuel history are transferred to the Worker.
+- Repeated reads: high, because browser-local React Query cache does not deduplicate across users, browsers, Workers isolates, or regions.
+- Cache hit rate: no shared cache found for these results.
+- Pagination effectiveness: weak for Neon transfer, because slicing occurs after broad reads.
+
+Expected direction and rough magnitude:
+
+Transfer scales with:
+
+```text
+structure page views
+x route calls per page
+x (visible structure rows + config rows + tab rows + fuel log rows)
+x average row width
+```
+
+Illustrative example only: `500 visible structures x 24 fuel samples x 100 bytes` is about `1.2 MB` of fuel-log payload per summary call before protocol and JSON overhead.
+
+Evidence still needed:
+
+- Neon top queries by rows and calls for structure tables, especially `structure_fuel_log`.
+- Cloudflare route counts for `/api/structures/*`.
+- Production row counts and average row sizes for structure tables.
+
+### Finding 2: Fleet tracking active pages can multiply Neon traffic through polling
+
+Severity: high.
+Confidence: medium-high.
+
+Relevant commits: `402de771`, `ca6993bd`, `a12254f0`.
+
+Before the recent fleet tracking work, there was less live-detail surface area. After the changes, active tracking views poll multiple protected endpoints at short intervals.
+
+Evidence:
+
+- Active tracking detail uses 5s polling for live/session/timeline/current-member data and 15s polling for location data in [`tracking-session-detail.tsx`](/Users/mcp/projects/auth-next/apps/ui/src/client/features/fleet-tracking/routes/tracking-session-detail.tsx:343).
+- Each protected core request enters global session middleware in [`session.ts`](/Users/mcp/projects/auth-next/apps/core/src/middleware/session.ts:50).
+- Session validation reads the session and updates `lastActivityAt` in [`auth.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/auth.service.ts:74) and [`auth.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/auth.service.ts:89).
+- Fleet access resolution calls `getTrackingSession` before many tracking endpoints in [`fleets.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/fleets.ts:713).
+- `getSessionTimeline` reads multiple event sets and merges/sorts them before slicing the requested page in [`durable-object.ts`](/Users/mcp/projects/auth-next/apps/fleets/src/durable-object.ts:1537) and [`durable-object.ts`](/Users/mcp/projects/auth-next/apps/fleets/src/durable-object.ts:1728).
+
+Mechanism that increases transfer:
+
+- Query frequency: high, due to 5s polling.
+- Repeated reads: high, because separate endpoints repeat auth/session/access checks.
+- Rows returned: potentially high for timeline data, because complete event collections are transferred before pagination.
+- Writes: elevated because session activity and IP tracking run on authenticated request paths.
+
+Expected direction and rough magnitude:
+
+```text
+active viewers
+x active minutes
+x 12 polling cycles per minute
+x protected endpoints per cycle
+x auth/session queries and writes
++ fleet route queries
+```
+
+A single active viewer can generate roughly 60 protected 5-second API calls per minute plus 15-second location calls. Production viewer counts are required to convert this into transfer.
+
+Evidence still needed:
+
+- Cloudflare request counts by fleet tracking route.
+- Neon query stats for fleet tracking tables and session tables.
+- Active fleet detail page concurrency during the spike.
+
+### Finding 3: Prediction-market reconciliation introduced new recurring Neon work
+
+Severity: medium.
+Confidence: medium.
+
+Relevant commits: `6e75f2aa`, `86bc80d3`.
+
+Before the prediction-market feature, this workload did not exist. Afterward, core cron invokes reconciliation every 5 minutes in [`index.ts`](/Users/mcp/projects/auth-next/apps/core/src/index.ts:218).
+
+Evidence:
+
+- Reconciliation has bounded close, refresh, backfill, and settlement loops in [`discord-market-reconcile.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/discord-market-reconcile.service.ts:65).
+- The cron path calls market detail methods during refresh/backfill/settlement work in [`discord-market-reconcile.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/discord-market-reconcile.service.ts:130).
+- `buildMarketDetails` loops market IDs and calls `buildMarketDetail`, which reads market and outcome rows separately, in [`shared.ts`](/Users/mcp/projects/auth-next/apps/prediction-markets/src/services/shared.ts:87).
+- A code comment documents a duplicate-post hazard if thread creation succeeds but attachment fails, which could cause repeated backfill attempts in [`discord-market-reconcile.service.ts`](/Users/mcp/projects/auth-next/apps/core/src/services/discord-market-reconcile.service.ts:166).
+
+Mechanism that increases transfer:
+
+- Background execution frequency: fixed every 5 minutes.
+- Query count: bounded but additive.
+- Retry/reprocessing: possible if Discord-side failures leave DB state incomplete.
+
+Evidence still needed:
+
+- Cron invocation count per environment.
+- Number of markets processed per tick.
+- Discord failure logs and repeated backfill attempts.
+- Neon query stats for prediction-market tables.
+
+### Finding 4: Service access audit can scan and write across all users
+
+Severity: medium.
+Confidence: medium.
+
+Relevant commit: `03f3d046`.
+
+Before this change, there was no service access audit workflow. Afterward, admins can start an audit run that scans user eligibility and writes audit rows.
+
+Evidence:
+
+- The workflow uses `SCAN_PAGE_SIZE = 500` and `MAX_SCAN_PAGES = 500` in [`service-access-audit.workflow.ts`](/Users/mcp/projects/auth-next/apps/core/src/workflows/service-access-audit.workflow.ts:44).
+- The scan loop fetches eligibility pages, enriches users, and inserts audit rows in [`service-access-audit.workflow.ts`](/Users/mcp/projects/auth-next/apps/core/src/workflows/service-access-audit.workflow.ts:251).
+- The scan query is set-based and paginated in [`service-eligibility.ts`](/Users/mcp/projects/auth-next/apps/core/src/lib/service-eligibility.ts:161).
+- The route prevents concurrent active runs, but repeated completed/failed runs remain possible through admin action in [`services-audit.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/services-audit.ts:74).
+
+Mechanism that increases transfer:
+
+- Rows scanned: proportional to user count.
+- Rows written: one audit row per scanned user.
+- Background retry impact: depends on Workflow attempts and failures.
+
+Evidence still needed:
+
+- Audit run count and status history.
+- Workflow retry count.
+- Audit row growth over time.
+
+### Finding 5: DB-backed sidebar external links are globally reusable but not edge-cached
+
+Severity: low-medium.
+Confidence: high for mechanism, low for total impact.
+
+Relevant commit: `c70792d1`.
+
+Before this change, sidebar external links were not served from this DB-backed route. Afterward, the UI requests enabled links from core.
+
+Evidence:
+
+- The route creates a DB client and reads enabled links in [`navigation-links.ts`](/Users/mcp/projects/auth-next/apps/core/src/routes/navigation-links.ts:27).
+- The UI uses browser-local React Query stale time, not shared edge caching, in [`sidebar-nav.tsx`](/Users/mcp/projects/auth-next/apps/ui/src/client/components/sidebar-nav.tsx:94).
+
+Mechanism that increases transfer:
+
+- Query frequency: one shared list can be fetched independently by every browser session.
+- Result size: likely small.
+- Cache gap: high, because this is a good candidate for shared cache.
+
+Evidence still needed:
+
+- Route count for `/api/navigation/external-links`.
+- Number and width of configured links.
+
+## 6. Cache-gap analysis
+
+| Data/query | Current behavior | Cache suitability | Recommended cache | Suggested TTL | Invalidation strategy | Security considerations |
+| ---------- | ---------------- | ----------------- | ----------------- | ------------- | --------------------- | ----------------------- |
+| Structures overview | Recomputed from Neon through broad service calls | High | Cloudflare Cache API or KV after SQL reduction | 30-120s with stale-while-revalidate | Version key on structure sync/config writes | Key by tenant/user permission-scope hash and feature/config version |
+| Structures tab lists | Broad visible data loaded, then filtered/sorted/paged in Worker | Medium-high | SQL-side reduction first, then Cache API/KV | 30-120s | Version on structure sync, config update, ACL update | Include tenant, permission scope, tab, filters, sort, page, page size |
+| Structure fuel summaries | Fuel history rows fetched for visible structures during summaries | High | Precomputed summary table, Durable Object cache, or KV | 5-15m | Update during fuel-log ingest or bump version per structure | Scope to visible structure IDs or permission scope |
+| Fleet active session bundle | Multiple endpoints polled independently | Medium | Combined endpoint plus short Durable Object/request cache | 1-5s | Natural expiry or event-driven version | Private/session-scoped; never public CDN cache raw fleet state |
+| Fleet timeline | Reads complete event sets before API pagination | Medium | SQL-side pagination and optional short DO cache | 1-10s for active sessions | Natural expiry; invalidate on new event | Key by session ID plus access check result |
+| Sidebar external links | DB read with browser-only 5m cache | High | Cache API or KV | 5-30m | Admin create/update/delete bumps version | Cache only for correct audience; include auth/audience dimension if needed |
+| Prediction-market public lists | DB reads and aggregates on list/leaderboard paths | Medium | Cache API/KV | 30-300s | Invalidate on market/bet/settlement write | Separate public, admin, and user-specific views |
+| Session/profile data | DB read on every authenticated API request | Limited | Request-scoped dedupe and short private cache where safe | Seconds to minutes | Logout/session revocation/user update | Must key by session/user and authorization scope |
+| Service audit run details | DB-backed report rows after run | Medium | Cache completed run summaries/pages | 5-60m | Immutable per completed run or version by run status | Admin-only; key by admin authorization |
+
+## 7. Duplicate-query and oversized-result analysis
+
+Confirmed duplicate-query risks:
+
+- Auth/session work runs on every authenticated API request, including short-interval polling paths.
+- Fleet active detail uses multiple independent polling hooks, causing repeated access resolution and repeated session middleware DB work.
+- Prediction-market detail building has a per-market loop that performs separate market/outcome reads.
+
+Confirmed oversized-result risks:
+
+- Structures list and overview paths load all visible structures and related rows before pagination.
+- Structure fuel history has no visible time/sample bound in the service method.
+- Fleet timeline loads member history, lifecycle events, boss changes, and ship events before merging and slicing.
+- SRP recent losses applies pagination late after collecting and enriching loss data, and can scan a legacy wallet-journal window.
+
+Potentially unnecessary row width:
+
+- Several Drizzle `findMany` or raw select paths retrieve whole rows where only summary fields appear to be needed. The structures and fleet timeline paths are the highest-risk examples.
+
+No confirmed server-render/client-hydration double-fetch issue was found. The UI is a React SPA using React Query; repeated browser fetching is controlled by hook stale times, but those caches are per browser only.
+
+## 8. Background-task analysis
+
+Relevant scheduled/background execution:
+
+- Core cron runs every 5 minutes and now calls prediction-market reconciliation.
+- Core also runs token invalid alerts, temp op expiry, market-post reconciliation, R2 export cleanup, and daily audit cleanup.
+- Other apps include scheduled workers for eve corporation data, eve character data, SRP, bills, fulcrum, markets, and paste.
+- Service access audit is Workflow-based and admin-triggered, not scheduled in the code reviewed.
+- Fleet monitoring uses Durable Objects and recent tracking features may write or read fleet state/history during active tracking sessions.
+
+Changes that could explain increased transfer:
+
+- Prediction-market reconciliation is a new recurring workload.
+- Fleet tracking additions can increase live request volume and history reads while sessions are active.
+- Structure sync/refactor changes likely changed which structure data is loaded and how often users view it.
+- Service access audit can produce a burst of reads/writes when executed.
+
+Things requiring production metrics:
+
+- Whether scheduled jobs are active in preview/staging as well as production.
+- Whether queue or workflow retries occurred.
+- Whether failed prediction-market Discord operations caused repeated processing.
+- Whether fleet tracking sessions were active during the transfer spike.
+
+## 9. Dependency and configuration analysis
+
+No recent dependency update was identified as a confirmed cause. The current architecture uses Neon directly from Workers through Drizzle and Neon HTTP/WebSocket drivers.
+
+Configuration observations:
+
+- Worker configs use JSONC and `nodejs_compat`.
+- Neon connection strings are referenced through environment variables/secrets, not hard-coded in the inspected code.
+- No Hyperdrive binding was found.
+- Several Workers have cron triggers. If multiple environments are deployed with production database credentials, scheduled jobs could multiply database traffic.
+
+Connection pooling or Hyperdrive may improve connection management and latency in the Workers runtime, especially for WebSocket or pooled code paths. It should not be treated as a substitute for application-level result caching when identical rows are repeatedly transferred from Neon.
+
+## 10. Estimated impact
+
+These are formulas and illustrative calculations, not production measurements.
+
+Structures:
+
+```text
+estimated transfer =
+structure page views
+x route calls per page
+x (visible structure rows + config rows + tab rows + fuel log rows)
+x average bytes per row
+```
+
+Illustration: if one summary call touches `500` visible structures and `24` fuel samples per structure at `100` bytes per sample, fuel samples alone are about `1.2 MB` per call before protocol and JSON overhead.
+
+Fleet active tracking:
+
+```text
+estimated request/query pressure =
+active viewers
+x active minutes
+x 12 polling cycles per minute
+x protected endpoints per cycle
+x auth/session/access DB work
+```
+
+A single active viewer can generate about 60 protected 5-second API calls per minute plus 15-second location calls. The Neon transfer impact then depends on session/profile row width, fleet timeline event count, and current member count.
+
+Prediction-market reconciliation:
+
+```text
+estimated daily work =
+288 cron ticks per day per environment
+x bounded close/refresh/backfill/settlement queries
+x per-market detail queries
+```
+
+Impact grows if many markets are eligible every tick or if Discord failures leave work retried.
+
+Service access audit:
+
+```text
+estimated work per run =
+ceil(user_count / 500) scan pages
++ enrichment queries
++ user_count audit-row inserts
++ aggregate summary queries
+```
+
+Impact is bursty and depends on admin runs and Workflow retries.
+
+## 11. Recommended remediation plan
+
+### Immediate
+
+Measure top SQL and route traffic before changing code. Expected benefit: confirms the cause and avoids optimizing the wrong path. Risk: low. Complexity: low. Files likely to change: none if existing dashboards/logs are sufficient. Metrics that should identify the issue: Neon rows returned, query calls, transfer, and Cloudflare route counts.
+
+Specifically inspect:
+
+- Neon top queries involving structure tables and `structure_fuel_log`.
+- Neon top queries involving fleet tracking/session tables.
+- Cloudflare route counts for `/api/structures/*` and `/api/fleets/tracking/*`.
+- Core cron invocation counts and prediction-market reconcile logs.
+- Service access audit workflow run and retry counts.
+
+### Near term
+
+Move structures filtering, sorting, pagination, and projections into SQL. Bound or precompute fuel summaries. Expected benefit: large reduction in rows transferred. Risk: medium, due to permission-sensitive structure visibility. Complexity: medium-high. Files likely to change: `apps/structures/src/services/structures.service.ts`, `apps/core/src/routes/structures.ts`, related tests. Test strategy: route parity tests, permission isolation tests, pagination/sort/filter tests. Metrics that should improve: rows returned and transfer for structure queries.
+
+Add shared caching for structures after SQL reduction. Use keys including tenant, user permission-scope hash, tab, filters, sort, page, page size, and config/data version. Expected benefit: fewer repeated identical reads. Risk: stale or unauthorized structure data if keyed incorrectly. Complexity: medium. Metrics that should improve: cache hit rate, Neon query calls, Worker subrequest latency.
+
+Combine fleet active-session polling into fewer endpoints and move timeline pagination into SQL. Expected benefit: fewer requests, fewer repeated auth checks, fewer timeline rows transferred. Risk: medium, because live fleet data is sensitive and freshness matters. Complexity: medium. Files likely to change: `apps/core/src/routes/fleets.ts`, `apps/fleets/src/durable-object.ts`, fleet tracking UI hooks. Metrics that should improve: API calls per active viewer-minute and fleet-table rows returned.
+
+Throttle session `lastActivityAt` and IP tracking writes. Expected benefit: lower write amplification on polling-heavy pages. Risk: low-medium, depending on session activity semantics. Complexity: low-medium. Files likely to change: `apps/core/src/services/auth.service.ts`, `apps/core/src/lib/ip-tracking.ts`. Metrics that should improve: session and user-IP writes per request.
+
+Cache sidebar external links with Cache API or KV. Expected benefit: remove a globally reusable nav query from common page views. Risk: low if audience is keyed correctly. Complexity: low. Files likely to change: `apps/core/src/routes/navigation-links.ts` and admin mutation invalidation code. Metrics that should improve: calls to sidebar link query.
+
+Batch prediction-market detail loading. Expected benefit: reduce per-market N+1 reads during reconciliation and list/detail enrichment. Risk: low-medium. Complexity: medium. Files likely to change: `apps/prediction-markets/src/services/shared.ts`, reconcile/read service tests. Metrics that should improve: prediction-market query calls per cron tick.
+
+### Longer term
+
+Evaluate Hyperdrive for Cloudflare-to-Neon connection management. Expected benefit: better connection reuse and latency. Risk: operational config complexity. Complexity: medium. Metrics that should improve: connection churn, latency, timeout/retry rates.
+
+Add route-level DB budgets and observability. Expected benefit: future regressions become visible before Neon transfer spikes. Risk: low if values are aggregated and secrets are not logged. Complexity: medium. Metrics that should improve: time to detect high-query routes.
+
+Separate production, staging, and preview scheduled execution where possible. Expected benefit: prevents duplicated background traffic against production Neon. Risk: deployment complexity. Complexity: medium. Metrics that should improve: cron/workflow invocations against production database.
+
+## 12. Verification plan
+
+Before remediation:
+
+- Capture 24-72 hours of Neon data transfer, query count, rows returned, rows written, active connections, slow queries, and top queries.
+- Capture Cloudflare Worker route counts, cron invocations, Workflow attempts, Queue retries, subrequest counts, and cache hit/miss data.
+- Segment by route family and deployment time.
+
+After each fix:
+
+- Compare the same metrics over a similar traffic window.
+- Confirm cache hits via `CF-Cache-Status`, cache-specific logs, or explicit internal metrics.
+- Confirm query-count and row-count reduction in Neon.
+- Run representative load tests for structures page loads and fleet active-session viewing.
+- Validate authorization isolation with at least two users whose structure/fleet visibility differs.
+
+Rollback criteria:
+
+- Increased 5xx or auth/permission errors.
+- Evidence of stale private data or cross-tenant/cross-user data exposure.
+- Incorrect pagination, counts, sorting, or fleet timeline order.
+- Cache invalidation failures after structure config or market/fleet updates.
+
+Suggested observation window:
+
+- At least one normal weekday.
+- Include one known fleet/event peak if fleet tracking is suspected.
+- Include at least one full cron cycle set for prediction-market reconciliation.
+
+Safe PostgreSQL checks, if `pg_stat_statements` is available on Neon:
+
+```sql
+select extname
+from pg_extension
+where extname = 'pg_stat_statements';
+
+select query, calls, rows, total_exec_time, mean_exec_time
+from pg_stat_statements
+order by rows desc
+limit 20;
+
+select query, calls, rows, total_exec_time, mean_exec_time
+from pg_stat_statements
+where query ilike '%structure_fuel_log%'
+   or query ilike '%fleet_member%'
+   or query ilike '%fleet_tracking%'
+   or query ilike '%prediction%'
+order by rows desc
+limit 20;
+```
+
+Safe row-size sampling examples:
+
+```sql
+select count(*)
+from structure_fuel_log;
+
+select avg(pg_column_size(t))
+from (
+	select *
+	from structure_fuel_log
+	limit 10000
+) as t;
+```
+
+Do not share raw query text publicly if it contains sensitive literals. Scrub tokens, connection strings, IDs, and private user data from exported logs.
+
+## 13. Unknowns and required access
+
+The following cannot be determined from the repository alone:
+
+- Neon dashboard transfer timeline.
+- Neon top queries by calls, rows, execution time, and transfer.
+- Whether `pg_stat_statements` is enabled.
+- Table row counts and average row sizes in production.
+- Cloudflare route-level request volume.
+- Worker invocation counts by environment.
+- Cron, Queue, Workflow, and Durable Object retry counts.
+- Cache hit/miss rates in production.
+- Production deployment timeline and environment topology.
+- Whether preview or staging deployments use the production Neon database.
+- Actual structures page usage, active fleet session concurrency, and prediction-market activity during the spike.
+
+Final verdict:
+
+```text
+Most likely cause:
+Structures list/overview endpoints repeatedly fetching broad Neon result sets, especially fuel history, without shared caching or SQL-side pagination.
+
+Confidence:
+High for the code mechanism; medium-high that it explains the production spike until Neon/Cloudflare metrics confirm volume.
+
+Why:
+Recent structures commits materially changed this area, and current code loads all visible structures plus related history/config data before slicing results.
+
+Relevant change:
+5a7658fc, 05a37a6b, dd47a73b, 592d1830 touching structures service/routes/UI.
+
+Recommended first action:
+Pull Neon top queries by calls/rows and Cloudflare route counts for /api/structures over the 2026-06-21 to 2026-07-21 window.
+
+Metric needed to confirm:
+A post-deploy rise in calls/rows/transfer for structure tables, especially structure_fuel_log, correlated with /api/structures route traffic.
+```

--- a/docs/MOONS_UTILISATION_ROADMAP.md
+++ b/docs/MOONS_UTILISATION_ROADMAP.md
@@ -1,0 +1,325 @@
+# Moon Scan Utilisation Roadmap
+
+Date: 2026-07-22
+
+## Scope
+
+This roadmap covers Moon Scan database and Worker utilisation only.
+
+Out of scope:
+
+- Structures work. Another owner is already handling that area.
+- General auth/session optimisation, except where Moon routes amplify it.
+- Product changes to Moon Scan functionality that are not needed for utilisation.
+
+## Current State
+
+Moon Scan is not in the same risk category as Structures because verified moon list reads already have a summary read model and SQL-side pagination through `MoonScanDO.getVerifiedMoonPage`.
+
+The remaining pressure points are narrower:
+
+- Profit sorting on verified moons falls back to full verified-moon hydration before pagination.
+- The normal verified-moons route performs request-time summary consistency checks and lazy backfill.
+- Region and system map endpoints compute coverage from broad moon ID sets.
+- CSV export repeats pricing/material input work per page.
+- The UI can amplify these routes through per-keystroke search and 5-second export polling.
+
+## Success Criteria
+
+- `/api/moon-scan/moons/verified` never scans all verified moon IDs during normal list requests.
+- Profit sorting uses SQL pagination or a precomputed read model, not full Worker-side hydration.
+- Region overview and region detail no longer transfer all scanned/verified moon IDs per request.
+- CSV export reuses pricing inputs across pages within a run.
+- UI search generates at most one API request per debounce window.
+- Moon-specific route logs expose path choice, row counts, page counts, and duration.
+- Neon top-query data shows lower rows returned and transfer for Moon Scan routes after rollout.
+
+## Phase 0: Measurement First
+
+Goal: prove the hot paths in production before changing behaviour.
+
+Tasks:
+
+- Add structured timing logs or metrics for `/moons/verified`.
+- Record whether the request used:
+  - summary-page path
+  - lazy summary backfill
+  - profit-sort/full-hydration path
+  - fallback legacy hydration after summary failure
+- Record request parameters that affect cost:
+  - `sortBy`
+  - `page`
+  - `pageSize`
+  - presence of `regionId`, `constellationId`, `rarity`, `search`
+- Record workload sizes:
+  - verified moon ID count
+  - summary missing count
+  - page moon count
+  - composition count
+  - ore type count
+  - material type count
+  - export page count
+- Add comparable metrics for:
+  - `/moons/regions`
+  - `/moons/region/:regionId`
+  - `/moons/system/:systemId`
+  - `/moons/verified/export`
+  - `/moons/verified/export/:workflowInstanceId`
+
+Acceptance:
+
+- We can answer which Moon route accounts for the most Worker CPU, DB rows returned, and repeated calls.
+- We can distinguish normal summary-page traffic from profit-sort and fallback traffic.
+
+## Phase 1: Remove Request-Time Summary Backfill
+
+Goal: keep the verified moon summary table fresh without doing global checks on reads.
+
+Problem:
+
+- The verified-moons route calls `getScanSummary()` and `getVerifiedMoonSummaryIds()` before paginated reads.
+- `getScanSummary()` returns all scanned and verified moon IDs.
+- `getVerifiedMoonSummaryIds()` returns all summary moon IDs.
+- Missing summaries are backfilled inline during user requests.
+
+Tasks:
+
+- Move summary creation/update to the write paths:
+  - `submitScans(..., autoVerify: true)`
+  - `verifyScan`
+  - `verifyScans`
+- Add a dedicated backfill workflow or admin maintenance endpoint for historical gaps.
+- Remove the global summary ID comparison from `/moons/verified`.
+- Keep a defensive fallback for summary read failures, but log it as exceptional.
+- Add a summary freshness check that can be run manually or on a schedule without blocking user reads.
+
+Acceptance:
+
+- A normal verified-moons page request performs one count query, one paginated summary query, and page-scoped composition/pricing work only.
+- New verified scans appear in `moon_verified_moon_summaries` immediately or through an explicit async job.
+- There is no per-request read of all verified moon IDs.
+
+## Phase 2: Precompute Profit For SQL Sorting
+
+Goal: make `metenoxProfit` and `tataraProfit` sorting as cheap as other verified moon sorts.
+
+Problem:
+
+- Sorting by profit currently hydrates every verified composition.
+- The Worker computes profitability for all verified moons, filters/sorts in memory, then slices the page.
+
+Recommended model:
+
+- Add profit fields to `moon_verified_moon_summaries`, or create a companion `moon_verified_moon_profit_summaries` table.
+- Store:
+  - `moonId`
+  - `metenoxProfit`
+  - `tataraProfit`
+  - `profitCalculatedAt`
+  - `pricingSnapshotAt`
+  - `settingsVersion` or equivalent invalidation marker
+- Index:
+  - `metenoxProfit`
+  - `tataraProfit`
+  - common compound filters such as `regionId, metenoxProfit` and `regionId, tataraProfit` if query plans need them.
+
+Tasks:
+
+- Extract the existing profit calculation into reusable server-side logic.
+- Add migration for the profit read model.
+- Update profit summaries when:
+  - a scan is verified
+  - extraction settings change
+  - structure profiles change
+  - market pricing snapshot changes or a scheduled refresh runs
+- Extend `getVerifiedMoonPage()` to support profit sort columns.
+- Remove the profit-sort legacy hydration path.
+
+Acceptance:
+
+- Profit sorting uses paginated SQL queries.
+- The number of compositions loaded for a verified page is bounded by `pageSize`.
+- Profit values are clearly timestamped so stale data is visible and debuggable.
+
+## Phase 3: Coverage Aggregates For Map Routes
+
+Goal: avoid broad scanned/verified moon ID transfer for region and system map views.
+
+Problem:
+
+- `/moons/regions` reads all scanned and verified moon IDs, then maps them to regions in Worker code.
+- `/moons/region/:regionId` resolves every moon in the region and calls `getMoonCoverage()` for the whole set.
+- `/moons/system/:systemId` is smaller but uses the same coverage method.
+
+Recommended model:
+
+- Maintain a coverage read model keyed by moon ID, system ID, and region ID.
+- At minimum, expose aggregate DO methods:
+  - `getRegionCoverageSummary(regionIds: string[])`
+  - `getSystemCoverageSummary(systemIds: string[])`
+  - `getMoonCoverage(moonIds: string[])` for small detail views only
+
+Tasks:
+
+- Add or derive fields for:
+  - scanned moon count by region
+  - verified moon count by region
+  - scanned moon count by system
+  - verified moon count by system
+- Update coverage aggregates on scan submit, verify, and reject.
+- Add a repair/backfill job for aggregate correctness.
+- Use aggregate methods in:
+  - `/moons/regions`
+  - `/moons/region/:regionId`
+  - `/moons/system/:systemId` where useful
+
+Acceptance:
+
+- Region overview does not transfer every scanned or verified moon ID.
+- Region detail computes per-system counts from aggregate data, not by checking every moon ID against scan tables.
+- Backfill can rebuild aggregates from source tables.
+
+## Phase 4: Shared Caching For Stable Moon Reads
+
+Goal: reduce repeated Worker and DB work across users, browsers, isolates, and regions.
+
+Candidate routes:
+
+- `/moons/regions`
+- `/moons/region/:regionId`
+- `/moons/system/:systemId`
+- `/leaderboard`
+- `/moons/verified` for non-sensitive, permission-gated result pages
+
+Cache strategy:
+
+- Always perform permission checks before returning cached protected data.
+- Key cached data by route, query params, and a Moon data version.
+- Use short TTLs first:
+  - regions: 5-15 minutes
+  - region detail: 1-5 minutes
+  - system detail: 1-5 minutes
+  - leaderboard: 1-5 minutes
+  - verified list pages: 1-5 minutes after summary/profit read models are fixed
+- Invalidate or version-bump on submit, verify, reject, settings update, and profit refresh.
+
+Acceptance:
+
+- Repeat requests for stable Moon pages avoid repeated Neon reads after permission check.
+- Cache keys cannot leak data across permission scopes.
+- Metrics show cache hit/miss rates by route.
+
+## Phase 5: CSV Export Efficiency
+
+Goal: keep export bounded and avoid repeated per-page pricing work.
+
+Current strengths:
+
+- Export requires `regionId` or `constellationId`, so it is scoped.
+- Export streams to R2 instead of building one large response body.
+
+Problems:
+
+- Each export page calls `getVerifiedMoonPage()`.
+- Each page then loads page compositions and calls pricing/material helpers.
+- Settings, profiles, type names, materials, and market prices can be repeated across pages.
+
+Tasks:
+
+- Build export-level pricing inputs once per workflow run where possible.
+- Cache `getMoonPricingInputs` by ore type set and pricing timestamp within the workflow.
+- Reuse settings and structure profiles across pages.
+- Add export metrics:
+  - page count
+  - row count
+  - composition count
+  - pricing lookup count
+  - elapsed duration
+- Consider using the profit read model for the CSV profit columns, then fetch ore detail only for row expansion.
+
+Acceptance:
+
+- Export pricing/material lookup count is not proportional to page count when inputs are unchanged.
+- Large scoped exports complete with predictable page-level work.
+- Export status polling does not dominate auth/session traffic.
+
+## Phase 6: UI Request Throttling
+
+Goal: reduce unnecessary protected API calls from the Moon UI.
+
+Tasks:
+
+- Debounce scanned-moon search input by 300-500ms.
+- Keep `page` reset local, but only send the debounced search value to `useScannedMoons`.
+- Back off export status polling:
+  - start at 2-5 seconds
+  - increase interval for long-running exports
+  - stop immediately on terminal status
+- Consider a lightweight status endpoint or session-activity throttle if export polling shows up in auth/session metrics.
+
+Acceptance:
+
+- Typing a search term does not issue one request per keystroke.
+- Long-running exports produce fewer protected status requests.
+- Existing React Query stale windows remain intact.
+
+## Rollout Plan
+
+1. Ship Phase 0 metrics.
+2. Validate production route mix for at least one normal traffic window.
+3. Ship Phase 6 UI throttling as a low-risk quick win.
+4. Ship Phase 1 summary write-path updates and remove read-time backfill.
+5. Ship Phase 2 profit read model behind metrics and compare results with current live calculation.
+6. Ship Phase 3 coverage aggregates and route rewrites.
+7. Add shared caching after the read models are stable.
+8. Optimise export internals once profit summaries are available.
+
+## Risks And Mitigations
+
+- Risk: profit values become stale.
+  - Mitigation: store calculation timestamps and refresh version markers.
+
+- Risk: aggregate coverage counts drift.
+  - Mitigation: keep source tables authoritative and provide a rebuild job.
+
+- Risk: cached protected data leaks across access scopes.
+  - Mitigation: permission-check before cache reads and key by access scope where needed.
+
+- Risk: removing lazy summary backfill hides historical gaps.
+  - Mitigation: create an explicit backfill workflow before removing the read-time path.
+
+- Risk: migration exists but production table was created by the runtime initializer without indexes.
+  - Mitigation: verify `0001_wandering_bloodstorm.sql` is applied in production and check query plans.
+
+## Production Evidence To Collect
+
+- Neon top queries for Moon tables by calls, rows returned, and transfer.
+- Cloudflare route counts for `/api/moon-scan/*`.
+- Worker CPU duration by Moon route.
+- DO RPC counts for:
+  - `getScanSummary`
+  - `getVerifiedMoonSummaryIds`
+  - `getVerifiedMoonPage`
+  - `getVerifiedCompositions`
+  - `getMoonCoverage`
+- Count of verified moons and scanned moons over time.
+- Export workflow frequency, duration, and row counts.
+
+## Expected Impact
+
+Highest expected impact:
+
+- Removing profit-sort full hydration.
+- Removing request-time summary backfill.
+- Replacing region coverage scans with aggregate counts.
+
+Medium expected impact:
+
+- Export pricing reuse.
+- Shared caching for region/system/leaderboard pages.
+
+Low-risk quick wins:
+
+- Search debounce.
+- Export polling backoff.
+- Metrics for route path choice and workload sizes.

--- a/packages/markets/src/index.ts
+++ b/packages/markets/src/index.ts
@@ -48,6 +48,9 @@ export interface Markets {
 		input: GetBatchMarketDataAtTimeInput
 	): Promise<GetBatchMarketDataResponse>
 
+	/** Return the revision of the daily price set used for time-relative lookups. */
+	getMarketDataRevisionAtTime(input: Pick<GetBatchMarketDataAtTimeInput, 'regionId' | 'atTime'>): Promise<string | null>
+
 	/**
 	 * Start automatic hourly snapshots for a region
 	 * Takes an immediate snapshot, then schedules hourly snapshots via alarm

--- a/packages/moon-scan/src/index.ts
+++ b/packages/moon-scan/src/index.ts
@@ -16,6 +16,8 @@ export type VerifiedMoonsSortBy =
 	| 'regionName'
 	| 'securityStatus'
 	| 'highestRarity'
+	| 'metenoxProfit'
+	| 'tataraProfit'
 
 export interface VerifiedMoonSummary {
 	moonId: string
@@ -37,11 +39,40 @@ export interface VerifiedMoonSummaryRecord extends VerifiedMoonSummary {
 }
 
 export interface VerifiedMoonPage {
-	items: VerifiedMoonSummary[]
+	items: Array<VerifiedMoonSummary & {
+		metenoxProfit?: string | null
+		tataraProfit?: string | null
+	}>
 	total: number
 	page: number
 	pageSize: number
 	constellations: Array<{ constellationId: string; constellationName: string }>
+}
+
+export interface MoonProfitabilityQueryInputs {
+	defaultReprocessingYield: string
+	defaultCycleDays: number
+	fuelBlockPriceOverride: string | null
+	magmaticGasPriceOverride: string | null
+	profiles: Array<{
+		id: StructureType
+		baseVolumePerHr: string
+		rigBonus: string
+		fuelPerHr: string
+		magmaticGasPerHr: string | null
+		nullsecModifier: string
+		isPassive: boolean
+	}>
+	typeMaterials: Array<{
+		oreTypeId: string
+		materialTypeId: string
+		quantity: number
+	}>
+	oreVolumes: Record<string, number>
+	prices: Array<{
+		typeId: string
+		price: number
+	}>
 }
 
 export interface VerifiedMoonRegionCount {
@@ -218,6 +249,7 @@ export interface MoonProfitability {
 	ores: OreWithProfitability[]
 	structures: StructureProfitability[]
 	updatedAt: string
+	pricingSnapshotDate: string | null
 }
 
 export interface MoonScanDO {
@@ -243,6 +275,7 @@ export interface MoonScanDO {
 		search?: string
 		sortBy: VerifiedMoonsSortBy
 		sortDir: 'asc' | 'desc'
+		profitability?: MoonProfitabilityQueryInputs
 	}): Promise<VerifiedMoonPage>
 	getVerifiedMoonSummaryIds(): Promise<string[]>
 	upsertVerifiedMoonSummaries(summaries: VerifiedMoonSummaryRecord[]): Promise<void>

--- a/packages/moon-scan/src/index.ts
+++ b/packages/moon-scan/src/index.ts
@@ -44,6 +44,11 @@ export interface VerifiedMoonPage {
 	constellations: Array<{ constellationId: string; constellationName: string }>
 }
 
+export interface VerifiedMoonRegionCount {
+	regionId: string
+	verifiedCount: number
+}
+
 const RARITY_BUCKETS: readonly OreRarity[] = ['R4', 'R8', 'R16', 'R32', 'R64']
 
 function getRarityByIndex(index: number): OreRarity {
@@ -75,6 +80,8 @@ export interface MoonScanOre {
 export interface MoonScan {
 	id: string
 	moonId: string
+	regionId: string | null
+	solarSystemId: string | null
 	submittedBy: string | null
 	submittedAt: string
 	status: MoonScanStatus
@@ -144,7 +151,20 @@ export interface StructureProfile {
 
 export interface SubmitScanInput {
 	moonId: string
+	regionId: string
+	solarSystemId: string
 	ores: MoonScanOre[]
+}
+
+export interface ScanLocation {
+	moonId: string
+	regionId: string
+	solarSystemId: string
+}
+
+export interface ScannedMoonRegionCount {
+	regionId: string
+	scannedCount: number
 }
 
 export interface ScanFilters {
@@ -226,9 +246,13 @@ export interface MoonScanDO {
 	}): Promise<VerifiedMoonPage>
 	getVerifiedMoonSummaryIds(): Promise<string[]>
 	upsertVerifiedMoonSummaries(summaries: VerifiedMoonSummaryRecord[]): Promise<void>
+	getVerifiedMoonCountsByRegionIds(regionIds: string[]): Promise<VerifiedMoonRegionCount[]>
 	// Leaderboard
 	getLeaderboard(window: LeaderboardWindow): Promise<LeaderboardEntry[]>
 	// Stats for map
+	getScannedMoonCountsByRegionIds(regionIds: string[]): Promise<ScannedMoonRegionCount[]>
+	getUnlocatedScannedMoonIds(limit: number, afterMoonId?: string): Promise<string[]>
+	backfillScanLocations(locations: ScanLocation[]): Promise<void>
 	getScanSummary(): Promise<{ scannedMoonIds: string[]; verifiedMoonIds: string[] }>
 	getMoonCoverage(moonIds: string[]): Promise<MoonCoverageStat[]>
 	// Character name resolution


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Cuts redundant Neon/DB and Worker work in the Moon Scan flow: read routes are now cached, verified-moon summaries and region/system moon counts are computed from DB-backed aggregates instead of per-request scans, and profitability sorting/pricing is pushed into SQL and shared across pages. Also adds a scan location (region/system) backfill so pricing/region queries can rely on stored `regionId`/`solarSystemId` instead of always resolving them via the Universe API, and improves pricing-source transparency and search UX in the UI.

## Changes
- `apps/core/src/routes/moon-scan.ts`:
  - Added `TimeCache` response caches (10s–24h TTLs) for verified-moons, regions, region detail, system detail, leaderboard, and pricing-input/pricing-revision lookups; caches are invalidated (`clearMoonScanReadCaches`/`clearMoonScanPricingCaches`) whenever scans are submitted/verified/rejected or extraction settings/structure profiles change.
  - `/moons/regions` and the verified-moons list now use DB-backed `getScannedMoonCountsByRegionIds`/`getVerifiedMoonCountsByRegionIds`/`getVerifiedMoonPage` instead of scanning all scan/verified moon IDs and resolving regions via the Universe API per request.
  - Extracted `getMoonPricingInputsForOreTypeIds`, cached by ore-type-id set + market pricing revision, and reused it so CSV export and the verified-moons list share pricing inputs instead of recomputing them; results now also carry `oreVolumes` and a `pricingSnapshotDate`.
  - Replaced the large inline profit-calculation closures in the verified-moons route with a shared `getMoonProfitValuesFromComposition` helper, and pushed profit-based sorting (`metenoxProfit`/`tataraProfit`) down into the DB query via `MoonProfitabilityQueryInputs`.
  - Added `resolveSolarSystemsWithCache`/`backfillScanLocations` to backfill missing `regionId`/`solarSystemId` on existing scans in batches.
  - Removed the per-request "scan all verified moon IDs / lazily backfill missing summaries" step from `/moons/verified`; verified-moon summaries are now upserted directly from the scan submit/verify/verify-all write paths via `queueVerifiedMoonSummaryUpsert` (fire-and-forget via `executionCtx.waitUntil`), with the old backfill logic moved to an on-demand admin endpoint.
- `apps/moon-scan/src/db/schema.ts` + `.migrations/0002_ancient_medusa.sql`: adds nullable `region_id`/`solar_system_id` columns to `moon_scans` plus a `(region_id, moon_id)` index.
- `apps/moon-scan/src/durable-object.ts` / `packages/moon-scan/src/index.ts`: `submitScan` now stores `regionId`/`solarSystemId`; adds `getVerifiedMoonCountsByRegionIds`, `getScannedMoonCountsByRegionIds`, `getUnlocatedScannedMoonIds`, and `backfillScanLocations` RPC methods; `getVerifiedMoonPage` accepts an optional `profitability` input and computes/sorts by `metenoxProfit`/`tataraProfit` via a raw-SQL CTE query.
- `apps/markets/src/durable-object.ts` / `packages/markets/src/index.ts`: adds `getMarketDataRevisionAtTime`, returning a revision token (`priceDate:updatedAt`) for the daily price set used in time-relative lookups, used to key the pricing-input cache.
- UI (`apps/ui/src/client/features/moon-scan/...`, `eve-time-display.tsx`): debounces the moon search input (400ms via `useDebounce`); adds a `pricingSnapshotDate` to profitability responses and surfaces a "Pricing Source: Global Daily Average / Snapshot: {date}" indicator on the scanned-moons list and moon detail profitability card, using a new `date` display variant on `EveTimeDisplay`.
- Added `docs/CACHING_IMPROVEMENTS.md` (investigation into recent Neon data-transfer growth across the repo) and `docs/MOONS_UTILISATION_ROADMAP.md` (phased plan for further reducing Moon Scan DB/Worker utilisation).

## Testing
Updated integration tests in `apps/core/src/routes/__tests__/moon-scan.access.route.test.ts` and `moon-scan.profitability-and-batching.route.test.ts` to cover the new region-count RPCs and DB-backed profitability sorting/pagination. No new test files were added.
<!-- claude:end -->