### PR TITLE
fix discord nickname ticker source

### DIFF
--- a/apps/core/src/services/__tests__/discord-role-sync.test.ts
+++ b/apps/core/src/services/__tests__/discord-role-sync.test.ts
@@ -168,6 +168,8 @@ function makeCharacter(
 		userId: string
 		characterId: string
 		characterName: string
+		corporationId: string
+		allianceId: string | null
 		is_primary: boolean
 	}> = {}
 ) {
@@ -176,6 +178,7 @@ function makeCharacter(
 		characterId: 'char-1',
 		characterName: 'Test Pilot',
 		corporationId: 'corp-1',
+		allianceId: null,
 		is_primary: true,
 		...overrides,
 	}
@@ -825,7 +828,12 @@ describe('updateUserDiscordRoles', () => {
 
 		it('should append the configured alliance ticker for corp members when that bucket is enabled', async () => {
 			dbQueryMocks.users.findFirst.mockResolvedValue(makeUser())
-			dbQueryMocks.userCharacters.findMany.mockResolvedValue([makeCharacter()])
+			dbQueryMocks.userCharacters.findFirst.mockResolvedValue(
+				makeCharacter({
+					corporationId: 'corp-1',
+					allianceId: 'alliance-1',
+				})
+			)
 			dbQueryMocks.discordServers.findMany.mockResolvedValue([
 				makeDiscordServer({
 					id: 'ds-1',
@@ -841,7 +849,7 @@ describe('updateUserDiscordRoles', () => {
 					guildId: 'guild-1',
 					isMemberCorporation: true,
 					corpMemberNicknameEnabled: true,
-					corpMemberNicknameSource: 'alliance',
+					corpMemberNicknameSource: 'corp',
 					corpMemberNicknameCustomTicker: null,
 				}),
 			])
@@ -852,11 +860,12 @@ describe('updateUserDiscordRoles', () => {
 				corporationId: 'corp-1',
 				name: 'Test Corp',
 				allianceId: 'alliance-1',
+				ticker: 'AKS.',
 			} as any)
 			tokenStoreStubMethods.getAllianceById.mockResolvedValue({
 				allianceId: 'alliance-1',
 				name: 'Test Alliance',
-				ticker: 'ALLY',
+				ticker: 'ALLY.',
 			} as any)
 			discordStubMethods.checkGuildMembershipWithBot.mockResolvedValue(['guild-1'])
 
@@ -865,13 +874,64 @@ describe('updateUserDiscordRoles', () => {
 			expect(discordStubMethods.updateUserNickname).toHaveBeenCalledWith(
 				'user-1',
 				['guild-1'],
-				'[ALLY] Test Pilot'
+				'[AKS.] Test Pilot'
+			)
+		})
+
+		it('should use the primary character affiliation for alliance guests', async () => {
+			dbQueryMocks.users.findFirst.mockResolvedValue(makeUser())
+			dbQueryMocks.userCharacters.findFirst.mockResolvedValue(
+				makeCharacter({
+					corporationId: 'guest-corp-1',
+					allianceId: 'guest-alliance-1',
+					characterName: 'Guest Pilot',
+				})
+			)
+			dbQueryMocks.discordServers.findMany.mockResolvedValue([
+				makeDiscordServer({
+					id: 'ds-1',
+					guildId: 'guild-1',
+					guildName: 'Nick Server',
+					manageNicknames: true,
+				}),
+			])
+			dbQueryMocks.corporationDiscordServers.findMany.mockResolvedValue([
+				makeCorpAttachment({
+					corporationId: 'corp-1',
+					discordServerId: 'ds-1',
+					guildId: 'guild-1',
+					isMemberCorporation: true,
+					allianceGuestNicknameEnabled: true,
+					allianceGuestNicknameSource: 'alliance',
+					allianceGuestNicknameCustomTicker: null,
+				}),
+			])
+			dbQueryMocks.managedCorporations.findMany.mockResolvedValue([])
+			eveCorpStubMethods.getCorporationInfo.mockResolvedValue({
+				corporationId: 'guest-corp-1',
+				name: 'Guest Corp',
+				ticker: 'GUEST.',
+				allianceId: 'guest-alliance-1',
+			} as any)
+			tokenStoreStubMethods.getAllianceById.mockResolvedValue({
+				allianceId: 'guest-alliance-1',
+				name: 'Guest Alliance',
+				ticker: 'ALLY.',
+			} as any)
+			discordStubMethods.checkGuildMembershipWithBot.mockResolvedValue(['guild-1'])
+
+			await updateUserDiscordNickname(mockEnv, 'user-1', ['guild-1'])
+
+			expect(discordStubMethods.updateUserNickname).toHaveBeenCalledWith(
+				'user-1',
+				['guild-1'],
+				'[ALLY.] Guest Pilot'
 			)
 		})
 
 		it('should use the custom ticker configured for the all-members bucket', async () => {
 			dbQueryMocks.users.findFirst.mockResolvedValue(makeUser())
-			dbQueryMocks.userCharacters.findMany.mockResolvedValue([makeCharacter()])
+			dbQueryMocks.userCharacters.findFirst.mockResolvedValue(makeCharacter())
 			dbQueryMocks.discordServers.findMany.mockResolvedValue([
 				makeDiscordServer({
 					id: 'ds-1',

--- a/apps/core/src/services/discord.service.ts
+++ b/apps/core/src/services/discord.service.ts
@@ -9,8 +9,6 @@ import { logger } from '@repo/hono-helpers'
 import { createDb } from '../db'
 import {
 	corporationDiscordServers,
-	corporationDiscordServerNicknameConfigs,
-	corporationDiscordServerScenarioRoles,
 	discordRoles,
 	discordServers,
 	managedCorporations,
@@ -19,7 +17,7 @@ import {
 	users,
 } from '../db/schema'
 
-import type { Discord, DiscordProfile, JoinServerResult } from '@repo/discord'
+import type { DiscordProfile, JoinServerResult } from '@repo/discord'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Groups } from '@repo/groups'
@@ -618,7 +616,7 @@ type CorporationTickerSources = {
 	allianceTicker: string | null
 }
 
-function normalizeDiscordTicker(ticker?: string | null): string | null {
+function normalizeCustomTicker(ticker?: string | null): string | null {
 	const normalized = ticker?.trim().toUpperCase().replace(/[^A-Z0-9]/g, '')
 	if (!normalized) {
 		return null
@@ -627,12 +625,12 @@ function normalizeDiscordTicker(ticker?: string | null): string | null {
 	return normalized.slice(0, 5)
 }
 
-function buildDiscordNicknameWithTickers(baseName: string, suffixes: string[]): string {
-	if (suffixes.length === 0) {
+function buildDiscordNicknameWithTickerPrefixes(baseName: string, prefixes: string[]): string {
+	if (prefixes.length === 0) {
 		return baseName
 	}
 
-	return `${suffixes.map((suffix) => `[${suffix}]`).join(' ')} ${baseName}`
+	return `${prefixes.map((prefix) => `[${prefix}]`).join(' ')} ${baseName}`
 }
 
 function getScenarioRoleRecord(
@@ -661,11 +659,11 @@ function resolveTickerPreference(
 	customTicker: string | null
 ): string | null {
 	if (source === 'custom') {
-		return normalizeDiscordTicker(customTicker)
+		return normalizeCustomTicker(customTicker)
 	}
 
-	const corpTicker = normalizeDiscordTicker(tickerSources.corpTicker)
-	const allianceTicker = normalizeDiscordTicker(tickerSources.allianceTicker)
+	const corpTicker = tickerSources.corpTicker?.length ? tickerSources.corpTicker : null
+	const allianceTicker = tickerSources.allianceTicker?.length ? tickerSources.allianceTicker : null
 
 	if (source === 'alliance') {
 		return allianceTicker ?? corpTicker
@@ -674,7 +672,7 @@ function resolveTickerPreference(
 	return corpTicker ?? allianceTicker
 }
 
-function resolveAttachmentNicknameSuffix(
+function resolveAttachmentNicknamePrefix(
 	attachment: CorporationDiscordNicknameFields,
 	isCorpMember: boolean,
 	isAllianceMember: boolean,
@@ -700,85 +698,78 @@ function resolveAttachmentNicknameSuffix(
 			continue
 		}
 
-		const suffix = resolveTickerPreference(bucket.source, tickerSources, bucket.customTicker)
-		if (suffix) {
-			return suffix
+		const prefix = resolveTickerPreference(bucket.source, tickerSources, bucket.customTicker)
+		if (prefix) {
+			return prefix
 		}
 	}
 
 	return null
 }
 
-async function getCorporationTickerSources(
+async function getPrimaryCharacterTickerSources(
 	db: ReturnType<typeof createDb>,
 	env: Env,
-	corporationIds: string[]
-): Promise<Map<string, CorporationTickerSources>> {
-	if (corporationIds.length === 0) {
-		return new Map()
-	}
-
-	const uniqueCorporationIds = Array.from(new Set(corporationIds))
-	const corpRows = await db.query.managedCorporations.findMany({
-		where: inArray(managedCorporations.corporationId, uniqueCorporationIds),
+	userId: string
+): Promise<
+	| {
+			primaryCharacterName: string
+			primaryCharacterCorporationId: string
+			primaryCharacterAllianceId: string | null
+			tickerSources: CorporationTickerSources
+	  }
+	| null
+> {
+	const primaryCharacter = await db.query.userCharacters.findFirst({
+		where: and(eq(userCharacters.userId, userId), eq(userCharacters.is_primary, true)),
 		columns: {
+			characterName: true,
 			corporationId: true,
-			ticker: true,
+			allianceId: true,
 		},
 	})
-	const corpTickerById = new Map(corpRows.map((row) => [row.corporationId, row.ticker]))
+
+	if (!primaryCharacter?.characterName || !primaryCharacter.corporationId) {
+		return null
+	}
 
 	const corpStub = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, 'default')
 	const tokenStoreStub = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
-	const corpInfoEntries = await Promise.all(
-		uniqueCorporationIds.map(async (corporationId) => {
-			try {
-				return [corporationId, await corpStub.getCorporationInfo(corporationId)] as const
-			} catch (error) {
-				logger.warn('[Discord] Failed to resolve corporation info for nickname routing', {
-					corporationId,
-					error: String(error),
-				})
-				return [corporationId, null] as const
-			}
-		})
-	)
-
-	const allianceIds = Array.from(
-		new Set(
-			corpInfoEntries
-				.map(([, corpInfo]) => corpInfo?.allianceId ?? null)
-				.filter((allianceId): allianceId is string => !!allianceId)
-		)
-	)
-
-	const allianceTickerById = new Map<string, string>()
-	await Promise.all(
-		allianceIds.map(async (allianceId) => {
-			try {
-				const allianceInfo = await tokenStoreStub.getAllianceById(allianceId)
-				if (allianceInfo?.ticker) {
-					allianceTickerById.set(allianceId, allianceInfo.ticker)
-				}
-			} catch (error) {
-				logger.warn('[Discord] Failed to resolve alliance info for nickname routing', {
-					allianceId,
-					error: String(error),
-				})
-			}
-		})
-	)
-
-	const result = new Map<string, CorporationTickerSources>()
-	for (const [corporationId, corpInfo] of corpInfoEntries) {
-		result.set(corporationId, {
-			corpTicker: corpTickerById.get(corporationId) ?? corpInfo?.ticker ?? null,
-			allianceTicker:
-				corpInfo?.allianceId ? allianceTickerById.get(corpInfo.allianceId) ?? null : null,
+	let corpTicker: string | null = null
+	try {
+		const corpInfo = await corpStub.getCorporationInfo(primaryCharacter.corporationId)
+		corpTicker = corpInfo?.ticker ?? null
+	} catch (error) {
+		logger.warn('[Discord] Failed to resolve primary character corporation info for nickname routing', {
+			userId,
+			corporationId: primaryCharacter.corporationId,
+			error: String(error),
 		})
 	}
 
-	return result
+	let allianceTicker: string | null = null
+	if (primaryCharacter.allianceId) {
+		try {
+			const allianceInfo = await tokenStoreStub.getAllianceById(primaryCharacter.allianceId)
+			allianceTicker = allianceInfo?.ticker ?? null
+		} catch (error) {
+			logger.warn('[Discord] Failed to resolve primary character alliance info for nickname routing', {
+				userId,
+				allianceId: primaryCharacter.allianceId,
+				error: String(error),
+			})
+		}
+	}
+
+	return {
+		primaryCharacterName: primaryCharacter.characterName,
+		primaryCharacterCorporationId: primaryCharacter.corporationId,
+		primaryCharacterAllianceId: primaryCharacter.allianceId ?? null,
+		tickerSources: {
+			corpTicker,
+			allianceTicker,
+		},
+	}
 }
 
 async function getUserAllianceMemberCorporationIds(
@@ -2707,30 +2698,11 @@ export async function updateUserDiscordNickname(
 		return // User doesn't have Discord linked
 	}
 
-	// Get all linked characters so nickname suffixes can reflect corp attachment buckets.
-	const userChars = await db.query.userCharacters.findMany({
-		where: eq(userCharacters.userId, userId),
-		columns: {
-			characterId: true,
-			characterName: true,
-			is_primary: true,
-		},
-	})
-
-	const primaryChar = userChars.find((char) => char.is_primary)
-	const primaryCharacterName = primaryChar?.characterName
-
-	if (!primaryCharacterName) {
+	// Resolve the ticker prefix from the primary character and configured attachment buckets.
+	const primaryCharacter = await getPrimaryCharacterTickerSources(db, env, userId)
+	if (!primaryCharacter) {
 		return // No primary character set
 	}
-
-	const characterIds = userChars.map((char) => char.characterId)
-	const userCorporationIds = await getUserCorporationIds(env, characterIds)
-	const userAllianceMemberCorporationIds = await getUserAllianceMemberCorporationIds(
-		db,
-		userCorporationIds
-	)
-	const isAllianceMember = userAllianceMemberCorporationIds.size > 0
 
 	// Get all servers with nickname management enabled.
 	// When guildIds are provided, only inspect that subset.
@@ -2781,38 +2753,32 @@ export async function updateUserDiscordNickname(
 		},
 	})
 
-	const tickerSourcesByCorporationId = await getCorporationTickerSources(
-		db,
-		env,
-		corpAttachments.map((attachment) => attachment.corporationId)
-	)
-
 	const nicknameToGuildIds = new Map<string, string[]>()
 	for (const server of activeServerSettings) {
-		const suffixes = new Set<string>()
+		const prefixes = new Set<string>()
 		const attachmentsForServer = corpAttachments.filter(
 			(attachment) => attachment.discordServerId === server.id
 		)
 
 		for (const attachment of attachmentsForServer) {
-			const suffix = resolveAttachmentNicknameSuffix(
+			const isCorpMember =
+				attachment.corporation.isMemberCorporation &&
+				attachment.corporationId === primaryCharacter.primaryCharacterCorporationId
+			const prefix = resolveAttachmentNicknamePrefix(
 				attachment as CorporationDiscordNicknameFields,
-				userCorporationIds.has(attachment.corporationId),
-				isAllianceMember,
-				tickerSourcesByCorporationId.get(attachment.corporationId) ?? {
-					corpTicker: null,
-					allianceTicker: null,
-				}
+				isCorpMember,
+				Boolean(primaryCharacter.primaryCharacterAllianceId),
+				primaryCharacter.tickerSources
 			)
 
-			if (suffix) {
-				suffixes.add(suffix)
+			if (prefix) {
+				prefixes.add(prefix)
 			}
 		}
 
-		const nickname = buildDiscordNicknameWithTickers(
-			primaryCharacterName,
-			Array.from(suffixes)
+		const nickname = buildDiscordNicknameWithTickerPrefixes(
+			primaryCharacter.primaryCharacterName,
+			Array.from(prefixes)
 		)
 		const existingGuildIds = nicknameToGuildIds.get(nickname) ?? []
 		existingGuildIds.push(server.guildId)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes Discord nickname ticker prefixes so they are resolved from the user's **primary character's** corporation/alliance, instead of being derived from ticker data across all of a user's linked characters and corp-membership buckets.

## Changes
- Replaced `getCorporationTickerSources` (which resolved ticker data for every corp attachment across all linked characters) with `getPrimaryCharacterTickerSources`, which looks up only the primary character's corporation and alliance ticker via `EveCorporationData` and `EveTokenStore`.
- `updateUserDiscordNickname` now determines corp/alliance membership and ticker sources solely from the primary character, dropping the prior full character-list/`getUserCorporationIds`/`getUserAllianceMemberCorporationIds` lookups for this path.
- Renamed helpers/variables from "suffix" to "prefix" terminology to match actual behavior (`buildDiscordNicknameWithTickers` → `buildDiscordNicknameWithTickerPrefixes`, `resolveAttachmentNicknameSuffix` → `resolveAttachmentNicknamePrefix`, `normalizeDiscordTicker` → `normalizeCustomTicker`).
- `resolveTickerPreference` no longer re-normalizes corp/alliance tickers pulled from ESI (only custom tickers are normalized), preserving tickers as returned (e.g. with trailing periods).
- Removed now-unused imports (`corporationDiscordServerNicknameConfigs`, `corporationDiscordServerScenarioRoles`, `Discord` type).

## Testing
- Updated `discord-role-sync.test.ts` unit tests to mock `userCharacters.findFirst` (primary character lookup) instead of `findMany`, and updated expected tickers/nicknames to match the new resolution logic.
- Added a new test case verifying alliance guest nicknames use the primary character's affiliation/ticker.
<!-- claude:end -->