### PR TITLE
fix UX bug with editing temp assign roles

### DIFF
--- a/apps/ui/src/client/routes/admin/discord-server-roles.tsx
+++ b/apps/ui/src/client/routes/admin/discord-server-roles.tsx
@@ -529,7 +529,7 @@ export default function AdminDiscordServerRolesPage() {
 						<CardContent className="space-y-3">
 							{selfAssignableRoles.isLoading ? (
 								<LoadingSpinner label="Loading self-assignable roles..." />
-							) : selfAssignableRoles.data?.length ? (
+						) : selfAssignableRoles.data?.length || isCreatingSelfAssignableRole ? (
 								<div className="overflow-x-auto rounded-lg border border-border/50 bg-card">
 									<Table>
 										<TableHeader>


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a UX bug on the admin Discord server roles page where starting to create a new self-assignable (temporary) role while the list was empty would incorrectly show the "no roles" empty state instead of the table containing the in-progress create row.

## Changes
- In `discord-server-roles.tsx`, the self-assignable roles table is now rendered when either roles already exist (`selfAssignableRoles.data?.length`) or a new role is currently being created (`isCreatingSelfAssignableRole`), so the inline create row (and its form) is reachable even when the list starts out empty.
<!-- claude:end -->
