### PR TITLE
Fix/srp query refactor

### DIFF
--- a/apps/core/src/routes/__tests__/srp.route.test.ts
+++ b/apps/core/src/routes/__tests__/srp.route.test.ts
@@ -110,15 +110,10 @@ function createApp(user?: SessionUser, db?: any) {
 		withdrawRequest: vi.fn(),
 		getComments: vi.fn().mockResolvedValue([]),
 		addComment: vi.fn(),
-		approveRequest: vi.fn(),
-		backfillRecentLossesFromCache: vi.fn().mockResolvedValue({
-			characterId: '7001',
-			cachedLosses: 0,
-			persistedLosses: 0,
-		}),
-		startRecentLossRefresh: vi.fn().mockResolvedValue({
-			allowed: true,
-			retryAfterMs: 0,
+	approveRequest: vi.fn(),
+	startRecentLossRefresh: vi.fn().mockResolvedValue({
+		allowed: true,
+		retryAfterMs: 0,
 			cooldownUntil: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
 			workflowInstanceId: 'workflow-1',
 			status: 'queued',
@@ -161,6 +156,18 @@ function makeRequest(overrides: Record<string, unknown> = {}) {
 	}
 }
 
+function sqlText(query: unknown): string {
+	if (typeof query === 'string') return query
+	if (query === null || typeof query !== 'object') return ''
+
+	const node = query as { queryChunks?: unknown[]; value?: unknown }
+	if (Array.isArray(node.queryChunks)) {
+		return node.queryChunks.map(sqlText).join('')
+	}
+	if (Array.isArray(node.value)) return node.value.join('')
+	return ''
+}
+
 function mockDbPrimaryCharacterRows(
 	rows: Array<{ userId: string; characterId: string; characterName?: string }>
 ) {
@@ -176,6 +183,58 @@ function mockDbPrimaryCharacterRows(
 			},
 		},
 	} as any)
+}
+
+function makeWalletHistoryDbMock(options: {
+	rows: Array<{
+		journalId: string
+		refType: string | null
+		amount: string
+		reason: string | null
+		recipientId: string | null
+		entryDate: Date | string | number | null
+		requestIdFromReason: string | null
+		linkedRequestId: string | null
+		expectedRequestCharacterId: string | null
+		hasRecipientMismatch: boolean
+		hasMissingReasonWarning: boolean
+		hasOpenAlert: boolean
+	}>
+	total: number
+	alerts: Array<{
+		journalId: string
+		kind: string
+		state: string
+		expectedAmount: string | null
+		observedAmount: string | null
+		expectedRecipientCharacterId: string | null
+		expectedRecipientCharacterName: string | null
+		actualRecipientCharacterId: string | null
+		actualRecipientCharacterName: string | null
+	}>
+}) {
+	const capturedQueries: string[] = []
+	const execute = vi.fn(async (query: unknown) => {
+		const text = sqlText(query).replace(/\s+/g, ' ').trim().toLowerCase()
+		capturedQueries.push(text)
+
+		if (text.includes('cast(count(*) as integer) as "total"')) {
+			return { rows: [{ total: options.total }] }
+		}
+		if (text.includes('from srp_payment_alerts')) {
+			return { rows: options.alerts }
+		}
+		if (text.includes('from wallet_history_base')) {
+			return { rows: options.rows }
+		}
+		return { rows: [] }
+	})
+
+	return {
+		db: { execute } as any,
+		execute,
+		capturedQueries,
+	}
 }
 
 describe('srp routes - permissions', () => {
@@ -299,6 +358,74 @@ describe('srp routes - permissions', () => {
 				}),
 			})
 		)
+	})
+
+	it('queries wallet history alerts-only pages in SQL', async () => {
+		const walletHistoryDb = makeWalletHistoryDbMock({
+			rows: [
+				{
+					journalId: '9001',
+					refType: 'corporation_account_withdrawal',
+					amount: '1000000',
+					reason: 'KM#12345 reimbursement',
+					recipientId: '7002',
+					entryDate: '2026-07-15T12:00:00.000Z',
+					requestIdFromReason: '12345',
+					linkedRequestId: '12345',
+					expectedRequestCharacterId: '7001',
+					hasRecipientMismatch: true,
+					hasMissingReasonWarning: false,
+					hasOpenAlert: true,
+				},
+			],
+			total: 1,
+			alerts: [
+				{
+					journalId: '9001',
+					kind: 'recipient_mismatch',
+					state: 'open',
+					expectedAmount: '1000000',
+					observedAmount: '1000000',
+					expectedRecipientCharacterId: '7001',
+					expectedRecipientCharacterName: 'Pilot One',
+					actualRecipientCharacterId: '7002',
+					actualRecipientCharacterName: 'Pilot Two',
+				},
+			],
+		})
+		const app = createApp(makeUser({ id: 'wallet-history-user', is_admin: true }), walletHistoryDb.db)
+		srpStub.getConfig.mockResolvedValue({ paymentProcessorCorporationId: '9000' })
+		resolverStub.resolveIds.mockResolvedValue({
+			'7001': 'Pilot One',
+			'7002': 'Pilot Two',
+		})
+
+		const response = await app.request(
+			'/api/srp/payments/wallet-history?alertsOnly=true&limit=1&offset=0',
+			{},
+			env
+		)
+		const body = await response.json<any>()
+
+		expect(response.status).toBe(200)
+		expect(body.total).toBe(1)
+		expect(body.limit).toBe(1)
+		expect(body.offset).toBe(0)
+		expect(body.items).toHaveLength(1)
+		expect(body.items[0]).toEqual(expect.objectContaining({ journalId: '9001' }))
+
+		expect(walletHistoryDb.execute).toHaveBeenCalledTimes(3)
+		const [rowsQuery, countQuery, alertsQuery] = walletHistoryDb.capturedQueries
+		expect(rowsQuery).toContain('from wallet_history_base')
+		expect(rowsQuery).toContain('where "hasopenalert" or "hasmissingreasonwarning"')
+		expect(rowsQuery).toContain('order by "entrydate" desc, "journalid" desc')
+		expect(rowsQuery).toContain('limit')
+		expect(rowsQuery).toContain('offset')
+		expect(countQuery).toContain('from wallet_history_base')
+		expect(countQuery).toContain('where "hasopenalert" or "hasmissingreasonwarning"')
+		expect(countQuery).toContain('cast(count(*) as integer) as "total"')
+		expect(alertsQuery).toContain('from srp_payment_alerts')
+		expect(alertsQuery).toContain('journal_id in')
 	})
 
 	it('exports paid SRP requests as CSV for reviewer users', async () => {
@@ -699,53 +826,6 @@ describe('srp routes - permissions', () => {
 				totalCharacters: 2,
 			},
 		})
-	})
-
-	it('backfills cached losses for all users with SRP request history', async () => {
-		const app = createApp(makeUser({ id: 'srp-backfill-admin', is_admin: true }))
-		const execute = vi.fn().mockResolvedValue({
-			rows: [{ userId: 'user-1' }, { userId: 'user-2' }],
-		})
-		const findMany = vi.fn().mockResolvedValue([
-			{ userId: 'user-1', characterId: '7001', characterName: 'Pilot One' },
-			{ userId: 'user-1', characterId: '7002', characterName: 'Pilot Two' },
-			{ userId: 'user-2', characterId: '8001', characterName: 'Other Pilot' },
-		])
-		createDbMock.mockReturnValue({
-			execute,
-			query: {
-				userCharacters: {
-					findMany,
-				},
-			},
-		} as any)
-
-		const response = await app.request('/api/srp/losses/refresh/backfill', { method: 'POST' }, env)
-		const body = await response.json<any>()
-
-		expect(response.status).toBe(202)
-		expect(body).toMatchObject({
-			success: true,
-			usersWithHistory: 2,
-			usersQueued: 2,
-			totalCharacters: 3,
-		})
-		expect(srpStub.backfillRecentLossesFromCache).toHaveBeenCalledTimes(3)
-		expect(srpStub.backfillRecentLossesFromCache).toHaveBeenCalledWith('7001')
-		expect(srpStub.backfillRecentLossesFromCache).toHaveBeenCalledWith('7002')
-		expect(srpStub.backfillRecentLossesFromCache).toHaveBeenCalledWith('8001')
-		expect(execute).toHaveBeenCalled()
-		expect(findMany).toHaveBeenCalled()
-	})
-
-	it('denies backfill refresh without manager access', async () => {
-		const app = createApp(makeUser({ id: 'srp-backfill-denied' }))
-
-		const response = await app.request('/api/srp/losses/refresh/backfill', { method: 'POST' }, env)
-
-		expect(response.status).toBe(403)
-		expect(await response.json()).toEqual({ error: 'Requires manager-or-higher permissions' })
-		expect(srpStub.backfillRecentLossesFromCache).not.toHaveBeenCalled()
 	})
 
 	it('denies non-owner non-staff from viewing another request', async () => {

--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -32,7 +32,6 @@ import type {
 	LossWithSRPStatus,
 	SRPCommentResponse,
 	SRPRequestResponse,
-	RecentLossRefreshCharacterInput,
 	RecentLossRefreshCoordinator,
 	RequestStatus,
 	Srp,
@@ -103,55 +102,6 @@ function normalizeUserRequestListResult(
 	}
 
 	return result
-}
-
-type SrpBackfillRefreshCandidate = {
-	userId: string
-	characters: RecentLossRefreshCharacterInput[]
-}
-
-async function loadSrpBackfillRefreshCandidates(db: ReturnType<typeof createDb>): Promise<SrpBackfillRefreshCandidate[]> {
-	const historyUsers = await db.execute<{ userId: string }>(
-		sql`select user_id::text as "userId"
-			from srp_requests
-			group by user_id
-			order by "userId" asc`
-	)
-
-	const userIds = [...new Set((historyUsers.rows ?? []).map((row) => row.userId).filter(Boolean))]
-	if (userIds.length === 0) return []
-
-	const rows = await db.query.userCharacters.findMany({
-		where: and(
-			inArray(userCharacters.userId, userIds),
-			eq(userCharacters.isDeleted, false),
-			eq(userCharacters.status, 'active')
-		),
-		orderBy: [asc(userCharacters.userId), desc(userCharacters.is_primary), asc(userCharacters.characterName)],
-		columns: {
-			userId: true,
-			characterId: true,
-			characterName: true,
-		},
-	})
-
-	const charactersByUser = new Map<string, RecentLossRefreshCharacterInput[]>()
-	for (const row of rows) {
-		const userId = String(row.userId)
-		const nextCharacters = charactersByUser.get(userId) ?? []
-		nextCharacters.push({
-			characterId: String(row.characterId),
-			characterName: row.characterName,
-		})
-		charactersByUser.set(userId, nextCharacters)
-	}
-
-	return userIds
-		.map((userId) => ({
-			userId,
-			characters: charactersByUser.get(userId) ?? [],
-		}))
-		.filter((candidate) => candidate.characters.length > 0)
 }
 
 function isValidSrpRequestId(requestId: string): boolean {
@@ -877,61 +827,6 @@ srp.get('/losses/refresh/status', async (c) => {
 	)
 	const status = await statusStub.getRecentLossRefreshStatus(user.id)
 	return c.json(status)
-})
-
-/**
- * Backfill the canonical SRP killmail table from the existing SRP DO cache
- * for all known users with SRP request history.
- * POST /api/srp/losses/refresh/backfill
- */
-srp.post('/losses/refresh/backfill', async (c) => {
-	const user = c.get('user')!
-	const canManage = await hasSrpTierPermission(c.env, user.id, 'manager', user.is_admin)
-	if (!canManage) return c.json({ error: 'Requires manager-or-higher permissions' }, 403)
-
-	const db = c.get('db') || createDb(c.env.DATABASE_URL)
-	const srpStub = getStub<Srp>(c.env.SRP, 'default')
-	const candidates = await loadSrpBackfillRefreshCandidates(db)
-	const totalCharacters = candidates.reduce((total, candidate) => total + candidate.characters.length, 0)
-	const executionCtx = getExecutionContextOrNull(c)
-
-	const launchBackfill = async () => {
-		for (const candidate of candidates) {
-			for (const character of candidate.characters) {
-				await srpStub.backfillRecentLossesFromCache(character.characterId)
-			}
-		}
-	}
-
-	if (executionCtx) {
-		waitUntilWithTelemetry(
-			executionCtx,
-			'srp.recent-loss-cache.backfill',
-			launchBackfill,
-			{
-				adminUserId: user.id,
-				usersWithHistory: candidates.length,
-				totalCharacters,
-			}
-		)
-	} else {
-		await launchBackfill()
-	}
-
-	return c.json(
-		{
-			success: true,
-			message:
-				candidates.length > 0
-					? 'SRP cached-loss backfill started'
-					: 'No SRP cached losses found to backfill',
-			usersWithHistory: candidates.length,
-			usersQueued: candidates.length,
-			totalCharacters,
-			skippedUsers: 0,
-		},
-		202
-	)
 })
 
 // =============================================================================
@@ -1692,6 +1587,215 @@ export function buildSrpWalletHistoryExportFileName(dateFrom: string, dateTo: st
 	return `srp-wallet-history-${dateFrom.slice(0, 10)}-${dateTo.slice(0, 10)}.csv`
 }
 
+function serializeWalletHistoryEntryDate(value: unknown): string {
+	if (value == null) {
+		return ''
+	}
+	if (typeof value === 'string') {
+		const parsed = parseDateOrNull(value)
+		if (parsed) return parsed.toISOString()
+	}
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return new Date(value).toISOString()
+	}
+	if (value && typeof value === 'object') {
+		try {
+			const rawValue = (value as { valueOf?: () => unknown }).valueOf?.()
+			if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+				return new Date(rawValue).toISOString()
+			}
+			if (typeof rawValue === 'string') {
+				const parsed = parseDateOrNull(rawValue)
+				if (parsed) return parsed.toISOString()
+			}
+		} catch {
+			// Fall through to the generic parse/error path below.
+		}
+		try {
+			const jsonValue = JSON.stringify(value)
+			if (jsonValue) {
+				const unquotedValue = jsonValue.startsWith('"') && jsonValue.endsWith('"')
+					? jsonValue.slice(1, -1)
+					: jsonValue
+				const parsed = parseDateOrNull(unquotedValue)
+				if (parsed) return parsed.toISOString()
+			}
+		} catch {
+			// Fall through to the generic parse/error path below.
+		}
+		if ('toISOString' in value) {
+			try {
+				return (value as { toISOString: () => string }).toISOString()
+			} catch {
+				// Fall through to the generic parse/error path below.
+			}
+		}
+	}
+	const parsed = parseDateOrNull(String(value))
+	if (parsed) return parsed.toISOString()
+	throw new Error(`Invalid wallet history entry date: ${String(value)}`)
+}
+
+function buildSrpWalletHistoryWhereClause(args: {
+	processorCorporationId: string
+	reason?: string
+	recipientId?: string
+	dateFrom?: string
+	dateTo?: string
+}) {
+	const whereParts = [
+		sql`wj.corporation_id = ${args.processorCorporationId}`,
+		sql`wj.ref_type = 'corporation_account_withdrawal'`,
+		sql`exists (
+			select 1
+			from user_characters recipient_char
+			where recipient_char.character_id = wj.second_party_id
+		)`,
+	]
+
+	if (args.reason) whereParts.push(sql`wj.reason ilike ${`%${args.reason}%`}`)
+	if (args.recipientId) whereParts.push(sql`wj.second_party_id = ${args.recipientId}`)
+	if (args.dateFrom) {
+		whereParts.push(
+			sql`wj.date >= ${args.dateFrom.includes('T') ? new Date(args.dateFrom) : new Date(`${args.dateFrom}T00:00:00.000Z`)}`
+		)
+	}
+	if (args.dateTo) {
+		whereParts.push(
+			sql`wj.date <= ${args.dateTo.includes('T') ? new Date(args.dateTo) : new Date(`${args.dateTo}T23:59:59.999Z`)}`
+		)
+	}
+
+	return sql.join(whereParts, sql` and `)
+}
+
+function buildSrpWalletHistoryBaseCte(args: {
+	processorCorporationId: string
+	whereClause: unknown
+}) {
+	return sql`
+		with wallet_history_base as (
+			select
+				wj.journal_id::text as "journalId",
+				wj.ref_type as "refType",
+				wj.amount as "amount",
+				wj.reason as "reason",
+				wj.second_party_id::text as "recipientId",
+				wj.date as "entryDate",
+				request_ref.request_id_from_reason as "requestIdFromReason",
+				req.id::text as "linkedRequestId",
+				req.character_id as "expectedRequestCharacterId",
+				coalesce(
+					(
+						wj.ref_type = 'corporation_account_withdrawal'
+						and wj.second_party_id is not null
+						and (wj.reason is null or btrim(wj.reason) = '')
+					),
+					false
+				) as "hasMissingReasonWarning",
+				coalesce(
+					req.character_id is not null
+					and wj.second_party_id is not null
+					and wj.second_party_id::text <> req.character_id,
+					false
+				) as "hasRecipientMismatch",
+				(
+					coalesce(alert_counts.open_alert_count, 0) > 0
+					or (
+						req.character_id is not null
+						and wj.second_party_id is not null
+						and wj.second_party_id::text <> req.character_id
+					)
+				) as "hasOpenAlert"
+			from corporation_wallet_journal as wj
+			left join lateral (
+				select (regexp_match(coalesce(wj.reason, ''), 'KM#([0-9]+)'))[1] as request_id_from_reason
+			) as request_ref on true
+			left join srp_requests as req on req.id = request_ref.request_id_from_reason
+			left join (
+				select
+					journal_id::text as journal_id,
+					count(*)::int as open_alert_count
+				from srp_payment_alerts
+				where payment_processor_corporation_id = ${args.processorCorporationId}
+					and state = 'open'
+				group by journal_id
+			) as alert_counts on alert_counts.journal_id = wj.journal_id::text
+			where ${args.whereClause}
+		)
+	`
+}
+
+function buildSrpWalletHistoryRowsQuery(args: {
+	processorCorporationId: string
+	whereClause: unknown
+	alertsOnly: boolean
+	limit: number
+	offset: number
+}) {
+	const baseCte = buildSrpWalletHistoryBaseCte({
+		processorCorporationId: args.processorCorporationId,
+		whereClause: args.whereClause,
+	})
+	const alertFilter = args.alertsOnly ? sql`where "hasOpenAlert" or "hasMissingReasonWarning"` : sql``
+
+	return sql`
+		${baseCte}
+		select
+			"journalId",
+			"refType",
+			"amount",
+			"reason",
+			"recipientId",
+			"entryDate",
+			"requestIdFromReason",
+			"linkedRequestId",
+			"expectedRequestCharacterId",
+			"hasRecipientMismatch",
+			"hasMissingReasonWarning",
+			"hasOpenAlert"
+		from wallet_history_base
+		${alertFilter}
+		order by "entryDate" desc, "journalId" desc
+		limit ${args.limit}
+		offset ${args.offset}
+	`
+}
+
+function buildSrpWalletHistoryCountQuery(args: {
+	processorCorporationId: string
+	whereClause: unknown
+	alertsOnly: boolean
+}) {
+	const baseCte = buildSrpWalletHistoryBaseCte({
+		processorCorporationId: args.processorCorporationId,
+		whereClause: args.whereClause,
+	})
+	const alertFilter = args.alertsOnly ? sql`where "hasOpenAlert" or "hasMissingReasonWarning"` : sql``
+
+	return sql`
+		${baseCte}
+		select cast(count(*) as integer) as "total"
+		from wallet_history_base
+		${alertFilter}
+	`
+}
+
+type WalletHistoryRow = {
+	journalId: string
+	refType: string | null
+	amount: string
+	reason: string | null
+	recipientId: string | null
+	entryDate: Date
+	requestIdFromReason: string | null
+	linkedRequestId: string | null
+	expectedRequestCharacterId: string | null
+	hasRecipientMismatch: boolean
+	hasMissingReasonWarning: boolean
+	hasOpenAlert: boolean
+}
+
 export async function writeSrpPaidRequestsExportToBucket(args: {
 	bucket: R2Bucket
 	exportKey: string
@@ -1959,10 +2063,7 @@ export async function writeSrpWalletHistoryExportToBucket(args: {
 			reason: row.reason,
 			recipientId: row.recipientId,
 			recipientName: row.recipientId ? (resolvedNames[row.recipientId] ?? null) : null,
-			entryDate:
-				row.entryDate instanceof Date
-					? row.entryDate.toISOString()
-					: new Date(String(row.entryDate)).toISOString(),
+			entryDate: serializeWalletHistoryEntryDate(row.entryDate),
 			matchingAlertKinds: alertKindsByJournalId.get(row.journalId) ?? [],
 			alertDetail:
 				paymentAlertDetailByJournalId.get(row.journalId) ??
@@ -2177,127 +2278,36 @@ srp.get('/payments/wallet-history', async (c) => {
 
 	const db = c.get('db')
 	if (!db) return c.json({ error: 'Database unavailable' }, 500)
-
-	const whereParts = [
-		sql`corporation_id = ${processorCorporationId}`,
-		sql`ref_type = 'corporation_account_withdrawal'`,
-		sql`exists (
-			select 1
-			from user_characters recipient_char
-			where recipient_char.character_id = second_party_id
-		)`,
-	]
-	if (reason) whereParts.push(sql`reason ilike ${`%${reason}%`}`)
-	if (recipientId) whereParts.push(sql`second_party_id = ${recipientId}`)
-	if (dateFrom) whereParts.push(sql`date >= ${dateFrom.includes('T') ? new Date(dateFrom) : new Date(`${dateFrom}T00:00:00.000Z`)}`)
-	if (dateTo) whereParts.push(sql`date <= ${dateTo.includes('T') ? new Date(dateTo) : new Date(`${dateTo}T23:59:59.999Z`)}`)
-	const whereClause = sql.join(whereParts, sql` and `)
+	const whereClause = buildSrpWalletHistoryWhereClause({
+		processorCorporationId,
+		reason: reason ?? undefined,
+		recipientId: recipientId ?? undefined,
+		dateFrom: dateFrom ?? undefined,
+		dateTo: dateTo ?? undefined,
+	})
 
 	const [rowsResult, countResult] = await Promise.all([
-		db.execute<{
-			journalId: string
-			refType: string | null
-			amount: string
-			reason: string | null
-			recipientId: string | null
-			entryDate: Date
-		}>(
-			alertsOnly
-				? sql`select
-						journal_id::text as "journalId",
-						ref_type as "refType",
-						amount as "amount",
-						reason as "reason",
-						second_party_id as "recipientId",
-						date as "entryDate"
-					from corporation_wallet_journal
-					where ${whereClause}
-					order by date desc`
-				: sql`select
-						journal_id::text as "journalId",
-						ref_type as "refType",
-						amount as "amount",
-						reason as "reason",
-						second_party_id as "recipientId",
-						date as "entryDate"
-					from corporation_wallet_journal
-					where ${whereClause}
-					order by date desc
-					limit ${limit}
-					offset ${offset}`
+		db.execute<WalletHistoryRow>(
+			buildSrpWalletHistoryRowsQuery({
+				processorCorporationId,
+				whereClause,
+				alertsOnly,
+				limit,
+				offset,
+			})
 		),
 		db.execute<{ total: number }>(
-			sql`select cast(count(*) as integer) as "total"
-				from corporation_wallet_journal
-				where ${whereClause}`
+			buildSrpWalletHistoryCountQuery({
+				processorCorporationId,
+				whereClause,
+				alertsOnly,
+			})
 		),
 	])
 
 	const rows = rowsResult.rows ?? []
-	const rawTotal = countResult.rows?.[0]?.total ?? 0
+	const total = countResult.rows?.[0]?.total ?? 0
 	const journalIds = [...new Set(rows.map((row) => row.journalId))]
-	const kmRequestIds = [
-		...new Set(
-			rows
-				.map((row) => {
-					const text = row.reason ?? ''
-					const match = text.match(SRP_REQUEST_ID_IN_REASON_REGEX)
-					return match?.[1] ?? null
-				})
-				.filter((value): value is string => Boolean(value))
-		),
-	]
-
-	const [matchingRequestsResult, paymentAlertsResult] = await Promise.all([
-		kmRequestIds.length > 0
-			? db.execute<{ id: string; characterId: string }>(
-					sql`select id::text as "id", character_id as "characterId"
-						from srp_requests
-						where id in ${sql`(${sql.join(kmRequestIds.map((id) => sql`${id}`), sql`,`)})`}`
-				)
-			: Promise.resolve({ rows: [] as Array<{ id: string; characterId: string }> }),
-		journalIds.length > 0
-			? db.execute<{
-					journalId: string
-					kind: string
-					state: string
-					expectedAmount: string | null
-					observedAmount: string | null
-					expectedRecipientCharacterId: string | null
-					expectedRecipientCharacterName: string | null
-					actualRecipientCharacterId: string | null
-					actualRecipientCharacterName: string | null
-				}>(
-					sql`select
-							journal_id::text as "journalId",
-							kind,
-							state,
-							expected_amount as "expectedAmount",
-							observed_amount as "observedAmount",
-							expected_recipient_character_id as "expectedRecipientCharacterId",
-							expected_recipient_character_name as "expectedRecipientCharacterName",
-							actual_recipient_character_id as "actualRecipientCharacterId",
-							actual_recipient_character_name as "actualRecipientCharacterName"
-						from srp_payment_alerts
-						where journal_id in ${sql`(${sql.join(journalIds.map((id) => sql`${id}`), sql`,`)})`}`
-				)
-			: Promise.resolve({
-					rows: [] as Array<{
-						journalId: string
-						kind: string
-						state: string
-						expectedAmount: string | null
-						observedAmount: string | null
-						expectedRecipientCharacterId: string | null
-						expectedRecipientCharacterName: string | null
-						actualRecipientCharacterId: string | null
-						actualRecipientCharacterName: string | null
-					}>,
-				}),
-	])
-	const requestById = new Map(
-		(matchingRequestsResult.rows ?? []).map((row) => [row.id, row.characterId])
-	)
 	const alertKindsByJournalId = new Map<string, string[]>()
 	const paymentAlertDetailByJournalId = new Map<
 		string,
@@ -2310,7 +2320,47 @@ srp.get('/payments/wallet-history', async (c) => {
 			actualRecipientCharacterName: string | null
 		}
 	>()
-	for (const row of paymentAlertsResult.rows ?? []) {
+	for (const row of
+		(
+			await (journalIds.length > 0
+				? db.execute<{
+						journalId: string
+						kind: string
+						state: string
+						expectedAmount: string | null
+						observedAmount: string | null
+						expectedRecipientCharacterId: string | null
+						expectedRecipientCharacterName: string | null
+						actualRecipientCharacterId: string | null
+						actualRecipientCharacterName: string | null
+					}>(
+						sql`select
+								journal_id::text as "journalId",
+								kind,
+								state,
+								expected_amount as "expectedAmount",
+								observed_amount as "observedAmount",
+								expected_recipient_character_id as "expectedRecipientCharacterId",
+								expected_recipient_character_name as "expectedRecipientCharacterName",
+								actual_recipient_character_id as "actualRecipientCharacterId",
+								actual_recipient_character_name as "actualRecipientCharacterName"
+							from srp_payment_alerts
+							where journal_id in ${sql`(${sql.join(journalIds.map((id) => sql`${id}`), sql`,`)})`}`
+					)
+				: Promise.resolve({
+						rows: [] as Array<{
+							journalId: string
+							kind: string
+							state: string
+							expectedAmount: string | null
+							observedAmount: string | null
+							expectedRecipientCharacterId: string | null
+							expectedRecipientCharacterName: string | null
+							actualRecipientCharacterId: string | null
+							actualRecipientCharacterName: string | null
+						}>,
+					})
+		)).rows ?? []) {
 		const existing = alertKindsByJournalId.get(row.journalId) ?? []
 		if (row.state === 'open' && !existing.includes(row.kind)) {
 			existing.push(row.kind)
@@ -2328,10 +2378,12 @@ srp.get('/payments/wallet-history', async (c) => {
 		}
 	}
 
-	const requestCharacterIds = [...new Set((matchingRequestsResult.rows ?? []).map((row) => row.characterId))]
 	const idsToResolve = [
 		...new Set(
-			[...rows.map((row) => row.recipientId), ...requestCharacterIds].filter(
+			[
+				...rows.map((row) => row.recipientId),
+				...rows.map((row) => row.expectedRequestCharacterId),
+			].filter(
 				(id): id is string => Boolean(id)
 			)
 		),
@@ -2340,41 +2392,23 @@ srp.get('/payments/wallet-history', async (c) => {
 	const resolvedNames: Record<string, string> =
 		idsToResolve.length > 0 ? await resolver.resolveIds(idsToResolve).catch(() => ({})) : {}
 
-	const computedItems = rows.map((row) => {
-			const requestIdFromReason = (() => {
-				const reasonText = row.reason ?? ''
-				const match = reasonText.match(SRP_REQUEST_ID_IN_REASON_REGEX)
-				return match?.[1] ?? null
-			})()
-			const expectedRequestCharacterId = requestIdFromReason
-				? (requestById.get(requestIdFromReason) ?? null)
-				: null
-			const hasRecipientMismatch = Boolean(
-				expectedRequestCharacterId && row.recipientId && row.recipientId !== expectedRequestCharacterId
-			)
-			const hasMissingReasonWarning = Boolean(
-				row.refType === 'corporation_account_withdrawal' &&
-					row.recipientId &&
-					(!row.reason || row.reason.trim().length === 0)
-			)
+	const items = rows.map((row) => {
+		const hasRecipientMismatch = Boolean(row.hasRecipientMismatch)
+		const expectedRecipientCharacterName = row.expectedRequestCharacterId
+			? (resolvedNames[row.expectedRequestCharacterId] ?? null)
+			: null
 
-			return {
+		return {
 			hasRecipientMismatch,
-			hasMissingReasonWarning,
-			linkedRequestId: (() => {
-				if (!requestIdFromReason) return null
-				return requestById.has(requestIdFromReason) ? requestIdFromReason : null
-			})(),
+			hasMissingReasonWarning: row.hasMissingReasonWarning,
+			linkedRequestId: row.linkedRequestId,
 			journalId: row.journalId,
 			refType: row.refType,
 			amount: row.amount,
 			reason: row.reason,
 			recipientId: row.recipientId,
 			recipientName: row.recipientId ? (resolvedNames[row.recipientId] ?? null) : null,
-			entryDate:
-				row.entryDate instanceof Date
-					? row.entryDate.toISOString()
-					: new Date(String(row.entryDate)).toISOString(),
+			entryDate: serializeWalletHistoryEntryDate(row.entryDate),
 			matchingAlertKinds: alertKindsByJournalId.get(row.journalId) ?? [],
 			alertDetail:
 				paymentAlertDetailByJournalId.get(row.journalId) ??
@@ -2382,30 +2416,21 @@ srp.get('/payments/wallet-history', async (c) => {
 					? {
 							expectedAmount: null,
 							observedAmount: row.amount,
-							expectedRecipientCharacterId: expectedRequestCharacterId,
-							expectedRecipientCharacterName: expectedRequestCharacterId
-								? (resolvedNames[expectedRequestCharacterId] ?? null)
-								: null,
+							expectedRecipientCharacterId: row.expectedRequestCharacterId,
+							expectedRecipientCharacterName,
 							actualRecipientCharacterId: row.recipientId,
 							actualRecipientCharacterName: row.recipientId
 								? (resolvedNames[row.recipientId] ?? null)
 								: null,
 					  }
 					: null),
-			hasOpenAlert:
-				(alertKindsByJournalId.get(row.journalId) ?? []).length > 0 ||
-				hasRecipientMismatch,
+			hasOpenAlert: row.hasOpenAlert,
 		}
 	})
 
-	const items = alertsOnly
-		? computedItems.filter((item) => item.hasOpenAlert || item.hasMissingReasonWarning)
-		: computedItems
-	const pagedItems = alertsOnly ? items.slice(offset, offset + limit) : items
-
 	return c.json({
-		items: pagedItems,
-		total: alertsOnly ? items.length : rawTotal,
+		items,
+		total,
 		limit,
 		offset,
 	})

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -26,7 +26,6 @@ import {
 } from './db/schema'
 import { buildEquippedByType } from './lib/equipment'
 import { SrpKillmailEsiClient, SrpKillmailNotFoundError } from './lib/killmail-esi'
-import { computeSrpPayout } from './lib/payout'
 import {
 	doesRecentLossCacheCoverCutoff,
 	mergeRecentLosses,
@@ -1211,31 +1210,6 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			characterId,
 			characterName: _characterName,
 			success: true,
-		}
-	}
-
-	async backfillRecentLossesFromCache(characterId: string): Promise<RecentLossCacheBackfillResult> {
-		const cached = await this.readRecentLossCache(characterId)
-		const cachedLosses = cached?.losses ?? []
-		if (cachedLosses.length === 0) {
-			return {
-				characterId,
-				cachedLosses: 0,
-				persistedLosses: 0,
-			}
-		}
-
-		const hydratedLosses = cachedLosses.map((loss) => ({
-			loss,
-			killmailData: buildKillmailDetailFromCachedLoss(characterId, loss.killmailId, loss.killmailHash, loss),
-		}))
-
-		await this.persistRecentLossesToCharacterData(characterId, hydratedLosses)
-
-		return {
-			characterId,
-			cachedLosses: cachedLosses.length,
-			persistedLosses: hydratedLosses.length,
 		}
 	}
 

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -31,6 +31,7 @@ import {
 	mergeRecentLosses,
 	isRecentLossRequestable,
 	selectRecentKillmailsUntilKnown,
+	ROOKIE_SHIP_TYPE_IDS,
 	type RecentLossCacheRecord,
 	type RecentLossCacheStorageRecord,
 } from './lib/recent-loss-cache'
@@ -85,11 +86,19 @@ import { logger } from '@repo/hono-helpers'
 
 const SRP_REQUIRED_KILLMAIL_SCOPES = ['esi-killmails.read_killmails.v1']
 
-function serializeLossItems(items?: KillmailDetail['victim']['items']): CharacterLossItemData[] | undefined {
+type LossItemLike = {
+	flag: number
+	item_type_id: number | string
+	quantity_destroyed?: number
+	quantity_dropped?: number
+	items?: LossItemLike[]
+}
+
+function serializeLossItems(items?: LossItemLike[]): CharacterLossItemData[] | undefined {
 	if (!items || items.length === 0) return undefined
 	return items.map((item) => ({
 		flag: item.flag,
-		item_type_id: item.item_type_id,
+		item_type_id: String(item.item_type_id),
 		quantity_destroyed: item.quantity_destroyed,
 		quantity_dropped: item.quantity_dropped,
 		items: serializeLossItems(item.items),
@@ -99,6 +108,21 @@ function serializeLossItems(items?: KillmailDetail['victim']['items']): Characte
 type HydratedRecentLoss = {
 	loss: CharacterLossData
 	killmailData: KillmailDetail & { killmail_hash?: string }
+}
+
+type RecentLossDbRow = {
+	characterId: string
+	killmailId: string
+	killmailHash: string
+	killmailTime: Date
+	isLoss: boolean | null
+	shipTypeId: string | null
+	shipTypeName: string | null
+	totalValue: string | null
+	solarSystemId: string | null
+	solarSystemName: string | null
+	victimCharacterId: string | null
+	killmailData: unknown | null
 }
 
 /**
@@ -215,6 +239,75 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	private async readMostRecentLoss(characterId: string): Promise<CharacterKillmailData | null> {
 		const charInstance = await this.getCharacterDataInstance(characterId)
 		return await charInstance.getMostRecentLoss().catch(() => null)
+	}
+
+	private mapRecentLossDbRowToLoss(row: RecentLossDbRow): CharacterLossData | null {
+		const killmailData =
+			row.killmailData && typeof row.killmailData === 'object'
+				? (row.killmailData as {
+						victim?: {
+							character_id?: number | string
+							ship_type_id?: number | string
+							items?: CharacterLossItemData[]
+						}
+						solar_system_id?: number | string
+				  })
+				: null
+		const victim = killmailData?.victim
+		const shipTypeId = row.shipTypeId ?? victim?.ship_type_id
+		const solarSystemId = row.solarSystemId ?? killmailData?.solar_system_id
+		const victimCharacterId = row.victimCharacterId ?? victim?.character_id
+
+		if (!shipTypeId || !solarSystemId || !victimCharacterId) {
+			return null
+		}
+
+		return {
+			killmailId: row.killmailId,
+			killmailHash: row.killmailHash,
+			killmailTime: row.killmailTime,
+			shipTypeId: String(shipTypeId),
+			totalValue: row.totalValue ?? '0',
+			solarSystemId: String(solarSystemId),
+			victimCharacterId: String(victimCharacterId),
+			victimItems: serializeLossItems(victim?.items),
+			shipTypeName: row.shipTypeName ?? undefined,
+			solarSystemName: row.solarSystemName ?? undefined,
+		}
+	}
+
+	private async readRecentLossRows(characterIds: string[], cutoffMs: number): Promise<RecentLossDbRow[]> {
+		if (characterIds.length === 0) return []
+
+		const characterIdList = sql.join(characterIds.map((id) => sql`${id}`), sql`, `)
+		const cutoff = new Date(cutoffMs)
+
+		const result = await this.db.execute<RecentLossDbRow>(sql`
+			select
+				character_id as "characterId",
+				killmail_id as "killmailId",
+				killmail_hash as "killmailHash",
+				killmail_time as "killmailTime",
+				is_loss as "isLoss",
+				ship_type_id as "shipTypeId",
+				ship_type_name as "shipTypeName",
+				total_value as "totalValue",
+				solar_system_id as "solarSystemId",
+				solar_system_name as "solarSystemName",
+				victim_character_id as "victimCharacterId",
+				killmail_data as "killmailData"
+			from character_killmails
+			where character_id in (${characterIdList})
+				and is_loss is true
+				and ship_type_id not in (${sql.join(
+					[...ROOKIE_SHIP_TYPE_IDS].map((shipTypeId) => sql`${shipTypeId}`),
+					sql`, `
+				)})
+				and killmail_time >= ${cutoff}
+			order by character_id asc, killmail_time desc, killmail_id desc
+		`)
+
+		return result.rows ?? []
 	}
 
 	private async persistRecentLossesToCharacterData(
@@ -982,14 +1075,23 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		const universeStub = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const allLosses = new Map<string, CharacterLossData>()
 		const failedCharacters: RecentLossRefreshCharacterFailure[] = []
+		const characterIds = characters.map((character) => character.characterId)
+		const [recentLossRows, cachedRecords] = await Promise.all([
+			this.readRecentLossRows(characterIds, cutoffMs),
+			Promise.all(characters.map((character) => this.readRecentLossCache(character.characterId))),
+		])
+		const recentLossesByCharacter = new Map<string, CharacterLossData[]>()
+		for (const row of recentLossRows) {
+			const loss = this.mapRecentLossDbRowToLoss(row)
+			if (!loss) continue
+			const existing = recentLossesByCharacter.get(row.characterId) ?? []
+			existing.push(loss)
+			recentLossesByCharacter.set(row.characterId, existing)
+		}
 
-		for (const character of characters) {
-			const charInstance = await this.getCharacterDataInstance(character.characterId)
-			const storedLosses = await charInstance.getRecentLosses(
-				1000,
-				new Date(cutoffMs)
-			).catch(() => [])
-			const cached = await this.readRecentLossCache(character.characterId)
+		for (const [index, character] of characters.entries()) {
+			const storedLosses = recentLossesByCharacter.get(character.characterId) ?? []
+			const cached = cachedRecords[index]
 			const mergedCharacterLosses = mergeRecentLosses(
 				storedLosses,
 				cached?.losses ?? [],
@@ -1044,7 +1146,6 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		}
 
 		const mergedLosses = [...allLosses.values()]
-			.filter((loss) => new Date(loss.killmailTime).getTime() >= cutoffMs)
 			.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime())
 		const total = mergedLosses.length
 		const effectiveLimit = typeof limit === 'number' ? Math.max(1, limit) : total
@@ -1203,8 +1304,13 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		}
 
 		const freshLosses = await this.fetchRecentLossesFromEsi(characterId, knownKillmailIds)
-		await this.persistRecentLossesToCharacterData(characterId, freshLosses, cacheCutoffMs)
-		await this.writeRecentLossCache(characterId, freshLosses.map((entry) => entry.loss), maxLossAgeDays)
+		const eligibleLosses = freshLosses.filter((entry) => isRecentLossRequestable(entry.loss))
+		await this.persistRecentLossesToCharacterData(characterId, eligibleLosses, cacheCutoffMs)
+		await this.writeRecentLossCache(
+			characterId,
+			eligibleLosses.map((entry) => entry.loss),
+			maxLossAgeDays
+		)
 
 		return {
 			characterId,

--- a/apps/srp/src/lib/recent-loss-cache.ts
+++ b/apps/srp/src/lib/recent-loss-cache.ts
@@ -21,6 +21,7 @@ export interface RecentKillmailSelection {
 }
 
 const POD_TYPE_IDS = new Set(['670', '33328'])
+export const ROOKIE_SHIP_TYPE_IDS = new Set(['588', '596', '601', '606'])
 
 function hasFittedImplants(loss: CharacterLossData): boolean {
 	return (
@@ -31,6 +32,10 @@ function hasFittedImplants(loss: CharacterLossData): boolean {
 }
 
 export function isRecentLossRequestable(loss: CharacterLossData): boolean {
+	if (ROOKIE_SHIP_TYPE_IDS.has(String(loss.shipTypeId))) {
+		return false
+	}
+
 	if (!POD_TYPE_IDS.has(String(loss.shipTypeId))) {
 		return true
 	}

--- a/apps/srp/src/test/unit/recent-loss-cache.unit.test.ts
+++ b/apps/srp/src/test/unit/recent-loss-cache.unit.test.ts
@@ -122,11 +122,18 @@ describe('recent-loss cache helpers', () => {
 		expect(shouldInvalidateRecentLossCache(null, 365)).toBe(false)
 	})
 
-	it('excludes empty capsules but keeps pods with fitted implants requestable', () => {
+	it('excludes rookie ships and empty capsules but keeps fitted pods requestable', () => {
 		expect(isRecentLossRequestable(buildLoss('10', '2026-06-02T03:00:00.000Z'))).toBe(true)
 		expect(
 			isRecentLossRequestable({
 				...buildLoss('11', '2026-06-02T03:00:00.000Z', {
+					shipTypeId: '588',
+				}),
+			})
+		).toBe(false)
+		expect(
+			isRecentLossRequestable({
+				...buildLoss('12', '2026-06-02T03:00:00.000Z', {
 					shipTypeId: '670',
 					victimItems: [],
 				}),
@@ -134,7 +141,7 @@ describe('recent-loss cache helpers', () => {
 		).toBe(false)
 		expect(
 			isRecentLossRequestable({
-				...buildLoss('12', '2026-06-02T03:00:00.000Z', {
+				...buildLoss('13', '2026-06-02T03:00:00.000Z', {
 					shipTypeId: '33328',
 					victimItems: [{ flag: 89, item_type_id: '1956' }],
 				}),

--- a/apps/srp/src/test/unit/recent-loss-refresh-flow.unit.test.ts
+++ b/apps/srp/src/test/unit/recent-loss-refresh-flow.unit.test.ts
@@ -77,6 +77,44 @@ describe('refreshRecentLossesForCharacter', () => {
 		expect(srp.writeRecentLossCache).toHaveBeenCalledWith('character-1', [refreshedLoss], 30)
 	})
 
+	it('filters rookie ships out before persisting refreshed losses', async () => {
+		const srp = Object.create(SrpDO.prototype) as Record<string, any>
+		const rookieLoss = buildLoss('301', '2026-07-07T00:00:00.000Z', {
+			shipTypeId: '588',
+		})
+		const eligibleLoss = buildLoss('302', '2026-07-06T00:00:00.000Z')
+
+		srp.readRecentLossCache = vi.fn().mockResolvedValue({
+			losses: [],
+			refreshedAtMs: Date.now(),
+			complete: false,
+			maxLossAgeDays: 30,
+		})
+		srp.readMostRecentLoss = vi.fn().mockResolvedValue(null)
+		srp.fetchRecentLossesFromEsi = vi.fn().mockResolvedValue([
+			{ loss: rookieLoss, killmailData: { killmail_id: rookieLoss.killmailId } },
+			{ loss: eligibleLoss, killmailData: { killmail_id: eligibleLoss.killmailId } },
+		])
+		srp.persistRecentLossesToCharacterData = vi.fn().mockResolvedValue(undefined)
+		srp.writeRecentLossCache = vi.fn().mockResolvedValue(undefined)
+		srp.getConfig = vi.fn().mockResolvedValue({ maxLossAgeDays: 30 })
+
+		const result = await srp.refreshRecentLossesForCharacter(
+			'user-1',
+			'character-1',
+			'Character One',
+			30
+		)
+
+		expect(result.success).toBe(true)
+		expect(srp.persistRecentLossesToCharacterData).toHaveBeenCalledWith(
+			'character-1',
+			[{ loss: eligibleLoss, killmailData: { killmail_id: eligibleLoss.killmailId } }],
+			expect.any(Number)
+		)
+		expect(srp.writeRecentLossCache).toHaveBeenCalledWith('character-1', [eligibleLoss], 30)
+	})
+
 	it('treats an empty refresh as a successful complete cache write', async () => {
 		const srp = Object.create(SrpDO.prototype) as Record<string, any>
 

--- a/apps/ui/src/client/features/srp/hooks.ts
+++ b/apps/ui/src/client/features/srp/hooks.ts
@@ -364,12 +364,6 @@ export function useRefreshKillmails() {
 	})
 }
 
-export function useRefreshSrpRecentLossesForAllKnownUsers() {
-	return useMutation({
-		mutationFn: () => api.refreshSrpRecentLossesForAllKnownUsers(),
-	})
-}
-
 export function useKillmailPreview(
 	killmailId: string | null,
 	killmailHash: string | null,

--- a/apps/ui/src/client/features/srp/routes/policies.tsx
+++ b/apps/ui/src/client/features/srp/routes/policies.tsx
@@ -23,7 +23,6 @@ import {
 	useDeletePolicy,
 	useSRPConfig,
 	useSRPPolicies,
-	useRefreshSrpRecentLossesForAllKnownUsers,
 	useUpdatePolicy,
 	useUpdateSRPConfig,
 } from '../hooks'
@@ -32,12 +31,7 @@ import { formatISK } from '../utils'
 import { MAX_SRP_LOSS_AGE_DAYS } from '@repo/srp'
 import type { CapConfig, PayoutModifierConfig } from '@repo/srp'
 import type { SelectOption } from '@/components/ui/select'
-import type {
-	SRPConfigResponse,
-	SRPPolicy,
-	SRPPredefinedAdhocModifier,
-	SRPRecentLossRefreshBackfillResponse,
-} from '../types'
+import type { SRPConfigResponse, SRPPolicy, SRPPredefinedAdhocModifier } from '../types'
 
 function isPayoutModifierConfig(c: unknown): c is PayoutModifierConfig {
 	return typeof c === 'object' && c !== null && 'rate' in c
@@ -68,10 +62,6 @@ export default function PoliciesPage() {
 	usePageTitle('SRP - Policies')
 
 	const { hasPermission, isAdmin } = useUserPermissions()
-	const refreshAllRecentLosses = useRefreshSrpRecentLossesForAllKnownUsers()
-	const [backfillSummary, setBackfillSummary] =
-		useState<SRPRecentLossRefreshBackfillResponse | null>(null)
-	const canLaunchBackfill = isAdmin || hasPermission('urn:srp:manager')
 
 	if (!(isAdmin || hasPermission('urn:srp:manager'))) {
 		return <Navigate to="/srp" replace />
@@ -101,62 +91,6 @@ export default function PoliciesPage() {
 			<PageHeader
 				title="SRP Policies"
 				description="Manage payout modifier and cap policies used during reviews"
-				action={
-					canLaunchBackfill ? (
-						<div className="flex flex-col items-end gap-2">
-							<div className="flex items-center gap-3">
-								{refreshAllRecentLosses.isPending ? (
-									<Badge variant="secondary" className="uppercase tracking-wide">
-										Launching backfill...
-									</Badge>
-								) : backfillSummary ? (
-									<Badge
-										variant={backfillSummary.usersQueued > 0 ? 'success' : 'secondary'}
-										className="uppercase tracking-wide"
-									>
-										{backfillSummary.usersQueued > 0 ? 'Backfill queued' : 'No history found'}
-									</Badge>
-								) : null}
-								<Button
-									variant="secondary"
-									onClick={async () => {
-										setBackfillSummary(null)
-										try {
-											const result = await refreshAllRecentLosses.mutateAsync()
-											setBackfillSummary(result)
-											toast.success(result.message, {
-												description:
-													result.usersQueued > 0
-														? `${result.usersQueued} users with ${result.totalCharacters} linked characters were queued.`
-														: 'No cached SRP losses were found.',
-											})
-										} catch (error: any) {
-											toast.error('Failed to launch SRP cache backfill', {
-												description: error.message,
-											})
-										}
-									}}
-									loading={refreshAllRecentLosses.isPending}
-									loadingText="Launching..."
-									showIcon={false}
-								>
-									Backfill cached SRP losses
-								</Button>
-							</div>
-							{refreshAllRecentLosses.isPending ? (
-								<p className="text-xs text-muted-foreground">
-									Waiting for the cache backfill jobs to queue...
-								</p>
-							) : backfillSummary ? (
-								<p className="text-xs text-muted-foreground">
-									{backfillSummary.usersQueued > 0
-										? `Queued ${backfillSummary.usersQueued} users covering ${backfillSummary.totalCharacters} linked characters from cache.`
-										: backfillSummary.message}
-								</p>
-							) : null}
-						</div>
-					) : undefined
-				}
 			/>
 
 			<div className="space-y-8">

--- a/apps/ui/src/client/features/srp/types.ts
+++ b/apps/ui/src/client/features/srp/types.ts
@@ -75,12 +75,3 @@ export interface MilitarySrpAssessment {
 export type SRPRequestWithMilitary = SRPRequestResponse & {
 	militarySrp?: MilitarySrpAssessment
 }
-
-export interface SRPRecentLossRefreshBackfillResponse {
-	success: boolean
-	message: string
-	usersWithHistory: number
-	usersQueued: number
-	totalCharacters: number
-	skippedUsers: number
-}

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -48,7 +48,6 @@ import type { TrackingSession } from '../features/fleet-tracking/types'
 import type {
 	RecentLossesResponse,
 	RequestListResponse,
-	SRPRecentLossRefreshBackfillResponse,
 } from '../features/srp/types'
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -4997,10 +4996,6 @@ export class ApiClient {
 		totalCharacters?: number
 	}> {
 		return this.post('/srp/losses/refresh', {})
-	}
-
-	async refreshSrpRecentLossesForAllKnownUsers(): Promise<SRPRecentLossRefreshBackfillResponse> {
-		return this.post('/srp/losses/refresh/backfill', {})
 	}
 
 	async getRecentLossRefreshStatus(): Promise<{

--- a/packages/srp/src/index.ts
+++ b/packages/srp/src/index.ts
@@ -161,7 +161,6 @@ export interface Srp {
 		characterName: string,
 		maxLossAgeDays: number
 	): Promise<RecentLossRefreshCharacterResult>
-	backfillRecentLossesFromCache(characterId: string): Promise<RecentLossCacheBackfillResult>
 
 	// Legacy review methods (kept for backward compat)
 	getPendingRequests(


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Refactors the SRP wallet-history endpoint to compute pagination, request-matching, and alert flags in SQL instead of in application code, and moves recent-loss lookups for refresh to a single bounded database query instead of per-character Durable Object cache reads. Also removes the now-unused manual "backfill cached losses" admin tool and excludes rookie ships from SRP-eligible losses.

## Changes
- `apps/core/src/routes/srp.ts`: Replaced the wallet-history handler's in-memory join/filter/pagination logic with SQL helpers (`buildSrpWalletHistoryWhereClause`, `buildSrpWalletHistoryBaseCte`, `buildSrpWalletHistoryRowsQuery`, `buildSrpWalletHistoryCountQuery`) built around a `wallet_history_base` CTE that computes `hasRecipientMismatch`, `hasMissingReasonWarning`, `hasOpenAlert`, and `linkedRequestId` directly in the query, so `alertsOnly` pagination and totals are correct at the SQL level instead of via post-fetch slicing.
- Added `serializeWalletHistoryEntryDate` to robustly normalize `entryDate` values (strings, numbers, date-like objects) using `parseDateOrNull`, replacing the previous `instanceof Date` / `new Date(String(...))` fallback.
- Removed the `/api/srp/losses/refresh/backfill` route, the `SrpDO.backfillRecentLossesFromCache` method, its `Srp` interface entry, and the corresponding UI button/hook/API client method/types in `apps/ui` (`useRefreshSrpRecentLossesForAllKnownUsers`, `SRPRecentLossRefreshBackfillResponse`, and the "Backfill cached SRP losses" control on the Policies page).
- `apps/srp/src/durable-object.ts`: Added `readRecentLossRows`/`mapRecentLossDbRowToLoss` to fetch recent losses for all characters in one bounded `character_killmails` query (filtered by cutoff and excluding rookie ship types) instead of looping per character over the character-data DO cache; recent-loss merging no longer re-filters by cutoff after the fact since the query already bounds it.
- `apps/srp/src/lib/recent-loss-cache.ts`: Added `ROOKIE_SHIP_TYPE_IDS` and excluded rookie ship losses from `isRecentLossRequestable`; fresh losses are now filtered through `isRecentLossRequestable` before being persisted/cached in the refresh flow.

## Testing
- Updated/added unit and route tests: `apps/core/src/routes/__tests__/srp.route.test.ts` now mocks the SQL-driven wallet-history queries (including a CTE-aware `sqlText` helper) and asserts the generated SQL for the alerts-only page; `apps/srp/src/test/unit/recent-loss-cache.unit.test.ts` and `recent-loss-refresh-flow.unit.test.ts` cover rookie-ship exclusion; tests for the removed backfill route/hook were deleted.
<!-- claude:end -->