### PR TITLE
Feat/structure ux tweaks

### DIFF
--- a/apps/structures/src/services/skyhook-summary.ts
+++ b/apps/structures/src/services/skyhook-summary.ts
@@ -2,6 +2,10 @@ import type {
 	StructureListSummary,
 	StructureSkyhookListItem,
 } from '@repo/structures'
+import {
+	SKYHOOK_SECURED_BAY_CAPACITY_M3,
+	SKYHOOK_SURPLUS_BAY_CAPACITY_M3,
+} from '@repo/structures'
 
 type SkyhookRaidableWindowSelection = {
 	structureId: string
@@ -32,9 +36,13 @@ export function summarizeSkyhooks(
 	let skyhookHighestFillPercent: number | null = null
 	let nextRaidableWindow: SkyhookRaidableWindowSelection | null = null
 	let currentRaidableCount = 0
+	const totalCapacity = SKYHOOK_SECURED_BAY_CAPACITY_M3 + SKYHOOK_SURPLUS_BAY_CAPACITY_M3
 
 	for (const item of items) {
-		const itemHighestFillPercent = Math.max(item.securedFillPercent, item.unsecuredFillPercent)
+		const itemHighestFillPercent =
+			((item.securedFillPercent * SKYHOOK_SECURED_BAY_CAPACITY_M3) +
+				(item.unsecuredFillPercent * SKYHOOK_SURPLUS_BAY_CAPACITY_M3)) /
+			totalCapacity
 		if (Number.isFinite(itemHighestFillPercent)) {
 			skyhookHighestFillPercent =
 				skyhookHighestFillPercent === null

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -3843,6 +3843,13 @@ function buildMoonDrillStructuresCte(
 			})
 			.from(operationalStructures)
 			.leftJoin(
+				moonDrillInventoryAggregate,
+				and(
+					eq(moonDrillInventoryAggregate.corporationId, operationalStructures.corporationId),
+					eq(moonDrillInventoryAggregate.structureId, operationalStructures.structureId)
+				)
+			)
+			.leftJoin(
 				structureMoonDrills,
 				eq(structureMoonDrills.structureId, operationalStructures.structureId)
 			)

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -21,6 +21,7 @@ import {
 	SKYHOOK_STRUCTURE_TYPE_IDS,
 	SOVEREIGNTY_STRUCTURE_TYPE_IDS,
 	STRUCTURE_REINFORCED_STATES,
+	FUEL_BLOCK_TYPE_IDS,
 	SKYHOOK_SECURED_BAY_CAPACITY_M3,
 	SKYHOOK_SURPLUS_BAY_CAPACITY_M3,
 	SKYHOOK_MAGMATIC_GAS_TYPE_ID,
@@ -2209,6 +2210,22 @@ function buildSkyhookReagentFillPercentExpression(
 	`
 }
 
+function buildSkyhookReagentVolumeExpression(source: any, stockType: 'secured' | 'unsecured') {
+	const magmaticGasStock =
+		stockType === 'secured' ? source.magmaticGasSecuredStock : source.magmaticGasUnsecuredStock
+	const superionicIceStock =
+		stockType === 'secured' ? source.superionicIceSecuredStock : source.superionicIceUnsecuredStock
+
+	return sql<number>`
+		(
+			coalesce(${magmaticGasStock}, 0)::numeric
+				* ${getSkyhookReagentUnitVolumeM3(SKYHOOK_MAGMATIC_GAS_TYPE_ID)}::numeric
+			+ coalesce(${superionicIceStock}, 0)::numeric
+				* ${getSkyhookReagentUnitVolumeM3(SKYHOOK_SUPERIONIC_ICE_TYPE_ID)}::numeric
+		)
+	`
+}
+
 function buildSkyhookSortOrder(
 	sortBy: StructureSkyhookListSortBy,
 	sortDirection: StructureListSortDirection,
@@ -2536,9 +2553,17 @@ async function buildSkyhookStructureSummaryFromSql(
 ): Promise<StructureListSummary> {
 	const rowsDb = db.with(skyhookStructures)
 	const currentRaidableExpression = getSkyhookCurrentRaidableExpression(skyhookStructures)
-	const securedFillPercent = buildSkyhookReagentFillPercentExpression(skyhookStructures, 'secured')
-	const unsecuredFillPercent = buildSkyhookReagentFillPercentExpression(skyhookStructures, 'unsecured')
-	const highestFillPercent = sql<number>`greatest(${securedFillPercent}, ${unsecuredFillPercent})`
+	const securedVolume = buildSkyhookReagentVolumeExpression(skyhookStructures, 'secured')
+	const unsecuredVolume = buildSkyhookReagentVolumeExpression(skyhookStructures, 'unsecured')
+	const highestFillPercent = sql<number>`
+		least(
+			(
+				(${securedVolume} + ${unsecuredVolume})
+				/ (${SKYHOOK_SECURED_BAY_CAPACITY_M3}::numeric + ${SKYHOOK_SURPLUS_BAY_CAPACITY_M3}::numeric)
+			) * 100,
+			100
+		)
+	`
 	const [totalResult, highestFillResult, workforceResult, raidableCountResult, nextRaidableResult] =
 		await Promise.all([
 			rowsDb
@@ -3339,6 +3364,8 @@ async function loadMoonDrillPageItems(
 			syncFailureReason: moonDrillStructures.syncFailureReason,
 			lastSyncedAt: moonDrillStructures.lastSyncedAt,
 			updatedAt: moonDrillStructures.updatedAt,
+			fuelBlockUnits: moonDrillStructures.fuelBlockUnits,
+			magmaticGasUnits: moonDrillStructures.magmaticGasUnits,
 			moonDrillStructureId: moonDrillStructures.moonDrillStructureId,
 			moonId: moonDrillStructures.moonId,
 			moonName: moonDrillStructures.moonName,
@@ -3361,17 +3388,19 @@ async function loadMoonDrillPageItems(
 			user.is_admin || canViewDetailsStructure(access, row.corporationId, structureTab)
 		const hasMoonDrillSnapshot = row.moonDrillStructureId !== null && row.moonId !== null
 
-		return {
-			...buildOperationalStructureListItem(row, canViewDetails),
-			name: row.structureName ?? row.structureId,
-			planetId: row.planetId ?? null,
-			planetName: row.planetName ?? null,
-			moonId: row.moonId ?? '',
-			moonName: row.moonName ?? null,
-			syncStatus: hasMoonDrillSnapshot ? getSnapshotSyncStatus(row.moonDrillLastSyncedAt) : 'warning',
-			syncFailureReason: hasMoonDrillSnapshot
-				? null
-				: 'Moon drill snapshot has not been ingested yet for this structure.',
+			return {
+				...buildOperationalStructureListItem(row, canViewDetails),
+				name: row.structureName ?? row.structureId,
+				planetId: row.planetId ?? null,
+				planetName: row.planetName ?? null,
+				moonId: row.moonId ?? '',
+				moonName: row.moonName ?? null,
+				fuelBlockUnits: row.fuelBlockUnits,
+				magmaticGasUnits: row.magmaticGasUnits,
+				syncStatus: hasMoonDrillSnapshot ? getSnapshotSyncStatus(row.moonDrillLastSyncedAt) : 'warning',
+				syncFailureReason: hasMoonDrillSnapshot
+					? null
+					: 'Moon drill snapshot has not been ingested yet for this structure.',
 			lastSyncedAt: toIso(row.moonDrillLastSyncedAt ?? row.lastSyncedAt),
 			updatedAt: toIso(row.moonDrillUpdatedAt ?? row.updatedAt) ?? new Date().toISOString(),
 		}
@@ -3696,6 +3725,10 @@ function buildMoonStructureSortOrder(
 			return [sortExpression(sql`coalesce(${source.regionName}, '')`), sortExpression(source.structureId)]
 		case 'planet':
 			return [sortExpression(sql`coalesce(${source.planetName}, '')`), sortExpression(source.structureId)]
+		case 'fuelBlocks':
+			return [sortExpression(source.fuelBlockUnits), sortExpression(source.structureId)]
+		case 'magmaticGas':
+			return [sortExpression(source.magmaticGasUnits), sortExpression(source.structureId)]
 		case 'system':
 			return [sortExpression(sql`coalesce(${source.systemName}, '')`), sortExpression(source.structureId)]
 		case 'type':
@@ -3722,12 +3755,52 @@ function buildMoonDrillStructuresCte(
 	planetId?: string
 ) {
 	const operationalStructures = buildOperationalStructuresSelectQuery(db, corpWhere).as('operational_structures')
+	const moonDrillInventoryAggregate = db.$with('moon_drill_inventory_aggregate').as(
+		db
+			.select({
+				corporationId: corporationStructureInventory.corporationId,
+				structureId: corporationStructureInventory.structureId,
+				fuelBlockUnits: sql<number>`
+					coalesce(
+						sum(
+							case
+								when ${inArray(corporationStructureInventory.typeId, [...FUEL_BLOCK_TYPE_IDS])}
+									then ${corporationStructureInventory.quantity}
+								else 0
+							end
+						),
+						0
+					)::int
+				`.as('fuelBlockUnits'),
+				magmaticGasUnits: sql<number>`
+					coalesce(
+						sum(
+							case
+								when ${corporationStructureInventory.typeId} = ${SKYHOOK_MAGMATIC_GAS_TYPE_ID}
+									then ${corporationStructureInventory.quantity}
+								else 0
+							end
+						),
+						0
+					)::int
+				`.as('magmaticGasUnits'),
+			})
+			.from(corporationStructureInventory)
+			.innerJoin(
+				operationalStructures,
+				and(
+					eq(corporationStructureInventory.corporationId, operationalStructures.corporationId),
+					eq(corporationStructureInventory.structureId, operationalStructures.structureId)
+				)
+			)
+			.groupBy(corporationStructureInventory.corporationId, corporationStructureInventory.structureId)
+	)
 	const conditions = [sql`true`]
 	if (planetId) {
 		conditions.push(eq(structureMoonGeographies.planetId, planetId))
 	}
 	return db.$with('moon_drill_structures').as(
-		db.with(operationalStructures)
+		db.with(operationalStructures, moonDrillInventoryAggregate)
 			.select({
 				structureId: sql<string>`${operationalStructures.structureId}`.as('structureId'),
 				corporationId: sql<string>`${operationalStructures.corporationId}`.as('corporationId'),
@@ -3754,6 +3827,12 @@ function buildMoonDrillStructuresCte(
 				syncFailureReason: sql<string | null>`${operationalStructures.syncFailureReason}`.as('syncFailureReason'),
 				lastSyncedAt: sql<Date | null>`${operationalStructures.lastSyncedAt}`.as('lastSyncedAt'),
 				updatedAt: sql<Date>`${operationalStructures.updatedAt}`.as('updatedAt'),
+				fuelBlockUnits: sql<number>`coalesce(${moonDrillInventoryAggregate.fuelBlockUnits}, 0)`.as(
+					'fuelBlockUnits'
+				),
+				magmaticGasUnits: sql<number>`coalesce(${moonDrillInventoryAggregate.magmaticGasUnits}, 0)`.as(
+					'magmaticGasUnits'
+				),
 				moonDrillStructureId: sql<string | null>`${structureMoonDrills.structureId}`.as('moonDrillStructureId'),
 				moonId: sql<string | null>`${structureMoonGeographies.moonId}`.as('moonId'),
 				moonName: sql<string | null>`${structureMoonGeographies.moonName}`.as('moonName'),

--- a/apps/structures/src/test/unit/services/skyhook-summary.test.ts
+++ b/apps/structures/src/test/unit/services/skyhook-summary.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { summarizeSkyhooks } from '../../../services/skyhook-summary'
+
+import type { StructureSkyhookListItem } from '@repo/structures'
+
+function makeSkyhook(overrides: Partial<StructureSkyhookListItem>): StructureSkyhookListItem {
+	return {
+		structureId: 'skyhook-1',
+		corporationId: 'corp-1',
+		corporationName: 'Test Corp',
+		typeId: '81080',
+		typeName: 'Orbital Skyhook',
+		systemId: '30000142',
+		systemName: 'Jita',
+		regionId: '10000002',
+		regionName: 'The Forge',
+		state: 'active',
+		nextStateAt: null,
+		lowPower: false,
+		hidden: false,
+		lowPowerAllowed: false,
+		assignedGroupId: null,
+		syncStatus: 'ok',
+		syncFailureReason: null,
+		lastSyncedAt: '2026-07-24T00:00:00.000Z',
+		updatedAt: '2026-07-24T00:00:00.000Z',
+		canViewDetails: true,
+		planetId: '40000001',
+		planetName: 'Planet I',
+		isActive: true,
+		effectiveWorkforce: 0,
+		totalReagents: 2,
+		totalSecuredStock: 0,
+		totalUnsecuredStock: 0,
+		totalSecuredVolumeM3: 0,
+		totalUnsecuredVolumeM3: 0,
+		securedCapacityM3: 70080,
+		unsecuredCapacityM3: 70080,
+		securedFillPercent: 100,
+		unsecuredFillPercent: 0,
+		reagents: [],
+		reinforcementTimerEnd: null,
+		theftVulnerabilityStart: null,
+		theftVulnerabilityEnd: null,
+		isRaidable: false,
+		...overrides,
+	}
+}
+
+describe('skyhook summary', () => {
+	it('normalizes the highest fill metric across the secured and surplus bays', () => {
+		const summary = summarizeSkyhooks([makeSkyhook({ securedFillPercent: 100, unsecuredFillPercent: 0 })])
+
+		expect(summary.skyhookHighestFillPercent).toBe(50)
+	})
+})

--- a/apps/ui/src/client/features/structures/query-utils.ts
+++ b/apps/ui/src/client/features/structures/query-utils.ts
@@ -44,7 +44,7 @@ function getMoonSortBy(sortBy: string | null | undefined): StructureMoonStructur
 function getSkyhookSortBy(sortBy: string | null | undefined): StructureSkyhookListSortBy {
 	return isIncluded(sortBy ?? '', STRUCTURE_SKYHOOK_LIST_SORT_FIELDS)
 		? (sortBy as StructureSkyhookListSortBy)
-		: 'fuel'
+		: 'skyhookSurplusFullness'
 }
 
 function getSovereigntySortBy(sortBy: string | null | undefined): StructureSovereigntyListSortBy {

--- a/apps/ui/src/client/features/structures/state/structure-table-store.ts
+++ b/apps/ui/src/client/features/structures/state/structure-table-store.ts
@@ -62,7 +62,7 @@ function defaultState(): StructureTableUiState {
 		tab: 'citadels',
 		filters: currentTabState.filters,
 		page: 1,
-		pageSize: 25,
+		pageSize: 10,
 		sortBy: currentTabState.sortBy,
 		sortDirection: currentTabState.sortDirection,
 		tabStateByTab,

--- a/apps/ui/src/client/features/structures/state/structure-table-store.ts
+++ b/apps/ui/src/client/features/structures/state/structure-table-store.ts
@@ -1,7 +1,14 @@
 import { createStore } from '@tanstack/store'
 import { useSyncExternalStore } from 'react'
 
-import type { StructureTab } from '@repo/structures'
+import {
+	STRUCTURE_COMMON_LIST_SORT_FIELDS,
+	STRUCTURE_MOON_STRUCTURE_LIST_SORT_FIELDS,
+	STRUCTURE_SKYHOOK_LIST_SORT_FIELDS,
+	STRUCTURE_SOVEREIGNTY_LIST_SORT_FIELDS,
+	type StructureSkyhookListSortBy,
+	type StructureTab,
+} from '@repo/structures'
 import type { StructureListSortBy, StructureListSortDirection } from '@/lib/api'
 
 export interface StructureTableFilters {
@@ -26,19 +33,114 @@ export interface StructureTableUiState {
 	pageSize: number
 	sortBy: StructureListSortBy
 	sortDirection: StructureListSortDirection
+	tabStateByTab: Partial<Record<StructureTab, StructureTableTabState>>
 }
 
-const STORAGE_KEY = 'structures.table-state.v1'
+interface StructureTableTabState {
+	filters: StructureTableFilters
+	sortBy: StructureListSortBy
+	sortDirection: StructureListSortDirection
+}
+
+const STORAGE_KEY = 'structures.table-state.v2'
+const LEGACY_STORAGE_KEY = 'structures.table-state.v1'
+const DEFAULT_SORT_BY: StructureListSortBy = 'fuel'
+const DEFAULT_SORT_DIRECTION: StructureListSortDirection = 'asc'
+const ALL_STRUCTURE_TABS: StructureTab[] = [
+	'citadels',
+	'sovereignty',
+	'skyhooks',
+	'navigation',
+	'mining-citadels',
+	'moon-drills',
+]
 
 function defaultState(): StructureTableUiState {
+	const tabStateByTab: Partial<Record<StructureTab, StructureTableTabState>> = {}
+	const currentTabState = defaultTabState('citadels')
 	return {
 		tab: 'citadels',
-		filters: {},
+		filters: currentTabState.filters,
 		page: 1,
 		pageSize: 25,
-		sortBy: 'fuel',
-		sortDirection: 'asc',
+		sortBy: currentTabState.sortBy,
+		sortDirection: currentTabState.sortDirection,
+		tabStateByTab,
 	}
+}
+
+function defaultSortForTab(tab: StructureTab): Pick<StructureTableTabState, 'sortBy' | 'sortDirection'> {
+	if (tab === 'skyhooks') {
+		return {
+			sortBy: 'skyhookSurplusFullness' as StructureSkyhookListSortBy,
+			sortDirection: 'desc',
+		}
+	}
+
+	return {
+		sortBy: DEFAULT_SORT_BY,
+		sortDirection: DEFAULT_SORT_DIRECTION,
+	}
+}
+
+function defaultTabState(tab: StructureTab): StructureTableTabState {
+	const defaultSort = defaultSortForTab(tab)
+	return {
+		filters: {},
+		...defaultSort,
+	}
+}
+
+function isValidSortByForTab(tab: StructureTab, sortBy: string | null | undefined): sortBy is StructureListSortBy {
+	const fields = (() => {
+		switch (tab) {
+			case 'skyhooks':
+				return STRUCTURE_SKYHOOK_LIST_SORT_FIELDS
+			case 'moon-drills':
+				return STRUCTURE_MOON_STRUCTURE_LIST_SORT_FIELDS
+			case 'sovereignty':
+				return STRUCTURE_SOVEREIGNTY_LIST_SORT_FIELDS
+			default:
+				return STRUCTURE_COMMON_LIST_SORT_FIELDS
+		}
+	})()
+
+	return typeof sortBy === 'string' && fields.includes(sortBy as never)
+}
+
+function normalizeTabState(
+	tab: StructureTab,
+	tabState: Partial<StructureTableTabState> | null | undefined
+): StructureTableTabState {
+	const defaults = defaultTabState(tab)
+	return {
+		filters: pruneFiltersForTab(tab, normalizeFilters(tabState?.filters ?? {})),
+		sortBy: isValidSortByForTab(tab, tabState?.sortBy) ? tabState.sortBy : defaults.sortBy,
+		sortDirection:
+			tabState?.sortDirection === 'asc' || tabState?.sortDirection === 'desc'
+				? tabState.sortDirection
+				: defaults.sortDirection,
+	}
+}
+
+function normalizeTabStateByTab(
+	tabStateByTab: Partial<Record<StructureTab, Partial<StructureTableTabState>>> | null | undefined
+): Partial<Record<StructureTab, StructureTableTabState>> {
+	const nextTabStateByTab: Partial<Record<StructureTab, StructureTableTabState>> = {}
+
+	for (const tab of ALL_STRUCTURE_TABS) {
+		if (!tabStateByTab?.[tab]) continue
+		nextTabStateByTab[tab] = normalizeTabState(tab, tabStateByTab[tab])
+	}
+
+	return nextTabStateByTab
+}
+
+function getTabState(
+	tab: StructureTab,
+	tabStateByTab: Partial<Record<StructureTab, StructureTableTabState>>
+): StructureTableTabState {
+	return tabStateByTab[tab] ?? defaultTabState(tab)
 }
 
 function normalizeFilters(filters: StructureTableFilters): StructureTableFilters {
@@ -175,16 +277,30 @@ function normalizeTab(tab: unknown): StructureTab {
 function readStateFromStorage(): StructureTableUiState {
 	if (typeof window === 'undefined') return defaultState()
 	try {
-		const raw = window.sessionStorage.getItem(STORAGE_KEY)
+		const raw = window.localStorage.getItem(STORAGE_KEY) ?? window.sessionStorage.getItem(LEGACY_STORAGE_KEY)
 		if (!raw) return defaultState()
-		const parsed = JSON.parse(raw) as StructureTableUiState
+		const parsed = JSON.parse(raw) as Partial<StructureTableUiState> & {
+			tabStateByTab?: Partial<Record<StructureTab, Partial<StructureTableTabState>>>
+		}
 		if (!parsed || typeof parsed !== 'object') return defaultState()
 		const tab = normalizeTab(parsed.tab)
+		const tabStateByTab = normalizeTabStateByTab(parsed.tabStateByTab)
+		if (parsed.tabStateByTab === undefined && parsed.filters && parsed.sortBy) {
+			tabStateByTab[tab] = normalizeTabState(tab, {
+				filters: parsed.filters,
+				sortBy: parsed.sortBy,
+				sortDirection: parsed.sortDirection,
+			})
+		}
+		const currentTabState = getTabState(tab, tabStateByTab)
 		return {
 			...defaultState(),
 			...parsed,
 			tab,
-			filters: pruneFiltersForTab(tab, normalizeFilters(parsed.filters ?? {})),
+			filters: currentTabState.filters,
+			sortBy: currentTabState.sortBy,
+			sortDirection: currentTabState.sortDirection,
+			tabStateByTab,
 		}
 	} catch {
 		return defaultState()
@@ -196,7 +312,13 @@ const structureTableStore = createStore<StructureTableUiState>(readStateFromStor
 function persistState(): void {
 	if (typeof window === 'undefined') return
 	try {
-		window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(structureTableStore.state))
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({
+				tab: structureTableStore.state.tab,
+				tabStateByTab: structureTableStore.state.tabStateByTab,
+			})
+		)
 	} catch {
 		// Ignore storage failures; the in-memory store still works for the session.
 	}
@@ -232,9 +354,24 @@ export function setStructureTableFilters(
 ): void {
 	updateState((previous) => {
 		const nextFilters = typeof patch === 'function' ? patch(previous.filters) : { ...previous.filters, ...patch }
+		const currentTabState = normalizeTabState(previous.tab, {
+			filters: previous.filters,
+			sortBy: previous.sortBy,
+			sortDirection: previous.sortDirection,
+		})
+		const nextTabState = normalizeTabState(previous.tab, {
+			...currentTabState,
+			filters: nextFilters,
+		})
 		return {
 			...previous,
-			filters: normalizeFilters(nextFilters),
+			filters: nextTabState.filters,
+			sortBy: nextTabState.sortBy,
+			sortDirection: nextTabState.sortDirection,
+			tabStateByTab: {
+				...previous.tabStateByTab,
+				[previous.tab]: nextTabState,
+			},
 			page: 1,
 		}
 	})
@@ -244,7 +381,26 @@ export function setStructureTableTab(tab: StructureTab): void {
 	updateState((previous) => ({
 		...previous,
 		tab,
-		filters: pruneFiltersForTab(tab, previous.filters),
+		...(() => {
+			const nextTabStateByTab = {
+				...previous.tabStateByTab,
+				[previous.tab]: normalizeTabState(previous.tab, {
+					filters: previous.filters,
+					sortBy: previous.sortBy,
+					sortDirection: previous.sortDirection,
+				}),
+			}
+			const nextTabState = getTabState(tab, nextTabStateByTab)
+			return {
+				filters: nextTabState.filters,
+				sortBy: nextTabState.sortBy,
+				sortDirection: nextTabState.sortDirection,
+				tabStateByTab: {
+					...nextTabStateByTab,
+					[tab]: nextTabState,
+				},
+			}
+		})(),
 		page: 1,
 	}))
 }
@@ -252,7 +408,22 @@ export function setStructureTableTab(tab: StructureTab): void {
 export function clearStructureTableFilters(): void {
 	updateState((previous) => ({
 		...previous,
-		filters: {},
+		...(() => {
+			const nextTabState = normalizeTabState(previous.tab, {
+				filters: {},
+				sortBy: previous.sortBy,
+				sortDirection: previous.sortDirection,
+			})
+			return {
+				filters: nextTabState.filters,
+				sortBy: nextTabState.sortBy,
+				sortDirection: nextTabState.sortDirection,
+				tabStateByTab: {
+					...previous.tabStateByTab,
+					[previous.tab]: nextTabState,
+				},
+			}
+		})(),
 		page: 1,
 	}))
 }
@@ -275,8 +446,24 @@ export function setStructureTablePageSize(pageSize: number): void {
 export function setStructureTableSort(sortBy: StructureListSortBy): void {
 	updateState((previous) => ({
 		...previous,
-		sortBy,
-		sortDirection: previous.sortBy === sortBy && previous.sortDirection === 'asc' ? 'desc' : 'asc',
+		...(() => {
+			const nextSortDirection =
+				previous.sortBy === sortBy && previous.sortDirection === 'asc' ? 'desc' : 'asc'
+			const nextTabState = normalizeTabState(previous.tab, {
+				filters: previous.filters,
+				sortBy,
+				sortDirection: nextSortDirection,
+			})
+			return {
+				filters: nextTabState.filters,
+				sortBy: nextTabState.sortBy,
+				sortDirection: nextTabState.sortDirection,
+				tabStateByTab: {
+					...previous.tabStateByTab,
+					[previous.tab]: nextTabState,
+				},
+			}
+		})(),
 		page: 1,
 	}))
 }

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -1887,7 +1887,7 @@ export default function StructuresPage() {
 								pageSize={pagination?.pageSize ?? tableState.pageSize}
 								onPageChange={setStructureTablePage}
 								onPageSizeChange={setStructureTablePageSize}
-								pageSizeOptions={[25, 50, 100]}
+								pageSizeOptions={[10, 25, 50, 100]}
 								itemLabel="structures"
 								nextButtonLoading={isFetching}
 								trailingAction={refreshButton}

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -1225,6 +1225,8 @@ export default function StructuresPage() {
 						</div>
 					</TableCell>
 					<TableCell>{fuelLabel}</TableCell>
+					<TableCell>{formatNullableNumber(structure.fuelBlockUnits)}</TableCell>
+					<TableCell>{formatNullableNumber(structure.magmaticGasUnits)}</TableCell>
 					<TableCell>
 						{structure.nextStateAt ? (
 							<DurationDisplay
@@ -1905,6 +1907,8 @@ export default function StructuresPage() {
 												<SortableHead field="name" label="Name" />
 												<SortableHead field="corporation" label="Corporation" />
 												<SortableHead field="fuel" label="Fuel" />
+												<SortableHead field="fuelBlocks" label="Fuel Blocks" />
+												<SortableHead field="magmaticGas" label="Magmatic Gas" />
 												<SortableHead field="nextStateAt" label="Next State In" />
 												<TableHead>Group</TableHead>
 												<TableHead>Sync</TableHead>

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -5,8 +5,11 @@ import {
 	ArrowUpDown,
 	CircleHelp,
 	Filter,
+	Flame,
+	Package,
 	RefreshCcw,
 	Shield,
+	Snowflake,
 } from 'lucide-react'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode, type UIEvent } from 'react'
 import { Link, Navigate } from 'react-router-dom'
@@ -19,11 +22,14 @@ import {
 } from '@repo/groups'
 import {
 	STRUCTURE_TABS,
+	FUEL_BLOCK_TYPE_IDS,
 	isReinforcedStructureState,
 	isStructureTab,
 	isStructureVulnerabilityState,
 	STRUCTURE_SYNC_ERROR_STALE_MS,
 	STRUCTURE_SYNC_WARNING_STALE_MS,
+	SKYHOOK_MAGMATIC_GAS_TYPE_ID,
+	SKYHOOK_SUPERIONIC_ICE_TYPE_ID,
 } from '@repo/structures'
 
 import { TableRefreshFrame } from '@/components/table-refresh-frame'
@@ -45,7 +51,7 @@ import { Select } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { formatDateTimeLong } from '@/lib/date-utils'
 import { formatDurationUntil } from '@/lib/duration-utils'
-import { allianceLogoUrl } from '@/lib/eve-images'
+import { allianceLogoUrl, typeIconUrl } from '@/lib/eve-images'
 import { getSkyhookVulnerabilityWindowDisplay } from '@/lib/skyhook-vulnerability-window'
 import { stripLeadingContextName } from '@/lib/structure-name-utils'
 import {
@@ -114,6 +120,7 @@ const BOOLEAN_FILTER_OPTIONS: SelectOption[] = [
 	{ value: 'true', label: 'Yes' },
 	{ value: 'false', label: 'No' },
 ]
+const FUEL_BLOCK_ICON_TYPE_ID = Array.from(FUEL_BLOCK_TYPE_IDS)[0] ?? '4051'
 
 function structureSyncStatusDescription(
 	structure: Pick<StructureListBaseItem, 'syncStatus' | 'syncFailureReason' | 'lastSyncedAt'>
@@ -192,6 +199,37 @@ function formatNullableDecimal(
 function formatPercent(value: number | null | undefined): string {
 	if (value === null || value === undefined || !Number.isFinite(value)) return '-'
 	return `${value.toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
+}
+
+function MoonDrillResourceCell({
+	typeId,
+	iconAlt,
+	fallbackIcon: FallbackIcon,
+	value,
+}: {
+	typeId: string
+	iconAlt: string
+	fallbackIcon: typeof Package | typeof Flame
+	value: number | null | undefined
+}) {
+	const [failed, setFailed] = useState(false)
+
+	return (
+		<div className="flex items-center gap-2">
+			{failed ? (
+				<FallbackIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+			) : (
+				<img
+					src={typeIconUrl(typeId, 32)}
+					alt={iconAlt}
+					className="h-4 w-4 shrink-0 rounded-sm"
+					loading="lazy"
+					onError={() => setFailed(true)}
+				/>
+			)}
+			<span className="tabular-nums">{formatNullableNumber(value)}</span>
+		</div>
+	)
 }
 
 function LiveDurationUntilText({
@@ -293,18 +331,49 @@ function formatReagentBurnRate(value: number | null | undefined): string {
 	return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}/hr`
 }
 
+function SovereigntyReagentAmount({
+	typeId,
+	value,
+}: {
+	typeId: string
+	value: number
+}) {
+	const [failed, setFailed] = useState(false)
+	const isGas = typeId === SKYHOOK_MAGMATIC_GAS_TYPE_ID
+	const FallbackIcon = isGas ? Flame : Snowflake
+
+	return (
+		<div className="flex items-center gap-2">
+			{failed ? (
+				<FallbackIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+			) : (
+				<img
+					src={typeIconUrl(typeId, 32)}
+					alt=""
+					className="h-4 w-4 shrink-0 rounded-sm"
+					loading="lazy"
+					onError={() => setFailed(true)}
+				/>
+			)}
+			<span className="font-medium tabular-nums">{formatNullableNumber(value)}</span>
+		</div>
+	)
+}
+
 function SovereigntyReagentCell({
+	typeId,
 	quantity,
 	burningPerHour,
 	estimatedDepletionAt,
 }: {
+	typeId: string
 	quantity: number
 	burningPerHour: number
 	estimatedDepletionAt: string | null
 }) {
 	return (
 		<div className="space-y-1.5">
-			<div className="font-medium tabular-nums">{formatNullableNumber(quantity)}</div>
+			<SovereigntyReagentAmount typeId={typeId} value={quantity} />
 			<div className="text-xs text-muted-foreground">
 				Burn {formatReagentBurnRate(burningPerHour)}
 			</div>
@@ -966,6 +1035,7 @@ export default function StructuresPage() {
 					<TableCell>{formatNullableDecimal(structure.activityDefenseMultiplier)}</TableCell>
 					<TableCell>
 						<SovereigntyReagentCell
+							typeId={SKYHOOK_MAGMATIC_GAS_TYPE_ID}
 							quantity={structure.magmaticGasQuantity}
 							burningPerHour={structure.magmaticGasBurningPerHour}
 							estimatedDepletionAt={structure.magmaticGasEstimatedDepletionAt}
@@ -973,6 +1043,7 @@ export default function StructuresPage() {
 					</TableCell>
 					<TableCell>
 						<SovereigntyReagentCell
+							typeId={SKYHOOK_SUPERIONIC_ICE_TYPE_ID}
 							quantity={structure.superionicIceQuantity}
 							burningPerHour={structure.superionicIceBurningPerHour}
 							estimatedDepletionAt={structure.superionicIceEstimatedDepletionAt}
@@ -1225,8 +1296,22 @@ export default function StructuresPage() {
 						</div>
 					</TableCell>
 					<TableCell>{fuelLabel}</TableCell>
-					<TableCell>{formatNullableNumber(structure.fuelBlockUnits)}</TableCell>
-					<TableCell>{formatNullableNumber(structure.magmaticGasUnits)}</TableCell>
+					<TableCell>
+						<MoonDrillResourceCell
+							typeId={FUEL_BLOCK_ICON_TYPE_ID}
+							iconAlt="Fuel block"
+							fallbackIcon={Package}
+							value={structure.fuelBlockUnits}
+						/>
+					</TableCell>
+					<TableCell>
+						<MoonDrillResourceCell
+							typeId={SKYHOOK_MAGMATIC_GAS_TYPE_ID}
+							iconAlt="Magmatic gas"
+							fallbackIcon={Flame}
+							value={structure.magmaticGasUnits}
+						/>
+					</TableCell>
 					<TableCell>
 						{structure.nextStateAt ? (
 							<DurationDisplay

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -38,12 +38,16 @@ export const STRUCTURE_COMMON_LIST_SORT_FIELDS = [
 
 export type StructureOperationalListSortBy = StructureCommonListSortBy
 
-export type StructureMoonStructureListSortBy = StructureCommonListSortBy | 'planet'
+export type StructureMoonStructureListSortBy = StructureCommonListSortBy | 'planet' | 'fuelBlocks' | 'magmaticGas'
 
 export const STRUCTURE_MOON_STRUCTURE_LIST_SORT_FIELDS = [
 	...STRUCTURE_COMMON_LIST_SORT_FIELDS,
 	'planet',
+	'fuelBlocks',
+	'magmaticGas',
 ] as const satisfies readonly StructureMoonStructureListSortBy[]
+
+export const FUEL_BLOCK_TYPE_IDS = new Set(['4051', '4246', '4247', '4312'])
 
 export type StructureSkyhookListSortBy =
 	| StructureCommonListSortBy
@@ -570,6 +574,8 @@ export interface StructureMoonDrillListItem
 	nextStateAt: string | null
 	fuelExpires: string | null
 	fuelAmount: number | null
+	fuelBlockUnits: number
+	magmaticGasUnits: number
 	lowPower: boolean
 }
 


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Improves the structures UX with per-tab table state, resource icons, and more accurate skyhook/moon-drill fuel metrics.

## Changes
- Skyhook "highest fill" metric is now a volume-weighted average across the secured and surplus reagent bays (previously the max of the two raw percentages), with corresponding SQL changes in `structures.service.ts` and a new unit test in `skyhook-summary.test.ts`.
- Moon drill listings now track and display fuel block units and magmatic gas units, aggregated from `corporationStructureInventory` via a new CTE, with new sortable `fuelBlocks`/`magmaticGas` columns and EVE type icons (with fallback icons on image load failure).
- Sovereignty reagent cells (magmatic gas / superionic ice) now show their EVE type icon next to the quantity.
- Structure table UI state moved from `sessionStorage` to `localStorage` and reworked to persist filters/sort per tab (`tabStateByTab`), with migration from the old `v1` single-state format.
- Default skyhook sort changed to `skyhookSurplusFullness`, and default/available page sizes updated (default 10, added 10 as an option).
- Added `FUEL_BLOCK_TYPE_IDS` constant to `@repo/structures`.

## Testing
- Added `apps/structures/src/test/unit/services/skyhook-summary.test.ts` covering the new volume-weighted fill percent calculation.
<!-- claude:end -->