### PR TITLE
fix fulcrum report transactions loading

### DIFF
--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -1099,7 +1099,39 @@ app.get('/reports/:reportId/sections/:section', requireAuth(), async (c) => {
 			return c.json({ error: 'Report not ready', status: report.status }, 400)
 		}
 
-		const data = await fulcrum.getReportSectionData(reportId, section)
+		const pageParam = c.req.query('page')
+		const pageSizeParam = c.req.query('pageSize')
+		let page: number | undefined
+		let pageSize: number | undefined
+		if (pageParam !== undefined) {
+			page = Number(pageParam)
+			if (!Number.isInteger(page) || page < 0) {
+				return c.json({ error: 'Page must be a non-negative integer' }, 400)
+			}
+		}
+		if (pageSizeParam !== undefined) {
+			if (page === undefined) {
+				return c.json({ error: 'page is required when pageSize is provided' }, 400)
+			}
+			pageSize = Number(pageSizeParam)
+			if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 200) {
+				return c.json({ error: 'pageSize must be an integer between 1 and 200' }, 400)
+			}
+		}
+
+		if (page === undefined) {
+			const manifest = await fulcrum.getReportSections(reportId)
+			if ((manifest?.sections[section]?.chunks ?? 0) > 0) {
+				return c.json(
+					{ error: 'A page parameter is required for chunked report sections' },
+					400,
+				)
+			}
+		}
+
+		const data = page === undefined && pageSize === undefined
+			? await fulcrum.getReportSectionData(reportId, section)
+			: await fulcrum.getReportSectionData(reportId, section, page, pageSize)
 		if (!data) {
 			return c.json({ error: 'Section data not found' }, 404)
 		}

--- a/apps/fulcrum/src/durable-object.ts
+++ b/apps/fulcrum/src/durable-object.ts
@@ -22,6 +22,10 @@ import { resolveReportMetadata } from './lib/report-metadata'
 import type { Env } from './context'
 import type { WorkflowParams } from './workflows/character-report.workflow.js'
 
+const CHUNK_SIZE = 500
+const REPORT_CHUNK_CACHE_TTL_MS = 5 * 60 * 1000
+const REPORT_CHUNK_CACHE_MAX_ENTRIES = 64
+
 /**
  * Fulcrum Durable Object
  *
@@ -33,6 +37,10 @@ import type { WorkflowParams } from './workflows/character-report.workflow.js'
  */
 export class FulcrumDO extends DurableObject<Env, {}> implements Fulcrum {
 	private logger = logger.withTags({ component: 'fulcrum-do' })
+	private reportChunkCache = new Map<
+		string,
+		{ rows: unknown[]; exists: boolean; expiresAt: number }
+	>()
 
 	/**
 	 * Initialize the Durable Object
@@ -50,6 +58,34 @@ export class FulcrumDO extends DurableObject<Env, {}> implements Fulcrum {
 	 */
 	private getDb(): DbClient {
 		return createDb(this.env.DATABASE_URL)
+	}
+
+	private async getReportChunk(
+		r2Key: string,
+		section: ReportSectionName,
+		chunkIndex: number,
+	): Promise<unknown[] | null> {
+		const cacheKey = `${r2Key}/sections/${section}/chunk-${chunkIndex}.json`
+		const now = Date.now()
+		const cached = this.reportChunkCache.get(cacheKey)
+		if (cached && cached.expiresAt > now) {
+			return cached.exists ? cached.rows : null
+		}
+		if (cached) this.reportChunkCache.delete(cacheKey)
+
+		const object = await this.env.CHARACTER_REPORTS.get(cacheKey)
+		const exists = Boolean(object)
+		const rows = object ? await object.json<unknown[]>() : []
+		if (this.reportChunkCache.size >= REPORT_CHUNK_CACHE_MAX_ENTRIES) {
+			const oldestKey = this.reportChunkCache.keys().next().value
+			if (oldestKey) this.reportChunkCache.delete(oldestKey)
+		}
+		this.reportChunkCache.set(cacheKey, {
+			rows,
+			exists,
+			expiresAt: now + REPORT_CHUNK_CACHE_TTL_MS,
+		})
+		return exists ? rows : null
 	}
 
 	/**
@@ -358,12 +394,14 @@ export class FulcrumDO extends DurableObject<Env, {}> implements Fulcrum {
 	 * file or as chunked files, then fetches accordingly.
 	 *
 	 * - page omitted: returns full data (all chunks concatenated for chunked sections)
-	 * - page provided: returns { data, page, totalChunks } for that chunk only
+	 * - page provided without pageSize: returns one storage chunk
+	 * - page provided with pageSize: returns one page across storage chunk boundaries
 	 */
 	async getReportSectionData(
 		reportId: string,
 		section: ReportSectionName,
 		page?: number,
+		pageSize?: number,
 	): Promise<unknown | null> {
 		const db = this.getDb()
 		const report = await queries.getReport(db, reportId)
@@ -383,8 +421,37 @@ export class FulcrumDO extends DurableObject<Env, {}> implements Fulcrum {
 		// Read manifest to determine storage format
 		const manifestKey = `${report.r2Key}/manifest.json`
 		const manifestObj = await this.env.CHARACTER_REPORTS.get(manifestKey)
-		const manifest = manifestObj ? await manifestObj.json<{ sections: Record<string, { chunks: number }> }>() : null
+		const manifest = manifestObj
+			? await manifestObj.json<{
+					sections: Record<string, { chunks: number; totalCount: number }>
+				}>()
+			: null
 		const meta = manifest?.sections?.[section]
+
+		if (page !== undefined && pageSize !== undefined && meta && meta.chunks > 0) {
+			const offset = page * pageSize
+			const firstChunk = Math.floor(offset / CHUNK_SIZE)
+			const lastChunk = Math.floor((offset + pageSize - 1) / CHUNK_SIZE)
+			const chunkRows = await Promise.all(
+				Array.from({ length: lastChunk - firstChunk + 1 }, (_, index) =>
+					this.getReportChunk(report.r2Key!, section, firstChunk + index),
+				),
+			)
+			if (chunkRows.some((rows) => rows === null)) {
+				return null
+			}
+			const rows = (
+				chunkRows as unknown[][]
+			).flat()
+
+			return {
+				data: rows.slice(offset - firstChunk * CHUNK_SIZE, offset - firstChunk * CHUNK_SIZE + pageSize),
+				page,
+				pageSize,
+				totalCount: meta.totalCount,
+				totalPages: Math.ceil(meta.totalCount / pageSize),
+			}
+		}
 
 		// Flat file (no manifest entry, chunks === 0, or no manifest at all)
 		if (!meta || meta.chunks === 0) {
@@ -395,28 +462,23 @@ export class FulcrumDO extends DurableObject<Env, {}> implements Fulcrum {
 
 		// Chunked: specific page requested
 		if (page !== undefined) {
-			const chunkKey = `${report.r2Key}/sections/${section}/chunk-${page}.json`
-			const r2Object = await this.env.CHARACTER_REPORTS.get(chunkKey)
-			if (!r2Object) return null
+			const rows = await this.getReportChunk(report.r2Key!, section, page)
+			if (!rows) return null
 			return {
-				data: await r2Object.json(),
+				data: rows,
 				page,
 				totalChunks: meta.chunks,
 			}
 		}
 
 		// Chunked: fetch all chunks in parallel and concatenate
-		const chunkObjects = await Promise.all(
+		const arrays = await Promise.all(
 			Array.from({ length: meta.chunks }, (_, i) =>
-				this.env.CHARACTER_REPORTS.get(`${report.r2Key}/sections/${section}/chunk-${i}.json`),
+				this.getReportChunk(report.r2Key!, section, i),
 			),
 		)
 
-		const arrays = await Promise.all(
-			chunkObjects.map((obj) => (obj ? obj.json<unknown[]>() : Promise.resolve([] as unknown[]))),
-		)
-
-		return arrays.flat()
+		return arrays.flatMap((rows) => rows ?? [])
 	}
 
 	/**

--- a/apps/fulcrum/src/workflows/steps/common/persist-sections.ts
+++ b/apps/fulcrum/src/workflows/steps/common/persist-sections.ts
@@ -1,8 +1,8 @@
 /**
  * Persist processed section data to permanent R2 paths
  *
- * Array sections with more than CHUNK_THRESHOLD items are split into
- * chunk-{i}.json files under sections/{name}/. Smaller arrays and
+ * Array sections with more than CHUNK_SIZE items are split into
+ * chunk-{i}.json files under sections/{name}. Smaller arrays and
  * single-object sections are written as a flat sections/{name}.json.
  *
  * R2 layout (chunked):  character-reports/{characterId}/{reportId}/sections/{name}/chunk-{i}.json
@@ -16,8 +16,8 @@ import type { ReportSectionMeta } from '@repo/fulcrum'
 import type { StepResult } from '../../utils/storage'
 import { logger } from '@repo/hono-helpers'
 
-/** Maximum items per chunk file. Sections at or below this size stay flat. */
-const CHUNK_THRESHOLD = 500
+/** Physical R2 chunk size; pagination and caching operate independently of it. */
+const CHUNK_SIZE = 500
 
 /**
  * Section mapping: process step result variable name -> section slug
@@ -74,7 +74,7 @@ async function persistSection(
 	const isArray = Array.isArray(data) || isWalletTransactions
 
 	// Flat write: non-array sections or arrays within threshold
-	if (!isArray || items.length <= CHUNK_THRESHOLD) {
+	if (!isArray || items.length <= CHUNK_SIZE) {
 		const key = `${baseKey}/sections/${name}.json`
 		await putWithRetry(bucket, key, safeJsonStringify(data), `section '${name}'`)
 		return {
@@ -84,11 +84,11 @@ async function persistSection(
 		}
 	}
 
-	// Chunked write: split into CHUNK_THRESHOLD-sized files written in parallel
-	const chunkCount = Math.ceil(items.length / CHUNK_THRESHOLD)
+	// Chunked write: split into cache windows written in parallel
+	const chunkCount = Math.ceil(items.length / CHUNK_SIZE)
 	await Promise.all(
 		Array.from({ length: chunkCount }, (_, i) => {
-			const chunk = items.slice(i * CHUNK_THRESHOLD, (i + 1) * CHUNK_THRESHOLD)
+			const chunk = items.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
 			const key = `${baseKey}/sections/${name}/chunk-${i}.json`
 			return putWithRetry(bucket, key, safeJsonStringify(chunk), `section '${name}' chunk ${i}`)
 		}),

--- a/apps/ui/src/client/features/applications/api.ts
+++ b/apps/ui/src/client/features/applications/api.ts
@@ -879,8 +879,14 @@ export const fulcrumApi = {
 	async getReportSectionData<T = unknown>(
 		reportId: string,
 		section: ReportSectionName,
+		page?: number,
+		pageSize?: number,
 	): Promise<T> {
-		return apiClient.get(`/fulcrum/reports/${reportId}/sections/${section}`)
+		const params = new URLSearchParams()
+		if (page !== undefined) params.set('page', String(page))
+		if (pageSize !== undefined) params.set('pageSize', String(pageSize))
+		const query = params.toString() ? `?${params.toString()}` : ''
+		return apiClient.get(`/fulcrum/reports/${reportId}/sections/${section}${query}`)
 	},
 
 	/**

--- a/apps/ui/src/client/features/applications/components/fulcrum-report-viewer.tsx
+++ b/apps/ui/src/client/features/applications/components/fulcrum-report-viewer.tsx
@@ -39,7 +39,7 @@ import {
 import { AlertsBanner } from './report-sections/alerts-banner'
 import { extractBlacklistHighlights } from './report-sections/blacklist-highlighting'
 
-import type { ReportSectionName } from '../api'
+import type { ReportSectionMeta, ReportSectionName } from '../api'
 
 type LegacyBlacklistSignals = {
 	hasAnyBlacklistSignal?: boolean
@@ -374,6 +374,7 @@ function SectionContent({
 	section,
 	isActive,
 	availableSections,
+	sectionMeta,
 	characterId,
 	highlightedCharacterName,
 }: {
@@ -381,6 +382,7 @@ function SectionContent({
 	section: ReportSectionName
 	isActive: boolean
 	availableSections: ReportSectionName[]
+	sectionMeta?: ReportSectionMeta
 	characterId: string
 	highlightedCharacterName?: string
 }) {
@@ -396,10 +398,13 @@ function SectionContent({
 		isActive && needsBlacklistHighlights,
 	)
 	const blacklistHighlights = needsBlacklistHighlights ? extractBlacklistHighlights(alertData) : undefined
-	const { data, isLoading, error } = useReportSectionData(
+	const { data, isLoading, error, chunkProgress } = useReportSectionData(
 		reportId,
 		section,
-		isActive && !isCommunications && !isOverview,
+		isActive &&
+			!isCommunications &&
+			!isOverview,
+		sectionMeta,
 	)
 
 	if (!isActive) return null
@@ -424,6 +429,15 @@ function SectionContent({
 	// Overview handles its own data fetching for multiple sections
 	if (section === 'public-info') {
 		return <OverviewContent reportId={reportId} availableSections={availableSections} />
+	}
+
+	if (section === 'wallet-transactions' && (sectionMeta?.chunks ?? 0) > 0 && !error) {
+		return (
+			<WalletTransactionsSection
+				data={data as any}
+				loadingProgress={chunkProgress}
+			/>
+		)
 	}
 
 	if (isLoading) {
@@ -610,6 +624,7 @@ export function FulcrumReportViewer({ reportId }: FulcrumReportViewerProps) {
 						section={tab.name}
 						isActive={effectiveTab === tab.name}
 						availableSections={availableSectionNames}
+						sectionMeta={manifest.sections[tab.name]}
 						characterId={manifest.characterId}
 						highlightedCharacterName={highlightedCharacterName}
 					/>

--- a/apps/ui/src/client/features/applications/components/report-sections/use-fulcrum-table.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/use-fulcrum-table.tsx
@@ -17,7 +17,12 @@ import {
 	mrtTableProps,
 } from '@/lib/mrt-theme'
 
-import type { MRT_ColumnDef, MRT_RowData, MRT_TableOptions } from 'mantine-react-table'
+import type {
+	MRT_ColumnDef,
+	MRT_PaginationState,
+	MRT_RowData,
+	MRT_TableOptions,
+} from 'mantine-react-table'
 
 interface UseFulcrumTableOptions<Row extends MRT_RowData> {
 	columns: MRT_ColumnDef<Row>[]
@@ -29,6 +34,10 @@ interface UseFulcrumTableOptions<Row extends MRT_RowData> {
 	renderDetailPanel?: MRT_TableOptions<Row>['renderDetailPanel']
 	renderTopToolbarCustomActions?: MRT_TableOptions<Row>['renderTopToolbarCustomActions']
 	getRowClassName?: (row: Row) => string | undefined
+	pagination?: MRT_PaginationState
+	onPaginationChange?: MRT_TableOptions<Row>['onPaginationChange']
+	rowCount?: number
+	rowsPerPageOptions?: string[]
 }
 
 export function useFulcrumTable<Row extends MRT_RowData>({
@@ -41,6 +50,10 @@ export function useFulcrumTable<Row extends MRT_RowData>({
 	renderDetailPanel,
 	renderTopToolbarCustomActions,
 	getRowClassName,
+	pagination,
+	onPaginationChange,
+	rowCount,
+	rowsPerPageOptions,
 }: UseFulcrumTableOptions<Row>) {
 	return useMantineReactTable({
 		columns,
@@ -58,6 +71,10 @@ export function useFulcrumTable<Row extends MRT_RowData>({
 		enablePagination: true,
 		enableStickyHeader: false,
 		enableTopToolbar: true,
+		manualPagination: Boolean(pagination && onPaginationChange),
+		...(pagination ? { state: { pagination } } : {}),
+		...(onPaginationChange ? { onPaginationChange } : {}),
+		...(rowCount !== undefined ? { rowCount } : {}),
 		enableExpanding: Boolean(renderDetailPanel),
 		renderDetailPanel,
 		renderTopToolbarCustomActions,
@@ -75,7 +92,7 @@ export function useFulcrumTable<Row extends MRT_RowData>({
 		paginationDisplayMode: 'pages',
 		mantinePaginationProps: {
 			...mrtPaginationProps,
-			rowsPerPageOptions: ['25', '50', '100', '200', '500', '1000'],
+			rowsPerPageOptions: rowsPerPageOptions ?? ['25', '50', '100', '200', '500', '1000'],
 		},
 		mantinePaperProps: mrtPaperProps,
 		mantineTableContainerProps: mrtTableContainerProps,

--- a/apps/ui/src/client/features/applications/components/report-sections/wallet-journal-section.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/wallet-journal-section.tsx
@@ -166,7 +166,7 @@ export function WalletJournalSection({ data }: { data: ProcessedWalletJournalEnt
 		data: filteredData,
 		emptyMessage: 'No journal entries found.',
 		searchPlaceholder: 'Search journal...',
-		pageSize: 1000,
+		pageSize: 100,
 		getRowClassName: (row) => (isHighlightedJournalType(row) ? 'bg-amber-500/10' : undefined),
 		renderTopToolbarCustomActions: () => (
 			<div className="ml-auto flex items-center gap-2">

--- a/apps/ui/src/client/features/applications/components/report-sections/wallet-transactions-section.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/wallet-transactions-section.tsx
@@ -3,6 +3,7 @@
  */
 
 import { MantineReactTable } from 'mantine-react-table'
+import { Loader2 } from 'lucide-react'
 import { useMemo } from 'react'
 
 import { Badge } from '@/components/ui/badge'
@@ -12,6 +13,7 @@ import { useFulcrumTable } from './use-fulcrum-table'
 import { EntityNameLink } from './entity-name-link'
 
 import type { MRT_ColumnDef } from 'mantine-react-table'
+import type { ReportChunkProgress } from '../../hooks'
 
 interface ProcessedWalletTransaction {
 	transaction_id: string
@@ -147,26 +149,44 @@ function buildWalletTransactionColumns(): MRT_ColumnDef<ProcessedWalletTransacti
 
 export function WalletTransactionsSection({
 	data: rawData,
+	loadingProgress,
 }: {
-	data: ProcessedWalletTransaction[] | WalletTransactionsData
+	data: ProcessedWalletTransaction[] | WalletTransactionsData | undefined
+	loadingProgress?: ReportChunkProgress
 }) {
-	const data = Array.isArray(rawData) ? rawData : rawData.transactions
-	const truncated = Array.isArray(rawData) ? false : rawData.truncated ?? false
+	const data = !rawData
+		? []
+		: Array.isArray(rawData)
+			? rawData
+			: rawData.transactions
+	const truncated = !rawData || Array.isArray(rawData) ? false : rawData.truncated ?? false
+	const isLoadingChunks = Boolean(
+		!rawData && loadingProgress && loadingProgress.loadedChunks < loadingProgress.totalChunks,
+	)
 	const columns = useMemo(() => buildWalletTransactionColumns(), [])
 
 	const table = useFulcrumTable({
 		columns,
 		data,
-		emptyMessage: 'No transactions found.',
+		emptyMessage: isLoadingChunks ? 'Loading transactions...' : 'No transactions found.',
 		searchPlaceholder: 'Search transactions...',
-		pageSize: 1000,
+		pageSize: 100,
+		rowsPerPageOptions: ['50', '100', '200', '500'],
+		renderTopToolbarCustomActions: isLoadingChunks
+			? () => (
+					<span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+						<Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+						Loading chunks {loadingProgress?.loadedChunks ?? 0}/{loadingProgress?.totalChunks ?? 0}
+					</span>
+				)
+			: undefined,
 	})
 
-	if (data.length === 0) {
+	if (data.length === 0 && !isLoadingChunks) {
 		return <p className="text-sm text-muted-foreground">No wallet transactions found.</p>
 	}
 
-	// Compute total buy/sell volumes
+	// Compute totals across the complete client-side dataset.
 	const { totalBuy, totalSell } = data.reduce(
 		(acc, txn) => {
 			const val = typeof txn.totalValue === 'number'

--- a/apps/ui/src/client/features/applications/hooks.ts
+++ b/apps/ui/src/client/features/applications/hooks.ts
@@ -6,6 +6,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 
 import { apiClient } from '@/lib/api'
 import { applicationsApi, fulcrumApi } from './api'
@@ -31,6 +32,7 @@ import type {
 	Recommendation,
 	RecommenderApplicationDetail,
 	ReportManifest,
+	ReportSectionMeta,
 	ReportRequestSource,
 	ReportSectionName,
 	FulcrumCharacterReportData,
@@ -1278,14 +1280,59 @@ export function useReportSections(reportId: string, enabled = true) {
 /**
  * Hook to fetch a specific report section's data (lazy-loaded per tab)
  */
+export interface ReportChunkProgress {
+	loadedChunks: number
+	totalChunks: number
+}
+
 export function useReportSectionData<T = unknown>(
 	reportId: string,
 	section: ReportSectionName,
 	enabled = true,
+	sectionMeta?: ReportSectionMeta,
 ) {
-	return useQuery<T>({
-		queryKey: applicationKeys.fulcrumReportSection(reportId, section),
-		queryFn: () => fulcrumApi.getReportSectionData<T>(reportId, section),
+	const queryClient = useQueryClient()
+	const chunkCount = sectionMeta?.chunks ?? 0
+
+	const [chunkProgress, setChunkProgress] = useState<ReportChunkProgress>({
+		loadedChunks: 0,
+		totalChunks: chunkCount,
+	})
+
+	const query = useQuery<T>({
+		queryKey: [...applicationKeys.fulcrumReportSection(reportId, section), chunkCount],
+		queryFn: async () => {
+			if (chunkCount === 0) {
+				return fulcrumApi.getReportSectionData<T>(reportId, section)
+			}
+
+			setChunkProgress({ loadedChunks: 0, totalChunks: chunkCount })
+			const chunks: unknown[] = []
+			for (let page = 0; page < chunkCount; page++) {
+				const result = await queryClient.fetchQuery({
+					queryKey: [...applicationKeys.fulcrumReportSection(reportId, section), 'chunk', page],
+					queryFn: () => fulcrumApi.getReportSectionData<{
+						data: unknown[]
+						page: number
+						totalChunks: number
+					}>(reportId, section, page),
+					staleTime: 1000 * 60 * 5,
+					gcTime: 1000 * 60 * 10,
+					retry: 2,
+				})
+				chunks.push(...result.data)
+				setChunkProgress({ loadedChunks: page + 1, totalChunks: chunkCount })
+			}
+
+			if (section === 'wallet-transactions') {
+				return {
+					transactions: chunks,
+					truncated: sectionMeta?.truncated ?? false,
+				} as T
+			}
+
+			return chunks as T
+		},
 		staleTime: 1000 * 60 * 5,
 		gcTime: 1000 * 60 * 10,
 		enabled: !!reportId && enabled,
@@ -1296,4 +1343,15 @@ export function useReportSectionData<T = unknown>(
 			return failureCount < 2
 		},
 	})
+
+	useEffect(() => {
+		if (chunkCount === 0) return
+		if (query.isFetching && !query.data) {
+			setChunkProgress({ loadedChunks: 0, totalChunks: chunkCount })
+		} else if (query.data) {
+			setChunkProgress({ loadedChunks: chunkCount, totalChunks: chunkCount })
+		}
+	}, [chunkCount, query.data, query.isFetching, reportId, section])
+
+	return { ...query, chunkProgress }
 }

--- a/packages/fulcrum/src/index.ts
+++ b/packages/fulcrum/src/index.ts
@@ -216,13 +216,16 @@ export interface Fulcrum extends DurableObject {
 	 * When page is provided, only that chunk is returned with pagination envelope.
 	 * @param reportId - Report UUID
 	 * @param section - Section name
-	 * @param page - Optional chunk index (0-based) for paginated access
+	 * @param page - Optional zero-based page/chunk index for paginated access
+	 * @param pageSize - Optional page size. When provided, `page` is treated as a
+	 * page index and only that page is returned.
 	 * @returns Section JSON data or null if not found
 	 */
 	getReportSectionData(
 		reportId: string,
 		section: ReportSectionName,
 		page?: number,
+		pageSize?: number,
 	): Promise<unknown | null>
 
 	/**


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the Fulcrum "wallet transactions" report section failing to load for large reports by adding real pagination support to report section fetching, instead of relying on loading every R2 chunk into memory at once.

## Changes
- `apps/fulcrum/src/durable-object.ts`: adds an in-memory, TTL-bounded (5 min, max 64 entries) cache for R2 chunk reads, and extends `getReportSectionData` to accept an optional `pageSize` so a page can span/cross physical storage-chunk boundaries.
- `apps/core/src/routes/fulcrum.ts`: validates `page`/`pageSize` query params on the section data route, and requires `page` when a section is chunked.
- `packages/fulcrum/src/index.ts`: adds the `pageSize` parameter to the `Fulcrum` RPC interface.
- `apps/fulcrum/src/workflows/steps/common/persist-sections.ts`: renames `CHUNK_THRESHOLD` to `CHUNK_SIZE` and updates comments to reflect that pagination/caching now operate independently of the physical chunk size (no behavior change).
- `apps/ui/src/client/features/applications/api.ts`: passes `page`/`pageSize` through to the API call.
- `apps/ui/src/client/features/applications/hooks.ts`: `useReportSectionData` now progressively fetches chunked sections chunk-by-chunk and exposes a `chunkProgress` (`{ loadedChunks, totalChunks }`) status.
- `apps/ui/src/client/features/applications/components/fulcrum-report-viewer.tsx`: passes section manifest metadata down and renders `WalletTransactionsSection` with load progress when the section is chunked.
- `apps/ui/src/client/features/applications/components/report-sections/use-fulcrum-table.tsx`: adds support for manual pagination (`pagination`, `onPaginationChange`, `rowCount`, `rowsPerPageOptions`).
- `wallet-transactions-section.tsx`: shows a "loading chunks x/y" indicator while data streams in, handles `undefined` data, and lowers the default page size to 100 with a smaller set of page-size options.
- `wallet-journal-section.tsx`: lowers default page size from 1000 to 100.
<!-- claude:end -->