### PR TITLE
corp management UX enhancements and fixes

### DIFF
--- a/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
+++ b/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
@@ -33,6 +33,7 @@ const hoisted = vi.hoisted(() => ({
 		getAttributes: vi.fn(),
 		getLastUpdated: vi.fn(),
 		getSensitiveData: vi.fn(),
+		fetchCharacterData: vi.fn(),
 		refreshPublicCharacterData: vi.fn(),
 	},
 	skills: {
@@ -193,6 +194,7 @@ describe('character detail access for HR page viewers', () => {
 			location: null,
 			skillQueue: [],
 		})
+		hoisted.characterInstance.fetchCharacterData.mockResolvedValue(undefined)
 		hoisted.characterInstance.refreshPublicCharacterData.mockResolvedValue({})
 		hoisted.skills.getAllSkills.mockResolvedValue([])
 		hoisted.skills.getSkillsMetadata.mockResolvedValue([])
@@ -270,6 +272,21 @@ describe('character detail access for HR page viewers', () => {
 		expect(body.skills?.totalSp).toBe(123456)
 		expect(body.private.wallet).toBe(123456789)
 		expect(body.private.status).toEqual({ state: 'active' })
+	})
+
+	it('returns not found when the character is missing from our data', async () => {
+		vi.mocked(db.query.userCharacters.findFirst).mockResolvedValue(null as any)
+		hoisted.characterInstance.getCharacterInfo.mockResolvedValue(null)
+		hoisted.characterInstance.fetchCharacterData.mockResolvedValue(undefined)
+
+		const app = createApp(makeUser(), db)
+		const res = await app.request('/api/characters/9999', {}, env)
+
+		await Promise.all(backgroundTasks.splice(0, backgroundTasks.length))
+
+		expect(res.status).toBe(404)
+		const body = (await res.json()) as any
+		expect(body.error).toBe('Character not found')
 	})
 
 	it('returns private data for HR users via open applications without shared corp membership', async () => {

--- a/apps/core/src/routes/characters.ts
+++ b/apps/core/src/routes/characters.ts
@@ -538,13 +538,6 @@ app.get('/:characterId/skills', requireAuth(), async (c) => {
 app.get('/:characterId', requireAuth(), async (c) => {
 	const characterIdStr = c.req.param('characterId')
 	const characterId = createEveCharacterId(characterIdStr)
-	const accessOrResponse = await resolveCharacterAccessContext(c, characterIdStr)
-
-	if (accessOrResponse instanceof Response) {
-		return accessOrResponse
-	}
-
-	const access = accessOrResponse
 	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
 	const eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
 
@@ -592,6 +585,13 @@ app.get('/:characterId', requireAuth(), async (c) => {
 			}
 		}
 
+		const accessOrResponse = await resolveCharacterAccessContext(c, characterIdStr)
+
+		if (accessOrResponse instanceof Response) {
+			return accessOrResponse
+		}
+
+		const access = accessOrResponse
 		const eveTokenStore = c.get('eveTokenStore')
 		if (!eveTokenStore) {
 			logger.error('eveTokenStore not found in context!')

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -234,7 +234,7 @@ type MembersAuthFilter =
 type MembersCoverageFilter = 'all' | 'full' | 'partial' | 'none' | 'unlinked'
 type MembersActivityFilter = 'all' | 'active' | 'inactive' | 'unknown'
 type MembersRoleFilter = 'all' | 'CEO' | 'Director' | 'Member'
-type MembersSortField = 'name' | 'role' | 'auth' | 'activity' | 'lastLogin' | 'joinDate'
+type MembersSortField = 'name' | 'role' | 'hrRole' | 'auth' | 'activity' | 'lastLogin' | 'joinDate'
 type MembersSortOrder = 'asc' | 'desc'
 
 type MembersQuery = {
@@ -354,6 +354,19 @@ function buildCorporationMemberCoverageSummary(
 	return coverage
 }
 
+function getHrRoleSortRank(role?: string | null): number {
+	switch (role) {
+		case 'hr_admin':
+			return 0
+		case 'hr_reviewer':
+			return 1
+		case 'hr_viewer':
+			return 2
+		default:
+			return 3
+	}
+}
+
 type AccountCoverageStatus = Exclude<MembersCoverageFilter, 'all'>
 
 function buildCoverageStatusByUserId(
@@ -444,6 +457,7 @@ function parseMembersQuery(c: Context<App>): MembersQuery {
 	const sortField: MembersSortField =
 		sortFieldRaw === 'name' ||
 			sortFieldRaw === 'role' ||
+			sortFieldRaw === 'hrRole' ||
 			sortFieldRaw === 'auth' ||
 			sortFieldRaw === 'activity' ||
 			sortFieldRaw === 'lastLogin' ||
@@ -488,7 +502,11 @@ function getMemberCoverageStatus(
 	return coverageByUserId.get(member.authUserId) ?? 'none'
 }
 
-function filterSortAndPaginateMembers(members: CorporationMemberListItem[], query: MembersQuery) {
+function filterSortAndPaginateMembers(
+	members: CorporationMemberListItem[],
+	query: MembersQuery,
+	hrRoleMap?: Map<string, string>
+) {
 	const AUTH_SORT_RANK: Record<'valid' | 'invalid' | 'unknown' | 'unlinked', number> = {
 		valid: 0,
 		invalid: 1,
@@ -554,6 +572,15 @@ function filterSortAndPaginateMembers(members: CorporationMemberListItem[], quer
 			case 'role': {
 				const roleOrder = { CEO: 0, Director: 1, Member: 2 }
 				comparison = roleOrder[a.role] - roleOrder[b.role]
+				if (comparison === 0) {
+					comparison = a.characterName.localeCompare(b.characterName)
+				}
+				break
+			}
+			case 'hrRole': {
+				const roleA = hrRoleMap?.get(a.authUserId || '') ?? null
+				const roleB = hrRoleMap?.get(b.authUserId || '') ?? null
+				comparison = getHrRoleSortRank(roleA) - getHrRoleSortRank(roleB)
 				if (comparison === 0) {
 					comparison = a.characterName.localeCompare(b.characterName)
 				}
@@ -634,7 +661,11 @@ function buildUnpaginatedMembersResponse(members: CorporationMemberListItem[]) {
 	}
 }
 
-function filterSortMembers(members: CorporationMemberListItem[], query: MembersQuery) {
+function filterSortMembers(
+	members: CorporationMemberListItem[],
+	query: MembersQuery,
+	hrRoleMap?: Map<string, string>
+) {
 	const AUTH_SORT_RANK: Record<'valid' | 'invalid' | 'unknown' | 'unlinked', number> = {
 		valid: 0,
 		invalid: 1,
@@ -700,6 +731,15 @@ function filterSortMembers(members: CorporationMemberListItem[], query: MembersQ
 			case 'role': {
 				const roleOrder = { CEO: 0, Director: 1, Member: 2 }
 				comparison = roleOrder[a.role] - roleOrder[b.role]
+				if (comparison === 0) {
+					comparison = a.characterName.localeCompare(b.characterName)
+				}
+				break
+			}
+			case 'hrRole': {
+				const roleA = hrRoleMap?.get(a.authUserId || '') ?? null
+				const roleB = hrRoleMap?.get(b.authUserId || '') ?? null
+				comparison = getHrRoleSortRank(roleA) - getHrRoleSortRank(roleB)
 				if (comparison === 0) {
 					comparison = a.characterName.localeCompare(b.characterName)
 				}
@@ -2183,6 +2223,9 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		const cached = await getCachedJson<CorporationMemberListItem[]>(cacheKey)
 		const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
 		const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
+		const hrStub = getStub<Hr>(c.env.HR, 'default')
+		const hrRoles = query.sortField === 'hrRole' ? await hrStub.getCorporationRoles(corporationId, true) : []
+		const hrRoleMap = hrRoles.length > 0 ? new Map(hrRoles.map((role) => [role.userId, role.role])) : undefined
 
 		const useBackendPagination =
 			!returnUnpaginated &&
@@ -2250,7 +2293,6 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 			)
 			const userIdToMainCharacterId = new Map(linkedUsers.map((u) => [u.id, u.mainCharacterId]))
 
-			const hrStub = getStub<Hr>(c.env.HR, 'default')
 			const blacklistStatuses =
 				pageCharacterIds.length > 0
 					? await hrStub.checkCharactersBlacklisted(pageCharacterIds)
@@ -2370,7 +2412,7 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 			})
 			const response = returnUnpaginated
 				? buildUnpaginatedMembersResponse(cached)
-				: filterSortAndPaginateMembers(cached, query)
+				: filterSortAndPaginateMembers(cached, query, hrRoleMap)
 			return c.json(response)
 		}
 
@@ -2439,7 +2481,6 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		})
 
 		// Bulk check blacklist status for all members
-		const hrStub = getStub<Hr>(c.env.HR, 'default')
 		const blacklistStatuses =
 			memberCharacterIds.length > 0
 				? await hrStub.checkCharactersBlacklisted(memberCharacterIds)
@@ -2517,7 +2558,7 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 
 		const response = returnUnpaginated
 			? buildUnpaginatedMembersResponse(membersWithDetails)
-			: filterSortAndPaginateMembers(membersWithDetails, query)
+			: filterSortAndPaginateMembers(membersWithDetails, query, hrRoleMap)
 		return c.json(response)
 	} catch (error) {
 		logger.error('[Corporations] Error fetching corporation members', {
@@ -2577,9 +2618,9 @@ app.get('/:corporationId/members/export', requireAuth(), async (c) => {
 		const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
 		const hrStub = getStub<Hr>(c.env.HR, 'default')
 		const members = await hydrateCorporationMembers(c, corporationId, managedCorp, corpStub, tokenStoreStub)
-		const filteredMembers = filterSortMembers(members, query)
 		const hrRoles = await hrStub.getCorporationRoles(corporationId, true)
 		const hrRoleMap = new Map(hrRoles.map((role) => [role.userId, role.role]))
+		const filteredMembers = filterSortMembers(members, query, hrRoleMap)
 		const csv = buildCorporationMembersCsv(filteredMembers, hrRoleMap)
 		const safeFileName = managedCorp.name
 			.trim()

--- a/apps/ui/src/client/features/applications/routes/corporations.tsx
+++ b/apps/ui/src/client/features/applications/routes/corporations.tsx
@@ -1,5 +1,5 @@
 import { useQueries } from '@tanstack/react-query'
-import { AlertCircle, Building2, FileText, Users } from 'lucide-react'
+import { AlertCircle, Building2, FileText, Settings2, Users } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
 
@@ -274,14 +274,16 @@ export default function CorporationsPage() {
 						user?.is_admin === true ||
 						isAuditor ||
 						accessibleCorporationIds.has(corporation.corporationId)
-					const canViewApplications =
-						corporation.isMemberCorporation &&
-						(user?.is_admin === true ||
-							isAuditor ||
-							accessibleCorporationIds.has(corporation.corporationId))
-					const pendingCount = canViewApplications
-						? applications.filter((application) => application.status === 'pending').length
-						: 0
+						const canViewApplications =
+							corporation.isMemberCorporation &&
+							(user?.is_admin === true ||
+								isAuditor ||
+								accessibleCorporationIds.has(corporation.corporationId))
+						const canConfigureCorporation =
+							user?.is_admin === true || corporationAccessEntry?.userRole === 'CEO'
+						const pendingCount = canViewApplications
+							? applications.filter((application) => application.status === 'pending').length
+							: 0
 					const underReviewCount = canViewApplications
 						? applications.filter((application) => application.status === 'under_review').length
 						: 0
@@ -316,25 +318,33 @@ export default function CorporationsPage() {
 									)}
 								</div>
 								<div className="self-end">
-									<div className="flex flex-nowrap gap-2">
+									<div className="flex flex-wrap gap-2">
 										{canAccessMembers && (
-											<Button variant="ghost" asChild>
+											<Button variant="ghost" asChild className="w-full sm:w-auto">
 												<Link to={`/corporations/${corporation.corporationId}/members`}>
 													<Users className="h-4 w-4" />
 													Members
 												</Link>
 											</Button>
 										)}
-										{canViewApplications && (
-											<Button variant={canAccessMembers ? 'ghost' : 'primary'} asChild>
-												<Link to={`/corporations/${corporation.corporationId}/applications`}>
-													<FileText className="h-4 w-4" />
-													Applications
-												</Link>
-											</Button>
-										)}
+											{canViewApplications && (
+												<Button variant={canAccessMembers ? 'ghost' : 'primary'} asChild className="w-full sm:w-auto">
+													<Link to={`/corporations/${corporation.corporationId}/applications`}>
+														<FileText className="h-4 w-4" />
+														Applications
+													</Link>
+												</Button>
+											)}
+											{canConfigureCorporation && (
+												<Button variant="ghost" asChild className="w-full sm:w-auto">
+													<Link to={`/corporations/${corporation.corporationId}/settings`}>
+														<Settings2 className="h-4 w-4" />
+														Configure
+													</Link>
+												</Button>
+											)}
+										</div>
 									</div>
-								</div>
 								<div className="justify-self-end self-end">
 									{applicationQuery?.isLoading ? (
 										<div className="flex gap-2">

--- a/apps/ui/src/client/features/corporations/api.ts
+++ b/apps/ui/src/client/features/corporations/api.ts
@@ -50,7 +50,7 @@ export type CorporationMembersAuthFilter =
 export type CorporationMembersCoverageFilter = 'all' | 'full' | 'partial' | 'none' | 'unlinked'
 export type CorporationMembersActivityFilter = 'all' | 'active' | 'inactive' | 'unknown'
 export type CorporationMembersRoleFilter = 'all' | 'CEO' | 'Director' | 'Member'
-export type CorporationMembersSortField = 'name' | 'role' | 'auth' | 'activity' | 'lastLogin' | 'joinDate'
+export type CorporationMembersSortField = 'name' | 'role' | 'hrRole' | 'auth' | 'activity' | 'lastLogin' | 'joinDate'
 export type CorporationMembersSortOrder = 'asc' | 'desc'
 
 export interface CorporationMembersQuery {

--- a/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
+++ b/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
@@ -7,20 +7,17 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import {
+	ArrowDown,
+	ArrowUp,
+	ArrowUpDown,
 	ChevronDown,
-	ChevronUp,
-	ExternalLink,
 	Heart,
-	Link2,
 	Shield,
 	ShieldBan,
-	ShieldOff,
 	Star,
 	User,
-	Users,
 } from 'lucide-react'
 import { useCallback, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { Badge } from '@/components/ui/badge'
@@ -49,9 +46,7 @@ import {
 	useGrantHrRole,
 	useRevokeHrRole,
 } from '../../hr'
-import {
-	myCorporationsApi,
-} from '../api'
+import { myCorporationsApi } from '../api'
 import { EmeritusConfirmationDialog } from './emeritus-confirmation-dialog'
 
 import type {
@@ -67,7 +62,6 @@ interface CorporationMembersTableProps {
 	members: CorporationMember[]
 	loading?: boolean
 	onMemberClick?: (member: CorporationMember) => void
-	onLinkAccount?: (member: CorporationMember) => void
 	showActions?: boolean
 	canManageHrRoles?: boolean
 	grantableHrRoles?: HrRoleType[]
@@ -161,7 +155,6 @@ export default function CorporationMembersTable({
 	members,
 	loading,
 	onMemberClick,
-	onLinkAccount,
 	showActions = true,
 	canManageHrRoles = false,
 	grantableHrRoles = ['hr_admin', 'hr_reviewer', 'hr_viewer'],
@@ -287,13 +280,29 @@ export default function CorporationMembersTable({
 	}
 
 	const SortIcon = ({ field }: { field: SortField }) => {
-		if (sortField !== field) return null
+		if (sortField !== field) {
+			return <ArrowUpDown className="h-3.5 w-3.5 opacity-60" />
+		}
+
 		return sortOrder === 'asc' ? (
-			<ChevronUp className="ml-1 h-3 w-3 inline" />
+			<ArrowUp className="h-3.5 w-3.5" />
 		) : (
-			<ChevronDown className="ml-1 h-3 w-3 inline" />
+			<ArrowDown className="h-3.5 w-3.5" />
 		)
 	}
+
+	const SortableHead = ({ field, label }: { field: SortField; label: string }) => (
+		<TableHead>
+			<button
+				type="button"
+				onClick={() => handleSort(field)}
+				className="inline-flex items-center gap-1 text-left text-muted-foreground hover:text-foreground"
+			>
+				<span>{label}</span>
+				<SortIcon field={field} />
+			</button>
+		</TableHead>
+	)
 
 	const stats = summary ?? {
 		total: members.length,
@@ -309,7 +318,6 @@ export default function CorporationMembersTable({
 	}
 	const pageLimit = pagination?.limit ?? query.limit ?? 50
 	const totalItems = pagination?.totalItems ?? 0
-	const hasPagination = (pagination?.totalPages ?? 1) > 1
 
 	const renderPaginationControls = () => (
 		<div className="border-b p-4">
@@ -439,53 +447,17 @@ export default function CorporationMembersTable({
 
 			{/* Table */}
 			<Card>
-				{hasPagination && renderPaginationControls()}
+				{renderPaginationControls()}
 				<Table>
 					<TableHeader>
 						<TableRow>
-							<TableHead
-								className="cursor-pointer hover:bg-muted/50"
-								onClick={() => handleSort('name')}
-							>
-								Member
-								<SortIcon field="name" />
-							</TableHead>
-							<TableHead
-								className="cursor-pointer hover:bg-muted/50"
-								onClick={() => handleSort('role')}
-							>
-								Role
-								<SortIcon field="role" />
-							</TableHead>
-							{canManageHrRoles && <TableHead>HR Role</TableHead>}
-							<TableHead
-								className="cursor-pointer hover:bg-muted/50"
-								onClick={() => handleSort('auth')}
-							>
-								Auth Account
-								<SortIcon field="auth" />
-							</TableHead>
-							<TableHead
-								className="cursor-pointer hover:bg-muted/50"
-								onClick={() => handleSort('activity')}
-							>
-								Activity
-								<SortIcon field="activity" />
-							</TableHead>
-							<TableHead
-								className="cursor-pointer hover:bg-muted/50"
-								onClick={() => handleSort('lastLogin')}
-							>
-								Last Login
-								<SortIcon field="lastLogin" />
-							</TableHead>
-							<TableHead
-								className="cursor-pointer hover:bg-muted/50"
-								onClick={() => handleSort('joinDate')}
-							>
-								Join Date
-								<SortIcon field="joinDate" />
-							</TableHead>
+							<SortableHead field="name" label="Member" />
+							<SortableHead field="role" label="Role" />
+							{canManageHrRoles && <SortableHead field="hrRole" label="HR Role" />}
+							<SortableHead field="auth" label="Auth Account" />
+							<SortableHead field="activity" label="Activity" />
+							<SortableHead field="lastLogin" label="Last Login" />
+							<SortableHead field="joinDate" label="Join Date" />
 							{showActions && (
 								<TableHead className="sticky right-0 z-20 bg-card text-right">
 									Actions
@@ -583,64 +555,58 @@ export default function CorporationMembersTable({
 									<div className="text-sm">{formatDate(member.joinDate)}</div>
 								</TableCell>
 								{showActions && (
-									<TableCell
-										className="sticky right-0 z-10 bg-card text-right"
-										onClick={(e) => e.stopPropagation()}
-									>
-										<ActionsMenu
-											items={[
-												{
-													label: 'View Profile',
-													intent: 'muted',
-													onClick: () => onMemberClick?.(member),
+								<TableCell
+									className="sticky right-0 z-10 bg-card text-right"
+									onClick={(e) => e.stopPropagation()}
+								>
+									<ActionsMenu
+										items={[
+											{
+												label: 'View Profile',
+												intent: 'muted',
+												onClick: () => onMemberClick?.(member),
+											},
+											{
+												label: 'Grant HR Role',
+												intent: 'confirm',
+												hidden: !canManageHrRoles || !member.hasAuthAccount || !!member.hrRole,
+												onClick: () => setGrantDialogMember(member),
+											},
+											{
+												label: 'Revoke HR Role',
+												intent: 'destructive',
+												hidden:
+													!canManageHrRoles ||
+													!member.hrRole ||
+													(!canRevokeHrAdmin && member.hrRole.role === 'hr_admin'),
+												onClick: () => setRevokeDialogMember(member),
+											},
+											{
+												label: 'Mark as Emeritus',
+												intent: 'secondary',
+												hidden:
+													!canManageEmeritus ||
+													!member.hasAuthAccount ||
+													member.role === 'CEO' ||
+													member.status === 'emeritus',
+												onClick: () => {
+													setEmeritusAction('mark')
+													setEmeritusDialogMember(member)
 												},
-												{
-													label: 'Link Account',
-													intent: 'primary',
-													hidden: member.hasAuthAccount || !onLinkAccount,
-													onClick: () => onLinkAccount?.(member),
+											},
+											{
+												label: 'Remove Emeritus',
+												intent: 'secondary',
+												hidden: !canManageEmeritus || member.status !== 'emeritus',
+												onClick: () => {
+													setEmeritusAction('remove')
+													setEmeritusDialogMember(member)
 												},
-												{
-													label: 'Grant HR Role',
-													intent: 'confirm',
-													hidden: !canManageHrRoles || !member.hasAuthAccount || !!member.hrRole,
-													onClick: () => setGrantDialogMember(member),
-												},
-												{
-													label: 'Revoke HR Role',
-													intent: 'destructive',
-													hidden:
-														!canManageHrRoles ||
-														!member.hrRole ||
-														(!canRevokeHrAdmin && member.hrRole.role === 'hr_admin'),
-													onClick: () => setRevokeDialogMember(member),
-												},
-												{
-													label: 'Mark as Emeritus',
-													intent: 'secondary',
-													hidden:
-														!canManageEmeritus ||
-														!member.hasAuthAccount ||
-														member.role === 'CEO' ||
-														member.status === 'emeritus',
-													onClick: () => {
-														setEmeritusAction('mark')
-														setEmeritusDialogMember(member)
-													},
-												},
-												{
-													label: 'Remove Emeritus',
-													intent: 'secondary',
-													hidden: !canManageEmeritus || member.status !== 'emeritus',
-													onClick: () => {
-														setEmeritusAction('remove')
-														setEmeritusDialogMember(member)
-													},
-												},
-											]}
-										/>
-									</TableCell>
-								)}
+											},
+										]}
+									/>
+								</TableCell>
+							)}
 							</TableRow>
 						))}
 						{paginatedMembers.length === 0 && (
@@ -657,7 +623,7 @@ export default function CorporationMembersTable({
 				</Table>
 
 				{/* Pagination */}
-				{hasPagination && renderPaginationControls()}
+				{renderPaginationControls()}
 			</Card>
 
 			{/* HR Role Dialogs */}

--- a/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
+++ b/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
@@ -235,15 +235,6 @@ export default function CorporationMembers() {
 		}))
 	}, [])
 
-	const handleLinkAccount = useCallback(
-		(member: CorporationMember) => {
-			// This would open a modal or navigate to a linking flow
-			// For now, just show a message
-			showError('Account linking not yet implemented')
-		},
-		[showError]
-	)
-
 	const handleExport = useCallback(async () => {
 		if (!corporationId || isExporting) return
 
@@ -450,14 +441,14 @@ export default function CorporationMembers() {
 					<CardContent>
 						{canUseHrTools ? (
 							<div className="flex flex-wrap gap-2">
-								<Button variant="primary" asChild>
+								<Button variant="primary" asChild className="w-full sm:w-auto">
 									<Link to={`/corporations/${corporationId}/applications`}>
 										<FileText className="h-4 w-4" />
 										Review Applications
 									</Link>
 								</Button>
 								{canManageHrRoles && (
-									<Button variant="ghost" asChild>
+									<Button variant="ghost" asChild className="w-full sm:w-auto">
 										<Link to={`/corporations/${corporationId}/hr/roles`}>
 											<Settings className="h-4 w-4" />
 											Manage HR Roles
@@ -465,7 +456,7 @@ export default function CorporationMembers() {
 									</Button>
 								)}
 								{canAccessSettings && (
-									<Button variant="ghost" asChild>
+									<Button variant="ghost" asChild className="w-full sm:w-auto">
 										<Link to={`/corporations/${corporationId}/settings`}>
 											<Settings className="h-4 w-4" />
 											Corporation Settings
@@ -587,14 +578,13 @@ export default function CorporationMembers() {
 					</Card>
 				}
 			>
-				<CorporationMembersTable
-					members={membersWithHrRoles ?? []}
-					loading={membersLoading && !membersResponse}
-					onMemberClick={handleMemberClick}
-					onLinkAccount={handleLinkAccount}
-					showActions={true}
-					canManageHrRoles={canManageHrRoles}
-					grantableHrRoles={[...grantableHrRoles]}
+					<CorporationMembersTable
+						members={membersWithHrRoles ?? []}
+						loading={membersLoading && !membersResponse}
+						onMemberClick={handleMemberClick}
+						showActions={true}
+						canManageHrRoles={canManageHrRoles}
+						grantableHrRoles={[...grantableHrRoles]}
 					canRevokeHrAdmin={canRevokeHrAdmin}
 					canManageEmeritus={canManageEmeritus}
 					corporationId={corporationId!}

--- a/apps/ui/src/client/routes/corporation-detail.tsx
+++ b/apps/ui/src/client/routes/corporation-detail.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query'
-import { AlertCircle, ArrowLeft, Building2, FileText } from 'lucide-react'
+import { AlertCircle, ArrowLeft, FileText } from 'lucide-react'
 import { useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
 
@@ -27,6 +27,7 @@ import { SubmitApplicationDialog } from '@/features/applications'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { api } from '@/lib/api'
+import { corporationLogoUrl } from '@/lib/eve-images'
 
 // ============================================================================
 // Component
@@ -122,8 +123,12 @@ export default function CorporationDetail() {
 			<Card className="mb-6">
 				<CardHeader>
 					<div className="flex items-start gap-4">
-						<div className="p-4 bg-primary/10 rounded-lg">
-							<Building2 className="h-16 w-16 text-primary" />
+						<div className="flex h-28 w-28 items-center justify-center rounded-lg bg-muted/30 p-4">
+							<img
+								src={corporationLogoUrl(corporation.corporationId, 256)}
+								alt={`${corporation.name} logo`}
+								className="h-full w-full rounded-md object-contain"
+							/>
 						</div>
 						<div className="flex-1">
 							<CardTitle className="text-3xl mb-2">{corporation.name}</CardTitle>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a 404 regression for characters not yet synced into our DB, adds HR role sorting/filtering polish, and improves corporation management UX (settings link, logo display, cleaner sortable table headers).

## Changes
- `characters.ts`: move `resolveCharacterAccessContext` access-check to run after fetching character data instead of before, so a character that exists on EVE but isn't in our DB yet can still be fetched/synced rather than short-circuiting into a premature response; add corresponding test for the "character missing from our data" 404 case (also mocks the new `fetchCharacterData` call).
- `corporations/index.ts`: add `hrRole` as a sortable field for the members list/export (`getHrRoleSortRank` ranks `hr_admin` > `hr_reviewer` > `hr_viewer` > none), threaded through `filterSortAndPaginateMembers`/`filterSortMembers` via a new `hrRoleMap` param; reorder `hrStub`/`hrRoleMap` lookups so the export endpoint builds the map before filtering/sorting instead of after.
- `corporation-members-table.tsx`: replace chevron-based sort icons with `ArrowUp`/`ArrowDown`/`ArrowUpDown`, extract a shared `SortableHead` component, always render pagination controls (drop the `hasPagination` gate), and remove the unused "Link Account" action/prop.
- `corporation-members.tsx`: remove the now-dead `handleLinkAccount` stub and drop `onLinkAccount` usage; make action buttons full-width on small screens (`w-full sm:w-auto`).
- `corporations.tsx` (applications route): add a "Configure" button/link to corporation settings for CEOs/admins, and make action buttons wrap/full-width responsively.
- `corporation-detail.tsx`: replace the generic `Building2` placeholder icon with the corporation's actual logo via `corporationLogoUrl`.

## Testing
Added a new integration test in `characters.hr-auditor.route.test.ts` covering the 404 path when a character isn't found in our data, including mocking the new `fetchCharacterData` call.
<!-- claude:end -->