### PR TITLE
tweak structures UX

### DIFF
--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -747,7 +747,7 @@ const NON_CITADEL_TYPE_IDS = [
 	...MOON_DRILL_STRUCTURE_TYPE_IDS,
 ]
 
-const NON_CITADEL_TYPE_NAMES = [...MINING_CITADEL_TYPE_NAMES, METENOX_MOON_DRILL_TYPE_NAME]
+const NON_CITADEL_TYPE_NAMES = [METENOX_MOON_DRILL_TYPE_NAME]
 
 function combineWhereConditions(conditions: Array<StructureWhereCondition | undefined>): any {
 	const defined = conditions.filter(

--- a/apps/ui/src/client/components/layout.tsx
+++ b/apps/ui/src/client/components/layout.tsx
@@ -31,6 +31,7 @@ export default function Layout() {
 	})
 	const sidebarOpenRef = useRef(sidebarOpen)
 	const location = useLocation()
+	const isStructuresPage = location.pathname === '/structures'
 
 	useEffect(() => {
 		window.localStorage.setItem(SIDEBAR_OPEN_STORAGE_KEY, sidebarOpen ? '1' : '0')
@@ -88,7 +89,7 @@ export default function Layout() {
 	}
 
 	return (
-		<div className="relative min-h-screen flex overflow-x-hidden">
+		<div className={cn('relative min-h-screen flex overflow-x-hidden', isStructuresPage && 'h-dvh overflow-hidden')}>
 			{/* Starfield Background */}
 			<Starfield />
 
@@ -124,7 +125,8 @@ export default function Layout() {
 			{/* Main Content Area */}
 				<div
 					className={cn(
-						'relative z-10 flex-1 flex flex-col min-w-0 overflow-x-hidden overflow-y-auto transition-[padding-left] duration-300 ease-in-out',
+					'relative z-10 flex-1 flex flex-col min-w-0 overflow-x-hidden overflow-y-auto transition-[padding-left] duration-300 ease-in-out',
+					isStructuresPage && 'min-h-0 overflow-y-hidden',
 						sidebarOpen ? 'lg:pl-64' : 'lg:pl-0'
 					)}
 				>
@@ -144,8 +146,8 @@ export default function Layout() {
 				) : null}
 
 				{/* Page Content */}
-				<main className="flex-1 relative z-10 p-4 md:p-6 lg:p-8">
-					<div className={cn('w-full mx-auto max-w-[120rem]')}>
+				<main className={cn('flex flex-1 flex-col relative z-10 p-4 md:p-6 lg:p-8', isStructuresPage && 'min-h-0 overflow-hidden')}>
+					<div className={cn('w-full mx-auto max-w-[120rem]', isStructuresPage && 'h-full')}>
 						<Outlet />
 					</div>
 				</main>

--- a/apps/ui/src/client/components/table-refresh-frame.tsx
+++ b/apps/ui/src/client/components/table-refresh-frame.tsx
@@ -28,7 +28,7 @@ export function TableRefreshFrame({
 	className,
 }: TableRefreshFrameProps) {
 	return (
-		<div className={cn('space-y-3', className)}>
+		<div className={cn('flex min-h-0 flex-col space-y-3', className)}>
 			{errorMessage && (
 				<div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700">
 					<div className="flex items-center justify-between gap-3">
@@ -45,7 +45,7 @@ export function TableRefreshFrame({
 				</div>
 			)}
 
-			<div className="relative">
+			<div className="relative min-h-0 flex-1">
 				{isRefreshing && (
 					<div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md bg-background/60 backdrop-blur-[1px]">
 						<div className="flex items-center gap-2 rounded-md border border-border/60 bg-background/90 px-3 py-2 text-sm text-muted-foreground shadow-sm">
@@ -54,7 +54,7 @@ export function TableRefreshFrame({
 						</div>
 					</div>
 				)}
-				<div className={isRefreshing ? 'opacity-60 transition-opacity' : 'transition-opacity'}>{children}</div>
+				<div className={cn('h-full min-h-0', isRefreshing ? 'opacity-60 transition-opacity' : 'transition-opacity')}>{children}</div>
 			</div>
 		</div>
 	)

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -11,8 +11,8 @@ import {
 	Shield,
 	Snowflake,
 } from 'lucide-react'
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode, type UIEvent } from 'react'
-import { Link, Navigate } from 'react-router-dom'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent, type ReactNode, type UIEvent } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
 
 import {
 	hasAllStructureManagerPermission,
@@ -506,6 +506,7 @@ export default function StructuresPage() {
 	usePageTitle('Structures')
 
 	const { user, isLoading: authLoading } = useAuth()
+	const navigate = useNavigate()
 	const { data: groups = [] } = useGroups({ limit: 100 })
 	const { permissions, isLoading: permissionsLoading } = useUserPermissions()
 	const canViewStructures = user?.is_admin === true || hasAnyStructurePermission(permissions)
@@ -692,6 +693,23 @@ export default function StructuresPage() {
 	const isFetching = isStructuresFetching
 	const refreshAll = () => {
 		void activeResponse.refetch()
+	}
+	const getStructureRowProps = (structure: Pick<StructureListBaseItem, 'structureId' | 'canViewDetails'>) => {
+		if (!structure.canViewDetails) return {}
+		return {
+			className: 'cursor-pointer transition-colors hover:bg-muted/40',
+			onClick: (event: MouseEvent<HTMLTableRowElement>) => {
+				if ((event.target as HTMLElement).closest('a,button')) return
+				navigate(`/structures/${structure.structureId}`)
+			},
+			onKeyDown: (event: KeyboardEvent<HTMLTableRowElement>) => {
+				if (event.key !== 'Enter' && event.key !== ' ') return
+				event.preventDefault()
+				navigate(`/structures/${structure.structureId}`)
+			},
+			tabIndex: 0,
+			role: 'link' as const,
+		}
 	}
 
 	useEffect(() => {
@@ -903,7 +921,7 @@ export default function StructuresPage() {
 				: '-'
 
 			return (
-				<TableRow key={structure.structureId}>
+				<TableRow key={structure.structureId} {...getStructureRowProps(structure)}>
 					<TableCell>
 						<SkyhookStateBadge state={structure.state} />
 					</TableCell>
@@ -988,7 +1006,7 @@ export default function StructuresPage() {
 		items.map((structure) => {
 			const vulnerabilityState = getSovereigntyVulnerabilityState(structure)
 			return (
-				<TableRow key={structure.structureId}>
+				<TableRow key={structure.structureId} {...getStructureRowProps(structure)}>
 					<TableCell>
 						<div className="space-y-1">
 							<Badge variant={vulnerabilityState.variant}>{vulnerabilityState.label}</Badge>
@@ -1084,7 +1102,7 @@ export default function StructuresPage() {
 	const renderSkyhookRows = (items: StructureSkyhookListItem[]) =>
 		items.map((structure) => {
 			return (
-				<TableRow key={structure.structureId}>
+				<TableRow key={structure.structureId} {...getStructureRowProps(structure)}>
 					<TableCell>
 						<SkyhookStateBadge state={structure.state} />
 					</TableCell>
@@ -1162,7 +1180,7 @@ export default function StructuresPage() {
 			const displayStructureName = stripLeadingContextName(structure.name, structure.systemName)
 
 			return (
-				<TableRow key={structure.structureId}>
+				<TableRow key={structure.structureId} {...getStructureRowProps(structure)}>
 					<TableCell>
 						<StructureStateBadge state={structure.state} />
 					</TableCell>
@@ -1271,7 +1289,7 @@ export default function StructuresPage() {
 				: '-'
 
 			return (
-				<TableRow key={structure.structureId}>
+				<TableRow key={structure.structureId} {...getStructureRowProps(structure)}>
 					<TableCell>
 						<StructureStateBadge state={structure.state} />
 					</TableCell>
@@ -1661,7 +1679,7 @@ export default function StructuresPage() {
 	}
 
 	return (
-		<Container className="space-y-6 py-6 2xl:!max-w-none">
+		<Container className="flex h-full min-h-0 flex-col space-y-6 overflow-hidden py-6 2xl:!max-w-none">
 			<PageHeader
 				title="Structures"
 				description="Track visible structures, review their current state, and fuel posture."
@@ -1834,7 +1852,7 @@ export default function StructuresPage() {
 				)}
 			</div>
 
-			<Card>
+			<Card className="flex min-h-0 flex-1 flex-col">
 				<CardHeader className="pb-3">
 					<div className="flex flex-wrap items-start justify-between gap-4">
 						<div>
@@ -1848,7 +1866,7 @@ export default function StructuresPage() {
 						</div>
 					</div>
 				</CardHeader>
-				<CardContent className="space-y-4">
+				<CardContent className="flex min-h-0 flex-1 flex-col space-y-4 overflow-hidden">
 					<Tabs
 						value={activeTab}
 						onValueChange={(value) => {
@@ -1879,7 +1897,7 @@ export default function StructuresPage() {
 								? specialFilterControls
 								: commonFilterControls}
 					</div>
-					<div className="space-y-4 border-t border-border/60 pt-4">
+					<div className="flex min-h-0 flex-1 flex-col space-y-4 border-t border-border/60 pt-4">
 						<div className="border-b p-3">
 							<UserSearchPaginationControls
 								totalCount={pagination?.totalCount ?? 0}
@@ -1894,6 +1912,7 @@ export default function StructuresPage() {
 							/>
 						</div>
 						<TableRefreshFrame
+							className="min-h-0 flex-1"
 							key={structuresContentKey}
 							isRefreshing={isSoftLoading}
 							refreshMessage="Refreshing structure list..."
@@ -1936,6 +1955,7 @@ export default function StructuresPage() {
 							<Table
 								containerRef={tableScrollContainerRef}
 								onContainerScroll={handleTableScroll}
+								containerClassName="h-full min-h-0"
 								className={cn(
 									'min-w-[118rem]',
 									isSovereigntyTab && 'min-w-[136rem]',


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Tweaks the Structures page UX: makes the structure table area fill the viewport with internal scrolling instead of page scrolling, makes table rows clickable/keyboard-navigable to open structure details, and fixes an incorrect type-name filter for non-citadel structures.

## Changes
- `apps/structures/src/services/structures.service.ts`: `NON_CITADEL_TYPE_NAMES` no longer includes `MINING_CITADEL_TYPE_NAMES`, leaving only `METENOX_MOON_DRILL_TYPE_NAME` (mining citadels are citadels, not non-citadel structures).
- `apps/ui/src/client/components/layout.tsx`: on the `/structures` route, constrains the layout to the viewport height (`h-dvh`, `overflow-hidden`) instead of allowing full-page scroll, so the table itself scrolls.
- `apps/ui/src/client/components/table-refresh-frame.tsx` and the `Table` usage in `structures.tsx`: adjusted flex/height classes (`min-h-0`, `flex-1`, `containerClassName`) so the refresh frame and table container can flex to fill available space.
- `apps/ui/src/client/routes/structures.tsx`:
  - Added `getStructureRowProps` to make structure table rows clickable (and keyboard-activatable via Enter/Space) to navigate to `/structures/:structureId`, ignoring clicks on nested links/buttons.
  - Applied the row props to all structure table row renderers (standard, sovereignty, skyhook, etc.).
  - Restructured the page container/card/content to a flex column layout with `min-h-0`/`flex-1`/`overflow-hidden` so the table area fills remaining vertical space.

## Testing
No tests included in the diff; changes are UI layout/behavior tweaks and a filter list correction.
<!-- claude:end -->
