### PR TITLE
remove details button and expand default page size

### DIFF
--- a/apps/ui/src/client/features/structures/state/structure-table-store.ts
+++ b/apps/ui/src/client/features/structures/state/structure-table-store.ts
@@ -62,7 +62,7 @@ function defaultState(): StructureTableUiState {
 		tab: 'citadels',
 		filters: currentTabState.filters,
 		page: 1,
-		pageSize: 10,
+		pageSize: 15,
 		sortBy: currentTabState.sortBy,
 		sortDirection: currentTabState.sortDirection,
 		tabStateByTab,

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -1,6 +1,5 @@
 import {
 	ArrowDown,
-	ArrowRight,
 	ArrowUp,
 	ArrowUpDown,
 	CircleHelp,
@@ -17,7 +16,6 @@ import { Link, Navigate, useNavigate } from 'react-router-dom'
 import {
 	hasAllStructureManagerPermission,
 	hasAnyStructurePermission,
-	hasStructureDetailsPermission,
 	hasStructureTabPermission,
 } from '@repo/groups'
 import {
@@ -510,7 +508,6 @@ export default function StructuresPage() {
 	const { data: groups = [] } = useGroups({ limit: 100 })
 	const { permissions, isLoading: permissionsLoading } = useUserPermissions()
 	const canViewStructures = user?.is_admin === true || hasAnyStructurePermission(permissions)
-	const canViewStructureDetails = user?.is_admin === true || hasStructureDetailsPermission(permissions)
 	const canManageStructures =
 		user?.is_admin === true || hasAllStructureManagerPermission(permissions)
 	const tableState = useStructureTableUiState((state) => state)
@@ -980,20 +977,6 @@ export default function StructuresPage() {
 							description={structureSyncStatusDescription(structure)}
 						/>
 					</TableCell>
-					{canViewStructureDetails && (
-						<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
-							{structure.canViewDetails ? (
-								<Button asChild size="sm" variant="ghost">
-									<Link to={`/structures/${structure.structureId}`}>
-										<ArrowRight className="h-4 w-4" />
-										Details
-									</Link>
-								</Button>
-							) : (
-								<span className="text-sm text-muted-foreground">-</span>
-							)}
-						</TableCell>
-					)}
 				</TableRow>
 			)
 		})
@@ -1081,20 +1064,6 @@ export default function StructuresPage() {
 							description={structureSyncStatusDescription(structure)}
 						/>
 					</TableCell>
-					{canViewStructureDetails && (
-						<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
-							{structure.canViewDetails ? (
-								<Button asChild size="sm" variant="ghost">
-									<Link to={`/structures/${structure.structureId}`}>
-										<ArrowRight className="h-4 w-4" />
-										Details
-									</Link>
-								</Button>
-							) : (
-								<span className="text-sm text-muted-foreground">-</span>
-							)}
-						</TableCell>
-					)}
 				</TableRow>
 			)
 		})
@@ -1156,20 +1125,6 @@ export default function StructuresPage() {
 							description={structureSyncStatusDescription(structure)}
 						/>
 					</TableCell>
-					{canViewStructureDetails && (
-						<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
-							{structure.canViewDetails ? (
-								<Button asChild size="sm" variant="ghost">
-									<Link to={`/structures/${structure.structureId}`}>
-										<ArrowRight className="h-4 w-4" />
-										Details
-									</Link>
-								</Button>
-							) : (
-								<span className="text-sm text-muted-foreground">-</span>
-							)}
-						</TableCell>
-					)}
 				</TableRow>
 			)
 		})
@@ -1251,20 +1206,6 @@ export default function StructuresPage() {
 							description={structureSyncStatusDescription(structure)}
 						/>
 					</TableCell>
-					{canViewStructureDetails && (
-						<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
-							{structure.canViewDetails ? (
-								<Button asChild size="sm" variant="ghost">
-									<Link to={`/structures/${structure.structureId}`}>
-										<ArrowRight className="h-4 w-4" />
-										Details
-									</Link>
-								</Button>
-							) : (
-								<span className="text-sm text-muted-foreground">-</span>
-							)}
-						</TableCell>
-					)}
 				</TableRow>
 			)
 		})
@@ -1349,20 +1290,6 @@ export default function StructuresPage() {
 							description={structureSyncStatusDescription(structure)}
 						/>
 					</TableCell>
-					{canViewStructureDetails && (
-						<TableCell className="sticky right-0 z-10 border-l border-border/50 bg-card text-right">
-							{structure.canViewDetails ? (
-								<Button asChild size="sm" variant="ghost">
-									<Link to={`/structures/${structure.structureId}`}>
-										<ArrowRight className="h-4 w-4" />
-										Details
-									</Link>
-								</Button>
-							) : (
-								<span className="text-sm text-muted-foreground">-</span>
-							)}
-						</TableCell>
-					)}
 				</TableRow>
 			)
 		})
@@ -1905,7 +1832,7 @@ export default function StructuresPage() {
 								pageSize={pagination?.pageSize ?? tableState.pageSize}
 								onPageChange={setStructureTablePage}
 								onPageSizeChange={setStructureTablePageSize}
-								pageSizeOptions={[10, 25, 50, 100]}
+								pageSizeOptions={[15, 25, 50, 100]}
 								itemLabel="structures"
 								nextButtonLoading={isFetching}
 								trailingAction={refreshButton}
@@ -2052,11 +1979,6 @@ export default function StructuresPage() {
 												<TableHead>Group</TableHead>
 												<TableHead>Sync</TableHead>
 											</>
-										)}
-										{canViewStructureDetails && (
-											<TableHead className="sticky right-0 z-20 table-header-bg border-l border-border/50 text-right">
-												Actions
-											</TableHead>
 										)}
 									</TableRow>
 								</TableHeader>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Simplifies the structures table by removing the per-row "Details" action/column and bumps the default (and minimum) page size from 10 to 15 rows.

## Changes
- Removed the sticky "Actions" column and its "Details" link/button from every structures table row variant, along with the now-unused `canViewStructureDetails` permission check, `hasStructureDetailsPermission` import, and `ArrowRight` icon import.
- Changed the default `pageSize` in `structure-table-store.ts` from `10` to `15`.
- Updated the pagination `pageSizeOptions` from `[10, 25, 50, 100]` to `[15, 25, 50, 100]`.
<!-- claude:end -->