### PR TITLE
fix skyhooks reinforcement timeer summary error

### DIFF
--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -901,10 +901,11 @@ function summarizeStructureSkyhook(
 	const reagentTotals = getSkyhookReagentSummaryFromStorageState(skyhook)
 	const reagents = getSkyhookReagentEntriesFromStorageState(skyhook)
 	const isRaidable = isSkyhookCurrentlyRaidable(skyhook)
+	const reinforcementTimerEnd = toIso(skyhook.reinforcementTimerEnd)
 	const normalizedState = getSkyhookState(
 		skyhook.state,
 		isRaidable,
-		skyhook.reinforcementTimerEnd ? skyhook.reinforcementTimerEnd.toISOString() : null
+		reinforcementTimerEnd
 	)
 
 	return {
@@ -949,18 +950,12 @@ function summarizeStructureSkyhook(
 			),
 			lastCycle: reagent.lastCycle,
 		})),
-		reinforcementTimerEnd: skyhook.reinforcementTimerEnd
-			? skyhook.reinforcementTimerEnd.toISOString()
-			: null,
-			theftVulnerabilityStart: skyhook.theftVulnerabilityStart
-				? skyhook.theftVulnerabilityStart.toISOString()
-				: null,
-			theftVulnerabilityEnd: skyhook.theftVulnerabilityEnd
-				? skyhook.theftVulnerabilityEnd.toISOString()
-				: null,
-			isRaidable,
-		}
+		reinforcementTimerEnd,
+		theftVulnerabilityStart: toIso(skyhook.theftVulnerabilityStart),
+		theftVulnerabilityEnd: toIso(skyhook.theftVulnerabilityEnd),
+		isRaidable,
 	}
+}
 
 function summarizeStructureMoonDrill(
 	moonDrill: typeof structureMoonDrills.$inferSelect | null,
@@ -2326,10 +2321,11 @@ function buildSkyhookListItemFromRow(
 ): RepoStructureSkyhookListItem {
 	const reagentSummary = getSkyhookReagentSummaryFromStorageState(row)
 	const reagentEntries = getSkyhookReagentEntriesFromStorageState(row)
+	const reinforcementTimerEnd = toIso(row.reinforcementTimerEnd)
 	const normalizedState = getSkyhookState(
 		row.state,
 		row.isRaidable ?? false,
-		row.reinforcementTimerEnd ? row.reinforcementTimerEnd.toISOString() : null
+		reinforcementTimerEnd
 	)
 
 	return {
@@ -2394,12 +2390,12 @@ function buildSkyhookListItemFromRow(
 			),
 			lastCycle: reagent.lastCycle,
 		})),
-			reinforcementTimerEnd: toIso(row.reinforcementTimerEnd),
-			theftVulnerabilityStart: toIso(row.theftVulnerabilityStart),
-			theftVulnerabilityEnd: toIso(row.theftVulnerabilityEnd),
-			isRaidable: row.isRaidable ?? false,
-		}
+		reinforcementTimerEnd,
+		theftVulnerabilityStart: toIso(row.theftVulnerabilityStart),
+		theftVulnerabilityEnd: toIso(row.theftVulnerabilityEnd),
+		isRaidable: row.isRaidable ?? false,
 	}
+}
 
 async function buildSkyhookStructureFilterOptionsFromSql(
 	db: DbClient<DbSchema>,

--- a/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
+++ b/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
@@ -332,4 +332,58 @@ describe('structure permission gating', () => {
 			}),
 		])
 	})
+
+	it('serializes reinforced skyhook timestamps returned as strings', async () => {
+		const reinforcementTimerEnd = '2026-01-01T06:00:00.000Z'
+		const db = makeDb({
+			structure: {
+				structureId: 'skyhook-1',
+				corporationId: 'corp-1',
+				name: 'Skyhook One',
+				typeId: '81080',
+				typeName: 'Orbital Skyhook',
+				systemId: '30000142',
+				systemName: 'Jita',
+				regionId: '10000002',
+				regionName: 'The Forge',
+				state: 'reinforced',
+				nextReinforceApply: null,
+				stateTimerEnd: null,
+				unanchorsAt: null,
+				fuelExpires: null,
+				fuelAmount: null,
+				fuelBurnRate: null,
+				lowPower: false,
+				syncStatus: 'ok',
+				syncFailureReason: null,
+				lastSyncedAt: new Date('2026-01-01T00:00:00Z'),
+				updatedAt: new Date('2026-01-01T00:00:00Z'),
+			},
+			skyhook: {
+				structureId: 'skyhook-1',
+				corporationId: 'corp-1',
+				state: 'reinforced',
+				isActive: true,
+				reinforcementTimerEnd,
+			},
+		})
+		const env = {
+			UNIVERSE: {} as never,
+			EVE_CORPORATION_DATA: {} as never,
+		}
+
+		const result = await getStructureDetail(
+			env as never,
+			db as never,
+			{
+				id: 'user-details',
+				is_admin: false,
+				roles: ['urn:structures:all:details'],
+			},
+			'skyhook-1'
+		)
+
+		expect(result?.skyhook?.state).toBe('reinforced')
+		expect(result?.skyhook?.reinforcementTimerEnd).toBe(reinforcementTimerEnd)
+	})
 })


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a runtime error when summarizing a skyhook structure's reinforcement timer: `reinforcementTimerEnd` (and the related theft-vulnerability timestamps) can be returned as a string rather than a `Date`, so calling `.toISOString()` directly on it would throw.

## Changes
- In `summarizeStructureSkyhook` and `buildSkyhookListItemFromRow` (`apps/structures/src/services/structures.service.ts`), replace direct `skyhook.reinforcementTimerEnd.toISOString()` calls with the existing `toIso()` helper, which safely coerces `Date`, `string`, or `number` values (or returns `null`).
- Apply the same `toIso()` treatment to `theftVulnerabilityStart`/`theftVulnerabilityEnd` for consistency.
- Clean up stray/broken indentation left in these two functions' return objects.
- Add a unit test verifying a reinforced skyhook with a string `reinforcementTimerEnd` serializes correctly via `getStructureDetail`.

## Testing
Added a unit test in `structure-permission-gating.test.ts` that constructs a reinforced skyhook with `reinforcementTimerEnd` as a string and asserts `getStructureDetail` returns it unchanged instead of throwing.
<!-- claude:end -->