### PR TITLE
split market price upserts to batches

### DIFF
--- a/apps/markets/src/test/unit/batching.unit.test.ts
+++ b/apps/markets/src/test/unit/batching.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { PRICE_INSERT_BATCH_SIZE, splitIntoBatches } from '../../utils/batching'
+
+describe('splitIntoBatches', () => {
+	it('returns no batches for an empty array', () => {
+		expect(splitIntoBatches([], PRICE_INSERT_BATCH_SIZE)).toEqual([])
+	})
+
+	it('keeps small inputs in a single batch', () => {
+		expect(splitIntoBatches([1, 2, 3], PRICE_INSERT_BATCH_SIZE)).toEqual([[1, 2, 3]])
+	})
+
+	it('splits larger inputs into fixed-size batches', () => {
+		const items = Array.from({ length: PRICE_INSERT_BATCH_SIZE + 3 }, (_, index) => index + 1)
+
+		expect(splitIntoBatches(items, PRICE_INSERT_BATCH_SIZE)).toEqual([
+			items.slice(0, PRICE_INSERT_BATCH_SIZE),
+			items.slice(PRICE_INSERT_BATCH_SIZE),
+		])
+	})
+
+	it('rejects invalid batch sizes', () => {
+		expect(() => splitIntoBatches([1, 2, 3], 0)).toThrow(
+			'batchSize must be greater than 0, got 0'
+		)
+	})
+})

--- a/apps/markets/src/utils/batching.ts
+++ b/apps/markets/src/utils/batching.ts
@@ -1,0 +1,14 @@
+export const PRICE_INSERT_BATCH_SIZE = 100
+
+export function splitIntoBatches<T>(items: readonly T[], batchSize: number): T[][] {
+	if (batchSize <= 0) {
+		throw new Error(`batchSize must be greater than 0, got ${batchSize}`)
+	}
+
+	const batches: T[][] = []
+	for (let index = 0; index < items.length; index += batchSize) {
+		batches.push(items.slice(index, index + batchSize))
+	}
+
+	return batches
+}

--- a/apps/markets/src/workflows/daily-price-batch.workflow.ts
+++ b/apps/markets/src/workflows/daily-price-batch.workflow.ts
@@ -11,6 +11,7 @@ import { insuranceDailyPrices, marketDailyPrices } from '../db/schema'
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
 import type { Env } from '../context'
 import { logger } from '@repo/hono-helpers'
+import { PRICE_INSERT_BATCH_SIZE, splitIntoBatches } from '../utils/batching'
 
 export interface DailyPriceBatchParams {
 	/** Target date in 'YYYY-MM-DD' format */
@@ -31,30 +32,26 @@ export interface DailyPriceBatchParams {
  * hour, parallel workflow instances triggered by the same cron share the same
  * in-memory response.
  *
- * Step 1: Fetch whitelist from Universe DO
- * Step 2: Fetch /markets/prices/ + /insurance/prices/ from ESI DO, process
- *         whitelist, upsert both tables in one pass
+ * Single step: fetch whitelist from Universe DO, fetch /markets/prices/ +
+ * /insurance/prices/ from ESI DO, process whitelist, and upsert both tables
+ * in one pass so no large payload crosses a workflow step boundary.
  */
 export class DailyPriceBatchWorkflow extends WorkflowEntrypoint<Env, DailyPriceBatchParams> {
 	async run(event: WorkflowEvent<DailyPriceBatchParams>, step: WorkflowStep): Promise<void> {
 		const { targetDate } = event.payload
 
-		// Step 1: fetch the whitelist
-		const typeIds = await step.do('fetch-whitelist', async () => {
-			const universeStub = getStub<Universe>(this.env.UNIVERSE, 'default')
-			return universeStub.getMarketPriceWhitelist()
-		})
-
-		if (typeIds.length === 0) {
-			logger.log('[DailyPriceWorkflow] Empty whitelist — nothing to upsert')
-			return
-		}
-
-		// Step 2: fetch both price sets then process the whitelist in one pass
 		await step.do(
 			'fetch-and-store',
 			{ retries: { limit: 3, delay: '10 seconds' }, timeout: '5 minutes' },
 			async () => {
+				const universeStub = getStub<Universe>(this.env.UNIVERSE, 'default')
+				const typeIds = await universeStub.getMarketPriceWhitelist()
+
+				if (typeIds.length === 0) {
+					logger.log('[DailyPriceWorkflow] Empty whitelist — nothing to upsert')
+					return
+				}
+
 				const esiStub = getStub<Esi>(this.env.ESI, 'global')
 
 				// Both calls are served from ESI DO cache after the first caller each hour
@@ -102,33 +99,45 @@ export class DailyPriceBatchWorkflow extends WorkflowEntrypoint<Env, DailyPriceB
 				const db = createDb(this.env.DATABASE_URL)
 
 				if (marketRows.length > 0) {
-					await db
-						.insert(marketDailyPrices)
-						.values(marketRows)
-						.onConflictDoUpdate({
-							target: [
-								marketDailyPrices.locationId,
-								marketDailyPrices.typeId,
-								marketDailyPrices.priceDate,
-							],
-							set: {
-								avgSellPrice: sql`EXCLUDED.avg_sell_price`,
-								updatedAt: sql`NOW()`,
-							},
-						})
+					const marketBatches = splitIntoBatches(marketRows, PRICE_INSERT_BATCH_SIZE)
+					for (const [batchIndex, batch] of marketBatches.entries()) {
+						logger.log(
+							`[DailyPriceWorkflow] Upserting market prices batch ${batchIndex + 1}/${marketBatches.length} (${batch.length} rows)`
+						)
+						await db
+							.insert(marketDailyPrices)
+							.values(batch)
+							.onConflictDoUpdate({
+								target: [
+									marketDailyPrices.locationId,
+									marketDailyPrices.typeId,
+									marketDailyPrices.priceDate,
+								],
+								set: {
+									avgSellPrice: sql`EXCLUDED.avg_sell_price`,
+									updatedAt: sql`NOW()`,
+								},
+							})
+					}
 				}
 
 				if (insuranceRows.length > 0) {
-					await db
-						.insert(insuranceDailyPrices)
-						.values(insuranceRows)
-						.onConflictDoUpdate({
-							target: [insuranceDailyPrices.typeId, insuranceDailyPrices.priceDate],
-							set: {
-								platinumCost: sql`EXCLUDED.platinum_cost`,
-								platinumPayout: sql`EXCLUDED.platinum_payout`,
-							},
-						})
+					const insuranceBatches = splitIntoBatches(insuranceRows, PRICE_INSERT_BATCH_SIZE)
+					for (const [batchIndex, batch] of insuranceBatches.entries()) {
+						logger.log(
+							`[DailyPriceWorkflow] Upserting insurance prices batch ${batchIndex + 1}/${insuranceBatches.length} (${batch.length} rows)`
+						)
+						await db
+							.insert(insuranceDailyPrices)
+							.values(batch)
+							.onConflictDoUpdate({
+								target: [insuranceDailyPrices.typeId, insuranceDailyPrices.priceDate],
+								set: {
+									platinumCost: sql`EXCLUDED.platinum_cost`,
+									platinumPayout: sql`EXCLUDED.platinum_payout`,
+								},
+							})
+					}
 				}
 
 				logger.log(


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Splits the market and insurance daily price upserts in `DailyPriceBatchWorkflow` into fixed-size batches instead of a single bulk `insert`, avoiding oversized single-statement upserts as the whitelist grows. Also collapses the previous two-step workflow (fetch whitelist, then fetch/store prices) into a single step so the whitelist never has to cross a workflow step boundary as a large payload.

## Changes
- Add `splitIntoBatches` utility (`apps/markets/src/utils/batching.ts`) and a `PRICE_INSERT_BATCH_SIZE` constant (100), with unit tests covering empty input, single-batch input, multi-batch splitting, and invalid batch sizes.
- Update `DailyPriceBatchWorkflow` to fetch the whitelist inside the same `fetch-and-store` step (instead of a separate `fetch-whitelist` step), and upsert `marketDailyPrices`/`insuranceDailyPrices` rows in batches via `splitIntoBatches`, logging progress per batch.

## Testing
- Added `apps/markets/src/test/unit/batching.unit.test.ts` covering `splitIntoBatches` behavior for empty, small, and larger-than-batch-size inputs, and invalid batch sizes.
<!-- claude:end -->