### PR TITLE
refactor structure ingest workflow to prioritize stale structures with individual cooldowns

### DIFF
--- a/apps/eve-corporation-data/.migrations/0031_lively_mariko_yashida.sql
+++ b/apps/eve-corporation-data/.migrations/0031_lively_mariko_yashida.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "structure_mining_citadel_extractions" ADD COLUMN "last_attempted_sync_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "structure_mining_citadel_extractions" ADD COLUMN "sync_failure_reason" text;--> statement-breakpoint
+ALTER TABLE "structure_moon_drills" ADD COLUMN "last_attempted_sync_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "structure_moon_drills" ADD COLUMN "sync_failure_reason" text;--> statement-breakpoint
+ALTER TABLE "structure_skyhooks" ADD COLUMN "last_attempted_sync_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "structure_sovereignty_hubs" ADD COLUMN "last_attempted_sync_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "corporation_structures_last_synced_at_idx" ON "corporation_structures" USING btree ("last_synced_at");

--- a/apps/eve-corporation-data/.migrations/meta/0031_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0031_snapshot.json
@@ -1,0 +1,3751 @@
+{
+  "id": "4f28141c-23b1-49ee-91d0-0fe47e37de88",
+  "prevId": "9d3c4d37-edcb-4394-9c6e-22340f8cac9c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_corporation_roles": {
+      "name": "character_corporation_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_at_hq": {
+          "name": "roles_at_hq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_base": {
+          "name": "roles_at_base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_other": {
+          "name": "roles_at_other",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "character_corporation_roles",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_corporation_roles_corporation_id_character_id_unique": {
+          "name": "character_corporation_roles_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_assets": {
+      "name": "corporation_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_blueprint_copy": {
+          "name": "is_blueprint_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_assets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_assets_corporation_id_item_id_unique": {
+          "name": "corporation_assets_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_config": {
+      "name": "corporation_config",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "corporation_type": {
+          "name": "corporation_type",
+          "type": "corporation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "members_last_sync": {
+          "name": "members_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_tracking_last_sync": {
+          "name": "member_tracking_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets_last_sync": {
+          "name": "wallets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_journal_last_sync": {
+          "name": "wallet_journal_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_transactions_last_sync": {
+          "name": "wallet_transactions_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assets_last_sync": {
+          "name": "assets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structures_last_sync": {
+          "name": "structures_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_last_sync": {
+          "name": "orders_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contracts_last_sync": {
+          "name": "contracts_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_jobs_last_sync": {
+          "name": "industry_jobs_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killmails_last_sync": {
+          "name": "killmails_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_config_include_in_background_refresh_idx": {
+          "name": "corporation_config_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_include_in_structure_asset_sync_idx": {
+          "name": "corporation_config_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_corporation_type_idx": {
+          "name": "corporation_config_corporation_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_member_tracking_last_sync_idx": {
+          "name": "corporation_config_member_tracking_last_sync_idx",
+          "columns": [
+            {
+              "expression": "member_tracking_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallets_last_sync_idx": {
+          "name": "corporation_config_wallets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_assets_last_sync_idx": {
+          "name": "corporation_config_assets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "assets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_structures_last_sync_idx": {
+          "name": "corporation_config_structures_last_sync_idx",
+          "columns": [
+            {
+              "expression": "structures_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_orders_last_sync_idx": {
+          "name": "corporation_config_orders_last_sync_idx",
+          "columns": [
+            {
+              "expression": "orders_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_contracts_last_sync_idx": {
+          "name": "corporation_config_contracts_last_sync_idx",
+          "columns": [
+            {
+              "expression": "contracts_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_industry_jobs_last_sync_idx": {
+          "name": "corporation_config_industry_jobs_last_sync_idx",
+          "columns": [
+            {
+              "expression": "industry_jobs_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_killmails_last_sync_idx": {
+          "name": "corporation_config_killmails_last_sync_idx",
+          "columns": [
+            {
+              "expression": "killmails_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_members_last_sync_idx": {
+          "name": "corporation_config_members_last_sync_idx",
+          "columns": [
+            {
+              "expression": "members_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_transactions_last_sync_idx": {
+          "name": "corporation_config_wallet_transactions_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_transactions_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_journal_last_sync_idx": {
+          "name": "corporation_config_wallet_journal_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_journal_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_contracts": {
+      "name": "corporation_contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptor_id": {
+          "name": "acceptor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyout": {
+          "name": "buyout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collateral": {
+          "name": "collateral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_accepted": {
+          "name": "date_accepted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_expired": {
+          "name": "date_expired",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_to_complete": {
+          "name": "days_to_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_location_id": {
+          "name": "end_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_corporation": {
+          "name": "for_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_corporation_id": {
+          "name": "issuer_corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward": {
+          "name": "reward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_location_id": {
+          "name": "start_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_contracts_leaderboard_all_time_idx": {
+          "name": "corporation_contracts_leaderboard_all_time_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_contracts_leaderboard_period_idx": {
+          "name": "corporation_contracts_leaderboard_period_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_contracts_contract_id_unique": {
+          "name": "corporation_contracts_contract_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contract_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_directors": {
+      "name": "corporation_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_healthy": {
+          "name": "is_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permanent_failure_at": {
+          "name": "permanent_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_directors_corp_healthy_idx": {
+          "name": "corporation_directors_corp_healthy_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_healthy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_next_retry_idx": {
+          "name": "corporation_directors_corp_next_retry_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_permanent_failure_idx": {
+          "name": "corporation_directors_corp_permanent_failure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permanent_failure_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_last_used_idx": {
+          "name": "corporation_directors_last_used_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_directors",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_directors_corporation_id_character_id_unique": {
+          "name": "corporation_directors_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_industry_jobs": {
+      "name": "corporation_industry_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_id": {
+          "name": "installer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_type_id": {
+          "name": "blueprint_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_location_id": {
+          "name": "blueprint_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_location_id": {
+          "name": "output_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs": {
+          "name": "runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_runs": {
+          "name": "licensed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_type_id": {
+          "name": "product_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_date": {
+          "name": "pause_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_character_id": {
+          "name": "completed_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successful_runs": {
+          "name": "successful_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_industry_jobs",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_industry_jobs_corporation_id_job_id_unique": {
+          "name": "corporation_industry_jobs_corporation_id_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_killmails": {
+      "name": "corporation_killmails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_id": {
+          "name": "killmail_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_hash": {
+          "name": "killmail_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_time": {
+          "name": "killmail_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_killmails",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_killmails_corporation_id_killmail_id_unique": {
+          "name": "corporation_killmails_corporation_id_killmail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "killmail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_member_tracking": {
+      "name": "corporation_member_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoff_date": {
+          "name": "logoff_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logon_date": {
+          "name": "logon_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_member_tracking",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_member_tracking_corporation_id_character_id_unique": {
+          "name": "corporation_member_tracking_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_members": {
+      "name": "corporation_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_members_character_id_idx": {
+          "name": "corporation_members_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_members",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_members_corporation_id_character_id_unique": {
+          "name": "corporation_members_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_orders": {
+      "name": "corporation_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escrow": {
+          "name": "escrow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_buy_order": {
+          "name": "is_buy_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issued": {
+          "name": "issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_volume": {
+          "name": "min_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_remain": {
+          "name": "volume_remain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_total": {
+          "name": "volume_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_division": {
+          "name": "wallet_division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_orders",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_orders_corporation_id_order_id_unique": {
+          "name": "corporation_orders_corporation_id_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_public_info": {
+      "name": "corporation_public_info",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ceo_id": {
+          "name": "ceo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_founded": {
+          "name": "date_founded",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_station_id": {
+          "name": "home_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "war_eligible": {
+          "name": "war_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory": {
+      "name": "corporation_structure_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_corp_structure_idx": {
+          "name": "corporation_structure_inventory_corp_structure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+          "name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structure_inventory_corporation_id_item_id_unique": {
+          "name": "corporation_structure_inventory_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structures": {
+      "name": "corporation_structures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_expires": {
+          "name": "fuel_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_amount": {
+          "name": "fuel_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_burn_rate": {
+          "name": "fuel_burn_rate",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refilled_at": {
+          "name": "last_refilled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_apply": {
+          "name": "next_reinforce_apply",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_hour": {
+          "name": "next_reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforce_hour": {
+          "name": "reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_timer_end": {
+          "name": "state_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_timer_start": {
+          "name": "state_timer_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unanchors_at": {
+          "name": "unanchors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_power": {
+          "name": "low_power",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structures_last_synced_at_idx": {
+          "name": "corporation_structures_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structures",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structures_structure_id_unique": {
+          "name": "corporation_structures_structure_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "structure_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_journal": {
+      "name": "corporation_wallet_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id_type": {
+          "name": "context_id_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_receiver_id": {
+          "name": "tax_receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_journal",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+          "name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "journal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_transactions": {
+      "name": "corporation_wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy": {
+          "name": "is_buy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "journal_ref_id": {
+          "name": "journal_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_transactions",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+          "name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallets": {
+      "name": "corporation_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallets_corporation_id_division_unique": {
+          "name": "corporation_wallets_corporation_id_division_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_fuel_log": {
+      "name": "structure_fuel_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_block_units": {
+          "name": "fuel_block_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_fuel_log_corp_structure_observed_idx": {
+          "name": "structure_fuel_log_corp_structure_observed_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_mining_citadel_extractions": {
+      "name": "structure_mining_citadel_extractions",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_start_time": {
+          "name": "extraction_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_arrival_time": {
+          "name": "chunk_arrival_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "natural_decay_time": {
+          "name": "natural_decay_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_mining_citadel_extractions_corporation_id_idx": {
+          "name": "structure_mining_citadel_extractions_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_citadel_extractions_last_synced_at_idx": {
+          "name": "structure_mining_citadel_extractions_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_drills": {
+      "name": "structure_moon_drills",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_drills_corporation_id_idx": {
+          "name": "structure_moon_drills_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_drills_last_synced_at_idx": {
+          "name": "structure_moon_drills_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_geographies": {
+      "name": "structure_moon_geographies",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_name": {
+          "name": "moon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_geographies_corporation_id_idx": {
+          "name": "structure_moon_geographies_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_moon_id_idx": {
+          "name": "structure_moon_geographies_moon_id_idx",
+          "columns": [
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_planet_id_idx": {
+          "name": "structure_moon_geographies_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_system_id_idx": {
+          "name": "structure_moon_geographies_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_last_synced_at_idx": {
+          "name": "structure_moon_geographies_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhook_reagents": {
+      "name": "structure_skyhook_reagents",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "magmatic_gas_secured_stock": {
+          "name": "magmatic_gas_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_unsecured_stock": {
+          "name": "magmatic_gas_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_last_cycle": {
+          "name": "magmatic_gas_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superionic_ice_secured_stock": {
+          "name": "superionic_ice_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_unsecured_stock": {
+          "name": "superionic_ice_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_last_cycle": {
+          "name": "superionic_ice_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhook_reagents_corporation_id_idx": {
+          "name": "structure_skyhook_reagents_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhooks": {
+      "name": "structure_skyhooks",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "effective_workforce": {
+          "name": "effective_workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforcement_timer_end": {
+          "name": "reinforcement_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_start": {
+          "name": "theft_vulnerability_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_end": {
+          "name": "theft_vulnerability_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhooks_corporation_id_idx": {
+          "name": "structure_skyhooks_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_planet_id_idx": {
+          "name": "structure_skyhooks_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_system_id_idx": {
+          "name": "structure_skyhooks_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_type_id_idx": {
+          "name": "structure_skyhooks_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_last_synced_at_idx": {
+          "name": "structure_skyhooks_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_hubs": {
+      "name": "structure_sovereignty_hubs",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_access_list_id": {
+          "name": "fuel_access_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_id": {
+          "name": "controller_alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_name": {
+          "name": "controller_alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay_last_updated": {
+          "name": "reagent_bay_last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay": {
+          "name": "reagent_bay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+        },
+        "upgrades": {
+          "name": "upgrades",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_transport": {
+          "name": "workforce_transport",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_hubs_corporation_id_idx": {
+          "name": "structure_sovereignty_hubs_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_system_id_idx": {
+          "name": "structure_sovereignty_hubs_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_type_id_idx": {
+          "name": "structure_sovereignty_hubs_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_last_synced_at_idx": {
+          "name": "structure_sovereignty_hubs_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_hubs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_systems": {
+      "name": "structure_sovereignty_systems",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_claimant_id": {
+          "name": "corporation_claimant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_since": {
+          "name": "claimed_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sovereignty_hub_structure_id": {
+          "name": "sovereignty_hub_structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capital_system": {
+          "name": "is_capital_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_defense_multiplier": {
+          "name": "activity_defense_multiplier",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "military_level": {
+          "name": "military_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industrial_level": {
+          "name": "industrial_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategic_level": {
+          "name": "strategic_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_systems_corporation_id_idx": {
+          "name": "structure_sovereignty_systems_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_region_id_idx": {
+          "name": "structure_sovereignty_systems_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_alliance_id_idx": {
+          "name": "structure_sovereignty_systems_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+          "name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+          "columns": [
+            {
+              "expression": "sovereignty_hub_structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_last_synced_at_idx": {
+          "name": "structure_sovereignty_systems_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_systems",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.corporation_type": {
+      "name": "corporation_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "alt",
+        "special_purpose",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/eve-corporation-data/.migrations/meta/_journal.json
+++ b/apps/eve-corporation-data/.migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1784827578420,
       "tag": "0030_curious_clea",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1784916519807,
+      "tag": "0031_lively_mariko_yashida",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/eve-corporation-data/src/db/schema.ts
+++ b/apps/eve-corporation-data/src/db/schema.ts
@@ -408,7 +408,10 @@ export const corporationStructures = pgTable(
 		>(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
-	(table) => [unique().on(table.structureId)]
+	(table) => [
+		unique().on(table.structureId),
+		index('corporation_structures_last_synced_at_idx').on(table.lastSyncedAt),
+	]
 )
 
 export const corporationStructureInventory = pgTable(

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -115,10 +115,16 @@ import type {
 	EsiSovereigntyHub,
 	EsiSovereigntySystem,
 	EveCorporationData,
+	SkyhookSyncPriority,
+	SovereigntyHubSyncPriority,
 	SkyhookStoreResult,
+	StructureSyncPriorityTarget,
+	StructureSyncFailureTarget,
 	SearchAssetsFilters,
 	WalletJournalWindowFilters,
 	WalletTransactionWindowFilters,
+	MoonDrillSyncPriority,
+	MiningCitadelSyncPriority,
 } from '@repo/eve-corporation-data'
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
 import type { EveCharacterId, EveStructureId } from '@repo/eve-types'
@@ -131,6 +137,7 @@ import type {
 } from '@repo/universe'
 import type { Env } from './context'
 import type { StructureInventoryRowInput } from './services/structure-inventory'
+import { buildPriorityQueuedEntries } from './services/structure-priority'
 
 function isSpecialStructureTab(
 	tab: ReturnType<typeof getStructureTabForTypeId>
@@ -208,6 +215,7 @@ const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS = 60 * 60
 const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY = 'shared:sovereignty-systems:refresh-lease'
 const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS = 2 * 60
 const ORBITAL_SKYHOOK_TYPE_ID = '81080'
+const STRUCTURE_ENRICHMENT_PRIORITY_LIMIT = 100
 const STRUCTURE_SNAPSHOT_BATCH_SIZE = 10
 const STRUCTURE_CLEANUP_BATCH_SIZE = 250
 
@@ -394,7 +402,9 @@ type MoonDrillStorageRow = {
 	structureId: string
 	corporationId: string
 	sourceSyncAt: Date
+	lastAttemptedSyncAt: Date
 	lastSyncedAt: Date
+	syncFailureReason: string | null
 	updatedAt: Date
 }
 
@@ -485,7 +495,9 @@ function buildMoonDrillStorageRow(input: {
 		structureId: structure.structureId,
 		corporationId,
 		sourceSyncAt: observedAt,
+		lastAttemptedSyncAt: observedAt,
 		lastSyncedAt: observedAt,
+		syncFailureReason: null,
 		updatedAt: observedAt,
 	}
 }
@@ -2437,9 +2449,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			const syncFailureReason = hydrationComplete
 				? null
 				: 'Structure details could not be fully hydrated during sync'
-			const hydrated = preserveStructureHydrationFields(existing, {
-				name: resolvedName,
-				typeName: resolvedTypeName,
+		const hydrated = preserveStructureHydrationFields(existing, {
+			name: resolvedName,
+			typeName: resolvedTypeName,
 				systemName: resolvedSystemName,
 				regionName: resolvedRegionName,
 				syncStatus,
@@ -2592,7 +2604,26 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			return
 		}
 
-		const synthesizedRows = moonDrillStructures
+		const syncPriorities = await this.getMoonDrillSyncPriorities(corporationId)
+		const liveMoonDrillIds = moonDrillStructures.map((structure) => structure.structureId)
+		const newMoonDrillIds = await this.getMissingStructureIdsForPriorityQueue(
+			corporationId,
+			'moon-drills',
+			liveMoonDrillIds
+		)
+		const prioritizedMoonDrillQueue = buildPriorityQueuedEntries(
+			moonDrillStructures.map((structure) => ({
+				id: structure.structureId,
+				structure,
+			})),
+			newMoonDrillIds,
+			syncPriorities
+		)
+		const prioritizedMoonDrillStructures = prioritizedMoonDrillQueue.entries.map(
+			({ entry }) => entry.structure
+		)
+
+		const synthesizedRows = prioritizedMoonDrillStructures
 			.map((structure) =>
 				buildMoonDrillStorageRow({
 					corporationId,
@@ -2611,6 +2642,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		const shouldPrune = synthesizedRows.length === moonDrillStructures.length
+		const pruneCandidateIds = prioritizedMoonDrillQueue.pruneCandidateIds
 		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 
 		for (let i = 0; i < synthesizedRows.length; i += BATCH_SIZE) {
@@ -2624,6 +2656,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						corporationId: sql`excluded.corporation_id`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
+						syncFailureReason: sql`excluded.sync_failure_reason`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})
@@ -2638,8 +2671,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			return
 		}
 
-		const currentStructureIds = new Set(synthesizedRows.map((row) => row.structureId))
-		const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
+		const departedStructureIds = pruneCandidateIds
 
 		await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
 			await this.getDb()
@@ -3375,16 +3407,16 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	/**
 	 * Store sovereignty hub snapshots (workflow-friendly)
 	 */
-	async storeSovereigntyHubs(corporationId: string, hubs: EsiSovereigntyHub[]): Promise<void> {
+	async storeSovereigntyHubs(
+		corporationId: string,
+		hubs: EsiSovereigntyHub[],
+		options: {
+			pruneCandidateIds?: readonly string[]
+		} = {}
+	): Promise<void> {
 		const now = new Date()
+		const pruneCandidateIds = [...new Set((options.pruneCandidateIds ?? []).map((id) => String(id)))]
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
-		const existingRows = await this.getDb().query.structureSovereigntyHubs.findMany({
-			where: eq(structureSovereigntyHubs.corporationId, corporationId),
-			columns: {
-				structureId: true,
-				updatedAt: true,
-			},
-		})
 		const controllerAllianceNames = await resolveAllianceNames(
 			tokenStore,
 			hubs.flatMap((hub) => (hub.controller_alliance_id ? [hub.controller_alliance_id] : []))
@@ -3392,7 +3424,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
 			hubs.length > 0
-				? await universe.resolveSolarSystemsByIds([...new Set(hubs.map((hub) => hub.system_id))])
+				? (await universe.resolveSolarSystemsByIds([
+						...new Set(hubs.map((hub) => hub.system_id)),
+					])) ?? {}
 				: {}
 		const values: SovereigntyHubInsertRow[] = hubs.map((hub) => {
 			const resolvedSystemName =
@@ -3436,31 +3470,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				workforceTransport: normalizeSovereigntyWorkforceTransport(hub.workforce_transport),
 				syncStatus: 'ok' as const,
 				syncFailureReason: null,
+				lastAttemptedSyncAt: now,
 				sourceSyncAt: now,
 				lastSyncedAt: now,
 				updatedAt: now,
 			}
 		})
 
-		if (values.length === 0) {
-			const currentStructureIds = new Set<string>()
-			const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
-
-			await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
-				await this.getDb()
-					.delete(structureSovereigntyHubs)
-					.where(
-						and(
-							eq(structureSovereigntyHubs.corporationId, corporationId),
-							inArray(structureSovereigntyHubs.structureId, batch)
-						)
-					)
-			})
-			return
-		}
-
-		const currentStructureIds = new Set(values.map((row) => row.structureId))
-		const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
 		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < values.length; i += BATCH_SIZE) {
 			const batch = values.slice(i, i + BATCH_SIZE)
@@ -3486,6 +3502,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						workforceTransport: sql`excluded.workforce_transport`,
 						syncStatus: sql`excluded.sync_status`,
 						syncFailureReason: sql`excluded.sync_failure_reason`,
+						lastAttemptedSyncAt: sql`excluded.last_attempted_sync_at`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
 						updatedAt: sql`excluded.updated_at`,
@@ -3493,7 +3510,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				})
 		}
 
-		await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+		await deleteIdsInBatches(pruneCandidateIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
 			await this.getDb()
 				.delete(structureSovereigntyHubs)
 				.where(
@@ -3505,30 +3522,383 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 	}
 
+	private async getTypeScopedStructureSyncPriorities(params: {
+		corporationId: string
+		targetTable: 'sovereignty' | 'skyhooks' | 'moon-drills' | 'mining-extractions'
+	}): Promise<
+		Array<{
+			structureId: string
+			lastAttemptedSyncAt: Date | null
+			lastSyncedAt: Date | null
+		}>
+	> {
+		const { corporationId, targetTable } = params
+		const now = new Date()
+		const successCutoff = new Date(now.getTime() - 60 * 60 * 1000)
+		const attemptCutoff = new Date(now.getTime() - 15 * 60 * 1000)
+		const rows: Array<{
+			structureId: string
+			lastAttemptedSyncAt: Date | null
+			lastSyncedAt: Date | null
+		}> = []
+
+		while (true) {
+			const batch =
+				targetTable === 'sovereignty'
+					? await this.getDb().query.structureSovereigntyHubs.findMany({
+							where: and(
+								eq(structureSovereigntyHubs.corporationId, corporationId),
+								sql`${structureSovereigntyHubs.lastSyncedAt} < ${successCutoff}`,
+								sql`coalesce(${structureSovereigntyHubs.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+							),
+							orderBy: [
+								asc(sql`coalesce(${structureSovereigntyHubs.lastSyncedAt}, to_timestamp(0))`),
+								asc(sql`coalesce(${structureSovereigntyHubs.lastAttemptedSyncAt}, to_timestamp(0))`),
+								asc(structureSovereigntyHubs.structureId),
+							],
+							columns: {
+								structureId: true,
+								lastAttemptedSyncAt: true,
+								lastSyncedAt: true,
+							},
+							limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+						})
+					: targetTable === 'skyhooks'
+						? await this.getDb().query.structureSkyhooks.findMany({
+								where: and(
+									eq(structureSkyhooks.corporationId, corporationId),
+									sql`${structureSkyhooks.lastSyncedAt} < ${successCutoff}`,
+									sql`coalesce(${structureSkyhooks.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+								),
+								orderBy: [
+									asc(sql`coalesce(${structureSkyhooks.lastSyncedAt}, to_timestamp(0))`),
+									asc(sql`coalesce(${structureSkyhooks.lastAttemptedSyncAt}, to_timestamp(0))`),
+									asc(structureSkyhooks.structureId),
+								],
+								columns: {
+									structureId: true,
+									lastAttemptedSyncAt: true,
+									lastSyncedAt: true,
+								},
+								limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+							})
+						: targetTable === 'moon-drills'
+							? await this.getDb().query.structureMoonDrills.findMany({
+									where: and(
+										eq(structureMoonDrills.corporationId, corporationId),
+										sql`${structureMoonDrills.lastSyncedAt} < ${successCutoff}`,
+										sql`coalesce(${structureMoonDrills.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+									),
+									orderBy: [
+										asc(sql`coalesce(${structureMoonDrills.lastSyncedAt}, to_timestamp(0))`),
+										asc(sql`coalesce(${structureMoonDrills.lastAttemptedSyncAt}, to_timestamp(0))`),
+										asc(structureMoonDrills.structureId),
+									],
+									columns: {
+										structureId: true,
+										lastAttemptedSyncAt: true,
+										lastSyncedAt: true,
+									},
+									limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+								})
+							: await this.getDb().query.structureMiningExtractions.findMany({
+									where: and(
+										eq(structureMiningExtractions.corporationId, corporationId),
+										sql`${structureMiningExtractions.lastSyncedAt} < ${successCutoff}`,
+										sql`coalesce(${structureMiningExtractions.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+									),
+									orderBy: [
+										asc(sql`coalesce(${structureMiningExtractions.lastSyncedAt}, to_timestamp(0))`),
+										asc(sql`coalesce(${structureMiningExtractions.lastAttemptedSyncAt}, to_timestamp(0))`),
+										asc(structureMiningExtractions.structureId),
+									],
+									columns: {
+										structureId: true,
+										lastAttemptedSyncAt: true,
+										lastSyncedAt: true,
+									},
+									limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+								})
+
+			if (batch.length === 0) {
+				break
+			}
+
+			rows.push(...batch)
+
+			switch (targetTable) {
+				case 'sovereignty':
+					await this.getDb()
+						.update(structureSovereigntyHubs)
+						.set({
+							lastAttemptedSyncAt: now,
+						})
+						.where(
+							and(
+								eq(structureSovereigntyHubs.corporationId, corporationId),
+								inArray(
+									structureSovereigntyHubs.structureId,
+									batch.map((row) => row.structureId)
+								)
+							)
+						)
+					break
+				case 'skyhooks':
+					await this.getDb()
+						.update(structureSkyhooks)
+						.set({
+							lastAttemptedSyncAt: now,
+						})
+						.where(
+							and(
+								eq(structureSkyhooks.corporationId, corporationId),
+								inArray(structureSkyhooks.structureId, batch.map((row) => row.structureId))
+							)
+						)
+					break
+				case 'moon-drills':
+					await this.getDb()
+						.update(structureMoonDrills)
+						.set({
+							lastAttemptedSyncAt: now,
+						})
+						.where(
+							and(
+								eq(structureMoonDrills.corporationId, corporationId),
+								inArray(structureMoonDrills.structureId, batch.map((row) => row.structureId))
+							)
+						)
+					break
+				case 'mining-extractions':
+					await this.getDb()
+						.update(structureMiningExtractions)
+						.set({
+							lastAttemptedSyncAt: now,
+						})
+						.where(
+							and(
+								eq(structureMiningExtractions.corporationId, corporationId),
+								inArray(
+									structureMiningExtractions.structureId,
+									batch.map((row) => row.structureId)
+								)
+							)
+						)
+					break
+			}
+		}
+
+		return rows.map((row) => ({
+			...row,
+			lastAttemptedSyncAt: row.lastAttemptedSyncAt ?? null,
+		}))
+	}
+
+	private async getTypeScopedStructureIds(params: {
+		corporationId: string
+		targetTable: 'sovereignty' | 'skyhooks' | 'moon-drills' | 'mining-extractions'
+	}): Promise<string[]> {
+		const { corporationId, targetTable } = params
+		switch (targetTable) {
+			case 'sovereignty':
+				return (
+					await this.getDb().query.structureSovereigntyHubs.findMany({
+						where: eq(structureSovereigntyHubs.corporationId, corporationId),
+						columns: {
+							structureId: true,
+						},
+					})
+				).map((row) => row.structureId)
+			case 'skyhooks':
+				return (
+					await this.getDb().query.structureSkyhooks.findMany({
+						where: eq(structureSkyhooks.corporationId, corporationId),
+						columns: {
+							structureId: true,
+						},
+					})
+				).map((row) => row.structureId)
+			case 'moon-drills':
+				return (
+					await this.getDb().query.structureMoonDrills.findMany({
+						where: eq(structureMoonDrills.corporationId, corporationId),
+						columns: {
+							structureId: true,
+						},
+					})
+				).map((row) => row.structureId)
+			case 'mining-extractions':
+				return (
+					await this.getDb().query.structureMiningExtractions.findMany({
+						where: eq(structureMiningExtractions.corporationId, corporationId),
+						columns: {
+							structureId: true,
+						},
+					})
+				).map((row) => row.structureId)
+		}
+	}
+
+	private async getTypeScopedMissingStructureIds(params: {
+		corporationId: string
+		targetTable: 'sovereignty' | 'skyhooks' | 'moon-drills' | 'mining-extractions'
+		structureIds: string[]
+	}): Promise<string[]> {
+		const { corporationId, targetTable, structureIds } = params
+		if (structureIds.length === 0) {
+			return []
+		}
+
+		const liveStructureIds = [...new Set(structureIds.map((structureId) => String(structureId)))]
+		const liveStructureRows = sql.join(
+			liveStructureIds.map((structureId, index) => sql`(${structureId}, ${index})`),
+			sql`, `
+		)
+
+		const targetTableRef =
+			targetTable === 'sovereignty'
+				? structureSovereigntyHubs
+				: targetTable === 'skyhooks'
+					? structureSkyhooks
+					: targetTable === 'moon-drills'
+						? structureMoonDrills
+						: structureMiningExtractions
+
+		const result = await this.getDb().execute<{ structureId: string }>(sql`
+			with live_ids(structure_id, position) as (
+				values ${liveStructureRows}
+			)
+			select live_ids.structure_id as "structureId"
+			from live_ids
+			left join ${targetTableRef}
+				on ${targetTableRef.corporationId} = ${corporationId}
+				and ${targetTableRef.structureId} = live_ids.structure_id
+			where ${targetTableRef.structureId} is null
+			order by live_ids.position asc
+		`)
+
+		return (result.rows ?? []).map((row) => row.structureId)
+	}
+
+	async getSovereigntyHubSyncPriorities(corporationId: string): Promise<SovereigntyHubSyncPriority[]> {
+		return await this.getTypeScopedStructureSyncPriorities({
+			corporationId,
+			targetTable: 'sovereignty',
+		})
+	}
+
+	async getMissingStructureIdsForPriorityQueue(
+		corporationId: string,
+		targetTable: StructureSyncPriorityTarget,
+		structureIds: string[]
+	): Promise<string[]> {
+		return await this.getTypeScopedMissingStructureIds({
+			corporationId,
+			targetTable,
+			structureIds,
+		})
+	}
+
+	async getSovereigntyHubStructureIds(corporationId: string): Promise<string[]> {
+		return await this.getTypeScopedStructureIds({
+			corporationId,
+			targetTable: 'sovereignty',
+		})
+	}
+
+	async getMoonDrillSyncPriorities(corporationId: string): Promise<MoonDrillSyncPriority[]> {
+		return await this.getTypeScopedStructureSyncPriorities({
+			corporationId,
+			targetTable: 'moon-drills',
+		})
+	}
+
+	async getMoonDrillStructureIds(corporationId: string): Promise<string[]> {
+		return await this.getTypeScopedStructureIds({
+			corporationId,
+			targetTable: 'moon-drills',
+		})
+	}
+
+	async getMiningCitadelSyncPriorities(corporationId: string): Promise<MiningCitadelSyncPriority[]> {
+		return await this.getTypeScopedStructureSyncPriorities({
+			corporationId,
+			targetTable: 'mining-extractions',
+		})
+	}
+
+	async getMiningCitadelStructureIds(corporationId: string): Promise<string[]> {
+		return await this.getTypeScopedStructureIds({
+			corporationId,
+			targetTable: 'mining-extractions',
+		})
+	}
+
+	async getSkyhookSyncPriorities(corporationId: string): Promise<SkyhookSyncPriority[]> {
+		return await this.getTypeScopedStructureSyncPriorities({
+			corporationId,
+			targetTable: 'skyhooks',
+		})
+	}
+
+	async getSkyhookStructureIds(corporationId: string): Promise<string[]> {
+		return await this.getTypeScopedStructureIds({
+			corporationId,
+			targetTable: 'skyhooks',
+		})
+	}
+
 	async markStructureEnrichmentSyncFailure(
 		corporationId: string,
 		target: 'sovereignty-hubs' | 'skyhooks',
 		failureReason: string
 	): Promise<void> {
-		const now = new Date()
-		const set = {
-			syncStatus: 'error' as const,
-			syncFailureReason: failureReason,
-			updatedAt: now,
+		const mappedTarget: StructureSyncFailureTarget =
+			target === 'sovereignty-hubs' ? 'sovereignty' : 'skyhooks'
+		await this.markStructureSyncFailureReason(corporationId, mappedTarget, failureReason)
+	}
+
+	async markStructureSyncFailureReason(
+		corporationId: string,
+		target: StructureSyncFailureTarget,
+		failureReason: string
+	): Promise<void> {
+		const update = async (tableName: StructureSyncFailureTarget): Promise<void> => {
+			switch (tableName) {
+				case 'structures':
+					await this.getDb()
+						.update(corporationStructures)
+						.set({ syncFailureReason: failureReason })
+						.where(eq(corporationStructures.corporationId, corporationId))
+					return
+				case 'sovereignty':
+					await this.getDb()
+						.update(structureSovereigntyHubs)
+						.set({ syncFailureReason: failureReason })
+						.where(eq(structureSovereigntyHubs.corporationId, corporationId))
+					return
+				case 'skyhooks':
+					await this.getDb()
+						.update(structureSkyhooks)
+						.set({ syncFailureReason: failureReason })
+						.where(eq(structureSkyhooks.corporationId, corporationId))
+					return
+				case 'moon-drills':
+					await this.getDb()
+						.update(structureMoonDrills)
+						.set({ syncFailureReason: failureReason })
+						.where(eq(structureMoonDrills.corporationId, corporationId))
+					return
+				case 'mining-extractions':
+					await this.getDb()
+						.update(structureMiningExtractions)
+						.set({ syncFailureReason: failureReason })
+						.where(eq(structureMiningExtractions.corporationId, corporationId))
+					return
+			}
 		}
 
-		if (target === 'sovereignty-hubs') {
-			await this.getDb()
-				.update(structureSovereigntyHubs)
-				.set(set)
-				.where(eq(structureSovereigntyHubs.corporationId, corporationId))
-			return
-		}
-
-		await this.getDb()
-			.update(structureSkyhooks)
-			.set(set)
-			.where(eq(structureSkyhooks.corporationId, corporationId))
+		await update(target)
 	}
 
 	/**
@@ -3536,9 +3906,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 */
 	async storeSkyhooks(
 		corporationId: string,
-		skyhooks: EsiCorporationSkyhook[]
+		skyhooks: EsiCorporationSkyhook[],
+		options: {
+			pruneCandidateIds?: readonly string[]
+		} = {}
 	): Promise<SkyhookStoreResult> {
 		const now = new Date()
+		const pruneCandidateIds = [...new Set((options.pruneCandidateIds ?? []).map((id) => String(id)))]
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const existingRows = await this.getDb().query.structureSkyhooks.findMany({
 			where: eq(structureSkyhooks.corporationId, corporationId),
@@ -3653,11 +4027,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				}
 
 					const storageRow: SkyhookInsertRow = {
-					...storageRowData,
-					syncStatus: 'ok' as const,
-					syncFailureReason: null,
-					updatedAt: now,
-				}
+						...storageRowData,
+						syncStatus: 'ok' as const,
+						syncFailureReason: null,
+						updatedAt: now,
+					}
 				const reagentStorageRow = buildSkyhookReagentStorageRow({
 					corporationId,
 					skyhook,
@@ -3688,12 +4062,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				})
 				return { prunedCount: 0 }
 			}
-			const prunableStateIds = filterPrunableStructureIds(existingRows, new Set<string>(), now)
-			const prunableBaseStructureIds = filterPrunableStructureIds(
-				existingBaseStructures,
-				new Set<string>(),
-				now
-			)
+			const prunableStateIds = pruneCandidateIds
+			const prunableBaseStructureIds = pruneCandidateIds
 
 			await deleteIdsInBatches(prunableStateIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
 				await this.getDb()
@@ -3726,9 +4096,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const values = synthesizedRows.map((row) => row.storageRow)
 		const reagentValues = synthesizedRows.map((row) => row.reagentStorageRow)
 
-		const currentStructureIds = new Set(baseValues.map((row) => row.structureId))
-		const departedBaseStructureIds = filterPrunableStructureIds(existingBaseStructures, currentStructureIds, now)
-		const departedStateIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
+		const departedBaseStructureIds = pruneCandidateIds
+		const departedStateIds = pruneCandidateIds
 		const BASE_BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < baseValues.length; i += BASE_BATCH_SIZE) {
 			const batch = baseValues.slice(i, i + BASE_BATCH_SIZE)
@@ -3787,10 +4156,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				.values(batch)
 				.onConflictDoUpdate({
 					target: structureSkyhooks.structureId,
-					set: {
-						corporationId: sql`excluded.corporation_id`,
-						planetId: sql`excluded.planet_id`,
-						planetName: sql`excluded.planet_name`,
+						set: {
+							corporationId: sql`excluded.corporation_id`,
+							planetId: sql`excluded.planet_id`,
+							planetName: sql`excluded.planet_name`,
 						systemId: sql`excluded.system_id`,
 						systemName: sql`excluded.system_name`,
 						typeId: sql`excluded.type_id`,
@@ -3798,14 +4167,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						isActive: sql`excluded.is_active`,
 						effectiveWorkforce: sql`excluded.effective_workforce`,
 						reinforcementTimerEnd: sql`excluded.reinforcement_timer_end`,
-						theftVulnerabilityStart: sql`excluded.theft_vulnerability_start`,
-						theftVulnerabilityEnd: sql`excluded.theft_vulnerability_end`,
-						syncStatus: sql`excluded.sync_status`,
-						syncFailureReason: sql`excluded.sync_failure_reason`,
-						lastObservedAt: sql`excluded.last_observed_at`,
-						sourceSyncAt: sql`excluded.source_sync_at`,
-						lastSyncedAt: sql`excluded.last_synced_at`,
-						updatedAt: sql`excluded.updated_at`,
+							theftVulnerabilityStart: sql`excluded.theft_vulnerability_start`,
+							theftVulnerabilityEnd: sql`excluded.theft_vulnerability_end`,
+							syncStatus: sql`excluded.sync_status`,
+							syncFailureReason: sql`excluded.sync_failure_reason`,
+							lastObservedAt: sql`excluded.last_observed_at`,
+							sourceSyncAt: sql`excluded.source_sync_at`,
+							lastSyncedAt: sql`excluded.last_synced_at`,
+							updatedAt: sql`excluded.updated_at`,
 					},
 				})
 		}
@@ -3875,12 +4244,27 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				chunkArrivalTime: parseDateOrNull(extraction.chunk_arrival_time) ?? null,
 				naturalDecayTime: parseDateOrNull(extraction.natural_decay_time) ?? null,
 				sourceSyncAt: now,
+				lastAttemptedSyncAt: now,
 				lastSyncedAt: now,
+				syncFailureReason: null,
 				updatedAt: now,
 			}
 		})
 
 		if (values.length === 0) {
+			const currentStructureIds = new Set<string>()
+			const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
+
+			await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
+				await this.getDb()
+					.delete(structureMiningExtractions)
+					.where(
+						and(
+							eq(structureMiningExtractions.corporationId, corporationId),
+							inArray(structureMiningExtractions.structureId, batch)
+						)
+					)
+			})
 			return
 		}
 
@@ -3899,8 +4283,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						extractionStartTime: sql`excluded.extraction_start_time`,
 						chunkArrivalTime: sql`excluded.chunk_arrival_time`,
 						naturalDecayTime: sql`excluded.natural_decay_time`,
+						lastAttemptedSyncAt: sql`excluded.last_attempted_sync_at`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
+						syncFailureReason: sql`excluded.sync_failure_reason`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -12,6 +12,7 @@
  */
 
 import { logger } from '@repo/hono-helpers'
+import { parseEsiErrorMetadata } from '@repo/workflow-utils'
 import {
 	transformAssets,
 	transformContracts,
@@ -44,9 +45,11 @@ import type {
 	EsiCorporationWalletJournalEntry,
 	EsiCorporationWalletTransaction,
 } from '@repo/eve-corporation-data'
-import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
+import type { EveTokenStore } from '@repo/eve-token-store'
 
 const SOVEREIGNTY_HUB_TYPE_ID = '32458'
+const SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE = 4
+const SKYHOOK_DETAIL_BATCH_SIZE = 4
 
 // ========================================================================
 // PUBLIC DATA FETCHING
@@ -346,18 +349,30 @@ export async function fetchSovereigntySystems(
 	})
 }
 
+function isRateLimitEsiError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error)
+	const metadata = parseEsiErrorMetadata(message)
+	return metadata?.status === 429 || message.includes('429 Too Many Requests')
+}
+
 export async function fetchSovereigntyHubs(
 	tokenStore: EveTokenStore,
 	corporationId: string,
-	characterId: string
-): Promise<EsiSovereigntyHub[]> {
-	type RawSovereigntyHubsListing = {
-		sovereignty_hubs: Array<{
-			id: number
-			solar_system_id: number
+	characterId: string,
+	options: {
+		prioritizedEntries: ReadonlyArray<{
+			index: number
+			entry: { id: number; solar_system_id: number }
 		}>
+		pruneCandidateIds?: readonly string[]
 	}
-
+): Promise<{
+	sovereigntyHubs: EsiSovereigntyHub[]
+	pruneCandidateIds: string[]
+	failureCount: number
+	rateLimitFailureCount: number
+	nonRateLimitFailureCount: number
+}> {
 	type RawSovereigntyHubDetail = {
 		id: number
 		solar_system_id: number
@@ -428,31 +443,28 @@ export async function fetchSovereigntyHubs(
 		}
 	}
 
-	const firstPage = await tokenStore.fetchEsi<RawSovereigntyHubsListing>(
-		`/corporations/${corporationId}/structures/sovereignty-hubs?page=1`,
-		characterId,
-		{ cacheMode: 'no-store' }
-	)
-	const sovereigntyHubs = [...firstPage.data.sovereignty_hubs]
-
-	for (let page = 2; page <= (firstPage.pages ?? 1); page += 1) {
-		const pageResponse = await tokenStore.fetchEsi<RawSovereigntyHubsListing>(
-			`/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
-			characterId,
-			{ cacheMode: 'no-store' }
-		)
-		sovereigntyHubs.push(...pageResponse.data.sovereignty_hubs)
+	const prioritizedHubs = options.prioritizedEntries
+	if (prioritizedHubs.length === 0) {
+		return {
+			sovereigntyHubs: [],
+			pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+			failureCount: 0,
+			rateLimitFailureCount: 0,
+			nonRateLimitFailureCount: 0,
+		}
 	}
 
-	if (sovereigntyHubs.length === 0) {
-		return []
-	}
+	const hubs: Array<{ index: number; hub: EsiSovereigntyHub }> = []
+	const failures: Array<{ structureId: string; error: string }> = []
+	let rateLimitFailureCount = 0
+	let nonRateLimitFailureCount = 0
 
-	const details: Array<EsiSovereigntyHub | null> = await Promise.all(
-		sovereigntyHubs.map(async (hub) => {
-			try {
+	for (let index = 0; index < prioritizedHubs.length; index += SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE) {
+		const batch = prioritizedHubs.slice(index, index + SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE)
+		const settled = await Promise.allSettled(
+			batch.map(async ({ entry }) => {
 				const detailResult = await tokenStore.fetchEsi<RawSovereigntyHubDetail>(
-					`/corporations/${corporationId}/structures/sovereignty-hubs/${hub.id}`,
+					`/corporations/${corporationId}/structures/sovereignty-hubs/${entry.id}`,
 					characterId,
 					{ cacheMode: 'no-store' }
 				)
@@ -468,15 +480,15 @@ export async function fetchSovereigntyHubs(
 						detail.fuel_access_list_id !== undefined && detail.fuel_access_list_id !== null
 							? String(detail.fuel_access_list_id)
 							: null,
-						reagent_bay: {
-							last_updated: detail.reagent_bay.last_updated,
-							reagents: detail.reagent_bay.reagents.map((reagent) => ({
-								type_id: String(reagent.type_id),
-								amount: reagent.amount,
-								burning_per_hour: reagent.burning_per_hour,
-								last_cycle: reagent.last_cycle,
-							})),
-						},
+					reagent_bay: {
+						last_updated: detail.reagent_bay.last_updated,
+						reagents: detail.reagent_bay.reagents.map((reagent) => ({
+							type_id: String(reagent.type_id),
+							amount: reagent.amount,
+							burning_per_hour: reagent.burning_per_hour,
+							last_cycle: reagent.last_cycle,
+						})),
+					},
 					resources: detail.resources,
 					upgrades: detail.upgrades.map((upgrade) => ({
 						type_id: String(upgrade.type_id),
@@ -491,32 +503,68 @@ export async function fetchSovereigntyHubs(
 						detail,
 					},
 				} as EsiSovereigntyHub
-			} catch (error) {
-				logger.warn('[ESI Fetch] Failed to enrich sovereignty hub', {
-					corporationId,
-					structureId: String(hub.id),
-					error: error instanceof Error ? error.message : String(error),
-				})
-				return null
-			}
-		})
-	)
+			})
+		)
 
-	return details.filter((hub): hub is EsiSovereigntyHub => hub !== null)
+		for (let resultIndex = 0; resultIndex < settled.length; resultIndex += 1) {
+			const result = settled[resultIndex]
+			const source = batch[resultIndex]
+			if (result.status === 'fulfilled') {
+				hubs.push({
+					index: source.index,
+					hub: result.value,
+				})
+				continue
+			}
+
+			if (isRateLimitEsiError(result.reason)) {
+				rateLimitFailureCount += 1
+			} else {
+				nonRateLimitFailureCount += 1
+			}
+			failures.push({
+				structureId: String(source.entry.id),
+				error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+			})
+		}
+	}
+
+	if (failures.length > 0) {
+		logger.warn('[ESI Fetch] Sovereignty hub detail fetch completed with partial failures', {
+			corporationId,
+			successCount: hubs.length,
+			failureCount: failures.length,
+			failures: failures.slice(0, 10),
+		})
+	}
+
+	return {
+		sovereigntyHubs: hubs.sort((a, b) => a.index - b.index).map((entry) => entry.hub),
+		pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+		failureCount: failures.length,
+		rateLimitFailureCount,
+		nonRateLimitFailureCount,
+	}
 }
 
 export async function fetchCorporationSkyhooks(
 	tokenStore: EveTokenStore,
 	corporationId: string,
-	characterId: string
-): Promise<EsiCorporationSkyhook[]> {
-	type RawCorporationSkyhooksListing = {
-		skyhooks: Array<{
-			id: number
-			planet_id: number
+	characterId: string,
+	options: {
+		prioritizedEntries: ReadonlyArray<{
+			index: number
+			entry: { id: number; planet_id: number }
 		}>
+		pruneCandidateIds?: readonly string[]
 	}
-
+): Promise<{
+	skyhooks: EsiCorporationSkyhook[]
+	pruneCandidateIds: string[]
+	failureCount: number
+	rateLimitFailureCount: number
+	nonRateLimitFailureCount: number
+}> {
 	type RawCorporationSkyhookDetail = {
 		id: number
 		planet_id: number
@@ -538,62 +586,99 @@ export async function fetchCorporationSkyhooks(
 		} | null
 	}
 
-	const listing = await tokenStore.fetchEsi<RawCorporationSkyhooksListing>(
-		`/corporations/${corporationId}/structures/skyhooks`,
-		characterId,
-		{ cacheMode: 'no-store' }
-	)
+	const prioritizedListing = options.prioritizedEntries
 
-	const skyhookListing = [...listing.data.skyhooks]
-	for (let page = 2; page <= (listing.pages ?? 1); page += 1) {
-		const pageResponse = await tokenStore.fetchEsi<RawCorporationSkyhooksListing>(
-			`/corporations/${corporationId}/structures/skyhooks?page=${page}`,
-			characterId,
-			{ cacheMode: 'no-store' }
+	if (prioritizedListing.length === 0) {
+		return {
+			skyhooks: [],
+			pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+			failureCount: 0,
+			rateLimitFailureCount: 0,
+			nonRateLimitFailureCount: 0,
+		}
+	}
+
+	const skyhooks: Array<{ index: number; skyhook: EsiCorporationSkyhook }> = []
+	const failures: Array<{ structureId: string; error: string }> = []
+	let rateLimitFailureCount = 0
+	let nonRateLimitFailureCount = 0
+
+	for (let index = 0; index < prioritizedListing.length; index += SKYHOOK_DETAIL_BATCH_SIZE) {
+		const batch = prioritizedListing.slice(index, index + SKYHOOK_DETAIL_BATCH_SIZE)
+		const settled = await Promise.allSettled(
+			batch.map(async ({ entry }) => {
+				const detailResult = await tokenStore.fetchEsi<RawCorporationSkyhookDetail>(
+					`/corporations/${corporationId}/structures/skyhooks/${entry.id}`,
+					characterId,
+					{ cacheMode: 'no-store' }
+				)
+
+				const detail = detailResult.data
+				const theftVulnerability = detail.theft_vulnerability ?? null
+
+				return {
+					structure_id: String(detail.id),
+					planet_id: String(detail.planet_id),
+					corporation_id: String(corporationId),
+					state: detail.state,
+					is_active: detail.is_active,
+					effective_workforce: detail.effective_workforce ?? null,
+					reagents:
+						detail.reagents?.map((reagent) => ({
+							type_id: String(reagent.type_id),
+							secured_stock: reagent.secured_stock,
+							unsecured_stock: reagent.unsecured_stock,
+							last_cycle: reagent.last_cycle,
+						})) ?? [],
+					reinforcement_timer: detail.reinforcement_timer ?? null,
+					theft_vulnerability: theftVulnerability,
+					raw: {
+						listing: entry,
+						detail,
+					},
+				} as EsiCorporationSkyhook
+			})
 		)
-		skyhookListing.push(...pageResponse.data.skyhooks)
+
+		for (let resultIndex = 0; resultIndex < settled.length; resultIndex += 1) {
+			const result = settled[resultIndex]
+			const source = batch[resultIndex]
+			if (result.status === 'fulfilled') {
+				skyhooks.push({
+					index: source.index,
+					skyhook: result.value,
+				})
+				continue
+			}
+
+			if (isRateLimitEsiError(result.reason)) {
+				rateLimitFailureCount += 1
+			} else {
+				nonRateLimitFailureCount += 1
+			}
+			failures.push({
+				structureId: String(source.entry.id),
+				error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+			})
+		}
 	}
 
-	if (skyhookListing.length === 0) {
-		return []
-	}
-
-	const skyhooks: Array<EsiCorporationSkyhook | null> = await Promise.all(
-		skyhookListing.map(async (skyhook) => {
-			const detailResult = await tokenStore.fetchEsi<RawCorporationSkyhookDetail>(
-				`/corporations/${corporationId}/structures/skyhooks/${skyhook.id}`,
-				characterId,
-				{ cacheMode: 'no-store' }
-			)
-
-			const detail = detailResult.data
-			const theftVulnerability = detail.theft_vulnerability ?? null
-
-			return {
-				structure_id: String(detail.id),
-				planet_id: String(detail.planet_id),
-				corporation_id: String(corporationId),
-				state: detail.state,
-				is_active: detail.is_active,
-				effective_workforce: detail.effective_workforce ?? null,
-				reagents:
-					detail.reagents?.map((reagent) => ({
-						type_id: String(reagent.type_id),
-						secured_stock: reagent.secured_stock,
-						unsecured_stock: reagent.unsecured_stock,
-						last_cycle: reagent.last_cycle,
-				})) ?? [],
-				reinforcement_timer: detail.reinforcement_timer ?? null,
-				theft_vulnerability: theftVulnerability,
-				raw: {
-					listing: skyhook,
-					detail,
-				},
-			} as EsiCorporationSkyhook
+	if (failures.length > 0) {
+		logger.warn('[ESI Fetch] Skyhook detail fetch completed with partial failures', {
+			corporationId,
+			successCount: skyhooks.length,
+			failureCount: failures.length,
+			failures: failures.slice(0, 10),
 		})
-	)
+	}
 
-	return skyhooks.filter((skyhook): skyhook is EsiCorporationSkyhook => skyhook !== null)
+	return {
+		skyhooks: skyhooks.sort((a, b) => a.index - b.index).map((entry) => entry.skyhook),
+		pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+		failureCount: failures.length,
+		rateLimitFailureCount,
+		nonRateLimitFailureCount,
+	}
 }
 
 /**

--- a/apps/eve-corporation-data/src/services/structure-priority.ts
+++ b/apps/eve-corporation-data/src/services/structure-priority.ts
@@ -1,0 +1,109 @@
+export type SyncPriorityLike = {
+	structureId: string
+	lastAttemptedSyncAt: Date | null
+	lastSyncedAt: Date | null
+}
+
+export function buildPriorityQueuedEntries<
+	T extends { id: string | number },
+	P extends SyncPriorityLike,
+>(
+	entries: readonly T[],
+	newStructureIds: readonly string[] = [],
+	syncPriorities: readonly P[] = []
+): {
+	entries: Array<{ index: number; entry: T; priority: P | null }>
+	pruneCandidateIds: string[]
+} {
+	const liveStructureIds = new Set(entries.map((entry) => String(entry.id)))
+	const newStructureIdSet = new Set(newStructureIds.map((structureId) => String(structureId)))
+	const livePriorities = syncPriorities.filter((priority) => liveStructureIds.has(priority.structureId))
+	const priorityByStructureId = new Map(
+		livePriorities.map((priority) => [priority.structureId, priority] as const)
+	)
+	const mappedEntries = entries.map((entry, index) => ({
+		entry,
+		index,
+		priority: priorityByStructureId.get(String(entry.id)) ?? null,
+	}))
+
+	const newEntries = mappedEntries.filter(
+		(entry) => newStructureIdSet.has(String(entry.entry.id)) && entry.priority === null
+	)
+	const prioritizedEntries = mappedEntries
+		.filter((entry) => entry.priority !== null)
+		.sort((a, b) => {
+			const aPriority = a.priority!
+			const bPriority = b.priority!
+			const aSynced = aPriority.lastSyncedAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const bSynced = bPriority.lastSyncedAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			if (aSynced !== bSynced) return aSynced - bSynced
+
+			const aAttempted =
+				aPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const bAttempted =
+				bPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			if (aAttempted !== bAttempted) return aAttempted - bAttempted
+
+			return a.index - b.index
+		})
+
+	const pruneCandidateIds = syncPriorities
+		.filter((priority) => !liveStructureIds.has(priority.structureId))
+		.map((priority) => priority.structureId)
+
+	return {
+		entries: [...newEntries, ...prioritizedEntries],
+		pruneCandidateIds,
+	}
+}
+
+export function buildPriorityOrderedEntries<T extends { id: string | number }, P extends SyncPriorityLike>(
+	entries: readonly T[],
+	syncPriorities: readonly P[] = [],
+	options: {
+		knownStructureIds?: readonly string[]
+	} = {}
+): Array<{ index: number; entry: T; priority: P | null }> {
+	const liveStructureIds = new Set(entries.map((entry) => String(entry.id)))
+	const knownStructureIds = options.knownStructureIds
+		? new Set(options.knownStructureIds.map((structureId) => String(structureId)))
+		: null
+	const livePriorities = syncPriorities.filter((priority) =>
+		liveStructureIds.has(priority.structureId) &&
+		(knownStructureIds === null || knownStructureIds.has(priority.structureId))
+	)
+	const priorityByStructureId = new Map(
+		livePriorities.map((priority) => [priority.structureId, priority] as const)
+	)
+	const mappedEntries = entries.map((entry, index) => ({
+		entry,
+		index,
+		priority: priorityByStructureId.get(String(entry.id)) ?? null,
+	}))
+
+	const newEntries = mappedEntries.filter((entry) => {
+		if (entry.priority !== null) return false
+		if (knownStructureIds === null) return true
+		return !knownStructureIds.has(String(entry.entry.id))
+	})
+	const prioritizedEntries = mappedEntries
+		.filter((entry) => entry.priority !== null)
+		.sort((a, b) => {
+			const aPriority = a.priority!
+			const bPriority = b.priority!
+			const aSynced = aPriority.lastSyncedAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const bSynced = bPriority.lastSyncedAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			if (aSynced !== bSynced) return aSynced - bSynced
+
+			const aAttempted =
+				aPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const bAttempted =
+				bPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			if (aAttempted !== bAttempted) return aAttempted - bAttempted
+
+			return a.index - b.index
+		})
+
+	return [...newEntries, ...prioritizedEntries]
+}

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -66,8 +66,16 @@ describe('esi structure enrichment ownership handling', () => {
 			fetchEsi: vi
 				.fn()
 				.mockResolvedValueOnce({
-					data: { skyhooks: [{ id: 71001, planet_id: 401 }] },
-					pages: 1,
+					data: {
+						id: 71002,
+						planet_id: 402,
+						state: 'active',
+						is_active: true,
+						effective_workforce: 6,
+						reagents: [],
+						reinforcement_timer: null,
+						theft_vulnerability: null,
+					},
 				})
 				.mockResolvedValueOnce({
 					data: {
@@ -90,22 +98,28 @@ describe('esi structure enrichment ownership handling', () => {
 				}),
 		}
 
-		const skyhooks = await fetchCorporationSkyhooks(
-			tokenStore as never,
-			'98000001',
-			'211'
-		)
+		const skyhookResult = await fetchCorporationSkyhooks(tokenStore as never, '98000001', '211', {
+			prioritizedEntries: [
+				{ index: 0, entry: { id: 71002, planet_id: 402 } },
+				{ index: 1, entry: { id: 71001, planet_id: 401 } },
+			],
+		})
 
 		expect(tokenStore.fetchEsi).toHaveBeenCalledTimes(2)
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			1,
+			'/corporations/98000001/structures/skyhooks/71002',
+			'211',
+			{ cacheMode: 'no-store' }
+		)
 		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
 			2,
 			'/corporations/98000001/structures/skyhooks/71001',
 			'211',
 			{ cacheMode: 'no-store' }
 		)
-		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
-			1,
-			'/corporations/98000001/structures/skyhooks',
+		expect(tokenStore.fetchEsi).not.toHaveBeenCalledWith(
+			'/corporations/98000001/structures/skyhooks/99999',
 			'211',
 			{ cacheMode: 'no-store' }
 		)
@@ -114,8 +128,21 @@ describe('esi structure enrichment ownership handling', () => {
 			'211',
 			{ cacheMode: 'no-store' }
 		)
-		expect(skyhooks).toHaveLength(1)
-		expect(skyhooks[0]).toMatchObject({
+		expect(skyhookResult.failureCount).toBe(0)
+		expect(skyhookResult.skyhooks.map((skyhook) => skyhook.structure_id)).toEqual([
+			'71002',
+			'71001',
+		])
+		expect(skyhookResult.skyhooks[0]).toMatchObject({
+			structure_id: '71002',
+			planet_id: '402',
+			corporation_id: '98000001',
+			state: 'active',
+			is_active: true,
+			effective_workforce: 6,
+			reagents: [],
+		})
+		expect(skyhookResult.skyhooks[1]).toMatchObject({
 			structure_id: '71001',
 			planet_id: '401',
 			corporation_id: '98000001',
@@ -131,6 +158,111 @@ describe('esi structure enrichment ownership handling', () => {
 				},
 			],
 		})
+	})
+
+	it('prioritizes stale skyhooks first and keeps partial successes when one detail request fails', async () => {
+		const tokenStore = {
+			fetchEsi: vi.fn().mockImplementation(async (path: string) => {
+				if (path === '/corporations/98000001/structures/skyhooks') {
+					return {
+						data: {
+							skyhooks: [
+								{ id: 40001, planet_id: 404 },
+								{ id: 30001, planet_id: 401 },
+								{ id: 10001, planet_id: 402 },
+								{ id: 20001, planet_id: 403 },
+							],
+						},
+						pages: 1,
+					}
+				}
+
+				if (path === '/corporations/98000001/structures/skyhooks/40001') {
+					return {
+						data: {
+							id: 40001,
+							planet_id: 404,
+							state: 'active',
+							is_active: true,
+						},
+					}
+				}
+
+				if (path === '/corporations/98000001/structures/skyhooks/30001') {
+					throw new Error('ESI request failed: 429 Too Many Requests')
+				}
+
+				if (path === '/corporations/98000001/structures/skyhooks/10001') {
+					return {
+						data: {
+							id: 10001,
+							planet_id: 402,
+							state: 'active',
+							is_active: true,
+						},
+					}
+				}
+
+				if (path === '/corporations/98000001/structures/skyhooks/20001') {
+					return {
+						data: {
+							id: 20001,
+							planet_id: 403,
+							state: 'active',
+							is_active: true,
+						},
+					}
+				}
+
+				throw new Error(`Unexpected path: ${path}`)
+			}),
+		}
+
+		const skyhookResult = await fetchCorporationSkyhooks(
+			tokenStore as never,
+			'98000001',
+			'211',
+			{
+				prioritizedEntries: [
+					{ index: 0, entry: { id: 40001, planet_id: 404 } },
+					{ index: 1, entry: { id: 30001, planet_id: 401 } },
+					{ index: 2, entry: { id: 10001, planet_id: 402 } },
+					{ index: 3, entry: { id: 20001, planet_id: 403 } },
+				],
+			}
+		)
+
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			1,
+			'/corporations/98000001/structures/skyhooks/40001',
+			'211',
+			{ cacheMode: 'no-store' }
+		)
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			2,
+			'/corporations/98000001/structures/skyhooks/30001',
+			'211',
+			{ cacheMode: 'no-store' }
+		)
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			3,
+			'/corporations/98000001/structures/skyhooks/10001',
+			'211',
+			{ cacheMode: 'no-store' }
+		)
+		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
+			4,
+			'/corporations/98000001/structures/skyhooks/20001',
+			'211',
+			{ cacheMode: 'no-store' }
+		)
+		expect(skyhookResult.failureCount).toBe(1)
+		expect(skyhookResult.skyhooks).toHaveLength(3)
+		expect(skyhookResult.skyhooks.map((skyhook) => skyhook.structure_id)).toEqual([
+			'40001',
+			'10001',
+			'20001',
+		])
 	})
 
 	it('uses the base structure row and requesting corporation id when building the stored skyhook row', () => {
@@ -171,7 +303,6 @@ describe('esi structure enrichment ownership handling', () => {
 			planetName: 'Planet One',
 			systemId: '30000142',
 			systemName: 'Jita',
-			name: null,
 			typeId: '35842',
 			state: 'vulnerable',
 		})
@@ -276,9 +407,24 @@ describe('esi structure enrichment ownership handling', () => {
 				.fn()
 				.mockResolvedValueOnce({
 					data: {
-						sovereignty_hubs: [{ id: 81001 }],
+						id: 81002,
+						solar_system_id: 30000143,
+						fuel_access_list_id: null,
+						reagent_bay: {
+							last_updated: '2026-07-12T19:36:46.834Z',
+							reagents: [],
+						},
+						resources: {
+							power: { allocated: 0, available: 0 },
+							workforce: { allocated: 0, available: 0 },
+						},
+						upgrades: [],
+						vulnerability_window: null,
+						workforce_transport: {
+							configuration: { transit: true },
+							state: { transit: true },
+						},
 					},
-					pages: 1,
 				})
 				.mockResolvedValueOnce({
 					data: {
@@ -303,16 +449,28 @@ describe('esi structure enrichment ownership handling', () => {
 				}),
 		}
 
-		const hubs = await fetchSovereigntyHubs(
-			tokenStore as never,
-			'98000001',
-			'211'
-		)
+		const hubResult = await fetchSovereigntyHubs(tokenStore as never, '98000001', '211', {
+			prioritizedEntries: [
+				{
+					index: 0,
+					entry: { id: 81002, solar_system_id: 30000143 },
+				},
+				{
+					index: 1,
+					entry: { id: 81001, solar_system_id: 30000142 },
+				},
+			],
+		})
 
 		expect(tokenStore.fetchEsi).toHaveBeenCalledTimes(2)
 		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
 			1,
-			'/corporations/98000001/structures/sovereignty-hubs?page=1',
+			'/corporations/98000001/structures/sovereignty-hubs/81002',
+			'211',
+			{ cacheMode: 'no-store' }
+		)
+		expect(tokenStore.fetchEsi).not.toHaveBeenCalledWith(
+			'/corporations/98000001/structures/sovereignty-hubs/99999',
 			'211',
 			{ cacheMode: 'no-store' }
 		)
@@ -322,13 +480,137 @@ describe('esi structure enrichment ownership handling', () => {
 			'211',
 			{ cacheMode: 'no-store' }
 		)
-		expect(hubs).toHaveLength(1)
-		expect(hubs[0]).toMatchObject({
-			structure_id: '81001',
-			corporation_id: '98000001',
-			system_id: '30000142',
-			type_id: SOVEREIGNTY_HUB_TYPE_ID,
-			name: null,
+		expect(hubResult.failureCount).toBe(0)
+		expect(hubResult.sovereigntyHubs).toHaveLength(2)
+		expect(hubResult.sovereigntyHubs).toEqual([
+			expect.objectContaining({
+				structure_id: '81002',
+				corporation_id: '98000001',
+				system_id: '30000143',
+				type_id: SOVEREIGNTY_HUB_TYPE_ID,
+				name: null,
+			}),
+			expect.objectContaining({
+				structure_id: '81001',
+				corporation_id: '98000001',
+				system_id: '30000142',
+				type_id: SOVEREIGNTY_HUB_TYPE_ID,
+				name: null,
+			}),
+		])
+	})
+
+	it('prioritizes stale sovereignty hubs first and keeps partial successes when one detail request fails', async () => {
+		const tokenStore = {
+			fetchEsi: vi.fn().mockImplementation(async (path: string) => {
+					if (path === '/corporations/98000001/structures/sovereignty-hubs?page=1') {
+						return {
+							data: {
+								sovereignty_hubs: [
+									{ id: 40001, solar_system_id: 404 },
+									{ id: 30001, solar_system_id: 401 },
+									{ id: 10001, solar_system_id: 402 },
+									{ id: 20001, solar_system_id: 403 },
+								],
+							},
+							pages: 1,
+						}
+					}
+
+					if (path === '/corporations/98000001/structures/sovereignty-hubs/40001') {
+						return {
+							data: {
+								id: 40001,
+								solar_system_id: 404,
+								fuel_access_list_id: null,
+								reagent_bay: {
+									last_updated: '2026-07-23T00:00:00.000Z',
+									reagents: [],
+								},
+								resources: {
+									power: { allocated: 0, available: 0 },
+									workforce: { allocated: 0, available: 0 },
+								},
+								upgrades: [],
+								vulnerability_window: null,
+								workforce_transport: {
+									configuration: { transit: true },
+									state: { transit: true },
+								},
+							},
+						}
+					}
+
+				if (path === '/corporations/98000001/structures/sovereignty-hubs/30001') {
+					throw new Error('ESI request failed: 429 Too Many Requests')
+				}
+
+				if (path === '/corporations/98000001/structures/sovereignty-hubs/10001') {
+					return {
+						data: {
+							id: 10001,
+							solar_system_id: 402,
+							fuel_access_list_id: null,
+							reagent_bay: {
+								last_updated: '2026-07-23T00:00:00.000Z',
+								reagents: [],
+							},
+							resources: {
+								power: { allocated: 0, available: 0 },
+								workforce: { allocated: 0, available: 0 },
+							},
+							upgrades: [],
+							vulnerability_window: null,
+							workforce_transport: {
+								configuration: { transit: true },
+								state: { transit: true },
+							},
+						},
+					}
+				}
+
+				if (path === '/corporations/98000001/structures/sovereignty-hubs/20001') {
+					return {
+						data: {
+							id: 20001,
+							solar_system_id: 403,
+							fuel_access_list_id: null,
+							reagent_bay: {
+								last_updated: '2026-07-23T00:00:00.000Z',
+								reagents: [],
+							},
+							resources: {
+								power: { allocated: 0, available: 0 },
+								workforce: { allocated: 0, available: 0 },
+							},
+							upgrades: [],
+							vulnerability_window: null,
+							workforce_transport: {
+								configuration: { transit: true },
+								state: { transit: true },
+							},
+						},
+					}
+				}
+
+				throw new Error(`Unexpected path: ${path}`)
+			}),
+		}
+
+		const hubResult = await fetchSovereigntyHubs(tokenStore as never, '98000001', '211', {
+			prioritizedEntries: [
+				{ index: 0, entry: { id: 40001, solar_system_id: 404 } },
+				{ index: 1, entry: { id: 30001, solar_system_id: 401 } },
+				{ index: 2, entry: { id: 10001, solar_system_id: 402 } },
+				{ index: 3, entry: { id: 20001, solar_system_id: 403 } },
+			],
 		})
+
+		expect(hubResult.failureCount).toBe(1)
+		expect(hubResult.sovereigntyHubs.map((hub) => hub.structure_id)).toEqual([
+			'40001',
+			'10001',
+			'20001',
+		])
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { structureMiningExtractions } from '../../../db/schema'
+
 const mocks = vi.hoisted(() => {
 	const findMany = vi.fn()
 	const onConflictDoUpdate = vi.fn()
 	const values = vi.fn(() => ({ onConflictDoUpdate }))
 	const insert = vi.fn(() => ({ values }))
-	const deleteMock = vi.fn()
+	const deleteWhere = vi.fn().mockResolvedValue(undefined)
+	const deleteMock = vi.fn(() => ({ where: deleteWhere }))
 	const resolveMoonGeographyByIds = vi.fn()
 	const getStub = vi.fn(() => ({
 		resolveMoonGeographyByIds,
@@ -17,6 +20,7 @@ const mocks = vi.hoisted(() => {
 		values,
 		insert,
 		deleteMock,
+		deleteWhere,
 		resolveMoonGeographyByIds,
 		getStub,
 	}
@@ -30,6 +34,11 @@ vi.mock('../../../db', () => ({
 				},
 			},
 		insert: mocks.insert,
+		update: vi.fn(() => ({
+			set: vi.fn(() => ({
+				where: vi.fn().mockResolvedValue(undefined),
+			})),
+		})),
 		delete: mocks.deleteMock,
 	})),
 }))
@@ -41,7 +50,7 @@ vi.mock('@repo/do-utils', () => ({
 import { EveCorporationDataDO } from '../../../durable-object'
 
 describe('storeMiningExtractions', () => {
-	it('preserves the last known mining snapshot when the extraction pull is empty', async () => {
+	it('stamps mining snapshot rows with attempt and success timestamps on insert', async () => {
 		mocks.findMany.mockResolvedValue([
 			{
 				structureId: 'structure-1',
@@ -66,13 +75,66 @@ describe('storeMiningExtractions', () => {
 			{
 				DATABASE_URL: 'postgres://example',
 				UNIVERSE: {} as never,
+				EVE_TOKEN_STORE: {} as never,
+			} as never
+		)
+
+		await doInstance.storeMiningExtractions('corp-1', [
+			{
+				structure_id: 'structure-1',
+				moon_id: 'moon-1',
+				extraction_start_time: '2026-07-01T00:00:00.000Z',
+				chunk_arrival_time: '2026-07-02T00:00:00.000Z',
+				natural_decay_time: '2026-07-03T00:00:00.000Z',
+				raw: {},
+			},
+		] as never)
+
+		expect(mocks.resolveMoonGeographyByIds).not.toHaveBeenCalled()
+		expect(mocks.insert).toHaveBeenCalled()
+		expect(mocks.values).toHaveBeenCalledWith([
+			expect.objectContaining({
+				structureId: 'structure-1',
+				lastAttemptedSyncAt: expect.any(Date),
+				lastSyncedAt: expect.any(Date),
+				sourceSyncAt: expect.any(Date),
+			}),
+		])
+	})
+
+	it('clears stale mining extraction rows when the ESI extraction list is empty', async () => {
+		vi.clearAllMocks()
+		mocks.findMany.mockResolvedValue([
+			{
+				structureId: 'structure-1',
+				corporationId: 'corp-1',
+				moonId: 'moon-1',
+				moonName: 'Old Moon',
+				planetId: 'planet-1',
+				planetName: 'Old Planet',
+				systemId: 'system-1',
+				systemName: 'Old System',
+				extractionStartTime: new Date('2026-07-01T00:00:00.000Z'),
+				chunkArrivalTime: new Date('2026-07-02T00:00:00.000Z'),
+				naturalDecayTime: new Date('2026-07-03T00:00:00.000Z'),
+				sourceSyncAt: new Date('2026-07-01T00:00:00.000Z'),
+				lastSyncedAt: new Date('2026-07-01T00:00:00.000Z'),
+				updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+			},
+		])
+
+		const doInstance = new EveCorporationDataDO(
+			{} as DurableObjectState,
+			{
+				DATABASE_URL: 'postgres://example',
+				UNIVERSE: {} as never,
+				EVE_TOKEN_STORE: {} as never,
 			} as never
 		)
 
 		await doInstance.storeMiningExtractions('corp-1', [])
 
-		expect(mocks.resolveMoonGeographyByIds).not.toHaveBeenCalled()
-		expect(mocks.insert).not.toHaveBeenCalled()
-		expect(mocks.deleteMock).not.toHaveBeenCalled()
+		expect(mocks.deleteMock).toHaveBeenCalledWith(structureMiningExtractions)
+		expect(mocks.values).not.toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -4,8 +4,6 @@ import {
 	corporationStructures,
 	structureMoonGeographies,
 	structureMoonDrills,
-	structureSkyhooks,
-	structureSovereigntyHubs,
 } from '../../../db/schema'
 import { EveCorporationDataDO } from '../../../durable-object'
 
@@ -49,6 +47,8 @@ vi.mock('@repo/do-utils', () => ({
 function makeDb() {
 	const where = vi.fn().mockResolvedValue(undefined)
 	const deleteMock = vi.fn(() => ({ where }))
+	const set = vi.fn(() => ({ where }))
+	const update = vi.fn(() => ({ set }))
 	const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
 	const values = vi.fn((rows) => ({ onConflictDoUpdate, rows }))
 	const insert = vi.fn(() => ({ values }))
@@ -94,8 +94,10 @@ function makeDb() {
 			},
 		},
 		delete: deleteMock,
+		update,
 		insert,
 		_where: where,
+		_set: set,
 		_values: values,
 	}
 }
@@ -116,6 +118,44 @@ function createDoInstance(db: ReturnType<typeof makeDb>) {
 }
 
 describe('structure prune cleanup', () => {
+	it('orders moon drill storage with new ids before stale priority rows', async () => {
+		const db = makeDb()
+		const instance = createDoInstance(db)
+
+		db.query.structureMoonDrills.findMany = vi
+			.fn()
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([
+				{
+					structureId: 'moon-2',
+					lastAttemptedSyncAt: new Date('2026-07-22T00:00:00.000Z'),
+					lastSyncedAt: new Date('2026-07-22T00:00:00.000Z'),
+				},
+			])
+			.mockResolvedValue([])
+
+		await (instance as any).storeMoonDrills('corp-1', [
+			{
+				structureId: 'moon-1',
+				corporationId: 'corp-1',
+				typeId: '81826',
+				typeName: 'Metenox Moon Drill',
+			},
+			{
+				structureId: 'moon-2',
+				corporationId: 'corp-1',
+				typeId: '81826',
+				typeName: 'Metenox Moon Drill',
+			},
+		])
+
+		expect(db._values).toHaveBeenCalled()
+		expect(db._values.mock.calls[0][0].map((row: { structureId: string }) => row.structureId)).toEqual([
+			'moon-1',
+			'moon-2',
+		])
+	})
+
 	it('prunes stale skyhook and mining snapshots when structures disappear from a successful sync', async () => {
 		const db = makeDb()
 		const instance = createDoInstance(db)
@@ -168,6 +208,12 @@ describe('structure prune cleanup', () => {
 		expect(db.delete).toHaveBeenNthCalledWith(2, structureMoonGeographies)
 		expect(db.delete).toHaveBeenNthCalledWith(3, structureMoonDrills)
 		expect(db._where).toHaveBeenCalledTimes(3)
+		expect(db._values).toHaveBeenCalledWith([
+			expect.objectContaining({
+				structureId: 'structure-1',
+				lastSyncedAt: expect.any(Date),
+			}),
+		])
 	})
 
 	it('keeps recently seen structures and their dependent snapshots during the prune grace period', async () => {
@@ -297,6 +343,7 @@ describe('structure prune cleanup', () => {
 		const db = makeDb()
 		const instance = createDoInstance(db)
 
+		mocks.getStub.mockReturnValueOnce({} as never)
 		mocks.getStub.mockReturnValueOnce({
 			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({
 				'30000142': {
@@ -347,7 +394,6 @@ describe('structure prune cleanup', () => {
 		expect(db._values).toHaveBeenCalled()
 		expect(db._values.mock.calls[0][0][0]).toMatchObject({
 			systemName: 'Jita',
-			name: 'Jita',
 			workforceTransport: {
 				configuration: {
 					mode: 'import',
@@ -420,6 +466,7 @@ describe('structure prune cleanup', () => {
 		])
 		const instance = createDoInstance(db)
 
+		mocks.getStub.mockReturnValueOnce({} as never)
 		mocks.getStub.mockReturnValueOnce({
 			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({
 				'30000142': {
@@ -467,7 +514,6 @@ describe('structure prune cleanup', () => {
 		expect(db._values).toHaveBeenCalled()
 		expect(db._values.mock.calls[0][0][0]).toMatchObject({
 			systemName: 'Jita',
-			name: null,
 		})
 	})
 
@@ -513,7 +559,7 @@ describe('structure prune cleanup', () => {
 		expect(db.insert).not.toHaveBeenCalled()
 	})
 
-	it('returns the number of skyhooks pruned when the upstream listing is empty', async () => {
+	it('does not prune skyhooks without explicit prune candidates when the upstream listing is empty', async () => {
 		const db = makeDb()
 		db.query.corporationStructures.findMany = vi.fn().mockResolvedValue([])
 		db.query.structureSkyhooks.findMany = vi.fn().mockResolvedValue([
@@ -534,12 +580,11 @@ describe('structure prune cleanup', () => {
 
 		const instance = createDoInstance(db)
 
-		await expect(instance.storeSkyhooks('corp-1', [])).resolves.toEqual({ prunedCount: 1 })
-		expect(db.delete).toHaveBeenCalledTimes(1)
-		expect(db.delete).toHaveBeenNthCalledWith(1, structureSkyhooks)
+		await expect(instance.storeSkyhooks('corp-1', [])).resolves.toEqual({ prunedCount: 0 })
+		expect(db.delete).not.toHaveBeenCalled()
 	})
 
-	it('counts both skyhook state rows and base structure rows when pruning an empty listing', async () => {
+	it('does not prune skyhook state rows or base rows without explicit prune candidates', async () => {
 		const db = makeDb()
 		const stale = new Date('2026-06-01T00:00:00.000Z')
 
@@ -569,9 +614,7 @@ describe('structure prune cleanup', () => {
 
 		const instance = createDoInstance(db)
 
-		await expect(instance.storeSkyhooks('corp-1', [])).resolves.toEqual({ prunedCount: 2 })
-		expect(db.delete).toHaveBeenCalledTimes(2)
-		expect(db.delete).toHaveBeenNthCalledWith(1, structureSkyhooks)
-		expect(db.delete).toHaveBeenNthCalledWith(2, corporationStructures)
+		await expect(instance.storeSkyhooks('corp-1', [])).resolves.toEqual({ prunedCount: 0 })
+		expect(db.delete).not.toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -6,6 +6,9 @@ const mocks = vi.hoisted(() => {
 	const readSharedSovereigntySystemsByIdsMock = vi.fn()
 	const refreshSharedSovereigntySystemsMock = vi.fn()
 	const resolveSolarSystemsByIdsMock = vi.fn()
+	const getSovereigntyHubSyncPrioritiesMock = vi.fn()
+	const getMissingStructureIdsForPriorityQueueMock = vi.fn()
+	const fetchEsiMock = vi.fn()
 	const getStubMock = vi.fn(() => ({
 		resolveSolarSystemsByIds: resolveSolarSystemsByIdsMock,
 	}))
@@ -16,6 +19,9 @@ const mocks = vi.hoisted(() => {
 		readSharedSovereigntySystemsByIdsMock,
 		refreshSharedSovereigntySystemsMock,
 		resolveSolarSystemsByIdsMock,
+		getSovereigntyHubSyncPrioritiesMock,
+		getMissingStructureIdsForPriorityQueueMock,
+		fetchEsiMock,
 		getStubMock,
 		createTokenStoreMock,
 	}
@@ -31,7 +37,12 @@ vi.mock('../../../services/esi-fetch', () => ({
 
 vi.mock('../../../workflows/utils/services', () => ({
 	createTokenStore: (...args: unknown[]) => mocks.createTokenStoreMock(...args),
-	getCorporationDataStub: vi.fn(),
+	getCorporationDataStub: vi.fn(() => ({
+		getSovereigntyHubSyncPriorities: (...args: unknown[]) =>
+			mocks.getSovereigntyHubSyncPrioritiesMock(...args),
+		getMissingStructureIdsForPriorityQueue: (...args: unknown[]) =>
+			mocks.getMissingStructureIdsForPriorityQueueMock(...args),
+	})),
 }))
 
 vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
@@ -45,7 +56,24 @@ import { fetchSovereigntyEnrichment } from '../../../workflows/steps/structures'
 
 describe('fetchSovereigntyEnrichment', () => {
 	it('enriches sovereignty hub names from resolved solar systems before persistence', async () => {
-		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.createTokenStoreMock.mockReturnValue({
+			fetchEsi: mocks.fetchEsiMock,
+		})
+		mocks.getSovereigntyHubSyncPrioritiesMock
+			.mockResolvedValueOnce([
+				{
+					structureId: '1',
+					lastAttemptedSyncAt: null,
+					lastSyncedAt: new Date('2026-07-22T00:00:00.000Z'),
+				},
+			])
+		mocks.getMissingStructureIdsForPriorityQueueMock.mockResolvedValue([])
+		mocks.fetchEsiMock.mockResolvedValueOnce({
+			data: {
+				sovereignty_hubs: [{ id: 1, solar_system_id: 30000142 }],
+			},
+			pages: 1,
+		})
 		mocks.readSharedSovereigntySystemsByIdsMock.mockResolvedValue([
 			{
 				system_id: '30000142',
@@ -63,33 +91,38 @@ describe('fetchSovereigntyEnrichment', () => {
 				raw: { claim: {} },
 			},
 		])
-		mocks.fetchSovereigntyHubsMock.mockResolvedValue([
-			{
-				structure_id: 'hub-1',
-				corporation_id: 'corp-1',
-				system_id: '30000142',
-				system_name: null,
-				name: null,
-				type_id: SOVEREIGNTY_HUB_TYPE_ID,
-				controller_alliance_id: null,
-				fuel_access_list_id: null,
-				reagent_bay: {
-					last_updated: '2026-07-12T19:36:46.834Z',
-					reagents: [],
+		mocks.fetchSovereigntyHubsMock.mockResolvedValue({
+			sovereigntyHubs: [
+				{
+					structure_id: 'hub-1',
+					corporation_id: 'corp-1',
+					system_id: '30000142',
+					system_name: null,
+					name: null,
+					type_id: SOVEREIGNTY_HUB_TYPE_ID,
+					controller_alliance_id: null,
+					fuel_access_list_id: null,
+					reagent_bay: {
+						last_updated: '2026-07-12T19:36:46.834Z',
+						reagents: [],
+					},
+					resources: {
+						power: { allocated: 0, available: 0 },
+						workforce: { allocated: 0, available: 0 },
+					},
+					upgrades: [],
+					vulnerability_window: null,
+					workforce_transport: {
+						configuration: { transit: true },
+						state: { transit: true },
+					},
+					raw: { detail: { id: 1 } },
 				},
-				resources: {
-					power: { allocated: 0, available: 0 },
-					workforce: { allocated: 0, available: 0 },
-				},
-				upgrades: [],
-				vulnerability_window: null,
-				workforce_transport: {
-					configuration: { transit: true },
-					state: { transit: true },
-				},
-				raw: { detail: { id: 1 } },
-			},
-		])
+			],
+			failureCount: 0,
+			rateLimitFailureCount: 0,
+			nonRateLimitFailureCount: 0,
+		})
 		mocks.resolveSolarSystemsByIdsMock.mockResolvedValue({
 			'30000142': {
 				solarSystemName: 'Jita',
@@ -104,7 +137,27 @@ describe('fetchSovereigntyEnrichment', () => {
 			'character-1'
 		)
 
-		expect(mocks.fetchSovereigntyHubsMock).toHaveBeenCalledWith({}, 'corp-1', 'character-1')
+		expect(mocks.fetchSovereigntyHubsMock).toHaveBeenCalledWith(
+			{
+				fetchEsi: mocks.fetchEsiMock,
+			},
+			'corp-1',
+			'character-1',
+			{
+				prioritizedEntries: [
+					{
+						index: 0,
+						entry: { id: 1, solar_system_id: 30000142 },
+						priority: {
+							structureId: '1',
+							lastAttemptedSyncAt: null,
+							lastSyncedAt: new Date('2026-07-22T00:00:00.000Z'),
+						},
+					},
+				],
+				pruneCandidateIds: [],
+			}
+		)
 		expect(mocks.readSharedSovereigntySystemsByIdsMock).toHaveBeenCalledWith(
 			{
 				UNIVERSE: {},
@@ -114,15 +167,19 @@ describe('fetchSovereigntyEnrichment', () => {
 		expect(mocks.getStubMock).toHaveBeenCalledWith({}, 'default')
 		expect(mocks.resolveSolarSystemsByIdsMock).toHaveBeenCalledWith(['30000142'])
 		expect(result?.sovereigntyHubs[0]).toMatchObject({
-			name: 'Jita',
+			name: null,
 			system_name: 'Jita',
 			controller_alliance_id: '123456789',
 		})
 	})
 
 	it('bubbles sovereignty scope mismatches so the workflow can surface sync failure state', async () => {
-		mocks.createTokenStoreMock.mockReturnValue({})
-		mocks.fetchSovereigntyHubsMock.mockRejectedValue(
+		mocks.createTokenStoreMock.mockReturnValue({
+			fetchEsi: mocks.fetchEsiMock,
+		})
+		mocks.getSovereigntyHubSyncPrioritiesMock.mockResolvedValueOnce([])
+		mocks.getMissingStructureIdsForPriorityQueueMock.mockResolvedValue([])
+		mocks.fetchEsiMock.mockRejectedValue(
 			new Error(
 				'ESI request failed: 401 Unauthorized - {"error":"missing scope"} | metadata={"status":401,"path":"/corporations/123/structures/sovereignty-hubs/"}'
 			)

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -16,6 +16,7 @@ const storeSovereigntyEnrichmentMock = vi.fn()
 const storeSkyhookEnrichmentMock = vi.fn()
 const storeMiningExtractionEnrichmentMock = vi.fn()
 const markStructureEnrichmentSyncFailureMock = vi.fn()
+const markStructureSyncFailureReasonMock = vi.fn()
 const selectDirectorMock = vi.fn()
 const verifyAllDirectorsHealthMock = vi.fn()
 const reconcileDirectorsFromCorporationRolesMock = vi.fn()
@@ -27,6 +28,7 @@ const clearTaxProjectionRetryIntentMock = vi.fn()
 const recordTaxProjectionRetryIntentMock = vi.fn()
 const sendHrDepartedMessagesMock = vi.fn()
 const triggerTaxProjectionRefreshMock = vi.fn()
+const parseEsiErrorMetadataMock = vi.fn((_message: string) => null as { status: number } | null)
 
 vi.mock('cloudflare:workers', () => {
 	class WorkflowEntrypoint<Env = unknown, Params = unknown> {
@@ -38,7 +40,6 @@ vi.mock('cloudflare:workers', () => {
 			this.env = env
 		}
 
-		// eslint-disable-next-line @typescript-eslint/require-await
 		async run(_event: unknown, _step: unknown): Promise<Params> {
 			throw new Error('WorkflowEntrypoint.run is not implemented in unit-test shim')
 		}
@@ -58,7 +59,7 @@ vi.mock('@repo/do-utils', () => ({
 vi.mock('@repo/workflow-utils', () => ({
 	NonRetryableError: class NonRetryableError extends Error {},
 	esiRetryOptions: {},
-	parseEsiErrorMetadata: () => null,
+	parseEsiErrorMetadata: (message: string) => parseEsiErrorMetadataMock(message),
 	withEsiRetryClassification: async (_label: string, fn: () => Promise<unknown> | unknown) =>
 		await fn(),
 }))
@@ -93,6 +94,8 @@ vi.mock('../../../workflows/steps/structures', () => ({
 		fetchMiningExtractionEnrichmentMock(...args),
 	markStructureEnrichmentSyncFailure: (...args: unknown[]) =>
 		markStructureEnrichmentSyncFailureMock(...args),
+	markStructureSyncFailureReason: (...args: unknown[]) =>
+		markStructureSyncFailureReasonMock(...args),
 	storeStructures: (...args: unknown[]) => storeStructuresMock(...args),
 	storeSovereigntyEnrichment: (...args: unknown[]) => storeSovereigntyEnrichmentMock(...args),
 	storeSkyhookEnrichment: (...args: unknown[]) => storeSkyhookEnrichmentMock(...args),
@@ -128,13 +131,22 @@ function createWorkflowEnv() {
 			structuresLastSync: null,
 		}),
 		getDirectors: vi.fn().mockResolvedValue([{ isHealthy: true }]),
+		getMiningCitadelSyncPriorities: vi.fn().mockResolvedValue([]),
+		getMiningCitadelStructureIds: vi.fn().mockResolvedValue([]),
+		getMissingStructureIdsForPriorityQueue: vi.fn().mockResolvedValue([]),
+		getSovereigntyHubSyncPriorities: vi.fn().mockResolvedValue([]),
+		getSovereigntyHubStructureIds: vi.fn().mockResolvedValue([]),
+		getSkyhookSyncPriorities: vi.fn().mockResolvedValue([]),
+		getSkyhookStructureIds: vi.fn().mockResolvedValue([]),
 	}
 
 	getStubMock.mockImplementation((namespace: unknown) => {
 		if (namespace === corpDataNamespace) {
 			return corpDataStub
 		}
-		return {}
+		return {
+			getMissingStructureIdsForPriorityQueue: vi.fn().mockResolvedValue([]),
+		}
 	})
 
 	return {
@@ -155,6 +167,7 @@ function createWorkflowEnv() {
 describe('EveCorporationSyncWorkflow', () => {
 	it('continues to asset sync even when the structure step fails', async () => {
 		vi.clearAllMocks()
+		parseEsiErrorMetadataMock.mockImplementation(() => null)
 		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
 
 		verifyAllDirectorsHealthMock.mockResolvedValue({
@@ -168,6 +181,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
 		fetchStructuresMock.mockRejectedValue(new Error('Station Manager access required'))
+		markStructureSyncFailureReasonMock.mockResolvedValue(undefined)
 		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
 		updateSyncTimestampsMock.mockResolvedValue(undefined)
 		updateCoreLastSyncMock.mockResolvedValue(undefined)
@@ -187,7 +201,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step, executedStepNames } = createStep()
+		const { step } = createStep()
 
 		await expect(
 			workflow.run(
@@ -208,17 +222,250 @@ describe('EveCorporationSyncWorkflow', () => {
 			trigger: 'cron',
 		})
 
-		expect(executedStepNames).toContain('fetch-structures')
-		expect(executedStepNames).toContain('sync-assets')
-		expect(syncAssetsMock).toHaveBeenCalledWith(
+		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
+		expect(markStructureSyncFailureReasonMock).toHaveBeenCalledWith(
 			env,
 			'693378155',
-			'900000001',
-			undefined
+			'structures',
+			'Station Manager access required'
 		)
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets'])
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			['assets', 'skyhooks']
+		)
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
+	})
+
+	it('keeps a prior structure failure sticky even if a later enrichment hits rate limit', async () => {
+		vi.clearAllMocks()
+		parseEsiErrorMetadataMock.mockImplementation((message: string) =>
+			message.includes('429 Too Many Requests')
+				? {
+						status: 429,
+					}
+				: null
+		)
+		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockRejectedValue(new Error('Station Manager access required'))
+		fetchSovereigntyEnrichmentMock.mockRejectedValue(
+			new Error(
+				'ESI request failed: 429 Too Many Requests - {"error":"ESI rate limit active"} | metadata={"status":429,"path":"/corporations/693378155/structures/sovereignty-hubs/10001"}'
+			)
+		)
+		markStructureSyncFailureReasonMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures', 'assets'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-1-rate-limit',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(markStructureSyncFailureReasonMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			'structures',
+			'Station Manager access required'
+		)
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			['assets', 'skyhooks']
+		)
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
+		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
+	})
+
+	it('keeps skyhook failures from suppressing the structures timestamp update', async () => {
+		vi.clearAllMocks()
+		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockResolvedValue([
+			{
+				structure_id: 'structure-1',
+				type_id: '35832',
+			},
+		])
+		fetchSovereigntyEnrichmentMock.mockResolvedValue(null)
+		fetchSkyhookEnrichmentMock.mockRejectedValue(new Error('skyhook boom'))
+		storeStructuresMock.mockResolvedValue(undefined)
+		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
+		storeSkyhookEnrichmentMock.mockResolvedValue(undefined)
+		storeMiningExtractionEnrichmentMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures', 'assets'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-1-skyhook',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			['assets', 'structures', 'skyhooks']
+		)
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
+		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
+	})
+
+	it('persists structure failure reasons for non-retryable store errors', async () => {
+		vi.clearAllMocks()
+		const { env, updateCorporationAuthHealth } = createWorkflowEnv()
+
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Director One',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		fetchStructuresMock.mockResolvedValue([
+			{
+				structure_id: 'structure-1',
+				type_id: '35832',
+			},
+		])
+		storeStructuresMock.mockRejectedValue(new Error('database write failed'))
+		markStructureSyncFailureReasonMock.mockResolvedValue(undefined)
+		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['structures', 'assets'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-1c',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(markStructureSyncFailureReasonMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			'structures',
+			'database write failed'
+		)
+		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
 	it('passes the current corporation structure listing through to storage so stale rows can be pruned', async () => {
@@ -289,11 +536,11 @@ describe('EveCorporationSyncWorkflow', () => {
 				type_id: '35832',
 			},
 		])
-		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001', ['structure-1'])
+		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
 		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
 			env,
 			'693378155',
-			['assets', 'structures']
+			['assets', 'structures', 'skyhooks']
 		)
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
@@ -325,6 +572,9 @@ describe('EveCorporationSyncWorkflow', () => {
 					structure_id: 'skyhook-1',
 				},
 			],
+			failureCount: 0,
+			rateLimitFailureCount: 0,
+			nonRateLimitFailureCount: 0,
 		})
 		storeStructuresMock.mockResolvedValue(undefined)
 		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
@@ -430,7 +680,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step, executedStepNames } = createStep()
+		const { step } = createStep()
 
 		await expect(
 			workflow.run(
@@ -458,14 +708,20 @@ describe('EveCorporationSyncWorkflow', () => {
 			'Sovereignty hub enrichment requires updated director scopes.'
 		)
 		expect(selectDirectorMock).toHaveBeenCalledTimes(1)
-		expect(executedStepNames).toContain('store-structure-sovereignty-enrichment-failure')
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [])
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['skyhooks'])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
 	it('runs mining enrichment for mining citadels and still continues to asset sync', async () => {
 		vi.clearAllMocks()
-		const { env, updateCorporationAuthHealth } = createWorkflowEnv()
+		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
+		corpDataStub.getMiningCitadelSyncPriorities.mockResolvedValue([
+			{
+				structureId: '1000001',
+				lastAttemptedSyncAt: null,
+				lastSyncedAt: new Date('2026-07-10T00:00:00.000Z'),
+			},
+		])
 
 		verifyAllDirectorsHealthMock.mockResolvedValue({
 			verified: 1,
@@ -516,7 +772,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step, executedStepNames } = createStep()
+		const { step } = createStep()
 
 		await expect(
 			workflow.run(
@@ -544,14 +800,20 @@ describe('EveCorporationSyncWorkflow', () => {
 				structure_id: '1000001',
 			},
 		])
-		expect(executedStepNames).toContain('sync-assets')
-		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001', ['1000001'])
+		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
 	it('keeps asset sync running when mining enrichment fails for a mining citadel run', async () => {
 		vi.clearAllMocks()
-		const { env, updateCorporationAuthHealth } = createWorkflowEnv()
+		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
+		corpDataStub.getMiningCitadelSyncPriorities.mockResolvedValue([
+			{
+				structureId: '2000001',
+				lastAttemptedSyncAt: null,
+				lastSyncedAt: new Date('2026-07-10T00:00:00.000Z'),
+			},
+		])
 
 		verifyAllDirectorsHealthMock.mockResolvedValue({
 			verified: 1,
@@ -595,7 +857,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step, executedStepNames } = createStep()
+		const { step } = createStep()
 
 		await expect(
 			workflow.run(
@@ -618,12 +880,11 @@ describe('EveCorporationSyncWorkflow', () => {
 
 		expect(fetchMiningExtractionEnrichmentMock).toHaveBeenCalledTimes(1)
 		expect(storeMiningExtractionEnrichmentMock).not.toHaveBeenCalled()
-		expect(executedStepNames).toContain('sync-assets')
-		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001', ['2000001'])
+		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
-	it('skips structure enrichment work when the structure sync is within the cooldown window', async () => {
+	it('still runs structure enrichment work even when the corp-level structure timestamp is stale', async () => {
 		vi.clearAllMocks()
 		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
 		corpDataStub.getCorporationSyncConfig.mockResolvedValue({
@@ -631,6 +892,13 @@ describe('EveCorporationSyncWorkflow', () => {
 			includeInStructureAssetSync: true,
 			structuresLastSync: new Date('2026-07-12T18:50:00.000Z'),
 		})
+		corpDataStub.getMiningCitadelSyncPriorities.mockResolvedValue([
+			{
+				structureId: '3000001',
+				lastAttemptedSyncAt: null,
+				lastSyncedAt: new Date('2026-07-10T00:00:00.000Z'),
+			},
+		])
 
 		verifyAllDirectorsHealthMock.mockResolvedValue({
 			verified: 1,
@@ -648,12 +916,17 @@ describe('EveCorporationSyncWorkflow', () => {
 				type_id: '35833',
 			},
 		])
+		fetchSovereigntyEnrichmentMock.mockResolvedValue(null)
 		storeStructuresMock.mockResolvedValue(undefined)
 		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
 		fetchSkyhookEnrichmentMock.mockResolvedValue({
 			skyhooks: [],
+			failureCount: 0,
+			rateLimitFailureCount: 0,
+			nonRateLimitFailureCount: 0,
 		})
-		storeSkyhookEnrichmentMock.mockResolvedValue(undefined)
+		storeSkyhookEnrichmentMock.mockResolvedValue({ prunedCount: 0 })
+		fetchMiningExtractionEnrichmentMock.mockResolvedValue([])
 		storeMiningExtractionEnrichmentMock.mockResolvedValue(undefined)
 		syncAssetsMock.mockResolvedValue({ assetsCount: 1 })
 		updateSyncTimestampsMock.mockResolvedValue(undefined)
@@ -674,7 +947,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step, executedStepNames } = createStep()
+		const { step } = createStep()
 
 		await expect(
 			workflow.run(
@@ -695,16 +968,17 @@ describe('EveCorporationSyncWorkflow', () => {
 			trigger: 'cron',
 		})
 
-		expect(fetchStructuresMock).not.toHaveBeenCalled()
-		expect(storeStructuresMock).not.toHaveBeenCalled()
-		expect(fetchSovereigntyEnrichmentMock).not.toHaveBeenCalled()
-		expect(fetchSkyhookEnrichmentMock).not.toHaveBeenCalled()
-		expect(storeSkyhookEnrichmentMock).not.toHaveBeenCalled()
-		expect(fetchMiningExtractionEnrichmentMock).not.toHaveBeenCalled()
-		expect(executedStepNames).not.toContain('store-structure-sovereignty-enrichment')
-		expect(executedStepNames).not.toContain('store-structure-skyhook-enrichment')
-		expect(executedStepNames).not.toContain('store-structure-mining-extraction-enrichment')
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets'])
+		expect(fetchStructuresMock).toHaveBeenCalled()
+		expect(storeStructuresMock).toHaveBeenCalled()
+		expect(fetchSovereigntyEnrichmentMock).toHaveBeenCalled()
+		expect(fetchSkyhookEnrichmentMock).toHaveBeenCalled()
+		expect(storeSkyhookEnrichmentMock).toHaveBeenCalled()
+		expect(fetchMiningExtractionEnrichmentMock).toHaveBeenCalled()
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			['assets', 'structures', 'skyhooks']
+		)
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -13,7 +13,12 @@ import {
 	refreshSharedSovereigntySystems,
 } from '../../utils/sovereignty-systems-cache'
 import type { Universe } from '@repo/universe'
-import type { SkyhookStoreResult } from '@repo/eve-corporation-data'
+import type {
+	SkyhookStoreResult,
+	SovereigntyHubSyncPriority,
+	StructureSyncFailureTarget,
+} from '@repo/eve-corporation-data'
+import { buildPriorityQueuedEntries } from '../../../services/structure-priority'
 
 import type { Env } from '../../../context'
 
@@ -27,11 +32,19 @@ export type MiningExtractionsData = Awaited<
 
 export interface SovereigntyEnrichmentData {
 	sovereigntySystems: SovereigntySystemsData | null
-	sovereigntyHubs: SovereigntyHubsData
+	sovereigntyHubs: SovereigntyHubsData['sovereigntyHubs']
+	pruneCandidateIds: string[]
+	failureCount: number
+	rateLimitFailureCount: number
+	nonRateLimitFailureCount: number
 }
 
 export interface SkyhookEnrichmentData {
-	skyhooks: CorporationSkyhooksData
+	skyhooks: CorporationSkyhooksData['skyhooks']
+	pruneCandidateIds: string[]
+	failureCount: number
+	rateLimitFailureCount: number
+	nonRateLimitFailureCount: number
 }
 
 function buildSovereigntyAllianceBySystemId(
@@ -79,24 +92,67 @@ export async function fetchSovereigntyEnrichment(
 	corporationId: string,
 	directorCharacterId: string
 ): Promise<SovereigntyEnrichmentData | null> {
-	const tokenStore = createTokenStore(env)
-
 	try {
-		const sovereigntyHubs = await esiFetch.fetchSovereigntyHubs(
+		const corpData = getCorporationDataStub(env, corporationId)
+		const syncPriorities: SovereigntyHubSyncPriority[] =
+			await corpData.getSovereigntyHubSyncPriorities(corporationId)
+		const tokenStore = createTokenStore(env)
+		const firstPass = await tokenStore.fetchEsi<{ sovereignty_hubs: Array<{ id: number; solar_system_id: number }> }>(
+			`/corporations/${corporationId}/structures/sovereignty-hubs?page=1`,
+			directorCharacterId,
+			{ cacheMode: 'no-store' }
+		)
+		const sovereigntyHubListing = [...firstPass.data.sovereignty_hubs]
+		for (let page = 2; page <= (firstPass.pages ?? 1); page += 1) {
+			const pageResponse = await tokenStore.fetchEsi<{ sovereignty_hubs: Array<{ id: number; solar_system_id: number }> }>(
+				`/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
+				directorCharacterId,
+				{ cacheMode: 'no-store' }
+			)
+			sovereigntyHubListing.push(...pageResponse.data.sovereignty_hubs)
+		}
+		const liveStructureIds = sovereigntyHubListing.map((hub) => String(hub.id))
+		const newStructureIds = await corpData.getMissingStructureIdsForPriorityQueue(
+			corporationId,
+			'sovereignty',
+			liveStructureIds
+		)
+		const prioritizedQueue = buildPriorityQueuedEntries(
+			sovereigntyHubListing,
+			newStructureIds,
+			syncPriorities
+		)
+		const sovereigntyHubResult = await esiFetch.fetchSovereigntyHubs(
 			tokenStore,
 			corporationId,
-			directorCharacterId
+			directorCharacterId,
+			{
+				prioritizedEntries: prioritizedQueue.entries,
+				pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
+			}
 		)
+		const collectedHubs = sovereigntyHubResult.sovereigntyHubs
+		const failureCount = sovereigntyHubResult.failureCount
+		const rateLimitFailureCount = sovereigntyHubResult.rateLimitFailureCount
+		const nonRateLimitFailureCount = sovereigntyHubResult.nonRateLimitFailureCount
+
+		if (collectedHubs.length === 0) {
+			return {
+				sovereigntySystems: null,
+				sovereigntyHubs: [],
+				pruneCandidateIds: [...sovereigntyHubResult.pruneCandidateIds],
+				failureCount,
+				rateLimitFailureCount,
+				nonRateLimitFailureCount,
+			}
+		}
+
 		const universe = getStub<Universe>(env.UNIVERSE, 'default')
 		const systemGeography =
-			sovereigntyHubs.length > 0
-				? await universe.resolveSolarSystemsByIds(
-						[...new Set(sovereigntyHubs.map((hub) => hub.system_id))]
-					)
-				: {}
+			await universe.resolveSolarSystemsByIds([...new Set(collectedHubs.map((hub) => hub.system_id))])
 		let sovereigntySystems = await readSharedSovereigntySystemsByIds(
 			env,
-			sovereigntyHubs.map((hub) => hub.system_id)
+			collectedHubs.map((hub) => hub.system_id)
 		)
 		if (!sovereigntySystems) {
 			logger.warn('[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache', {
@@ -106,7 +162,7 @@ export async function fetchSovereigntyEnrichment(
 		}
 
 		const allianceBySystemId = buildSovereigntyAllianceBySystemId(sovereigntySystems)
-		const enrichedSovereigntyHubs = sovereigntyHubs.map((hub) => ({
+		const enrichedSovereigntyHubs = collectedHubs.map((hub) => ({
 			...hub,
 			system_name: systemGeography[hub.system_id]?.solarSystemName ?? hub.system_name ?? null,
 			controller_alliance_id: allianceBySystemId.get(hub.system_id) ?? null,
@@ -115,12 +171,17 @@ export async function fetchSovereigntyEnrichment(
 		logger.debug('[StructuresStep] Fetched sovereignty structure enrichment', {
 			corporationId,
 			sovereigntySystems: sovereigntySystems?.length ?? 0,
-			sovereigntyHubs: sovereigntyHubs.length,
+			sovereigntyHubs: collectedHubs.length,
+			failureCount,
 		})
 
 		return {
 			sovereigntySystems,
 			sovereigntyHubs: enrichedSovereigntyHubs,
+			pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
+			failureCount,
+			rateLimitFailureCount,
+			nonRateLimitFailureCount,
 		}
 	} catch (error) {
 		if (shouldSuppressDirectorUnhealthyOnStructureEnrichmentAuthFailure(error)) {
@@ -135,22 +196,57 @@ export async function fetchSkyhookEnrichment(
 	corporationId: string,
 	directorCharacterId: string
 ): Promise<SkyhookEnrichmentData | null> {
-	const tokenStore = createTokenStore(env)
-
 	try {
-		const skyhooks = await esiFetch.fetchCorporationSkyhooks(
+		const corpData = getCorporationDataStub(env, corporationId)
+		const syncPriorities = await corpData.getSkyhookSyncPriorities(corporationId)
+		const tokenStore = createTokenStore(env)
+		const firstPass = await tokenStore.fetchEsi<{ skyhooks: Array<{ id: number; planet_id: number }> }>(
+			`/corporations/${corporationId}/structures/skyhooks`,
+			directorCharacterId,
+			{ cacheMode: 'no-store' }
+		)
+		const skyhookListing = [...firstPass.data.skyhooks]
+		for (let page = 2; page <= (firstPass.pages ?? 1); page += 1) {
+			const pageResponse = await tokenStore.fetchEsi<{ skyhooks: Array<{ id: number; planet_id: number }> }>(
+				`/corporations/${corporationId}/structures/skyhooks?page=${page}`,
+				directorCharacterId,
+				{ cacheMode: 'no-store' }
+			)
+			skyhookListing.push(...pageResponse.data.skyhooks)
+		}
+		const liveStructureIds = skyhookListing.map((skyhook) => String(skyhook.id))
+		const newStructureIds = await corpData.getMissingStructureIdsForPriorityQueue(
+			corporationId,
+			'skyhooks',
+			liveStructureIds
+		)
+		const prioritizedQueue = buildPriorityQueuedEntries(skyhookListing, newStructureIds, syncPriorities)
+		const skyhookResult = await esiFetch.fetchCorporationSkyhooks(
 			tokenStore,
 			corporationId,
-			directorCharacterId
+			directorCharacterId,
+			{
+				prioritizedEntries: prioritizedQueue.entries,
+				pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
+			}
 		)
+		const skyhooks = skyhookResult.skyhooks
+		const failureCount = skyhookResult.failureCount
+		const rateLimitFailureCount = skyhookResult.rateLimitFailureCount
+		const nonRateLimitFailureCount = skyhookResult.nonRateLimitFailureCount
 
 		logger.debug('[StructuresStep] Fetched skyhook enrichment', {
 			corporationId,
 			skyhooks: skyhooks.length,
+			failureCount,
 		})
 
 		return {
 			skyhooks,
+			pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
+			failureCount,
+			rateLimitFailureCount,
+			nonRateLimitFailureCount,
 		}
 	} catch (error) {
 		if (shouldSuppressDirectorUnhealthyOnStructureEnrichmentAuthFailure(error)) {
@@ -160,20 +256,30 @@ export async function fetchSkyhookEnrichment(
 	}
 }
 
+export async function markStructureSyncFailureReason(
+	env: Env,
+	corporationId: string,
+	target: StructureSyncFailureTarget,
+	failureReason: string
+): Promise<void> {
+	const corpData = getCorporationDataStub(env, corporationId)
+	await corpData.markStructureSyncFailureReason(corporationId, target, failureReason)
+
+	logger.warn('[StructuresStep] Marked structure sync failure reason', {
+		corporationId,
+		target,
+		failureReason,
+	})
+}
+
 export async function markStructureEnrichmentSyncFailure(
 	env: Env,
 	corporationId: string,
 	target: StructureEnrichmentSyncTarget,
 	failureReason: string
 ): Promise<void> {
-	const corpData = getCorporationDataStub(env, corporationId)
-	await corpData.markStructureEnrichmentSyncFailure(corporationId, target, failureReason)
-
-	logger.warn('[StructuresStep] Marked structure enrichment sync failure', {
-		corporationId,
-		target,
-		failureReason,
-	})
+	const mappedTarget = target === 'sovereignty-hubs' ? 'sovereignty' : 'skyhooks'
+	await markStructureSyncFailureReason(env, corporationId, mappedTarget, failureReason)
 }
 
 export async function storeSovereigntyEnrichment(
@@ -186,7 +292,9 @@ export async function storeSovereigntyEnrichment(
 		enrichment.sovereigntySystems
 			? corpData.storeSovereigntySystems(corporationId, enrichment.sovereigntySystems)
 			: Promise.resolve(),
-		corpData.storeSovereigntyHubs(corporationId, enrichment.sovereigntyHubs),
+		corpData.storeSovereigntyHubs(corporationId, enrichment.sovereigntyHubs, {
+			pruneCandidateIds: enrichment.pruneCandidateIds,
+		}),
 	])
 
 	logger.info('[StructuresStep] Stored sovereignty enrichment', {
@@ -202,7 +310,9 @@ export async function storeSkyhookEnrichment(
 	enrichment: SkyhookEnrichmentData
 ): Promise<SkyhookStoreResult> {
 	const corpData = getCorporationDataStub(env, corporationId)
-	const result = await corpData.storeSkyhooks(corporationId, enrichment.skyhooks)
+	const result = await corpData.storeSkyhooks(corporationId, enrichment.skyhooks, {
+		pruneCandidateIds: enrichment.pruneCandidateIds,
+	})
 
 	logger.info('[StructuresStep] Stored skyhook enrichment', {
 		corporationId,

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -39,11 +39,13 @@ import {
 	fetchSovereigntyEnrichment,
 	fetchStructures,
 	markStructureEnrichmentSyncFailure,
+	markStructureSyncFailureReason,
 	storeMiningExtractionEnrichment,
 	storeSkyhookEnrichment,
 	storeSovereigntyEnrichment,
 	storeStructures,
 } from './steps/structures'
+import { buildPriorityQueuedEntries } from '../services/structure-priority'
 import {
 	StructureEnrichmentScopeMismatchError,
 } from './utils/structure-enrichment-auth'
@@ -63,6 +65,7 @@ import type {
 	EveCorporationData,
 	EveCorporationSyncDataType,
 	EsiCorporationStructure,
+	StructureSyncPriorityTarget,
 } from '@repo/eve-corporation-data'
 import type { Env } from '../context'
 import type {
@@ -74,14 +77,9 @@ import type {
 
 const STEP_RETRY_OPTIONS = esiRetryOptions
 const MINING_CITADEL_STRUCTURE_TYPE_IDS = new Set(['35833', '35834'])
-const STRUCTURE_ENRICHMENT_COOLDOWN_HOURS = 1
 
 function isMiningCitadelStructure(structure: Pick<EsiCorporationStructure, 'type_id'>): boolean {
 	return MINING_CITADEL_STRUCTURE_TYPE_IDS.has(structure.type_id)
-}
-
-function addHours(date: Date, hours: number): Date {
-	return new Date(date.getTime() + hours * 60 * 60 * 1000)
 }
 
 const ROLE_REQUIREMENTS_BY_DATA_TYPE: Partial<
@@ -94,6 +92,7 @@ const ROLE_REQUIREMENTS_BY_DATA_TYPE: Partial<
 	'wallet-transactions': ['Accountant', 'Junior_Accountant'],
 	assets: ['Director'],
 	structures: ['Station_Manager'],
+	skyhooks: ['Director'],
 	orders: ['Accountant', 'Junior_Accountant', 'Trader'],
 	contracts: ['Director'],
 	'industry-jobs': ['Factory_Manager'],
@@ -189,14 +188,8 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			)
 
 			const structureAssetSyncEnabled = corporationConfig?.includeInStructureAssetSync ?? false
-			const structureEnrichmentNextAllowedAt = corporationConfig?.structuresLastSync
-				? addHours(corporationConfig.structuresLastSync, STRUCTURE_ENRICHMENT_COOLDOWN_HOURS)
-				: null
-			const workflowObservedAt = event.timestamp ?? new Date()
-			const structureEnrichmentCooldownActive =
-				structureEnrichmentNextAllowedAt !== null &&
-				structureEnrichmentNextAllowedAt > workflowObservedAt
 			let structureSyncCompleted = false
+			let skyhooksSync: SyncStepResult<'skyhooks'> | null = null
 			const shouldSync = createShouldSyncPredicate(dataTypes, {
 				disabledDataTypes: structureAssetSyncEnabled ? [] : ['assets'],
 			})
@@ -700,151 +693,280 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			}
 
 			if (shouldSyncAuthenticated('structures')) {
-				if (structureEnrichmentCooldownActive) {
-					logger.info('[EveCorporationSyncWorkflow] Skipping structure sync due to cooldown', {
-						corporationId,
-						nextAllowedAt: structureEnrichmentNextAllowedAt?.toISOString() ?? null,
-					})
-				} else {
-					// Keep the structure refresh from blocking the asset projection refresh.
-					// The inventory path can fall back to the DB or refresh structures on its own.
-					structuresSync = await step.do('sync-structures', {}, async () => {
-						let structureSyncHadFailure = false
-						let structuresCount = 0
-						let sovereigntySystemsCount = 0
-						let sovereigntyHubsCount = 0
-						let skyhooksCount = 0
-						let skyhooksReturnedCount = 0
-						let skyhooksPrunedCount = 0
-						let miningExtractionsCount = 0
+				// Keep the structure refresh from blocking the asset projection refresh.
+				// The inventory path can fall back to the DB or refresh structures on its own.
+				structuresSync = await step.do('sync-structures', {}, async () => {
+					let structureSyncHadFailure = false
+					let structuresCount = 0
+					let sovereigntySystemsCount = 0
+					let sovereigntyHubsCount = 0
+					let miningExtractionsCount = 0
+					const corpData = getStub<EveCorporationData>(this.env.EVE_CORPORATION_DATA, corporationId)
 
-						try {
-							const structures = await runDirectorStepWithFailover({
-								stepName: 'fetch-structures',
-								timeout: '5 minutes',
-								requiredRoles: ['Station_Manager'],
-								persistResult: false,
-								run: (directorCharacterId) =>
-									fetchStructures(this.env, corporationId, directorCharacterId),
-							})
-							structuresCount = structures.length
+					try {
+						const structures = await runDirectorStepWithFailover({
+							stepName: 'fetch-structures',
+							timeout: '5 minutes',
+							requiredRoles: ['Station_Manager'],
+							persistResult: false,
+							run: (directorCharacterId) =>
+								fetchStructures(this.env, corporationId, directorCharacterId),
+						})
+						structuresCount = structures.length
 
-							await storeStructures(this.env, corporationId, structures)
+						await storeStructures(this.env, corporationId, structures)
 
-							const miningCitadelStructureIds = new Set(
-								structures
-									.filter((structure) => isMiningCitadelStructure(structure))
-									.map((structure) => String(structure.structure_id))
-							)
-							if (miningCitadelStructureIds.size > 0) {
-								try {
-									const fetchedMiningExtractions = await runDirectorStepWithFailover({
-										stepName: 'fetch-structure-mining-extraction-enrichment',
-										timeout: '10 minutes',
-										requiredRoles: ['Station_Manager'],
-										persistResult: false,
-										run: (directorCharacterId) =>
-											fetchMiningExtractionEnrichment(
-												this.env,
-												corporationId,
-												directorCharacterId
-											),
-									})
-									const miningExtractions = fetchedMiningExtractions.filter((extraction) =>
-										miningCitadelStructureIds.has(String(extraction.structure_id))
+						const miningCitadelStructureIds = new Set(
+							structures
+								.filter((structure) => isMiningCitadelStructure(structure))
+								.map((structure) => String(structure.structure_id))
+						)
+
+						if (miningCitadelStructureIds.size > 0) {
+							try {
+								const miningCitadelPriorities =
+									await corpData.getMiningCitadelSyncPriorities(corporationId)
+								const newMiningCitadelStructureIds =
+									await corpData.getMissingStructureIdsForPriorityQueue(
+										corporationId,
+										'mining-extractions' as StructureSyncPriorityTarget,
+										[...miningCitadelStructureIds]
 									)
-									miningExtractionsCount = miningExtractions.length
+								const prioritizedMiningCitadelQueue = buildPriorityQueuedEntries(
+									[...miningCitadelStructureIds].map((structureId) => ({
+										id: structureId,
+									})),
+									newMiningCitadelStructureIds,
+									miningCitadelPriorities
+								)
+								const prioritizedMiningCitadelIds = prioritizedMiningCitadelQueue.entries.map(
+									({ entry }) => entry.id
+								)
 
-									if (miningExtractions.length > 0) {
-										await storeMiningExtractionEnrichment(
+								const fetchedMiningExtractions = await runDirectorStepWithFailover({
+									stepName: 'fetch-structure-mining-extraction-enrichment',
+									timeout: '10 minutes',
+									requiredRoles: ['Station_Manager'],
+									persistResult: false,
+									run: (directorCharacterId) =>
+										fetchMiningExtractionEnrichment(
 											this.env,
 											corporationId,
-											miningExtractions
+											directorCharacterId
+										),
+								})
+								const miningExtractionByStructureId = new Map(
+									fetchedMiningExtractions.map((extraction) => [
+										String(extraction.structure_id),
+										extraction,
+									])
+								)
+								const prioritizedMiningExtractions = prioritizedMiningCitadelIds
+									.map((structureId) => miningExtractionByStructureId.get(structureId) ?? null)
+									.filter(
+										(
+											extraction
+										): extraction is (typeof fetchedMiningExtractions)[number] =>
+											extraction !== null
+									)
+								miningExtractionsCount = prioritizedMiningExtractions.length
+
+								for (let index = 0; index < prioritizedMiningExtractions.length; index += 100) {
+									const batch = prioritizedMiningExtractions.slice(index, index + 100)
+									if (batch.length === 0) continue
+									await storeMiningExtractionEnrichment(this.env, corporationId, batch)
+								}
+							} catch (error) {
+								const metadata =
+									error instanceof Error ? parseEsiErrorMetadata(error.message) : null
+								const isRateLimitError = metadata?.status === 429
+								structureSyncHadFailure ||= !isRateLimitError
+								if (!isRateLimitError) {
+									try {
+										await markStructureSyncFailureReason(
+											this.env,
+											corporationId,
+											'mining-extractions',
+											error instanceof Error ? error.message : String(error)
+										)
+									} catch (markError) {
+										logger.warn(
+											'[EveCorporationSyncWorkflow] Mining extraction failure reason could not be persisted',
+											{
+												corporationId,
+												error: markError instanceof Error ? markError.message : String(markError),
+											}
 										)
 									}
-								} catch (error) {
-									structureSyncHadFailure = true
-									logger.warn(
-										'[EveCorporationSyncWorkflow] Mining extraction enrichment failed; continuing without it',
-										{
-											corporationId,
-											error: error instanceof Error ? error.message : String(error),
-										}
-									)
 								}
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Mining extraction enrichment failed; continuing without it',
+									{
+										corporationId,
+										error: error instanceof Error ? error.message : String(error),
+										isRateLimitError,
+									}
+								)
 							}
-						} catch (error) {
-							structureSyncHadFailure = true
+						}
+					} catch (error) {
+						const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
+						const isRateLimitError = metadata?.status === 429
+						structureSyncHadFailure ||= !isRateLimitError
+						if (!isRateLimitError) {
+							try {
+								await markStructureSyncFailureReason(
+									this.env,
+									corporationId,
+									'structures',
+									error instanceof Error ? error.message : String(error)
+								)
+							} catch (markError) {
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Structure sync failure reason could not be persisted',
+									{
+										corporationId,
+										error: markError instanceof Error ? markError.message : String(markError),
+									}
+								)
+							}
+						}
+						logger.warn('[EveCorporationSyncWorkflow] Structure sync failed; continuing to asset sync', {
+							corporationId,
+							error: error instanceof Error ? error.message : String(error),
+							isRateLimitError,
+						})
+					}
+
+					try {
+						const sovereigntyEnrichment = await runDirectorStepWithFailover({
+							stepName: 'fetch-structure-sovereignty-enrichment',
+							timeout: '10 minutes',
+							requiredRoles: ['Station_Manager'],
+							persistResult: false,
+							run: (directorCharacterId) =>
+								fetchSovereigntyEnrichment(this.env, corporationId, directorCharacterId),
+						})
+
+						if (sovereigntyEnrichment) {
+							await storeSovereigntyEnrichment(
+								this.env,
+								corporationId,
+								sovereigntyEnrichment
+							)
+							sovereigntySystemsCount = sovereigntyEnrichment.sovereigntySystems?.length ?? 0
+							sovereigntyHubsCount = sovereigntyEnrichment.sovereigntyHubs.length
+
+							if (sovereigntyEnrichment.nonRateLimitFailureCount > 0) {
+								structureSyncHadFailure = true
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Sovereignty enrichment completed with partial non-rate-limit failures',
+									{
+										corporationId,
+										successCount: sovereigntyEnrichment.sovereigntyHubs.length,
+										failureCount: sovereigntyEnrichment.failureCount,
+										rateLimitFailureCount: sovereigntyEnrichment.rateLimitFailureCount,
+										nonRateLimitFailureCount: sovereigntyEnrichment.nonRateLimitFailureCount,
+									}
+								)
+							} else if (sovereigntyEnrichment.rateLimitFailureCount > 0) {
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Sovereignty enrichment completed with rate-limit pressure; preserving successful rows',
+									{
+										corporationId,
+										successCount: sovereigntyEnrichment.sovereigntyHubs.length,
+										rateLimitFailureCount: sovereigntyEnrichment.rateLimitFailureCount,
+									}
+								)
+							}
+						}
+					} catch (error) {
+						const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
+						const isRateLimitError = metadata?.status === 429
+						structureSyncHadFailure ||= !isRateLimitError
+
+						if (error instanceof StructureEnrichmentScopeMismatchError) {
+							try {
+								await markStructureEnrichmentSyncFailure(
+									this.env,
+									corporationId,
+									error.target,
+									error.message
+								)
+							} catch (markError) {
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch could not be persisted',
+									{
+										corporationId,
+										error: markError instanceof Error ? markError.message : String(markError),
+									}
+								)
+							}
 							logger.warn(
-								'[EveCorporationSyncWorkflow] Structure sync failed; continuing to asset sync',
+								'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch; marking sync failure',
+								{
+									corporationId,
+									error: error.message,
+								}
+							)
+						} else if (isRateLimitError) {
+							logger.warn(
+								'[EveCorporationSyncWorkflow] Sovereignty enrichment hit rate limit; preserving previously synced rows',
+								{
+									corporationId,
+									error: error instanceof Error ? error.message : String(error),
+								}
+							)
+						} else {
+							try {
+								await markStructureSyncFailureReason(
+									this.env,
+									corporationId,
+									'sovereignty',
+									error instanceof Error ? error.message : String(error)
+								)
+							} catch (markError) {
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Sovereignty failure reason could not be persisted',
+									{
+										corporationId,
+										error: markError instanceof Error ? markError.message : String(markError),
+									}
+								)
+							}
+							logger.warn(
+								'[EveCorporationSyncWorkflow] Sovereignty enrichment failed; continuing without it',
 								{
 									corporationId,
 									error: error instanceof Error ? error.message : String(error),
 								}
 							)
 						}
+					}
 
-						try {
-							const sovereigntyEnrichment = await runDirectorStepWithFailover({
-								stepName: 'fetch-structure-sovereignty-enrichment',
-								timeout: '10 minutes',
-								requiredRoles: ['Station_Manager'],
-								persistResult: false,
-								run: (directorCharacterId) =>
-									fetchSovereigntyEnrichment(this.env, corporationId, directorCharacterId),
-							})
+					const completed = !structureSyncHadFailure
+					structureSyncCompleted = completed
+					return {
+						dataType: 'structures' as const,
+						stats: {
+							structuresCount,
+							sovereigntySystemsCount,
+							sovereigntyHubsCount,
+							miningExtractionsCount,
+						},
+						completed,
+					}
+				})
+				}
 
-							if (sovereigntyEnrichment) {
-								await storeSovereigntyEnrichment(
-									this.env,
-									corporationId,
-									sovereigntyEnrichment
-								)
-								sovereigntySystemsCount =
-									sovereigntyEnrichment.sovereigntySystems?.length ?? 0
-								sovereigntyHubsCount = sovereigntyEnrichment.sovereigntyHubs.length
-							}
-						} catch (error) {
-							structureSyncHadFailure = true
-							if (error instanceof StructureEnrichmentScopeMismatchError) {
-								try {
-									await step.do(
-										'store-structure-sovereignty-enrichment-failure',
-										{},
-										async () =>
-											await markStructureEnrichmentSyncFailure(
-												this.env,
-												corporationId,
-												error.target,
-												error.message
-											)
-									)
-								} catch (markError) {
-									logger.warn(
-										'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch could not be persisted',
-										{
-											corporationId,
-											error: markError instanceof Error ? markError.message : String(markError),
-										}
-									)
-								}
-								logger.warn(
-									'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch; marking sync failure',
-									{
-										corporationId,
-										error: error.message,
-									}
-								)
-							} else {
-								logger.warn(
-									'[EveCorporationSyncWorkflow] Sovereignty enrichment failed; continuing without it',
-									{
-										corporationId,
-										error: error instanceof Error ? error.message : String(error),
-									}
-								)
-							}
-						}
+				const shouldSyncSkyhooks =
+					shouldSyncAuthenticated('structures') || shouldSyncAuthenticated('skyhooks')
+
+				if (shouldSyncSkyhooks) {
+					skyhooksSync = await step.do('sync-skyhooks', {}, async () => {
+						let skyhooksCount = 0
+						let skyhooksReturnedCount = 0
+						let skyhooksPrunedCount = 0
 
 						try {
 							const skyhookEnrichment = await runDirectorStepWithFailover({
@@ -865,21 +987,40 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 								skyhooksCount = skyhookEnrichment.skyhooks.length
 								skyhooksReturnedCount = skyhookEnrichment.skyhooks.length
 								skyhooksPrunedCount = skyhookStoreResult.prunedCount
+
+								if (skyhookEnrichment.nonRateLimitFailureCount > 0) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Skyhook enrichment completed with partial non-rate-limit failures',
+										{
+											corporationId,
+											successCount: skyhookEnrichment.skyhooks.length,
+											failureCount: skyhookEnrichment.failureCount,
+											rateLimitFailureCount: skyhookEnrichment.rateLimitFailureCount,
+											nonRateLimitFailureCount: skyhookEnrichment.nonRateLimitFailureCount,
+										}
+									)
+								} else if (skyhookEnrichment.rateLimitFailureCount > 0) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Skyhook enrichment completed with rate-limit pressure; preserving successful rows',
+										{
+											corporationId,
+											successCount: skyhookEnrichment.skyhooks.length,
+											rateLimitFailureCount: skyhookEnrichment.rateLimitFailureCount,
+										}
+									)
+								}
 							}
 						} catch (error) {
-							structureSyncHadFailure = true
+							const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
+							const isRateLimitError = metadata?.status === 429
+
 							if (error instanceof StructureEnrichmentScopeMismatchError) {
 								try {
-									await step.do(
-										'store-structure-skyhook-enrichment-failure',
-										{},
-										async () =>
-											await markStructureEnrichmentSyncFailure(
-												this.env,
-												corporationId,
-												error.target,
-												error.message
-											)
+									await markStructureEnrichmentSyncFailure(
+										this.env,
+										corporationId,
+										error.target,
+										error.message
 									)
 								} catch (markError) {
 									logger.warn(
@@ -897,7 +1038,31 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 										error: error.message,
 									}
 								)
+							} else if (isRateLimitError) {
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Skyhook enrichment hit rate limit; preserving previously synced rows',
+									{
+										corporationId,
+										error: error instanceof Error ? error.message : String(error),
+									}
+								)
 							} else {
+								try {
+									await markStructureSyncFailureReason(
+										this.env,
+										corporationId,
+										'skyhooks',
+										error instanceof Error ? error.message : String(error)
+									)
+								} catch (markError) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Skyhook failure reason could not be persisted',
+										{
+											corporationId,
+											error: markError instanceof Error ? markError.message : String(markError),
+										}
+									)
+								}
 								logger.warn(
 									'[EveCorporationSyncWorkflow] Skyhook enrichment failed; continuing without it',
 									{
@@ -908,26 +1073,18 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 							}
 						}
 
-						const completed = !structureSyncHadFailure
-						structureSyncCompleted = completed
 						return {
-							dataType: 'structures' as const,
+							dataType: 'skyhooks' as const,
 							stats: {
-								structuresCount,
-								sovereigntySystemsCount,
-								sovereigntyHubsCount,
 								skyhooksCount,
 								skyhooksReturnedCount,
 								skyhooksPrunedCount,
-								miningExtractionsCount,
 							},
-							completed,
 						}
 					})
 				}
-			}
 
-			if (shouldSyncAuthenticated('assets')) {
+				if (shouldSyncAuthenticated('assets')) {
 				logger.info('[EveCorporationSyncWorkflow] Asset sync selected for this run', {
 					corporationId,
 					trigger,
@@ -1032,6 +1189,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 				walletTransactionsSync,
 				assetsSync,
 				structuresSync,
+				skyhooksSync,
 				ordersSync,
 				contractsSync,
 				industryJobsSync,

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -2760,6 +2760,7 @@ function buildSovereigntyStructuresCte(db: DbClient<DbSchema>, corpWhere: any) {
 					coalesce(${structureSovereigntyHubs.syncStatus}, 'warning')
 				`.as('syncStatus'),
 				syncFailureReason: structureSovereigntyHubs.syncFailureReason,
+				lastAttemptedSyncAt: structureSovereigntyHubs.lastAttemptedSyncAt,
 				sourceSyncAt: structureSovereigntyHubs.sourceSyncAt,
 				lastSyncedAt: sql<Date | null>`
 					coalesce(${structureSovereigntyHubs.lastSyncedAt}, ${structureSovereigntySystems.lastSyncedAt})
@@ -3111,6 +3112,7 @@ async function loadSovereigntyPageItems(
 			workforceTransport: sovereigntyStructures.workforceTransport,
 			syncStatus: sovereigntyStructures.syncStatus,
 			syncFailureReason: sovereigntyStructures.syncFailureReason,
+			lastAttemptedSyncAt: sovereigntyStructures.lastAttemptedSyncAt,
 			sourceSyncAt: sovereigntyStructures.sourceSyncAt,
 			lastSyncedAt: sovereigntyStructures.lastSyncedAt,
 			updatedAt: sovereigntyStructures.updatedAt,
@@ -3157,6 +3159,7 @@ async function loadSovereigntyPageItems(
 				},
 			syncStatus: (row.syncStatus ?? 'warning') as typeof structureSovereigntyHubs.$inferSelect['syncStatus'],
 			syncFailureReason: row.syncFailureReason,
+			lastAttemptedSyncAt: row.lastAttemptedSyncAt,
 			sourceSyncAt: row.sourceSyncAt,
 			lastSyncedAt: row.lastSyncedAt,
 			updatedAt: row.updatedAt,

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -21,6 +21,7 @@ export type EveCorporationSyncDataType =
 	| 'wallet-transactions'
 	| 'assets'
 	| 'structures'
+	| 'skyhooks'
 	| 'orders'
 	| 'contracts'
 	| 'industry-jobs'
@@ -437,6 +438,53 @@ export interface WalletTransactionsStoreResult {
 
 export interface SkyhookStoreResult {
 	prunedCount: number
+}
+
+export interface StructureSyncPriority {
+	structureId: string
+	lastAttemptedSyncAt: Date | null
+	lastSyncedAt: Date | null
+}
+
+export type SkyhookSyncPriority = StructureSyncPriority
+
+export type SovereigntyHubSyncPriority = StructureSyncPriority
+
+export type MoonDrillSyncPriority = StructureSyncPriority
+
+export type MiningCitadelSyncPriority = StructureSyncPriority
+
+export type StructureSyncFailureTarget =
+	| 'structures'
+	| 'sovereignty'
+	| 'skyhooks'
+	| 'moon-drills'
+	| 'mining-extractions'
+
+/**
+ * Targets for live-list based structure-priority queries.
+ */
+export type StructureSyncPriorityTarget =
+	| 'sovereignty'
+	| 'skyhooks'
+	| 'moon-drills'
+	| 'mining-extractions'
+
+/**
+ * A compact structure-priority queue entry used by enrichment batching.
+ */
+export interface StructurePriorityQueueEntry<P extends StructureSyncPriority = StructureSyncPriority> {
+	entry: { id: string | number }
+	index: number
+	priority: P | null
+}
+
+export interface StructurePriorityQueueResult<
+	T extends { id: string | number },
+	P extends StructureSyncPriority = StructureSyncPriority,
+> {
+	entries: Array<StructurePriorityQueueEntry<P> & { entry: T }>
+	pruneCandidateIds: string[]
 }
 
 /**
@@ -1357,7 +1405,42 @@ export interface EveCorporationData {
 	/**
 	 * Store sovereignty hub snapshots (workflow-friendly)
 	 */
-	storeSovereigntyHubs(corporationId: string, hubs: EsiSovereigntyHub[]): Promise<void>
+	storeSovereigntyHubs(
+		corporationId: string,
+		hubs: EsiSovereigntyHub[],
+		options?: {
+			pruneCandidateIds?: readonly string[]
+		}
+	): Promise<void>
+
+	/**
+	 * Read the current sovereignty hub sync priority order for a corporation.
+	 */
+	getSovereigntyHubSyncPriorities(corporationId: string): Promise<SovereigntyHubSyncPriority[]>
+
+	/**
+	 * Return the sovereignty hub IDs that are missing from the live listing.
+	 */
+	getMissingStructureIdsForPriorityQueue(
+		corporationId: string,
+		target: StructureSyncPriorityTarget,
+		structureIds: string[]
+	): Promise<string[]>
+
+	/**
+	 * Read the current sovereignty hub structure IDs for a corporation.
+	 */
+	getSovereigntyHubStructureIds(corporationId: string): Promise<string[]>
+
+	/**
+	 * Read the current moon-drill sync priority order for a corporation.
+	 */
+	getMoonDrillSyncPriorities(corporationId: string): Promise<MoonDrillSyncPriority[]>
+
+	/**
+	 * Read the current moon-drill structure IDs for a corporation.
+	 */
+	getMoonDrillStructureIds(corporationId: string): Promise<string[]>
 
 	/**
 	 * Mark a structure-enrichment snapshot as failed without discarding the last good data.
@@ -1369,9 +1452,46 @@ export interface EveCorporationData {
 	): Promise<void>
 
 	/**
+	 * Mark a structure ingest snapshot as failed without discarding the last good data.
+	 */
+	markStructureSyncFailureReason(
+		corporationId: string,
+		target: StructureSyncFailureTarget,
+		failureReason: string
+	): Promise<void>
+
+	/**
 	 * Store skyhook snapshots (workflow-friendly)
 	 */
-	storeSkyhooks(corporationId: string, skyhooks: EsiCorporationSkyhook[]): Promise<SkyhookStoreResult>
+	storeSkyhooks(
+		corporationId: string,
+		skyhooks: EsiCorporationSkyhook[],
+		options?: {
+			pruneCandidateIds?: readonly string[]
+		}
+	): Promise<SkyhookStoreResult>
+
+	/**
+	 * Read the current skyhook sync priority order for a corporation.
+	 */
+	getSkyhookSyncPriorities(corporationId: string): Promise<SkyhookSyncPriority[]>
+
+	/**
+	 * Read the current skyhook structure IDs for a corporation.
+	 */
+	getSkyhookStructureIds(corporationId: string): Promise<string[]>
+
+	/**
+	 * Read the current mining-citadel sync priority order for a corporation.
+	 */
+	getMiningCitadelSyncPriorities(
+		corporationId: string
+	): Promise<MiningCitadelSyncPriority[]>
+
+	/**
+	 * Read the current mining-citadel structure IDs for a corporation.
+	 */
+	getMiningCitadelStructureIds(corporationId: string): Promise<string[]>
 
 	/**
 	 * Store mining extraction snapshots (workflow-friendly)

--- a/packages/structures-db-schema/src/index.ts
+++ b/packages/structures-db-schema/src/index.ts
@@ -192,6 +192,7 @@ export const structureSovereigntyHubs = pgTable(
 			}),
 		syncStatus: text('sync_status', { enum: ['ok', 'warning', 'error'] }).notNull().default('ok'),
 		syncFailureReason: text('sync_failure_reason'),
+		lastAttemptedSyncAt: timestamp('last_attempted_sync_at', { withTimezone: true }),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
@@ -226,6 +227,7 @@ export const structureSkyhooks = pgTable(
 		theftVulnerabilityEnd: timestamp('theft_vulnerability_end', { withTimezone: true }),
 		syncStatus: text('sync_status', { enum: ['ok', 'warning', 'error'] }).notNull().default('ok'),
 		syncFailureReason: text('sync_failure_reason'),
+		lastAttemptedSyncAt: timestamp('last_attempted_sync_at', { withTimezone: true }),
 		lastObservedAt: timestamp('last_observed_at', { withTimezone: true }),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
@@ -270,7 +272,9 @@ export const structureMoonDrills = pgTable(
 			.notNull()
 			.references(() => managedCorporations.corporationId, { onDelete: 'cascade' }),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
+		lastAttemptedSyncAt: timestamp('last_attempted_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
+		syncFailureReason: text('sync_failure_reason'),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [
@@ -320,7 +324,9 @@ export const structureMiningExtractions = pgTable(
 		chunkArrivalTime: timestamp('chunk_arrival_time', { withTimezone: true }),
 		naturalDecayTime: timestamp('natural_decay_time', { withTimezone: true }),
 		sourceSyncAt: timestamp('source_sync_at', { withTimezone: true }),
+		lastAttemptedSyncAt: timestamp('last_attempted_sync_at', { withTimezone: true }),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
+		syncFailureReason: text('sync_failure_reason'),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [


### PR DESCRIPTION
individual cooldowns

<!-- claude:begin -->
## Summary
Refactors the corporation-data structure ingest workflow to sync structures (sovereignty hubs, skyhooks, moon drills, mining citadel extractions) using per-structure priority queues and cooldowns instead of a single corporation-wide cooldown gate. This lets stale/never-synced structures be refreshed sooner while structures synced recently or attempted recently are deprioritized, and lets skyhooks sync independently of the broader structures sync.

## Changes
- Add `services/structure-priority.ts` with `buildPriorityQueuedEntries`/`buildPriorityOrderedEntries` to order live structure listings by oldest `lastSyncedAt`/`lastAttemptedSyncAt`, surface newly-seen structures first, and compute prune candidates.
- Add `lastAttemptedSyncAt` and `syncFailureReason` columns (with a new `corporation_structures_last_synced_at_idx` index) across sovereignty hub, skyhook, moon-drill, and mining-extraction tables via a generated Drizzle migration.
- `EveCorporationDataDO`: add per-target sync-priority/structure-id lookups (sovereignty, skyhooks, moon-drills, mining-extractions), a generalized `markStructureSyncFailureReason`, and `storeSovereigntyHubs`/`storeSkyhooks` now accept explicit `pruneCandidateIds` computed from the priority queue instead of diffing against all existing rows.
- `esi-fetch.ts`: `fetchSovereigntyHubs`/`fetchCorporationSkyhooks` now fetch structure details in small batches (`Promise.allSettled`) against a prioritized entry list, tracking rate-limit vs. non-rate-limit failure counts and returning prune candidates alongside successfully-fetched hubs/skyhooks.
- `sync-workflow.ts`: remove the corporation-wide `structureEnrichmentCooldown`; split skyhook sync into its own `sync-skyhooks` step (gated separately, requiring the `Director` role) so it can run even when general structure sync is skipped; mining-citadel extraction fetches are now prioritized and stored in batches; failures are classified as rate-limit vs. non-rate-limit and persisted via `markStructureSyncFailureReason`.
- Export new shared types (`StructureSyncPriority`, `StructureSyncPriorityTarget`, `StructureSyncFailureTarget`, etc.) from `@repo/eve-corporation-data` and add `'skyhooks'` to `EveCorporationSyncDataType`.

## Testing
- Updated/added unit tests for `structure-mining-storage`, `structure-prune-cleanup`, `esi-fetch` structure enrichment, and the `structure-enrichment`/`sync-workflow` workflow tests.
<!-- claude:end -->
