### PR TITLE
Fix/revert ceo reconcile

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -1570,28 +1570,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 * Takes pre-fetched data and stores it in the database
 	 */
 	async storePublicInfo(corporationId: string, publicInfo: any): Promise<void> {
-		await this.getDb()
-			.insert(corporationPublicInfo)
-			.values({
-				...publicInfo,
-				updatedAt: new Date(),
-			})
-			.onConflictDoUpdate({
-				target: corporationPublicInfo.corporationId,
-				set: {
-					name: publicInfo.name,
-					ticker: publicInfo.ticker,
-					ceoId: publicInfo.ceoId,
-					memberCount: publicInfo.memberCount,
-					shares: publicInfo.shares,
-					taxRate: publicInfo.taxRate,
-					url: publicInfo.url,
-					allianceId: publicInfo.allianceId,
-					factionId: publicInfo.factionId,
-					warEligible: publicInfo.warEligible,
-					updatedAt: sql`excluded.updated_at`,
-				},
-			})
+		await this.upsertPublicInfo(corporationId, publicInfo as CorporationPublicData)
 	}
 
 	/**
@@ -3016,28 +2995,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const data = await esiFetch.fetchPublicInfo(tokenStore, corporationId)
 
-		await this.getDb()
-			.insert(corporationPublicInfo)
-			.values({
-				...data,
-				updatedAt: new Date(),
-			})
-			.onConflictDoUpdate({
-				target: corporationPublicInfo.corporationId,
-				set: {
-					name: data.name,
-					ticker: data.ticker,
-					ceoId: data.ceoId,
-					memberCount: data.memberCount,
-					shares: data.shares,
-					taxRate: data.taxRate,
-					url: data.url,
-					allianceId: data.allianceId,
-					factionId: data.factionId,
-					warEligible: data.warEligible,
-					updatedAt: sql`excluded.updated_at`,
-				},
-			})
+			await this.upsertPublicInfo(corporationId, data as CorporationPublicData)
 
 		const previousAllianceId = previousInfo?.allianceId ?? null
 		const nextAllianceId = data.allianceId ?? null
@@ -3074,6 +3032,63 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					)
 				}
 			}
+		}
+	}
+
+	private async upsertPublicInfo(
+		corporationId: string,
+		publicInfo: CorporationPublicData
+	): Promise<void> {
+		await this.getDb()
+			.insert(corporationPublicInfo)
+			.values({
+				...publicInfo,
+				updatedAt: new Date(),
+			})
+			.onConflictDoUpdate({
+				target: corporationPublicInfo.corporationId,
+				set: {
+					name: publicInfo.name,
+					ticker: publicInfo.ticker,
+					ceoId: publicInfo.ceoId,
+					creatorId: publicInfo.creatorId,
+					dateFounded: publicInfo.dateFounded,
+					description: publicInfo.description,
+					homeStationId: publicInfo.homeStationId,
+					memberCount: publicInfo.memberCount,
+					shares: publicInfo.shares,
+					taxRate: publicInfo.taxRate,
+					url: publicInfo.url,
+					allianceId: publicInfo.allianceId,
+					factionId: publicInfo.factionId,
+					warEligible: publicInfo.warEligible,
+					updatedAt: sql`excluded.updated_at`,
+				},
+			})
+
+		const storedPublicInfo = await this.getCorporationInfo(corporationId)
+		if (
+			!storedPublicInfo ||
+			storedPublicInfo.corporationId !== corporationId ||
+			storedPublicInfo.ceoId !== publicInfo.ceoId ||
+			storedPublicInfo.creatorId !== publicInfo.creatorId ||
+			storedPublicInfo.name !== publicInfo.name ||
+			storedPublicInfo.ticker !== publicInfo.ticker ||
+			storedPublicInfo.memberCount !== publicInfo.memberCount ||
+			storedPublicInfo.shares !== publicInfo.shares ||
+			storedPublicInfo.taxRate !== publicInfo.taxRate ||
+			storedPublicInfo.url !== publicInfo.url ||
+			storedPublicInfo.allianceId !== publicInfo.allianceId ||
+			storedPublicInfo.factionId !== publicInfo.factionId ||
+			storedPublicInfo.warEligible !== publicInfo.warEligible ||
+			(storedPublicInfo.dateFounded?.toISOString() ?? null) !==
+				(publicInfo.dateFounded?.toISOString() ?? null) ||
+			storedPublicInfo.description !== publicInfo.description ||
+			storedPublicInfo.homeStationId !== publicInfo.homeStationId
+		) {
+			throw new Error(
+				`Failed to persist corporation public info for corporation ID ${corporationId}`
+			)
 		}
 	}
 

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -62,7 +62,9 @@ export async function fetchPublicInfo(
 	tokenStore: EveTokenStore,
 	corporationId: string
 ): Promise<any> {
-	const response = await tokenStore.fetchPublicEsi<any>(`/corporations/${corporationId}`)
+	const response = await tokenStore.fetchPublicEsi<any>(`/corporations/${corporationId}`, {
+		cacheMode: 'no-store',
+	})
 
 	return {
 		corporationId: String(corporationId),

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -4,7 +4,6 @@ import { EveCorporationSyncWorkflow } from '../../../workflows/sync-workflow'
 import { StructureEnrichmentScopeMismatchError } from '../../../workflows/utils/structure-enrichment-auth'
 
 import type { WorkflowStep } from 'cloudflare:workers'
-import type { Env } from '../../../context'
 
 const getStubMock = vi.fn()
 const syncAssetsMock = vi.fn()
@@ -16,8 +15,6 @@ const storeStructuresMock = vi.fn()
 const storeSovereigntyEnrichmentMock = vi.fn()
 const storeSkyhookEnrichmentMock = vi.fn()
 const storeMiningExtractionEnrichmentMock = vi.fn()
-const fetchPublicInfoMock = vi.fn()
-const storePublicInfoMock = vi.fn()
 const markStructureEnrichmentSyncFailureMock = vi.fn()
 const markStructureSyncFailureReasonMock = vi.fn()
 const selectDirectorMock = vi.fn()
@@ -69,11 +66,6 @@ vi.mock('@repo/workflow-utils', () => ({
 
 vi.mock('../../../workflows/steps/assets', () => ({
 	syncAssets: (...args: unknown[]) => syncAssetsMock(...args),
-}))
-
-vi.mock('../../../workflows/steps/public-info', () => ({
-	fetchPublicInfo: (...args: unknown[]) => fetchPublicInfoMock(...args),
-	storePublicInfo: (...args: unknown[]) => storePublicInfoMock(...args),
 }))
 
 vi.mock('../../../workflows/steps/common', () => ({
@@ -131,17 +123,8 @@ function createStep() {
 
 function createWorkflowEnv() {
 	const corpDataNamespace = { __ns: 'EVE_CORPORATION_DATA' } as unknown as DurableObjectNamespace
-	const tokenStoreNamespace = { __ns: 'EVE_TOKEN_STORE' } as unknown as DurableObjectNamespace
 	const updateCorporationAuthHealth = vi.fn().mockResolvedValue(undefined)
-	const addDirector = vi.fn().mockResolvedValue(undefined)
-	const getCharacterOwner = vi.fn()
-	const coreStub = {
-		updateCorporationAuthHealth,
-		getCharacterOwner,
-	}
 	const corpDataStub = {
-		addDirector,
-		getCorporationInfo: vi.fn().mockResolvedValue(null),
 		getCorporationSyncConfig: vi.fn().mockResolvedValue({
 			includeInBackgroundRefresh: true,
 			includeInStructureAssetSync: true,
@@ -156,18 +139,10 @@ function createWorkflowEnv() {
 		getSkyhookSyncPriorities: vi.fn().mockResolvedValue([]),
 		getSkyhookStructureIds: vi.fn().mockResolvedValue([]),
 	}
-	const tokenStoreStub = {
-		fetchPublicEsi: vi.fn(),
-		fetchCharacterAffiliations: vi.fn(),
-		resolveIds: vi.fn(),
-	}
 
 	getStubMock.mockImplementation((namespace: unknown) => {
 		if (namespace === corpDataNamespace) {
 			return corpDataStub
-		}
-		if (namespace === tokenStoreNamespace) {
-			return tokenStoreStub
 		}
 		return {
 			getMissingStructureIdsForPriorityQueue: vi.fn().mockResolvedValue([]),
@@ -177,295 +152,19 @@ function createWorkflowEnv() {
 	return {
 		env: {
 			DATABASE_URL: 'postgres://test',
-			NAME: 'eve-corporation-data',
-			ENVIRONMENT: 'VITEST',
-			SENTRY_RELEASE: 'test',
-			EVE_TOKEN_STORE: tokenStoreNamespace,
+			EVE_TOKEN_STORE: {},
 			CORPORATION_TAX: {},
 			EVE_CORPORATION_DATA: corpDataNamespace,
-			CORE: coreStub,
-		} as unknown as Env,
+			CORE: {
+				updateCorporationAuthHealth,
+			},
+		} as never,
 		corpDataStub,
-		tokenStoreStub,
 		updateCorporationAuthHealth,
 	}
 }
 
 describe('EveCorporationSyncWorkflow', () => {
-	it('bootstraps the current CEO when no healthy director is selectable', async () => {
-	vi.clearAllMocks()
-	const { env, corpDataStub, tokenStoreStub, updateCorporationAuthHealth } =
-		createWorkflowEnv()
-
-	vi.mocked(env.CORE.getCharacterOwner).mockResolvedValue({
-		userId: 'user-12345',
-		isPrimary: true,
-	})
-	vi.mocked(tokenStoreStub.fetchCharacterAffiliations).mockResolvedValue([
-		{
-			character_id: 12345,
-			corporation_id: 693378155,
-		},
-	] as never)
-	vi.mocked(tokenStoreStub.resolveIds).mockResolvedValue({
-		12345: 'Bootstrap CEO',
-	} as never)
-	corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '12345' } as never)
-	fetchPublicInfoMock.mockResolvedValue({
-		corporationId: '693378155',
-		name: 'Corp',
-		ceoId: '12345',
-		})
-		storePublicInfoMock.mockResolvedValue(undefined)
-		verifyAllDirectorsHealthMock.mockResolvedValue({
-			verified: 0,
-			failed: 1,
-		})
-		selectDirectorMock
-			.mockResolvedValueOnce(null)
-			.mockResolvedValueOnce({
-				directorId: 'director-1',
-				characterId: '12345',
-				characterName: 'Bootstrap CEO',
-			})
-		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue(undefined)
-		updateSyncTimestampsMock.mockResolvedValue(undefined)
-		updateCoreLastSyncMock.mockResolvedValue(undefined)
-		recordDirectorSuccessMock.mockResolvedValue(undefined)
-		replayTaxProjectionRetryIntentMock.mockResolvedValue({
-			replayed: false,
-			succeeded: false,
-			retryCount: 0,
-			reason: 'none',
-		})
-		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
-		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
-		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
-		triggerTaxProjectionRefreshMock.mockResolvedValue({
-			triggered: false,
-			reason: 'not-needed',
-		})
-
-		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step } = createStep()
-
-		await expect(
-			workflow.run(
-				{
-					payload: {
-						corporationId: '693378155',
-						dataTypes: ['public-info'],
-						trigger: 'cron',
-					},
-					instanceId: 'wf-bootstrap-ceo',
-					timestamp: new Date('2026-07-12T19:36:47.369Z'),
-				} as never,
-				step
-			)
-		).resolves.toMatchObject({
-			success: true,
-			corporationId: '693378155',
-			trigger: 'cron',
-		})
-
-		expect(corpDataStub.addDirector).toHaveBeenCalledWith('693378155', '12345', 'Bootstrap CEO', 0)
-		expect(reconcileDirectorsFromCorporationRolesMock).toHaveBeenCalledWith(
-			env,
-			'693378155',
-			'12345'
-		)
-		expect(updateCorporationAuthHealth).toHaveBeenCalled()
-
-		selectDirectorMock.mockReset()
-		fetchPublicInfoMock.mockReset()
-		storePublicInfoMock.mockReset()
-	})
-
-	it('explicitly verifies a linked CEO even when healthy directors already exist', async () => {
-		vi.clearAllMocks()
-		const { env, corpDataStub, tokenStoreStub } = createWorkflowEnv()
-
-		vi.mocked(env.CORE.getCharacterOwner).mockResolvedValue({
-			userId: 'user-12345',
-			isPrimary: true,
-		})
-		vi.mocked(tokenStoreStub.fetchCharacterAffiliations).mockResolvedValue([
-			{
-				character_id: 12345,
-				corporation_id: 693378155,
-			},
-		] as never)
-		vi.mocked(tokenStoreStub.resolveIds).mockResolvedValue({
-			12345: 'Linked CEO',
-		} as never)
-		corpDataStub.getDirectors.mockResolvedValue([
-			{
-				directorId: 'director-1',
-				characterId: '900000001',
-				characterName: 'Healthy Director',
-				isHealthy: true,
-			},
-		] as never)
-		fetchPublicInfoMock.mockResolvedValue({
-			corporationId: '693378155',
-			name: 'Corp',
-			ceoId: '12345',
-		})
-		storePublicInfoMock.mockResolvedValue(undefined)
-		verifyAllDirectorsHealthMock.mockResolvedValue({
-			verified: 1,
-			failed: 0,
-		})
-		selectDirectorMock.mockResolvedValue({
-			directorId: 'director-1',
-			characterId: '900000001',
-			characterName: 'Healthy Director',
-		})
-		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue({
-			added: 0,
-			removed: 0,
-			discovered: 1,
-			skippedUnlinked: 0,
-		})
-		updateSyncTimestampsMock.mockResolvedValue(undefined)
-		updateCoreLastSyncMock.mockResolvedValue(undefined)
-		recordDirectorSuccessMock.mockResolvedValue(undefined)
-		replayTaxProjectionRetryIntentMock.mockResolvedValue({
-			replayed: false,
-			succeeded: false,
-			retryCount: 0,
-			reason: 'none',
-		})
-		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
-		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
-		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
-		triggerTaxProjectionRefreshMock.mockResolvedValue({
-			triggered: false,
-			reason: 'not-needed',
-		})
-
-		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step } = createStep()
-
-		await expect(
-			workflow.run(
-				{
-					payload: {
-						corporationId: '693378155',
-						dataTypes: ['public-info'],
-						trigger: 'cron',
-					},
-					instanceId: 'wf-linked-ceo',
-					timestamp: new Date('2026-07-12T19:36:47.369Z'),
-				} as never,
-				step
-			)
-		).resolves.toMatchObject({
-			success: true,
-			corporationId: '693378155',
-			trigger: 'cron',
-		})
-
-		expect(env.CORE.getCharacterOwner).toHaveBeenCalledWith('12345')
-	expect(corpDataStub.addDirector).toHaveBeenCalledWith('693378155', '12345', 'Linked CEO', 0)
-	expect(reconcileDirectorsFromCorporationRolesMock).toHaveBeenCalledWith(
-		env,
-		'693378155',
-		'900000001'
-	)
-	})
-
-	it('does not promote a linked CEO when live affiliation shows a different corporation', async () => {
-		vi.clearAllMocks()
-		const { env, corpDataStub, tokenStoreStub } = createWorkflowEnv()
-
-		vi.mocked(env.CORE.getCharacterOwner).mockResolvedValue({
-			userId: 'user-12345',
-			isPrimary: true,
-		})
-		vi.mocked(tokenStoreStub.fetchCharacterAffiliations).mockResolvedValue([
-			{
-				character_id: 12345,
-				corporation_id: 555555555,
-			},
-		] as never)
-		corpDataStub.getDirectors.mockResolvedValue([
-			{
-				directorId: 'director-1',
-				characterId: '900000001',
-				characterName: 'Healthy Director',
-				isHealthy: true,
-			},
-		] as never)
-		fetchPublicInfoMock.mockResolvedValue({
-			corporationId: '693378155',
-			name: 'Corp',
-			ceoId: '12345',
-		})
-		storePublicInfoMock.mockResolvedValue(undefined)
-		verifyAllDirectorsHealthMock.mockResolvedValue({
-			verified: 1,
-			failed: 0,
-		})
-		selectDirectorMock.mockResolvedValue({
-			directorId: 'director-1',
-			characterId: '900000001',
-			characterName: 'Healthy Director',
-		})
-		reconcileDirectorsFromCorporationRolesMock.mockResolvedValue({
-			added: 0,
-			removed: 0,
-			discovered: 1,
-			skippedUnlinked: 0,
-		})
-		updateSyncTimestampsMock.mockResolvedValue(undefined)
-		updateCoreLastSyncMock.mockResolvedValue(undefined)
-		recordDirectorSuccessMock.mockResolvedValue(undefined)
-		replayTaxProjectionRetryIntentMock.mockResolvedValue({
-			replayed: false,
-			succeeded: false,
-			retryCount: 0,
-			reason: 'none',
-		})
-		clearTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
-		recordTaxProjectionRetryIntentMock.mockResolvedValue(undefined)
-		sendHrDepartedMessagesMock.mockResolvedValue(undefined)
-		triggerTaxProjectionRefreshMock.mockResolvedValue({
-			triggered: false,
-			reason: 'not-needed',
-		})
-
-		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step } = createStep()
-
-		await expect(
-			workflow.run(
-				{
-					payload: {
-						corporationId: '693378155',
-						dataTypes: ['public-info'],
-						trigger: 'cron',
-					},
-					instanceId: 'wf-linked-ceo-mismatch',
-					timestamp: new Date('2026-07-12T19:36:47.369Z'),
-				} as never,
-				step
-			)
-		).resolves.toMatchObject({
-			success: true,
-			corporationId: '693378155',
-			trigger: 'cron',
-		})
-
-		expect(env.CORE.getCharacterOwner).toHaveBeenCalledWith('12345')
-		expect(corpDataStub.addDirector).not.toHaveBeenCalled()
-		expect(reconcileDirectorsFromCorporationRolesMock).toHaveBeenCalledWith(
-			env,
-			'693378155',
-			'900000001'
-		)
-	})
-
 	it('continues to asset sync even when the structure step fails', async () => {
 		vi.clearAllMocks()
 		parseEsiErrorMetadataMock.mockImplementation(() => null)

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -67,10 +67,6 @@ import type {
 	EsiCorporationStructure,
 	StructureSyncPriorityTarget,
 } from '@repo/eve-corporation-data'
-import type {
-	EsiCharacterAffiliation,
-	EveTokenStore,
-} from '@repo/eve-token-store'
 import type { Env } from '../context'
 import type {
 	DirectorInfo,
@@ -101,68 +97,6 @@ const ROLE_REQUIREMENTS_BY_DATA_TYPE: Partial<
 	contracts: ['Director'],
 	'industry-jobs': ['Factory_Manager'],
 	killmails: ['Director'],
-}
-
-async function ensureLinkedCeoDirector(
-	env: Env,
-	corporationId: string,
-	ceoId: string
-): Promise<{ linked: boolean; added: boolean }> {
-	const owner = await env.CORE.getCharacterOwner(ceoId)
-	if (!owner) {
-		logger.info('[EveCorporationSyncWorkflow] Public CEO is not linked to a user', {
-			corporationId,
-			ceoId,
-		})
-		return { linked: false, added: false }
-	}
-
-	const tokenStore = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
-	const affiliations = await tokenStore.fetchCharacterAffiliations([ceoId])
-	const affiliation = affiliations.find(
-		(entry: EsiCharacterAffiliation) => String(entry.character_id) === ceoId
-	)
-	if (!affiliation) {
-		logger.info('[EveCorporationSyncWorkflow] Linked CEO has no live affiliation data', {
-			corporationId,
-			ceoId,
-			userId: owner.userId,
-		})
-		return { linked: true, added: false }
-	}
-
-	if (String(affiliation.corporation_id) !== corporationId) {
-		logger.info('[EveCorporationSyncWorkflow] Linked CEO is not a member of this corporation', {
-			corporationId,
-			ceoId,
-			userId: owner.userId,
-			characterCorporationId: String(affiliation.corporation_id),
-		})
-		return { linked: true, added: false }
-	}
-
-	const corpData = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, corporationId)
-	const resolvedNames = await tokenStore.resolveIds([ceoId])
-	const characterName = resolvedNames[ceoId]?.trim() || ceoId
-	const existingDirectors = await corpData.getDirectors(corporationId)
-	const existingDirector = existingDirectors.find((director) => director.characterId === ceoId)
-
-	if (!existingDirector) {
-		await corpData.addDirector(corporationId, ceoId, characterName, 0)
-		logger.info('[EveCorporationSyncWorkflow] Linked CEO added to director roster', {
-			corporationId,
-			ceoId,
-			userId: owner.userId,
-		})
-		return { linked: true, added: true }
-	}
-
-	logger.info('[EveCorporationSyncWorkflow] Linked CEO already present in director roster', {
-		corporationId,
-		ceoId,
-		userId: owner.userId,
-	})
-	return { linked: true, added: false }
 }
 
 function getRequiredRoleSets(
@@ -256,7 +190,6 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			const structureAssetSyncEnabled = corporationConfig?.includeInStructureAssetSync ?? false
 			let structureSyncCompleted = false
 			let skyhooksSync: SyncStepResult<'skyhooks'> | null = null
-			let publicInfo: Awaited<ReturnType<typeof fetchPublicInfo>> | null = null
 			const shouldSync = createShouldSyncPredicate(dataTypes, {
 				disabledDataTypes: structureAssetSyncEnabled ? [] : ['assets'],
 			})
@@ -313,43 +246,6 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 					}
 				}
 			)
-
-			const bootstrapCorpInfo = publicInfo ?? (await corpData.getCorporationInfo(corporationId))
-
-			if (!director && bootstrapCorpInfo?.ceoId) {
-				logger.warn('[EveCorporationSyncWorkflow] No healthy director selected; bootstrapping from public CEO', {
-					corporationId,
-					ceoId: bootstrapCorpInfo.ceoId,
-				})
-
-				await step.do(
-					'bootstrap-ceo-director',
-					{ timeout: '30 seconds' },
-					() => ensureLinkedCeoDirector(this.env, corporationId, bootstrapCorpInfo.ceoId)
-				)
-
-				director = await step.do(
-					'reselect-director-after-ceo-bootstrap',
-					{
-						retries: { limit: 3, delay: '2 seconds', backoff: 'exponential' },
-						timeout: '30 seconds',
-					},
-					async () => {
-						try {
-							return await selectDirector(this.env, corporationId, { requiredRoleSets })
-						} catch (error) {
-							logger.error(
-								'[EveCorporationSyncWorkflow] reselect-director-after-ceo-bootstrap failed',
-								{
-									corporationId,
-									error: error instanceof Error ? error.message : String(error),
-								}
-							)
-							return null
-						}
-					}
-				)
-			}
 
 			if (!director) {
 				logger.warn(
@@ -555,7 +451,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			let killmailsSync: SyncStepResult<'killmails'> | null = null
 
 			if (shouldSync('public-info')) {
-				publicInfo = await step.do(
+				const publicInfo = await step.do(
 					'fetch-public-info',
 					{ ...STEP_RETRY_OPTIONS, timeout: '1 minute' },
 					() =>
@@ -571,12 +467,6 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						stats: { corporationName: publicInfo.name },
 					}
 				})
-
-				if (publicInfo.ceoId) {
-					await step.do('verify-linked-ceo-director', { timeout: '30 seconds' }, async () => {
-						return await ensureLinkedCeoDirector(this.env, corporationId, publicInfo.ceoId)
-					})
-				}
 			}
 
 			if (shouldSyncAuthenticated('members')) {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Reverts the CEO reconciliation logic added in #569 and removes caching for the corporation public info fetch, replacing it with a write verification step to confirm the public info upsert actually persisted as expected.

## Changes
- Removed `ensureLinkedCeoDirector` and the director bootstrap/verification steps from `EveCorporationSyncWorkflow` (`sync-workflow.ts`), along with the now-unused `EsiCharacterAffiliation`/`EveTokenStore` imports and related test coverage in `sync-workflow.test.ts`.
- Consolidated the two duplicated `corporationPublicInfo` upsert blocks in `EveCorporationDataDO` into a single private `upsertPublicInfo` method, extending it to also set `creatorId`, `dateFounded`, `description`, and `homeStationId` on conflict.
- Added a post-write verification check in `upsertPublicInfo` that re-reads the stored corporation info and throws if any field doesn't match what was just written, guarding against silent write failures.
- Set `cacheMode: 'no-store'` on the `fetchPublicInfo` ESI call so corporation public info is always fetched fresh instead of served from cache.

## Testing
- Removed the now-invalid unit tests exercising the reverted CEO bootstrap/verification workflow steps from `sync-workflow.test.ts`.
<!-- claude:end -->