### PR TITLE
add corp ceo reconciliation to corp sync to detect and heal ceo changes

### DIFF
--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -4,6 +4,7 @@ import { EveCorporationSyncWorkflow } from '../../../workflows/sync-workflow'
 import { StructureEnrichmentScopeMismatchError } from '../../../workflows/utils/structure-enrichment-auth'
 
 import type { WorkflowStep } from 'cloudflare:workers'
+import type { Env } from '../../../context'
 
 const getStubMock = vi.fn()
 const syncAssetsMock = vi.fn()
@@ -176,11 +177,14 @@ function createWorkflowEnv() {
 	return {
 		env: {
 			DATABASE_URL: 'postgres://test',
+			NAME: 'eve-corporation-data',
+			ENVIRONMENT: 'VITEST',
+			SENTRY_RELEASE: 'test',
 			EVE_TOKEN_STORE: tokenStoreNamespace,
 			CORPORATION_TAX: {},
 			EVE_CORPORATION_DATA: corpDataNamespace,
 			CORE: coreStub,
-		},
+		} as unknown as Env,
 		corpDataStub,
 		tokenStoreStub,
 		updateCorporationAuthHealth,

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -15,6 +15,8 @@ const storeStructuresMock = vi.fn()
 const storeSovereigntyEnrichmentMock = vi.fn()
 const storeSkyhookEnrichmentMock = vi.fn()
 const storeMiningExtractionEnrichmentMock = vi.fn()
+const fetchPublicInfoMock = vi.fn()
+const storePublicInfoMock = vi.fn()
 const markStructureEnrichmentSyncFailureMock = vi.fn()
 const markStructureSyncFailureReasonMock = vi.fn()
 const selectDirectorMock = vi.fn()
@@ -66,6 +68,11 @@ vi.mock('@repo/workflow-utils', () => ({
 
 vi.mock('../../../workflows/steps/assets', () => ({
 	syncAssets: (...args: unknown[]) => syncAssetsMock(...args),
+}))
+
+vi.mock('../../../workflows/steps/public-info', () => ({
+	fetchPublicInfo: (...args: unknown[]) => fetchPublicInfoMock(...args),
+	storePublicInfo: (...args: unknown[]) => storePublicInfoMock(...args),
 }))
 
 vi.mock('../../../workflows/steps/common', () => ({
@@ -123,8 +130,17 @@ function createStep() {
 
 function createWorkflowEnv() {
 	const corpDataNamespace = { __ns: 'EVE_CORPORATION_DATA' } as unknown as DurableObjectNamespace
+	const tokenStoreNamespace = { __ns: 'EVE_TOKEN_STORE' } as unknown as DurableObjectNamespace
 	const updateCorporationAuthHealth = vi.fn().mockResolvedValue(undefined)
+	const addDirector = vi.fn().mockResolvedValue(undefined)
+	const getCharacterOwner = vi.fn()
+	const coreStub = {
+		updateCorporationAuthHealth,
+		getCharacterOwner,
+	}
 	const corpDataStub = {
+		addDirector,
+		getCorporationInfo: vi.fn().mockResolvedValue(null),
 		getCorporationSyncConfig: vi.fn().mockResolvedValue({
 			includeInBackgroundRefresh: true,
 			includeInStructureAssetSync: true,
@@ -139,10 +155,18 @@ function createWorkflowEnv() {
 		getSkyhookSyncPriorities: vi.fn().mockResolvedValue([]),
 		getSkyhookStructureIds: vi.fn().mockResolvedValue([]),
 	}
+	const tokenStoreStub = {
+		fetchPublicEsi: vi.fn(),
+		fetchCharacterAffiliations: vi.fn(),
+		resolveIds: vi.fn(),
+	}
 
 	getStubMock.mockImplementation((namespace: unknown) => {
 		if (namespace === corpDataNamespace) {
 			return corpDataStub
+		}
+		if (namespace === tokenStoreNamespace) {
+			return tokenStoreStub
 		}
 		return {
 			getMissingStructureIdsForPriorityQueue: vi.fn().mockResolvedValue([]),
@@ -152,19 +176,292 @@ function createWorkflowEnv() {
 	return {
 		env: {
 			DATABASE_URL: 'postgres://test',
-			EVE_TOKEN_STORE: {},
+			EVE_TOKEN_STORE: tokenStoreNamespace,
 			CORPORATION_TAX: {},
 			EVE_CORPORATION_DATA: corpDataNamespace,
-			CORE: {
-				updateCorporationAuthHealth,
-			},
-		} as never,
+			CORE: coreStub,
+		},
 		corpDataStub,
+		tokenStoreStub,
 		updateCorporationAuthHealth,
 	}
 }
 
 describe('EveCorporationSyncWorkflow', () => {
+	it('bootstraps the current CEO when no healthy director is selectable', async () => {
+	vi.clearAllMocks()
+	const { env, corpDataStub, tokenStoreStub, updateCorporationAuthHealth } =
+		createWorkflowEnv()
+
+	vi.mocked(env.CORE.getCharacterOwner).mockResolvedValue({
+		userId: 'user-12345',
+		isPrimary: true,
+	})
+	vi.mocked(tokenStoreStub.fetchCharacterAffiliations).mockResolvedValue([
+		{
+			character_id: 12345,
+			corporation_id: 693378155,
+		},
+	] as never)
+	vi.mocked(tokenStoreStub.resolveIds).mockResolvedValue({
+		12345: 'Bootstrap CEO',
+	} as never)
+	corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '12345' } as never)
+	fetchPublicInfoMock.mockResolvedValue({
+		corporationId: '693378155',
+		name: 'Corp',
+		ceoId: '12345',
+		})
+		storePublicInfoMock.mockResolvedValue(undefined)
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 0,
+			failed: 1,
+		})
+		selectDirectorMock
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce({
+				directorId: 'director-1',
+				characterId: '12345',
+				characterName: 'Bootstrap CEO',
+			})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['public-info'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-bootstrap-ceo',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(corpDataStub.addDirector).toHaveBeenCalledWith('693378155', '12345', 'Bootstrap CEO', 0)
+		expect(reconcileDirectorsFromCorporationRolesMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			'12345'
+		)
+		expect(updateCorporationAuthHealth).toHaveBeenCalled()
+
+		selectDirectorMock.mockReset()
+		fetchPublicInfoMock.mockReset()
+		storePublicInfoMock.mockReset()
+	})
+
+	it('explicitly verifies a linked CEO even when healthy directors already exist', async () => {
+		vi.clearAllMocks()
+		const { env, corpDataStub, tokenStoreStub } = createWorkflowEnv()
+
+		vi.mocked(env.CORE.getCharacterOwner).mockResolvedValue({
+			userId: 'user-12345',
+			isPrimary: true,
+		})
+		vi.mocked(tokenStoreStub.fetchCharacterAffiliations).mockResolvedValue([
+			{
+				character_id: 12345,
+				corporation_id: 693378155,
+			},
+		] as never)
+		vi.mocked(tokenStoreStub.resolveIds).mockResolvedValue({
+			12345: 'Linked CEO',
+		} as never)
+		corpDataStub.getDirectors.mockResolvedValue([
+			{
+				directorId: 'director-1',
+				characterId: '900000001',
+				characterName: 'Healthy Director',
+				isHealthy: true,
+			},
+		] as never)
+		fetchPublicInfoMock.mockResolvedValue({
+			corporationId: '693378155',
+			name: 'Corp',
+			ceoId: '12345',
+		})
+		storePublicInfoMock.mockResolvedValue(undefined)
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Healthy Director',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue({
+			added: 0,
+			removed: 0,
+			discovered: 1,
+			skippedUnlinked: 0,
+		})
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['public-info'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-linked-ceo',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(env.CORE.getCharacterOwner).toHaveBeenCalledWith('12345')
+	expect(corpDataStub.addDirector).toHaveBeenCalledWith('693378155', '12345', 'Linked CEO', 0)
+	expect(reconcileDirectorsFromCorporationRolesMock).toHaveBeenCalledWith(
+		env,
+		'693378155',
+		'900000001'
+	)
+	})
+
+	it('does not promote a linked CEO when live affiliation shows a different corporation', async () => {
+		vi.clearAllMocks()
+		const { env, corpDataStub, tokenStoreStub } = createWorkflowEnv()
+
+		vi.mocked(env.CORE.getCharacterOwner).mockResolvedValue({
+			userId: 'user-12345',
+			isPrimary: true,
+		})
+		vi.mocked(tokenStoreStub.fetchCharacterAffiliations).mockResolvedValue([
+			{
+				character_id: 12345,
+				corporation_id: 555555555,
+			},
+		] as never)
+		corpDataStub.getDirectors.mockResolvedValue([
+			{
+				directorId: 'director-1',
+				characterId: '900000001',
+				characterName: 'Healthy Director',
+				isHealthy: true,
+			},
+		] as never)
+		fetchPublicInfoMock.mockResolvedValue({
+			corporationId: '693378155',
+			name: 'Corp',
+			ceoId: '12345',
+		})
+		storePublicInfoMock.mockResolvedValue(undefined)
+		verifyAllDirectorsHealthMock.mockResolvedValue({
+			verified: 1,
+			failed: 0,
+		})
+		selectDirectorMock.mockResolvedValue({
+			directorId: 'director-1',
+			characterId: '900000001',
+			characterName: 'Healthy Director',
+		})
+		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue({
+			added: 0,
+			removed: 0,
+			discovered: 1,
+			skippedUnlinked: 0,
+		})
+		updateSyncTimestampsMock.mockResolvedValue(undefined)
+		updateCoreLastSyncMock.mockResolvedValue(undefined)
+		recordDirectorSuccessMock.mockResolvedValue(undefined)
+		replayTaxProjectionRetryIntentMock.mockResolvedValue({
+			replayed: false,
+			succeeded: false,
+			retryCount: 0,
+			reason: 'none',
+		})
+		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
+		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
+		triggerTaxProjectionRefreshMock.mockResolvedValue({
+			triggered: false,
+			reason: 'not-needed',
+		})
+
+		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
+		const { step } = createStep()
+
+		await expect(
+			workflow.run(
+				{
+					payload: {
+						corporationId: '693378155',
+						dataTypes: ['public-info'],
+						trigger: 'cron',
+					},
+					instanceId: 'wf-linked-ceo-mismatch',
+					timestamp: new Date('2026-07-12T19:36:47.369Z'),
+				} as never,
+				step
+			)
+		).resolves.toMatchObject({
+			success: true,
+			corporationId: '693378155',
+			trigger: 'cron',
+		})
+
+		expect(env.CORE.getCharacterOwner).toHaveBeenCalledWith('12345')
+		expect(corpDataStub.addDirector).not.toHaveBeenCalled()
+		expect(reconcileDirectorsFromCorporationRolesMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			'900000001'
+		)
+	})
+
 	it('continues to asset sync even when the structure step fails', async () => {
 		vi.clearAllMocks()
 		parseEsiErrorMetadataMock.mockImplementation(() => null)

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -67,6 +67,10 @@ import type {
 	EsiCorporationStructure,
 	StructureSyncPriorityTarget,
 } from '@repo/eve-corporation-data'
+import type {
+	EsiCharacterAffiliation,
+	EveTokenStore,
+} from '@repo/eve-token-store'
 import type { Env } from '../context'
 import type {
 	DirectorInfo,
@@ -115,7 +119,9 @@ async function ensureLinkedCeoDirector(
 
 	const tokenStore = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
 	const affiliations = await tokenStore.fetchCharacterAffiliations([ceoId])
-	const affiliation = affiliations.find((entry) => String(entry.character_id) === ceoId)
+	const affiliation = affiliations.find(
+		(entry: EsiCharacterAffiliation) => String(entry.character_id) === ceoId
+	)
 	if (!affiliation) {
 		logger.info('[EveCorporationSyncWorkflow] Linked CEO has no live affiliation data', {
 			corporationId,

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -99,6 +99,66 @@ const ROLE_REQUIREMENTS_BY_DATA_TYPE: Partial<
 	killmails: ['Director'],
 }
 
+async function ensureLinkedCeoDirector(
+	env: Env,
+	corporationId: string,
+	ceoId: string
+): Promise<{ linked: boolean; added: boolean }> {
+	const owner = await env.CORE.getCharacterOwner(ceoId)
+	if (!owner) {
+		logger.info('[EveCorporationSyncWorkflow] Public CEO is not linked to a user', {
+			corporationId,
+			ceoId,
+		})
+		return { linked: false, added: false }
+	}
+
+	const tokenStore = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
+	const affiliations = await tokenStore.fetchCharacterAffiliations([ceoId])
+	const affiliation = affiliations.find((entry) => String(entry.character_id) === ceoId)
+	if (!affiliation) {
+		logger.info('[EveCorporationSyncWorkflow] Linked CEO has no live affiliation data', {
+			corporationId,
+			ceoId,
+			userId: owner.userId,
+		})
+		return { linked: true, added: false }
+	}
+
+	if (String(affiliation.corporation_id) !== corporationId) {
+		logger.info('[EveCorporationSyncWorkflow] Linked CEO is not a member of this corporation', {
+			corporationId,
+			ceoId,
+			userId: owner.userId,
+			characterCorporationId: String(affiliation.corporation_id),
+		})
+		return { linked: true, added: false }
+	}
+
+	const corpData = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, corporationId)
+	const resolvedNames = await tokenStore.resolveIds([ceoId])
+	const characterName = resolvedNames[ceoId]?.trim() || ceoId
+	const existingDirectors = await corpData.getDirectors(corporationId)
+	const existingDirector = existingDirectors.find((director) => director.characterId === ceoId)
+
+	if (!existingDirector) {
+		await corpData.addDirector(corporationId, ceoId, characterName, 0)
+		logger.info('[EveCorporationSyncWorkflow] Linked CEO added to director roster', {
+			corporationId,
+			ceoId,
+			userId: owner.userId,
+		})
+		return { linked: true, added: true }
+	}
+
+	logger.info('[EveCorporationSyncWorkflow] Linked CEO already present in director roster', {
+		corporationId,
+		ceoId,
+		userId: owner.userId,
+	})
+	return { linked: true, added: false }
+}
+
 function getRequiredRoleSets(
 	shouldSync: (type: EveCorporationSyncDataType) => boolean
 ): CorporationRole[][] {
@@ -190,6 +250,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			const structureAssetSyncEnabled = corporationConfig?.includeInStructureAssetSync ?? false
 			let structureSyncCompleted = false
 			let skyhooksSync: SyncStepResult<'skyhooks'> | null = null
+			let publicInfo: Awaited<ReturnType<typeof fetchPublicInfo>> | null = null
 			const shouldSync = createShouldSyncPredicate(dataTypes, {
 				disabledDataTypes: structureAssetSyncEnabled ? [] : ['assets'],
 			})
@@ -246,6 +307,43 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 					}
 				}
 			)
+
+			const bootstrapCorpInfo = publicInfo ?? (await corpData.getCorporationInfo(corporationId))
+
+			if (!director && bootstrapCorpInfo?.ceoId) {
+				logger.warn('[EveCorporationSyncWorkflow] No healthy director selected; bootstrapping from public CEO', {
+					corporationId,
+					ceoId: bootstrapCorpInfo.ceoId,
+				})
+
+				await step.do(
+					'bootstrap-ceo-director',
+					{ timeout: '30 seconds' },
+					() => ensureLinkedCeoDirector(this.env, corporationId, bootstrapCorpInfo.ceoId)
+				)
+
+				director = await step.do(
+					'reselect-director-after-ceo-bootstrap',
+					{
+						retries: { limit: 3, delay: '2 seconds', backoff: 'exponential' },
+						timeout: '30 seconds',
+					},
+					async () => {
+						try {
+							return await selectDirector(this.env, corporationId, { requiredRoleSets })
+						} catch (error) {
+							logger.error(
+								'[EveCorporationSyncWorkflow] reselect-director-after-ceo-bootstrap failed',
+								{
+									corporationId,
+									error: error instanceof Error ? error.message : String(error),
+								}
+							)
+							return null
+						}
+					}
+				)
+			}
 
 			if (!director) {
 				logger.warn(
@@ -451,7 +549,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			let killmailsSync: SyncStepResult<'killmails'> | null = null
 
 			if (shouldSync('public-info')) {
-				const publicInfo = await step.do(
+				publicInfo = await step.do(
 					'fetch-public-info',
 					{ ...STEP_RETRY_OPTIONS, timeout: '1 minute' },
 					() =>
@@ -467,6 +565,12 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						stats: { corporationName: publicInfo.name },
 					}
 				})
+
+				if (publicInfo.ceoId) {
+					await step.do('verify-linked-ceo-director', { timeout: '30 seconds' }, async () => {
+						return await ensureLinkedCeoDirector(this.env, corporationId, publicInfo.ceoId)
+					})
+				}
 			}
 
 			if (shouldSyncAuthenticated('members')) {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Adds CEO reconciliation logic to the corporation sync workflow so that CEO changes (and cases where no healthy director exists) are automatically detected and healed by promoting the corporation's current CEO to the director roster when appropriate.

## Changes

- Added `ensureLinkedCeoDirector` in `sync-workflow.ts`, which looks up the user linked to the public CEO character, verifies their live ESI affiliation actually matches the corporation, and adds them to the director roster via `addDirector` if not already present.
- When director selection yields no healthy director, the workflow now bootstraps from the corporation's stored/fetched public CEO info, runs `ensureLinkedCeoDirector`, and retries director selection (`reselect-director-after-ceo-bootstrap`) before giving up.
- During the `public-info` sync step, the workflow now also runs `verify-linked-ceo-director` after fetching public info, even when a healthy director already exists, to keep the roster in sync with CEO changes.
- CEO promotion is skipped if the CEO isn't linked to a user or if the character's live affiliation shows they've left the corporation, preventing incorrect promotions.

## Testing

- Added unit tests in `sync-workflow.test.ts` covering: bootstrapping a director when none is selectable, verifying/promoting a linked CEO when healthy directors already exist, and skipping promotion when the live affiliation shows the CEO is in a different corporation.
<!-- claude:end -->