### PR TITLE
add chunk loader to journal and increase cache time

### DIFF
--- a/apps/ui/src/client/features/applications/components/fulcrum-report-viewer.tsx
+++ b/apps/ui/src/client/features/applications/components/fulcrum-report-viewer.tsx
@@ -440,6 +440,15 @@ function SectionContent({
 		)
 	}
 
+	if (section === 'wallet-journal' && (sectionMeta?.chunks ?? 0) > 0 && !error) {
+		return (
+			<WalletJournalSection
+				data={data as any}
+				loadingProgress={chunkProgress}
+			/>
+		)
+	}
+
 	if (isLoading) {
 		return (
 			<div className="space-y-4">

--- a/apps/ui/src/client/features/applications/components/report-sections/contracts-section.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/contracts-section.tsx
@@ -480,6 +480,7 @@ export function ContractsSection({ data }: { data: ProcessedContract[] }) {
 		data: filtered,
 		emptyMessage: 'No contracts match the current filters',
 		searchPlaceholder: 'Search contracts...',
+		compactRows: true,
 		renderDetailPanel: ({ row }) => <ContractDetails contract={row.original} />,
 	})
 

--- a/apps/ui/src/client/features/applications/components/report-sections/use-fulcrum-table.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/use-fulcrum-table.tsx
@@ -38,6 +38,7 @@ interface UseFulcrumTableOptions<Row extends MRT_RowData> {
 	onPaginationChange?: MRT_TableOptions<Row>['onPaginationChange']
 	rowCount?: number
 	rowsPerPageOptions?: string[]
+	compactRows?: boolean
 }
 
 export function useFulcrumTable<Row extends MRT_RowData>({
@@ -54,6 +55,7 @@ export function useFulcrumTable<Row extends MRT_RowData>({
 	onPaginationChange,
 	rowCount,
 	rowsPerPageOptions,
+	compactRows = false,
 }: UseFulcrumTableOptions<Row>) {
 	return useMantineReactTable({
 		columns,
@@ -72,6 +74,7 @@ export function useFulcrumTable<Row extends MRT_RowData>({
 		enableStickyHeader: false,
 		enableTopToolbar: true,
 		manualPagination: Boolean(pagination && onPaginationChange),
+		positionPagination: 'both',
 		...(pagination ? { state: { pagination } } : {}),
 		...(onPaginationChange ? { onPaginationChange } : {}),
 		...(rowCount !== undefined ? { rowCount } : {}),
@@ -101,7 +104,11 @@ export function useFulcrumTable<Row extends MRT_RowData>({
 		mantineTableHeadCellProps: mrtTableHeadCellProps,
 		mantineTableBodyCellProps: mrtTableBodyCellProps,
 		mantineTableBodyRowProps: ({ row }) => ({
-			className: cn('mrt-grid__row', getRowClassName?.(row.original as Row)),
+			className: cn(
+				'mrt-grid__row',
+				compactRows && 'mrt-grid__compact-row',
+				getRowClassName?.(row.original as Row),
+			),
 			style: mrtRowStyle(row.index),
 		}),
 		renderEmptyRowsFallback: () => (

--- a/apps/ui/src/client/features/applications/components/report-sections/wallet-journal-section.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/wallet-journal-section.tsx
@@ -4,6 +4,7 @@
 
 import { useMemo, useState } from 'react'
 import { MantineReactTable } from 'mantine-react-table'
+import { Loader2 } from 'lucide-react'
 
 import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { Select } from '@/components/ui/select'
@@ -11,6 +12,7 @@ import { useFulcrumTable } from './use-fulcrum-table'
 import { EntityNameLink } from './entity-name-link'
 
 import type { MRT_ColumnDef } from 'mantine-react-table'
+import type { ReportChunkProgress } from '../../hooks'
 
 interface ProcessedWalletJournalEntry {
 	id: string
@@ -136,15 +138,25 @@ function buildWalletJournalColumns(): MRT_ColumnDef<ProcessedWalletJournalEntry>
 	]
 }
 
-export function WalletJournalSection({ data }: { data: ProcessedWalletJournalEntry[] }) {
+export function WalletJournalSection({
+	data,
+	loadingProgress,
+}: {
+	data: ProcessedWalletJournalEntry[] | undefined
+	loadingProgress?: ReportChunkProgress
+}) {
+	const rows = data ?? []
+	const isLoadingChunks = Boolean(
+		!data && loadingProgress && loadingProgress.loadedChunks < loadingProgress.totalChunks,
+	)
 	const [refTypeFilter, setRefTypeFilter] = useState<string>('all')
 	const columns = useMemo(() => buildWalletJournalColumns(), [])
 	const availableRefTypes = useMemo(
 		() =>
 			Array.from(
-				new Set(data.map((entry) => entry.refTypeLabel).filter((type): type is string => Boolean(type))),
+				new Set(rows.map((entry) => entry.refTypeLabel).filter((type): type is string => Boolean(type))),
 			).sort(),
-		[data],
+		[rows],
 	)
 	const refTypeOptions = useMemo(
 		() => [
@@ -156,20 +168,27 @@ export function WalletJournalSection({ data }: { data: ProcessedWalletJournalEnt
 	const filteredData = useMemo(
 		() =>
 			refTypeFilter === 'all'
-				? data
-				: data.filter((entry) => (entry.refTypeLabel ?? 'Unknown') === refTypeFilter),
-		[data, refTypeFilter],
+				? rows
+				: rows.filter((entry) => (entry.refTypeLabel ?? 'Unknown') === refTypeFilter),
+		[rows, refTypeFilter],
 	)
 
 	const table = useFulcrumTable({
 		columns,
 		data: filteredData,
-		emptyMessage: 'No journal entries found.',
+		emptyMessage: isLoadingChunks ? 'Loading journal entries...' : 'No journal entries found.',
 		searchPlaceholder: 'Search journal...',
 		pageSize: 100,
+		compactRows: true,
 		getRowClassName: (row) => (isHighlightedJournalType(row) ? 'bg-amber-500/10' : undefined),
 		renderTopToolbarCustomActions: () => (
 			<div className="ml-auto flex items-center gap-2">
+				{isLoadingChunks && (
+					<span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+						<Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+						Loading chunks {loadingProgress?.loadedChunks ?? 0}/{loadingProgress?.totalChunks ?? 0}
+					</span>
+				)}
 				<label htmlFor="journal-ref-type-filter" className="text-xs font-medium text-muted-foreground">
 					Transaction Type
 				</label>
@@ -183,18 +202,18 @@ export function WalletJournalSection({ data }: { data: ProcessedWalletJournalEnt
 					className="w-56"
 				/>
 				<span className="text-xs text-muted-foreground">
-					{filteredData.length} / {data.length}
+					{filteredData.length} / {rows.length}
 				</span>
 			</div>
 		),
 	})
 
-	if (data.length === 0) {
+	if (rows.length === 0 && !isLoadingChunks) {
 		return <p className="text-sm text-muted-foreground">No journal entries found.</p>
 	}
 
 	// Most recent entry's balance is the current wallet balance
-	const currentBalance = data[0]?.balanceFormatted
+	const currentBalance = rows[0]?.balanceFormatted
 
 	return (
 		<div className="space-y-3">

--- a/apps/ui/src/client/features/applications/components/report-sections/wallet-transactions-section.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/wallet-transactions-section.tsx
@@ -172,6 +172,7 @@ export function WalletTransactionsSection({
 		searchPlaceholder: 'Search transactions...',
 		pageSize: 100,
 		rowsPerPageOptions: ['50', '100', '200', '500'],
+		compactRows: true,
 		renderTopToolbarCustomActions: isLoadingChunks
 			? () => (
 					<span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/apps/ui/src/client/features/applications/hooks.ts
+++ b/apps/ui/src/client/features/applications/hooks.ts
@@ -95,6 +95,8 @@ export const applicationKeys = {
 		[...applicationKeys.all, 'user-history', userId] as const,
 }
 
+const REPORT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
 export const hrUserKeys = {
 	all: ['hr', 'users'] as const,
 	characters: (userId: string) => [...hrUserKeys.all, userId, 'characters'] as const,
@@ -1270,8 +1272,8 @@ export function useReportSections(reportId: string, enabled = true) {
 	return useQuery<ReportManifest>({
 		queryKey: applicationKeys.fulcrumReportSections(reportId),
 		queryFn: () => fulcrumApi.getReportSections(reportId),
-		staleTime: 1000 * 60 * 5,
-		gcTime: 1000 * 60 * 10,
+		staleTime: REPORT_CACHE_TTL_MS,
+		gcTime: REPORT_CACHE_TTL_MS,
 		enabled: !!reportId && enabled,
 		retry: 2,
 	})
@@ -1284,6 +1286,8 @@ export interface ReportChunkProgress {
 	loadedChunks: number
 	totalChunks: number
 }
+
+const REPORT_CHUNK_FETCH_CONCURRENCY = 3
 
 export function useReportSectionData<T = unknown>(
 	reportId: string,
@@ -1308,20 +1312,33 @@ export function useReportSectionData<T = unknown>(
 
 			setChunkProgress({ loadedChunks: 0, totalChunks: chunkCount })
 			const chunks: unknown[] = []
-			for (let page = 0; page < chunkCount; page++) {
-				const result = await queryClient.fetchQuery({
-					queryKey: [...applicationKeys.fulcrumReportSection(reportId, section), 'chunk', page],
-					queryFn: () => fulcrumApi.getReportSectionData<{
-						data: unknown[]
-						page: number
-						totalChunks: number
-					}>(reportId, section, page),
-					staleTime: 1000 * 60 * 5,
-					gcTime: 1000 * 60 * 10,
-					retry: 2,
+			for (let batchStart = 0; batchStart < chunkCount; batchStart += REPORT_CHUNK_FETCH_CONCURRENCY) {
+				const batchPages = Array.from(
+					{ length: Math.min(REPORT_CHUNK_FETCH_CONCURRENCY, chunkCount - batchStart) },
+					(_, index) => batchStart + index,
+				)
+				const batchResults = await Promise.all(
+					batchPages.map((page) =>
+						queryClient.fetchQuery({
+							queryKey: [...applicationKeys.fulcrumReportSection(reportId, section), 'chunk', page],
+							queryFn: () => fulcrumApi.getReportSectionData<{
+								data: unknown[]
+								page: number
+								totalChunks: number
+							}>(reportId, section, page),
+							staleTime: REPORT_CACHE_TTL_MS,
+							gcTime: REPORT_CACHE_TTL_MS,
+							retry: 2,
+						}),
+					),
+				)
+				for (const result of batchResults) {
+					chunks.push(...result.data)
+				}
+				setChunkProgress({
+					loadedChunks: Math.min(batchStart + batchResults.length, chunkCount),
+					totalChunks: chunkCount,
 				})
-				chunks.push(...result.data)
-				setChunkProgress({ loadedChunks: page + 1, totalChunks: chunkCount })
 			}
 
 			if (section === 'wallet-transactions') {
@@ -1333,8 +1350,8 @@ export function useReportSectionData<T = unknown>(
 
 			return chunks as T
 		},
-		staleTime: 1000 * 60 * 5,
-		gcTime: 1000 * 60 * 10,
+		staleTime: REPORT_CACHE_TTL_MS,
+		gcTime: REPORT_CACHE_TTL_MS,
 		enabled: !!reportId && enabled,
 		retry: (failureCount, error) => {
 			// Don't retry on 404 (section genuinely missing)

--- a/apps/ui/src/client/styles/globals.css
+++ b/apps/ui/src/client/styles/globals.css
@@ -365,6 +365,12 @@ body {
 	font-size: 0.875rem;
 }
 
+/* Keep dense financial/report tables readable without changing other MRT tables. */
+.mrt-grid__paper .mrt-grid__compact-row > td {
+	padding-bottom: 0.35rem;
+	padding-top: 0.35rem;
+}
+
 .mrt-grid__paper .mantine-Paper-root,
 .mrt-grid__paper .mantine-ScrollArea-root,
 .mrt-grid__paper .mantine-Table-root {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a chunk-loading indicator to the wallet journal report section and speeds up/lengthens caching of Fulcrum report data, since report chunks were previously fetched one at a time and re-fetched too often.

## Changes
- `WalletJournalSection` now accepts a `loadingProgress` prop and renders a spinner with "Loading chunks X/Y" while chunks are still streaming in, mirroring the existing wallet-transactions behavior.
- `SectionContent` in `fulcrum-report-viewer.tsx` renders `WalletJournalSection` with chunk progress whenever the section has chunks and hasn't errored.
- Report chunk fetching now runs in batches of 3 concurrent requests (`REPORT_CHUNK_FETCH_CONCURRENCY`) instead of strictly sequential, fetching all chunks faster.
- Report section and chunk queries' `staleTime`/`gcTime` increased from 5/10 minutes to a shared 24-hour `REPORT_CACHE_TTL_MS`.
- Added a `compactRows` option to `useFulcrumTable`, applied to the contracts, wallet-journal, and wallet-transactions tables, with a new `.mrt-grid__compact-row` CSS class for tighter row padding.
- Table pagination controls now render at both the top and bottom (`positionPagination: 'both'`).

## Testing
Not evident from the diff — no test changes included.
<!-- claude:end -->