### PR TITLE
add SRP fleet details discord command

### DIFF
--- a/apps/broadcasts/eslint.config.ts
+++ b/apps/broadcasts/eslint.config.ts
@@ -1,7 +1,5 @@
-import { defineConfig } from '@repo/eslint-config'
+import { defineConfig, getConfig } from '@repo/eslint-config'
 
-export default defineConfig({
-	typescript: {
-		project: './tsconfig.json',
-	},
-})
+const config = getConfig(import.meta.url)
+
+export default defineConfig([config])

--- a/apps/broadcasts/src/durable-object.ts
+++ b/apps/broadcasts/src/durable-object.ts
@@ -37,6 +37,7 @@ import type {
 	BroadcastTarget,
 	BroadcastTemplate,
 	BroadcastWithDetails,
+	SrpFleetBroadcastLookup,
 	CreateBroadcastRequest,
 	CreateBroadcastTargetRequest,
 	CreateBroadcastTemplateRequest,
@@ -101,7 +102,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 		}))
 	}
 
-	async getTarget(targetId: string, userId: string): Promise<BroadcastTarget | null> {
+	async getTarget(targetId: string, _userId: string): Promise<BroadcastTarget | null> {
 		const target = await this.db.query.broadcastTargets.findFirst({
 			where: eq(broadcastTargets.id, targetId),
 		})
@@ -182,7 +183,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 		}
 	}
 
-	async deleteTarget(targetId: string, userId: string): Promise<void> {
+	async deleteTarget(targetId: string, _userId: string): Promise<void> {
 		await this.db.delete(broadcastTargets).where(eq(broadcastTargets.id, targetId))
 	}
 
@@ -253,7 +254,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 			}))
 	}
 
-	async getTemplate(templateId: string, userId: string): Promise<BroadcastTemplate | null> {
+	async getTemplate(templateId: string, _userId: string): Promise<BroadcastTemplate | null> {
 		const template = await this.db.query.broadcastTemplates.findFirst({
 			where: eq(broadcastTemplates.id, templateId),
 		})
@@ -401,7 +402,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 		}
 	}
 
-	async deleteTemplate(templateId: string, userId: string): Promise<void> {
+	async deleteTemplate(templateId: string, _userId: string): Promise<void> {
 		const template = await this.db.query.broadcastTemplates.findFirst({
 			where: eq(broadcastTemplates.id, templateId),
 		})
@@ -546,7 +547,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 			return { content: args.content, srpMode: null, srpToken: null, doctrineId }
 		}
 
-		let nextContent = { ...args.content }
+		const nextContent = { ...args.content }
 		if (srpMode === 'disabled' || srpMode === 'coalition') {
 			if ('__srpToken' in nextContent) {
 				delete nextContent.__srpToken
@@ -601,7 +602,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 			offset?: number
 		}
 	): Promise<BroadcastPage> {
-		let whereConditions = []
+		const whereConditions = []
 
 		if (filters?.permissionId) {
 			whereConditions.push(eq(broadcasts.permissionId, filters.permissionId))
@@ -660,7 +661,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 		}
 	}
 
-	async getBroadcast(broadcastId: string, userId: string): Promise<BroadcastWithDetails | null> {
+	async getBroadcast(broadcastId: string, _userId: string): Promise<BroadcastWithDetails | null> {
 		const broadcast = await this.db.query.broadcasts.findFirst({
 			where: eq(broadcasts.id, broadcastId),
 		})
@@ -741,6 +742,39 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 		if (!link) return null
 		if (link.srpMode !== 'blanket' && link.srpMode !== 'military') return null
 		return this.getBroadcast(link.broadcastId, userId)
+	}
+
+	async getSrpFleetBroadcastByToken(srpToken: string): Promise<SrpFleetBroadcastLookup | null> {
+		const normalized = srpToken.trim()
+		if (!normalized) return null
+
+		const [row] = await this.db
+			.select({
+				content: broadcasts.content,
+				srpToken: broadcastSessionLinks.srpToken,
+				doctrineId: broadcastSessionLinks.doctrineId,
+				fleetSessionId: broadcastSessionLinks.fleetSessionId,
+			})
+			.from(broadcastSessionLinks)
+			.innerJoin(broadcasts, eq(broadcasts.id, broadcastSessionLinks.broadcastId))
+			.where(
+				and(
+					eq(broadcastSessionLinks.srpToken, normalized),
+					or(
+						eq(broadcastSessionLinks.srpMode, 'blanket'),
+						eq(broadcastSessionLinks.srpMode, 'military')
+					)
+				)
+			)
+			.limit(1)
+
+		if (!row?.srpToken) return null
+		return {
+			content: row.content as Record<string, unknown>,
+			srpToken: row.srpToken,
+			doctrineId: row.doctrineId,
+			fleetSessionId: row.fleetSessionId,
+		}
 	}
 
 	async getBroadcastByFleetSessionId(
@@ -1066,7 +1100,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 	async updateBroadcast(
 		broadcastId: string,
 		data: UpdateBroadcastRequest,
-		userId: string
+		_userId: string
 	): Promise<Broadcast> {
 		const existing = await this.db.query.broadcasts.findFirst({
 			where: eq(broadcasts.id, broadcastId),
@@ -1114,7 +1148,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 		}
 	}
 
-	async deleteBroadcast(broadcastId: string, userId: string): Promise<void> {
+	async deleteBroadcast(broadcastId: string, _userId: string): Promise<void> {
 		// Fetch deliveries and target config before deleting so we can clean up Discord
 		const broadcast = await this.db.query.broadcasts.findFirst({
 			where: eq(broadcasts.id, broadcastId),
@@ -1316,7 +1350,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 			.where(eq(broadcasts.id, broadcastId))
 	}
 
-	async getDeliveries(broadcastId: string, userId: string): Promise<BroadcastDelivery[]> {
+	async getDeliveries(broadcastId: string, _userId: string): Promise<BroadcastDelivery[]> {
 		const deliveries = await this.db.query.broadcastDeliveries.findMany({
 			where: eq(broadcastDeliveries.broadcastId, broadcastId),
 		})

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -95,7 +95,6 @@ import type {
 	UserDetails,
 } from '@repo/admin'
 import type { Core } from '@repo/core'
-import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Hr } from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
 import type { App, Env } from './context'
@@ -968,6 +967,7 @@ export class CoreWorker extends WorkerEntrypoint<Env> {
 			data?: {
 				content: string
 				flags?: number
+				embeds?: unknown[]
 			}
 		}
 		coreUserId: string | null

--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -18,8 +18,7 @@ import { buildCsvLine, createR2MultipartTextWriter, parseDateOrNull } from '@rep
 import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from '../db'
-import { managedCorporations, userCharacters } from '../db/schema'
-import { waitUntilWithTelemetry } from '../lib/background-task'
+import { discordServers, managedCorporations, userCharacters } from '../db/schema'
 import { isExportArtifactExpired } from '../lib/export-retention'
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import { normalizeWorkflowStatus } from '../lib/workflow-status'
@@ -2831,6 +2830,24 @@ srp.get('/config', async (c) => {
 	}
 
 	return c.json(config)
+})
+
+/**
+ * Get active Discord guilds available for SRP output configuration.
+ * GET /api/srp/config/discord-guilds
+ */
+srp.get('/config/discord-guilds', async (c) => {
+	const user = c.get('user')!
+	const canManage = await hasSrpTierPermission(c.env, user.id, 'manager', user.is_admin)
+	if (!canManage) return c.json({ error: 'Requires manager-or-higher permissions' }, 403)
+
+	const db = createDb(c.env.DATABASE_URL)
+	const rows = await db
+		.select({ id: discordServers.id, guildId: discordServers.guildId, guildName: discordServers.guildName })
+		.from(discordServers)
+		.where(eq(discordServers.isActive, true))
+		.orderBy(asc(discordServers.guildName))
+	return c.json(rows)
 })
 
 /**

--- a/apps/core/src/services/discord-commands.service.ts
+++ b/apps/core/src/services/discord-commands.service.ts
@@ -15,7 +15,7 @@ import {
 	registerDiscordCommand,
 } from './discord-command-registry.service'
 
-import type { Discord, DiscordSlashCommandDefinition } from '@repo/discord'
+import type { Discord, DiscordEmbed, DiscordSlashCommandDefinition } from '@repo/discord'
 import type { Env } from '../context'
 import type { createDb } from '../db'
 import type { DiscordCommandOptionAlias } from './discord-command-registry.service'
@@ -48,6 +48,7 @@ export interface DiscordInteractionResponse {
 	data?: {
 		content: string
 		flags?: number
+		embeds?: DiscordEmbed[]
 	}
 }
 
@@ -91,7 +92,10 @@ export interface ExecuteDiscordSlashCommandResult {
 		| 'execution-failed'
 }
 
-export type CommandEnv = Pick<Env, 'GROUPS' | 'DISCORD' | 'PREDICTION_MARKETS'>
+export type CommandEnv = Pick<
+	Env,
+	'GROUPS' | 'DISCORD' | 'PREDICTION_MARKETS' | 'BROADCASTS' | 'FLEETS' | 'SRP' | 'DOCTRINES'
+>
 
 function normalizeCommandName(name: string): string {
 	return name.trim().toLowerCase()

--- a/apps/core/src/services/discord-programmatic-commands/__tests__/srpfleet.test.ts
+++ b/apps/core/src/services/discord-programmatic-commands/__tests__/srpfleet.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SRPFLEET_PROGRAMMATIC_COMMAND } from '../srpfleet'
+
+import type { DiscordEmbed } from '@repo/discord'
+import type { ProgrammaticCommandContext, ProgrammaticCommandEnv } from '../types'
+
+const hoisted = vi.hoisted(() => ({
+	getConfig: vi.fn(),
+	getSrpFleetBroadcastByToken: vi.fn(),
+	getSrpFleetSessionDetails: vi.fn(),
+	getDoctrineName: vi.fn(),
+	getRequestEligibilityData: vi.fn(),
+	wasSessionMemberAt: vi.fn(),
+	sendMessage: vi.fn(),
+	getCachedUserPermissions: vi.fn(),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: vi.fn(() => ({
+		getConfig: hoisted.getConfig,
+		getSrpFleetBroadcastByToken: hoisted.getSrpFleetBroadcastByToken,
+		getSrpFleetSessionDetails: hoisted.getSrpFleetSessionDetails,
+		getDoctrineName: hoisted.getDoctrineName,
+		getRequestEligibilityData: hoisted.getRequestEligibilityData,
+		wasSessionMemberAt: hoisted.wasSessionMemberAt,
+		sendMessage: hoisted.sendMessage,
+	})),
+}))
+
+vi.mock('../../../lib/groups-cache', () => ({
+	getCachedUserPermissions: hoisted.getCachedUserPermissions,
+}))
+
+function ctx(overrides: Partial<ProgrammaticCommandContext> = {}): ProgrammaticCommandContext {
+	return {
+		optionValues: { token: 'FleetToken', killmail_id: '12345' },
+		coreUserId: 'user-1',
+		isAdmin: false,
+		env: {
+			GROUPS: {},
+			DISCORD: {},
+			PREDICTION_MARKETS: {},
+			BROADCASTS: {},
+			FLEETS: {},
+			SRP: {},
+		} as unknown as ProgrammaticCommandEnv,
+		input: {
+			commandName: 'srpfleet',
+			discordUserId: 'discord-1',
+			guildId: 'guild-1',
+			channelId: 'channel-1',
+		},
+		interactionId: 'interaction-1',
+		...overrides,
+	}
+}
+
+describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		hoisted.getConfig.mockResolvedValue({
+			srpDiscordGuildId: 'guild-1',
+			srpDiscordChannelId: 'channel-1',
+		})
+		hoisted.getSrpFleetBroadcastByToken.mockResolvedValue({
+			fleetSessionId: 'session-1',
+			doctrineId: null,
+			srpToken: 'FleetToken',
+			content: {
+				fleetName: 'Standing Fleet',
+				doctrine: 'Armor HAC',
+			},
+		})
+		hoisted.getSrpFleetSessionDetails.mockResolvedValue({
+			sessionId: 'session-1',
+			sessionName: 'Tracking Session',
+			fleetId: 'fleet-1',
+			status: 'ended',
+			startedAt: '2026-01-01T10:00:00.000Z',
+			endedAt: '2026-01-01T12:00:00.000Z',
+			commanderCharacterIds: ['100', '200'],
+			commanderCharacterNames: { '100': 'Initial FC', '200': 'Final FC' },
+			motd: '<font size="14">Comms<br><b>Standing</b></font>',
+		})
+		hoisted.getRequestEligibilityData.mockResolvedValue({
+			requestId: '12345',
+			victimCharacterId: '300',
+			victimCharacterName: 'Victim Pilot',
+			lossDate: '2026-01-01T11:00:00.000Z',
+		})
+		hoisted.wasSessionMemberAt.mockResolvedValue(true)
+		hoisted.getCachedUserPermissions.mockResolvedValue([{ urn: 'urn:srp:reviewer' }])
+		hoisted.sendMessage.mockResolvedValue({ success: true, messageId: 'message-1' })
+	})
+
+	it('defers ephemerally and declares the Killmail ID option', () => {
+		expect(SRPFLEET_PROGRAMMATIC_COMMAND.deferral).toBe('defer-ephemeral')
+		expect(SRPFLEET_PROGRAMMATIC_COMMAND.options?.map((option) => option.name)).toEqual([
+			'token',
+			'killmail_id',
+		])
+	})
+
+	it('returns the fleet embed and point-in-time eligibility result', async () => {
+		const result = await SRPFLEET_PROGRAMMATIC_COMMAND.handler(ctx())
+
+		expect(result.data?.content).toContain('posted')
+		const embed = hoisted.sendMessage.mock.calls[0]?.[2]?.embeds?.[0] as DiscordEmbed | undefined
+		expect(embed?.title).toContain('Standing Fleet')
+		expect(embed?.fields?.find((field) => field.name === 'MOTD')?.value).toContain('Comms\nStanding')
+		expect(embed?.fields?.find((field) => field.name === 'SRP Token')?.value).toBe('FleetToken')
+		expect(embed?.fields?.find((field) => field.name === 'Eligibility Check')?.value).toContain(
+			'Member of fleet at loss: Yes'
+		)
+		expect(hoisted.wasSessionMemberAt).toHaveBeenCalledWith(
+		'session-1',
+		'300',
+		'2026-01-01T11:00:00.000Z'
+	)
+	})
+
+	it('rejects an invocation from the wrong channel before looking up the token', async () => {
+		const result = await SRPFLEET_PROGRAMMATIC_COMMAND.handler(
+			ctx({ input: { ...ctx().input, channelId: 'other-channel' } })
+		)
+
+		expect(result.data?.content).toContain('configured SRP channel')
+		expect(hoisted.getSrpFleetBroadcastByToken).not.toHaveBeenCalled()
+		expect(hoisted.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it('allows site admins without SRP permission URNs', async () => {
+		hoisted.getCachedUserPermissions.mockResolvedValue([])
+		const result = await SRPFLEET_PROGRAMMATIC_COMMAND.handler(ctx({ isAdmin: true }))
+
+		expect(result.data?.content).toContain('posted')
+		expect(hoisted.sendMessage).toHaveBeenCalledTimes(1)
+	})
+
+	it('resolves the linked doctrine name without loading doctrine fittings', async () => {
+		hoisted.getSrpFleetBroadcastByToken.mockResolvedValue({
+			fleetSessionId: 'session-1',
+			doctrineId: 'doctrine-1',
+			srpToken: 'FleetToken',
+			content: { fleetName: 'Standing Fleet' },
+		})
+		hoisted.getDoctrineName.mockResolvedValue('Armor HAC')
+
+		await SRPFLEET_PROGRAMMATIC_COMMAND.handler(ctx())
+
+		expect(hoisted.getDoctrineName).toHaveBeenCalledWith('doctrine-1')
+		const embed = hoisted.sendMessage.mock.calls[0]?.[2]?.embeds?.[0] as DiscordEmbed | undefined
+		expect(embed?.fields?.find((field) => field.name === 'Doctrine')?.value).toBe('Armor HAC')
+	})
+})

--- a/apps/core/src/services/discord-programmatic-commands/index.ts
+++ b/apps/core/src/services/discord-programmatic-commands/index.ts
@@ -2,6 +2,7 @@ import { EVETIME_PROGRAMMATIC_COMMAND } from './evetime'
 import { HOW_PROGRAMMATIC_COMMAND } from './how'
 import { MARKET_PROGRAMMATIC_COMMAND } from './market'
 import { PING_SLOW_PROGRAMMATIC_COMMAND } from './ping-slow'
+import { SRPFLEET_PROGRAMMATIC_COMMAND } from './srpfleet'
 
 import type { ProgrammaticCommandDefinition } from './types'
 
@@ -9,6 +10,7 @@ export { EVETIME_PROGRAMMATIC_COMMAND } from './evetime'
 export { HOW_PROGRAMMATIC_COMMAND } from './how'
 export { MARKET_PROGRAMMATIC_COMMAND } from './market'
 export { PING_SLOW_PROGRAMMATIC_COMMAND } from './ping-slow'
+export { SRPFLEET_PROGRAMMATIC_COMMAND } from './srpfleet'
 export type { DeferralMode, ProgrammaticCommandDefinition } from './types'
 
 export const PROGRAMMATIC_COMMAND_DEFINITIONS: ProgrammaticCommandDefinition[] = [
@@ -16,6 +18,7 @@ export const PROGRAMMATIC_COMMAND_DEFINITIONS: ProgrammaticCommandDefinition[] =
 	HOW_PROGRAMMATIC_COMMAND,
 	MARKET_PROGRAMMATIC_COMMAND,
 	PING_SLOW_PROGRAMMATIC_COMMAND,
+	SRPFLEET_PROGRAMMATIC_COMMAND,
 ]
 
 export const programmaticCommandDefinitionByName = new Map(

--- a/apps/core/src/services/discord-programmatic-commands/srpfleet.ts
+++ b/apps/core/src/services/discord-programmatic-commands/srpfleet.ts
@@ -1,0 +1,190 @@
+import { DISCORD_SLASH_COMMAND_OPTION_TYPE } from '@repo/discord'
+import { getStub } from '@repo/do-utils'
+
+import { getCachedUserPermissions } from '../../lib/groups-cache'
+import { ephemeralCommandResponse } from './types'
+import { parseDateOrNull } from '@repo/worker-utils'
+
+import type { Broadcasts } from '@repo/broadcasts'
+import type { Discord, DiscordEmbed } from '@repo/discord'
+import type { Doctrines } from '@repo/doctrines'
+import type { Fleets } from '@repo/fleets'
+import type { Srp } from '@repo/srp'
+import type { ProgrammaticCommandDefinition, ProgrammaticCommandResponse } from './types'
+
+const SRP_STAFF_URNS = new Set(['urn:srp:reviewer', 'urn:srp:payer', 'urn:srp:manager'])
+const MAX_EMBED_FIELD_LENGTH = 1024
+
+function textValue(value: unknown): string | null {
+	if (typeof value === 'string' && value.trim()) return value.trim()
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	if (value && typeof value === 'object') {
+		const candidate = value as Record<string, unknown>
+		for (const key of ['name', 'label', 'value', 'text', 'custom']) {
+			const text = textValue(candidate[key])
+			if (text) return text
+		}
+	}
+	return null
+}
+
+function truncate(value: string, max = MAX_EMBED_FIELD_LENGTH): string {
+	return value.length <= max ? value : `${value.slice(0, max - 1).trimEnd()}…`
+}
+
+function sanitizeMotd(value: string | null): string {
+	if (!value) return 'Unavailable'
+	return truncate(
+		value
+			.replace(/<br\s*\/?>/gi, '\n')
+			.replace(/<[^>]*>/g, '')
+			.replace(/\n{3,}/g, '\n\n')
+			.trim() || 'Unavailable'
+	)
+}
+
+function discordTimestamp(value: string | null, fallback: string): string {
+	if (!value) return fallback
+	const timestamp = parseDateOrNull(value)?.getTime()
+	if (timestamp === undefined || timestamp === null || !Number.isFinite(timestamp)) return fallback
+	return `<t:${Math.floor(timestamp / 1000)}:f>`
+}
+
+function buildComparisonError(message: string): string {
+	return `Eligibility comparison unavailable: ${message}`
+}
+
+export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
+	name: 'srpfleet',
+	description: 'Show SRP fleet details for a fleet broadcast token.',
+	deferral: 'defer-ephemeral',
+	options: [
+		{
+			type: DISCORD_SLASH_COMMAND_OPTION_TYPE.STRING,
+			name: 'token',
+			description: 'SRP token from the fleet broadcast.',
+			required: true,
+			min_length: 1,
+			max_length: 255,
+		},
+		{
+			type: DISCORD_SLASH_COMMAND_OPTION_TYPE.STRING,
+			name: 'killmail_id',
+			description: 'Killmail ID for an optional SRP eligibility check.',
+			required: false,
+			max_length: 32,
+		},
+	],
+	handler: async ({ optionValues, coreUserId, isAdmin, env, input }) => {
+		if (!isAdmin) {
+			const permissions = await getCachedUserPermissions(env, coreUserId)
+			if (!permissions.some((permission) => SRP_STAFF_URNS.has(permission.urn))) {
+				return ephemeralCommandResponse('You need SRP reviewer, payer, or manager permissions to use this command.')
+			}
+		}
+
+		const srp = getStub<Srp>(env.SRP, 'default')
+		const config = await srp.getConfig()
+		const configuredGuildId = config?.srpDiscordGuildId?.trim()
+		const configuredChannelId = config?.srpDiscordChannelId?.trim()
+		if (!configuredGuildId || !configuredChannelId) {
+			return ephemeralCommandResponse('The SRP Discord channel is not configured.')
+		}
+		if (input.guildId !== configuredGuildId || input.channelId !== configuredChannelId) {
+			return ephemeralCommandResponse('This command can only be used in the configured SRP channel.')
+		}
+
+		const token = optionValues.token?.trim()
+		if (!token) return ephemeralCommandResponse('An SRP broadcast token is required.')
+
+		const broadcasts = getStub<Broadcasts>(env.BROADCASTS, 'default')
+		const broadcast = await broadcasts.getSrpFleetBroadcastByToken(token)
+		if (!broadcast?.fleetSessionId) {
+			return ephemeralCommandResponse('No fleet session was found for that SRP token.')
+		}
+
+		const fleets = getStub<Fleets>(env.FLEETS, 'default')
+		const details = await fleets.getSrpFleetSessionDetails(broadcast.fleetSessionId)
+		if (!details) return ephemeralCommandResponse('The fleet session could not be found.')
+
+		const content = broadcast.content ?? {}
+		const fleetName = textValue(content.fleetName) ?? textValue(content.fleet_name) ?? details.sessionName
+		let doctrine = textValue(content.doctrine) ?? textValue(content.doctrineName)
+		if (!doctrine && broadcast.doctrineId) {
+			try {
+				const doctrines = getStub<Doctrines>(env.DOCTRINES, 'default')
+				doctrine = await doctrines.getDoctrineName(broadcast.doctrineId)
+			} catch {
+				// Doctrine lookup is best effort; the fleet result remains useful without it.
+			}
+		}
+		doctrine ??= 'Unavailable'
+		const commanders = details.commanderCharacterIds.map((id, index) => {
+			const name = details.commanderCharacterNames[id] ?? id
+			const label = index === 0 ? 'Initial Commander' : index === details.commanderCharacterIds.length - 1 ? 'Final Commander' : 'Commander Handoff'
+			return `${label}: ${name}`
+		})
+
+		const comparisonId = optionValues.killmail_id?.trim()
+		let comparison: string | null = null
+		if (comparisonId) {
+			try {
+				if (!/^\d+$/.test(comparisonId)) {
+					comparison = buildComparisonError('Killmail ID must be numeric.')
+				} else {
+					const request = await srp.getRequestEligibilityData(comparisonId)
+					if (!request) {
+						comparison = buildComparisonError(`no SRP request was found for Killmail ID ${comparisonId}.`)
+					} else {
+						const memberAtLoss = await fleets.wasSessionMemberAt(
+							details.sessionId,
+							request.victimCharacterId,
+							request.lossDate
+						)
+						comparison = [
+							`Killmail ID: ${comparisonId}`,
+							`Victim: ${request.victimCharacterName}`,
+							`Loss time: ${discordTimestamp(request.lossDate, request.lossDate)}`,
+							`Member of fleet at loss: ${memberAtLoss ? 'Yes' : 'No'}`,
+						].join('\n')
+					}
+				}
+			} catch {
+				comparison = buildComparisonError('the request or fleet membership data could not be read.')
+			}
+		}
+
+		const fields: NonNullable<DiscordEmbed['fields']> = [
+			{ name: 'Fleet Commander(s)', value: truncate(commanders.join('\n') || 'Unavailable') },
+			{ name: 'Doctrine', value: truncate(doctrine) },
+			{ name: 'MOTD', value: sanitizeMotd(details.motd) },
+			{ name: 'SRP Token', value: truncate(token) },
+			{
+				name: 'Fleet Period',
+				value: `${discordTimestamp(details.startedAt, 'Unknown start')} - ${discordTimestamp(details.endedAt, 'Ongoing')}`,
+			},
+		]
+		if (comparison) {
+			fields.push({
+				name: 'Eligibility Check',
+				value: truncate(comparison),
+			})
+		}
+
+		const embed: DiscordEmbed = {
+			title: `SRP Fleet Details: ${truncate(fleetName, 200)}`,
+			fields,
+			color: 0x2f80ed,
+		}
+		const discord = getStub<Discord>(env.DISCORD, 'default')
+		const sent = await discord.sendMessage(configuredGuildId, configuredChannelId, {
+			content: '\u200b',
+			embeds: [embed],
+			allowEveryone: false,
+		})
+		if (!sent.success) {
+			return ephemeralCommandResponse('The fleet details could not be posted to the configured SRP channel.')
+		}
+		return ephemeralCommandResponse('Fleet details posted to the configured SRP channel.')
+	},
+}

--- a/apps/core/src/services/discord-programmatic-commands/types.ts
+++ b/apps/core/src/services/discord-programmatic-commands/types.ts
@@ -1,4 +1,4 @@
-import type { DiscordSlashCommandDefinition } from '@repo/discord'
+import type { DiscordEmbed, DiscordSlashCommandDefinition } from '@repo/discord'
 import type { Env } from '../../context'
 import type { ExecuteDiscordSlashCommandInput } from '../discord-commands.service'
 import type { DiscordCommandOptionAlias } from '../discord-command-registry.service'
@@ -8,6 +8,7 @@ export interface ProgrammaticCommandResponse {
 	data?: {
 		content: string
 		flags?: number
+		embeds?: DiscordEmbed[]
 	}
 }
 
@@ -22,7 +23,10 @@ export interface ProgrammaticCommandResponse {
 export type DeferralMode = 'sync' | 'defer-public' | 'defer-ephemeral'
 
 /** Subset of bindings a programmatic handler may use. Extend as new command surfaces need more. */
-export type ProgrammaticCommandEnv = Pick<Env, 'GROUPS' | 'DISCORD' | 'PREDICTION_MARKETS'>
+export type ProgrammaticCommandEnv = Pick<
+	Env,
+	'GROUPS' | 'DISCORD' | 'PREDICTION_MARKETS' | 'BROADCASTS' | 'FLEETS' | 'SRP' | 'DOCTRINES'
+>
 
 export interface ProgrammaticCommandContext {
 	optionValues: Record<string, string>

--- a/apps/discord/eslint.config.ts
+++ b/apps/discord/eslint.config.ts
@@ -1,7 +1,5 @@
-import { defineConfig } from '@repo/eslint-config'
+import { defineConfig, getConfig } from '@repo/eslint-config'
 
-export default defineConfig({
-	typescript: {
-		project: './tsconfig.json',
-	},
-})
+const config = getConfig(import.meta.url)
+
+export default defineConfig([config])

--- a/apps/discord/src/context.ts
+++ b/apps/discord/src/context.ts
@@ -62,9 +62,10 @@ export type Env = SharedHonoEnv & {
 			ok: boolean
 			response: {
 				type: number
-				data?: {
+			data?: {
 					content: string
 					flags?: number
+					embeds?: unknown[]
 				}
 			}
 			coreUserId: string | null

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -9,7 +9,7 @@ import { DiscordDO, DiscordGatewayDO } from './durable-object'
 import * as discordService from './services/discord.service'
 import { resolveDeferralMode, resolveSubcommandKey } from './utils/interaction-routing'
 
-import type { Discord } from '@repo/discord'
+import type { Discord, DiscordEmbed } from '@repo/discord'
 import type { App, DiscordInteractionOption, DiscordInteractionRouting } from './context'
 
 const DISCORD_INTERACTION_PING = 1
@@ -130,7 +130,10 @@ async function runDeferredCommand(
 		// Zero-width space fallback: Discord rejects empty content on an edit.
 		const content = execution.response.data?.content ?? '​'
 		const stub = getStub<Discord>(env.DISCORD, 'default')
-		const result = await stub.editOriginalInteractionResponse(ctx.token, { content })
+		const result = await stub.editOriginalInteractionResponse(ctx.token, {
+			content,
+			embeds: execution.response.data?.embeds as DiscordEmbed[] | undefined,
+		})
 
 		if (!result.success) {
 			logger.error('[DiscordInteractions] Failed to deliver deferred response', {
@@ -726,7 +729,7 @@ const app = new Hono<App>()
 
 const sentryApp = withSentry(app)
 
-async function scheduled(event: ScheduledEvent, env: App['Bindings'], _ctx: ExecutionContext): Promise<void> {
+	async function scheduled(event: ScheduledEvent, _env: App['Bindings'], _ctx: ExecutionContext): Promise<void> {
 	// Intentionally stubbed: the Discord gateway listener has been disabled because
 	// the always-on websocket bootstrap caused unacceptable hosting cost inflation.
 	// We keep the scheduled entrypoint and gateway DO stub in place so the feature can

--- a/apps/doctrines/eslint.config.ts
+++ b/apps/doctrines/eslint.config.ts
@@ -1,7 +1,5 @@
-import { defineConfig } from '@repo/eslint-config'
+import { defineConfig, getConfig } from '@repo/eslint-config'
 
-export default defineConfig({
-	typescript: {
-		project: './tsconfig.json',
-	},
-})
+const config = getConfig(import.meta.url)
+
+export default defineConfig([config])

--- a/apps/doctrines/src/durable-object.ts
+++ b/apps/doctrines/src/durable-object.ts
@@ -273,6 +273,15 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 		}
 	}
 
+	async getDoctrineName(id: string): Promise<string | null> {
+		const [doctrine] = await this.db
+			.select({ name: schema.doctrinesDoctrines.name })
+			.from(schema.doctrinesDoctrines)
+			.where(and(eq(schema.doctrinesDoctrines.id, id), isNull(schema.doctrinesDoctrines.deletedAt)))
+			.limit(1)
+		return doctrine?.name ?? null
+	}
+
 	async updateDoctrine(id: string, data: UpdateDoctrineRequest & { updatedBy?: string }): Promise<Doctrine> {
 		const updates: Partial<typeof schema.doctrinesDoctrines.$inferInsert> = {
 			updatedAt: new Date(),

--- a/apps/fleets/eslint.config.ts
+++ b/apps/fleets/eslint.config.ts
@@ -1,7 +1,5 @@
-import { defineConfig } from '@repo/eslint-config'
+import { defineConfig, getConfig } from '@repo/eslint-config'
 
-export default defineConfig({
-	typescript: {
-		project: './tsconfig.json',
-	},
-})
+const config = getConfig(import.meta.url)
+
+export default defineConfig([config])

--- a/apps/fleets/package.json
+++ b/apps/fleets/package.json
@@ -31,6 +31,7 @@
 		"@repo/hono-helpers": "workspace:*",
 		"@repo/tools": "workspace:*",
 		"@repo/universe": "workspace:*",
+		"@repo/worker-utils": "workspace:*",
 		"drizzle-orm": "0.44.7",
 		"hono": "4.10.6",
 		"workers-tagged-logger": "0.13.7",

--- a/apps/fleets/src/durable-object.ts
+++ b/apps/fleets/src/durable-object.ts
@@ -9,63 +9,34 @@ import {
 	gt,
 	gte,
 	inArray,
-	isNull,
 	isNotNull,
+	isNull,
 	lt,
 	lte,
 	or,
 	sql,
 } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import { assertEveCharacterId, createEveCharacterId } from '@repo/eve-types'
 import { buildEsiUserKey, EsiRateLimitGuard, EsiRateLimitStore } from '@repo/esi-rate-limit'
+import { createEveCharacterId } from '@repo/eve-types'
 import {
-	EsiGetCharacterFleetInformation,
 	esiGetCharacterFleetInformationSchema,
-	EsiGetFleetInformation,
 	esiGetFleetInformationSchema,
-	EsiGetFleetMembers,
 	esiGetFleetMembersSchema,
-	FleetDetailsResponse,
-	FleetInformation,
-	FleetJoinResult,
-	Fleets,
-	KickTrackingSessionMemberResult,
-	QuickJoinCreationResult,
-	QuickJoinInvitation,
-	QuickJoinValidationResult,
-	CharacterRecentSessionRow,
-	CharacterStatsResult,
-	CorpRollupRow,
-	SessionCurrentMemberRow,
-	SessionLiveMemberLocation,
-	SessionLiveSnapshotResult,
-	SessionMemberShipHistoryRow,
-	SessionRosterRow,
-	SessionSummary,
-	SessionCommanderEvent,
-	SessionTimelineResult,
-	SessionTimelineRow,
 	StartTrackingSessionError,
-	StartTrackingSessionResult,
-	StatsOverviewResult,
-	StatsRange,
-	TrackingSession,
-	TrackingSessionListFilter,
-	TrackingSessionListResult,
 } from '@repo/fleets'
 import { logger } from '@repo/hono-helpers'
+import { parseDateOrNull } from '@repo/worker-utils'
 
-import { Env } from './context'
 import {
-	fleetInvitations,
 	fleetCommanderAccessAnchors,
 	fleetCommanderEvents,
+	fleetInvitations,
 	fleetMemberHistory,
-	fleetMemberships,
 	fleetMemberShipEvents,
-	fleetTrackingSessionEvents,
+	fleetMemberships,
 	fleetSummaries,
+	fleetTrackingSessionEvents,
 	fleetTrackingSessions,
 	schema,
 } from './db/schema'
@@ -73,8 +44,41 @@ import {
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { EveCharacterId } from '@repo/eve-types'
-import type { FleetMonitor } from '@repo/fleets'
+import type {
+	CharacterRecentSessionRow,
+	CharacterStatsResult,
+	CorpRollupRow,
+	EsiGetCharacterFleetInformation,
+	EsiGetFleetInformation,
+	EsiGetFleetMembers,
+	FleetDetailsResponse,
+	FleetInformation,
+	FleetJoinResult,
+	FleetMonitor,
+	FleetMonitorState,
+	Fleets,
+	KickTrackingSessionMemberResult,
+	QuickJoinCreationResult,
+	QuickJoinValidationResult,
+	SessionCommanderEvent,
+	SessionCurrentMemberRow,
+	SessionLiveMemberLocation,
+	SessionLiveSnapshotResult,
+	SessionMemberShipHistoryRow,
+	SessionRosterRow,
+	SessionSummary,
+	SessionTimelineResult,
+	SessionTimelineRow,
+	SrpFleetSessionDetails,
+	StartTrackingSessionResult,
+	StatsOverviewResult,
+	StatsRange,
+	TrackingSession,
+	TrackingSessionListFilter,
+	TrackingSessionListResult,
+} from '@repo/fleets'
 import type { Universe } from '@repo/universe'
+import type { Env } from './context'
 
 const LIVE_FLEET_ESI_OPTIONS = { cacheMode: 'no-store' } as const
 
@@ -91,10 +95,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 	private db: ReturnType<typeof createDbClient<typeof schema>>
 	private readonly esiRateLimits: EsiRateLimitGuard
 
-	private formatFleetKickError(
-		response: Pick<Response, 'status'>,
-		details = ''
-	): string {
+	private formatFleetKickError(response: Pick<Response, 'status'>, details = ''): string {
 		let parsedDetails = details
 		if (parsedDetails) {
 			try {
@@ -171,7 +172,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 	private async getMonitorStateForFleet(
 		fleetId: string
-	): Promise<import('@repo/fleets').FleetMonitorState | null> {
+	): Promise<FleetMonitorState | null> {
 		try {
 			const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
 			const state = await monitorStub.getMonitorState()
@@ -188,9 +189,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 		}
 	}
 
-	private async getLatestCommanderBySessionIds(
-		sessionIds: string[]
-	): Promise<Map<string, string>> {
+	private async getLatestCommanderBySessionIds(sessionIds: string[]): Promise<Map<string, string>> {
 		if (sessionIds.length === 0) return new Map()
 
 		const rows = await this.db
@@ -212,12 +211,10 @@ export class FleetsDO extends DurableObject implements Fleets {
 		return latestBySession
 	}
 
-	private getEffectiveSessionStatus(
-		session: {
-			status: string
-			endedAt: Date | null
-		},
-	): TrackingSession['status'] {
+	private getEffectiveSessionStatus(session: {
+		status: string
+		endedAt: Date | null
+	}): TrackingSession['status'] {
 		return session.status === 'active' && session.endedAt === null ? 'active' : 'ended'
 	}
 
@@ -323,15 +320,14 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 
 		// Check fleet info to verify boss
-		let fleetData: EsiGetFleetInformation
 		try {
 			const fleetResponse = await tokenStore.fetchEsi<EsiGetFleetInformation>(
 				`/fleets/${fleetId}/`,
 				fleetBossId,
 				LIVE_FLEET_ESI_OPTIONS
 			)
-			fleetData = esiGetFleetInformationSchema.parse(fleetResponse.data)
-		} catch (error) {
+			esiGetFleetInformationSchema.parse(fleetResponse.data)
+		} catch {
 			throw new Error('Unable to verify fleet ownership')
 		}
 
@@ -340,18 +336,15 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const expiresAt = new Date(Date.now() + expiresInHours * 60 * 60 * 1000)
 
 		// Store in database
-		const [invitation] = await this.db
-			.insert(fleetInvitations)
-			.values({
-				token,
-				fleetBossId,
-				fleetId,
-				expiresAt,
-				maxUses: maxUses || null,
-				usesCount: 0,
-				isActive: true,
-			})
-			.returning()
+		await this.db.insert(fleetInvitations).values({
+			token,
+			fleetBossId,
+			fleetId,
+			expiresAt,
+			maxUses: maxUses || null,
+			usesCount: 0,
+			isActive: true,
+		})
 
 		return {
 			token,
@@ -415,7 +408,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				LIVE_FLEET_ESI_OPTIONS
 			)
 			fleetInfo = esiGetFleetInformationSchema.parse(fleetResponse.data)
-		} catch (error) {
+		} catch {
 			// Fleet info fetch failed, but invitation is valid
 			fleetInfo = undefined
 		}
@@ -467,17 +460,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 
-		let fleetInfo: EsiGetFleetInformation
-		try {
-			const fleetResponse = await tokenStore.fetchEsi<EsiGetFleetInformation>(
-				`/fleets/${fleetId}/`,
-				characterId,
-				LIVE_FLEET_ESI_OPTIONS
-			)
-			fleetInfo = esiGetFleetInformationSchema.parse(fleetResponse.data)
-		} catch (error) {
-			throw error
-		}
+		const fleetResponse = await tokenStore.fetchEsi<EsiGetFleetInformation>(
+			`/fleets/${fleetId}/`,
+			characterId,
+			LIVE_FLEET_ESI_OPTIONS
+		)
+		const fleetInfo: EsiGetFleetInformation = esiGetFleetInformationSchema.parse(fleetResponse.data)
 
 		let members: EsiGetFleetMembers | undefined
 		let memberCount = 0
@@ -615,10 +603,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				'[Fleet Join] First member station_id type:',
 				typeof membersResponse.data[0]?.station_id
 			)
-			logger.log(
-				'[Fleet Join] First member station_id value:',
-				membersResponse.data[0]?.station_id
-			)
+			logger.log('[Fleet Join] First member station_id value:', membersResponse.data[0]?.station_id)
 
 			const members = esiGetFleetMembersSchema.parse(membersResponse.data)
 
@@ -793,7 +778,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				LIVE_FLEET_ESI_OPTIONS
 			)
 			fleetInfo = esiGetFleetInformationSchema.parse(fleetResponse.data)
-		} catch (error) {
+		} catch {
 			fleetInfo = null
 		}
 
@@ -851,9 +836,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 		// 1. Pre-flight ESI
 		let fleetInfo: FleetInformation
 		try {
-			fleetInfo = await this.getCharacterFleetInformation(
-				createEveCharacterId(characterId)
-			)
+			fleetInfo = await this.getCharacterFleetInformation(createEveCharacterId(characterId))
 		} catch (error) {
 			logger.error('[FleetsDO startTrackingSession] ESI pre-flight failed', {
 				characterId,
@@ -926,9 +909,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 					eventType: 'resumed',
 					observedAt: now,
 				})
-				await this.db
-					.delete(fleetSummaries)
-					.where(eq(fleetSummaries.trackingSessionId, sessionId))
+				await this.db.delete(fleetSummaries).where(eq(fleetSummaries.trackingSessionId, sessionId))
 			}
 		} else {
 			if (action === 'new' && mostRecentStatus === 'active') {
@@ -963,10 +944,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 
 		// 4. Spawn the FleetMonitor DO and initialize it
 		try {
-			const fleetMonitorStub = getStub<FleetMonitor>(
-				this.env.FLEET_MONITOR,
-				`fleet-${fleetId}`
-			)
+			const fleetMonitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
 			await fleetMonitorStub.initializeMonitoring(fleetId, characterId, sessionId, {
 				force: true,
 				previousFleetBossCharacterId,
@@ -1061,11 +1039,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 	/**
 	 * List tracking sessions, filterable.
 	 */
-	async listTrackingSessions(filter: TrackingSessionListFilter): Promise<TrackingSessionListResult> {
+	async listTrackingSessions(
+		filter: TrackingSessionListFilter
+	): Promise<TrackingSessionListResult> {
 		const limit = Math.min(Math.max(filter.limit ?? 50, 1), 200)
 		const offset = Math.max(filter.offset ?? 0, 0)
-		const fleetBossCharacterIds =
-			filter.fleetBossCharacterIds ?? filter.commanderCharacterIds ?? []
+		const fleetBossCharacterIds = filter.fleetBossCharacterIds ?? filter.commanderCharacterIds ?? []
 
 		const conditions = []
 		const activeSessionCondition = and(
@@ -1129,7 +1108,9 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.from(fleetTrackingSessions)
 			.where(where)
 		const total = totalResult[0]?.count ?? 0
-		const commanderMap = await this.getLatestCommanderBySessionIds(items.map((row) => row.session.id))
+		const commanderMap = await this.getLatestCommanderBySessionIds(
+			items.map((row) => row.session.id)
+		)
 
 		return {
 			items: items.map((row) =>
@@ -1266,7 +1247,10 @@ export class FleetsDO extends DurableObject implements Fleets {
 				snapshot: null,
 			}
 		}
-		if (this.getEffectiveSessionStatus({ status: session.status, endedAt: session.endedAt }) !== 'active') {
+		if (
+			this.getEffectiveSessionStatus({ status: session.status, endedAt: session.endedAt }) !==
+			'active'
+		) {
 			return {
 				state: 'inactive',
 				message: 'This fleet tracking session is no longer active.',
@@ -1385,7 +1369,8 @@ export class FleetsDO extends DurableObject implements Fleets {
 		if (args.characterId) {
 			histConditions.push(eq(fleetMemberHistory.characterId, args.characterId))
 		}
-		const wantHistEvents = !args.eventType || args.eventType === 'join' || args.eventType === 'leave'
+		const wantHistEvents =
+			!args.eventType || args.eventType === 'join' || args.eventType === 'leave'
 		if (args.eventType === 'join' || args.eventType === 'leave') {
 			histConditions.push(eq(fleetMemberHistory.eventType, args.eventType))
 		}
@@ -1504,7 +1489,9 @@ export class FleetsDO extends DurableObject implements Fleets {
 			id: `boss-${row.id}`,
 			characterId: row.commanderCharacterId,
 			eventType:
-				row.eventType === 'initial' ? ('fleet_boss_initial' as const) : ('fleet_boss_change' as const),
+				row.eventType === 'initial'
+					? ('fleet_boss_initial' as const)
+					: ('fleet_boss_change' as const),
 			shipTypeId: 0,
 			shipTypeName: null,
 			previousShipTypeId: null,
@@ -1559,9 +1546,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 			characterName: row.characterName,
 			eventTimestamp: row.eventTimestamp.toISOString(),
 		}))
-		const merged = [...historyItems, ...lifecycleItems, ...bossChangeItems, ...shipChangeItems].sort((a, b) =>
-			b.eventTimestamp.localeCompare(a.eventTimestamp)
-		)
+		const merged = [
+			...historyItems,
+			...lifecycleItems,
+			...bossChangeItems,
+			...shipChangeItems,
+		].sort((a, b) => b.eventTimestamp.localeCompare(a.eventTimestamp))
 		const total = merged.length
 		const items = merged.slice(offset, offset + limit)
 
@@ -1616,9 +1606,9 @@ export class FleetsDO extends DurableObject implements Fleets {
 		}))
 	}
 
-	private async getFleetBossAttributionBySession(range: StatsRange): Promise<
-		Map<string, Map<string, { minutes: number; hasActiveTime: boolean }>>
-	> {
+	private async getFleetBossAttributionBySession(
+		range: StatsRange
+	): Promise<Map<string, Map<string, { minutes: number; hasActiveTime: boolean }>>> {
 		const from = new Date(range.from)
 		const to = new Date(range.to)
 
@@ -1754,11 +1744,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				if (eventTime > windowEnd) break
 
 				if (active && eventTime > windowStart) {
-					addMinutes(
-						sessionMap,
-						currentBossId,
-						eventTime - Math.max(cursor, windowStart)
-					)
+					addMinutes(sessionMap, currentBossId, eventTime - Math.max(cursor, windowStart))
 				}
 
 				cursor = eventTime
@@ -1797,6 +1783,92 @@ export class FleetsDO extends DurableObject implements Fleets {
 			finalMemberCount: row.finalMemberCount,
 			motd: row.motd,
 		}
+	}
+
+	/** Minimal read projection for SRP staff tooling. */
+	async getSrpFleetSessionDetails(sessionId: string): Promise<SrpFleetSessionDetails | null> {
+		const session = await this.getTrackingSession(sessionId)
+		if (!session) return null
+
+		const [commanderEvents, summary, liveSnapshot] = await Promise.all([
+			this.getSessionCommanderHistory(sessionId),
+			session.status === 'ended'
+				? this.getSessionSummary(sessionId).catch(() => null)
+				: Promise.resolve(null),
+			session.status === 'active'
+				? this.getSessionLiveSnapshot(sessionId).catch(() => null)
+				: Promise.resolve(null),
+		])
+
+		const commanderCharacterIds = Array.from(
+			new Set(
+				[
+					session.characterId,
+					...commanderEvents.flatMap((event) => [
+						event.previousCommanderCharacterId,
+						event.commanderCharacterId,
+					]),
+				].filter((id): id is string => Boolean(id))
+			)
+		)
+		let commanderCharacterNames: Record<string, string> = {}
+		try {
+			const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
+			commanderCharacterNames = await tokenStore.resolveIds(commanderCharacterIds)
+		} catch (error) {
+			logger.warn('[FleetsDO] Failed to resolve SRP commander names', {
+				sessionId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+
+		return {
+			sessionId: session.id,
+			sessionName: session.name,
+			fleetId: session.fleetId,
+			status: session.status,
+			startedAt: session.startedAt,
+			endedAt: session.endedAt,
+			commanderCharacterIds,
+			commanderCharacterNames,
+			motd: summary?.motd ?? liveSnapshot?.snapshot?.motd ?? null,
+		}
+	}
+
+	async wasSessionMemberAt(
+		sessionId: string,
+		characterId: string,
+		occurredAt: string
+	): Promise<boolean> {
+		const occurred = parseDateOrNull(occurredAt)
+		if (!occurred) return false
+
+		const [session] = await this.db
+			.select({
+				fleetId: fleetTrackingSessions.fleetId,
+				startedAt: fleetTrackingSessions.startedAt,
+				endedAt: fleetTrackingSessions.endedAt,
+			})
+			.from(fleetTrackingSessions)
+			.where(eq(fleetTrackingSessions.id, sessionId))
+			.limit(1)
+		if (!session || !session.fleetId) return false
+		if (occurred < session.startedAt || (session.endedAt && occurred > session.endedAt))
+			return false
+
+		const [membership] = await this.db
+			.select({ id: fleetMemberShipEvents.id })
+			.from(fleetMemberShipEvents)
+			.where(
+				and(
+					eq(fleetMemberShipEvents.trackingSessionId, sessionId),
+					eq(fleetMemberShipEvents.characterId, characterId),
+					lte(fleetMemberShipEvents.startedAt, occurred),
+					or(isNull(fleetMemberShipEvents.endedAt), gte(fleetMemberShipEvents.endedAt, occurred))
+				)
+			)
+			.limit(1)
+		return Boolean(membership)
 	}
 
 	/**
@@ -1863,10 +1935,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 		}
 
 		try {
-			const monitorStub = getStub<FleetMonitor>(
-				this.env.FLEET_MONITOR,
-				`fleet-${session.fleetId}`
-			)
+			const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${session.fleetId}`)
 			const status = await monitorStub.getFleetStatus()
 			if (!status?.members?.length) {
 				return []
@@ -1883,7 +1952,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				stationId: member.station_id ?? null,
 				stationName:
 					member.station_id !== null && member.station_id !== undefined
-						? stationNames[String(member.station_id)] ?? null
+						? (stationNames[String(member.station_id)] ?? null)
 						: null,
 				updatedAt,
 			}))
@@ -1954,7 +2023,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 			// For open segments (endedAt null), use session end if session has ended, else now.
 			let totalMs = 0
 			for (const seg of segments) {
-				const segEnd = seg.endedAt ? seg.endedAt.getTime() : sessionEndedMs ?? now.getTime()
+				const segEnd = seg.endedAt ? seg.endedAt.getTime() : (sessionEndedMs ?? now.getTime())
 				const segDur = segEnd - seg.startedAt.getTime()
 				if (segDur > 0) totalMs += segDur
 			}
@@ -2086,8 +2155,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 					method: 'DELETE',
 					accessToken,
 					parse: async () => undefined,
-					buildError: ({ response, body }) =>
-						new Error(this.formatFleetKickError(response, body)),
+					buildError: ({ response, body }) => new Error(this.formatFleetKickError(response, body)),
 				})
 
 				results.push({ characterId: memberCharacterId, success: true })
@@ -2133,9 +2201,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				totalMinutes: sql<number>`coalesce(sum(${fleetSummaries.durationMinutes}), 0)::int`,
 			})
 			.from(fleetSummaries)
-			.where(
-				and(gte(fleetSummaries.startedAt, from), lt(fleetSummaries.startedAt, to))
-			)
+			.where(and(gte(fleetSummaries.startedAt, from), lt(fleetSummaries.startedAt, to)))
 
 		// Active (still running) sessions started in the window — include their
 		// session count but their durations aren't in fleet_summaries yet.
@@ -2161,10 +2227,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 			})
 			.from(fleetMemberHistory)
 			.where(
-				and(
-					gte(fleetMemberHistory.eventTimestamp, from),
-					lt(fleetMemberHistory.eventTimestamp, to)
-				)
+				and(gte(fleetMemberHistory.eventTimestamp, from), lt(fleetMemberHistory.eventTimestamp, to))
 			)
 
 		const bossAttributionBySession = await this.getFleetBossAttributionBySession(range)
@@ -2208,7 +2271,11 @@ export class FleetsDO extends DurableObject implements Fleets {
 				)
 			)
 			.groupBy(fleetMemberShipEvents.characterId)
-			.orderBy(desc(sql`sum(extract(epoch from least(coalesce(${fleetMemberShipEvents.endedAt}, ${to.toISOString()}::timestamp), ${to.toISOString()}::timestamp) - greatest(${fleetMemberShipEvents.startedAt}, ${from.toISOString()}::timestamp)))`))
+			.orderBy(
+				desc(
+					sql`sum(extract(epoch from least(coalesce(${fleetMemberShipEvents.endedAt}, ${to.toISOString()}::timestamp), ${to.toISOString()}::timestamp) - greatest(${fleetMemberShipEvents.startedAt}, ${from.toISOString()}::timestamp)))`
+				)
+			)
 			.limit(10)
 
 		// Top ships by total clamped time in window. Includes any ship-event that
@@ -2257,10 +2324,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 			})
 			.from(fleetTrackingSessions)
 			.where(
-				and(
-					gte(fleetTrackingSessions.startedAt, from),
-					lt(fleetTrackingSessions.startedAt, to)
-				)
+				and(gte(fleetTrackingSessions.startedAt, from), lt(fleetTrackingSessions.startedAt, to))
 			)
 			.groupBy(sql`to_char(${fleetTrackingSessions.startedAt}, 'YYYY-MM-DD')`)
 			.orderBy(sql`to_char(${fleetTrackingSessions.startedAt}, 'YYYY-MM-DD')`)
@@ -2479,11 +2543,10 @@ export class FleetsDO extends DurableObject implements Fleets {
 		for (const [sessionId, sessionMap] of bossAttributionBySession.entries()) {
 			for (const [bossCharacterId, stats] of sessionMap.entries()) {
 				if (!stats.hasActiveTime) continue
-				const entry =
-					bossAggregates.get(bossCharacterId) ?? {
-						minutesAsFC: 0,
-						sessionIds: new Set<string>(),
-					}
+				const entry = bossAggregates.get(bossCharacterId) ?? {
+					minutesAsFC: 0,
+					sessionIds: new Set<string>(),
+				}
 				entry.minutesAsFC += stats.minutes
 				entry.sessionIds.add(sessionId)
 				bossAggregates.set(bossCharacterId, entry)
@@ -2502,7 +2565,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 		}
 		for (const row of recentRows) {
 			const bossMinutes = row.sessionId
-				? bossAttributionBySession.get(row.sessionId)?.get(row.characterId)?.minutes ?? 0
+				? (bossAttributionBySession.get(row.sessionId)?.get(row.characterId)?.minutes ?? 0)
 				: 0
 			const recent: CharacterRecentSessionRow = {
 				sessionId: row.sessionId,
@@ -2564,10 +2627,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 	 * Distinct character IDs that joined a fleet while in the given corporation
 	 * during the window. Used to seed the corp-stats per-character rollup.
 	 */
-	async getCharactersByCorpInWindow(
-		corporationId: string,
-		range: StatsRange
-	): Promise<string[]> {
+	async getCharactersByCorpInWindow(corporationId: string, range: StatsRange): Promise<string[]> {
 		const from = new Date(range.from)
 		const to = new Date(range.to)
 
@@ -2774,8 +2834,6 @@ export class FleetsDO extends DurableObject implements Fleets {
 	 * Fetch handler for HTTP requests to the Durable Object
 	 */
 	async fetch(request: Request): Promise<Response> {
-		const url = new URL(request.url)
-
 		// WebSocket upgrade handling
 		if (request.headers.get('Upgrade') === 'websocket') {
 			const pair = new WebSocketPair()

--- a/apps/srp/eslint.config.ts
+++ b/apps/srp/eslint.config.ts
@@ -1,7 +1,5 @@
-import { defineConfig } from '@repo/eslint-config'
+import { defineConfig, getConfig } from '@repo/eslint-config'
 
-export default defineConfig({
-	typescript: {
-		project: './tsconfig.json',
-	},
-})
+const config = getConfig(import.meta.url)
+
+export default defineConfig([config])

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -40,7 +40,6 @@ import {
 	DEFAULT_POD_SLOT_CAPACITIES,
 	parseShipSlotCapacitiesFromDogmaAttributes,
 } from './lib/ship-slot-capacities'
-import { isEquippedSlot } from './lib/slot-flags'
 import { formatSrpRequest } from './lib/format-request'
 
 import type { srpRequests as srpRequestsTable } from './db/schema'
@@ -49,7 +48,6 @@ type KillmailDataJson = NonNullable<typeof srpRequestsTable.$inferInsert.killmai
 
 import type {
 	CharacterKillmailData,
-	CharacterKillmailUpsertData,
 	CharacterLossData,
 	CharacterLossItemData,
 	EveCharacterData,
@@ -58,18 +56,16 @@ import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { LatestMarketPrice, Markets } from '@repo/markets'
 import type {
-	AppliedModifier,
 	CreateSRPPolicy,
 	RecentLossRefreshCharacterFailure,
 	RecentLossRefreshCharacterInput,
-	RecentLossCacheBackfillResult,
 	RecentLossRefreshCharacterResult,
 	RecentLossesResponse,
-	LossWithSRPStatus,
 	RequestStatus,
 	Srp,
 	SRPCommentResponse,
 	SRPConfigResponse,
+	SrpRequestEligibilityData,
 	SRPPaymentMismatchAlert,
 	SRPPolicy,
 	SRPPolicyConfig,
@@ -438,7 +434,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 					item_type_id?: number | string
 					type_id?: number | string
 					typeId?: number | string
-					items?: Array<any>
+					items?: any[]
 			  }>)
 			: []
 		if (itemPrices.length === 0 && killmailItems.length === 0) return
@@ -587,7 +583,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			flag?: number
 			quantity_destroyed?: number
 			quantity_dropped?: number
-			items?: Array<any>
+			items?: any[]
 		}>,
 		inheritedFlag?: number
 	): Array<{
@@ -632,12 +628,12 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	private collectVictimItemTypeIds(
 		items: Array<{
 			item_type_id?: number | string
-			items?: Array<any>
+			items?: any[]
 		}>
 	): string[] {
 		const typeIds = new Set<string>()
 
-		const walk = (rows: Array<{ item_type_id?: number | string; items?: Array<any> }>) => {
+		const walk = (rows: Array<{ item_type_id?: number | string; items?: any[] }>) => {
 			for (const row of rows) {
 				if (row.item_type_id != null) {
 					typeIds.add(String(row.item_type_id))
@@ -839,7 +835,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			item_type_id?: number | string
 			type_id?: number | string
 			typeId?: number | string
-			items?: Array<any>
+			items?: any[]
 		}>)
 		const [typeMap, systemMap] = await Promise.all([
 			universeStub
@@ -860,7 +856,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 				item_type_id?: number | string
 				type_id?: number | string
 				typeId?: number | string
-				items?: Array<any>
+				items?: any[]
 			}>,
 			typeMap as Record<string, { typeName?: string | null; groupId?: string | null }>
 		)
@@ -1052,6 +1048,25 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		}
 
 		return await this.formatRequestWithShipSlotCapacities(request)
+	}
+
+	async getRequestEligibilityData(requestId: string): Promise<SrpRequestEligibilityData | null> {
+		const request = await this.db.query.srpRequests.findFirst({
+			where: eq(srpRequests.id, requestId.trim()),
+			columns: {
+				id: true,
+				characterId: true,
+				characterName: true,
+				lossDate: true,
+			},
+		})
+		if (!request) return null
+		return {
+			requestId: request.id,
+			victimCharacterId: request.characterId,
+			victimCharacterName: request.characterName,
+			lossDate: request.lossDate.toISOString(),
+		}
 	}
 
 	/**
@@ -1802,6 +1817,14 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			typeof metadata.srpGroupId === 'string' && metadata.srpGroupId.trim().length > 0
 				? metadata.srpGroupId.trim()
 				: undefined
+		const srpDiscordGuildId =
+			typeof metadata.srpDiscordGuildId === 'string' && metadata.srpDiscordGuildId.trim().length > 0
+				? metadata.srpDiscordGuildId.trim()
+				: undefined
+		const srpDiscordChannelId =
+			typeof metadata.srpDiscordChannelId === 'string' && metadata.srpDiscordChannelId.trim().length > 0
+				? metadata.srpDiscordChannelId.trim()
+				: undefined
 
 		return {
 			id: config.id,
@@ -1811,6 +1834,8 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			maxLossAgeDays: Math.min(config.maxLossAgeDays, MAX_SRP_LOSS_AGE_DAYS),
 			paymentProcessorCorporationId,
 			srpGroupId,
+			srpDiscordGuildId,
+			srpDiscordChannelId,
 			metadata,
 			predefinedAdhocModifiers,
 			createdBy: config.createdBy,
@@ -1857,6 +1882,20 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 				mergedMetadata.srpGroupId = updates.srpGroupId.trim()
 			} else {
 				delete mergedMetadata.srpGroupId
+			}
+		}
+		if (updates.srpDiscordGuildId !== undefined) {
+			if (updates.srpDiscordGuildId && updates.srpDiscordGuildId.trim()) {
+				mergedMetadata.srpDiscordGuildId = updates.srpDiscordGuildId.trim()
+			} else {
+				delete mergedMetadata.srpDiscordGuildId
+			}
+		}
+		if (updates.srpDiscordChannelId !== undefined) {
+			if (updates.srpDiscordChannelId && updates.srpDiscordChannelId.trim()) {
+				mergedMetadata.srpDiscordChannelId = updates.srpDiscordChannelId.trim()
+			} else {
+				delete mergedMetadata.srpDiscordChannelId
 			}
 		}
 

--- a/apps/srp/src/recent-loss-refresh-coordinator.ts
+++ b/apps/srp/src/recent-loss-refresh-coordinator.ts
@@ -9,7 +9,6 @@ import type {
 	RecentLossRefreshStatusRecord,
 	RecentLossRefreshStatusResponse,
 } from '@repo/srp'
-import type { SrpRecentLossRefreshWorkflowParams } from './workflows/recent-loss-refresh.workflow'
 import type { Env } from './context'
 
 export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implements RecentLossRefreshCoordinator {

--- a/apps/srp/src/workflows/srp-payment-status-check.ts
+++ b/apps/srp/src/workflows/srp-payment-status-check.ts
@@ -1,4 +1,4 @@
-import { WorkflowEntrypoint, WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import { WorkflowEntrypoint } from 'cloudflare:workers'
 
 import { sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
@@ -15,6 +15,8 @@ import type { EsiTypeResolver } from '@repo/esi'
 import type { SRPRequestResponse, Srp } from '@repo/srp'
 import type { Env } from '../context'
 import { logger } from '@repo/hono-helpers'
+
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
 
 export interface SrpPaymentStatusCheckWorkflowParams {
 	requestId: string

--- a/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
+++ b/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
@@ -259,7 +259,7 @@ export default function CorporationMembers() {
 			a.href = downloadUrl
 
 			const contentDisposition = response.headers.get('content-disposition') ?? ''
-			const match = contentDisposition.match(/filename=\"?([^\";]+)\"?/i)
+			const match = contentDisposition.match(/filename="?([^";]+)"?/i)
 			a.download = match?.[1] ?? `${corpName}-members-${new Date().toISOString().split('T')[0]}.csv`
 			a.click()
 			URL.revokeObjectURL(downloadUrl)

--- a/apps/ui/src/client/features/srp/hooks.ts
+++ b/apps/ui/src/client/features/srp/hooks.ts
@@ -3,6 +3,8 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import { NotFoundError, api } from '@/lib/api'
 
+import type { UpdateSRPConfig } from '@repo/srp'
+
 import { srpKeys } from './query-keys'
 import {
 	isSrpLossesQueryKey,
@@ -35,7 +37,6 @@ import type {
 	RequestStatus,
 	RecentLossesResponse,
 	SRPCommentResponse,
-	SRPConfigResponse,
 	SRPRequestResponse,
 	SRPPaymentMismatchAlert,
 	SRPReviewSubmission,
@@ -333,6 +334,14 @@ export function useSRPConfig() {
 		queryKey: srpKeys.config(),
 		queryFn: () => api.getSRPConfig(),
 		staleTime: 1000 * 60 * 10,
+	})
+}
+
+export function useSRPDiscordGuilds() {
+	return useQuery({
+		queryKey: srpKeys.discordGuilds(),
+		queryFn: () => api.getSRPDiscordGuilds(),
+		staleTime: 1000 * 60 * 5,
 	})
 }
 
@@ -835,7 +844,7 @@ export function useSrpWalletHistory(params: {
 export function useUpdateSRPConfig() {
 	const queryClient = useQueryClient()
 	return useMutation({
-		mutationFn: (data: Partial<SRPConfigResponse>) => api.updateSRPConfig(data),
+		mutationFn: (data: UpdateSRPConfig) => api.updateSRPConfig(data),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: srpKeys.config() })
 		},

--- a/apps/ui/src/client/features/srp/query-keys.ts
+++ b/apps/ui/src/client/features/srp/query-keys.ts
@@ -56,6 +56,7 @@ export const srpKeys = {
 
 	// Config
 	config: () => [...srpKeys.all, 'config'] as const,
+	discordGuilds: () => [...srpKeys.config(), 'discord-guilds'] as const,
 
 	// Policies
 	policies: () => [...srpKeys.all, 'policies'] as const,

--- a/apps/ui/src/client/features/srp/routes/policies.tsx
+++ b/apps/ui/src/client/features/srp/routes/policies.tsx
@@ -22,6 +22,7 @@ import {
 	useCreatePolicy,
 	useDeletePolicy,
 	useSRPConfig,
+	useSRPDiscordGuilds,
 	useSRPPolicies,
 	useUpdatePolicy,
 	useUpdateSRPConfig,
@@ -122,10 +123,13 @@ function GeneralConfigPanel({ config }: { config?: SRPConfigResponse }) {
 	const [maxLossAgeDays, setMaxLossAgeDays] = useState('30')
 	const [paymentProcessorCorporationId, setPaymentProcessorCorporationId] = useState('')
 	const [srpGroupId, setSrpGroupId] = useState('')
+	const [srpDiscordGuildId, setSrpDiscordGuildId] = useState('')
+	const [srpDiscordChannelId, setSrpDiscordChannelId] = useState('')
 	const [paymentProcessorCorporationOptions, setPaymentProcessorCorporationOptions] = useState<
 		SelectOption[]
 	>([])
 	const [srpGroupOptions, setSrpGroupOptions] = useState<SelectOption[]>([])
+	const { data: discordServers = [] } = useSRPDiscordGuilds()
 
 	useEffect(() => {
 		if (!config) return
@@ -134,6 +138,8 @@ function GeneralConfigPanel({ config }: { config?: SRPConfigResponse }) {
 		setMaxLossAgeDays(String(config.maxLossAgeDays))
 		setPaymentProcessorCorporationId(config.paymentProcessorCorporationId ?? '')
 		setSrpGroupId(config.srpGroupId ?? '')
+		setSrpDiscordGuildId(config.srpDiscordGuildId ?? '')
+		setSrpDiscordChannelId(config.srpDiscordChannelId ?? '')
 	}, [config])
 
 	useEffect(() => {
@@ -211,13 +217,15 @@ function GeneralConfigPanel({ config }: { config?: SRPConfigResponse }) {
 		try {
 			await updateConfigMutation.mutateAsync({
 				defaultCoverageRate: String((Number.parseFloat(defaultCoverageRatePercent) || 0) / 100),
-				maxPayoutAmount: maxPayoutAmount.trim() ? maxPayoutAmount.trim() : null,
+					maxPayoutAmount: maxPayoutAmount.trim() ? maxPayoutAmount.trim() : null,
 				maxLossAgeDays: Math.max(1, Number.parseInt(maxLossAgeDays, 10) || 30),
 				paymentProcessorCorporationId: paymentProcessorCorporationId.trim()
-					? paymentProcessorCorporationId.trim()
-					: null,
-				srpGroupId: srpGroupId.trim() ? srpGroupId.trim() : null,
-			} as any)
+						? paymentProcessorCorporationId.trim()
+						: null,
+					srpGroupId: srpGroupId.trim() ? srpGroupId.trim() : null,
+					srpDiscordGuildId: srpDiscordGuildId.trim() ? srpDiscordGuildId.trim() : null,
+					srpDiscordChannelId: srpDiscordChannelId.trim() ? srpDiscordChannelId.trim() : null,
+			})
 			toast.success('SRP configuration saved')
 		} catch (error: any) {
 			toast.error('Failed to save SRP configuration', { description: error.message })
@@ -298,6 +306,35 @@ function GeneralConfigPanel({ config }: { config?: SRPConfigResponse }) {
 								)
 							}
 						/>
+					</div>
+					<div>
+						<Label htmlFor="srpDiscordGuildId">SRP Discord Guild</Label>
+						<Select
+							inputId="srpDiscordGuildId"
+							value={srpDiscordGuildId}
+							onValueChange={(next) => {
+								setSrpDiscordGuildId(next)
+								if (next !== srpDiscordGuildId) setSrpDiscordChannelId('')
+							}}
+							options={discordServers.map((server) => ({
+								value: server.guildId,
+								label: `${server.guildName} (${server.guildId})`,
+							}))}
+							placeholder="Select a Discord guild..."
+						/>
+					</div>
+					<div>
+						<Label htmlFor="srpDiscordChannelId">SRP Discord Channel ID</Label>
+						<Input
+							id="srpDiscordChannelId"
+							value={srpDiscordChannelId}
+							onChange={(event) => setSrpDiscordChannelId(event.target.value)}
+							placeholder="Discord channel ID"
+							inputMode="numeric"
+						/>
+						<p className="mt-1 text-xs text-muted-foreground">
+							/srpfleet results are only shown when invoked from this channel.
+						</p>
 					</div>
 					<div className="sm:col-span-2">
 						<Label htmlFor="srpGroupId">SRP Group</Label>

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -12,6 +12,7 @@ import type {
 } from '@repo/admin'
 import type { FreightRoute } from '@repo/freight'
 import type { InventoryDisplayBay as SharedInventoryDisplayBay } from '@repo/inventory-display'
+import type { UpdateSRPConfig } from '@repo/srp'
 import type {
 	StructureCitadelListQuery as RepoStructureCitadelListQuery,
 	StructureMoonStructureListFilterOptions as RepoStructureMoonStructureListFilterOptions,
@@ -4976,6 +4977,10 @@ export class ApiClient {
 		return this.get('/srp/config')
 	}
 
+	async getSRPDiscordGuilds(): Promise<Array<{ id: string; guildId: string; guildName: string }>> {
+		return this.get('/srp/config/discord-guilds')
+	}
+
 	async searchSRPPaymentProcessorCorporations(
 		query: string
 	): Promise<Array<{ corporationId: string; name: string }>> {
@@ -4987,7 +4992,7 @@ export class ApiClient {
 	/**
 	 * Update SRP configuration (admin only)
 	 */
-	async updateSRPConfig(data: any): Promise<any> {
+	async updateSRPConfig(data: UpdateSRPConfig): Promise<unknown> {
 		return this.patch('/srp/config', data)
 	}
 

--- a/packages/broadcasts/src/index.ts
+++ b/packages/broadcasts/src/index.ts
@@ -110,6 +110,13 @@ export interface BroadcastWithDetails extends Broadcast {
 	deliveries: BroadcastDelivery[]
 }
 
+export interface SrpFleetBroadcastLookup {
+	content: Record<string, unknown>
+	srpToken: string
+	doctrineId: string | null
+	fleetSessionId: string | null
+}
+
 export interface BroadcastPage {
 	rows: Broadcast[]
 	rowCount: number
@@ -400,6 +407,9 @@ export interface Broadcasts {
 	 * @returns Broadcast details or null if not found
 	 */
 	getBroadcastBySrpToken(srpToken: string, userId: string): Promise<BroadcastWithDetails | null>
+
+	/** Resolve only the broadcast fields needed by SRP fleet tooling. */
+	getSrpFleetBroadcastByToken(srpToken: string): Promise<SrpFleetBroadcastLookup | null>
 
 	/**
 	 * Resolve a broadcast by linked fleet tracking session id.

--- a/packages/doctrines/src/index.ts
+++ b/packages/doctrines/src/index.ts
@@ -313,6 +313,7 @@ export interface Doctrines {
 	createDoctrine(data: CreateDoctrineRequest & { updatedBy?: string }): Promise<Doctrine>
 	getDoctrines(filters: ListDoctrinesFilters): Promise<Doctrine[]>
 	getDoctrine(id: string): Promise<DoctrineWithFittings | null>
+	getDoctrineName(id: string): Promise<string | null>
 	updateDoctrine(
 		id: string,
 		data: UpdateDoctrineRequest & { updatedBy?: string }

--- a/packages/eslint-config/src/default.config.ts
+++ b/packages/eslint-config/src/default.config.ts
@@ -43,6 +43,14 @@ export function getConfig(importMetaUrl: string): Array<Linter.Config<Linter.Rul
 		...tseslint.configs.recommended,
 		importPlugin.flatConfigs.recommended,
 		...turboConfig,
+		{
+			rules: {
+				'turbo/no-undeclared-env-vars': [
+					'error',
+					{ allowList: ['^LOCAL_DEV_DISABLE_AUXILIARY_WORKERS$'] },
+				],
+			},
+		},
 
 		// TypeScript Configuration
 		{

--- a/packages/fleets/src/index.ts
+++ b/packages/fleets/src/index.ts
@@ -253,6 +253,10 @@ export interface Fleets extends DurableObject {
 	 * written yet (only present after the session has ended).
 	 */
 	getSessionSummary(sessionId: string): Promise<SessionSummary | null>
+	/** Return the minimal fleet/session projection needed by the SRP Discord command. */
+	getSrpFleetSessionDetails(sessionId: string): Promise<SrpFleetSessionDetails | null>
+	/** Check whether a character was in the tracked session at a specific time. */
+	wasSessionMemberAt(sessionId: string, characterId: string, occurredAt: string): Promise<boolean>
 
 	/**
 	 * Get the current member roster for an active session, derived from open
@@ -543,6 +547,18 @@ export interface SessionSummary {
 	durationMinutes: number | null
 	peakMemberCount: number
 	finalMemberCount: number
+	motd: string | null
+}
+
+export interface SrpFleetSessionDetails {
+	sessionId: string
+	sessionName: string
+	fleetId: string | null
+	status: TrackingSessionStatus
+	startedAt: string
+	endedAt: string | null
+	commanderCharacterIds: string[]
+	commanderCharacterNames: Record<string, string>
 	motd: string | null
 }
 

--- a/packages/srp/src/index.ts
+++ b/packages/srp/src/index.ts
@@ -139,6 +139,7 @@ export interface Srp {
 		notes?: string
 	): Promise<SRPRequestResponse>
 	getRequest(requestId: string, userId: string): Promise<SRPRequestResponse | null>
+	getRequestEligibilityData(requestId: string): Promise<SrpRequestEligibilityData | null>
 	getPublicRequestSummary(requestId: string): Promise<SRPPublicRequestSummaryResponse | null>
 	getUserRequests(
 		userId: string,
@@ -495,6 +496,8 @@ export const UpdateSRPConfigSchema = z.object({
 	maxLossAgeDays: z.number().int().positive().max(MAX_SRP_LOSS_AGE_DAYS).optional(),
 	paymentProcessorCorporationId: z.string().nullable().optional(),
 	srpGroupId: z.string().nullable().optional(),
+	srpDiscordGuildId: z.string().regex(/^\d{17,20}$/).nullable().optional(),
+	srpDiscordChannelId: z.string().regex(/^\d{17,20}$/).nullable().optional(),
 	metadata: z.record(z.string(), z.unknown()).optional(),
 	predefinedAdhocModifiers: z.array(PredefinedAdhocModifierSchema).optional(),
 })
@@ -667,12 +670,21 @@ export interface SRPConfigResponse {
 	maxLossAgeDays: number
 	paymentProcessorCorporationId?: string
 	srpGroupId?: string
+	srpDiscordGuildId?: string
+	srpDiscordChannelId?: string
 	metadata?: Record<string, unknown>
 	predefinedAdhocModifiers?: SRPPredefinedAdhocModifier[]
 	createdBy: string
 	effectiveFrom: string
 	effectiveTo?: string
 	createdAt: string
+}
+
+export interface SrpRequestEligibilityData {
+	requestId: string
+	victimCharacterId: string
+	victimCharacterName: string
+	lossDate: string
 }
 
 export interface SRPPaymentMismatchAlert {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1305,6 +1305,9 @@ importers:
       '@repo/universe':
         specifier: workspace:*
         version: link:../../packages/universe
+      '@repo/worker-utils':
+        specifier: workspace:*
+        version: link:../../packages/worker-utils
       drizzle-orm:
         specifier: 0.44.7
         version: 0.44.7(@cloudflare/workers-types@4.20260501.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(bun-types@1.3.2(@types/react@19.2.6))(mysql2@3.15.3)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a `/srpfleet` Discord slash command that posts fleet/SRP details (commanders, doctrine, MOTD, SRP token, fleet period, and an optional killmail-based eligibility check) to a configured SRP channel, plus the admin UI and backend plumbing needed to configure that channel.

## Changes
- New Discord command `srpfleet` (`apps/core/src/services/discord-programmatic-commands/srpfleet.ts`): validates the invoking guild/channel against SRP config, resolves a broadcast by SRP token, pulls fleet session details, optionally compares a killmail's victim/loss time against fleet membership, and posts a Discord embed.
- Added `embeds` support end-to-end for Discord interaction responses (`ProgrammaticCommandResponse`, `ExecuteDiscordSlashCommandResult`, `editOriginalInteractionResponse`, and the Discord/Core `Env` types).
- New DO RPC methods to support the command:
  - `Broadcasts.getSrpFleetBroadcastByToken` (looks up a broadcast + linked fleet session by SRP token, for blanket/military SRP modes only)
  - `Fleets.getSrpFleetSessionDetails` and `Fleets.wasSessionMemberAt`
  - `Doctrines.getDoctrineName`
  - `Srp.getRequestEligibilityData`
- Added `srpDiscordGuildId`/`srpDiscordChannelId` to the SRP config (schema, `UpdateSRPConfigSchema` validation, `SRPConfigResponse`), a new `GET /api/srp/config/discord-guilds` endpoint, and a UI panel on the SRP policies page to pick the guild/channel.
- `CommandEnv`/`ProgrammaticCommandEnv` extended with `BROADCASTS`, `FLEETS`, `SRP`, `DOCTRINES` bindings.
- Added a new `turbo/no-undeclared-env-vars` allowlist entry and migrated several apps' `eslint.config.ts` files to the `getConfig(import.meta.url)` pattern.
- Misc cleanup: unused `userId` params in `BroadcastsDO` prefixed with `_`, unused imports/vars removed, `let` → `const` fixes, and formatting-only changes across `apps/fleets/src/durable-object.ts` and `apps/srp/src/durable-object.ts`.
- Added `@repo/worker-utils` dependency to `apps/fleets`.

## Testing
- Added `apps/core/src/services/discord-programmatic-commands/__tests__/srpfleet.test.ts`, covering: option/deferral shape, posting the fleet embed with eligibility check, channel-mismatch rejection, admin bypass of SRP permission checks, and doctrine name resolution.
<!-- claude:end -->