### PR TITLE
fix the srp payment status RPC error

### DIFF
--- a/apps/srp/src/workflows/srp-payment-status-check.ts
+++ b/apps/srp/src/workflows/srp-payment-status-check.ts
@@ -939,7 +939,7 @@ export class SrpPaymentStatusCheckWorkflow extends WorkflowEntrypoint<
 					reasonNeedle,
 					srpGroupId: config?.srpGroupId?.trim() ?? '',
 					srpStub: {
-						updateReviewState: srpStub.updateReviewState.bind(srpStub),
+						updateReviewState: (...args) => srpStub.updateReviewState(...args),
 					},
 					workflowInstanceId,
 				})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a runtime RPC error in the SRP payment status check workflow by replacing an unsafe `.bind()` call on a Durable Object RPC stub method with an arrow function wrapper.

## Changes
- In `apps/srp/src/workflows/srp-payment-status-check.ts`, changed `updateReviewState: srpStub.updateReviewState.bind(srpStub)` to `updateReviewState: (...args) => srpStub.updateReviewState(...args)` when constructing the `srpStub` argument passed to `processPaymentStatus`.

## Testing
Not evident from the diff/commits.
<!-- claude:end -->
