### PR TITLE
stop public info endpoint force refetch and stop re-checking legacy after applied

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -567,7 +567,7 @@ export class CoreWorker extends WorkerEntrypoint<Env> {
 		if (!ownership) return { modernUserId: null, items: [] }
 
 		const legacyStub = getStub<Legacy>(this.env.LEGACY, 'default')
-		await legacyStub.recheckUser(ownership.userId, 'system:fulcrum-report', { force: true })
+		await legacyStub.recheckUser(ownership.userId, 'system:fulcrum-report')
 		const listing = await legacyStub.listMigrations({
 			page: 1,
 			pageSize: 100,

--- a/apps/core/src/services/character-affiliation-hydration.service.ts
+++ b/apps/core/src/services/character-affiliation-hydration.service.ts
@@ -43,7 +43,7 @@ export async function hydrateCharacterAffiliation(
 	const { db, env, characterId, executionCtx } = params
 	const eveCharacterData = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
 
-	const publicRefreshResult = await eveCharacterData.refreshPublicCharacterData(characterId, true)
+	const publicRefreshResult = await eveCharacterData.refreshPublicCharacterData(characterId, false)
 
 	if (publicRefreshResult.isDeleted) {
 		await markCharacterDeletedEverywhere(db, env, characterId)

--- a/apps/core/src/services/mumble.service.ts
+++ b/apps/core/src/services/mumble.service.ts
@@ -615,7 +615,7 @@ export async function provisionTempopGuest(
 
 	// Fetch identity + affiliation (no persistence to core tables).
 	const characterStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
-	const publicData = await characterStub.refreshPublicCharacterData(characterId, true)
+	const publicData = await characterStub.refreshPublicCharacterData(characterId, false)
 	const characterName = publicData.characterName ?? `Pilot ${characterId}`
 	const corporationId = publicData.currentCorporationId ?? null
 	const allianceId = publicData.currentAllianceId ?? null

--- a/apps/core/src/workflows/steps/update-character/update-character-public.ts
+++ b/apps/core/src/workflows/steps/update-character/update-character-public.ts
@@ -42,7 +42,7 @@ export async function updateCharacterPublicInfo(
 	const logger = getWorkflowLogger(ctx, 'update-character-public-info')
 	const eveCharDataStub = getStub<EveCharacterData>(ctx.env.EVE_CHARACTER_DATA, characterId)
 
-	const publicRefreshResult = await eveCharDataStub.refreshPublicCharacterData(characterId, true)
+	const publicRefreshResult = await eveCharDataStub.refreshPublicCharacterData(characterId, false)
 
 	if (publicRefreshResult.isDeleted) {
 		await markCharacterDeletedEverywhere(ctx.db, ctx.env, characterId, {

--- a/apps/legacy/src/durable-object.ts
+++ b/apps/legacy/src/durable-object.ts
@@ -754,6 +754,29 @@ export class LegacyDO extends DurableObject<Env> implements Legacy {
 		if (!targetUser) {
 			throw new Error('Target user not found')
 		}
+		if (!force) {
+			// Terminal migrations are sticky during normal rechecks: once a user has an
+			// applied or dismissed legacy migration, later non-forced rechecks should
+			// not reopen the queue for that user.
+			const terminalMigrations = await this.db.query.legacyMigrationQueue.findMany({
+				where: and(
+					eq(legacyMigrationQueue.modernUserId, modernUserId),
+					inArray(legacyMigrationQueue.status, ['applied', 'dismissed'])
+				),
+				columns: { legacyAuthUserId: true },
+			})
+			if (terminalMigrations.length > 0) {
+				return {
+					ok: true,
+					modernUserId,
+					legacyAuthUserIds: [...new Set(terminalMigrations.map((row) => row.legacyAuthUserId))],
+					created: 0,
+					updated: 0,
+					dismissed: 0,
+					matches: [],
+				}
+			}
+		}
 		const modernCharacterIds = [...new Set(targetUser.characters.map((c) => c.characterId))]
 		if (modernCharacterIds.length === 0) {
 			return { ok: true, modernUserId, created: 0, updated: 0, dismissed: 0, matches: [] }

--- a/apps/legacy/src/index.test.ts
+++ b/apps/legacy/src/index.test.ts
@@ -268,7 +268,7 @@ describe('legacy durable object rpc', () => {
 		)
 	})
 
-	it('keeps an applied migration applied when a recheck finds no new evidence', async () => {
+	it('does not re-trigger an applied migration on a normal recheck', async () => {
 		migrationQueueFindMany
 			.mockResolvedValueOnce([
 				{
@@ -303,14 +303,14 @@ describe('legacy durable object rpc', () => {
 
 		expect(result.ok).toBe(true)
 		expect(result.legacyAuthUserIds).toEqual(['legacy-1'])
-		expect(updateSetMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				status: 'applied',
-			})
-		)
+		expect(result.created).toBe(0)
+		expect(result.updated).toBe(0)
+		expect(result.dismissed).toBe(0)
+		expect(updateSetMock).not.toHaveBeenCalled()
+		expect(actionInsertValues).not.toHaveBeenCalled()
 	})
 
-	it('reopens an applied migration when a recheck finds new evidence', async () => {
+	it('reopens an applied migration when force recheck finds new evidence', async () => {
 		legacyCharactersFindMany.mockResolvedValue([
 			{ characterId: '2001', characterName: 'One', source: 'esi_owner' },
 			{ characterId: '2002', characterName: 'Two', source: 'xml_account' },
@@ -348,6 +348,7 @@ describe('legacy durable object rpc', () => {
 		)
 
 		expect(result.ok).toBe(true)
+		expect(result.legacyAuthUserIds).toEqual(['legacy-1'])
 		expect(updateSetMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				status: 'pending',


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Stops two sources of unnecessary work: character public-info refreshes no longer force a re-fetch on every read, and the legacy migration recheck no longer reopens a user's migration queue once it has reached a terminal (`applied`/`dismissed`) state.

## Changes
- `refreshPublicCharacterData` is now called with `force: false` in `character-affiliation-hydration.service.ts`, `mumble.service.ts`, and `update-character-public.ts`, so cached public character data is reused instead of always force-refetching from ESI.
- Removed the `{ force: true }` option from the `legacyStub.recheckUser` call in `apps/core/src/index.ts`'s fulcrum-report handler.
- `LegacyDO.recheckUser` now short-circuits non-forced rechecks: if the user already has any `applied` or `dismissed` migration, it returns immediately without re-querying characters or touching the queue, keeping terminal migrations sticky.
- Updated `apps/legacy/src/index.test.ts` to match: renamed/adjusted tests to assert that a normal recheck no longer touches the queue (`updateSetMock`/`actionInsertValues` not called) while a forced recheck still reopens an applied migration on new evidence.

## Testing
- Updated unit tests in `apps/legacy/src/index.test.ts` cover both the non-forced short-circuit path and the forced-recheck reopening path.
<!-- claude:end -->