### PR TITLE
tweak SRP UX and optimize count queries

### DIFF
--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -993,6 +993,41 @@ srp.get('/requests/by-status', async (c) => {
 })
 
 /**
+ * Get a count of SRP requests by status without fetching rows.
+ * GET /api/srp/requests/by-status/count?status=pending
+ */
+srp.get('/requests/by-status/count', async (c) => {
+	const user = c.get('user')!
+	const statusParsed = ReviewQueueStatusQuerySchema.safeParse(c.req.query('status'))
+	if (!statusParsed.success) {
+		return c.json({ error: 'Invalid status' }, 400)
+	}
+
+	const characterName = c.req.query('characterName')?.trim() || undefined
+	const shipTypeName = c.req.query('shipTypeName')?.trim() || undefined
+	const solarSystemName = c.req.query('solarSystemName')?.trim() || undefined
+	const dateFrom = c.req.query('dateFrom')?.trim() || undefined
+	const dateTo = c.req.query('dateTo')?.trim() || undefined
+
+	const canAccessCount =
+		statusParsed.data === 'approved'
+			? await hasSrpTierPermission(c.env, user.id, 'payer', user.is_admin)
+			: await hasSrpTierPermission(c.env, user.id, 'reviewer', user.is_admin)
+	if (!canAccessCount) return c.json({ error: 'Requires SRP staff permissions' }, 403)
+
+	const srpStub = getStub<Srp>(c.env.SRP, 'default')
+	const total = await srpStub.getRequestCountByStatus(statusParsed.data, {
+		characterName,
+		shipTypeName,
+		solarSystemName,
+		dateFrom,
+		dateTo,
+	})
+
+	return c.json({ total })
+})
+
+/**
  * Get search values for review queue filters
  * GET /api/srp/requests/search-values?status=pending&field=character&query=ab
  */

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -185,6 +185,77 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		})
 	}
 
+	private buildReviewQueueConditions(
+		status: RequestStatus,
+		options: {
+			characterName?: string
+			shipTypeName?: string
+			solarSystemName?: string
+			dateFrom?: string
+			dateTo?: string
+		} = {}
+	): { where: ReturnType<typeof and>; oldestFirst: boolean } {
+		const { characterName, shipTypeName, solarSystemName, dateFrom, dateTo } = options
+
+		const startDate = dateFrom
+			? (dateFrom.includes('T')
+				? new Date(dateFrom)
+				: new Date(`${dateFrom}T00:00:00.000Z`))
+			: null
+		const endDate = dateTo
+			? (dateTo.includes('T')
+				? new Date(dateTo)
+				: new Date(`${dateTo}T23:59:59.999Z`))
+			: null
+
+		const conditions =
+			status === 'paid'
+				? [inArray(srpRequests.requestStatus, ['payment_pending', 'paid'])]
+				: [eq(srpRequests.requestStatus, status)]
+		if (characterName) conditions.push(ilike(srpRequests.characterName, `%${characterName}%`))
+		if (shipTypeName) conditions.push(ilike(srpRequests.shipTypeName, `%${shipTypeName}%`))
+		if (solarSystemName) conditions.push(ilike(srpRequests.solarSystemName, `%${solarSystemName}%`))
+		if (startDate) conditions.push(gte(srpRequests.lossDate, startDate))
+		if (endDate) conditions.push(lte(srpRequests.lossDate, endDate))
+
+		return {
+			where: and(...conditions),
+			oldestFirst: status === 'pending' || status === 'needs_context',
+		}
+	}
+
+	private async getReviewQueueCount(
+		status: RequestStatus,
+		options: {
+			characterName?: string
+			shipTypeName?: string
+			solarSystemName?: string
+			dateFrom?: string
+			dateTo?: string
+		} = {}
+	): Promise<number> {
+		const cacheKey = this.buildReviewQueueCountCacheKey({
+			status,
+			characterName: options.characterName,
+			shipTypeName: options.shipTypeName,
+			solarSystemName: options.solarSystemName,
+			dateFrom: options.dateFrom,
+			dateTo: options.dateTo,
+		})
+		const cached = this.reviewQueueCountCache.get(cacheKey)
+		const now = Date.now()
+		if (cached && cached.expiresAt > now) return cached.value
+
+		const { where } = this.buildReviewQueueConditions(status, options)
+		const [row] = await this.db.select({ count: sql<number>`count(*)::int` }).from(srpRequests).where(where)
+		const count = row?.count ?? 0
+		this.reviewQueueCountCache.set(cacheKey, {
+			value: count,
+			expiresAt: now + SrpDO.REVIEW_QUEUE_COUNT_CACHE_TTL_MS,
+		})
+		return count
+	}
+
 	private convertKillmailDetailToLoss(killmail: KillmailDetail & { killmail_hash?: string }): CharacterLossData | null {
 		if (!killmail.killmail_hash) return null
 		const victimCharacterId = killmail.victim.character_id
@@ -2239,31 +2310,8 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			dateTo?: string
 		} = {}
 	): Promise<{ requests: SRPRequestResponse[]; total: number }> {
-		const { limit = 25, offset = 0, characterName, shipTypeName, solarSystemName, dateFrom, dateTo } = options
-
-		const startDate = dateFrom
-			? (dateFrom.includes('T')
-				? new Date(dateFrom)
-				: new Date(`${dateFrom}T00:00:00.000Z`))
-			: null
-		const endDate = dateTo
-			? (dateTo.includes('T')
-				? new Date(dateTo)
-				: new Date(`${dateTo}T23:59:59.999Z`))
-			: null
-
-		const conditions =
-			status === 'paid'
-				? [inArray(srpRequests.requestStatus, ['payment_pending', 'paid'])]
-				: [eq(srpRequests.requestStatus, status)]
-		if (characterName) conditions.push(ilike(srpRequests.characterName, `%${characterName}%`))
-		if (shipTypeName) conditions.push(ilike(srpRequests.shipTypeName, `%${shipTypeName}%`))
-		if (solarSystemName) conditions.push(ilike(srpRequests.solarSystemName, `%${solarSystemName}%`))
-		if (startDate) conditions.push(gte(srpRequests.lossDate, startDate))
-		if (endDate) conditions.push(lte(srpRequests.lossDate, endDate))
-
-		const where = and(...conditions)
-		const oldestFirst = status === 'pending' || status === 'needs_context'
+		const { limit = 25, offset = 0 } = options
+		const { where, oldestFirst } = this.buildReviewQueueConditions(status, options)
 
 		const [requests, count] = await Promise.all([
 			this.db.query.srpRequests.findMany({
@@ -2272,33 +2320,23 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 				limit,
 				offset,
 			}),
-			(async () => {
-				const cacheKey = this.buildReviewQueueCountCacheKey({
-					status,
-					characterName,
-					shipTypeName,
-					solarSystemName,
-					dateFrom,
-					dateTo,
-				})
-				const cached = this.reviewQueueCountCache.get(cacheKey)
-				const now = Date.now()
-				if (cached && cached.expiresAt > now) return cached.value
-
-				const [row] = await this.db
-					.select({ count: sql<number>`count(*)::int` })
-					.from(srpRequests)
-					.where(where)
-				const count = row?.count ?? 0
-				this.reviewQueueCountCache.set(cacheKey, {
-					value: count,
-					expiresAt: now + SrpDO.REVIEW_QUEUE_COUNT_CACHE_TTL_MS,
-				})
-				return count
-			})(),
+			this.getReviewQueueCount(status, options),
 		])
 
 		return { requests: await Promise.all(requests.map((r) => this.formatRequest(r))), total: count }
+	}
+
+	async getRequestCountByStatus(
+		status: RequestStatus,
+		options: {
+			characterName?: string
+			shipTypeName?: string
+			solarSystemName?: string
+			dateFrom?: string
+			dateTo?: string
+		} = {}
+	): Promise<number> {
+		return this.getReviewQueueCount(status, options)
 	}
 
 	async getSearchValues(

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -115,7 +115,7 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 	const derivedPaymentQueueCount = useReviewQueueStatusCount('approved')
 	const { data: reviewQueueData } = useQuery({
 		queryKey: ['srp', 'sidebar-review-count'],
-		queryFn: () => api.get<{ total: number }>('/srp/requests/by-status?status=pending&limit=1&offset=0'),
+		queryFn: () => api.getRequestCountByStatus('pending'),
 		placeholderData: (previousData) => previousData,
 		staleTime: 1000 * 60 * 5,
 		gcTime: 1000 * 60 * 5,
@@ -123,7 +123,7 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 	})
 	const { data: paymentQueueData } = useQuery({
 		queryKey: ['srp', 'sidebar-payment-count'],
-		queryFn: () => api.get<{ total: number }>('/srp/requests/by-status?status=approved&limit=1&offset=0'),
+		queryFn: () => api.getRequestCountByStatus('approved'),
 		placeholderData: (previousData) => previousData,
 		staleTime: 1000 * 60 * 5,
 		gcTime: 1000 * 60 * 5,

--- a/apps/ui/src/client/features/srp/hooks.ts
+++ b/apps/ui/src/client/features/srp/hooks.ts
@@ -121,6 +121,8 @@ function refreshQueuePagesHard(queryClient: ReturnType<typeof useQueryClient>) {
 	void queryClient.invalidateQueries({ queryKey: srpKeys.pending() })
 	void queryClient.invalidateQueries({ queryKey: srpKeys.payments() })
 	void queryClient.invalidateQueries({ queryKey: srpKeys.pendingPayoutTotal() })
+	void queryClient.invalidateQueries({ queryKey: ['srp', 'sidebar-review-count'] })
+	void queryClient.invalidateQueries({ queryKey: ['srp', 'sidebar-payment-count'] })
 }
 
 function refreshQueueBadgesSoft(
@@ -140,6 +142,8 @@ function refreshQueueBadgesSoft(
 			)
 		},
 	})
+	void queryClient.invalidateQueries({ queryKey: ['srp', 'sidebar-review-count'] })
+	void queryClient.invalidateQueries({ queryKey: ['srp', 'sidebar-payment-count'] })
 }
 
 function adjustPendingPayoutTotalCaches(
@@ -558,7 +562,7 @@ export function useWithdrawRequest() {
 	return useMutation({
 		mutationFn: ({ id, notes }: { id: string; notes?: string }) =>
 			api.withdrawSRPRequest(id, notes ? { notes } : undefined),
-		onSuccess: (request: SRPRequestResponse) => {
+	onSuccess: (request: SRPRequestResponse) => {
 			updateOverlayRequestStatus({
 				requestId: request.id,
 				requestStatus: request.requestStatus,
@@ -566,6 +570,7 @@ export function useWithdrawRequest() {
 			setRequestStatusAcrossCaches(queryClient, request)
 			void queryClient.invalidateQueries({ queryKey: srpKeys.requests() })
 			invalidateLossQueries(queryClient)
+			refreshQueuePagesHard(queryClient)
 		},
 	})
 }

--- a/apps/ui/src/client/features/srp/routes/payments.tsx
+++ b/apps/ui/src/client/features/srp/routes/payments.tsx
@@ -179,11 +179,35 @@ function PaymentStack() {
 		)
 	}
 
+	const refreshButton = (
+		<Button variant="secondary" size="sm" onClick={() => void refetch()} loading={isFetching} loadingText="Refreshing...">
+			Refresh Queue
+		</Button>
+	)
+	const queueSummaryCard = (
+		<Card className="p-4">
+			<div className="flex items-start justify-between gap-3">
+				<div>
+					<div className="text-sm text-muted-foreground">Pending Payout Total</div>
+					<div className="mt-1 font-mono text-2xl font-semibold tabular-nums text-success">
+						{formatISKShort(pendingPayoutTotal)}
+					</div>
+				</div>
+				{refreshButton}
+			</div>
+		</Card>
+	)
+
 	if (sortedRequests.length === 0) {
 		return (
-			<div className="mt-4 rounded-lg border border-dashed p-12 text-center">
-				<h3 className="mb-2 font-semibold">All caught up!</h3>
-				<p className="text-sm text-muted-foreground">No approved requests awaiting payment submission.</p>
+			<div className="relative mt-4 space-y-3">
+				{queueSummaryCard}
+				<Card className="border-dashed p-10 text-center">
+					<h3 className="text-lg font-semibold">All caught up!</h3>
+					<p className="mt-2 text-sm text-muted-foreground">
+						No approved requests awaiting payment submission.
+					</p>
+				</Card>
 			</div>
 		)
 	}
@@ -228,19 +252,7 @@ function PaymentStack() {
 
 	return (
 		<div ref={containerRef} className="relative mt-4 space-y-3">
-			<Card className="p-4">
-				<div className="flex items-start justify-between gap-3">
-					<div>
-						<div className="text-sm text-muted-foreground">Pending Payout Total</div>
-						<div className="mt-1 font-mono text-2xl font-semibold tabular-nums text-success">
-							{formatISKShort(pendingPayoutTotal)}
-						</div>
-					</div>
-					<Button variant="secondary" size="sm" onClick={() => void refetch()}>
-						Refresh Queue
-					</Button>
-				</div>
-			</Card>
+			{queueSummaryCard}
 			{[...ghosts.values()].map((ghost) => (
 				<GhostPaymentCard key={ghost.request.id} request={ghost.request} top={ghost.top} />
 			))}

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -4697,6 +4697,27 @@ export class ApiClient {
 		return this.get(`/srp/payments/pending${query ? `?${query}` : ''}`)
 	}
 
+	async getRequestCountByStatus(
+		status: 'pending' | 'needs_context' | 'approved' | 'payment_pending' | 'rejected' | 'paid',
+		params?: {
+			characterName?: string
+			shipTypeName?: string
+			solarSystemName?: string
+			dateFrom?: string
+			dateTo?: string
+		}
+	): Promise<{ total: number }> {
+		const searchParams = new URLSearchParams()
+		searchParams.set('status', status)
+		if (params?.characterName) searchParams.set('characterName', params.characterName)
+		if (params?.shipTypeName) searchParams.set('shipTypeName', params.shipTypeName)
+		if (params?.solarSystemName) searchParams.set('solarSystemName', params.solarSystemName)
+		if (params?.dateFrom) searchParams.set('dateFrom', params.dateFrom)
+		if (params?.dateTo) searchParams.set('dateTo', params.dateTo)
+
+		return this.get(`/srp/requests/by-status/count?${searchParams.toString()}`)
+	}
+
 	async getPendingPayoutTotal(params?: {
 		corporationId?: string
 	}): Promise<{ pendingPayoutTotal: string }> {

--- a/packages/srp/src/index.ts
+++ b/packages/srp/src/index.ts
@@ -201,6 +201,16 @@ export interface Srp {
 			dateTo?: string
 		}
 	): Promise<{ requests: SRPRequestResponse[]; total: number }>
+	getRequestCountByStatus(
+		status: RequestStatus,
+		options?: {
+			characterName?: string
+			shipTypeName?: string
+			solarSystemName?: string
+			dateFrom?: string
+			dateTo?: string
+		}
+	): Promise<number>
 
 	getSearchValues(
 		status: RequestStatus,


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a dedicated count-only endpoint for SRP review queue statuses to avoid fetching full row data just to display badge counts, and tweaks the SRP payments UI so the payout summary card and refresh state are more consistent.

## Changes
- Add `GET /api/srp/requests/by-status/count` route (`apps/core/src/routes/srp.ts`) that validates the status and permission tier, then returns just `{ total }`.
- Refactor `SrpDO` (`apps/srp/src/durable-object.ts`): extract shared `buildReviewQueueConditions` and `getReviewQueueCount` helpers used by both `getReviewQueue` and the new `getRequestCountByStatus` RPC method (with cached counts).
- Add `getRequestCountByStatus` to the `Srp` interface (`packages/srp/src/index.ts`) and the API client (`apps/ui/src/client/lib/api.ts`).
- Update sidebar nav (`sidebar-nav.tsx`) to call `api.getRequestCountByStatus(...)` instead of requesting full `by-status` pages with `limit=1` just to read the total.
- Invalidate the sidebar review/payment count queries on hard/soft queue refreshes, and trigger a hard refresh after withdrawing a request (`features/srp/hooks.ts`).
- Show the "Pending Payout Total" summary card (with a loading state on the Refresh Queue button) even when the payment queue is empty (`features/srp/routes/payments.tsx`).

## Testing
Not evident from the diff — no test changes included.
<!-- claude:end -->