### PR TITLE
remove unnecessary enrichments in SRP request listing queries

### DIFF
--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -934,10 +934,9 @@ srp.get('/requests', async (c) => {
 		c.env.DATABASE_URL
 	)
 	const withSystemRegions = await enrichRequestsWithSystemRegions(withCharacterRoles, c.env)
-	const requests = await enrichRequestsWithMilitarySrp(withSystemRegions, c.env)
 
 	return c.json({
-		requests,
+		requests: withSystemRegions,
 		total: requestsRaw.total,
 		limit: pagination.data.limit,
 		offset: pagination.data.offset,
@@ -982,9 +981,8 @@ srp.get('/requests/by-status', async (c) => {
 		c.env.DATABASE_URL
 	)
 	const withSystemRegions = await enrichRequestsWithSystemRegions(withCharacterRoles, c.env)
-	const requests = await enrichRequestsWithMilitarySrp(withSystemRegions, c.env)
 	return c.json({
-		requests,
+		requests: withSystemRegions,
 		total: result.total,
 		limit,
 		offset,
@@ -1066,14 +1064,14 @@ srp.get('/requests/:id', async (c) => {
 		return c.json({ error: 'Invalid request id' }, 400)
 	}
 
+	const canSeeInternalHistory = await hasAnyPermission(c.env, user.id, SRP_ROLE_URNS, user.is_admin)
 	const srpStub = getStub<Srp>(c.env.SRP, 'default')
-	const request = await srpStub.getRequest(requestId, user.id)
+	const request = await srpStub.getRequest(requestId, user.id, canSeeInternalHistory)
 
 	if (!request) {
 		return c.json({ error: 'Request not found' }, 404)
 	}
 
-	const canSeeInternalHistory = await hasAnyPermission(c.env, user.id, SRP_ROLE_URNS, user.is_admin)
 	const canViewRequest = request.userId === user.id || canSeeInternalHistory
 	if (!canViewRequest) {
 		return c.json({ error: 'Not authorized to view this request' }, 403)
@@ -1546,14 +1544,10 @@ srp.get('/payments/pending', async (c) => {
 
 	const srpStub = getStub<Srp>(c.env.SRP, 'default')
 	const requestsRaw = await srpStub.getPendingPayments(corporationId, limit, offset)
-	const requests = await enrichRequestsWithMilitarySrp(
-		requestsRaw as RequestWithCharacterRole[],
-		c.env
-	)
 
 	return c.json({
-		requests,
-		total: requests.length,
+		requests: requestsRaw,
+		total: requestsRaw.length,
 		limit,
 		offset,
 	})

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -40,11 +40,58 @@ import {
 	DEFAULT_POD_SLOT_CAPACITIES,
 	parseShipSlotCapacitiesFromDogmaAttributes,
 } from './lib/ship-slot-capacities'
-import { formatSrpRequest } from './lib/format-request'
+import { formatSrpRequest, formatSrpRequestSummary } from './lib/format-request'
 
 import type { srpRequests as srpRequestsTable } from './db/schema'
 
 type KillmailDataJson = NonNullable<typeof srpRequestsTable.$inferInsert.killmailData>
+
+const srpRequestListColumns = {
+	id: srpRequests.id,
+	userId: srpRequests.userId,
+	characterId: srpRequests.characterId,
+	characterName: srpRequests.characterName,
+	corporationName: srpRequests.corporationName,
+	shipTypeId: srpRequests.shipTypeId,
+	shipTypeName: srpRequests.shipTypeName,
+	shipValue: srpRequests.shipValue,
+	solarSystemId: srpRequests.solarSystemId,
+	solarSystemName: srpRequests.solarSystemName,
+	lossDate: srpRequests.lossDate,
+	requestStatus: srpRequests.requestStatus,
+	approvedAmount: srpRequests.approvedAmount,
+	reviewedAt: srpRequests.reviewedAt,
+	createdAt: srpRequests.createdAt,
+	updatedAt: srpRequests.updatedAt,
+}
+
+const srpMyRequestListColumns = {
+	id: srpRequests.id,
+	userId: srpRequests.userId,
+	characterId: srpRequests.characterId,
+	characterName: srpRequests.characterName,
+	shipTypeId: srpRequests.shipTypeId,
+	shipTypeName: srpRequests.shipTypeName,
+	solarSystemId: srpRequests.solarSystemId,
+	solarSystemName: srpRequests.solarSystemName,
+	lossDate: srpRequests.lossDate,
+	requestStatus: srpRequests.requestStatus,
+	approvedAmount: srpRequests.approvedAmount,
+	createdAt: srpRequests.createdAt,
+	updatedAt: srpRequests.updatedAt,
+}
+
+const srpPaymentListColumns = {
+	id: srpRequests.id,
+	characterName: srpRequests.characterName,
+	corporationName: srpRequests.corporationName,
+	shipTypeName: srpRequests.shipTypeName,
+	lossDate: srpRequests.lossDate,
+	approvedAmount: srpRequests.approvedAmount,
+	reviewedAt: srpRequests.reviewedAt,
+	createdAt: srpRequests.createdAt,
+	updatedAt: srpRequests.updatedAt,
+}
 
 import type {
 	CharacterKillmailData,
@@ -1025,13 +1072,14 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	/**
 	 * Get a single SRP request
 	 */
-	async getRequest(requestId: string, userId: string): Promise<SRPRequestResponse | null> {
+	async getRequest(
+		requestId: string,
+		userId: string,
+		includeShipSlotCapacities = false
+	): Promise<SRPRequestResponse | null> {
 		const request = await this.db.query.srpRequests.findFirst({
 			where: eq(srpRequests.id, requestId),
 				with: {
-					comments: {
-						orderBy: asc(srpComments.createdAt),
-					},
 					history: {
 						orderBy: asc(srpRequestHistory.timestamp),
 						limit: 50,
@@ -1042,12 +1090,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		if (!request) return null
 
 		// Check if user has access (owner, reviewer, or admin handled by core worker)
-		if (request.userId !== userId) {
-			// Only return public comments if not the owner
-			request.comments = request.comments?.filter((c) => c.visibility === 'public')
-		}
-
-		return await this.formatRequestWithShipSlotCapacities(request)
+		return includeShipSlotCapacities
+			? await this.formatRequestWithShipSlotCapacities(request)
+			: await this.formatRequestForRequestor(request)
 	}
 
 	async getRequestEligibilityData(requestId: string): Promise<SrpRequestEligibilityData | null> {
@@ -1115,12 +1160,13 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 
 		const where = and(...conditions)
 		const [requests, countRows] = await Promise.all([
-			this.db.query.srpRequests.findMany({
-				where,
-				orderBy: desc(srpRequests.createdAt),
-				limit,
-				offset,
-			}),
+			this.db
+				.select(srpMyRequestListColumns)
+				.from(srpRequests)
+				.where(where)
+				.orderBy(desc(srpRequests.createdAt))
+				.limit(limit)
+				.offset(offset),
 			this.db
 				.select({ count: sql<number>`count(*)::int` })
 				.from(srpRequests)
@@ -1128,7 +1174,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		])
 
 		return {
-			requests: await Promise.all(requests.map((r) => this.formatRequest(r))),
+			requests: requests.map((r) => formatSrpRequestSummary(r)),
 			total: countRows[0]?.count ?? 0,
 		}
 	}
@@ -1723,17 +1769,20 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		limit = 50,
 		offset = 0
 	): Promise<SRPRequestResponse[]> {
-		const requests = await this.db.query.srpRequests.findMany({
-			where: and(
-				corporationId ? eq(srpRequests.corporationId, corporationId) : undefined,
-				eq(srpRequests.requestStatus, 'approved')
-			),
-			orderBy: [asc(srpRequests.createdAt)],
-			limit,
-			offset,
-		})
+		const requests = await this.db
+			.select(srpPaymentListColumns)
+			.from(srpRequests)
+			.where(
+				and(
+					corporationId ? eq(srpRequests.corporationId, corporationId) : undefined,
+					eq(srpRequests.requestStatus, 'approved')
+				)
+			)
+			.orderBy(asc(srpRequests.createdAt))
+			.limit(limit)
+			.offset(offset)
 
-		return await Promise.all(requests.map((r) => this.formatRequest(r)))
+		return requests.map((r) => formatSrpRequestSummary(r))
 	}
 
 	async getPendingPayoutTotal(corporationId?: string): Promise<string> {
@@ -2214,6 +2263,29 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		return formatSrpRequest(request)
 	}
 
+	private async formatRequestForRequestor(request: any): Promise<SRPRequestResponse> {
+		const formatted = formatSrpRequest(request)
+		const {
+			reviewerId: _reviewerId,
+			reviewerCharacterName: _reviewerCharacterName,
+			reviewNotes: _reviewNotes,
+			srpEquipmentValue: _srpEquipmentValue,
+			srpInsurancePremium: _srpInsurancePremium,
+			srpInsurancePayout: _srpInsurancePayout,
+			srpNetInsurance: _srpNetInsurance,
+			srpCalculatedValue: _srpCalculatedValue,
+			srpFinalValue: _srpFinalValue,
+			srpPriceSnapshotTime: _srpPriceSnapshotTime,
+			srpItemPrices: _srpItemPrices,
+			killmailItemNames: _killmailItemNames,
+			killmailItemGroupIds: _killmailItemGroupIds,
+			killmailItems: _killmailItems,
+			shipSlotCapacities: _shipSlotCapacities,
+			...requestorRequest
+		} = formatted
+		return requestorRequest
+	}
+
 	private async formatRequestWithShipSlotCapacities(request: any): Promise<SRPRequestResponse> {
 		const formatted = await this.formatRequest(request)
 		formatted.shipSlotCapacities = await this.resolveShipSlotCapacities(formatted.shipTypeId)
@@ -2353,16 +2425,17 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		const { where, oldestFirst } = this.buildReviewQueueConditions(status, options)
 
 		const [requests, count] = await Promise.all([
-			this.db.query.srpRequests.findMany({
-				where,
-				orderBy: oldestFirst ? srpRequests.createdAt : desc(srpRequests.createdAt),
-				limit,
-				offset,
-			}),
+			this.db
+				.select(srpRequestListColumns)
+				.from(srpRequests)
+				.where(where)
+				.orderBy(oldestFirst ? srpRequests.createdAt : desc(srpRequests.createdAt))
+				.limit(limit)
+				.offset(offset),
 			this.getReviewQueueCount(status, options),
 		])
 
-		return { requests: await Promise.all(requests.map((r) => this.formatRequest(r))), total: count }
+		return { requests: requests.map((r) => formatSrpRequestSummary(r)), total: count }
 	}
 
 	async getRequestCountByStatus(

--- a/apps/srp/src/lib/format-request.ts
+++ b/apps/srp/src/lib/format-request.ts
@@ -79,3 +79,17 @@ export function formatSrpRequest(request: any): SRPRequestResponse {
 			})),
 	}
 }
+
+export function formatSrpRequestSummary(request: any): SRPRequestResponse {
+	const formatted = formatSrpRequest(request)
+	const {
+		srpItemPrices: _srpItemPrices,
+		killmailItemNames: _killmailItemNames,
+		killmailItemGroupIds: _killmailItemGroupIds,
+		killmailItems: _killmailItems,
+		comments: _comments,
+		history: _history,
+		...summary
+	} = formatted
+	return summary
+}

--- a/packages/srp/src/index.ts
+++ b/packages/srp/src/index.ts
@@ -138,7 +138,7 @@ export interface Srp {
 		actorCharacterName: string,
 		notes?: string
 	): Promise<SRPRequestResponse>
-	getRequest(requestId: string, userId: string): Promise<SRPRequestResponse | null>
+	getRequest(requestId: string, userId: string, includeShipSlotCapacities?: boolean): Promise<SRPRequestResponse | null>
 	getRequestEligibilityData(requestId: string): Promise<SrpRequestEligibilityData | null>
 	getPublicRequestSummary(requestId: string): Promise<SRPPublicRequestSummaryResponse | null>
 	getUserRequests(


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Optimizes the SRP request listing endpoints (`/requests`, `/requests/by-status`, `/payments/pending`) by dropping an unnecessary military-SRP enrichment step and narrowing the DB queries/response payload to only the columns actually needed for list views. Also tightens what a non-reviewer sees when viewing a single request.

## Changes
- Removed `enrichRequestsWithMilitarySrp` calls from the `/requests`, `/requests/by-status`, and `/payments/pending` list endpoints in `apps/core/src/routes/srp.ts`, returning the already-enriched/raw results directly instead.
- Moved the `canSeeInternalHistory` permission check in `GET /requests/:id` above the DO call and passed it into `srpStub.getRequest(...)` as a new `includeShipSlotCapacities` flag, so the SRP durable object itself decides which fields to include.
- Added `srpRequestListColumns`, `srpMyRequestListColumns`, and `srpPaymentListColumns` column sets in `apps/srp/src/durable-object.ts` and switched `getUserRequests`, `getPendingPayments`, and the review queue query from `db.query.srpRequests.findMany` (full row + relations) to scoped `db.select(...)` projections.
- Replaced per-row async `formatRequest` calls in list queries with a new synchronous `formatSrpRequestSummary` (in `apps/srp/src/lib/format-request.ts`), which strips fields not needed in list views (item prices, killmail item details, comments, history).
- Added `formatRequestForRequestor` in the durable object to strip reviewer-only/sensitive SRP fields (reviewer info, review notes, SRP valuation breakdowns, killmail item details, ship slot capacities) when a non-reviewer fetches their own request; the `comments` relation and manual owner/public-comment filtering were removed from `getRequest` since comments are no longer fetched there.
- Updated the `Srp` interface (`packages/srp/src/index.ts`) to add the optional `includeShipSlotCapacities` parameter to `getRequest`.
<!-- claude:end -->