### PR TITLE
post-maint bug stomping

### DIFF
--- a/apps/bills/eslint.config.ts
+++ b/apps/bills/eslint.config.ts
@@ -7,6 +7,6 @@ const config = getConfig(import.meta.url)
 export default defineConfig([
 	config,
 	{
-		ignores: ['vite.config.ts', 'vitest.config.ts'],
+		ignores: ['vite.config.ts', 'vitest.config.ts', 'vitest.unit.config.ts'],
 	},
 ]) as Config

--- a/apps/bills/src/db/index.ts
+++ b/apps/bills/src/db/index.ts
@@ -4,13 +4,30 @@ import * as schema from './schema'
 
 import type { DbClient } from '@repo/db-utils'
 
+export interface CreateDbOptions {
+	queryTimeoutMs?: number
+}
+
 /**
  * Create a database client instance
  * @param databaseUrl - The Neon database connection URL
  * @returns A configured Drizzle database client
  */
-export function createDb(databaseUrl: string): DbClient<typeof schema> {
-	return createDbClient(databaseUrl, schema)
+export function createDb(
+	databaseUrl: string,
+	options: CreateDbOptions = {}
+): DbClient<typeof schema> {
+	return createDbClient(
+		databaseUrl,
+		schema,
+		options.queryTimeoutMs === undefined
+			? undefined
+			: {
+					// Neon HTTP requests otherwise have no application-level deadline. Keep a
+					// stalled request from outliving the Workflow step that owns this client.
+					fetchOptions: { signal: AbortSignal.timeout(options.queryTimeoutMs) },
+				}
+	)
 }
 
 export type BillsDb = ReturnType<typeof createDb>

--- a/apps/bills/src/test/unit/workflows/bill-payment-status-check.test.ts
+++ b/apps/bills/src/test/unit/workflows/bill-payment-status-check.test.ts
@@ -11,18 +11,13 @@ const updateCheckTimestampMock = vi.fn()
 const getStubMock = vi.fn()
 
 vi.mock('cloudflare:workers', () => {
-	class WorkflowEntrypoint<Env = unknown, Params = unknown> {
+	class WorkflowEntrypoint<Env = unknown> {
 		protected readonly ctx: unknown
 		protected readonly env: Env
 
 		constructor(ctx: unknown, env: Env) {
 			this.ctx = ctx
 			this.env = env
-		}
-
-		// eslint-disable-next-line @typescript-eslint/require-await
-		async run(_event: unknown, _step: unknown): Promise<Params> {
-			throw new Error('WorkflowEntrypoint.run is not implemented in unit-test shim')
 		}
 	}
 
@@ -61,8 +56,9 @@ type MockContext = {
 	}
 }
 
-function createStep() {
+function createStep(retryStepNames: string[] = []) {
 	const executedStepNames: string[] = []
+	const retrySteps = new Set(retryStepNames)
 	const doMock = vi.fn(
 		async (name: string, optionsOrHandler: unknown, maybeHandler?: () => unknown) => {
 			executedStepNames.push(name)
@@ -70,7 +66,12 @@ function createStep() {
 				typeof optionsOrHandler === 'function'
 					? (optionsOrHandler as () => unknown)
 					: (maybeHandler as () => unknown)
-			return await handler()
+			try {
+				return await handler()
+			} catch (error) {
+				if (!retrySteps.has(name)) throw error
+				return await handler()
+			}
 		}
 	)
 
@@ -128,9 +129,10 @@ function createWorkflowAndContext() {
 			BILLS: billsNamespace,
 		} as never
 	)
-	vi.spyOn(workflow as unknown as { createContext: () => unknown }, 'createContext').mockReturnValue(
-		ctx
-	)
+	vi.spyOn(
+		workflow as unknown as { createContext: () => unknown },
+		'createContext'
+	).mockReturnValue(ctx)
 
 	return {
 		workflow,
@@ -169,11 +171,10 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 		await workflow.run({ payload: { billId: 'bill-1' }, instanceId: 'wf-1' } as never, step)
 
 		expect(executedStepNames).toEqual([
-			'fetch-bill-data',
-			'find-and-post-payments',
-			'check-payment-status',
-			'sync-tax-assessment-bill-status',
+			'reconcile-payment-data',
+			'finalize-payment-state',
 			'update-check-timestamp',
+			'sync-bill-effects',
 		])
 		expect(taxSyncMock).toHaveBeenCalledWith('system:bills:payment-status-check', {
 			id: 'bill-1',
@@ -190,7 +191,11 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 			noPaymentStep.step
 		)
 		expect(refreshBillLifecycleStatus).toHaveBeenCalledTimes(1)
-		expect(noPaymentStep.executedStepNames).toContain('refresh-overdue-status')
+		expect(noPaymentStep.executedStepNames).toEqual([
+			'reconcile-payment-data',
+			'finalize-payment-state',
+			'update-check-timestamp',
+		])
 
 		vi.clearAllMocks()
 		fetchBillDataMock.mockResolvedValue({
@@ -215,7 +220,12 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 			withPaymentStep.step
 		)
 		expect(withPayment.refreshBillLifecycleStatus).not.toHaveBeenCalled()
-		expect(withPaymentStep.executedStepNames).not.toContain('refresh-overdue-status')
+		expect(withPaymentStep.executedStepNames).toEqual([
+			'reconcile-payment-data',
+			'finalize-payment-state',
+			'update-check-timestamp',
+			'sync-bill-effects',
+		])
 	})
 
 	it('syncs tax status when payment status transition marks bill as paid', async () => {
@@ -226,10 +236,11 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 		})
 
 		const { workflow, taxSyncMock, enqueueBillNotificationEventMock } = createWorkflowAndContext()
-		const { step } = createStep()
+		const { step, doMock } = createStep()
 
 		await workflow.run({ payload: { billId: 'bill-1' }, instanceId: 'wf-1' } as never, step)
 
+		expect(doMock).toHaveBeenCalledTimes(4)
 		expect(taxSyncMock).toHaveBeenCalledWith('system:bills:payment-status-check', {
 			id: 'bill-1',
 			status: 'paid',
@@ -291,5 +302,29 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 		)
 		expect(second.taxSyncMock).not.toHaveBeenCalled()
 		expect(second.enqueueBillNotificationEventMock).not.toHaveBeenCalled()
+		expect(secondStep.executedStepNames).toEqual([
+			'reconcile-payment-data',
+			'finalize-payment-state',
+			'update-check-timestamp',
+		])
+	})
+
+	it('does not recompute transition flags when the timestamp step retries', async () => {
+		checkPaymentStatusMock.mockResolvedValueOnce({
+			markedPaid: true,
+			statusBefore: 'issued',
+			statusAfter: 'paid',
+		})
+		updateCheckTimestampMock
+			.mockRejectedValueOnce(new Error('temporary timestamp failure'))
+			.mockResolvedValueOnce({ updated: true })
+
+		const { workflow } = createWorkflowAndContext()
+		const { step } = createStep(['update-check-timestamp'])
+
+		await workflow.run({ payload: { billId: 'bill-1' }, instanceId: 'wf-1' } as never, step)
+
+		expect(checkPaymentStatusMock).toHaveBeenCalledTimes(1)
+		expect(updateCheckTimestampMock).toHaveBeenCalledTimes(2)
 	})
 })

--- a/apps/bills/src/workflows/bill-payment-status-check.ts
+++ b/apps/bills/src/workflows/bill-payment-status-check.ts
@@ -1,6 +1,7 @@
-import { WorkflowEntrypoint, WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import { WorkflowEntrypoint } from 'cloudflare:workers'
 
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
 import { BillService } from '../services/bill.service'
@@ -9,10 +10,12 @@ import { fetchBillData } from './steps/fetch-bill-data'
 import { findPaymentsForBill } from './steps/find-payments/find-payments'
 import { updateCheckTimestamp } from './steps/update-check-timestamp'
 
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
 import type { BillStatus } from '@repo/bills'
 import type { Env } from '../context'
 import type { WorkflowContext } from './context'
-import { logger } from '@repo/hono-helpers'
+
+const DATABASE_QUERY_TIMEOUT_MS = 25_000
 
 const TAX_SYNC_ACTOR = 'system:bills:payment-status-check'
 type CorporationTaxSyncStub = {
@@ -69,7 +72,7 @@ export class BillPaymentStatusCheckWorkflow extends WorkflowEntrypoint<Env, Work
 	 * MUST be called inside step.do() callbacks since services don't survive hibernation.
 	 */
 	private createContext(billId: string, workflowInstanceId: string): WorkflowContext {
-		const db = createDb(this.env.DATABASE_URL)
+		const db = createDb(this.env.DATABASE_URL, { queryTimeoutMs: DATABASE_QUERY_TIMEOUT_MS })
 		return {
 			env: this.env,
 			workflowInstanceId,
@@ -96,92 +99,34 @@ export class BillPaymentStatusCheckWorkflow extends WorkflowEntrypoint<Env, Work
 		logger.log('[Workflow] Starting payment status check', logContext)
 
 		try {
-			// Step 1: Fetch bill data
-			const fetchBillDataResult = await step.do(
-				'fetch-bill-data',
+			// Step 1: Fetch bill data and record any new payments in one durable DB step.
+			const paymentReconciliationResult = await step.do(
+				'reconcile-payment-data',
 				{
 					retries: {
 						limit: 3,
 						delay: 1000,
 						backoff: 'exponential',
 					},
-					timeout: '30 seconds',
+					timeout: '1 minute',
 				},
-				() => {
+				async () => {
 					const ctx = this.createContext(billId, workflowInstanceId)
-					return fetchBillData(ctx)
+					const billDataResult = await fetchBillData(ctx)
+					const paymentLookupResult = await findPaymentsForBill(ctx, billDataResult.bill)
+					return { ...billDataResult, ...paymentLookupResult }
 				}
 			)
 
 			logger.log('[Workflow] Fetched bill data', {
 				...logContext,
-				status: fetchBillDataResult.bill.status,
+				status: paymentReconciliationResult.bill.status,
 			})
 
-			// Step 2: Find payments
-			const paymentLookupResult = await step.do(
-				'find-and-post-payments',
-				{
-					retries: {
-						limit: 3,
-						delay: 1000,
-						backoff: 'exponential',
-					},
-					timeout: '1 minute',
-				},
-				() => {
-					const ctx = this.createContext(billId, workflowInstanceId)
-					return findPaymentsForBill(ctx, fetchBillDataResult.bill)
-				}
-			)
-
-			// Step 3: If no new payment was recorded in this run, explicitly normalize overdue state.
-			const overdueRefreshResult =
-				paymentLookupResult.newPaymentsRecorded === 0
-					? await step.do(
-							'refresh-overdue-status',
-							{
-								retries: {
-									limit: 3,
-									delay: 1000,
-									backoff: 'exponential',
-								},
-								timeout: '30 seconds',
-							},
-							() => {
-								const ctx = this.createContext(billId, workflowInstanceId)
-								return ctx.billService.refreshBillLifecycleStatus(ctx.billId)
-							}
-						)
-					: {
-							overdueMarked: false,
-							lateFeeChanged: false,
-							billStatus: fetchBillDataResult.bill.status,
-						}
-
-			if (overdueRefreshResult.overdueMarked) {
-				await step.do(
-					'enqueue-overdue-notification',
-					{
-						retries: {
-							limit: 3,
-							delay: 1000,
-							backoff: 'exponential',
-						},
-						timeout: '30 seconds',
-					},
-					async () => {
-						const billsStub = getStub<BillsNotificationStub>(this.env.BILLS, 'default')
-						return billsStub.enqueueBillNotificationEvent(billId, 'overdue', {
-							source: 'bill_payment_status_workflow',
-						})
-					}
-				)
-			}
-
-			// Step 4: Check payment status
+			// Step 2: Normalize lifecycle state and evaluate payment status. Keep the transition
+			// result durable so a later timestamp retry cannot re-run it and lose its edge flags.
 			const paymentStatusResult = await step.do(
-				'check-payment-status',
+				'finalize-payment-state',
 				{
 					retries: {
 						limit: 3,
@@ -190,66 +135,70 @@ export class BillPaymentStatusCheckWorkflow extends WorkflowEntrypoint<Env, Work
 					},
 					timeout: '1 minute',
 				},
-				() => {
+				async () => {
 					const ctx = this.createContext(billId, workflowInstanceId)
-					return checkPaymentStatus(ctx)
+					const overdueRefreshResult =
+						paymentReconciliationResult.newPaymentsRecorded === 0
+							? await ctx.billService.refreshBillLifecycleStatus(ctx.billId)
+							: {
+									overdueMarked: false,
+									lateFeeChanged: false,
+									billStatus: paymentReconciliationResult.bill.status,
+								}
+					const paymentStatus = await checkPaymentStatus(ctx)
+					return { ...overdueRefreshResult, ...paymentStatus }
 				}
 			)
 
-			logger.log('[Workflow] Checked payment status', logContext)
-
-			if (paymentStatusResult.markedPaid) {
-				await step.do(
-					'enqueue-paid-notification',
-					{
-						retries: {
-							limit: 3,
-							delay: 1000,
-							backoff: 'exponential',
-						},
-						timeout: '30 seconds',
-					},
-					async () => {
-						const billsStub = getStub<BillsNotificationStub>(this.env.BILLS, 'default')
-						return billsStub.enqueueBillNotificationEvent(billId, 'paid', {
-							source: 'bill_payment_status_workflow',
-						})
-					}
-				)
-			}
-
-			// Step 3.5: Sync tax assessment bill status if this run changed payment data/status.
-			const shouldSyncTaxAssessment =
-				fetchBillDataResult.bill.externalSourceType === 'corporation_tax_assessment' &&
-				(paymentLookupResult.newPaymentsRecorded > 0 ||
-					paymentStatusResult.markedPaid ||
-					overdueRefreshResult.overdueMarked)
-			if (shouldSyncTaxAssessment) {
-				await step.do(
-					'sync-tax-assessment-bill-status',
-					{
-						retries: {
-							limit: 3,
-							delay: 1000,
-							backoff: 'exponential',
-						},
-						timeout: '30 seconds',
-					},
-					async () => {
-						const taxStub = getStub<CorporationTaxSyncStub>(this.env.CORPORATION_TAX, 'default')
-						return taxStub.syncBillStatus(TAX_SYNC_ACTOR, {
-							id: billId,
-							status: paymentStatusResult.statusAfter as BillStatus,
-						})
-					}
-				)
-			}
-
-			// Step 4: Update last checked timestamp even if no status change
+			// Keep this independent from state transitions. If it retries, the durable
+			// paymentStatusResult above is reused instead of being recomputed.
 			await step.do('update-check-timestamp', () => {
 				const ctx = this.createContext(billId, workflowInstanceId)
 				return updateCheckTimestamp(ctx)
 			})
+
+			logger.log('[Workflow] Checked payment status', logContext)
+
+			const shouldSyncTaxAssessment =
+				paymentReconciliationResult.bill.externalSourceType === 'corporation_tax_assessment' &&
+				(paymentReconciliationResult.newPaymentsRecorded > 0 ||
+					paymentStatusResult.markedPaid ||
+					paymentStatusResult.overdueMarked)
+			const shouldEnqueueNotification =
+				paymentStatusResult.overdueMarked || paymentStatusResult.markedPaid
+			if (shouldSyncTaxAssessment || shouldEnqueueNotification) {
+				await step.do(
+					'sync-bill-effects',
+					{
+						retries: {
+							limit: 3,
+							delay: 1000,
+							backoff: 'exponential',
+						},
+						timeout: '30 seconds',
+					},
+					async () => {
+						const billsStub = getStub<BillsNotificationStub>(this.env.BILLS, 'default')
+						if (paymentStatusResult.overdueMarked) {
+							await billsStub.enqueueBillNotificationEvent(billId, 'overdue', {
+								source: 'bill_payment_status_workflow',
+							})
+						}
+						if (paymentStatusResult.markedPaid) {
+							await billsStub.enqueueBillNotificationEvent(billId, 'paid', {
+								source: 'bill_payment_status_workflow',
+							})
+						}
+						if (shouldSyncTaxAssessment) {
+							const taxStub = getStub<CorporationTaxSyncStub>(this.env.CORPORATION_TAX, 'default')
+							await taxStub.syncBillStatus(TAX_SYNC_ACTOR, {
+								id: billId,
+								status: paymentStatusResult.statusAfter as BillStatus,
+							})
+						}
+					}
+				)
+			}
 
 			logger.log('[Workflow] Payment status check completed', logContext)
 

--- a/apps/bills/src/workflows/bill-schedule-executor.ts
+++ b/apps/bills/src/workflows/bill-schedule-executor.ts
@@ -1,10 +1,10 @@
-import { WorkflowEntrypoint, WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import { WorkflowEntrypoint } from 'cloudflare:workers'
 
 import { getStub } from '@repo/do-utils'
 
-import type { Bills, ScheduleExecutionResult } from '@repo/bills'
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import type { Bills } from '@repo/bills'
 import type { Env } from '../context'
-import { logger } from '@repo/hono-helpers'
 
 /**
  * Bill Schedule Executor Workflow
@@ -44,30 +44,9 @@ export class BillScheduleExecutorWorkflow extends WorkflowEntrypoint<Env, { sche
 			}
 		)
 
-		// Step 2: Handle execution result
 		if (!result.success) {
-			await step.do('handle-failure', async () => {
-				// Log the failure
-				logger.error(`Schedule ${scheduleId} execution failed:`, result.error)
-
-				return { notified: false }
-			})
-
 			throw new Error(`Schedule execution failed: ${result.error}`)
 		}
-
-		// Step 3: Handle success
-		await step.do('handle-success', async () => {
-			if (result.groupBillId) {
-				logger.log(
-					`Schedule ${scheduleId} executed successfully, created group bill ${result.groupBillId} with ${result.billCount} sub-bills`
-				)
-			} else {
-				logger.log(`Schedule ${scheduleId} executed successfully, created bill ${result.billId}`)
-			}
-
-			return { billId: result.billId, groupBillId: result.groupBillId, billCount: result.billCount }
-		})
 
 		return {
 			success: true,

--- a/apps/bills/src/workflows/steps/fetch-bill-data/fetch-bill-data.ts
+++ b/apps/bills/src/workflows/steps/fetch-bill-data/fetch-bill-data.ts
@@ -3,10 +3,22 @@ import { eq } from '@repo/db-utils'
 import { bills } from '../../../db/schema'
 import { getWorkflowLogger } from '../../context'
 
+import type { BillStatus, EntityType } from '@repo/bills'
 import type { WorkflowContext } from '../../context'
 
+export interface BillPaymentCheckData {
+	id: string
+	status: BillStatus
+	payeeId: string | null
+	payeeType: EntityType | null
+	payerType: EntityType
+	paymentToken: string
+	createdAt: string
+	externalSourceType: string | null
+}
+
 export interface FetchBillDataResult {
-	bill: typeof bills.$inferSelect
+	bill: BillPaymentCheckData
 }
 
 /**
@@ -33,6 +45,15 @@ export async function fetchBillData(ctx: WorkflowContext): Promise<FetchBillData
 	})
 
 	return {
-		bill,
+		bill: {
+			id: bill.id,
+			status: bill.status,
+			payeeId: bill.payeeId,
+			payeeType: bill.payeeType,
+			payerType: bill.payerType,
+			paymentToken: bill.paymentToken,
+			createdAt: bill.createdAt.toISOString(),
+			externalSourceType: bill.externalSourceType,
+		},
 	}
 }

--- a/apps/bills/src/workflows/steps/find-payments/find-payments.ts
+++ b/apps/bills/src/workflows/steps/find-payments/find-payments.ts
@@ -1,10 +1,11 @@
-import { eq, sql } from '@repo/db-utils'
+import { sql } from '@repo/db-utils'
 
-import { billPayments } from '../../../db/schema'
 import { getWorkflowLogger } from '../../context'
 
-import type { bills } from '../../../db/schema'
 import type { WorkflowContext } from '../../context'
+import type { BillPaymentCheckData } from '../fetch-bill-data'
+
+const MAX_NEW_PAYMENT_TRANSACTIONS_PER_RUN = 100
 
 type CorporationWalletPaymentRow = {
 	journalId: string
@@ -44,7 +45,7 @@ function parseAmountToBigInt(rawAmount: string): bigint | null {
 
 async function findPaymentTransactionsForCorporationFromDb(
 	ctx: WorkflowContext,
-	billData: typeof bills.$inferSelect
+	billData: BillPaymentCheckData
 ): Promise<CorporationWalletPaymentRow[]> {
 	const logger = getWorkflowLogger(ctx, 'find-payment-transaction-for-corporation-db')
 
@@ -59,10 +60,13 @@ async function findPaymentTransactionsForCorporationFromDb(
 	})
 
 	if (!corporationId) {
-		logger.warn('[Workflow] Skipping corporation payment transaction lookup because corporation ID is missing', {
-			billId: ctx.billId,
-			workflowInstanceId: ctx.workflowInstanceId,
-		})
+		logger.warn(
+			'[Workflow] Skipping corporation payment transaction lookup because corporation ID is missing',
+			{
+				billId: ctx.billId,
+				workflowInstanceId: ctx.workflowInstanceId,
+			}
+		)
 		return []
 	}
 
@@ -79,15 +83,20 @@ async function findPaymentTransactionsForCorporationFromDb(
 			and amount::numeric > 0
 			and reason is not null
 			and reason like ${tokenNeedle}
+			and not exists (
+				select 1
+				from bill_payments
+				where bill_payments.esi_transaction_id = corporation_wallet_journal.journal_id::text
+			)
 		order by date asc
-		limit 500`
+		limit ${MAX_NEW_PAYMENT_TRANSACTIONS_PER_RUN}`
 	)
 	return results.rows ?? []
 }
 
 async function findPaymentTransactionsForCharacterFromDb(
 	ctx: WorkflowContext,
-	billData: typeof bills.$inferSelect
+	billData: BillPaymentCheckData
 ): Promise<CharacterWalletPaymentRow[]> {
 	const logger = getWorkflowLogger(ctx, 'find-payment-transaction-for-character-db')
 
@@ -102,10 +111,13 @@ async function findPaymentTransactionsForCharacterFromDb(
 	})
 
 	if (!characterId) {
-		logger.warn('[Workflow] Skipping character payment transaction lookup because character ID is missing', {
-			billId: ctx.billId,
-			workflowInstanceId: ctx.workflowInstanceId,
-		})
+		logger.warn(
+			'[Workflow] Skipping character payment transaction lookup because character ID is missing',
+			{
+				billId: ctx.billId,
+				workflowInstanceId: ctx.workflowInstanceId,
+			}
+		)
 		return []
 	}
 
@@ -122,15 +134,20 @@ async function findPaymentTransactionsForCharacterFromDb(
 			and amount::numeric > 0
 			and reason is not null
 			and reason like ${tokenNeedle}
+			and not exists (
+				select 1
+				from bill_payments
+				where bill_payments.esi_transaction_id = character_wallet_journal.journal_id::text
+			)
 		order by date asc
-		limit 500`
+		limit ${MAX_NEW_PAYMENT_TRANSACTIONS_PER_RUN}`
 	)
 	return results.rows ?? []
 }
 
 export async function findPaymentsForBill(
 	ctx: WorkflowContext,
-	billData: typeof bills.$inferSelect
+	billData: BillPaymentCheckData
 ): Promise<{ newPaymentsRecorded: number }> {
 	const logger = getWorkflowLogger(ctx, 'check-character-payment-status')
 	let newPaymentsRecorded = 0
@@ -166,9 +183,6 @@ export async function findPaymentsForBill(
 			return { newPaymentsRecorded }
 		}
 		for (const paymentTransaction of paymentTransactions) {
-			const existingPayment = await ctx.db.query.billPayments.findFirst({
-				where: eq(billPayments.esiTransactionId, paymentTransaction.journalId),
-			})
 			const amount = parseAmountToBigInt(paymentTransaction.amount)
 			if (amount === null || amount <= 0n) {
 				logger.warn('[Workflow] Skipping corporation payment transaction with invalid amount', {
@@ -193,9 +207,7 @@ export async function findPaymentsForBill(
 				paidByType: 'corporation',
 				esiTransactionId: paymentTransaction.journalId,
 			})
-			if (!existingPayment) {
-				newPaymentsRecorded += 1
-			}
+			newPaymentsRecorded += 1
 		}
 		logger.info('[Workflow] Processed corporation payment transactions from persisted data', {
 			billId: ctx.billId,
@@ -220,9 +232,6 @@ export async function findPaymentsForBill(
 		}
 
 		for (const paymentTransaction of paymentTransactions) {
-			const existingPayment = await ctx.db.query.billPayments.findFirst({
-				where: eq(billPayments.esiTransactionId, paymentTransaction.journalId),
-			})
 			const amount = parseAmountToBigInt(paymentTransaction.amount)
 			if (amount === null || amount <= 0n) {
 				logger.warn('[Workflow] Skipping character payment transaction with invalid amount', {
@@ -247,9 +256,7 @@ export async function findPaymentsForBill(
 				paidByType: billData.payerType ?? 'character',
 				esiTransactionId: paymentTransaction.journalId,
 			})
-			if (!existingPayment) {
-				newPaymentsRecorded += 1
-			}
+			newPaymentsRecorded += 1
 		}
 
 		logger.info('[Workflow] Processed character payment transactions from persisted data', {

--- a/apps/bills/vitest.config.ts
+++ b/apps/bills/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	plugins: [
 		cloudflareTest({
 			wrangler: {
-				configPath: './wrangler.jsonc',
+				configPath: './wrangler.test.jsonc',
 			},
 		}),
 	],

--- a/apps/bills/wrangler.test.jsonc
+++ b/apps/bills/wrangler.test.jsonc
@@ -1,0 +1,19 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "bills-test",
+	"main": "src/index.ts",
+	"compatibility_date": "2026-07-30",
+	"compatibility_flags": ["nodejs_compat"],
+	"workers_dev": false,
+	"routes": [],
+	"logpush": false,
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "BILLS",
+				"class_name": "Bills"
+			}
+		]
+	},
+	"migrations": [{ "tag": "v1", "new_sqlite_classes": ["Bills"] }]
+}

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -6,22 +6,21 @@ import { getStub } from '@repo/do-utils'
 import {
 	captureException,
 	logger,
-	withWorkerLogContext,
 	withNotFound,
 	withOnError,
 	withSentry,
+	withWorkerLogContext,
 	withWorkersLogger,
 } from '@repo/hono-helpers'
 
 import { createDb } from './db'
 import { discordMemberAuditRuns, userCharacters, userIpAddresses, users } from './db/schema'
 import { CoreDO } from './durable-object'
-import { TemporaryRoleAssignmentsDO } from './temporary-role-assignments-do'
-import { cleanupExpiredExportArtifacts } from './lib/export-retention'
 import { waitUntilWithTelemetry } from './lib/background-task'
+import { cleanupExpiredExportArtifacts } from './lib/export-retention'
 import { IMMUNITAS_ALERT_DRAIN_CRON } from './lib/immunitas-alerts'
-import { TOKEN_INVALID_ALERT_DRAIN_CRON } from './lib/token-invalid-alerts'
 import { getStructureAssetsDebugBucket } from './lib/structure-assets-debug'
+import { TOKEN_INVALID_ALERT_DRAIN_CRON } from './lib/token-invalid-alerts'
 import { triggerDiscordRefreshWorkflow, triggerUserRefreshWorkflow } from './lib/workflow-triggers'
 import { csrfProtection } from './middleware/csrf'
 import { sessionMiddleware } from './middleware/session'
@@ -85,6 +84,7 @@ import {
 } from './services/discord-components.service'
 import { reconcileMarketPosts } from './services/discord-market-reconcile.service'
 import { DkpService } from './services/dkp.service'
+import { TemporaryRoleAssignmentsDO } from './temporary-role-assignments-do'
 
 import type {
 	CharacterOwnerInfo,
@@ -111,13 +111,11 @@ import type {
 
 const csrf = csrfProtection()
 const app = new Hono<App>()
-	.use(
-		'*',
-		(c, next) =>
-			withWorkersLogger(c.env.NAME, {
-				environment: c.env.ENVIRONMENT,
-				release: c.env.SENTRY_RELEASE,
-			})(c, next)
+	.use('*', (c, next) =>
+		withWorkersLogger(c.env.NAME, {
+			environment: c.env.ENVIRONMENT,
+			release: c.env.SENTRY_RELEASE,
+		})(c, next)
 	)
 
 	// Dev-only OAuth issuer proxy for local client harnesses.
@@ -209,39 +207,59 @@ const app = new Hono<App>()
 // HTTP handler is wrapped with Sentry for automatic error tracking
 const sentryApp = withSentry(app)
 
+const DISCORD_REFRESH_CRON = '5-55/10 * * * *'
+const EXPORT_CLEANUP_CRON = '*/30 * * * *'
+const TEMPOP_EXPIRY_CRON = '*/10 * * * *'
+const MARKET_RECONCILIATION_CRON = '*/15 * * * *'
+
 export default {
 	fetch: sentryApp.fetch.bind(sentryApp),
 	async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
 		await withWorkerLogContext('core-scheduled', env, async () => {
 			const scheduledLogger = logger.withTags({ component: 'core-scheduled' })
 			const coreStub = getStub<Core>(env.CORE, 'default')
-			if (event.cron === '3-58/5 * * * *') {
+			if (event.cron === DISCORD_REFRESH_CRON) {
 				const result = await coreStub.processPendingDiscordRefreshes()
 				if (result.processed > 0) {
 					scheduledLogger.info('[Core:Scheduled] Processed pending Discord refreshes', result)
 				}
+			}
 
+			if (event.cron === TEMPOP_EXPIRY_CRON) {
 				const tempopResult = await coreStub.processExpiredTempops()
 				if (tempopResult.expired > 0) {
 					scheduledLogger.info('[Core:Scheduled] Expired Mumble temp-ops', tempopResult)
 				}
+			}
 
+			if (event.cron === MARKET_RECONCILIATION_CRON) {
 				// Prediction-markets forum-post drift sweep: auto-close due markets + refresh/backfill
 				// posts. Best-effort and out-of-band so a slow Discord run never delays the cron; a real
 				// failure is paged, not swallowed.
 				ctx.waitUntil(
 					reconcileMarketPosts(createDb(env.DATABASE_URL), env)
 						.then((r) => {
-							if (r.closed > 0 || r.refreshed > 0 || r.posted > 0 || r.notified > 0 || r.failed > 0) {
+							if (
+								r.closed > 0 ||
+								r.refreshed > 0 ||
+								r.posted > 0 ||
+								r.notified > 0 ||
+								r.failed > 0
+							) {
 								scheduledLogger.info('[Core:Scheduled] Prediction-market reconcile', r)
 							}
 						})
 						.catch((error) => captureException(error as Error, { tags: { job: 'pm-reconcile' } }))
 				)
+			}
 
+			if (event.cron === EXPORT_CLEANUP_CRON) {
 				ctx.waitUntil(
-					cleanupExpiredExportArtifacts(getStructureAssetsDebugBucket(env), 'structure-assets-debug').catch(
-						(error) => captureException(error as Error, { tags: { job: 'structure-assets-debug-cleanup' } })
+					cleanupExpiredExportArtifacts(
+						getStructureAssetsDebugBucket(env),
+						'structure-assets-debug'
+					).catch((error) =>
+						captureException(error as Error, { tags: { job: 'structure-assets-debug-cleanup' } })
 					)
 				)
 			}

--- a/apps/core/src/lib/immunitas-alerts.ts
+++ b/apps/core/src/lib/immunitas-alerts.ts
@@ -70,7 +70,8 @@ function formatRequestorGroups(groups: ImmunitasAccessRequestorGroup[], maxGroup
 	const lines: string[] = []
 
 	for (const group of visibleGroups) {
-		const label = group.requestorLabels[0]?.trim() || group.requestorUserId.trim() || 'Unknown requester'
+		const label =
+			group.requestorLabels[0]?.trim() || group.requestorUserId.trim() || 'Unknown requester'
 		const attemptLabel =
 			group.attemptCount === 1 ? '1 blocked attempt' : `${group.attemptCount} blocked attempts`
 		lines.push(`• ${label} (${attemptLabel})`)
@@ -102,7 +103,9 @@ export function buildImmunitasAccessAlertMessage(input: {
 }): MessageContent {
 	const accessTypeLabel = getAccessTypeLabel(input.accessType)
 	const attemptLabel =
-		input.attemptCount === 1 ? 'One unauthorized attempt' : `${input.attemptCount} unauthorized attempts`
+		input.attemptCount === 1
+			? 'One unauthorized attempt'
+			: `${input.attemptCount} unauthorized attempts`
 	const description =
 		input.attemptCount === 1
 			? 'One unauthorized attempt to access an immunitas account was blocked.'
@@ -153,14 +156,11 @@ export async function queueImmunitasAccessAlertForUser(
 		accessType: ImmunitasAccessType
 		source?: string
 	}
-): Promise<
-	| {
-			added: number
-			skipped: number
-			pendingCount: number
-	  }
-	| null
-> {
+): Promise<{
+	added: number
+	skipped: number
+	pendingCount: number
+} | null> {
 	const targetCharacterLabel = input.targetCharacterLabel.trim()
 	if (!targetCharacterLabel) {
 		return null

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -23,11 +23,17 @@
 	},
 	"workers_dev": false,
 	"triggers": {
-		// Runs 3 minutes after the 5-minute corporation data refresh cron,
-		// giving corp sync time to detect departures and enqueue pending refreshes.
-		// A separate half-hour cron drains token invalidation DMs.
-		// Also runs daily at midnight UTC for Discord member audit cleanup.
-		"crons": ["3-58/5 * * * *", "15,45 * * * *", "0 0 * * *"]
+		// Discord refreshes run 5 minutes after the 10-minute corporation data refresh cron.
+		// The remaining maintenance jobs use independent schedules so each can be adjusted separately.
+		// Token invalidation alerts drain twice hourly; Discord member audit history is cleaned at midnight.
+		"crons": [
+			"5-55/10 * * * *",
+			"*/30 * * * *",
+			"*/10 * * * *",
+			"*/15 * * * *",
+			"15,45 * * * *",
+			"0 0 * * *"
+		]
 	},
 	"vars": {
 		"NAME": "core",

--- a/apps/eve-corporation-data/.migrations/0032_inventory_snapshot_expand.sql
+++ b/apps/eve-corporation-data/.migrations/0032_inventory_snapshot_expand.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "corporation_structure_inventory_snapshots" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"corporation_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"activated_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "corporation_structure_inventory" DROP CONSTRAINT "corporation_structure_inventory_corporation_id_item_id_unique";--> statement-breakpoint
+ALTER TABLE "corporation_structure_inventory" ADD COLUMN "snapshot_id" uuid;--> statement-breakpoint
+ALTER TABLE "corporation_structure_inventory_snapshots" ADD CONSTRAINT "corp_inv_snapshots_corp_fk" FOREIGN KEY ("corporation_id") REFERENCES "public"."corporation_config"("corporation_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "corporation_structure_inventory_snapshots_corp_activated_idx" ON "corporation_structure_inventory_snapshots" USING btree ("corporation_id","activated_at","created_at");--> statement-breakpoint
+ALTER TABLE "corporation_structure_inventory" ADD CONSTRAINT "corp_inv_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."corporation_structure_inventory_snapshots"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "corporation_structure_inventory_snapshot_structure_idx" ON "corporation_structure_inventory" USING btree ("snapshot_id","corporation_id","structure_id");--> statement-breakpoint
+ALTER TABLE "corporation_structure_inventory" ADD CONSTRAINT "corp_inv_snapshot_item_uniq" UNIQUE("corporation_id","snapshot_id","item_id");

--- a/apps/eve-corporation-data/.migrations/0033_inventory_snapshot_backfill.sql
+++ b/apps/eve-corporation-data/.migrations/0033_inventory_snapshot_backfill.sql
@@ -1,0 +1,17 @@
+-- Custom SQL migration file, put your code below! --
+WITH new_snapshots AS (
+	INSERT INTO "corporation_structure_inventory_snapshots" (
+		"corporation_id",
+		"created_at",
+		"activated_at"
+	)
+	SELECT DISTINCT "corporation_id", now(), now()
+	FROM "corporation_structure_inventory"
+	WHERE "snapshot_id" IS NULL
+	RETURNING "id", "corporation_id"
+)
+UPDATE "corporation_structure_inventory" AS inventory
+SET "snapshot_id" = snapshots."id"
+FROM new_snapshots AS snapshots
+WHERE inventory."corporation_id" = snapshots."corporation_id"
+	AND inventory."snapshot_id" IS NULL;

--- a/apps/eve-corporation-data/.migrations/0034_inventory_snapshot_contract.sql
+++ b/apps/eve-corporation-data/.migrations/0034_inventory_snapshot_contract.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "corporation_structure_inventory" ALTER COLUMN "snapshot_id" SET NOT NULL;

--- a/apps/eve-corporation-data/.migrations/meta/0032_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0032_snapshot.json
@@ -1,0 +1,3711 @@
+{
+	"id": "b77ee11a-5ebf-431c-9d25-7d897cd8b0ea",
+	"prevId": "4f28141c-23b1-49ee-91d0-0fe47e37de88",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.character_corporation_roles": {
+			"name": "character_corporation_roles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"roles": {
+					"name": "roles",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"roles_at_hq": {
+					"name": "roles_at_hq",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"roles_at_base": {
+					"name": "roles_at_base",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"roles_at_other": {
+					"name": "roles_at_other",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "character_corporation_roles",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"character_corporation_roles_corporation_id_character_id_unique": {
+					"name": "character_corporation_roles_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_assets": {
+			"name": "corporation_assets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_singleton": {
+					"name": "is_singleton",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"location_flag": {
+					"name": "location_flag",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_type": {
+					"name": "location_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_blueprint_copy": {
+					"name": "is_blueprint_copy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_assets",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_assets_corporation_id_item_id_unique": {
+					"name": "corporation_assets_corporation_id_item_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "item_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_config": {
+			"name": "corporation_config",
+			"schema": "",
+			"columns": {
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"last_verified": {
+					"name": "last_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_verified": {
+					"name": "is_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"include_in_background_refresh": {
+					"name": "include_in_background_refresh",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"include_in_structure_asset_sync": {
+					"name": "include_in_structure_asset_sync",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"corporation_type": {
+					"name": "corporation_type",
+					"type": "corporation_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'other'"
+				},
+				"members_last_sync": {
+					"name": "members_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_tracking_last_sync": {
+					"name": "member_tracking_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallets_last_sync": {
+					"name": "wallets_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallet_journal_last_sync": {
+					"name": "wallet_journal_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallet_transactions_last_sync": {
+					"name": "wallet_transactions_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"assets_last_sync": {
+					"name": "assets_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"structures_last_sync": {
+					"name": "structures_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"orders_last_sync": {
+					"name": "orders_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contracts_last_sync": {
+					"name": "contracts_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"industry_jobs_last_sync": {
+					"name": "industry_jobs_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"killmails_last_sync": {
+					"name": "killmails_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"corporation_config_include_in_background_refresh_idx": {
+					"name": "corporation_config_include_in_background_refresh_idx",
+					"columns": [
+						{
+							"expression": "include_in_background_refresh",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_include_in_structure_asset_sync_idx": {
+					"name": "corporation_config_include_in_structure_asset_sync_idx",
+					"columns": [
+						{
+							"expression": "include_in_structure_asset_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_corporation_type_idx": {
+					"name": "corporation_config_corporation_type_idx",
+					"columns": [
+						{
+							"expression": "corporation_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_member_tracking_last_sync_idx": {
+					"name": "corporation_config_member_tracking_last_sync_idx",
+					"columns": [
+						{
+							"expression": "member_tracking_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_wallets_last_sync_idx": {
+					"name": "corporation_config_wallets_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallets_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_assets_last_sync_idx": {
+					"name": "corporation_config_assets_last_sync_idx",
+					"columns": [
+						{
+							"expression": "assets_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_structures_last_sync_idx": {
+					"name": "corporation_config_structures_last_sync_idx",
+					"columns": [
+						{
+							"expression": "structures_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_orders_last_sync_idx": {
+					"name": "corporation_config_orders_last_sync_idx",
+					"columns": [
+						{
+							"expression": "orders_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_contracts_last_sync_idx": {
+					"name": "corporation_config_contracts_last_sync_idx",
+					"columns": [
+						{
+							"expression": "contracts_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_industry_jobs_last_sync_idx": {
+					"name": "corporation_config_industry_jobs_last_sync_idx",
+					"columns": [
+						{
+							"expression": "industry_jobs_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_killmails_last_sync_idx": {
+					"name": "corporation_config_killmails_last_sync_idx",
+					"columns": [
+						{
+							"expression": "killmails_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_members_last_sync_idx": {
+					"name": "corporation_config_members_last_sync_idx",
+					"columns": [
+						{
+							"expression": "members_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_wallet_transactions_last_sync_idx": {
+					"name": "corporation_config_wallet_transactions_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallet_transactions_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_wallet_journal_last_sync_idx": {
+					"name": "corporation_config_wallet_journal_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallet_journal_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_contracts": {
+			"name": "corporation_contracts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"contract_id": {
+					"name": "contract_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"acceptor_id": {
+					"name": "acceptor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"assignee_id": {
+					"name": "assignee_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"availability": {
+					"name": "availability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"buyout": {
+					"name": "buyout",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"collateral": {
+					"name": "collateral",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_accepted": {
+					"name": "date_accepted",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_completed": {
+					"name": "date_completed",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_expired": {
+					"name": "date_expired",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_issued": {
+					"name": "date_issued",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"days_to_complete": {
+					"name": "days_to_complete",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_location_id": {
+					"name": "end_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"for_corporation": {
+					"name": "for_corporation",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"issuer_corporation_id": {
+					"name": "issuer_corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"issuer_id": {
+					"name": "issuer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"price": {
+					"name": "price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reward": {
+					"name": "reward",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_location_id": {
+					"name": "start_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume": {
+					"name": "volume",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_contracts_leaderboard_all_time_idx": {
+					"name": "corporation_contracts_leaderboard_all_time_idx",
+					"columns": [
+						{
+							"expression": "assignee_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "acceptor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_contracts_leaderboard_period_idx": {
+					"name": "corporation_contracts_leaderboard_period_idx",
+					"columns": [
+						{
+							"expression": "assignee_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "date_completed",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "acceptor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_contracts_contract_id_unique": {
+					"name": "corporation_contracts_contract_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["contract_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_directors": {
+			"name": "corporation_directors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_name": {
+					"name": "character_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 100
+				},
+				"is_healthy": {
+					"name": "is_healthy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_health_check": {
+					"name": "last_health_check",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_used": {
+					"name": "last_used",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"failure_count": {
+					"name": "failure_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_failure_reason": {
+					"name": "last_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_retry_at": {
+					"name": "next_retry_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"permanent_failure_at": {
+					"name": "permanent_failure_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_directors_corp_healthy_idx": {
+					"name": "corporation_directors_corp_healthy_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_healthy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_directors_corp_next_retry_idx": {
+					"name": "corporation_directors_corp_next_retry_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_retry_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_directors_corp_permanent_failure_idx": {
+					"name": "corporation_directors_corp_permanent_failure_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "permanent_failure_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_directors_last_used_idx": {
+					"name": "corporation_directors_last_used_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "last_used",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_directors",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_directors_corporation_id_character_id_unique": {
+					"name": "corporation_directors_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_industry_jobs": {
+			"name": "corporation_industry_jobs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"job_id": {
+					"name": "job_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"installer_id": {
+					"name": "installer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"facility_id": {
+					"name": "facility_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"activity_id": {
+					"name": "activity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_id": {
+					"name": "blueprint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_type_id": {
+					"name": "blueprint_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_location_id": {
+					"name": "blueprint_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"output_location_id": {
+					"name": "output_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"runs": {
+					"name": "runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost": {
+					"name": "cost",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"licensed_runs": {
+					"name": "licensed_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"probability": {
+					"name": "probability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_type_id": {
+					"name": "product_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"duration": {
+					"name": "duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pause_date": {
+					"name": "pause_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_date": {
+					"name": "completed_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_character_id": {
+					"name": "completed_character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"successful_runs": {
+					"name": "successful_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_industry_jobs",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_industry_jobs_corporation_id_job_id_unique": {
+					"name": "corporation_industry_jobs_corporation_id_job_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "job_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_killmails": {
+			"name": "corporation_killmails",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_id": {
+					"name": "killmail_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_hash": {
+					"name": "killmail_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_time": {
+					"name": "killmail_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_killmails",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_killmails_corporation_id_killmail_id_unique": {
+					"name": "corporation_killmails_corporation_id_killmail_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "killmail_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_member_tracking": {
+			"name": "corporation_member_tracking",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_id": {
+					"name": "base_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"logoff_date": {
+					"name": "logoff_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"logon_date": {
+					"name": "logon_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ship_type_id": {
+					"name": "ship_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_member_tracking",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_member_tracking_corporation_id_character_id_unique": {
+					"name": "corporation_member_tracking_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_members": {
+			"name": "corporation_members",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_members_character_id_idx": {
+					"name": "corporation_members_character_id_idx",
+					"columns": [
+						{
+							"expression": "character_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_members",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_members_corporation_id_character_id_unique": {
+					"name": "corporation_members_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_orders": {
+			"name": "corporation_orders",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"order_id": {
+					"name": "order_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"duration": {
+					"name": "duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"escrow": {
+					"name": "escrow",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_buy_order": {
+					"name": "is_buy_order",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"issued": {
+					"name": "issued",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"issued_by": {
+					"name": "issued_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"min_volume": {
+					"name": "min_volume",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"price": {
+					"name": "price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"range": {
+					"name": "range",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume_remain": {
+					"name": "volume_remain",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume_total": {
+					"name": "volume_total",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wallet_division": {
+					"name": "wallet_division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_orders",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_orders_corporation_id_order_id_unique": {
+					"name": "corporation_orders_corporation_id_order_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "order_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_public_info": {
+			"name": "corporation_public_info",
+			"schema": "",
+			"columns": {
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ticker": {
+					"name": "ticker",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ceo_id": {
+					"name": "ceo_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"creator_id": {
+					"name": "creator_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_founded": {
+					"name": "date_founded",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"home_station_id": {
+					"name": "home_station_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_count": {
+					"name": "member_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shares": {
+					"name": "shares",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax_rate": {
+					"name": "tax_rate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"alliance_id": {
+					"name": "alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"faction_id": {
+					"name": "faction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"war_eligible": {
+					"name": "war_eligible",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structure_inventory": {
+			"name": "corporation_structure_inventory",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_singleton": {
+					"name": "is_singleton",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"location_flag": {
+					"name": "location_flag",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_type": {
+					"name": "location_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_structure_inventory_corp_structure_idx": {
+					"name": "corporation_structure_inventory_corp_structure_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_structure_inventory_snapshot_structure_idx": {
+					"name": "corporation_structure_inventory_snapshot_structure_idx",
+					"columns": [
+						{
+							"expression": "snapshot_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+					"name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"corp_inv_snapshot_fk": {
+					"name": "corp_inv_snapshot_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"tableTo": "corporation_structure_inventory_snapshots",
+					"columnsFrom": ["snapshot_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corp_inv_snapshot_item_uniq": {
+					"name": "corp_inv_snapshot_item_uniq",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "snapshot_id", "item_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structure_inventory_snapshots": {
+			"name": "corporation_structure_inventory_snapshots",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"activated_at": {
+					"name": "activated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"corporation_structure_inventory_snapshots_corp_activated_idx": {
+					"name": "corporation_structure_inventory_snapshots_corp_activated_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "activated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corp_inv_snapshots_corp_fk": {
+					"name": "corp_inv_snapshots_corp_fk",
+					"tableFrom": "corporation_structure_inventory_snapshots",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structures": {
+			"name": "corporation_structures",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_name": {
+					"name": "type_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_name": {
+					"name": "region_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"profile_id": {
+					"name": "profile_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_expires": {
+					"name": "fuel_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fuel_amount": {
+					"name": "fuel_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fuel_burn_rate": {
+					"name": "fuel_burn_rate",
+					"type": "numeric(12, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_refilled_at": {
+					"name": "last_refilled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_reinforce_apply": {
+					"name": "next_reinforce_apply",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_reinforce_hour": {
+					"name": "next_reinforce_hour",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reinforce_hour": {
+					"name": "reinforce_hour",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state_timer_end": {
+					"name": "state_timer_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state_timer_start": {
+					"name": "state_timer_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unanchors_at": {
+					"name": "unanchors_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"low_power": {
+					"name": "low_power",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"services": {
+					"name": "services",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_structures_last_synced_at_idx": {
+					"name": "corporation_structures_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_structures",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_structures_structure_id_unique": {
+					"name": "corporation_structures_structure_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["structure_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallet_journal": {
+			"name": "corporation_wallet_journal",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"journal_id": {
+					"name": "journal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"balance": {
+					"name": "balance",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"context_id": {
+					"name": "context_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"context_id_type": {
+					"name": "context_id_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date": {
+					"name": "date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"first_party_id": {
+					"name": "first_party_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ref_type": {
+					"name": "ref_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"second_party_id": {
+					"name": "second_party_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax": {
+					"name": "tax",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax_receiver_id": {
+					"name": "tax_receiver_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallet_journal",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+					"name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "division", "journal_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallet_transactions": {
+			"name": "corporation_wallet_transactions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_buy": {
+					"name": "is_buy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_personal": {
+					"name": "is_personal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"journal_ref_id": {
+					"name": "journal_ref_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unit_price": {
+					"name": "unit_price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallet_transactions",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+					"name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "division", "transaction_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallets": {
+			"name": "corporation_wallets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"balance": {
+					"name": "balance",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallets",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallets_corporation_id_division_unique": {
+					"name": "corporation_wallets_corporation_id_division_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "division"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_fuel_log": {
+			"name": "structure_fuel_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_block_units": {
+					"name": "fuel_block_units",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_fuel_log_corp_structure_observed_idx": {
+					"name": "structure_fuel_log_corp_structure_observed_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "structure_fuel_log",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_fuel_log",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_mining_citadel_extractions": {
+			"name": "structure_mining_citadel_extractions",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"extraction_start_time": {
+					"name": "extraction_start_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"chunk_arrival_time": {
+					"name": "chunk_arrival_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"natural_decay_time": {
+					"name": "natural_decay_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_mining_citadel_extractions_corporation_id_idx": {
+					"name": "structure_mining_citadel_extractions_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_mining_citadel_extractions_last_synced_at_idx": {
+					"name": "structure_mining_citadel_extractions_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_mining_citadel_extractions",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_mining_citadel_extractions",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_moon_drills": {
+			"name": "structure_moon_drills",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_moon_drills_corporation_id_idx": {
+					"name": "structure_moon_drills_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_drills_last_synced_at_idx": {
+					"name": "structure_moon_drills_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_moon_drills",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_moon_drills",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_moon_geographies": {
+			"name": "structure_moon_geographies",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"moon_id": {
+					"name": "moon_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"moon_name": {
+					"name": "moon_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"planet_id": {
+					"name": "planet_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"planet_name": {
+					"name": "planet_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_moon_geographies_corporation_id_idx": {
+					"name": "structure_moon_geographies_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_moon_id_idx": {
+					"name": "structure_moon_geographies_moon_id_idx",
+					"columns": [
+						{
+							"expression": "moon_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_planet_id_idx": {
+					"name": "structure_moon_geographies_planet_id_idx",
+					"columns": [
+						{
+							"expression": "planet_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_system_id_idx": {
+					"name": "structure_moon_geographies_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_last_synced_at_idx": {
+					"name": "structure_moon_geographies_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_moon_geographies",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_moon_geographies",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_skyhook_reagents": {
+			"name": "structure_skyhook_reagents",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"magmatic_gas_secured_stock": {
+					"name": "magmatic_gas_secured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"magmatic_gas_unsecured_stock": {
+					"name": "magmatic_gas_unsecured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"magmatic_gas_last_cycle": {
+					"name": "magmatic_gas_last_cycle",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"superionic_ice_secured_stock": {
+					"name": "superionic_ice_secured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"superionic_ice_unsecured_stock": {
+					"name": "superionic_ice_unsecured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"superionic_ice_last_cycle": {
+					"name": "superionic_ice_last_cycle",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_skyhook_reagents_corporation_id_idx": {
+					"name": "structure_skyhook_reagents_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_skyhook_reagents",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_skyhook_reagents",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_skyhooks": {
+			"name": "structure_skyhooks",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"planet_id": {
+					"name": "planet_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"planet_name": {
+					"name": "planet_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"effective_workforce": {
+					"name": "effective_workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reinforcement_timer_end": {
+					"name": "reinforcement_timer_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theft_vulnerability_start": {
+					"name": "theft_vulnerability_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theft_vulnerability_end": {
+					"name": "theft_vulnerability_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_observed_at": {
+					"name": "last_observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_skyhooks_corporation_id_idx": {
+					"name": "structure_skyhooks_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_planet_id_idx": {
+					"name": "structure_skyhooks_planet_id_idx",
+					"columns": [
+						{
+							"expression": "planet_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_system_id_idx": {
+					"name": "structure_skyhooks_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_type_id_idx": {
+					"name": "structure_skyhooks_type_id_idx",
+					"columns": [
+						{
+							"expression": "type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_last_synced_at_idx": {
+					"name": "structure_skyhooks_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_skyhooks",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_skyhooks",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_sovereignty_hubs": {
+			"name": "structure_sovereignty_hubs",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_access_list_id": {
+					"name": "fuel_access_list_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"controller_alliance_id": {
+					"name": "controller_alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"controller_alliance_name": {
+					"name": "controller_alliance_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reagent_bay_last_updated": {
+					"name": "reagent_bay_last_updated",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reagent_bay": {
+					"name": "reagent_bay",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+				},
+				"resources": {
+					"name": "resources",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+				},
+				"upgrades": {
+					"name": "upgrades",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"vulnerability_window_start": {
+					"name": "vulnerability_window_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_end": {
+					"name": "vulnerability_window_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_transport": {
+					"name": "workforce_transport",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_sovereignty_hubs_corporation_id_idx": {
+					"name": "structure_sovereignty_hubs_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_hubs_system_id_idx": {
+					"name": "structure_sovereignty_hubs_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_hubs_type_id_idx": {
+					"name": "structure_sovereignty_hubs_type_id_idx",
+					"columns": [
+						{
+							"expression": "type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_hubs_last_synced_at_idx": {
+					"name": "structure_sovereignty_hubs_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_sovereignty_hubs",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_sovereignty_systems": {
+			"name": "structure_sovereignty_systems",
+			"schema": "",
+			"columns": {
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_name": {
+					"name": "region_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claim_type": {
+					"name": "claim_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alliance_id": {
+					"name": "alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"alliance_name": {
+					"name": "alliance_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"corporation_claimant_id": {
+					"name": "corporation_claimant_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"faction_id": {
+					"name": "faction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_since": {
+					"name": "claimed_since",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sovereignty_hub_structure_id": {
+					"name": "sovereignty_hub_structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_capital_system": {
+					"name": "is_capital_system",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_start": {
+					"name": "vulnerability_window_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_end": {
+					"name": "vulnerability_window_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"activity_defense_multiplier": {
+					"name": "activity_defense_multiplier",
+					"type": "numeric(12, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"military_level": {
+					"name": "military_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"industrial_level": {
+					"name": "industrial_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"strategic_level": {
+					"name": "strategic_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_sovereignty_systems_corporation_id_idx": {
+					"name": "structure_sovereignty_systems_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_region_id_idx": {
+					"name": "structure_sovereignty_systems_region_id_idx",
+					"columns": [
+						{
+							"expression": "region_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_alliance_id_idx": {
+					"name": "structure_sovereignty_systems_alliance_id_idx",
+					"columns": [
+						{
+							"expression": "alliance_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+					"name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+					"columns": [
+						{
+							"expression": "sovereignty_hub_structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_last_synced_at_idx": {
+					"name": "structure_sovereignty_systems_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_sovereignty_systems",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.corporation_type": {
+			"name": "corporation_type",
+			"schema": "public",
+			"values": ["member", "alt", "special_purpose", "other"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/apps/eve-corporation-data/.migrations/meta/0033_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0033_snapshot.json
@@ -1,0 +1,3711 @@
+{
+	"id": "54d43ce2-0524-47d5-9ac3-7363355f7e05",
+	"prevId": "b77ee11a-5ebf-431c-9d25-7d897cd8b0ea",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.character_corporation_roles": {
+			"name": "character_corporation_roles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"roles": {
+					"name": "roles",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"roles_at_hq": {
+					"name": "roles_at_hq",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"roles_at_base": {
+					"name": "roles_at_base",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"roles_at_other": {
+					"name": "roles_at_other",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "character_corporation_roles",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"character_corporation_roles_corporation_id_character_id_unique": {
+					"name": "character_corporation_roles_corporation_id_character_id_unique",
+					"columns": ["corporation_id", "character_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_assets": {
+			"name": "corporation_assets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_singleton": {
+					"name": "is_singleton",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"location_flag": {
+					"name": "location_flag",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_type": {
+					"name": "location_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_blueprint_copy": {
+					"name": "is_blueprint_copy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_assets",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_assets_corporation_id_item_id_unique": {
+					"name": "corporation_assets_corporation_id_item_id_unique",
+					"columns": ["corporation_id", "item_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_config": {
+			"name": "corporation_config",
+			"schema": "",
+			"columns": {
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"last_verified": {
+					"name": "last_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_verified": {
+					"name": "is_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"include_in_background_refresh": {
+					"name": "include_in_background_refresh",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"include_in_structure_asset_sync": {
+					"name": "include_in_structure_asset_sync",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"corporation_type": {
+					"name": "corporation_type",
+					"type": "corporation_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'other'"
+				},
+				"members_last_sync": {
+					"name": "members_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_tracking_last_sync": {
+					"name": "member_tracking_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallets_last_sync": {
+					"name": "wallets_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallet_journal_last_sync": {
+					"name": "wallet_journal_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallet_transactions_last_sync": {
+					"name": "wallet_transactions_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"assets_last_sync": {
+					"name": "assets_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"structures_last_sync": {
+					"name": "structures_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"orders_last_sync": {
+					"name": "orders_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contracts_last_sync": {
+					"name": "contracts_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"industry_jobs_last_sync": {
+					"name": "industry_jobs_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"killmails_last_sync": {
+					"name": "killmails_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"corporation_config_include_in_background_refresh_idx": {
+					"name": "corporation_config_include_in_background_refresh_idx",
+					"columns": [
+						{
+							"expression": "include_in_background_refresh",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_include_in_structure_asset_sync_idx": {
+					"name": "corporation_config_include_in_structure_asset_sync_idx",
+					"columns": [
+						{
+							"expression": "include_in_structure_asset_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_corporation_type_idx": {
+					"name": "corporation_config_corporation_type_idx",
+					"columns": [
+						{
+							"expression": "corporation_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_member_tracking_last_sync_idx": {
+					"name": "corporation_config_member_tracking_last_sync_idx",
+					"columns": [
+						{
+							"expression": "member_tracking_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_wallets_last_sync_idx": {
+					"name": "corporation_config_wallets_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallets_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_assets_last_sync_idx": {
+					"name": "corporation_config_assets_last_sync_idx",
+					"columns": [
+						{
+							"expression": "assets_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_structures_last_sync_idx": {
+					"name": "corporation_config_structures_last_sync_idx",
+					"columns": [
+						{
+							"expression": "structures_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_orders_last_sync_idx": {
+					"name": "corporation_config_orders_last_sync_idx",
+					"columns": [
+						{
+							"expression": "orders_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_contracts_last_sync_idx": {
+					"name": "corporation_config_contracts_last_sync_idx",
+					"columns": [
+						{
+							"expression": "contracts_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_industry_jobs_last_sync_idx": {
+					"name": "corporation_config_industry_jobs_last_sync_idx",
+					"columns": [
+						{
+							"expression": "industry_jobs_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_killmails_last_sync_idx": {
+					"name": "corporation_config_killmails_last_sync_idx",
+					"columns": [
+						{
+							"expression": "killmails_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_members_last_sync_idx": {
+					"name": "corporation_config_members_last_sync_idx",
+					"columns": [
+						{
+							"expression": "members_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_wallet_transactions_last_sync_idx": {
+					"name": "corporation_config_wallet_transactions_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallet_transactions_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_config_wallet_journal_last_sync_idx": {
+					"name": "corporation_config_wallet_journal_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallet_journal_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_contracts": {
+			"name": "corporation_contracts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"contract_id": {
+					"name": "contract_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"acceptor_id": {
+					"name": "acceptor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"assignee_id": {
+					"name": "assignee_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"availability": {
+					"name": "availability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"buyout": {
+					"name": "buyout",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"collateral": {
+					"name": "collateral",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_accepted": {
+					"name": "date_accepted",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_completed": {
+					"name": "date_completed",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_expired": {
+					"name": "date_expired",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_issued": {
+					"name": "date_issued",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"days_to_complete": {
+					"name": "days_to_complete",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_location_id": {
+					"name": "end_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"for_corporation": {
+					"name": "for_corporation",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"issuer_corporation_id": {
+					"name": "issuer_corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"issuer_id": {
+					"name": "issuer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"price": {
+					"name": "price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reward": {
+					"name": "reward",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_location_id": {
+					"name": "start_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume": {
+					"name": "volume",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_contracts_leaderboard_all_time_idx": {
+					"name": "corporation_contracts_leaderboard_all_time_idx",
+					"columns": [
+						{
+							"expression": "assignee_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "acceptor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_contracts_leaderboard_period_idx": {
+					"name": "corporation_contracts_leaderboard_period_idx",
+					"columns": [
+						{
+							"expression": "assignee_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "date_completed",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "acceptor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_contracts_contract_id_unique": {
+					"name": "corporation_contracts_contract_id_unique",
+					"columns": ["contract_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_directors": {
+			"name": "corporation_directors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_name": {
+					"name": "character_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 100
+				},
+				"is_healthy": {
+					"name": "is_healthy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_health_check": {
+					"name": "last_health_check",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_used": {
+					"name": "last_used",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"failure_count": {
+					"name": "failure_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_failure_reason": {
+					"name": "last_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_retry_at": {
+					"name": "next_retry_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"permanent_failure_at": {
+					"name": "permanent_failure_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_directors_corp_healthy_idx": {
+					"name": "corporation_directors_corp_healthy_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_healthy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_directors_corp_next_retry_idx": {
+					"name": "corporation_directors_corp_next_retry_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_retry_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_directors_corp_permanent_failure_idx": {
+					"name": "corporation_directors_corp_permanent_failure_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "permanent_failure_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_directors_last_used_idx": {
+					"name": "corporation_directors_last_used_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "last_used",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_directors",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_directors_corporation_id_character_id_unique": {
+					"name": "corporation_directors_corporation_id_character_id_unique",
+					"columns": ["corporation_id", "character_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_industry_jobs": {
+			"name": "corporation_industry_jobs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"job_id": {
+					"name": "job_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"installer_id": {
+					"name": "installer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"facility_id": {
+					"name": "facility_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"activity_id": {
+					"name": "activity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_id": {
+					"name": "blueprint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_type_id": {
+					"name": "blueprint_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_location_id": {
+					"name": "blueprint_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"output_location_id": {
+					"name": "output_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"runs": {
+					"name": "runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost": {
+					"name": "cost",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"licensed_runs": {
+					"name": "licensed_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"probability": {
+					"name": "probability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_type_id": {
+					"name": "product_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"duration": {
+					"name": "duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pause_date": {
+					"name": "pause_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_date": {
+					"name": "completed_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_character_id": {
+					"name": "completed_character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"successful_runs": {
+					"name": "successful_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_industry_jobs",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_industry_jobs_corporation_id_job_id_unique": {
+					"name": "corporation_industry_jobs_corporation_id_job_id_unique",
+					"columns": ["corporation_id", "job_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_killmails": {
+			"name": "corporation_killmails",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_id": {
+					"name": "killmail_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_hash": {
+					"name": "killmail_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_time": {
+					"name": "killmail_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_killmails",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_killmails_corporation_id_killmail_id_unique": {
+					"name": "corporation_killmails_corporation_id_killmail_id_unique",
+					"columns": ["corporation_id", "killmail_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_member_tracking": {
+			"name": "corporation_member_tracking",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_id": {
+					"name": "base_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"logoff_date": {
+					"name": "logoff_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"logon_date": {
+					"name": "logon_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ship_type_id": {
+					"name": "ship_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_member_tracking",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_member_tracking_corporation_id_character_id_unique": {
+					"name": "corporation_member_tracking_corporation_id_character_id_unique",
+					"columns": ["corporation_id", "character_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_members": {
+			"name": "corporation_members",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_members_character_id_idx": {
+					"name": "corporation_members_character_id_idx",
+					"columns": [
+						{
+							"expression": "character_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_members",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_members_corporation_id_character_id_unique": {
+					"name": "corporation_members_corporation_id_character_id_unique",
+					"columns": ["corporation_id", "character_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_orders": {
+			"name": "corporation_orders",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"order_id": {
+					"name": "order_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"duration": {
+					"name": "duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"escrow": {
+					"name": "escrow",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_buy_order": {
+					"name": "is_buy_order",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"issued": {
+					"name": "issued",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"issued_by": {
+					"name": "issued_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"min_volume": {
+					"name": "min_volume",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"price": {
+					"name": "price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"range": {
+					"name": "range",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume_remain": {
+					"name": "volume_remain",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume_total": {
+					"name": "volume_total",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wallet_division": {
+					"name": "wallet_division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_orders",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_orders_corporation_id_order_id_unique": {
+					"name": "corporation_orders_corporation_id_order_id_unique",
+					"columns": ["corporation_id", "order_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_public_info": {
+			"name": "corporation_public_info",
+			"schema": "",
+			"columns": {
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ticker": {
+					"name": "ticker",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ceo_id": {
+					"name": "ceo_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"creator_id": {
+					"name": "creator_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_founded": {
+					"name": "date_founded",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"home_station_id": {
+					"name": "home_station_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_count": {
+					"name": "member_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shares": {
+					"name": "shares",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax_rate": {
+					"name": "tax_rate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"alliance_id": {
+					"name": "alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"faction_id": {
+					"name": "faction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"war_eligible": {
+					"name": "war_eligible",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structure_inventory": {
+			"name": "corporation_structure_inventory",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_singleton": {
+					"name": "is_singleton",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"location_flag": {
+					"name": "location_flag",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_type": {
+					"name": "location_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_structure_inventory_corp_structure_idx": {
+					"name": "corporation_structure_inventory_corp_structure_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"corporation_structure_inventory_snapshot_structure_idx": {
+					"name": "corporation_structure_inventory_snapshot_structure_idx",
+					"columns": [
+						{
+							"expression": "snapshot_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				},
+				"corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+					"name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"columnsFrom": ["structure_id"],
+					"tableTo": "corporation_structures",
+					"columnsTo": ["structure_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"corp_inv_snapshot_fk": {
+					"name": "corp_inv_snapshot_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"columnsFrom": ["snapshot_id"],
+					"tableTo": "corporation_structure_inventory_snapshots",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corp_inv_snapshot_item_uniq": {
+					"name": "corp_inv_snapshot_item_uniq",
+					"columns": ["corporation_id", "snapshot_id", "item_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structure_inventory_snapshots": {
+			"name": "corporation_structure_inventory_snapshots",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"activated_at": {
+					"name": "activated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"corporation_structure_inventory_snapshots_corp_activated_idx": {
+					"name": "corporation_structure_inventory_snapshots_corp_activated_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "activated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"corp_inv_snapshots_corp_fk": {
+					"name": "corp_inv_snapshots_corp_fk",
+					"tableFrom": "corporation_structure_inventory_snapshots",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structures": {
+			"name": "corporation_structures",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_name": {
+					"name": "type_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_name": {
+					"name": "region_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"profile_id": {
+					"name": "profile_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_expires": {
+					"name": "fuel_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fuel_amount": {
+					"name": "fuel_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fuel_burn_rate": {
+					"name": "fuel_burn_rate",
+					"type": "numeric(12, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_refilled_at": {
+					"name": "last_refilled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_reinforce_apply": {
+					"name": "next_reinforce_apply",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_reinforce_hour": {
+					"name": "next_reinforce_hour",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reinforce_hour": {
+					"name": "reinforce_hour",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state_timer_end": {
+					"name": "state_timer_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state_timer_start": {
+					"name": "state_timer_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unanchors_at": {
+					"name": "unanchors_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"low_power": {
+					"name": "low_power",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"services": {
+					"name": "services",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_structures_last_synced_at_idx": {
+					"name": "corporation_structures_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_structures",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_structures_structure_id_unique": {
+					"name": "corporation_structures_structure_id_unique",
+					"columns": ["structure_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallet_journal": {
+			"name": "corporation_wallet_journal",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"journal_id": {
+					"name": "journal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"balance": {
+					"name": "balance",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"context_id": {
+					"name": "context_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"context_id_type": {
+					"name": "context_id_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date": {
+					"name": "date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"first_party_id": {
+					"name": "first_party_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ref_type": {
+					"name": "ref_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"second_party_id": {
+					"name": "second_party_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax": {
+					"name": "tax",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax_receiver_id": {
+					"name": "tax_receiver_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallet_journal",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+					"name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+					"columns": ["corporation_id", "division", "journal_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallet_transactions": {
+			"name": "corporation_wallet_transactions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_buy": {
+					"name": "is_buy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_personal": {
+					"name": "is_personal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"journal_ref_id": {
+					"name": "journal_ref_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unit_price": {
+					"name": "unit_price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallet_transactions",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+					"name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+					"columns": ["corporation_id", "division", "transaction_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallets": {
+			"name": "corporation_wallets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"balance": {
+					"name": "balance",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallets",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallets_corporation_id_division_unique": {
+					"name": "corporation_wallets_corporation_id_division_unique",
+					"columns": ["corporation_id", "division"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_fuel_log": {
+			"name": "structure_fuel_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_block_units": {
+					"name": "fuel_block_units",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_fuel_log_corp_structure_observed_idx": {
+					"name": "structure_fuel_log_corp_structure_observed_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "structure_fuel_log",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "corporation_config",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_fuel_log",
+					"columnsFrom": ["structure_id"],
+					"tableTo": "corporation_structures",
+					"columnsTo": ["structure_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_mining_citadel_extractions": {
+			"name": "structure_mining_citadel_extractions",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"extraction_start_time": {
+					"name": "extraction_start_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"chunk_arrival_time": {
+					"name": "chunk_arrival_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"natural_decay_time": {
+					"name": "natural_decay_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_mining_citadel_extractions_corporation_id_idx": {
+					"name": "structure_mining_citadel_extractions_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_mining_citadel_extractions_last_synced_at_idx": {
+					"name": "structure_mining_citadel_extractions_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_mining_citadel_extractions",
+					"columnsFrom": ["structure_id"],
+					"tableTo": "corporation_structures",
+					"columnsTo": ["structure_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_mining_citadel_extractions",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "managed_corporations",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_moon_drills": {
+			"name": "structure_moon_drills",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_moon_drills_corporation_id_idx": {
+					"name": "structure_moon_drills_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_moon_drills_last_synced_at_idx": {
+					"name": "structure_moon_drills_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_moon_drills",
+					"columnsFrom": ["structure_id"],
+					"tableTo": "corporation_structures",
+					"columnsTo": ["structure_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_moon_drills",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "managed_corporations",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_moon_geographies": {
+			"name": "structure_moon_geographies",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"moon_id": {
+					"name": "moon_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"moon_name": {
+					"name": "moon_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"planet_id": {
+					"name": "planet_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"planet_name": {
+					"name": "planet_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_moon_geographies_corporation_id_idx": {
+					"name": "structure_moon_geographies_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_moon_geographies_moon_id_idx": {
+					"name": "structure_moon_geographies_moon_id_idx",
+					"columns": [
+						{
+							"expression": "moon_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_moon_geographies_planet_id_idx": {
+					"name": "structure_moon_geographies_planet_id_idx",
+					"columns": [
+						{
+							"expression": "planet_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_moon_geographies_system_id_idx": {
+					"name": "structure_moon_geographies_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_moon_geographies_last_synced_at_idx": {
+					"name": "structure_moon_geographies_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_moon_geographies",
+					"columnsFrom": ["structure_id"],
+					"tableTo": "corporation_structures",
+					"columnsTo": ["structure_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_moon_geographies",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "managed_corporations",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_skyhook_reagents": {
+			"name": "structure_skyhook_reagents",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"magmatic_gas_secured_stock": {
+					"name": "magmatic_gas_secured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"magmatic_gas_unsecured_stock": {
+					"name": "magmatic_gas_unsecured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"magmatic_gas_last_cycle": {
+					"name": "magmatic_gas_last_cycle",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"superionic_ice_secured_stock": {
+					"name": "superionic_ice_secured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"superionic_ice_unsecured_stock": {
+					"name": "superionic_ice_unsecured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"superionic_ice_last_cycle": {
+					"name": "superionic_ice_last_cycle",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_skyhook_reagents_corporation_id_idx": {
+					"name": "structure_skyhook_reagents_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_skyhook_reagents",
+					"columnsFrom": ["structure_id"],
+					"tableTo": "corporation_structures",
+					"columnsTo": ["structure_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_skyhook_reagents",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "managed_corporations",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_skyhooks": {
+			"name": "structure_skyhooks",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"planet_id": {
+					"name": "planet_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"planet_name": {
+					"name": "planet_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"effective_workforce": {
+					"name": "effective_workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reinforcement_timer_end": {
+					"name": "reinforcement_timer_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theft_vulnerability_start": {
+					"name": "theft_vulnerability_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theft_vulnerability_end": {
+					"name": "theft_vulnerability_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_observed_at": {
+					"name": "last_observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_skyhooks_corporation_id_idx": {
+					"name": "structure_skyhooks_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_skyhooks_planet_id_idx": {
+					"name": "structure_skyhooks_planet_id_idx",
+					"columns": [
+						{
+							"expression": "planet_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_skyhooks_system_id_idx": {
+					"name": "structure_skyhooks_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_skyhooks_type_id_idx": {
+					"name": "structure_skyhooks_type_id_idx",
+					"columns": [
+						{
+							"expression": "type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_skyhooks_last_synced_at_idx": {
+					"name": "structure_skyhooks_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_skyhooks",
+					"columnsFrom": ["structure_id"],
+					"tableTo": "corporation_structures",
+					"columnsTo": ["structure_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_skyhooks",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "managed_corporations",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_sovereignty_hubs": {
+			"name": "structure_sovereignty_hubs",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_access_list_id": {
+					"name": "fuel_access_list_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"controller_alliance_id": {
+					"name": "controller_alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"controller_alliance_name": {
+					"name": "controller_alliance_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reagent_bay_last_updated": {
+					"name": "reagent_bay_last_updated",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reagent_bay": {
+					"name": "reagent_bay",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+				},
+				"resources": {
+					"name": "resources",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+				},
+				"upgrades": {
+					"name": "upgrades",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"vulnerability_window_start": {
+					"name": "vulnerability_window_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_end": {
+					"name": "vulnerability_window_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_transport": {
+					"name": "workforce_transport",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_sovereignty_hubs_corporation_id_idx": {
+					"name": "structure_sovereignty_hubs_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_sovereignty_hubs_system_id_idx": {
+					"name": "structure_sovereignty_hubs_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_sovereignty_hubs_type_id_idx": {
+					"name": "structure_sovereignty_hubs_type_id_idx",
+					"columns": [
+						{
+							"expression": "type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_sovereignty_hubs_last_synced_at_idx": {
+					"name": "structure_sovereignty_hubs_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_sovereignty_hubs",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "managed_corporations",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_sovereignty_systems": {
+			"name": "structure_sovereignty_systems",
+			"schema": "",
+			"columns": {
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_name": {
+					"name": "region_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claim_type": {
+					"name": "claim_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alliance_id": {
+					"name": "alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"alliance_name": {
+					"name": "alliance_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"corporation_claimant_id": {
+					"name": "corporation_claimant_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"faction_id": {
+					"name": "faction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_since": {
+					"name": "claimed_since",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sovereignty_hub_structure_id": {
+					"name": "sovereignty_hub_structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_capital_system": {
+					"name": "is_capital_system",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_start": {
+					"name": "vulnerability_window_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_end": {
+					"name": "vulnerability_window_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"activity_defense_multiplier": {
+					"name": "activity_defense_multiplier",
+					"type": "numeric(12, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"military_level": {
+					"name": "military_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"industrial_level": {
+					"name": "industrial_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"strategic_level": {
+					"name": "strategic_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_sovereignty_systems_corporation_id_idx": {
+					"name": "structure_sovereignty_systems_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_sovereignty_systems_region_id_idx": {
+					"name": "structure_sovereignty_systems_region_id_idx",
+					"columns": [
+						{
+							"expression": "region_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_sovereignty_systems_alliance_id_idx": {
+					"name": "structure_sovereignty_systems_alliance_id_idx",
+					"columns": [
+						{
+							"expression": "alliance_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+					"name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+					"columns": [
+						{
+							"expression": "sovereignty_hub_structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"structure_sovereignty_systems_last_synced_at_idx": {
+					"name": "structure_sovereignty_systems_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_sovereignty_systems",
+					"columnsFrom": ["corporation_id"],
+					"tableTo": "managed_corporations",
+					"columnsTo": ["corporation_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.corporation_type": {
+			"name": "corporation_type",
+			"schema": "public",
+			"values": ["member", "alt", "special_purpose", "other"]
+		}
+	},
+	"schemas": {},
+	"views": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/apps/eve-corporation-data/.migrations/meta/0034_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0034_snapshot.json
@@ -1,0 +1,3711 @@
+{
+	"id": "ebef1847-e147-45a6-bb71-b3fab4a3ddf7",
+	"prevId": "54d43ce2-0524-47d5-9ac3-7363355f7e05",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.character_corporation_roles": {
+			"name": "character_corporation_roles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"roles": {
+					"name": "roles",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"roles_at_hq": {
+					"name": "roles_at_hq",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"roles_at_base": {
+					"name": "roles_at_base",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"roles_at_other": {
+					"name": "roles_at_other",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "character_corporation_roles",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"character_corporation_roles_corporation_id_character_id_unique": {
+					"name": "character_corporation_roles_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_assets": {
+			"name": "corporation_assets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_singleton": {
+					"name": "is_singleton",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"location_flag": {
+					"name": "location_flag",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_type": {
+					"name": "location_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_blueprint_copy": {
+					"name": "is_blueprint_copy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_assets",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_assets_corporation_id_item_id_unique": {
+					"name": "corporation_assets_corporation_id_item_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "item_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_config": {
+			"name": "corporation_config",
+			"schema": "",
+			"columns": {
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"last_verified": {
+					"name": "last_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_verified": {
+					"name": "is_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"include_in_background_refresh": {
+					"name": "include_in_background_refresh",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"include_in_structure_asset_sync": {
+					"name": "include_in_structure_asset_sync",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"corporation_type": {
+					"name": "corporation_type",
+					"type": "corporation_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'other'"
+				},
+				"members_last_sync": {
+					"name": "members_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_tracking_last_sync": {
+					"name": "member_tracking_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallets_last_sync": {
+					"name": "wallets_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallet_journal_last_sync": {
+					"name": "wallet_journal_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wallet_transactions_last_sync": {
+					"name": "wallet_transactions_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"assets_last_sync": {
+					"name": "assets_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"structures_last_sync": {
+					"name": "structures_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"orders_last_sync": {
+					"name": "orders_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contracts_last_sync": {
+					"name": "contracts_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"industry_jobs_last_sync": {
+					"name": "industry_jobs_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"killmails_last_sync": {
+					"name": "killmails_last_sync",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"corporation_config_include_in_background_refresh_idx": {
+					"name": "corporation_config_include_in_background_refresh_idx",
+					"columns": [
+						{
+							"expression": "include_in_background_refresh",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_include_in_structure_asset_sync_idx": {
+					"name": "corporation_config_include_in_structure_asset_sync_idx",
+					"columns": [
+						{
+							"expression": "include_in_structure_asset_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_corporation_type_idx": {
+					"name": "corporation_config_corporation_type_idx",
+					"columns": [
+						{
+							"expression": "corporation_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_member_tracking_last_sync_idx": {
+					"name": "corporation_config_member_tracking_last_sync_idx",
+					"columns": [
+						{
+							"expression": "member_tracking_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_wallets_last_sync_idx": {
+					"name": "corporation_config_wallets_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallets_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_assets_last_sync_idx": {
+					"name": "corporation_config_assets_last_sync_idx",
+					"columns": [
+						{
+							"expression": "assets_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_structures_last_sync_idx": {
+					"name": "corporation_config_structures_last_sync_idx",
+					"columns": [
+						{
+							"expression": "structures_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_orders_last_sync_idx": {
+					"name": "corporation_config_orders_last_sync_idx",
+					"columns": [
+						{
+							"expression": "orders_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_contracts_last_sync_idx": {
+					"name": "corporation_config_contracts_last_sync_idx",
+					"columns": [
+						{
+							"expression": "contracts_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_industry_jobs_last_sync_idx": {
+					"name": "corporation_config_industry_jobs_last_sync_idx",
+					"columns": [
+						{
+							"expression": "industry_jobs_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_killmails_last_sync_idx": {
+					"name": "corporation_config_killmails_last_sync_idx",
+					"columns": [
+						{
+							"expression": "killmails_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_members_last_sync_idx": {
+					"name": "corporation_config_members_last_sync_idx",
+					"columns": [
+						{
+							"expression": "members_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_wallet_transactions_last_sync_idx": {
+					"name": "corporation_config_wallet_transactions_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallet_transactions_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_config_wallet_journal_last_sync_idx": {
+					"name": "corporation_config_wallet_journal_last_sync_idx",
+					"columns": [
+						{
+							"expression": "wallet_journal_last_sync",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_contracts": {
+			"name": "corporation_contracts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"contract_id": {
+					"name": "contract_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"acceptor_id": {
+					"name": "acceptor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"assignee_id": {
+					"name": "assignee_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"availability": {
+					"name": "availability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"buyout": {
+					"name": "buyout",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"collateral": {
+					"name": "collateral",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_accepted": {
+					"name": "date_accepted",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_completed": {
+					"name": "date_completed",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_expired": {
+					"name": "date_expired",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_issued": {
+					"name": "date_issued",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"days_to_complete": {
+					"name": "days_to_complete",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_location_id": {
+					"name": "end_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"for_corporation": {
+					"name": "for_corporation",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"issuer_corporation_id": {
+					"name": "issuer_corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"issuer_id": {
+					"name": "issuer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"price": {
+					"name": "price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reward": {
+					"name": "reward",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_location_id": {
+					"name": "start_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume": {
+					"name": "volume",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_contracts_leaderboard_all_time_idx": {
+					"name": "corporation_contracts_leaderboard_all_time_idx",
+					"columns": [
+						{
+							"expression": "assignee_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "acceptor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_contracts_leaderboard_period_idx": {
+					"name": "corporation_contracts_leaderboard_period_idx",
+					"columns": [
+						{
+							"expression": "assignee_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "date_completed",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "acceptor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_contracts_contract_id_unique": {
+					"name": "corporation_contracts_contract_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["contract_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_directors": {
+			"name": "corporation_directors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_name": {
+					"name": "character_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"priority": {
+					"name": "priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 100
+				},
+				"is_healthy": {
+					"name": "is_healthy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_health_check": {
+					"name": "last_health_check",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_used": {
+					"name": "last_used",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"failure_count": {
+					"name": "failure_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_failure_reason": {
+					"name": "last_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_retry_at": {
+					"name": "next_retry_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"permanent_failure_at": {
+					"name": "permanent_failure_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_directors_corp_healthy_idx": {
+					"name": "corporation_directors_corp_healthy_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_healthy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_directors_corp_next_retry_idx": {
+					"name": "corporation_directors_corp_next_retry_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_retry_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_directors_corp_permanent_failure_idx": {
+					"name": "corporation_directors_corp_permanent_failure_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "permanent_failure_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_directors_last_used_idx": {
+					"name": "corporation_directors_last_used_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "last_used",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_directors",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_directors_corporation_id_character_id_unique": {
+					"name": "corporation_directors_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_industry_jobs": {
+			"name": "corporation_industry_jobs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"job_id": {
+					"name": "job_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"installer_id": {
+					"name": "installer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"facility_id": {
+					"name": "facility_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"activity_id": {
+					"name": "activity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_id": {
+					"name": "blueprint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_type_id": {
+					"name": "blueprint_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blueprint_location_id": {
+					"name": "blueprint_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"output_location_id": {
+					"name": "output_location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"runs": {
+					"name": "runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost": {
+					"name": "cost",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"licensed_runs": {
+					"name": "licensed_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"probability": {
+					"name": "probability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_type_id": {
+					"name": "product_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"duration": {
+					"name": "duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pause_date": {
+					"name": "pause_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_date": {
+					"name": "completed_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_character_id": {
+					"name": "completed_character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"successful_runs": {
+					"name": "successful_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_industry_jobs",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_industry_jobs_corporation_id_job_id_unique": {
+					"name": "corporation_industry_jobs_corporation_id_job_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "job_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_killmails": {
+			"name": "corporation_killmails",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_id": {
+					"name": "killmail_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_hash": {
+					"name": "killmail_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"killmail_time": {
+					"name": "killmail_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_killmails",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_killmails_corporation_id_killmail_id_unique": {
+					"name": "corporation_killmails_corporation_id_killmail_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "killmail_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_member_tracking": {
+			"name": "corporation_member_tracking",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_id": {
+					"name": "base_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"logoff_date": {
+					"name": "logoff_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"logon_date": {
+					"name": "logon_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ship_type_id": {
+					"name": "ship_type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_member_tracking",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_member_tracking_corporation_id_character_id_unique": {
+					"name": "corporation_member_tracking_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_members": {
+			"name": "corporation_members",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"character_id": {
+					"name": "character_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_members_character_id_idx": {
+					"name": "corporation_members_character_id_idx",
+					"columns": [
+						{
+							"expression": "character_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_members",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_members_corporation_id_character_id_unique": {
+					"name": "corporation_members_corporation_id_character_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "character_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_orders": {
+			"name": "corporation_orders",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"order_id": {
+					"name": "order_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"duration": {
+					"name": "duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"escrow": {
+					"name": "escrow",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_buy_order": {
+					"name": "is_buy_order",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"issued": {
+					"name": "issued",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"issued_by": {
+					"name": "issued_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"min_volume": {
+					"name": "min_volume",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"price": {
+					"name": "price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"range": {
+					"name": "range",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume_remain": {
+					"name": "volume_remain",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"volume_total": {
+					"name": "volume_total",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wallet_division": {
+					"name": "wallet_division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_orders",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_orders_corporation_id_order_id_unique": {
+					"name": "corporation_orders_corporation_id_order_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "order_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_public_info": {
+			"name": "corporation_public_info",
+			"schema": "",
+			"columns": {
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ticker": {
+					"name": "ticker",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ceo_id": {
+					"name": "ceo_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"creator_id": {
+					"name": "creator_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_founded": {
+					"name": "date_founded",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"home_station_id": {
+					"name": "home_station_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_count": {
+					"name": "member_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shares": {
+					"name": "shares",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax_rate": {
+					"name": "tax_rate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"alliance_id": {
+					"name": "alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"faction_id": {
+					"name": "faction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"war_eligible": {
+					"name": "war_eligible",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structure_inventory": {
+			"name": "corporation_structure_inventory",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_singleton": {
+					"name": "is_singleton",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"location_flag": {
+					"name": "location_flag",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_type": {
+					"name": "location_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_structure_inventory_corp_structure_idx": {
+					"name": "corporation_structure_inventory_corp_structure_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"corporation_structure_inventory_snapshot_structure_idx": {
+					"name": "corporation_structure_inventory_snapshot_structure_idx",
+					"columns": [
+						{
+							"expression": "snapshot_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+					"name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"corp_inv_snapshot_fk": {
+					"name": "corp_inv_snapshot_fk",
+					"tableFrom": "corporation_structure_inventory",
+					"tableTo": "corporation_structure_inventory_snapshots",
+					"columnsFrom": ["snapshot_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corp_inv_snapshot_item_uniq": {
+					"name": "corp_inv_snapshot_item_uniq",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "snapshot_id", "item_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structure_inventory_snapshots": {
+			"name": "corporation_structure_inventory_snapshots",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"activated_at": {
+					"name": "activated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"corporation_structure_inventory_snapshots_corp_activated_idx": {
+					"name": "corporation_structure_inventory_snapshots_corp_activated_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "activated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corp_inv_snapshots_corp_fk": {
+					"name": "corp_inv_snapshots_corp_fk",
+					"tableFrom": "corporation_structure_inventory_snapshots",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_structures": {
+			"name": "corporation_structures",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_name": {
+					"name": "type_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_name": {
+					"name": "region_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"profile_id": {
+					"name": "profile_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_expires": {
+					"name": "fuel_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fuel_amount": {
+					"name": "fuel_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fuel_burn_rate": {
+					"name": "fuel_burn_rate",
+					"type": "numeric(12, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_refilled_at": {
+					"name": "last_refilled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_reinforce_apply": {
+					"name": "next_reinforce_apply",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_reinforce_hour": {
+					"name": "next_reinforce_hour",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reinforce_hour": {
+					"name": "reinforce_hour",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state_timer_end": {
+					"name": "state_timer_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state_timer_start": {
+					"name": "state_timer_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unanchors_at": {
+					"name": "unanchors_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"low_power": {
+					"name": "low_power",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"services": {
+					"name": "services",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"corporation_structures_last_synced_at_idx": {
+					"name": "corporation_structures_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_structures",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_structures_structure_id_unique": {
+					"name": "corporation_structures_structure_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["structure_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallet_journal": {
+			"name": "corporation_wallet_journal",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"journal_id": {
+					"name": "journal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"balance": {
+					"name": "balance",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"context_id": {
+					"name": "context_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"context_id_type": {
+					"name": "context_id_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date": {
+					"name": "date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"first_party_id": {
+					"name": "first_party_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ref_type": {
+					"name": "ref_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"second_party_id": {
+					"name": "second_party_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax": {
+					"name": "tax",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tax_receiver_id": {
+					"name": "tax_receiver_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallet_journal",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+					"name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "division", "journal_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallet_transactions": {
+			"name": "corporation_wallet_transactions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transaction_id": {
+					"name": "transaction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_buy": {
+					"name": "is_buy",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_personal": {
+					"name": "is_personal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"journal_ref_id": {
+					"name": "journal_ref_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unit_price": {
+					"name": "unit_price",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallet_transactions",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+					"name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "division", "transaction_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.corporation_wallets": {
+			"name": "corporation_wallets",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"division": {
+					"name": "division",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"balance": {
+					"name": "balance",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "corporation_wallets",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"corporation_wallets_corporation_id_division_unique": {
+					"name": "corporation_wallets_corporation_id_division_unique",
+					"nullsNotDistinct": false,
+					"columns": ["corporation_id", "division"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_fuel_log": {
+			"name": "structure_fuel_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true,
+					"default": "gen_random_uuid()"
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_block_units": {
+					"name": "fuel_block_units",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_fuel_log_corp_structure_observed_idx": {
+					"name": "structure_fuel_log_corp_structure_observed_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+					"name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+					"tableFrom": "structure_fuel_log",
+					"tableTo": "corporation_config",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_fuel_log",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_mining_citadel_extractions": {
+			"name": "structure_mining_citadel_extractions",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"extraction_start_time": {
+					"name": "extraction_start_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"chunk_arrival_time": {
+					"name": "chunk_arrival_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"natural_decay_time": {
+					"name": "natural_decay_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_mining_citadel_extractions_corporation_id_idx": {
+					"name": "structure_mining_citadel_extractions_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_mining_citadel_extractions_last_synced_at_idx": {
+					"name": "structure_mining_citadel_extractions_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_mining_citadel_extractions",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_mining_citadel_extractions",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_moon_drills": {
+			"name": "structure_moon_drills",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_moon_drills_corporation_id_idx": {
+					"name": "structure_moon_drills_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_drills_last_synced_at_idx": {
+					"name": "structure_moon_drills_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_moon_drills",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_moon_drills",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_moon_geographies": {
+			"name": "structure_moon_geographies",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"moon_id": {
+					"name": "moon_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"moon_name": {
+					"name": "moon_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"planet_id": {
+					"name": "planet_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"planet_name": {
+					"name": "planet_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_moon_geographies_corporation_id_idx": {
+					"name": "structure_moon_geographies_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_moon_id_idx": {
+					"name": "structure_moon_geographies_moon_id_idx",
+					"columns": [
+						{
+							"expression": "moon_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_planet_id_idx": {
+					"name": "structure_moon_geographies_planet_id_idx",
+					"columns": [
+						{
+							"expression": "planet_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_system_id_idx": {
+					"name": "structure_moon_geographies_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_moon_geographies_last_synced_at_idx": {
+					"name": "structure_moon_geographies_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_moon_geographies",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_moon_geographies",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_skyhook_reagents": {
+			"name": "structure_skyhook_reagents",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"magmatic_gas_secured_stock": {
+					"name": "magmatic_gas_secured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"magmatic_gas_unsecured_stock": {
+					"name": "magmatic_gas_unsecured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"magmatic_gas_last_cycle": {
+					"name": "magmatic_gas_last_cycle",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"superionic_ice_secured_stock": {
+					"name": "superionic_ice_secured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"superionic_ice_unsecured_stock": {
+					"name": "superionic_ice_unsecured_stock",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"superionic_ice_last_cycle": {
+					"name": "superionic_ice_last_cycle",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_skyhook_reagents_corporation_id_idx": {
+					"name": "structure_skyhook_reagents_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_skyhook_reagents",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_skyhook_reagents",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_skyhooks": {
+			"name": "structure_skyhooks",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"planet_id": {
+					"name": "planet_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"planet_name": {
+					"name": "planet_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"effective_workforce": {
+					"name": "effective_workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reinforcement_timer_end": {
+					"name": "reinforcement_timer_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theft_vulnerability_start": {
+					"name": "theft_vulnerability_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theft_vulnerability_end": {
+					"name": "theft_vulnerability_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_observed_at": {
+					"name": "last_observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_skyhooks_corporation_id_idx": {
+					"name": "structure_skyhooks_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_planet_id_idx": {
+					"name": "structure_skyhooks_planet_id_idx",
+					"columns": [
+						{
+							"expression": "planet_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_system_id_idx": {
+					"name": "structure_skyhooks_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_type_id_idx": {
+					"name": "structure_skyhooks_type_id_idx",
+					"columns": [
+						{
+							"expression": "type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_skyhooks_last_synced_at_idx": {
+					"name": "structure_skyhooks_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+					"name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+					"tableFrom": "structure_skyhooks",
+					"tableTo": "corporation_structures",
+					"columnsFrom": ["structure_id"],
+					"columnsTo": ["structure_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_skyhooks",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_sovereignty_hubs": {
+			"name": "structure_sovereignty_hubs",
+			"schema": "",
+			"columns": {
+				"structure_id": {
+					"name": "structure_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fuel_access_list_id": {
+					"name": "fuel_access_list_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"controller_alliance_id": {
+					"name": "controller_alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"controller_alliance_name": {
+					"name": "controller_alliance_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reagent_bay_last_updated": {
+					"name": "reagent_bay_last_updated",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reagent_bay": {
+					"name": "reagent_bay",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+				},
+				"resources": {
+					"name": "resources",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+				},
+				"upgrades": {
+					"name": "upgrades",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"vulnerability_window_start": {
+					"name": "vulnerability_window_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_end": {
+					"name": "vulnerability_window_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_transport": {
+					"name": "workforce_transport",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+				},
+				"sync_status": {
+					"name": "sync_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ok'"
+				},
+				"sync_failure_reason": {
+					"name": "sync_failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_attempted_sync_at": {
+					"name": "last_attempted_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_sovereignty_hubs_corporation_id_idx": {
+					"name": "structure_sovereignty_hubs_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_hubs_system_id_idx": {
+					"name": "structure_sovereignty_hubs_system_id_idx",
+					"columns": [
+						{
+							"expression": "system_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_hubs_type_id_idx": {
+					"name": "structure_sovereignty_hubs_type_id_idx",
+					"columns": [
+						{
+							"expression": "type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_hubs_last_synced_at_idx": {
+					"name": "structure_sovereignty_hubs_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_sovereignty_hubs",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.structure_sovereignty_systems": {
+			"name": "structure_sovereignty_systems",
+			"schema": "",
+			"columns": {
+				"system_id": {
+					"name": "system_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"system_name": {
+					"name": "system_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_id": {
+					"name": "region_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region_name": {
+					"name": "region_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"corporation_id": {
+					"name": "corporation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claim_type": {
+					"name": "claim_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"alliance_id": {
+					"name": "alliance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"alliance_name": {
+					"name": "alliance_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"corporation_claimant_id": {
+					"name": "corporation_claimant_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"faction_id": {
+					"name": "faction_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_since": {
+					"name": "claimed_since",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sovereignty_hub_structure_id": {
+					"name": "sovereignty_hub_structure_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_capital_system": {
+					"name": "is_capital_system",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_start": {
+					"name": "vulnerability_window_start",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vulnerability_window_end": {
+					"name": "vulnerability_window_end",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"activity_defense_multiplier": {
+					"name": "activity_defense_multiplier",
+					"type": "numeric(12, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"military_level": {
+					"name": "military_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"industrial_level": {
+					"name": "industrial_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"strategic_level": {
+					"name": "strategic_level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source_sync_at": {
+					"name": "source_sync_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_synced_at": {
+					"name": "last_synced_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"structure_sovereignty_systems_corporation_id_idx": {
+					"name": "structure_sovereignty_systems_corporation_id_idx",
+					"columns": [
+						{
+							"expression": "corporation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_region_id_idx": {
+					"name": "structure_sovereignty_systems_region_id_idx",
+					"columns": [
+						{
+							"expression": "region_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_alliance_id_idx": {
+					"name": "structure_sovereignty_systems_alliance_id_idx",
+					"columns": [
+						{
+							"expression": "alliance_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+					"name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+					"columns": [
+						{
+							"expression": "sovereignty_hub_structure_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"structure_sovereignty_systems_last_synced_at_idx": {
+					"name": "structure_sovereignty_systems_last_synced_at_idx",
+					"columns": [
+						{
+							"expression": "last_synced_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+					"name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+					"tableFrom": "structure_sovereignty_systems",
+					"tableTo": "managed_corporations",
+					"columnsFrom": ["corporation_id"],
+					"columnsTo": ["corporation_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.corporation_type": {
+			"name": "corporation_type",
+			"schema": "public",
+			"values": ["member", "alt", "special_purpose", "other"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/apps/eve-corporation-data/.migrations/meta/_journal.json
+++ b/apps/eve-corporation-data/.migrations/meta/_journal.json
@@ -1,230 +1,251 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1761099619236,
-      "tag": "0000_dazzling_natasha_romanoff",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1761110912747,
-      "tag": "0001_mature_legion",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1761111712115,
-      "tag": "0002_amused_starbolt",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1761111737470,
-      "tag": "0003_natural_rage",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1761160474761,
-      "tag": "0004_clean_tinkerer",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1761744369304,
-      "tag": "0005_stormy_captain_flint",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1761747572400,
-      "tag": "0006_uneven_ricochet",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1761747676930,
-      "tag": "0007_famous_unicorn",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1762957583759,
-      "tag": "0008_curved_gamma_corps",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1762957633914,
-      "tag": "0009_brown_the_hunter",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1762957839616,
-      "tag": "0010_redundant_susan_delgado",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1762965216030,
-      "tag": "0011_melodic_punisher",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1763040426490,
-      "tag": "0012_tiny_exodus",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1763040690210,
-      "tag": "0013_quiet_jazinda",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1763331803557,
-      "tag": "0014_dazzling_monster_badoon",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1779900405297,
-      "tag": "0015_woozy_human_robot",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1781300366548,
-      "tag": "0016_numerous_molly_hayes",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1781388311665,
-      "tag": "0017_stormy_queen_noir",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1781388451291,
-      "tag": "0018_lame_risque",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1781407594809,
-      "tag": "0019_free_lethal_legion",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1781594825288,
-      "tag": "0020_flippant_vapor",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1781634026073,
-      "tag": "0021_dry_korg",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1783949372726,
-      "tag": "0022_striped_tempest",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1783975959015,
-      "tag": "0023_left_young_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1784085393701,
-      "tag": "0024_kind_sir_ram",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1784112964441,
-      "tag": "0025_mysterious_lady_mastermind",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1784260492391,
-      "tag": "0026_shiny_revanche",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1784616356949,
-      "tag": "0027_unusual_korath",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1784768869865,
-      "tag": "0028_wakeful_juggernaut",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1784788914282,
-      "tag": "0029_brainy_killraven",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1784827578420,
-      "tag": "0030_curious_clea",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1784916519807,
-      "tag": "0031_lively_mariko_yashida",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1761099619236,
+			"tag": "0000_dazzling_natasha_romanoff",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1761110912747,
+			"tag": "0001_mature_legion",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1761111712115,
+			"tag": "0002_amused_starbolt",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1761111737470,
+			"tag": "0003_natural_rage",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1761160474761,
+			"tag": "0004_clean_tinkerer",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1761744369304,
+			"tag": "0005_stormy_captain_flint",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1761747572400,
+			"tag": "0006_uneven_ricochet",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1761747676930,
+			"tag": "0007_famous_unicorn",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1762957583759,
+			"tag": "0008_curved_gamma_corps",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1762957633914,
+			"tag": "0009_brown_the_hunter",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1762957839616,
+			"tag": "0010_redundant_susan_delgado",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1762965216030,
+			"tag": "0011_melodic_punisher",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1763040426490,
+			"tag": "0012_tiny_exodus",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1763040690210,
+			"tag": "0013_quiet_jazinda",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1763331803557,
+			"tag": "0014_dazzling_monster_badoon",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1779900405297,
+			"tag": "0015_woozy_human_robot",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1781300366548,
+			"tag": "0016_numerous_molly_hayes",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1781388311665,
+			"tag": "0017_stormy_queen_noir",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1781388451291,
+			"tag": "0018_lame_risque",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1781407594809,
+			"tag": "0019_free_lethal_legion",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1781594825288,
+			"tag": "0020_flippant_vapor",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1781634026073,
+			"tag": "0021_dry_korg",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1783949372726,
+			"tag": "0022_striped_tempest",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1783975959015,
+			"tag": "0023_left_young_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1784085393701,
+			"tag": "0024_kind_sir_ram",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1784112964441,
+			"tag": "0025_mysterious_lady_mastermind",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1784260492391,
+			"tag": "0026_shiny_revanche",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1784616356949,
+			"tag": "0027_unusual_korath",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1784768869865,
+			"tag": "0028_wakeful_juggernaut",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1784788914282,
+			"tag": "0029_brainy_killraven",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1784827578420,
+			"tag": "0030_curious_clea",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1784916519807,
+			"tag": "0031_lively_mariko_yashida",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1785538247429,
+			"tag": "0032_inventory_snapshot_expand",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1785538256449,
+			"tag": "0033_inventory_snapshot_backfill",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1785538275535,
+			"tag": "0034_inventory_snapshot_contract",
+			"breakpoints": true
+		}
+	]
 }

--- a/apps/eve-corporation-data/src/db/schema.ts
+++ b/apps/eve-corporation-data/src/db/schema.ts
@@ -1,5 +1,6 @@
 import {
 	boolean,
+	foreignKey,
 	index,
 	integer,
 	jsonb,
@@ -13,9 +14,9 @@ import {
 } from 'drizzle-orm/pg-core'
 
 import {
+	structureMiningExtractions,
 	structureMoonDrills,
 	structureMoonGeographies,
-	structureMiningExtractions,
 	structureSkyhookReagents,
 	structureSkyhooks,
 	structureSovereigntyHubs,
@@ -67,7 +68,9 @@ export const corporationConfig = pgTable(
 		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 		includeInBackgroundRefresh: boolean('include_in_background_refresh').default(false).notNull(),
-		includeInStructureAssetSync: boolean('include_in_structure_asset_sync').default(false).notNull(),
+		includeInStructureAssetSync: boolean('include_in_structure_asset_sync')
+			.default(false)
+			.notNull(),
 		corporationType: corporationTypeEnum('corporation_type').default('other').notNull(),
 		membersLastSync: timestamp('members_last_sync', { withTimezone: true }),
 		memberTrackingLastSync: timestamp('member_tracking_last_sync', { withTimezone: true }),
@@ -397,7 +400,9 @@ export const corporationStructures = pgTable(
 		stateTimerStart: timestamp('state_timer_start', { withTimezone: true }),
 		unanchorsAt: timestamp('unanchors_at', { withTimezone: true }),
 		lowPower: boolean('low_power').notNull().default(false),
-		syncStatus: text('sync_status', { enum: ['ok', 'warning', 'error'] }).notNull().default('ok'),
+		syncStatus: text('sync_status', { enum: ['ok', 'warning', 'error'] })
+			.notNull()
+			.default('ok'),
 		syncFailureReason: text('sync_failure_reason'),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
 		services: jsonb('services').$type<
@@ -414,6 +419,28 @@ export const corporationStructures = pgTable(
 	]
 )
 
+export const corporationStructureInventorySnapshots = pgTable(
+	'corporation_structure_inventory_snapshots',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		corporationId: text('corporation_id').notNull(),
+		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+		activatedAt: timestamp('activated_at', { withTimezone: true }),
+	},
+	(table) => [
+		foreignKey({
+			columns: [table.corporationId],
+			foreignColumns: [corporationConfig.corporationId],
+			name: 'corp_inv_snapshots_corp_fk',
+		}),
+		index('corporation_structure_inventory_snapshots_corp_activated_idx').on(
+			table.corporationId,
+			table.activatedAt,
+			table.createdAt
+		),
+	]
+)
+
 export const corporationStructureInventory = pgTable(
 	'corporation_structure_inventory',
 	{
@@ -421,6 +448,7 @@ export const corporationStructureInventory = pgTable(
 		corporationId: text('corporation_id')
 			.notNull()
 			.references(() => corporationConfig.corporationId),
+		snapshotId: uuid('snapshot_id').notNull(),
 		structureId: text('structure_id')
 			.notNull()
 			.references(() => corporationStructures.structureId, { onDelete: 'cascade' }),
@@ -433,8 +461,18 @@ export const corporationStructureInventory = pgTable(
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [
-		unique().on(table.corporationId, table.itemId),
+		foreignKey({
+			columns: [table.snapshotId],
+			foreignColumns: [corporationStructureInventorySnapshots.id],
+			name: 'corp_inv_snapshot_fk',
+		}).onDelete('cascade'),
+		unique('corp_inv_snapshot_item_uniq').on(table.corporationId, table.snapshotId, table.itemId),
 		index('corporation_structure_inventory_corp_structure_idx').on(
+			table.corporationId,
+			table.structureId
+		),
+		index('corporation_structure_inventory_snapshot_structure_idx').on(
+			table.snapshotId,
 			table.corporationId,
 			table.structureId
 		),
@@ -641,6 +679,7 @@ export const schema = {
 	structureMoonDrills,
 	structureMoonGeographies,
 	structureMiningExtractions,
+	corporationStructureInventorySnapshots,
 	corporationStructureInventory,
 	structureFuelLog,
 }

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -11,23 +11,22 @@ import {
 	isNotNull,
 	lt,
 	lte,
+	ne,
 	or,
 	sql,
 } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger, TimeCache } from '@repo/hono-helpers'
-import { parseDateOrNull } from '@repo/worker-utils'
-import { retryWithBackoff } from '@repo/workflow-utils'
 import {
+	getStructureTabForTypeId,
 	SKYHOOK_MAGMATIC_GAS_TYPE_ID,
 	SKYHOOK_MAGMATIC_GAS_TYPE_NAME,
 	SKYHOOK_SUPERIONIC_ICE_TYPE_ID,
 	SKYHOOK_SUPERIONIC_ICE_TYPE_NAME,
-	getStructureTabForTypeId,
 	summarizeSovereigntyReagentBay,
-	type StructureSovereigntyTransportState,
-	type SovereigntyReagentEntry,
 } from '@repo/structures'
+import { parseDateOrNull } from '@repo/worker-utils'
+import { retryWithBackoff } from '@repo/workflow-utils'
 
 import { createDb } from './db'
 import {
@@ -43,31 +42,31 @@ import {
 	corporationOrders,
 	corporationPublicInfo,
 	corporationStructureInventory,
+	corporationStructureInventorySnapshots,
 	corporationStructures,
 	corporationWalletJournal,
 	corporationWallets,
 	corporationWalletTransactions,
 	structureFuelLog,
-	structureMoonGeographies,
-	structureMoonDrills,
 	structureMiningExtractions,
+	structureMoonDrills,
+	structureMoonGeographies,
 	structureSkyhookReagents,
 	structureSkyhooks,
 	structureSovereigntyHubs,
 	structureSovereigntySystems,
 } from './db/schema'
-import { syncAssetsPaged, dedupeByItemId, type RawEsiAsset } from './services/assets-paging-sync'
+import { dedupeByItemId, syncAssetsPaged } from './services/assets-paging-sync'
 import { DirectorManager } from './services/director-manager'
 import * as esiFetch from './services/esi-fetch'
+import { deriveStructureFuelHistoryMetrics } from './services/structure-fuel-history'
 import { preserveStructureHydrationFields } from './services/structure-hydration'
 import {
-	summarizeFuelBlockUnitsByStructure,
 	projectStructureInventoryFromStoredAssets,
+	summarizeFuelBlockUnitsByStructure,
 } from './services/structure-inventory'
-import {
-	deriveStructureFuelHistoryMetrics,
-	type StructureFuelHistorySample,
-} from './services/structure-fuel-history'
+import { buildPriorityQueuedEntries } from './services/structure-priority'
+
 import type { SQL } from 'drizzle-orm'
 import type {
 	CharacterCorporationRolesData,
@@ -115,33 +114,33 @@ import type {
 	EsiSovereigntyHub,
 	EsiSovereigntySystem,
 	EveCorporationData,
+	MiningCitadelSyncPriority,
+	MoonDrillSyncPriority,
+	SearchAssetsFilters,
+	SkyhookStoreResult,
 	SkyhookSyncPriority,
 	SovereigntyHubSyncPriority,
-	SkyhookStoreResult,
-	StructureSyncPriorityTarget,
 	StructureSyncFailureTarget,
-	SearchAssetsFilters,
+	StructureSyncPriorityTarget,
 	WalletJournalWindowFilters,
 	WalletTransactionWindowFilters,
-	MoonDrillSyncPriority,
-	MiningCitadelSyncPriority,
 } from '@repo/eve-corporation-data'
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
 import type { EveCharacterId, EveStructureId } from '@repo/eve-types'
+import type { SovereigntyReagentEntry, StructureSovereigntyTransportState } from '@repo/structures'
 import type {
-	Universe,
 	EsiGetStructureResponse,
+	Universe,
 	UniversePlanetGeography,
 	UniverseRegion,
 	UniverseSolarSystem,
 } from '@repo/universe'
 import type { Env } from './context'
+import type { RawEsiAsset } from './services/assets-paging-sync'
+import type { StructureFuelHistorySample } from './services/structure-fuel-history'
 import type { StructureInventoryRowInput } from './services/structure-inventory'
-import { buildPriorityQueuedEntries } from './services/structure-priority'
 
-function isSpecialStructureTab(
-	tab: ReturnType<typeof getStructureTabForTypeId>
-): boolean {
+function isSpecialStructureTab(tab: ReturnType<typeof getStructureTabForTypeId>): boolean {
 	return tab === 'sovereignty' || tab === 'skyhooks'
 }
 
@@ -216,8 +215,11 @@ const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY = 'shared:sovereignty-systems
 const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS = 2 * 60
 const ORBITAL_SKYHOOK_TYPE_ID = '81080'
 const STRUCTURE_ENRICHMENT_PRIORITY_LIMIT = 100
+const STRUCTURE_INVENTORY_ASSET_BATCH_SIZE = 250
 const STRUCTURE_SNAPSHOT_BATCH_SIZE = 10
 const STRUCTURE_CLEANUP_BATCH_SIZE = 250
+const INVENTORY_SNAPSHOT_CLEANUP_BATCH_SIZE = 250
+const INVENTORY_SNAPSHOT_CLEANUP_MAX_BATCHES = 4
 
 function chunkArray<T>(items: readonly T[], size: number): T[][] {
 	const chunks: T[][] = []
@@ -1012,9 +1014,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	/**
 	 * Get the lightweight corporation sync configuration for workflow gating
 	 */
-	async getCorporationSyncConfig(
-		corporationId: string
-	): Promise<{
+	async getCorporationSyncConfig(corporationId: string): Promise<{
 		includeInBackgroundRefresh: boolean
 		includeInStructureAssetSync: boolean
 		structuresLastSync: Date | null
@@ -2016,6 +2016,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 * Store assets (workflow-friendly)
 	 */
 	async storeAssets(corporationId: string, assets: any[]): Promise<void> {
+		await this.storeAssetsPage(corporationId, assets, new Date())
+	}
+
+	private async storeAssetsPage(
+		corporationId: string,
+		assets: any[],
+		observedAt: Date
+	): Promise<void> {
 		const dedupedAssets = dedupeByItemId(assets, (asset) => String(asset.item_id))
 		const BATCH_SIZE = 25
 		for (let i = 0; i < dedupedAssets.length; i += BATCH_SIZE) {
@@ -2030,7 +2038,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				quantity: asset.quantity,
 				typeId: asset.type_id,
 				isBlueprintCopy: asset.is_blueprint_copy,
-				updatedAt: new Date(),
+				updatedAt: observedAt,
 			}))
 
 			await this.getDb()
@@ -2063,60 +2071,207 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		return new Set(rows.map((row) => row.structureId))
 	}
 
-	private async rebuildStructureInventoryFromStoredAssets(
-		corporationId: string,
-		ownedStructureIds: ReadonlySet<string>
-	): Promise<StructureInventoryRowInput[]> {
-		const structureIds = [...ownedStructureIds]
-		if (structureIds.length === 0) {
-			return []
-		}
+	private async getActiveStructureInventorySnapshotId(
+		corporationId: string
+	): Promise<string | null> {
+		const snapshot = await this.getDb().query.corporationStructureInventorySnapshots.findFirst({
+			where: and(
+				eq(corporationStructureInventorySnapshots.corporationId, corporationId),
+				isNotNull(corporationStructureInventorySnapshots.activatedAt)
+			),
+			orderBy: [
+				desc(corporationStructureInventorySnapshots.activatedAt),
+				desc(corporationStructureInventorySnapshots.createdAt),
+			],
+			columns: { id: true },
+		})
 
-		const projectedRows: StructureInventoryRowInput[] = []
-		const BATCH_SIZE = 100
-		for (let i = 0; i < structureIds.length; i += BATCH_SIZE) {
-			const batch = structureIds.slice(i, i + BATCH_SIZE)
-			const rawAssets = await this.getDb().query.corporationAssets.findMany({
-				where: and(
-					eq(corporationAssets.corporationId, corporationId),
-					inArray(corporationAssets.locationId, batch),
-					eq(corporationAssets.locationType, 'item')
-				),
-				orderBy: [
-					asc(corporationAssets.locationId),
-					asc(corporationAssets.locationFlag),
-					asc(corporationAssets.typeId),
-					asc(corporationAssets.itemId),
-				],
-			})
-
-			projectedRows.push(
-				...projectStructureInventoryFromStoredAssets(
-					corporationId,
-					ownedStructureIds,
-					rawAssets.map((asset) => ({
-						itemId: asset.itemId,
-						isSingleton: asset.isSingleton,
-						locationFlag: asset.locationFlag,
-						locationId: asset.locationId,
-						locationType: asset.locationType,
-						quantity: asset.quantity,
-						typeId: asset.typeId,
-					}))
-				)
-			)
-		}
-
-		return projectedRows
+		return snapshot?.id ?? null
 	}
 
-	async storeStructureInventory(corporationId: string, inventory: StructureInventoryRowInput[]): Promise<void> {
-		const observedAt = new Date()
+	private async createStructureInventorySnapshot(
+		corporationId: string,
+		createdAt: Date
+	): Promise<string> {
+		const [snapshot] = await this.getDb()
+			.insert(corporationStructureInventorySnapshots)
+			.values({ corporationId, createdAt })
+			.returning({ id: corporationStructureInventorySnapshots.id })
+
+		if (!snapshot) {
+			throw new Error(`Failed to create structure inventory snapshot for ${corporationId}`)
+		}
+
+		return snapshot.id
+	}
+
+	private async activateStructureInventorySnapshot(
+		corporationId: string,
+		snapshotId: string,
+		activatedAt: Date
+	): Promise<void> {
+		const [activatedSnapshot] = await this.getDb()
+			.update(corporationStructureInventorySnapshots)
+			.set({ activatedAt })
+			.where(
+				and(
+					eq(corporationStructureInventorySnapshots.id, snapshotId),
+					eq(corporationStructureInventorySnapshots.corporationId, corporationId)
+				)
+			)
+			.returning({ id: corporationStructureInventorySnapshots.id })
+
+		if (!activatedSnapshot) {
+			throw new Error(`Failed to activate structure inventory snapshot ${snapshotId}`)
+		}
+	}
+
+	private async cleanupOldStructureInventorySnapshots(
+		corporationId: string,
+		activeSnapshotId: string
+	): Promise<void> {
+		const db = this.getDb()
+		const activeSnapshot = await db.query.corporationStructureInventorySnapshots.findFirst({
+			where: and(
+				eq(corporationStructureInventorySnapshots.id, activeSnapshotId),
+				eq(corporationStructureInventorySnapshots.corporationId, corporationId)
+			),
+			columns: { activatedAt: true },
+		})
+		if (!activeSnapshot?.activatedAt) {
+			return
+		}
+
+		for (let batchNumber = 0; batchNumber < INVENTORY_SNAPSHOT_CLEANUP_MAX_BATCHES; batchNumber++) {
+			const snapshot = await db.query.corporationStructureInventorySnapshots.findFirst({
+				where: and(
+					eq(corporationStructureInventorySnapshots.corporationId, corporationId),
+					ne(corporationStructureInventorySnapshots.id, activeSnapshotId),
+					isNotNull(corporationStructureInventorySnapshots.activatedAt),
+					lt(corporationStructureInventorySnapshots.activatedAt, activeSnapshot.activatedAt)
+				),
+				orderBy: [
+					asc(corporationStructureInventorySnapshots.createdAt),
+					asc(corporationStructureInventorySnapshots.id),
+				],
+				columns: { id: true },
+			})
+			if (!snapshot) {
+				return
+			}
+
+			const inventoryRows = await db.query.corporationStructureInventory.findMany({
+				where: eq(corporationStructureInventory.snapshotId, snapshot.id),
+				columns: { id: true },
+				limit: INVENTORY_SNAPSHOT_CLEANUP_BATCH_SIZE,
+			})
+			if (inventoryRows.length > 0) {
+				await db.delete(corporationStructureInventory).where(
+					and(
+						eq(corporationStructureInventory.snapshotId, snapshot.id),
+						inArray(
+							corporationStructureInventory.id,
+							inventoryRows.map((row) => row.id)
+						)
+					)
+				)
+				continue
+			}
+
+			await db
+				.delete(corporationStructureInventorySnapshots)
+				.where(eq(corporationStructureInventorySnapshots.id, snapshot.id))
+		}
+	}
+
+	private async finalizeStructureInventorySnapshot(
+		corporationId: string,
+		snapshotId: string,
+		activatedAt: Date
+	): Promise<void> {
+		await this.activateStructureInventorySnapshot(corporationId, snapshotId, activatedAt)
+		try {
+			await this.cleanupOldStructureInventorySnapshots(corporationId, snapshotId)
+		} catch (error) {
+			logger.warn('[EveCorporationData] Failed to clean up old structure inventory snapshots', {
+				corporationId,
+				snapshotId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+
+	private async *iterateStructureInventoryFromStoredAssets(
+		corporationId: string,
+		ownedStructureIds: ReadonlySet<string>
+	): AsyncGenerator<StructureInventoryRowInput[], void, undefined> {
+		for (const structureId of ownedStructureIds) {
+			let lastItemId: string | null = null
+
+			while (true) {
+				const conditions = [
+					eq(corporationAssets.corporationId, corporationId),
+					eq(corporationAssets.locationId, structureId),
+					eq(corporationAssets.locationType, 'item'),
+				]
+				if (lastItemId !== null) {
+					conditions.push(gt(corporationAssets.itemId, lastItemId))
+				}
+
+				const rawAssets = await this.getDb().query.corporationAssets.findMany({
+					where: and(...conditions),
+					columns: {
+						itemId: true,
+						isSingleton: true,
+						locationFlag: true,
+						locationId: true,
+						locationType: true,
+						quantity: true,
+						typeId: true,
+					},
+					orderBy: asc(corporationAssets.itemId),
+					limit: STRUCTURE_INVENTORY_ASSET_BATCH_SIZE,
+				})
+
+				if (rawAssets.length === 0) {
+					break
+				}
+
+				yield projectStructureInventoryFromStoredAssets(corporationId, ownedStructureIds, rawAssets)
+
+				lastItemId = rawAssets[rawAssets.length - 1]?.itemId ?? null
+				if (rawAssets.length < STRUCTURE_INVENTORY_ASSET_BATCH_SIZE || lastItemId === null) {
+					break
+				}
+			}
+		}
+	}
+
+	async storeStructureInventory(
+		corporationId: string,
+		inventory: StructureInventoryRowInput[]
+	): Promise<void> {
 		const ownedStructureIds = await this.getOwnedStructureIds(corporationId)
-		const fuelBlockUnitsByStructure = summarizeFuelBlockUnitsByStructure(
-			ownedStructureIds,
-			inventory
-		)
+		const inventoryBatches = (async function* (): AsyncGenerator<
+			StructureInventoryRowInput[],
+			void,
+			undefined
+		> {
+			const BATCH_SIZE = 100
+			for (let i = 0; i < inventory.length; i += BATCH_SIZE) {
+				yield inventory.slice(i, i + BATCH_SIZE)
+			}
+		})()
+
+		await this.storeStructureInventoryBatches(corporationId, ownedStructureIds, inventoryBatches)
+	}
+
+	private async storeStructureInventoryBatches(
+		corporationId: string,
+		ownedStructureIds: ReadonlySet<string>,
+		inventoryBatches: AsyncIterable<readonly StructureInventoryRowInput[]>
+	): Promise<number> {
+		const observedAt = new Date()
 		const previousFuelRows = ownedStructureIds.size
 			? await this.getDb().query.structureFuelLog.findMany({
 					where: and(
@@ -2133,35 +2288,48 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			}
 			previousFuelBlockUnitsByStructure.set(row.structureId, row.fuelBlockUnits)
 		}
+		const db = this.getDb()
+		const snapshotId = await this.createStructureInventorySnapshot(corporationId, observedAt)
+
+		const fuelBlockUnitsByStructure = new Map<string, number>()
+		for (const structureId of ownedStructureIds) {
+			fuelBlockUnitsByStructure.set(structureId, 0)
+		}
+
+		let inventoryRowCount = 0
+		for await (const batch of inventoryBatches) {
+			const batchFuelBlockUnits = summarizeFuelBlockUnitsByStructure(ownedStructureIds, batch)
+			for (const [structureId, fuelBlockUnits] of batchFuelBlockUnits) {
+				fuelBlockUnitsByStructure.set(
+					structureId,
+					(fuelBlockUnitsByStructure.get(structureId) ?? 0) + fuelBlockUnits
+				)
+			}
+
+			if (batch.length > 0) {
+				await db.insert(corporationStructureInventory).values(
+					batch.map((row) => ({
+						corporationId: String(corporationId),
+						snapshotId,
+						structureId: row.structureId,
+						itemId: row.itemId,
+						isSingleton: row.isSingleton,
+						locationFlag: row.locationFlag,
+						locationType: row.locationType,
+						quantity: row.quantity,
+						typeId: row.typeId,
+						updatedAt: observedAt,
+					}))
+				)
+			}
+			inventoryRowCount += batch.length
+		}
 		const refilledStructureIds = Array.from(fuelBlockUnitsByStructure.entries())
 			.filter(([structureId, fuelBlockUnits]) => {
 				const previousFuelBlockUnits = previousFuelBlockUnitsByStructure.get(structureId)
 				return previousFuelBlockUnits !== undefined && fuelBlockUnits > previousFuelBlockUnits
 			})
 			.map(([structureId]) => structureId)
-
-		const db = this.getDb()
-		await db
-			.delete(corporationStructureInventory)
-			.where(eq(corporationStructureInventory.corporationId, corporationId))
-
-		const BATCH_SIZE = 100
-		for (let i = 0; i < inventory.length; i += BATCH_SIZE) {
-			const batch = inventory.slice(i, i + BATCH_SIZE)
-			const valuesToInsert = batch.map((row) => ({
-				corporationId: String(corporationId),
-				structureId: row.structureId,
-				itemId: row.itemId,
-				isSingleton: row.isSingleton,
-				locationFlag: row.locationFlag,
-				locationType: row.locationType,
-				quantity: row.quantity,
-				typeId: row.typeId,
-				updatedAt: observedAt,
-			}))
-
-			await db.insert(corporationStructureInventory).values(valuesToInsert)
-		}
 
 		if (ownedStructureIds.size > 0) {
 			const fuelHistoryRows = Array.from(fuelBlockUnitsByStructure.entries()).map(
@@ -2177,7 +2345,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			logger.info('[EveCorporationData] Writing structure fuel log snapshot', {
 				corporationId,
 				ownedStructureCount: ownedStructureIds.size,
-				inventoryRowCount: inventory.length,
+				inventoryRowCount,
 				fuelLogRowCount: fuelHistoryRows.length,
 				refilledStructureCount: refilledStructureIds.length,
 				zeroFuelStructureCount: fuelHistoryRows.filter((row) => row.fuelBlockUnits === 0).length,
@@ -2269,6 +2437,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					)
 				)
 			)
+
+		await this.finalizeStructureInventorySnapshot(corporationId, snapshotId, observedAt)
+
+		return inventoryRowCount
 	}
 
 	private async getStructureInventoryNextAllowedAt(corporationId: string): Promise<Date | null> {
@@ -2428,9 +2600,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			const syncFailureReason = hydrationComplete
 				? null
 				: 'Structure details could not be fully hydrated during sync'
-		const hydrated = preserveStructureHydrationFields(existing, {
-			name: resolvedName,
-			typeName: resolvedTypeName,
+			const hydrated = preserveStructureHydrationFields(existing, {
+				name: resolvedName,
+				typeName: resolvedTypeName,
 				systemName: resolvedSystemName,
 				regionName: resolvedRegionName,
 				syncStatus,
@@ -2556,7 +2728,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): Promise<void> {
 		const now = new Date()
 		const moonDrillStructures = structures.filter(
-			(structure) => getStructureTabForTypeId(structure.typeId, structure.typeName) === 'moon-drills'
+			(structure) =>
+				getStructureTabForTypeId(structure.typeId, structure.typeName) === 'moon-drills'
 		)
 		const existingRows = await this.getDb().query.structureMoonDrills.findMany({
 			where: eq(structureMoonDrills.corporationId, corporationId),
@@ -2568,18 +2741,26 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		if (moonDrillStructures.length === 0) {
 			const currentStructureIds = new Set<string>()
-			const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
+			const departedStructureIds = filterPrunableStructureIds(
+				existingRows,
+				currentStructureIds,
+				now
+			)
 
-			await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
-				await this.getDb()
-					.delete(structureMoonDrills)
-					.where(
-						and(
-							eq(structureMoonDrills.corporationId, corporationId),
-							inArray(structureMoonDrills.structureId, batch)
+			await deleteIdsInBatches(
+				departedStructureIds,
+				STRUCTURE_CLEANUP_BATCH_SIZE,
+				async (batch) => {
+					await this.getDb()
+						.delete(structureMoonDrills)
+						.where(
+							and(
+								eq(structureMoonDrills.corporationId, corporationId),
+								inArray(structureMoonDrills.structureId, batch)
+							)
 						)
-					)
-			})
+				}
+			)
 			return
 		}
 
@@ -2613,10 +2794,23 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			.filter((row): row is MoonDrillStorageRow => row !== null)
 
 		if (synthesizedRows.length === 0) {
-			logger.warn('[storeMoonDrills] Preserving existing moon drill snapshot because synthesis failed', {
-				corporationId,
-				structureCount: moonDrillStructures.length,
-			})
+			if (prioritizedMoonDrillStructures.length === 0) {
+				logger.info(
+					'[storeMoonDrills] No moon drill snapshot refresh was due; preserving existing snapshot',
+					{
+						corporationId,
+						structureCount: moonDrillStructures.length,
+						priorityCount: syncPriorities.length,
+						newStructureCount: newMoonDrillIds.length,
+					}
+				)
+			} else {
+				logger.warn('[storeMoonDrills] Could not synthesize eligible moon drill snapshot rows', {
+					corporationId,
+					structureCount: moonDrillStructures.length,
+					eligibleStructureCount: prioritizedMoonDrillStructures.length,
+				})
+			}
 			return
 		}
 
@@ -2725,26 +2919,37 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		if (moonGeographyStructures.length === 0) {
 			const currentStructureIds = new Set<string>()
-			const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
+			const departedStructureIds = filterPrunableStructureIds(
+				existingRows,
+				currentStructureIds,
+				now
+			)
 
-			await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
-				await this.getDb()
-					.delete(structureMoonGeographies)
-					.where(
-						and(
-							eq(structureMoonGeographies.corporationId, corporationId),
-							inArray(structureMoonGeographies.structureId, batch)
+			await deleteIdsInBatches(
+				departedStructureIds,
+				STRUCTURE_CLEANUP_BATCH_SIZE,
+				async (batch) => {
+					await this.getDb()
+						.delete(structureMoonGeographies)
+						.where(
+							and(
+								eq(structureMoonGeographies.corporationId, corporationId),
+								inArray(structureMoonGeographies.structureId, batch)
+							)
 						)
-					)
-			})
+				}
+			)
 			return
 		}
 
 		if (synthesizedRows.length === 0) {
-			logger.warn('[storeMoonGeographies] Preserving existing moon geography snapshot because synthesis failed', {
-				corporationId,
-				structureCount: moonGeographyStructures.length,
-			})
+			logger.warn(
+				'[storeMoonGeographies] Preserving existing moon geography snapshot because synthesis failed',
+				{
+					corporationId,
+					structureCount: moonGeographyStructures.length,
+				}
+			)
 			return
 		}
 
@@ -2774,11 +2979,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		if (!shouldPrune) {
-			logger.warn('[storeMoonGeographies] Skipping moon geography prune because synthesis was partial', {
-				corporationId,
-				synthesizedCount: synthesizedRows.length,
-				candidateCount: moonGeographyStructures.length,
-			})
+			logger.warn(
+				'[storeMoonGeographies] Skipping moon geography prune because synthesis was partial',
+				{
+					corporationId,
+					synthesizedCount: synthesizedRows.length,
+					candidateCount: moonGeographyStructures.length,
+				}
+			)
 			return
 		}
 
@@ -2845,49 +3053,70 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		this.assertNonNpcCorporation(corporationId)
 
 		const ownedStructureIds = new Set([String(structureId)])
-		const inventoryRows = await this.rebuildStructureInventoryFromStoredAssets(
+		const db = this.getDb()
+		const activeSnapshotId = await this.getActiveStructureInventorySnapshotId(corporationId)
+		const observedAt = new Date()
+		const snapshotId = await this.createStructureInventorySnapshot(corporationId, observedAt)
+
+		if (activeSnapshotId !== null) {
+			const existingRows = db
+				.select({
+					corporationId: corporationStructureInventory.corporationId,
+					snapshotId: sql<string>`${snapshotId}`.as('snapshotId'),
+					structureId: corporationStructureInventory.structureId,
+					itemId: corporationStructureInventory.itemId,
+					isSingleton: corporationStructureInventory.isSingleton,
+					locationFlag: corporationStructureInventory.locationFlag,
+					locationType: corporationStructureInventory.locationType,
+					quantity: corporationStructureInventory.quantity,
+					typeId: corporationStructureInventory.typeId,
+					updatedAt: corporationStructureInventory.updatedAt,
+				})
+				.from(corporationStructureInventory)
+				.where(
+					and(
+						eq(corporationStructureInventory.corporationId, corporationId),
+						eq(corporationStructureInventory.snapshotId, activeSnapshotId),
+						ne(corporationStructureInventory.structureId, String(structureId))
+					)
+				)
+
+			await db.insert(corporationStructureInventory).select(existingRows)
+		}
+
+		let inventoryCount = 0
+		for await (const batch of this.iterateStructureInventoryFromStoredAssets(
 			corporationId,
 			ownedStructureIds
-		)
-		const rowsForStructure = inventoryRows.filter(
-			(row) => row.structureId === String(structureId)
-		)
-
-		const db = this.getDb()
-		await db
-			.delete(corporationStructureInventory)
-			.where(
-				and(
-					eq(corporationStructureInventory.corporationId, corporationId),
-					eq(corporationStructureInventory.structureId, String(structureId))
+		)) {
+			if (batch.length > 0) {
+				await db.insert(corporationStructureInventory).values(
+					batch.map((row) => ({
+						corporationId: String(corporationId),
+						snapshotId,
+						structureId: row.structureId,
+						itemId: row.itemId,
+						isSingleton: row.isSingleton,
+						locationFlag: row.locationFlag,
+						locationType: row.locationType,
+						quantity: row.quantity,
+						typeId: row.typeId,
+						updatedAt: observedAt,
+					}))
 				)
-			)
-
-		const BATCH_SIZE = 100
-		for (let i = 0; i < rowsForStructure.length; i += BATCH_SIZE) {
-			const batch = rowsForStructure.slice(i, i + BATCH_SIZE)
-			await db.insert(corporationStructureInventory).values(
-				batch.map((row) => ({
-					corporationId: String(corporationId),
-					structureId: row.structureId,
-					itemId: row.itemId,
-					isSingleton: row.isSingleton,
-					locationFlag: row.locationFlag,
-					locationType: row.locationType,
-					quantity: row.quantity,
-					typeId: row.typeId,
-					updatedAt: new Date(),
-				}))
-			)
+			}
+			inventoryCount += batch.length
 		}
+
+		await this.finalizeStructureInventorySnapshot(corporationId, snapshotId, observedAt)
 
 		logger.info('[EveCorporationData] Rebuilt structure inventory snapshot from stored assets', {
 			corporationId,
 			structureId: String(structureId),
-			inventoryCount: rowsForStructure.length,
+			inventoryCount,
 		})
 
-		return { inventoryCount: rowsForStructure.length }
+		return { inventoryCount }
 	}
 
 	/**
@@ -2995,7 +3224,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const data = await esiFetch.fetchPublicInfo(tokenStore, corporationId)
 
-			await this.upsertPublicInfo(corporationId, data as CorporationPublicData)
+		await this.upsertPublicInfo(corporationId, data as CorporationPublicData)
 
 		const previousAllianceId = previousInfo?.allianceId ?? null
 		const nextAllianceId = data.allianceId ?? null
@@ -3117,7 +3346,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const regionIds = [
 			...new Set(
 				Object.values(systemGeography)
-					.filter((system): system is NonNullable<(typeof systemGeography)[string]> => system !== null)
+					.filter(
+						(system): system is NonNullable<(typeof systemGeography)[string]> => system !== null
+					)
 					.map((system) => system.regionId)
 					.filter((regionId): regionId is string => Boolean(regionId))
 			),
@@ -3136,8 +3367,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			const claimedSince = parseDateOrNull(system.claimed_since) ?? null
 			const vulnerabilityWindowStart = parseDateOrNull(system.vulnerability_window?.start) ?? null
 			const vulnerabilityWindowEnd = parseDateOrNull(system.vulnerability_window?.end) ?? null
-			const resolvedSystemName =
-				resolvedSystem?.solarSystemName ?? system.system_name ?? null
+			const resolvedSystemName = resolvedSystem?.solarSystemName ?? system.system_name ?? null
 
 			return {
 				systemId: system.system_id,
@@ -3430,7 +3660,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		} = {}
 	): Promise<void> {
 		const now = new Date()
-		const pruneCandidateIds = [...new Set((options.pruneCandidateIds ?? []).map((id) => String(id)))]
+		const pruneCandidateIds = [
+			...new Set((options.pruneCandidateIds ?? []).map((id) => String(id))),
+		]
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const controllerAllianceNames = await resolveAllianceNames(
 			tokenStore,
@@ -3439,9 +3671,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
 			hubs.length > 0
-				? (await universe.resolveSolarSystemsByIds([
+				? ((await universe.resolveSolarSystemsByIds([
 						...new Set(hubs.map((hub) => hub.system_id)),
-					])) ?? {}
+					])) ?? {})
 				: {}
 		const values: SovereigntyHubInsertRow[] = hubs.map((hub) => {
 			const resolvedSystemName =
@@ -3568,7 +3800,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 							),
 							orderBy: [
 								asc(sql`coalesce(${structureSovereigntyHubs.lastSyncedAt}, to_timestamp(0))`),
-								asc(sql`coalesce(${structureSovereigntyHubs.lastAttemptedSyncAt}, to_timestamp(0))`),
+								asc(
+									sql`coalesce(${structureSovereigntyHubs.lastAttemptedSyncAt}, to_timestamp(0))`
+								),
 								asc(structureSovereigntyHubs.structureId),
 							],
 							columns: {
@@ -3624,7 +3858,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 									),
 									orderBy: [
 										asc(sql`coalesce(${structureMiningExtractions.lastSyncedAt}, to_timestamp(0))`),
-										asc(sql`coalesce(${structureMiningExtractions.lastAttemptedSyncAt}, to_timestamp(0))`),
+										asc(
+											sql`coalesce(${structureMiningExtractions.lastAttemptedSyncAt}, to_timestamp(0))`
+										),
 										asc(structureMiningExtractions.structureId),
 									],
 									columns: {
@@ -3667,7 +3903,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						.where(
 							and(
 								eq(structureSkyhooks.corporationId, corporationId),
-								inArray(structureSkyhooks.structureId, batch.map((row) => row.structureId))
+								inArray(
+									structureSkyhooks.structureId,
+									batch.map((row) => row.structureId)
+								)
 							)
 						)
 					break
@@ -3680,7 +3919,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						.where(
 							and(
 								eq(structureMoonDrills.corporationId, corporationId),
-								inArray(structureMoonDrills.structureId, batch.map((row) => row.structureId))
+								inArray(
+									structureMoonDrills.structureId,
+									batch.map((row) => row.structureId)
+								)
 							)
 						)
 					break
@@ -3795,7 +4037,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		return (result.rows ?? []).map((row) => row.structureId)
 	}
 
-	async getSovereigntyHubSyncPriorities(corporationId: string): Promise<SovereigntyHubSyncPriority[]> {
+	async getSovereigntyHubSyncPriorities(
+		corporationId: string
+	): Promise<SovereigntyHubSyncPriority[]> {
 		return await this.getTypeScopedStructureSyncPriorities({
 			corporationId,
 			targetTable: 'sovereignty',
@@ -3835,7 +4079,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 	}
 
-	async getMiningCitadelSyncPriorities(corporationId: string): Promise<MiningCitadelSyncPriority[]> {
+	async getMiningCitadelSyncPriorities(
+		corporationId: string
+	): Promise<MiningCitadelSyncPriority[]> {
 		return await this.getTypeScopedStructureSyncPriorities({
 			corporationId,
 			targetTable: 'mining-extractions',
@@ -3927,7 +4173,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		} = {}
 	): Promise<SkyhookStoreResult> {
 		const now = new Date()
-		const pruneCandidateIds = [...new Set((options.pruneCandidateIds ?? []).map((id) => String(id)))]
+		const pruneCandidateIds = [
+			...new Set((options.pruneCandidateIds ?? []).map((id) => String(id))),
+		]
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const existingRows = await this.getDb().query.structureSkyhooks.findMany({
 			where: eq(structureSkyhooks.corporationId, corporationId),
@@ -4041,12 +4289,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					return null
 				}
 
-					const storageRow: SkyhookInsertRow = {
-						...storageRowData,
-						syncStatus: 'ok' as const,
-						syncFailureReason: null,
-						updatedAt: now,
-					}
+				const storageRow: SkyhookInsertRow = {
+					...storageRowData,
+					syncStatus: 'ok' as const,
+					syncFailureReason: null,
+					updatedAt: now,
+				}
 				const reagentStorageRow = buildSkyhookReagentStorageRow({
 					corporationId,
 					skyhook,
@@ -4071,10 +4319,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		if (synthesizedRows.length === 0) {
 			if (skyhooks.length > 0) {
-				logger.warn('[storeSkyhooks] Preserving existing skyhook snapshot because synthesis failed', {
-					corporationId,
-					skyhookCount: skyhooks.length,
-				})
+				logger.warn(
+					'[storeSkyhooks] Preserving existing skyhook snapshot because synthesis failed',
+					{
+						corporationId,
+						skyhookCount: skyhooks.length,
+					}
+				)
 				return { prunedCount: 0 }
 			}
 			const prunableStateIds = pruneCandidateIds
@@ -4085,10 +4336,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					.delete(structureSkyhooks)
 					.where(
 						and(
-						eq(structureSkyhooks.corporationId, corporationId),
-						inArray(structureSkyhooks.structureId, batch)
+							eq(structureSkyhooks.corporationId, corporationId),
+							inArray(structureSkyhooks.structureId, batch)
+						)
 					)
-				)
 			})
 			await deleteIdsInBatches(
 				prunableBaseStructureIds,
@@ -4171,10 +4422,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				.values(batch)
 				.onConflictDoUpdate({
 					target: structureSkyhooks.structureId,
-						set: {
-							corporationId: sql`excluded.corporation_id`,
-							planetId: sql`excluded.planet_id`,
-							planetName: sql`excluded.planet_name`,
+					set: {
+						corporationId: sql`excluded.corporation_id`,
+						planetId: sql`excluded.planet_id`,
+						planetName: sql`excluded.planet_name`,
 						systemId: sql`excluded.system_id`,
 						systemName: sql`excluded.system_name`,
 						typeId: sql`excluded.type_id`,
@@ -4182,14 +4433,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						isActive: sql`excluded.is_active`,
 						effectiveWorkforce: sql`excluded.effective_workforce`,
 						reinforcementTimerEnd: sql`excluded.reinforcement_timer_end`,
-							theftVulnerabilityStart: sql`excluded.theft_vulnerability_start`,
-							theftVulnerabilityEnd: sql`excluded.theft_vulnerability_end`,
-							syncStatus: sql`excluded.sync_status`,
-							syncFailureReason: sql`excluded.sync_failure_reason`,
-							lastObservedAt: sql`excluded.last_observed_at`,
-							sourceSyncAt: sql`excluded.source_sync_at`,
-							lastSyncedAt: sql`excluded.last_synced_at`,
-							updatedAt: sql`excluded.updated_at`,
+						theftVulnerabilityStart: sql`excluded.theft_vulnerability_start`,
+						theftVulnerabilityEnd: sql`excluded.theft_vulnerability_end`,
+						syncStatus: sql`excluded.sync_status`,
+						syncFailureReason: sql`excluded.sync_failure_reason`,
+						lastObservedAt: sql`excluded.last_observed_at`,
+						sourceSyncAt: sql`excluded.source_sync_at`,
+						lastSyncedAt: sql`excluded.last_synced_at`,
+						updatedAt: sql`excluded.updated_at`,
 					},
 				})
 		}
@@ -4268,18 +4519,26 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		if (values.length === 0) {
 			const currentStructureIds = new Set<string>()
-			const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
+			const departedStructureIds = filterPrunableStructureIds(
+				existingRows,
+				currentStructureIds,
+				now
+			)
 
-			await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
-				await this.getDb()
-					.delete(structureMiningExtractions)
-					.where(
-						and(
-							eq(structureMiningExtractions.corporationId, corporationId),
-							inArray(structureMiningExtractions.structureId, batch)
+			await deleteIdsInBatches(
+				departedStructureIds,
+				STRUCTURE_CLEANUP_BATCH_SIZE,
+				async (batch) => {
+					await this.getDb()
+						.delete(structureMiningExtractions)
+						.where(
+							and(
+								eq(structureMiningExtractions.corporationId, corporationId),
+								inArray(structureMiningExtractions.structureId, batch)
+							)
 						)
-					)
-			})
+				}
+			)
 			return
 		}
 
@@ -4885,12 +5144,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	): Promise<number> {
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const basePath = `/corporations/${corporationId}/assets`
+		const syncStartedAt = new Date()
 		const result = await syncAssetsPaged({
 			fetchPage: (page) =>
 				tokenStore.fetchEsi(`${basePath}?page=${page}`, characterId, {
 					cacheMode: 'no-store',
 				}) as Promise<EsiResponse<RawEsiAsset[]>>,
-			storeAssets: (assets) => this.storeAssets(corporationId, assets),
+			storeAssets: (assets) => this.storeAssetsPage(corporationId, assets, syncStartedAt),
 			onProgress: ({ page, totalPages, totalAssets }) => {
 				if (page % 10 === 0 || page === totalPages) {
 					logger.debug('[fetchAndStoreAssets] Page progress', {
@@ -4901,6 +5161,17 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					})
 				}
 			},
+		})
+		await this.getDb()
+			.delete(corporationAssets)
+			.where(
+				and(
+					eq(corporationAssets.corporationId, corporationId),
+					lt(corporationAssets.updatedAt, syncStartedAt)
+				)
+			)
+		logger.debug('[fetchAndStoreAssets] Pruned stale asset rows after successful sync', {
+			corporationId,
 		})
 
 		return result.assetsCount
@@ -5010,26 +5281,28 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				}
 			)
 			const result = await this.fetchAndStoreAssetsByCharacter(corporationId, characterId)
-			const inventoryRows = await this.rebuildStructureInventoryFromStoredAssets(
+			const inventoryCount = await this.storeStructureInventoryBatches(
 				corporationId,
-				ownedStructureIds
+				ownedStructureIds,
+				this.iterateStructureInventoryFromStoredAssets(corporationId, ownedStructureIds)
 			)
-
-			await this.storeStructureInventory(corporationId, inventoryRows)
 			await this.updateCorporationSyncTimestamp(corporationId, 'assetsLastSync')
 			logger.info('[EveCorporationData] Stored structure inventory snapshot', {
 				corporationId,
 				fetchedAssetCount: result,
-				storedInventoryCount: inventoryRows.length,
+				storedInventoryCount: inventoryCount,
 			})
 
-			return inventoryRows.length
+			return inventoryCount
 		} catch (error) {
-			logger.error('[fetchAndStoreStructureInventory] Failed to insert structure inventory', {
-				corporationId,
-				error: error instanceof Error ? error.message : String(error),
-				errorStack: error instanceof Error ? error.stack : undefined,
-			})
+			logger.error(
+				'[fetchAndStoreStructureInventory] Failed to store structure inventory snapshot',
+				{
+					corporationId,
+					error: error instanceof Error ? error.message : String(error),
+					errorStack: error instanceof Error ? error.stack : undefined,
+				}
+			)
 
 			const path = `/corporations/${corporationId}/assets`
 			try {
@@ -5195,7 +5468,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		this.courierLeaderboardCache.clear()
 	}
 
-	private dedupeContractsByContractId(contracts: EsiCorporationContract[]): EsiCorporationContract[] {
+	private dedupeContractsByContractId(
+		contracts: EsiCorporationContract[]
+	): EsiCorporationContract[] {
 		const byContractId = new Map<string, EsiCorporationContract>()
 		for (const contract of contracts) {
 			byContractId.set(String(contract.contract_id), contract)
@@ -6389,12 +6664,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		structureId?: string,
 		limit?: number
 	): Promise<CorporationStructureInventoryData[]> {
+		const activeSnapshotId = await this.getActiveStructureInventorySnapshotId(corporationId)
+		if (activeSnapshotId === null) {
+			return []
+		}
+
 		const where = structureId
 			? and(
 					eq(corporationStructureInventory.corporationId, corporationId),
+					eq(corporationStructureInventory.snapshotId, activeSnapshotId),
 					eq(corporationStructureInventory.structureId, structureId)
 				)
-			: eq(corporationStructureInventory.corporationId, corporationId)
+			: and(
+					eq(corporationStructureInventory.corporationId, corporationId),
+					eq(corporationStructureInventory.snapshotId, activeSnapshotId)
+				)
 
 		const results = await this.getDb().query.corporationStructureInventory.findMany({
 			where,
@@ -6527,9 +6811,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			syncFailureReason: structure.syncFailureReason,
 			lastSyncedAt: structure.lastSyncedAt,
 			services: structure.services,
-		updatedAt: structure.updatedAt,
+			updatedAt: structure.updatedAt,
+		}
 	}
-}
 
 	/**
 	 * Get complete assets data
@@ -6735,12 +7019,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				.select({
 					acceptorId: distinctContracts.acceptorId,
 					contractsCompleted: sql<number>`count(*)`.as('contracts_completed'),
-					totalVolume: sql<number>`coalesce(sum(cast(${distinctContracts.volume} as numeric)), 0)`.as(
-						'total_volume'
-					),
-					totalReward: sql<number>`coalesce(sum(cast(${distinctContracts.reward} as numeric)), 0)`.as(
-						'total_reward'
-					),
+					totalVolume:
+						sql<number>`coalesce(sum(cast(${distinctContracts.volume} as numeric)), 0)`.as(
+							'total_volume'
+						),
+					totalReward:
+						sql<number>`coalesce(sum(cast(${distinctContracts.reward} as numeric)), 0)`.as(
+							'total_reward'
+						),
 					oldestContract: sql<Date | null>`min(${distinctContracts.dateCompleted})`.as(
 						'oldest_contract'
 					),

--- a/apps/eve-corporation-data/src/scheduled.ts
+++ b/apps/eve-corporation-data/src/scheduled.ts
@@ -5,18 +5,20 @@ import {
 	computeNextAttemptAtMs,
 	enrichQueueEntry,
 	selectPriorityDrain,
-	type EnrichedQueueEntry,
-	type QueueEntry,
-	type RefreshBucket,
 } from './workflows/utils/background-refresh-batching'
 import { refreshSharedSovereigntySystems } from './workflows/utils/sovereignty-systems-cache'
 
 import type { Env } from './context'
+import type {
+	EnrichedQueueEntry,
+	QueueEntry,
+	RefreshBucket,
+} from './workflows/utils/background-refresh-batching'
 
 const BACKGROUND_REFRESH_QUEUE_KEY = 'background-refresh:workflow-create-queue:v1'
 // Keep the per-run fan-out small so the workflow creator does not overwhelm
 // Workers or ESI. The KV queue retains the remainder for later cron ticks.
-const BACKGROUND_REFRESH_DRAIN_LIMIT = 20
+const BACKGROUND_REFRESH_DRAIN_LIMIT = 30
 const RATE_LIMIT_BACKOFF_BASE_MS = 15_000
 const RATE_LIMIT_BACKOFF_MAX_MS = 10 * 60 * 1000
 
@@ -56,7 +58,7 @@ async function saveQueue(cache: KVNamespace, queue: QueueEntry[]): Promise<void>
 /**
  * Background Corporation Data Refresh Handler
  *
- * This handler runs on a scheduled cron trigger (every 15 minutes) and:
+ * This handler runs on a scheduled cron trigger (every 10 minutes) and:
  * 1. Queries the core worker for corporations with includeInBackgroundRefresh = true
  * 2. Creates workflow instances for each corporation
  * 3. Handles "already running" workflows gracefully
@@ -257,7 +259,11 @@ async function createWorkflowInstance(
 			const existingInstance = await env.EVE_CORPORATION_SYNC.get(corporationId)
 			const status = await existingInstance.status()
 
-			if (status.status === 'running' || status.status === 'queued' || status.status === 'waiting') {
+			if (
+				status.status === 'running' ||
+				status.status === 'queued' ||
+				status.status === 'waiting'
+			) {
 				logger.info('[BackgroundRefresh] Workflow already running, skipping', {
 					corporationId,
 					corporationName,

--- a/apps/eve-corporation-data/src/test/unit/scheduled.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/scheduled.test.ts
@@ -13,7 +13,9 @@ import type {
 	EnrichedQueueEntry,
 } from '../../workflows/utils/background-refresh-batching'
 
-function makeCorporation(overrides: Partial<BackgroundRefreshCorporation> = {}): BackgroundRefreshCorporation {
+function makeCorporation(
+	overrides: Partial<BackgroundRefreshCorporation> = {}
+): BackgroundRefreshCorporation {
 	return {
 		corporationId: '1',
 		name: 'Test Corp',
@@ -90,7 +92,9 @@ function buildRefreshSimulationCorporations(now: number): BackgroundRefreshCorpo
 	]
 }
 
-function getStaticBucket(corporation: BackgroundRefreshCorporation): 'structure-asset' | 'member' | 'alt-special' | 'other' {
+function getStaticBucket(
+	corporation: BackgroundRefreshCorporation
+): 'structure-asset' | 'member' | 'alt-special' | 'other' {
 	if (corporation.includeInStructureAssetSync) return 'structure-asset'
 	if (corporation.isMemberCorporation) return 'member'
 	if (corporation.isAltCorp || corporation.isSpecialPurpose) return 'alt-special'
@@ -125,7 +129,9 @@ function formatDurationMs(ms: number): string {
 		hours > 0 ? `${hours}h` : null,
 		minutes > 0 || hours > 0 ? `${minutes}m` : null,
 		`${seconds}s`,
-	].filter((part): part is string => part !== null).join(' ')
+	]
+		.filter((part): part is string => part !== null)
+		.join(' ')
 }
 
 function simulateRefreshRuns(
@@ -139,8 +145,13 @@ function simulateRefreshRuns(
 	refreshCounts: Map<string, number>
 	refreshTimelineByCorp: Map<string, number[]>
 } {
-	const corpStateById = new Map(corporations.map((corp) => [corp.corporationId, { ...corp }] as const))
-	let queueByCorpId = new Map<string, { corporationId: string; name: string; nextAttemptAtMs: number; attempt: number }>()
+	const corpStateById = new Map(
+		corporations.map((corp) => [corp.corporationId, { ...corp }] as const)
+	)
+	let queueByCorpId = new Map<
+		string,
+		{ corporationId: string; name: string; nextAttemptAtMs: number; attempt: number }
+	>()
 
 	for (const corporation of corporations) {
 		queueByCorpId.set(corporation.corporationId, {
@@ -176,7 +187,7 @@ function simulateRefreshRuns(
 				if (!corporation) return null
 				return enrichQueueEntry(entry, corporation, runAt)
 			})
-		.filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+			.filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 
 		let { draining } = selectPriorityDrain(due, batchSize)
 		if (draining.length < batchSize) {
@@ -339,14 +350,19 @@ describe('scheduled background refresh selection', () => {
 						nextAttemptAtMs: 0,
 						attempt: 0,
 					},
-					makeCorporation({ isMemberCorporation: true, lastSync: new Date(now - 45 * 60 * 1000).toISOString() }),
+					makeCorporation({
+						isMemberCorporation: true,
+						lastSync: new Date(now - 45 * 60 * 1000).toISOString(),
+					}),
 					now
 				)
 			),
 		]
 
 		const selected = selectPriorityDrain(due, 8)
-		const selectedBackstopCount = selected.draining.filter((entry) => entry.bucket === 'backstop').length
+		const selectedBackstopCount = selected.draining.filter(
+			(entry) => entry.bucket === 'backstop'
+		).length
 		expect(selectedBackstopCount).toBe(2)
 		expect(selected.draining.map((entry) => entry.corporationId)).toEqual([
 			'backstop-0',
@@ -365,8 +381,8 @@ describe('scheduled background refresh selection', () => {
 			corporations,
 			startMs,
 			24,
-			5 * 60 * 1000,
-			20
+			10 * 60 * 1000,
+			30
 		)
 		const metrics = summarizeSimulationMetrics(corporations, refreshTimelineByCorp)
 
@@ -383,7 +399,7 @@ describe('scheduled background refresh selection', () => {
 			)
 		)
 
-		expect(selectedByRun[0]?.length).toBeLessThanOrEqual(20)
+		expect(selectedByRun[0]?.length).toBeLessThanOrEqual(30)
 		expect(new Set(selectedByRun.flat().map((entry) => entry.corporationId)).size).toBe(110)
 		expect(refreshCounts.size).toBe(110)
 		expect([...refreshCounts.values()].every((count) => count >= 1)).toBe(true)

--- a/apps/eve-corporation-data/wrangler.jsonc
+++ b/apps/eve-corporation-data/wrangler.jsonc
@@ -8,7 +8,7 @@
 	"routes": [],
 	"logpush": false,
 	"triggers": {
-		"crons": ["*/5 * * * *"]
+		"crons": ["*/10 * * * *"]
 	},
 	"observability": {
 		"enabled": true,
@@ -25,9 +25,7 @@
 		}
 	],
 	"queues": {
-		"producers": [
-			{ "queue": "hr-member-departed", "binding": "hr-member-departed" }
-		]
+		"producers": [{ "queue": "hr-member-departed", "binding": "hr-member-departed" }]
 	},
 	"services": [
 		{

--- a/apps/eve-token-store/eslint.config.ts
+++ b/apps/eve-token-store/eslint.config.ts
@@ -1,7 +1,3 @@
-import { defineConfig } from '@repo/eslint-config'
+import { getConfig } from '@repo/eslint-config'
 
-export default defineConfig({
-	typescript: {
-		project: './tsconfig.json',
-	},
-})
+export default getConfig(import.meta.url)

--- a/apps/eve-token-store/package.json
+++ b/apps/eve-token-store/package.json
@@ -18,8 +18,9 @@
 		"preview": "run-vite-preview",
 		"repair-migration": "tsx ./src/scripts/repair-migration.ts",
 		"tail": "run-wrangler-tail",
-		"test": "run-vitest",
-		"test:focused": "run-vitest --config vitest.node.config.ts"
+		"test": "run-vitest --config vitest.node.config.ts",
+		"test:focused": "run-vitest --config vitest.node.config.ts",
+		"test:workers": "run-vitest --config vitest.config.ts"
 	},
 	"dependencies": {
 		"@neondatabase/serverless": "1.0.2",

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -6,6 +6,12 @@ import { and, asc, eq, gt, gte, inArray, isNull, lt, lte, or } from '@repo/db-ut
 import { getStub } from '@repo/do-utils'
 import { EsiRequestClient } from '@repo/esi'
 import { buildEsiUserKey, buildPublicEsiUserKey, EsiRateLimitStore } from '@repo/esi-rate-limit'
+import {
+	EVE_SSO_SCOPES_ALL,
+	EVE_SSO_SCOPES_PUBLIC_ONLY,
+	getMissingScopes,
+	hasAllScopes,
+} from '@repo/eve-token-store'
 import { logger, toErrorLogDetails } from '@repo/hono-helpers'
 import { parseJsonResponse } from '@repo/worker-utils'
 
@@ -28,12 +34,6 @@ import {
 } from './lib/token-health'
 
 import type { EsiCacheScopeContext, EsiResponse as SharedEsiResponse } from '@repo/esi'
-import {
-	EVE_SSO_SCOPES_ALL,
-	EVE_SSO_SCOPES_PUBLIC_ONLY,
-	hasAllScopes,
-	getMissingScopes,
-} from '@repo/eve-token-store'
 import type {
 	AuthorizationUrlResponse,
 	CachedEveMetadata,
@@ -46,9 +46,9 @@ import type {
 	EveTokenResponse,
 	EveTokenStore,
 	EveVerifyResponse,
-	TokenRefreshResult,
 	PublicDataVerifyResult,
 	TokenInfo,
+	TokenRefreshResult,
 	TokenValidationResult,
 } from '@repo/eve-token-store'
 import type { EveCharacterId } from '@repo/eve-types'
@@ -462,10 +462,12 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			const scopes = verifyResponse.Scopes ? verifyResponse.Scopes.split(' ') : []
 			if (!hasAllScopes(scopes, EVE_SSO_SCOPES_ALL)) {
 				const missingScopes = getMissingScopes(scopes, EVE_SSO_SCOPES_ALL)
-				logger.withTags({ operation: 'handleCallback', state }).warn('Callback token missing scopes', {
-					characterId: verifyResponse.CharacterID,
-					missingScopes,
-				})
+				logger
+					.withTags({ operation: 'handleCallback', state })
+					.warn('Callback token missing scopes', {
+						characterId: verifyResponse.CharacterID,
+						missingScopes,
+					})
 				return {
 					success: false,
 					error: `Missing required scopes: ${missingScopes.join(', ')}`,
@@ -526,109 +528,109 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			if (cooldownUntilMs > nowMs) {
 				logger
 					.withTags({ operation: 'refreshToken', characterId })
-						.warn('Skipping refresh: token is in cooldown window', {
-							cooldownUntil: new Date(cooldownUntilMs).toISOString(),
-						})
-					return {
-						characterId,
-						success: false,
-						status: 'transient_error',
-						error: `Token refresh cooldown active until ${new Date(cooldownUntilMs).toISOString()}`,
-					}
+					.info('Skipping refresh: token is in cooldown window', {
+						cooldownUntil: new Date(cooldownUntilMs).toISOString(),
+					})
+				return {
+					characterId,
+					success: false,
+					status: 'transient_error',
+					error: `Token refresh cooldown active until ${new Date(cooldownUntilMs).toISOString()}`,
 				}
+			}
 
-				const character = await this.db.query.eveCharacters.findFirst({
-					where: eq(eveCharacters.characterId, String(characterId)),
-				})
+			const character = await this.db.query.eveCharacters.findFirst({
+				where: eq(eveCharacters.characterId, String(characterId)),
+			})
 
-				if (!character) {
-					logger.withTags({ operation: 'refreshToken', characterId }).error('Character not found')
-					return {
-						characterId,
-						success: false,
-						status: 'token_missing',
-						error: 'Character not found',
-					}
+			if (!character) {
+				logger.withTags({ operation: 'refreshToken', characterId }).error('Character not found')
+				return {
+					characterId,
+					success: false,
+					status: 'token_missing',
+					error: 'Character not found',
 				}
-				if (character.deletedAt) {
-					logger.withTags({ operation: 'refreshToken', characterId }).error(
-						'Character is marked deleted'
-					)
-					return {
-						characterId,
-						success: false,
-						status: 'character_deleted',
-						error: 'Character is marked deleted',
-					}
+			}
+			if (character.deletedAt) {
+				logger
+					.withTags({ operation: 'refreshToken', characterId })
+					.error('Character is marked deleted')
+				return {
+					characterId,
+					success: false,
+					status: 'character_deleted',
+					error: 'Character is marked deleted',
 				}
+			}
 
-				// Get token record
-				const tokenRecord = await this.db.query.eveTokens.findFirst({
-					where: eq(eveTokens.characterId, character.id),
+			// Get token record
+			const tokenRecord = await this.db.query.eveTokens.findFirst({
+				where: eq(eveTokens.characterId, character.id),
 			})
 
 			if (!tokenRecord) {
 				logger
 					.withTags({ operation: 'refreshToken', characterId })
-						.error('Token or refresh token not found', {
-							hasTokenRecord: false,
-							hasRefreshToken: false,
-						})
-					return {
-						characterId,
-						success: false,
-						status: 'token_missing',
-						error: 'Token or refresh token not found',
-					}
+					.error('Token or refresh token not found', {
+						hasTokenRecord: false,
+						hasRefreshToken: false,
+					})
+				return {
+					characterId,
+					success: false,
+					status: 'token_missing',
+					error: 'Token or refresh token not found',
 				}
-				if (tokenRecord.permanentInvalidAt) {
-					logger
-						.withTags({ operation: 'refreshToken', characterId })
-						.warn('Skipping refresh: token is permanently invalid', {
-							permanentInvalidAt: tokenRecord.permanentInvalidAt.toISOString(),
-							reason: tokenRecord.permanentInvalidReason,
-						})
-					return {
-						characterId,
-						success: false,
-						status: 'permanent_invalid',
-						error: tokenRecord.permanentInvalidReason ?? 'Token is permanently invalid',
-					}
+			}
+			if (tokenRecord.permanentInvalidAt) {
+				logger
+					.withTags({ operation: 'refreshToken', characterId })
+					.warn('Skipping refresh: token is permanently invalid', {
+						permanentInvalidAt: tokenRecord.permanentInvalidAt.toISOString(),
+						reason: tokenRecord.permanentInvalidReason,
+					})
+				return {
+					characterId,
+					success: false,
+					status: 'permanent_invalid',
+					error: tokenRecord.permanentInvalidReason ?? 'Token is permanently invalid',
 				}
-				if (tokenRecord.nextRetryAt && tokenRecord.nextRetryAt.getTime() > nowMs) {
-					logger
-						.withTags({ operation: 'refreshToken', characterId })
-						.warn('Skipping refresh: token retry cooldown is active', {
-							nextRetryAt: tokenRecord.nextRetryAt.toISOString(),
-						})
-					return {
-						characterId,
-						success: false,
-						status: 'transient_error',
-						error: `Token refresh cooldown active until ${tokenRecord.nextRetryAt.toISOString()}`,
-					}
+			}
+			if (tokenRecord.nextRetryAt && tokenRecord.nextRetryAt.getTime() > nowMs) {
+				logger
+					.withTags({ operation: 'refreshToken', characterId })
+					.info('Skipping refresh: token retry cooldown is active', {
+						nextRetryAt: tokenRecord.nextRetryAt.toISOString(),
+					})
+				return {
+					characterId,
+					success: false,
+					status: 'transient_error',
+					error: `Token refresh cooldown active until ${tokenRecord.nextRetryAt.toISOString()}`,
 				}
-				if (shouldForcePermanentByInvalidAge(tokenRecord.invalidSince)) {
-					await this.db
-						.update(eveTokens)
+			}
+			if (shouldForcePermanentByInvalidAge(tokenRecord.invalidSince)) {
+				await this.db
+					.update(eveTokens)
 					.set({
 						permanentInvalidAt: new Date(),
-							permanentInvalidReason:
-								tokenRecord.permanentInvalidReason ?? 'Invalid state exceeded 7-day backstop',
-							updatedAt: new Date(),
-						})
-						.where(eq(eveTokens.id, tokenRecord.id))
-					return {
-						characterId,
-						success: false,
-						status: 'permanent_invalid',
-						error: 'Invalid state exceeded 7-day backstop',
-					}
+						permanentInvalidReason:
+							tokenRecord.permanentInvalidReason ?? 'Invalid state exceeded 7-day backstop',
+						updatedAt: new Date(),
+					})
+					.where(eq(eveTokens.id, tokenRecord.id))
+				return {
+					characterId,
+					success: false,
+					status: 'permanent_invalid',
+					error: 'Invalid state exceeded 7-day backstop',
 				}
-				if (!tokenRecord.refreshToken) {
-					const permanentlyInvalid = isRefreshBackstopExpired(tokenRecord.expiresAt)
-					await this.db
-						.update(eveTokens)
+			}
+			if (!tokenRecord.refreshToken) {
+				const permanentlyInvalid = isRefreshBackstopExpired(tokenRecord.expiresAt)
+				await this.db
+					.update(eveTokens)
 					.set({
 						invalidSince: tokenRecord.invalidSince ?? new Date(),
 						lastValidationAt: new Date(),
@@ -640,20 +642,20 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 						updatedAt: new Date(),
 					})
 					.where(eq(eveTokens.id, tokenRecord.id))
-					logger
-						.withTags({ operation: 'refreshToken', characterId })
-						.error('Token or refresh token not found', {
-							hasTokenRecord: true,
-							hasRefreshToken: false,
-							permanentlyInvalid,
-						})
-					return {
-						characterId,
-						success: false,
-						status: permanentlyInvalid ? 'permanent_invalid' : 'invalid_token',
-						error: 'Token is expired and has no refresh token',
-					}
+				logger
+					.withTags({ operation: 'refreshToken', characterId })
+					.error('Token or refresh token not found', {
+						hasTokenRecord: true,
+						hasRefreshToken: false,
+						permanentlyInvalid,
+					})
+				return {
+					characterId,
+					success: false,
+					status: permanentlyInvalid ? 'permanent_invalid' : 'invalid_token',
+					error: 'Token is expired and has no refresh token',
 				}
+			}
 
 			// Decrypt refresh token
 			const refreshToken = await this.decrypt(tokenRecord.refreshToken)
@@ -696,65 +698,63 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 				.update(eveCharacters)
 				.set({ lastRefreshAt: new Date() })
 				.where(eq(eveCharacters.characterId, String(characterId)))
-				await this.clearTokenRefreshCooldown(characterId).catch((error) => {
-					// Cooldown cleanup is advisory; never fail a successful refresh because storage is transiently unhealthy.
-					logger
-						.withTags({ operation: 'refreshToken', characterId })
+			await this.clearTokenRefreshCooldown(characterId).catch((error) => {
+				// Cooldown cleanup is advisory; never fail a successful refresh because storage is transiently unhealthy.
+				logger
+					.withTags({ operation: 'refreshToken', characterId })
 					.warn('Failed to clear token refresh cooldown', {
 						error: error instanceof Error ? error.message : String(error),
 						errorDetails: toErrorLogDetails(error),
-						})
-				})
+					})
+			})
 
+			return {
+				characterId,
+				success: true,
+				status: 'refreshed',
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			if (isPermanentTokenDecryptionFailure(message)) {
+				const character = await this.db.query.eveCharacters.findFirst({
+					where: eq(eveCharacters.characterId, String(characterId)),
+				})
+				if (character) {
+					await this.db
+						.update(eveTokens)
+						.set({
+							invalidSince: new Date(),
+							lastValidationAt: new Date(),
+							lastValidationStatus: 'permanent_invalid',
+							nextRetryAt: null,
+							permanentInvalidAt: new Date(),
+							permanentInvalidReason: message,
+							updatedAt: new Date(),
+						})
+						.where(eq(eveTokens.characterId, character.id))
+				}
+				logger
+					.withTags({ operation: 'refreshToken', characterId })
+					.warn('Permanent token decryption failure; disabled further refresh attempts', {
+						error: message,
+						errorDetails: toErrorLogDetails(error),
+					})
 				return {
 					characterId,
-					success: true,
-					status: 'refreshed',
+					success: false,
+					status: 'permanent_invalid',
+					error: message,
 				}
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error)
-				if (isPermanentTokenDecryptionFailure(message)) {
-					const character = await this.db.query.eveCharacters.findFirst({
-						where: eq(eveCharacters.characterId, String(characterId)),
-					})
-					if (character) {
-						await this.db
-							.update(eveTokens)
-							.set({
-								invalidSince: new Date(),
-								lastValidationAt: new Date(),
-								lastValidationStatus: 'permanent_invalid',
-								nextRetryAt: null,
-								permanentInvalidAt: new Date(),
-								permanentInvalidReason: message,
-								updatedAt: new Date(),
-							})
-							.where(eq(eveTokens.characterId, character.id))
-					}
-					logger
-						.withTags({ operation: 'refreshToken', characterId })
-						.warn('Permanent token decryption failure; disabled further refresh attempts', {
-							error: message,
-							errorDetails: toErrorLogDetails(error),
-						})
-					return {
-						characterId,
-						success: false,
-						status: 'permanent_invalid',
-						error: message,
-					}
-				}
-				let tokenState:
-				| {
-						expiresAt: string
-						hasRefreshToken: boolean
-						invalidSince: string | null
-						lastValidationStatus: string | null
-						nextRetryAt: string | null
-						permanentInvalidAt: string | null
-						permanentInvalidReason: string | null
-				  }
-				| null = null
+			}
+			let tokenState: {
+				expiresAt: string
+				hasRefreshToken: boolean
+				invalidSince: string | null
+				lastValidationStatus: string | null
+				nextRetryAt: string | null
+				permanentInvalidAt: string | null
+				permanentInvalidReason: string | null
+			} | null = null
 			if (isPermanentRefreshFailure(message)) {
 				const character = await this.db.query.eveCharacters.findFirst({
 					where: eq(eveCharacters.characterId, String(characterId)),
@@ -774,18 +774,18 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 						})
 						.where(eq(eveTokens.characterId, character.id))
 				}
-					logger
-						.withTags({ operation: 'refreshToken', characterId })
-						.warn('Permanent token refresh failure; disabled further refresh attempts', {
-							error: message,
-							errorDetails: toErrorLogDetails(error),
-						})
-					return {
-						characterId,
-						success: false,
-						status: 'permanent_invalid',
+				logger
+					.withTags({ operation: 'refreshToken', characterId })
+					.warn('Permanent token refresh failure; disabled further refresh attempts', {
 						error: message,
-					}
+						errorDetails: toErrorLogDetails(error),
+					})
+				return {
+					characterId,
+					success: false,
+					status: 'permanent_invalid',
+					error: message,
+				}
 			}
 			const character = await this.db.query.eveCharacters.findFirst({
 				where: eq(eveCharacters.characterId, String(characterId)),
@@ -828,24 +828,22 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 						errorDetails: toErrorLogDetails(error),
 					})
 			})
-				logger
-					.withTags({ operation: 'refreshToken', characterId })
-					.error('Token refresh failed', {
-						error: message,
-						errorDetails: toErrorLogDetails(error),
-					tokenState,
-					transientCooldownUntil: new Date(
-						Date.now() + TOKEN_REFRESH_TRANSIENT_COOLDOWN_MS
-					).toISOString(),
-				})
-				return {
-					characterId,
-					success: false,
-					status: 'transient_error',
-					error: message,
-				}
+			logger.withTags({ operation: 'refreshToken', characterId }).error('Token refresh failed', {
+				error: message,
+				errorDetails: toErrorLogDetails(error),
+				tokenState,
+				transientCooldownUntil: new Date(
+					Date.now() + TOKEN_REFRESH_TRANSIENT_COOLDOWN_MS
+				).toISOString(),
+			})
+			return {
+				characterId,
+				success: false,
+				status: 'transient_error',
+				error: message,
 			}
 		}
+	}
 
 	/**
 	 * Get token information (without actual token values)
@@ -1280,8 +1278,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 				const refreshed = await this.refreshTokenWithResult(characterId)
 				if (!refreshed.success) {
 					return {
-						status:
-							refreshed.status === 'refreshed' ? 'transient_error' : refreshed.status,
+						status: refreshed.status === 'refreshed' ? 'transient_error' : refreshed.status,
 						error: refreshed.error ?? 'Token refresh failed',
 					}
 				}
@@ -1905,7 +1902,10 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	): Promise<EsiResponse<T>> {
 		const scope = EveTokenStoreDO.PUBLIC_CACHE_SCOPE
 		const cacheMode = options?.cacheMode ?? 'default'
-		const cached = cacheMode === 'no-store' ? null : await this.getCachedResponse<T>(scope, path, undefined, true)
+		const cached =
+			cacheMode === 'no-store'
+				? null
+				: await this.getCachedResponse<T>(scope, path, undefined, true)
 		if (cached) {
 			const now = Date.now()
 			const lastModified = cached.lastModified?.getTime()
@@ -1991,13 +1991,21 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			: EveTokenStoreDO.PUBLIC_CACHE_SCOPE
 		const cacheKey = this.getEsiCacheKey(scope, path)
 
-		// Delete all cache entries matching this key (including all pages if paginated)
-		// Use LIKE to match all pages: /path?page=1, /path?page=2, etc.
+		// Delete the base entry and page entries without LIKE/GLOB pattern matching.
+		// SQLite can reject wildcard patterns as too complex even when the key itself is small.
 		const baseKey = cacheKey.split('?')[0]
+		const queryKeyPrefix = `${baseKey}?`
+		const pageKeyPrefix = `${baseKey}:page:`
 		const result = await this.state.storage.sql.exec(
-			`DELETE FROM esi_cache WHERE cache_key LIKE ? OR cache_key = ?`,
-			`${baseKey}%`,
-			cacheKey
+			`DELETE FROM esi_cache
+			 WHERE cache_key = ?
+			    OR substr(cache_key, 1, length(?)) = ?
+			    OR substr(cache_key, 1, length(?)) = ?`,
+			cacheKey,
+			queryKeyPrefix,
+			queryKeyPrefix,
+			pageKeyPrefix,
+			pageKeyPrefix
 		)
 
 		const deletedCount = result.rowsWritten || 0

--- a/apps/structures/src/db/index.ts
+++ b/apps/structures/src/db/index.ts
@@ -1,7 +1,8 @@
-import { createDbClient } from '@repo/db-utils'
 import { alertDestinations, discordServers, managedCorporations, users } from '@repo/core-db-schema'
+import { createDbClient } from '@repo/db-utils'
 import {
 	corporationStructureInventory,
+	corporationStructureInventorySnapshots,
 	corporationStructures,
 	structureFuelLog,
 } from '@repo/eve-corporation-data-db-schema'
@@ -17,6 +18,7 @@ export const querySchema = {
 	users,
 	managedCorporations,
 	corporationStructures,
+	corporationStructureInventorySnapshots,
 	corporationStructureInventory,
 	structureFuelLog,
 }

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -1,34 +1,30 @@
 import { managedCorporations } from '@repo/core-db-schema'
-import { and, asc, desc, eq, inArray, isNotNull, isNull, lte, notInArray, or, sql } from '@repo/db-utils'
+import {
+	and,
+	asc,
+	desc,
+	eq,
+	inArray,
+	isNotNull,
+	isNull,
+	lte,
+	notInArray,
+	or,
+	sql,
+} from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import {
 	corporationStructureInventory,
+	corporationStructureInventorySnapshots,
 	corporationStructures,
 	structureFuelLog,
 } from '@repo/eve-corporation-data-db-schema'
 import { parseFittingSlotFlag } from '@repo/eve-fitting/flags'
-import {
-	parseStructurePermissionUrn,
-	STRUCTURE_PERMISSION_SCOPE_ALL,
-} from '@repo/groups'
+import { parseStructurePermissionUrn, STRUCTURE_PERMISSION_SCOPE_ALL } from '@repo/groups'
 import { logger } from '@repo/hono-helpers'
 import { summarizeInventoryRows } from '@repo/inventory-display'
 import {
-	METENOX_MOON_DRILL_TYPE_NAME,
-	MINING_CITADEL_TYPE_NAMES,
-	MOON_DRILL_STRUCTURE_TYPE_IDS,
-	NAVIGATION_STRUCTURE_TYPE_IDS,
-	SKYHOOK_STRUCTURE_TYPE_IDS,
-	SOVEREIGNTY_STRUCTURE_TYPE_IDS,
-	STRUCTURE_REINFORCED_STATES,
 	FUEL_BLOCK_TYPE_IDS,
-	SKYHOOK_SECURED_BAY_CAPACITY_M3,
-	SKYHOOK_SURPLUS_BAY_CAPACITY_M3,
-	SKYHOOK_MAGMATIC_GAS_TYPE_ID,
-	SKYHOOK_MAGMATIC_GAS_TYPE_NAME,
-	SKYHOOK_SUPERIONIC_ICE_TYPE_ID,
-	SKYHOOK_SUPERIONIC_ICE_TYPE_NAME,
-	SOVEREIGNTY_HUB_TYPE_ID,
 	getSkyhookFullness,
 	getSkyhookReagentEntriesFromStorageState,
 	getSkyhookReagentSummaryFromStorageState,
@@ -36,39 +32,27 @@ import {
 	getSovereigntyReagentBayReagents,
 	getSovereigntyReagentBaySummary,
 	getStructureTabForTypeId,
+	METENOX_MOON_DRILL_TYPE_NAME,
+	MINING_CITADEL_TYPE_NAMES,
+	MOON_DRILL_STRUCTURE_TYPE_IDS,
+	NAVIGATION_STRUCTURE_TYPE_IDS,
+	SKYHOOK_MAGMATIC_GAS_TYPE_ID,
+	SKYHOOK_MAGMATIC_GAS_TYPE_NAME,
+	SKYHOOK_SECURED_BAY_CAPACITY_M3,
+	SKYHOOK_STRUCTURE_TYPE_IDS,
+	SKYHOOK_SUPERIONIC_ICE_TYPE_ID,
+	SKYHOOK_SUPERIONIC_ICE_TYPE_NAME,
+	SKYHOOK_SURPLUS_BAY_CAPACITY_M3,
+	SOVEREIGNTY_HUB_TYPE_ID,
+	SOVEREIGNTY_STRUCTURE_TYPE_IDS,
+	STRUCTURE_REINFORCED_STATES,
 	STRUCTURE_SYNC_ERROR_STALE_MS,
 	STRUCTURE_SYNC_WARNING_STALE_MS,
-	type StructureMoonStructureListSortBy,
-	type StructureCommonListSortBy,
-	type StructureSkyhookListSortBy,
-	type StructureSovereigntyListSortBy,
-	type StructureCitadelListQuery,
-	type StructureMoonDrillListQuery,
-	type StructureMiningCitadelListQuery,
-	type StructureMiningCitadelListItem as RepoStructureMiningCitadelListItem,
-	type StructureMiningCitadelListResponse as RepoStructureMiningCitadelListResponse,
-	type StructureNavigationListQuery,
-	type StructureSovereigntyListFilterOptions as RepoStructureSovereigntyListFilterOptions,
-	type StructureSovereigntyListItem as RepoStructureSovereigntyListItem,
-	type StructureSovereigntyListResponse as RepoStructureSovereigntyListResponse,
-	type StructureSovereigntyListSummary as RepoStructureSovereigntyListSummary,
-	type StructureSovereigntyReagent,
-	type StructureSovereigntyTransportState,
-	type StructureMoonDrillListItem as RepoStructureMoonDrillListItem,
-	type StructureMoonDrillListResponse as RepoStructureMoonDrillListResponse,
-	type StructureMoonDrillSummary as RepoStructureMoonDrillSummary,
-	type StructureMiningCitadelSummary as RepoStructureMiningCitadelSummary,
-	type StructureSkyhookListItem as RepoStructureSkyhookListItem,
-	type StructureSkyhookListResponse as RepoStructureSkyhookListResponse,
-	type StructureSkyhookListQuery,
-	type StructureSovereigntyListQuery,
-	type StructureTab,
-	type SkyhookReagentStorageState,
 } from '@repo/structures'
 import {
+	structureMiningExtractions,
 	structureMoonDrills,
 	structureMoonGeographies,
-	structureMiningExtractions,
 	structureSkyhookReagents,
 	structureSkyhooks,
 	structureSovereigntyHubs,
@@ -88,6 +72,34 @@ import { buildStructureFuelUsageHistory } from './structure-fuel-history'
 import type { DbClient } from '@repo/db-utils'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { InventoryDisplayBay } from '@repo/inventory-display'
+import type {
+	StructureMiningCitadelListItem as RepoStructureMiningCitadelListItem,
+	StructureMiningCitadelListResponse as RepoStructureMiningCitadelListResponse,
+	StructureMiningCitadelSummary as RepoStructureMiningCitadelSummary,
+	StructureMoonDrillListItem as RepoStructureMoonDrillListItem,
+	StructureMoonDrillListResponse as RepoStructureMoonDrillListResponse,
+	StructureMoonDrillSummary as RepoStructureMoonDrillSummary,
+	StructureSkyhookListItem as RepoStructureSkyhookListItem,
+	StructureSkyhookListResponse as RepoStructureSkyhookListResponse,
+	StructureSovereigntyListFilterOptions as RepoStructureSovereigntyListFilterOptions,
+	StructureSovereigntyListItem as RepoStructureSovereigntyListItem,
+	StructureSovereigntyListResponse as RepoStructureSovereigntyListResponse,
+	StructureSovereigntyListSummary as RepoStructureSovereigntyListSummary,
+	SkyhookReagentStorageState,
+	StructureCitadelListQuery,
+	StructureCommonListSortBy,
+	StructureMiningCitadelListQuery,
+	StructureMoonDrillListQuery,
+	StructureMoonStructureListSortBy,
+	StructureNavigationListQuery,
+	StructureSkyhookListQuery,
+	StructureSkyhookListSortBy,
+	StructureSovereigntyListQuery,
+	StructureSovereigntyListSortBy,
+	StructureSovereigntyReagent,
+	StructureSovereigntyTransportState,
+	StructureTab,
+} from '@repo/structures'
 import type { Env, SessionUser } from '../context'
 import type { DbSchema } from '../db'
 import type {
@@ -119,7 +131,10 @@ function getSkyhookState(
 
 function isSkyhookCurrentlyRaidable(
 	structure:
-		| Pick<typeof structureSkyhooks.$inferSelect, 'theftVulnerabilityStart' | 'theftVulnerabilityEnd'>
+		| Pick<
+				typeof structureSkyhooks.$inferSelect,
+				'theftVulnerabilityStart' | 'theftVulnerabilityEnd'
+		  >
 		| null
 		| undefined
 ): boolean {
@@ -902,11 +917,7 @@ function summarizeStructureSkyhook(
 	const reagents = getSkyhookReagentEntriesFromStorageState(skyhook)
 	const isRaidable = isSkyhookCurrentlyRaidable(skyhook)
 	const reinforcementTimerEnd = toIso(skyhook.reinforcementTimerEnd)
-	const normalizedState = getSkyhookState(
-		skyhook.state,
-		isRaidable,
-		reinforcementTimerEnd
-	)
+	const normalizedState = getSkyhookState(skyhook.state, isRaidable, reinforcementTimerEnd)
 
 	return {
 		planetId: skyhook.planetId ?? null,
@@ -1156,9 +1167,25 @@ async function loadStructureInventoryDetailData(
 	db: DbClient<DbSchema>,
 	structure: StructureSourceRecord
 ): Promise<StructureInventoryBaySummary[]> {
+	const activeSnapshot = await db.query.corporationStructureInventorySnapshots.findFirst({
+		where: and(
+			eq(corporationStructureInventorySnapshots.corporationId, structure.corporationId),
+			isNotNull(corporationStructureInventorySnapshots.activatedAt)
+		),
+		orderBy: [
+			desc(corporationStructureInventorySnapshots.activatedAt),
+			desc(corporationStructureInventorySnapshots.createdAt),
+		],
+		columns: { id: true },
+	})
+	if (!activeSnapshot) {
+		return []
+	}
+
 	const rows = await db.query.corporationStructureInventory.findMany({
 		where: and(
 			eq(corporationStructureInventory.corporationId, structure.corporationId),
+			eq(corporationStructureInventory.snapshotId, activeSnapshot.id),
 			eq(corporationStructureInventory.structureId, structure.structureId)
 		),
 	})
@@ -1773,7 +1800,8 @@ async function getStructureContext(
 		return null
 	}
 
-	const canViewDetails = user.is_admin || canViewDetailsStructure(access, structure.corporationId, structureTab)
+	const canViewDetails =
+		user.is_admin || canViewDetailsStructure(access, structure.corporationId, structureTab)
 	if (requireDetailsPermission && !canViewDetails) {
 		return null
 	}
@@ -1995,7 +2023,10 @@ function buildOperationalStructureListItem(
 		hidden: row.hidden ?? false,
 		lowPowerAllowed: row.lowPowerAllowed ?? false,
 		assignedGroupId: row.assignedGroupId,
-		syncStatus: getStructureSyncStatus(row.syncStatus as StructureListItem['syncStatus'], row.lastSyncedAt),
+		syncStatus: getStructureSyncStatus(
+			row.syncStatus as StructureListItem['syncStatus'],
+			row.lastSyncedAt
+		),
 		syncFailureReason: row.syncFailureReason,
 		lastSyncedAt: toIso(row.lastSyncedAt),
 		updatedAt: toIso(row.updatedAt) ?? new Date().toISOString(),
@@ -2021,7 +2052,9 @@ function buildStructureContextsWhere(
 		conditions.push(eq(corporationStructures.corporationId, query.corporationId))
 	}
 	if (!accessibleCorporations.hasGlobalAccess) {
-		conditions.push(inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds]))
+		conditions.push(
+			inArray(corporationStructures.corporationId, [...accessibleCorporations.corporationIds])
+		)
 	}
 	if (query.lowPower === 'true') {
 		conditions.push(eq(corporationStructures.lowPower, true))
@@ -2055,7 +2088,10 @@ function buildStructureContextsWhere(
 	if (query.lowPowerAllowed === 'true') {
 		conditions.push(eq(structureConfigs.lowPowerAllowed, true))
 	} else if (query.lowPowerAllowed === 'false') {
-		conditions.push(or(eq(structureConfigs.lowPowerAllowed, false), isNull(structureConfigs.structureId)) ?? sql`false`)
+		conditions.push(
+			or(eq(structureConfigs.lowPowerAllowed, false), isNull(structureConfigs.structureId)) ??
+				sql`false`
+		)
 	}
 	const hiddenVisibilityWhere = buildHiddenVisibilityWhere(access, tabFilter)
 	const hiddenVisibilityConditions: StructureWhereCondition[] = [
@@ -2100,7 +2136,10 @@ function buildOperationalStructuresSelectQuery(db: DbClient<DbSchema>, corpWhere
 		})
 		.from(corporationStructures)
 		.leftJoin(structureConfigs, eq(structureConfigs.structureId, corporationStructures.structureId))
-		.leftJoin(managedCorporations, eq(managedCorporations.corporationId, corporationStructures.corporationId))
+		.leftJoin(
+			managedCorporations,
+			eq(managedCorporations.corporationId, corporationStructures.corporationId)
+		)
 		.where(corpWhere ?? sql`true`)
 }
 
@@ -2114,7 +2153,9 @@ function buildSkyhookStructuresCte(db: DbClient<DbSchema>, corpWhere: any) {
 			.select({
 				structureId: sql<string>`${corporationStructures.structureId}`.as('structureId'),
 				corporationId: sql<string>`${corporationStructures.corporationId}`.as('corporationId'),
-				corporationName: sql<string>`coalesce(${managedCorporations.name}, '')`.as('corporationName'),
+				corporationName: sql<string>`coalesce(${managedCorporations.name}, '')`.as(
+					'corporationName'
+				),
 				structureName: sql<string | null>`${corporationStructures.name}`.as('structureName'),
 				typeId: sql<string>`${corporationStructures.typeId}`.as('typeId'),
 				typeName: sql<string | null>`${corporationStructures.typeName}`.as('typeName'),
@@ -2124,23 +2165,33 @@ function buildSkyhookStructuresCte(db: DbClient<DbSchema>, corpWhere: any) {
 				regionName: sql<string | null>`${corporationStructures.regionName}`.as('regionName'),
 				state: sql<string>`${corporationStructures.state}`.as('state'),
 				stateTimerEnd: sql<Date | null>`${corporationStructures.stateTimerEnd}`.as('stateTimerEnd'),
-				nextReinforceApply: sql<Date | null>`${corporationStructures.nextReinforceApply}`.as('nextReinforceApply'),
+				nextReinforceApply: sql<Date | null>`${corporationStructures.nextReinforceApply}`.as(
+					'nextReinforceApply'
+				),
 				unanchorsAt: sql<Date | null>`${corporationStructures.unanchorsAt}`.as('unanchorsAt'),
 				fuelExpires: sql<Date | null>`${corporationStructures.fuelExpires}`.as('fuelExpires'),
 				fuelAmount: sql<number | null>`${corporationStructures.fuelAmount}`.as('fuelAmount'),
 				fuelBurnRate: sql<string | null>`${corporationStructures.fuelBurnRate}`.as('fuelBurnRate'),
 				lowPower: sql<boolean>`${corporationStructures.lowPower}`.as('lowPower'),
 				hidden: sql<boolean | null>`${structureConfigs.hidden}`.as('hidden'),
-				lowPowerAllowed: sql<boolean | null>`${structureConfigs.lowPowerAllowed}`.as('lowPowerAllowed'),
-				assignedGroupId: sql<string | null>`${structureConfigs.assignedGroupId}`.as('assignedGroupId'),
+				lowPowerAllowed: sql<boolean | null>`${structureConfigs.lowPowerAllowed}`.as(
+					'lowPowerAllowed'
+				),
+				assignedGroupId: sql<string | null>`${structureConfigs.assignedGroupId}`.as(
+					'assignedGroupId'
+				),
 				syncStatus: sql<string>`${corporationStructures.syncStatus}`.as('syncStatus'),
-				syncFailureReason: sql<string | null>`${corporationStructures.syncFailureReason}`.as('syncFailureReason'),
+				syncFailureReason: sql<string | null>`${corporationStructures.syncFailureReason}`.as(
+					'syncFailureReason'
+				),
 				lastSyncedAt: sql<Date | null>`${corporationStructures.lastSyncedAt}`.as('lastSyncedAt'),
 				updatedAt: sql<Date>`${corporationStructures.updatedAt}`.as('updatedAt'),
 				planetId: sql<string | null>`${structureSkyhooks.planetId}`.as('planetId'),
 				planetName: sql<string | null>`${structureSkyhooks.planetName}`.as('planetName'),
 				isActive: sql<boolean | null>`${structureSkyhooks.isActive}`.as('isActive'),
-				effectiveWorkforce: sql<number | null>`${structureSkyhooks.effectiveWorkforce}`.as('effectiveWorkforce'),
+				effectiveWorkforce: sql<number | null>`${structureSkyhooks.effectiveWorkforce}`.as(
+					'effectiveWorkforce'
+				),
 				magmaticGasSecuredStock: sql<number>`
 					coalesce(${structureSkyhookReagents.magmaticGasSecuredStock}, 0)
 				`.as('magmaticGasSecuredStock'),
@@ -2156,9 +2207,10 @@ function buildSkyhookStructuresCte(db: DbClient<DbSchema>, corpWhere: any) {
 				superionicIceUnsecuredStock: sql<number>`
 					coalesce(${structureSkyhookReagents.superionicIceUnsecuredStock}, 0)
 				`.as('superionicIceUnsecuredStock'),
-				superionicIceLastCycle: sql<Date | null>`${structureSkyhookReagents.superionicIceLastCycle}`.as(
-					'superionicIceLastCycle'
-				),
+				superionicIceLastCycle:
+					sql<Date | null>`${structureSkyhookReagents.superionicIceLastCycle}`.as(
+						'superionicIceLastCycle'
+					),
 				reinforcementTimerEnd: sql<Date | null>`${structureSkyhooks.reinforcementTimerEnd}`.as(
 					'reinforcementTimerEnd'
 				),
@@ -2170,21 +2222,27 @@ function buildSkyhookStructuresCte(db: DbClient<DbSchema>, corpWhere: any) {
 				),
 			})
 			.from(corporationStructures)
-			.leftJoin(structureConfigs, eq(structureConfigs.structureId, corporationStructures.structureId))
-			.leftJoin(structureSkyhooks, eq(structureSkyhooks.structureId, corporationStructures.structureId))
+			.leftJoin(
+				structureConfigs,
+				eq(structureConfigs.structureId, corporationStructures.structureId)
+			)
+			.leftJoin(
+				structureSkyhooks,
+				eq(structureSkyhooks.structureId, corporationStructures.structureId)
+			)
 			.leftJoin(
 				structureSkyhookReagents,
 				eq(structureSkyhookReagents.structureId, corporationStructures.structureId)
 			)
-			.leftJoin(managedCorporations, eq(managedCorporations.corporationId, corporationStructures.corporationId))
+			.leftJoin(
+				managedCorporations,
+				eq(managedCorporations.corporationId, corporationStructures.corporationId)
+			)
 			.where(corpWhere ?? sql`true`)
 	)
 }
 
-function buildSkyhookReagentFillPercentExpression(
-	source: any,
-	stockType: 'secured' | 'unsecured'
-) {
+function buildSkyhookReagentFillPercentExpression(source: any, stockType: 'secured' | 'unsecured') {
 	const magmaticGasStock =
 		stockType === 'secured' ? source.magmaticGasSecuredStock : source.magmaticGasUnsecuredStock
 	const superionicIceStock =
@@ -2273,19 +2331,37 @@ function buildSkyhookSortOrder(
 		case 'workforce':
 			return [sortExpression(source.effectiveWorkforce), sortExpression(source.structureId)]
 		case 'name':
-			return [sortExpression(sql`coalesce(${source.structureName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.structureName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'corporation':
-			return [sortExpression(sql`coalesce(${source.corporationName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.corporationName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'region':
-			return [sortExpression(sql`coalesce(${source.regionName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.regionName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'system':
-			return [sortExpression(sql`coalesce(${source.systemName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.systemName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'type':
-			return [sortExpression(sql`coalesce(${source.typeName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.typeName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'state':
 			return [sortExpression(source.state), sortExpression(source.structureId)]
 		case 'group':
-			return [sortExpression(sql`coalesce(${source.assignedGroupId}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.assignedGroupId}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'syncStatus':
 			return [
 				sortExpression(
@@ -2298,7 +2374,10 @@ function buildSkyhookSortOrder(
 	}
 }
 
-function buildSkyhookVisibilityWhere(access: StructureAccessScope, query: StructureSkyhookListQuery): any {
+function buildSkyhookVisibilityWhere(
+	access: StructureAccessScope,
+	query: StructureSkyhookListQuery
+): any {
 	const conditions: StructureWhereCondition[] = []
 	const baseWhere = buildStructureContextsWhere(access, query, 'skyhooks')
 	if (baseWhere) {
@@ -2322,11 +2401,7 @@ function buildSkyhookListItemFromRow(
 	const reagentSummary = getSkyhookReagentSummaryFromStorageState(row)
 	const reagentEntries = getSkyhookReagentEntriesFromStorageState(row)
 	const reinforcementTimerEnd = toIso(row.reinforcementTimerEnd)
-	const normalizedState = getSkyhookState(
-		row.state,
-		row.isRaidable ?? false,
-		reinforcementTimerEnd
-	)
+	const normalizedState = getSkyhookState(row.state, row.isRaidable ?? false, reinforcementTimerEnd)
 
 	return {
 		structureId: row.structureId,
@@ -2402,57 +2477,58 @@ async function buildSkyhookStructureFilterOptionsFromSql(
 	skyhookStructures: ReturnType<typeof buildSkyhookStructuresCte>
 ): Promise<StructureListFilterOptions> {
 	const rowsDb = db.with(skyhookStructures)
-	const [corporations, assignedGroups, regions, systems, states, types, planets] = await Promise.all([
-		rowsDb
-			.selectDistinct({
-				corporationId: skyhookStructures.corporationId,
-				corporationName: skyhookStructures.corporationName,
-			})
-			.from(skyhookStructures)
-			.orderBy(asc(skyhookStructures.corporationName)),
-		rowsDb
-			.selectDistinct({
-				assignedGroupId: skyhookStructures.assignedGroupId,
-			})
-			.from(skyhookStructures)
-			.where(isNotNull(skyhookStructures.assignedGroupId))
-			.orderBy(asc(skyhookStructures.assignedGroupId)),
-		rowsDb
-			.selectDistinct({
-				regionId: skyhookStructures.regionId,
-				regionName: skyhookStructures.regionName,
-			})
-			.from(skyhookStructures)
-			.orderBy(asc(skyhookStructures.regionName)),
-		rowsDb
-			.selectDistinct({
-				systemId: skyhookStructures.systemId,
-				systemName: skyhookStructures.systemName,
-			})
-			.from(skyhookStructures)
-			.orderBy(asc(skyhookStructures.systemName)),
-		rowsDb
-			.selectDistinct({
-				state: skyhookStructures.state,
-			})
-			.from(skyhookStructures)
-			.orderBy(asc(skyhookStructures.state)),
-		rowsDb
-			.selectDistinct({
-				typeId: skyhookStructures.typeId,
-				typeName: skyhookStructures.typeName,
-			})
-			.from(skyhookStructures)
-			.orderBy(asc(skyhookStructures.typeName)),
-		rowsDb
-			.selectDistinct({
-				planetId: skyhookStructures.planetId,
-				planetName: skyhookStructures.planetName,
-			})
-			.from(skyhookStructures)
-			.where(isNotNull(skyhookStructures.planetId))
-			.orderBy(asc(skyhookStructures.planetName)),
-	])
+	const [corporations, assignedGroups, regions, systems, states, types, planets] =
+		await Promise.all([
+			rowsDb
+				.selectDistinct({
+					corporationId: skyhookStructures.corporationId,
+					corporationName: skyhookStructures.corporationName,
+				})
+				.from(skyhookStructures)
+				.orderBy(asc(skyhookStructures.corporationName)),
+			rowsDb
+				.selectDistinct({
+					assignedGroupId: skyhookStructures.assignedGroupId,
+				})
+				.from(skyhookStructures)
+				.where(isNotNull(skyhookStructures.assignedGroupId))
+				.orderBy(asc(skyhookStructures.assignedGroupId)),
+			rowsDb
+				.selectDistinct({
+					regionId: skyhookStructures.regionId,
+					regionName: skyhookStructures.regionName,
+				})
+				.from(skyhookStructures)
+				.orderBy(asc(skyhookStructures.regionName)),
+			rowsDb
+				.selectDistinct({
+					systemId: skyhookStructures.systemId,
+					systemName: skyhookStructures.systemName,
+				})
+				.from(skyhookStructures)
+				.orderBy(asc(skyhookStructures.systemName)),
+			rowsDb
+				.selectDistinct({
+					state: skyhookStructures.state,
+				})
+				.from(skyhookStructures)
+				.orderBy(asc(skyhookStructures.state)),
+			rowsDb
+				.selectDistinct({
+					typeId: skyhookStructures.typeId,
+					typeName: skyhookStructures.typeName,
+				})
+				.from(skyhookStructures)
+				.orderBy(asc(skyhookStructures.typeName)),
+			rowsDb
+				.selectDistinct({
+					planetId: skyhookStructures.planetId,
+					planetName: skyhookStructures.planetName,
+				})
+				.from(skyhookStructures)
+				.where(isNotNull(skyhookStructures.planetId))
+				.orderBy(asc(skyhookStructures.planetName)),
+		])
 
 	return {
 		corporations: (corporations as Array<{ corporationId?: unknown; corporationName?: unknown }>)
@@ -2464,8 +2540,11 @@ async function buildSkyhookStructureFilterOptionsFromSql(
 						: typeof row.corporationId === 'string'
 							? row.corporationId
 							: '',
-				}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			}))
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		assignedGroups: (assignedGroups as Array<{ assignedGroupId?: unknown }>)
 			.map((row) => ({
 				value: typeof row.assignedGroupId === 'string' ? row.assignedGroupId : '',
@@ -2480,7 +2559,7 @@ async function buildSkyhookStructureFilterOptionsFromSql(
 						? row.regionName
 						: typeof row.regionId === 'string'
 							? row.regionId
-						: '',
+							: '',
 			}))
 			.filter((option) => option.value.length > 0),
 		systems: (systems as Array<{ systemId?: unknown; systemName?: unknown }>)
@@ -2492,14 +2571,20 @@ async function buildSkyhookStructureFilterOptionsFromSql(
 						: typeof row.systemId === 'string'
 							? row.systemId
 							: '',
-				}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			}))
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		states: (states as Array<{ state?: unknown }>)
 			.map((row) => ({
 				value: typeof row.state === 'string' ? row.state : '',
 				label: typeof row.state === 'string' ? row.state : '',
 			}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		types: (types as Array<{ typeId?: unknown; typeName?: unknown }>)
 			.map((row) => ({
 				value: typeof row.typeId === 'string' ? row.typeId : '',
@@ -2509,8 +2594,11 @@ async function buildSkyhookStructureFilterOptionsFromSql(
 						: typeof row.typeId === 'string'
 							? row.typeId
 							: '',
-				}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			}))
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		alliances: [],
 		planets: (planets as Array<{ planetId?: unknown; planetName?: unknown }>)
 			.map((row) => ({
@@ -2569,9 +2657,9 @@ async function buildSkyhookStructureSummaryFromSql(
 				.from(skyhookStructures),
 			rowsDb
 				.select({
-					skyhookHighestFillPercent: sql<number | null>`max(${highestFillPercent})::double precision`.as(
-						'skyhookHighestFillPercent'
-					),
+					skyhookHighestFillPercent: sql<
+						number | null
+					>`max(${highestFillPercent})::double precision`.as('skyhookHighestFillPercent'),
 				})
 				.from(skyhookStructures),
 			rowsDb
@@ -2625,11 +2713,17 @@ async function buildSkyhookStructureSummaryFromSql(
 
 function buildSovereigntyReagentMetricSql(
 	source: any,
-	summaryField: 'magmaticGasQuantity' | 'magmaticGasBurningPerHour' | 'superionicIceQuantity' | 'superionicIceBurningPerHour',
+	summaryField:
+		| 'magmaticGasQuantity'
+		| 'magmaticGasBurningPerHour'
+		| 'superionicIceQuantity'
+		| 'superionicIceBurningPerHour',
 	reagentField: 'amount' | 'burningPerHour',
 	typeId: string
 ) {
-	const summaryValue = sql<string | null>`nullif(${source.reagentBay} -> 'summary' ->> ${summaryField}, '')`
+	const summaryValue = sql<
+		string | null
+	>`nullif(${source.reagentBay} -> 'summary' ->> ${summaryField}, '')`
 	const arrayValue = sql<number>`
 		(
 			select coalesce(sum((reagent ->> ${reagentField})::numeric), 0)
@@ -2699,8 +2793,9 @@ function buildSovereigntySortOrder(
 ) {
 	const descending = sortDirection === 'desc'
 	const sortExpression = (expression: any) => (descending ? desc(expression) : asc(expression))
-	const depletionSort = (field: 'magmaticGasEstimatedDepletionAt' | 'superionicIceEstimatedDepletionAt') =>
-		sortExpression(buildSovereigntySummaryDateSql(source, field))
+	const depletionSort = (
+		field: 'magmaticGasEstimatedDepletionAt' | 'superionicIceEstimatedDepletionAt'
+	) => sortExpression(buildSovereigntySummaryDateSql(source, field))
 
 	switch (sortBy) {
 		case 'fuel':
@@ -2711,15 +2806,30 @@ function buildSovereigntySortOrder(
 		case 'updatedAt':
 			return [sortExpression(source.updatedAt), sortExpression(source.structureId)]
 		case 'name':
-			return [sortExpression(sql`coalesce(${source.structureName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.structureName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'corporation':
-			return [sortExpression(sql`coalesce(${source.corporationName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.corporationName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'region':
-			return [sortExpression(sql`coalesce(${source.regionName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.regionName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'system':
-			return [sortExpression(sql`coalesce(${source.systemName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.systemName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'type':
-			return [sortExpression(sql`coalesce(${source.typeName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.typeName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'syncStatus':
 			return [
 				sortExpression(
@@ -2732,7 +2842,10 @@ function buildSovereigntySortOrder(
 		case 'magmaticGasEstimatedDepletionAt':
 			return [depletionSort('magmaticGasEstimatedDepletionAt'), sortExpression(source.structureId)]
 		case 'superionicIceEstimatedDepletionAt':
-			return [depletionSort('superionicIceEstimatedDepletionAt'), sortExpression(source.structureId)]
+			return [
+				depletionSort('superionicIceEstimatedDepletionAt'),
+				sortExpression(source.structureId),
+			]
 		default:
 			return [sortExpression(source.structureId)]
 	}
@@ -2885,7 +2998,8 @@ async function buildSovereigntyStructureFilterOptionsFromSql(
 		${sovereigntyStructures.vulnerabilityWindowStart} is null
 		or ${sovereigntyStructures.vulnerabilityWindowEnd} is null
 	`
-	const [corporations, regions, systems, controllerAlliances, vulnerabilityCounts] = await Promise.all([
+	const [corporations, regions, systems, controllerAlliances, vulnerabilityCounts] =
+		await Promise.all([
 			rowsDb
 				.selectDistinct({
 					corporationId: sovereigntyStructures.corporationId,
@@ -2922,7 +3036,7 @@ async function buildSovereigntyStructureFilterOptionsFromSql(
 					unknown: sql<number>`coalesce(sum(case when ${unknownExpression} then 1 else 0 end), 0)::int`,
 				})
 				.from(sovereigntyStructures),
-	])
+		])
 
 	return {
 		corporations: corporations
@@ -2930,7 +3044,10 @@ async function buildSovereigntyStructureFilterOptionsFromSql(
 				value: row.corporationId,
 				label: row.corporationName ?? row.corporationId,
 			}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		assignedGroups: [],
 		regions: regions
 			.map((row) => ({
@@ -2943,7 +3060,10 @@ async function buildSovereigntyStructureFilterOptionsFromSql(
 				value: row.systemId,
 				label: row.systemName ?? row.systemId,
 			}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		controllerAlliances: controllerAlliances
 			.map((row) => ({
 				value: row.controllerAllianceId ?? '',
@@ -2952,7 +3072,9 @@ async function buildSovereigntyStructureFilterOptionsFromSql(
 			.filter((option) => option.value.length > 0),
 		vulnerabilityStates: [
 			vulnerabilityCounts[0]?.vulnerable ? { value: 'vulnerable', label: 'Vulnerable' } : null,
-			vulnerabilityCounts[0]?.invulnerable ? { value: 'invulnerable', label: 'Invulnerable' } : null,
+			vulnerabilityCounts[0]?.invulnerable
+				? { value: 'invulnerable', label: 'Invulnerable' }
+				: null,
 			vulnerabilityCounts[0]?.unknown ? { value: 'unknown', label: 'Unknown' } : null,
 		].filter((entry): entry is NonNullable<typeof entry> => entry !== null),
 	}
@@ -3029,42 +3151,52 @@ async function buildSovereigntyStructureSummaryFromSql(
 			and ${superionicIceDepletionExpression}::timestamptz <= ${lowFuelThresholdAt}
 		)
 	`
-	const [totalResult, lowFuelResult, vulnerableResult, invulnerableResult, unknownResult, hubBurnRateResult] =
-		await Promise.all([
-			rowsDb
-				.select({
-					total: sql<number>`count(*)::int`,
-				})
-				.from(sovereigntyStructures),
-			rowsDb
-				.select({
-					count: sql<number>`coalesce(sum(case when ${lowFuelExpression} then 1 else 0 end), 0)::int`,
-				})
-				.from(sovereigntyStructures),
-			rowsDb
-				.select({
-					count: sql<number>`coalesce(sum(case when ${vulnerableExpression} then 1 else 0 end), 0)::int`,
-				})
-				.from(sovereigntyStructures),
-			rowsDb
-				.select({
-					count: sql<number>`coalesce(sum(case when ${invulnerableExpression} then 1 else 0 end), 0)::int`,
-				})
-				.from(sovereigntyStructures),
-			rowsDb
-				.select({
-					count: sql<number>`coalesce(sum(case when ${vulnerableExpression} or ${invulnerableExpression} then 0 else 1 end), 0)::int`,
-				})
-				.from(sovereigntyStructures),
-			rowsDb
-				.select({
-					magmaticGasBurningPerHour: sql<string | null>`sum(case when ${magmaticGasQuantityExpression} > 0 and ${magmaticGasBurningPerHourExpression} > 0 then ${magmaticGasBurningPerHourExpression} else 0 end)::text`,
-					magmaticGasBurningSampleCount: sql<number>`coalesce(sum(case when ${magmaticGasQuantityExpression} > 0 and ${magmaticGasBurningPerHourExpression} > 0 then 1 else 0 end), 0)::int`,
-					superionicIceBurningPerHour: sql<string | null>`sum(case when ${superionicIceQuantityExpression} > 0 and ${superionicIceBurningPerHourExpression} > 0 then ${superionicIceBurningPerHourExpression} else 0 end)::text`,
-					superionicIceBurningSampleCount: sql<number>`coalesce(sum(case when ${superionicIceQuantityExpression} > 0 and ${superionicIceBurningPerHourExpression} > 0 then 1 else 0 end), 0)::int`,
-				})
-				.from(sovereigntyStructures),
-		])
+	const [
+		totalResult,
+		lowFuelResult,
+		vulnerableResult,
+		invulnerableResult,
+		unknownResult,
+		hubBurnRateResult,
+	] = await Promise.all([
+		rowsDb
+			.select({
+				total: sql<number>`count(*)::int`,
+			})
+			.from(sovereigntyStructures),
+		rowsDb
+			.select({
+				count: sql<number>`coalesce(sum(case when ${lowFuelExpression} then 1 else 0 end), 0)::int`,
+			})
+			.from(sovereigntyStructures),
+		rowsDb
+			.select({
+				count: sql<number>`coalesce(sum(case when ${vulnerableExpression} then 1 else 0 end), 0)::int`,
+			})
+			.from(sovereigntyStructures),
+		rowsDb
+			.select({
+				count: sql<number>`coalesce(sum(case when ${invulnerableExpression} then 1 else 0 end), 0)::int`,
+			})
+			.from(sovereigntyStructures),
+		rowsDb
+			.select({
+				count: sql<number>`coalesce(sum(case when ${vulnerableExpression} or ${invulnerableExpression} then 0 else 1 end), 0)::int`,
+			})
+			.from(sovereigntyStructures),
+		rowsDb
+			.select({
+				magmaticGasBurningPerHour: sql<
+					string | null
+				>`sum(case when ${magmaticGasQuantityExpression} > 0 and ${magmaticGasBurningPerHourExpression} > 0 then ${magmaticGasBurningPerHourExpression} else 0 end)::text`,
+				magmaticGasBurningSampleCount: sql<number>`coalesce(sum(case when ${magmaticGasQuantityExpression} > 0 and ${magmaticGasBurningPerHourExpression} > 0 then 1 else 0 end), 0)::int`,
+				superionicIceBurningPerHour: sql<
+					string | null
+				>`sum(case when ${superionicIceQuantityExpression} > 0 and ${superionicIceBurningPerHourExpression} > 0 then ${superionicIceBurningPerHourExpression} else 0 end)::text`,
+				superionicIceBurningSampleCount: sql<number>`coalesce(sum(case when ${superionicIceQuantityExpression} > 0 and ${superionicIceBurningPerHourExpression} > 0 then 1 else 0 end), 0)::int`,
+			})
+			.from(sovereigntyStructures),
+	])
 
 	return {
 		total: totalResult[0]?.total ?? 0,
@@ -3154,31 +3286,29 @@ async function loadSovereigntyPageItems(
 			controllerAllianceId: row.controllerAllianceId,
 			controllerAllianceName: row.controllerAllianceName,
 			reagentBayLastUpdated: row.reagentBayLastUpdated,
-			reagentBay:
-				row.reagentBay ?? {
-					lastUpdated: '',
-					reagents: [],
+			reagentBay: row.reagentBay ?? {
+				lastUpdated: '',
+				reagents: [],
+			},
+			resources: row.resources ?? {
+				power: {
+					allocated: 0,
+					available: 0,
 				},
-			resources:
-				row.resources ?? {
-					power: {
-						allocated: 0,
-						available: 0,
-					},
-					workforce: {
-						allocated: 0,
-						available: 0,
-					},
+				workforce: {
+					allocated: 0,
+					available: 0,
 				},
+			},
 			upgrades: row.upgrades ?? [],
 			vulnerabilityWindowStart: row.vulnerabilityWindowStart,
 			vulnerabilityWindowEnd: row.vulnerabilityWindowEnd,
-			workforceTransport:
-				row.workforceTransport ?? {
-					configuration: { mode: 'unknown', systems: [] },
-					state: { mode: 'unknown', systems: [] },
-				},
-			syncStatus: (row.syncStatus ?? 'warning') as typeof structureSovereigntyHubs.$inferSelect['syncStatus'],
+			workforceTransport: row.workforceTransport ?? {
+				configuration: { mode: 'unknown', systems: [] },
+				state: { mode: 'unknown', systems: [] },
+			},
+			syncStatus: (row.syncStatus ??
+				'warning') as (typeof structureSovereigntyHubs.$inferSelect)['syncStatus'],
 			syncFailureReason: row.syncFailureReason,
 			lastAttemptedSyncAt: row.lastAttemptedSyncAt,
 			sourceSyncAt: row.sourceSyncAt,
@@ -3384,19 +3514,21 @@ async function loadMoonDrillPageItems(
 			user.is_admin || canViewDetailsStructure(access, row.corporationId, structureTab)
 		const hasMoonDrillSnapshot = row.moonDrillStructureId !== null && row.moonId !== null
 
-			return {
-				...buildOperationalStructureListItem(row, canViewDetails),
-				name: row.structureName ?? row.structureId,
-				planetId: row.planetId ?? null,
-				planetName: row.planetName ?? null,
-				moonId: row.moonId ?? '',
-				moonName: row.moonName ?? null,
-				fuelBlockUnits: row.fuelBlockUnits,
-				magmaticGasUnits: row.magmaticGasUnits,
-				syncStatus: hasMoonDrillSnapshot ? getSnapshotSyncStatus(row.moonDrillLastSyncedAt) : 'warning',
-				syncFailureReason: hasMoonDrillSnapshot
-					? null
-					: 'Moon drill snapshot has not been ingested yet for this structure.',
+		return {
+			...buildOperationalStructureListItem(row, canViewDetails),
+			name: row.structureName ?? row.structureId,
+			planetId: row.planetId ?? null,
+			planetName: row.planetName ?? null,
+			moonId: row.moonId ?? '',
+			moonName: row.moonName ?? null,
+			fuelBlockUnits: row.fuelBlockUnits,
+			magmaticGasUnits: row.magmaticGasUnits,
+			syncStatus: hasMoonDrillSnapshot
+				? getSnapshotSyncStatus(row.moonDrillLastSyncedAt)
+				: 'warning',
+			syncFailureReason: hasMoonDrillSnapshot
+				? null
+				: 'Moon drill snapshot has not been ingested yet for this structure.',
 			lastSyncedAt: toIso(row.moonDrillLastSyncedAt ?? row.lastSyncedAt),
 			updatedAt: toIso(row.moonDrillUpdatedAt ?? row.updatedAt) ?? new Date().toISOString(),
 		}
@@ -3485,7 +3617,8 @@ async function loadMiningCitadelPageItems(
 				extractionStartTime: null,
 				chunkArrivalTime: null,
 				naturalDecayTime: null,
-				syncFailureReason: 'Mining extraction snapshot has not been ingested yet for this structure.',
+				syncFailureReason:
+					'Mining extraction snapshot has not been ingested yet for this structure.',
 				lastSyncedAt: toIso(row.lastSyncedAt),
 				updatedAt: toIso(row.updatedAt) ?? new Date().toISOString(),
 			}
@@ -3564,7 +3697,10 @@ async function buildOperationalStructureFilterOptions(
 				value: row.corporationId,
 				label: row.corporationName ?? row.corporationId,
 			}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		assignedGroups: assignedGroups
 			.map((row) => ({
 				value: row.assignedGroupId ?? '',
@@ -3582,19 +3718,28 @@ async function buildOperationalStructureFilterOptions(
 				value: row.systemId,
 				label: row.systemName ?? row.systemId,
 			}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		states: states
 			.map((row) => ({
 				value: row.state,
 				label: row.state,
 			}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		types: types
 			.map((row) => ({
 				value: row.typeId,
 				label: row.typeName ?? row.typeId,
 			}))
-			.filter((option, index, options) => options.findIndex((candidate) => candidate.value === option.value) === index),
+			.filter(
+				(option, index, options) =>
+					options.findIndex((candidate) => candidate.value === option.value) === index
+			),
 		alliances: [],
 		planets: [],
 		raidableStates: [],
@@ -3611,9 +3756,14 @@ function buildOperationalLowFuelWhere(
 	>,
 	structureSource: { fuelAmount: any; fuelExpires: any } = corporationStructures
 ) {
-	const lowFuelExpiresAt = new Date(Date.now() + moduleConfig.lowFuelTimeThresholdHours * HOURS_TO_MS)
+	const lowFuelExpiresAt = new Date(
+		Date.now() + moduleConfig.lowFuelTimeThresholdHours * HOURS_TO_MS
+	)
 	return or(
-		and(isNotNull(structureSource.fuelAmount), lte(structureSource.fuelAmount, moduleConfig.lowFuelAmountThreshold)),
+		and(
+			isNotNull(structureSource.fuelAmount),
+			lte(structureSource.fuelAmount, moduleConfig.lowFuelAmountThreshold)
+		),
 		and(
 			isNull(structureSource.fuelAmount),
 			isNotNull(structureSource.fuelExpires),
@@ -3632,44 +3782,46 @@ async function buildOperationalStructureSummary(
 	const reinforcedStates = [...STRUCTURE_REINFORCED_STATES]
 	const [totalResult, lowFuelResult, lowPowerResult, reinforcedResult, fuelBurnRateResult] =
 		await Promise.all([
-		rowsDb
-			.select({
-				total: sql<number>`count(*)::int`,
-			})
-			.from(operationalStructures),
-		rowsDb
-			.select({
-				count: sql<number>`count(*)::int`,
-			})
-			.from(operationalStructures)
-			.where(lowFuelWhere),
-		rowsDb
-			.select({
-				count: sql<number>`count(*)::int`,
-			})
-			.from(operationalStructures)
-			.where(
-				and(
-					eq(operationalStructures.lowPower, true),
-					or(
-						eq(operationalStructures.lowPowerAllowed, false),
-						isNull(operationalStructures.lowPowerAllowed)
+			rowsDb
+				.select({
+					total: sql<number>`count(*)::int`,
+				})
+				.from(operationalStructures),
+			rowsDb
+				.select({
+					count: sql<number>`count(*)::int`,
+				})
+				.from(operationalStructures)
+				.where(lowFuelWhere),
+			rowsDb
+				.select({
+					count: sql<number>`count(*)::int`,
+				})
+				.from(operationalStructures)
+				.where(
+					and(
+						eq(operationalStructures.lowPower, true),
+						or(
+							eq(operationalStructures.lowPowerAllowed, false),
+							isNull(operationalStructures.lowPowerAllowed)
+						)
 					)
-				)
-			),
-		rowsDb
-			.select({
-				count: sql<number>`count(*)::int`,
-			})
-			.from(operationalStructures)
-			.where(inArray(operationalStructures.state, reinforcedStates)),
-		rowsDb
-			.select({
-				estimatedFuelBurnRatePerHour: sql<string | null>`sum(${operationalStructures.fuelBurnRate})::text`,
-				fuelBurnRateSampleCount: sql<number>`count(${operationalStructures.fuelBurnRate})::int`,
-			})
-			.from(operationalStructures),
-	])
+				),
+			rowsDb
+				.select({
+					count: sql<number>`count(*)::int`,
+				})
+				.from(operationalStructures)
+				.where(inArray(operationalStructures.state, reinforcedStates)),
+			rowsDb
+				.select({
+					estimatedFuelBurnRatePerHour: sql<
+						string | null
+					>`sum(${operationalStructures.fuelBurnRate})::text`,
+					fuelBurnRateSampleCount: sql<number>`count(${operationalStructures.fuelBurnRate})::int`,
+				})
+				.from(operationalStructures),
+		])
 
 	return {
 		total: totalResult[0]?.total ?? 0,
@@ -3714,25 +3866,46 @@ function buildMoonStructureSortOrder(
 				sortExpression(source.structureId),
 			]
 		case 'name':
-			return [sortExpression(sql`coalesce(${source.structureName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.structureName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'corporation':
-			return [sortExpression(sql`coalesce(${source.corporationName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.corporationName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'region':
-			return [sortExpression(sql`coalesce(${source.regionName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.regionName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'planet':
-			return [sortExpression(sql`coalesce(${source.planetName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.planetName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'fuelBlocks':
 			return [sortExpression(source.fuelBlockUnits), sortExpression(source.structureId)]
 		case 'magmaticGas':
 			return [sortExpression(source.magmaticGasUnits), sortExpression(source.structureId)]
 		case 'system':
-			return [sortExpression(sql`coalesce(${source.systemName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.systemName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'type':
-			return [sortExpression(sql`coalesce(${source.typeName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.typeName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'state':
 			return [sortExpression(source.state), sortExpression(source.structureId)]
 		case 'group':
-			return [sortExpression(sql`coalesce(${source.assignedGroupId}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.assignedGroupId}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'syncStatus':
 			return [
 				sortExpression(
@@ -3745,12 +3918,27 @@ function buildMoonStructureSortOrder(
 	}
 }
 
-function buildMoonDrillStructuresCte(
-	db: DbClient<DbSchema>,
-	corpWhere: any,
-	planetId?: string
-) {
-	const operationalStructures = buildOperationalStructuresSelectQuery(db, corpWhere).as('operational_structures')
+function buildMoonDrillStructuresCte(db: DbClient<DbSchema>, corpWhere: any, planetId?: string) {
+	const operationalStructures = buildOperationalStructuresSelectQuery(db, corpWhere).as(
+		'operational_structures'
+	)
+	const activeSnapshotId = db
+		.select({ id: corporationStructureInventorySnapshots.id })
+		.from(corporationStructureInventorySnapshots)
+		.where(
+			and(
+				eq(
+					corporationStructureInventorySnapshots.corporationId,
+					corporationStructureInventory.corporationId
+				),
+				isNotNull(corporationStructureInventorySnapshots.activatedAt)
+			)
+		)
+		.orderBy(
+			desc(corporationStructureInventorySnapshots.activatedAt),
+			desc(corporationStructureInventorySnapshots.createdAt)
+		)
+		.limit(1)
 	const moonDrillInventoryAggregate = db.$with('moon_drill_inventory_aggregate').as(
 		db
 			.select({
@@ -3789,19 +3977,28 @@ function buildMoonDrillStructuresCte(
 					eq(corporationStructureInventory.structureId, operationalStructures.structureId)
 				)
 			)
-			.groupBy(corporationStructureInventory.corporationId, corporationStructureInventory.structureId)
+			.where(eq(corporationStructureInventory.snapshotId, activeSnapshotId))
+			.groupBy(
+				corporationStructureInventory.corporationId,
+				corporationStructureInventory.structureId
+			)
 	)
 	const conditions = [sql`true`]
 	if (planetId) {
 		conditions.push(eq(structureMoonGeographies.planetId, planetId))
 	}
 	return db.$with('moon_drill_structures').as(
-		db.with(operationalStructures, moonDrillInventoryAggregate)
+		db
+			.with(operationalStructures, moonDrillInventoryAggregate)
 			.select({
 				structureId: sql<string>`${operationalStructures.structureId}`.as('structureId'),
 				corporationId: sql<string>`${operationalStructures.corporationId}`.as('corporationId'),
-				corporationName: sql<string>`${operationalStructures.corporationName}`.as('corporationName'),
-				structureName: sql<string | null>`${operationalStructures.structureName}`.as('structureName'),
+				corporationName: sql<string>`${operationalStructures.corporationName}`.as(
+					'corporationName'
+				),
+				structureName: sql<string | null>`${operationalStructures.structureName}`.as(
+					'structureName'
+				),
 				typeId: sql<string>`${operationalStructures.typeId}`.as('typeId'),
 				typeName: sql<string | null>`${operationalStructures.typeName}`.as('typeName'),
 				systemId: sql<string>`${operationalStructures.systemId}`.as('systemId'),
@@ -3810,32 +4007,47 @@ function buildMoonDrillStructuresCte(
 				regionName: sql<string | null>`${operationalStructures.regionName}`.as('regionName'),
 				state: sql<string>`${operationalStructures.state}`.as('state'),
 				stateTimerEnd: sql<Date | null>`${operationalStructures.stateTimerEnd}`.as('stateTimerEnd'),
-				nextReinforceApply: sql<Date | null>`${operationalStructures.nextReinforceApply}`.as('nextReinforceApply'),
+				nextReinforceApply: sql<Date | null>`${operationalStructures.nextReinforceApply}`.as(
+					'nextReinforceApply'
+				),
 				unanchorsAt: sql<Date | null>`${operationalStructures.unanchorsAt}`.as('unanchorsAt'),
 				fuelExpires: sql<Date | null>`${operationalStructures.fuelExpires}`.as('fuelExpires'),
 				fuelAmount: sql<number | null>`${operationalStructures.fuelAmount}`.as('fuelAmount'),
 				fuelBurnRate: sql<string | null>`${operationalStructures.fuelBurnRate}`.as('fuelBurnRate'),
 				lowPower: sql<boolean>`${operationalStructures.lowPower}`.as('lowPower'),
 				hidden: sql<boolean | null>`${operationalStructures.hidden}`.as('hidden'),
-				lowPowerAllowed: sql<boolean | null>`${operationalStructures.lowPowerAllowed}`.as('lowPowerAllowed'),
-				assignedGroupId: sql<string | null>`${operationalStructures.assignedGroupId}`.as('assignedGroupId'),
+				lowPowerAllowed: sql<boolean | null>`${operationalStructures.lowPowerAllowed}`.as(
+					'lowPowerAllowed'
+				),
+				assignedGroupId: sql<string | null>`${operationalStructures.assignedGroupId}`.as(
+					'assignedGroupId'
+				),
 				syncStatus: sql<string>`${operationalStructures.syncStatus}`.as('syncStatus'),
-				syncFailureReason: sql<string | null>`${operationalStructures.syncFailureReason}`.as('syncFailureReason'),
+				syncFailureReason: sql<string | null>`${operationalStructures.syncFailureReason}`.as(
+					'syncFailureReason'
+				),
 				lastSyncedAt: sql<Date | null>`${operationalStructures.lastSyncedAt}`.as('lastSyncedAt'),
 				updatedAt: sql<Date>`${operationalStructures.updatedAt}`.as('updatedAt'),
 				fuelBlockUnits: sql<number>`coalesce(${moonDrillInventoryAggregate.fuelBlockUnits}, 0)`.as(
 					'fuelBlockUnits'
 				),
-				magmaticGasUnits: sql<number>`coalesce(${moonDrillInventoryAggregate.magmaticGasUnits}, 0)`.as(
-					'magmaticGasUnits'
+				magmaticGasUnits:
+					sql<number>`coalesce(${moonDrillInventoryAggregate.magmaticGasUnits}, 0)`.as(
+						'magmaticGasUnits'
+					),
+				moonDrillStructureId: sql<string | null>`${structureMoonDrills.structureId}`.as(
+					'moonDrillStructureId'
 				),
-				moonDrillStructureId: sql<string | null>`${structureMoonDrills.structureId}`.as('moonDrillStructureId'),
 				moonId: sql<string | null>`${structureMoonGeographies.moonId}`.as('moonId'),
 				moonName: sql<string | null>`${structureMoonGeographies.moonName}`.as('moonName'),
 				planetId: sql<string | null>`${structureMoonGeographies.planetId}`.as('planetId'),
 				planetName: sql<string | null>`${structureMoonGeographies.planetName}`.as('planetName'),
-				moonDrillLastSyncedAt: sql<Date | null>`${structureMoonDrills.lastSyncedAt}`.as('moonDrillLastSyncedAt'),
-				moonDrillUpdatedAt: sql<Date | null>`${structureMoonDrills.updatedAt}`.as('moonDrillUpdatedAt'),
+				moonDrillLastSyncedAt: sql<Date | null>`${structureMoonDrills.lastSyncedAt}`.as(
+					'moonDrillLastSyncedAt'
+				),
+				moonDrillUpdatedAt: sql<Date | null>`${structureMoonDrills.updatedAt}`.as(
+					'moonDrillUpdatedAt'
+				),
 			})
 			.from(operationalStructures)
 			.leftJoin(
@@ -3862,18 +4074,25 @@ function buildMiningCitadelStructuresCte(
 	corpWhere: any,
 	planetId?: string
 ) {
-	const operationalStructures = buildOperationalStructuresSelectQuery(db, corpWhere).as('operational_structures')
+	const operationalStructures = buildOperationalStructuresSelectQuery(db, corpWhere).as(
+		'operational_structures'
+	)
 	const conditions = [sql`true`]
 	if (planetId) {
 		conditions.push(eq(structureMoonGeographies.planetId, planetId))
 	}
 	return db.$with('mining_citadel_structures').as(
-		db.with(operationalStructures)
+		db
+			.with(operationalStructures)
 			.select({
 				structureId: sql<string>`${operationalStructures.structureId}`.as('structureId'),
 				corporationId: sql<string>`${operationalStructures.corporationId}`.as('corporationId'),
-				corporationName: sql<string>`${operationalStructures.corporationName}`.as('corporationName'),
-				structureName: sql<string | null>`${operationalStructures.structureName}`.as('structureName'),
+				corporationName: sql<string>`${operationalStructures.corporationName}`.as(
+					'corporationName'
+				),
+				structureName: sql<string | null>`${operationalStructures.structureName}`.as(
+					'structureName'
+				),
 				typeId: sql<string>`${operationalStructures.typeId}`.as('typeId'),
 				typeName: sql<string | null>`${operationalStructures.typeName}`.as('typeName'),
 				systemId: sql<string>`${operationalStructures.systemId}`.as('systemId'),
@@ -3882,29 +4101,50 @@ function buildMiningCitadelStructuresCte(
 				regionName: sql<string | null>`${operationalStructures.regionName}`.as('regionName'),
 				state: sql<string>`${operationalStructures.state}`.as('state'),
 				stateTimerEnd: sql<Date | null>`${operationalStructures.stateTimerEnd}`.as('stateTimerEnd'),
-				nextReinforceApply: sql<Date | null>`${operationalStructures.nextReinforceApply}`.as('nextReinforceApply'),
+				nextReinforceApply: sql<Date | null>`${operationalStructures.nextReinforceApply}`.as(
+					'nextReinforceApply'
+				),
 				unanchorsAt: sql<Date | null>`${operationalStructures.unanchorsAt}`.as('unanchorsAt'),
 				fuelExpires: sql<Date | null>`${operationalStructures.fuelExpires}`.as('fuelExpires'),
 				fuelAmount: sql<number | null>`${operationalStructures.fuelAmount}`.as('fuelAmount'),
 				fuelBurnRate: sql<string | null>`${operationalStructures.fuelBurnRate}`.as('fuelBurnRate'),
 				lowPower: sql<boolean>`${operationalStructures.lowPower}`.as('lowPower'),
 				hidden: sql<boolean | null>`${operationalStructures.hidden}`.as('hidden'),
-				lowPowerAllowed: sql<boolean | null>`${operationalStructures.lowPowerAllowed}`.as('lowPowerAllowed'),
-				assignedGroupId: sql<string | null>`${operationalStructures.assignedGroupId}`.as('assignedGroupId'),
+				lowPowerAllowed: sql<boolean | null>`${operationalStructures.lowPowerAllowed}`.as(
+					'lowPowerAllowed'
+				),
+				assignedGroupId: sql<string | null>`${operationalStructures.assignedGroupId}`.as(
+					'assignedGroupId'
+				),
 				syncStatus: sql<string>`${operationalStructures.syncStatus}`.as('syncStatus'),
-				syncFailureReason: sql<string | null>`${operationalStructures.syncFailureReason}`.as('syncFailureReason'),
+				syncFailureReason: sql<string | null>`${operationalStructures.syncFailureReason}`.as(
+					'syncFailureReason'
+				),
 				lastSyncedAt: sql<Date | null>`${operationalStructures.lastSyncedAt}`.as('lastSyncedAt'),
 				updatedAt: sql<Date>`${operationalStructures.updatedAt}`.as('updatedAt'),
-				miningExtractionStructureId: sql<string | null>`${structureMiningExtractions.structureId}`.as('miningExtractionStructureId'),
+				miningExtractionStructureId: sql<
+					string | null
+				>`${structureMiningExtractions.structureId}`.as('miningExtractionStructureId'),
 				moonId: sql<string | null>`${structureMoonGeographies.moonId}`.as('moonId'),
 				moonName: sql<string | null>`${structureMoonGeographies.moonName}`.as('moonName'),
 				planetId: sql<string | null>`${structureMoonGeographies.planetId}`.as('planetId'),
 				planetName: sql<string | null>`${structureMoonGeographies.planetName}`.as('planetName'),
-				miningExtractionLastSyncedAt: sql<Date | null>`${structureMiningExtractions.lastSyncedAt}`.as('miningExtractionLastSyncedAt'),
-				miningExtractionUpdatedAt: sql<Date | null>`${structureMiningExtractions.updatedAt}`.as('miningExtractionUpdatedAt'),
-				extractionStartTime: sql<Date | null>`${structureMiningExtractions.extractionStartTime}`.as('extractionStartTime'),
-				chunkArrivalTime: sql<Date | null>`${structureMiningExtractions.chunkArrivalTime}`.as('chunkArrivalTime'),
-				naturalDecayTime: sql<Date | null>`${structureMiningExtractions.naturalDecayTime}`.as('naturalDecayTime'),
+				miningExtractionLastSyncedAt:
+					sql<Date | null>`${structureMiningExtractions.lastSyncedAt}`.as(
+						'miningExtractionLastSyncedAt'
+					),
+				miningExtractionUpdatedAt: sql<Date | null>`${structureMiningExtractions.updatedAt}`.as(
+					'miningExtractionUpdatedAt'
+				),
+				extractionStartTime: sql<Date | null>`${structureMiningExtractions.extractionStartTime}`.as(
+					'extractionStartTime'
+				),
+				chunkArrivalTime: sql<Date | null>`${structureMiningExtractions.chunkArrivalTime}`.as(
+					'chunkArrivalTime'
+				),
+				naturalDecayTime: sql<Date | null>`${structureMiningExtractions.naturalDecayTime}`.as(
+					'naturalDecayTime'
+				),
 			})
 			.from(operationalStructures)
 			.leftJoin(
@@ -3952,19 +4192,37 @@ function buildOperationalSortOrder(
 				sortExpression(source.structureId),
 			]
 		case 'name':
-			return [sortExpression(sql`coalesce(${source.structureName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.structureName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'corporation':
-			return [sortExpression(sql`coalesce(${source.corporationName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.corporationName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'region':
-			return [sortExpression(sql`coalesce(${source.regionName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.regionName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'system':
-			return [sortExpression(sql`coalesce(${source.systemName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.systemName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'type':
-			return [sortExpression(sql`coalesce(${source.typeName}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.typeName}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'state':
 			return [sortExpression(source.state), sortExpression(source.structureId)]
 		case 'group':
-			return [sortExpression(sql`coalesce(${source.assignedGroupId}, '')`), sortExpression(source.structureId)]
+			return [
+				sortExpression(sql`coalesce(${source.assignedGroupId}, '')`),
+				sortExpression(source.structureId),
+			]
 		case 'syncStatus':
 			return [
 				sortExpression(
@@ -4091,28 +4349,22 @@ async function listOperationalStructures(
 		const [filterOptions, summary, pageItems] = await Promise.all([
 			buildOperationalStructureFilterOptions(db, operationalStructures),
 			buildOperationalStructureSummary(db, operationalStructures, moduleConfig),
-			loadOperationalStructurePageItems(
-				db,
-				user,
-				access,
-				query,
-				operationalStructures
-			),
+			loadOperationalStructurePageItems(db, user, access, query, operationalStructures),
 		])
 		const totalCount = summary.total
 		const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
 		const page = Math.min(requestedPage, totalPages)
 		const items =
 			page === requestedPage
-			? pageItems
-			: await loadOperationalStructurePageItems(
-					db,
-					user,
-					access,
-					query,
-					operationalStructures,
-					page
-				)
+				? pageItems
+				: await loadOperationalStructurePageItems(
+						db,
+						user,
+						access,
+						query,
+						operationalStructures,
+						page
+					)
 
 		return {
 			items: items as unknown as StructureListItem[],
@@ -4152,13 +4404,7 @@ async function listOperationalStructures(
 		const [filterOptions, summary, pageItems] = await Promise.all([
 			buildSkyhookStructureFilterOptionsFromSql(db, skyhookStructures),
 			buildSkyhookStructureSummaryFromSql(db, skyhookStructures),
-			loadSkyhookPageItems(
-				db,
-				user,
-				access,
-				skyhookQuery,
-				skyhookStructures
-			),
+			loadSkyhookPageItems(db, user, access, skyhookQuery, skyhookStructures),
 		])
 		const totalCount = summary.total
 		const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
@@ -4166,14 +4412,7 @@ async function listOperationalStructures(
 		const items =
 			page === requestedPage
 				? pageItems
-				: await loadSkyhookPageItems(
-						db,
-						user,
-						access,
-						skyhookQuery,
-						skyhookStructures,
-						page
-					)
+				: await loadSkyhookPageItems(db, user, access, skyhookQuery, skyhookStructures, page)
 
 		return {
 			items: items as unknown as StructureListItem[],
@@ -4289,11 +4528,12 @@ export async function listMoonDrillStructures(
 }
 
 function getSnapshotSyncStatus(lastSyncedAt: unknown): 'ok' | 'warning' | 'error' {
-	const parsed = lastSyncedAt instanceof Date
-		? lastSyncedAt
-		: typeof lastSyncedAt === 'string' || typeof lastSyncedAt === 'number'
-			? new Date(lastSyncedAt)
-			: null
+	const parsed =
+		lastSyncedAt instanceof Date
+			? lastSyncedAt
+			: typeof lastSyncedAt === 'string' || typeof lastSyncedAt === 'number'
+				? new Date(lastSyncedAt)
+				: null
 	if (!parsed || Number.isNaN(parsed.getTime())) {
 		return 'warning'
 	}
@@ -4359,9 +4599,10 @@ function buildSovereigntyListItem(input: {
 	} = buildStructureListItem(context)
 
 	const hubSummary = hubRow ? summarizeStructureSovereigntyHub(hubRow) : null
-	const explicitSyncFailure = hubRow?.syncStatus === 'error'
-		? (hubRow.syncFailureReason ?? 'Sovereignty hub sync failed.')
-		: null
+	const explicitSyncFailure =
+		hubRow?.syncStatus === 'error'
+			? (hubRow.syncFailureReason ?? 'Sovereignty hub sync failed.')
+			: null
 	const syncStatus = explicitSyncFailure
 		? 'error'
 		: hasHubSnapshot

--- a/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
+++ b/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
@@ -148,6 +148,9 @@ function makeDb() {
 	const corporationStructureInventory = {
 		findMany: vi.fn().mockResolvedValue([]),
 	}
+	const corporationStructureInventorySnapshots = {
+		findFirst: vi.fn().mockResolvedValue({ id: 'snapshot-1' }),
+	}
 	const structureFuelLog = {
 		findMany: vi.fn().mockResolvedValue([]),
 	}
@@ -525,6 +528,7 @@ function makeDb() {
 			structureModuleConfig,
 			structureConfigs,
 			managedCorporations,
+			corporationStructureInventorySnapshots,
 			corporationStructureInventory,
 			structureFuelLog,
 			structureSovereigntyHubs,

--- a/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
+++ b/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
@@ -1,5 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+	canEditStructure,
+	canViewDetailsStructure,
+	canViewSensitiveStructure,
+	computeStructureAccess,
+	getStructureAccessTarget,
+	getStructureDetail,
+	hasAnyStructureAccess,
+	hasStructureAccessForTab,
+} from '../../../services/structures.service'
+
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
 }))
@@ -12,17 +23,6 @@ vi.mock('@repo/hono-helpers', () => ({
 		warn: vi.fn(),
 	},
 }))
-
-import {
-	canEditStructure,
-	canViewDetailsStructure,
-	canViewSensitiveStructure,
-	computeStructureAccess,
-	getStructureAccessTarget,
-	getStructureDetail,
-	hasAnyStructureAccess,
-	hasStructureAccessForTab,
-} from '../../../services/structures.service'
 
 type FakeDb = {
 	query: {
@@ -65,12 +65,16 @@ type FakeDb = {
 		corporationStructureInventory: {
 			findMany: ReturnType<typeof vi.fn>
 		}
+		corporationStructureInventorySnapshots: {
+			findFirst: ReturnType<typeof vi.fn>
+		}
 	}
 }
 
-function makeDb(options: { structure?: Record<string, unknown>; skyhook?: Record<string, unknown> } = {}): FakeDb {
-	const structure =
-		options.structure ?? {
+function makeDb(
+	options: { structure?: Record<string, unknown>; skyhook?: Record<string, unknown> } = {}
+): FakeDb {
+	const structure = options.structure ?? {
 		structureId: 'structure-1',
 		corporationId: 'corp-1',
 		name: 'Structure One',
@@ -94,8 +98,7 @@ function makeDb(options: { structure?: Record<string, unknown>; skyhook?: Record
 		updatedAt: new Date('2026-01-01T00:00:00Z'),
 	}
 
-	const skyhook =
-		options.skyhook ?? {
+	const skyhook = options.skyhook ?? {
 		structureId: 'skyhook-1',
 		corporationId: 'corp-1',
 		name: 'Skyhook One',
@@ -188,6 +191,9 @@ function makeDb(options: { structure?: Record<string, unknown>; skyhook?: Record
 			},
 			corporationStructureInventory: {
 				findMany: vi.fn().mockResolvedValue([]),
+			},
+			corporationStructureInventorySnapshots: {
+				findFirst: vi.fn().mockResolvedValue({ id: 'snapshot-1' }),
 			},
 		},
 	} as unknown as FakeDb

--- a/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
@@ -9,9 +9,9 @@
 import { formatDistanceToNow } from 'date-fns'
 import { AlertCircle, ArrowLeft, Briefcase, Lock } from 'lucide-react'
 import { useState } from 'react'
-import toast from '@/lib/toast'
 import { Link, Navigate, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 
+import { Badge } from '@/components/ui/badge'
 import {
 	Breadcrumb,
 	BreadcrumbItem,
@@ -20,6 +20,7 @@ import {
 	BreadcrumbPage,
 	BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { LoadingSpinner } from '@/components/ui/loading'
@@ -30,23 +31,22 @@ import { useConfirmationDialog } from '@/hooks/useConfirmationDialog'
 import { useEntityNames } from '@/hooks/useEntityNames'
 import { useMessage } from '@/hooks/useMessage'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import toast from '@/lib/toast'
 
-import { useHrPermissionCheck } from '../../hr/hooks'
 import { useCanAccessCorporation } from '../../corporations/hooks'
+import { useHrPermissionCheck } from '../../hr/hooks'
 import { AccessDeniedCard } from '../components/access-denied-card'
 import { AddHRNoteDialog } from '../components/add-hr-note-dialog'
 import { ApplicationActionPanel } from '../components/application-action-panel'
+import { ApplicationCharacterStack } from '../components/application-character-stack'
 import { ApplicationHistoryPanel } from '../components/application-history-panel'
 import { ApplicationStaffNotesPanel } from '../components/application-staff-notes-panel'
 import { ApplicationStatusBadge } from '../components/application-status-badge'
 import { ApplicationTimeline } from '../components/application-timeline'
-import { ApplicationCharacterStack } from '../components/application-character-stack'
 import { CharacterIdentitySummary } from '../components/character-identity-summary'
 import { FulcrumPanel } from '../components/fulcrum-panel'
 import { HRNotesList } from '../components/hr-notes-list'
 import { MessagesPanel } from '../components/messages-panel'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { RecommendationList } from '../components/recommendation-list'
 import { OPEN_APPLICATION_STATUSES } from '../constants'
 import {
@@ -54,12 +54,13 @@ import {
 	useApplicationActivity,
 	useApplicationStaffNotes,
 	useDeleteHRNote,
-	useHRNotes,
 	useHRNote,
+	useHRNotes,
 	useHrUserCharacters,
 	useMessageCount,
 	useRecommendations,
 } from '../hooks'
+import { resolveApplicationActionRole } from '../utils/application-action-role'
 import { canViewFulcrumTab } from '../utils/fulcrum-access'
 import { FORBIDDEN_PRIVATE_DATA_MESSAGE } from '../utils/private-data'
 
@@ -81,11 +82,14 @@ export default function HrApplicationReview() {
 	const initialTab = searchParams.get('tab') || 'details'
 	const { user, isAuthenticated, isLoading: authLoading, permissions } = useAuth()
 	const isAuditor = permissions.some((permission) => permission.urn === 'urn:hr:auditor')
-	const { canAccess: hasCorporationAccess, isLoading: corporationAccessLoading, corporation: accessCorp } =
-		useCanAccessCorporation(corporationId ?? '')
+	const {
+		canAccess: hasCorporationAccess,
+		isLoading: corporationAccessLoading,
+		corporation: accessCorp,
+		userRole: accessUserRole,
+	} = useCanAccessCorporation(corporationId ?? '')
 	const isMemberCorporation = accessCorp?.isMemberCorporation === true
-	const canViewCorporationApplications =
-		user?.is_admin === true || isAuditor || isMemberCorporation
+	const canViewCorporationApplications = user?.is_admin === true || isAuditor || isMemberCorporation
 
 	// Dialog state for HR Notes
 	const [addNoteDialogOpen, setAddNoteDialogOpen] = useState(false)
@@ -97,7 +101,8 @@ export default function HrApplicationReview() {
 	const deleteHrNote = useDeleteHRNote()
 
 	// Check HR permission (userId derived from authenticated session)
-	const shouldCheckPermission = !!corporationId && canViewCorporationApplications && user?.is_admin !== true
+	const shouldCheckPermission =
+		!!corporationId && canViewCorporationApplications && user?.is_admin !== true
 	const { data: permission, isLoading: permissionLoading } = useHrPermissionCheck(
 		shouldCheckPermission ? { corporationId } : null
 	)
@@ -133,20 +138,25 @@ export default function HrApplicationReview() {
 		}
 	)
 	const globalUserNotesCount = globalUserNotes.length
-	const { data: hrCharacters = [] } = useHrUserCharacters(
-		application?.userId ?? '',
-		{
-			enabled: !!application?.userId && canViewCorporationApplications,
-		},
-	)
+	const { data: hrCharacters = [] } = useHrUserCharacters(application?.userId ?? '', {
+		enabled: !!application?.userId && canViewCorporationApplications,
+	})
 	const canViewApplicationPrivateData =
 		!!application &&
 		canViewCorporationApplications &&
-		(user?.is_admin === true || isAuditor || isMemberCorporation || OPEN_APPLICATION_STATUSES.includes(application.status))
+		(user?.is_admin === true ||
+			isAuditor ||
+			isMemberCorporation ||
+			OPEN_APPLICATION_STATUSES.includes(application.status))
 	const canShowFulcrumTab = canViewFulcrumTab({
 		applicationStatus: application?.status,
 		currentRole: permission?.currentRole,
 		isAdmin: user?.is_admin === true,
+	})
+	const applicationActionRole = resolveApplicationActionRole({
+		isSiteAdmin: user?.is_admin === true,
+		corporationRole: accessUserRole,
+		permissionRole: permission?.currentRole,
 	})
 
 	// Fetch selected HR note for edit/delete
@@ -159,9 +169,7 @@ export default function HrApplicationReview() {
 	})
 
 	// Fetch total SP for main character + alts
-	const allCharacterIds = application
-		? [application.characterId, ...altCharacterIds]
-		: []
+	const allCharacterIds = application ? [application.characterId, ...altCharacterIds] : []
 	const markCharacterNameCopied = async (characterId: string, characterName: string) => {
 		if (!characterName.trim()) return
 		try {
@@ -184,11 +192,15 @@ export default function HrApplicationReview() {
 		walletByCharacterId[allCharacterIds[i]] = null
 		metricsLoadingByCharacterId[allCharacterIds[i]] = false
 	}
-	const privateDataUnavailableMessage = !canViewApplicationPrivateData ? FORBIDDEN_PRIVATE_DATA_MESSAGE : null
+	const privateDataUnavailableMessage = !canViewApplicationPrivateData
+		? FORBIDDEN_PRIVATE_DATA_MESSAGE
+		: null
 	const hrCharacterTokenStateById = new Map(
 		hrCharacters.map((character) => [character.characterId, character.hasValidToken])
 	)
-	const hrCharacterById = new Map(hrCharacters.map((character) => [character.characterId, character]))
+	const hrCharacterById = new Map(
+		hrCharacters.map((character) => [character.characterId, character])
+	)
 	const esiStateByCharacterId: Record<string, boolean | null> = {}
 	for (const characterId of allCharacterIds) {
 		esiStateByCharacterId[characterId] = hrCharacterTokenStateById.get(characterId) ?? null
@@ -200,9 +212,7 @@ export default function HrApplicationReview() {
 	)
 
 	const applicationsPath = `/corporations/${corporationId}/applications`
-	const memberProfilePath = application
-		? `/hr/users/${application.userId}`
-		: null
+	const memberProfilePath = application ? `/hr/users/${application.userId}` : null
 	const memberProfileState = application
 		? {
 				source: 'applications' as const,
@@ -267,7 +277,12 @@ export default function HrApplicationReview() {
 	}
 
 	// Loading state
-	if (authLoading || corporationAccessLoading || (shouldCheckPermission && permissionLoading) || (canViewCorporationApplications && applicationLoading)) {
+	if (
+		authLoading ||
+		corporationAccessLoading ||
+		(shouldCheckPermission && permissionLoading) ||
+		(canViewCorporationApplications && applicationLoading)
+	) {
 		return (
 			<Container>
 				<div className="flex items-center justify-center min-h-[400px]">
@@ -279,7 +294,10 @@ export default function HrApplicationReview() {
 
 	// Access denied - no HR role
 	// Check permission - site admins always have access
-	if (!canViewCorporationApplications || (!permission?.hasPermission && !user?.is_admin && !isAuditor)) {
+	if (
+		!canViewCorporationApplications ||
+		(!permission?.hasPermission && !user?.is_admin && !isAuditor)
+	) {
 		return (
 			<Container>
 				<AccessDeniedCard
@@ -297,7 +315,11 @@ export default function HrApplicationReview() {
 			<Container>
 				<AccessDeniedCard
 					title="Failed to Load Application"
-					message={applicationError instanceof Error ? applicationError.message : 'An unexpected error occurred'}
+					message={
+						applicationError instanceof Error
+							? applicationError.message
+							: 'An unexpected error occurred'
+					}
 					backLabel="Back to Applications"
 					backHref={applicationsPath}
 				/>
@@ -317,9 +339,7 @@ export default function HrApplicationReview() {
 					</CardHeader>
 					<CardContent className="text-center">
 						<Button asChild variant="ghost">
-							<Link to={applicationsPath}>
-								Back to Applications
-							</Link>
+							<Link to={applicationsPath}>Back to Applications</Link>
 						</Button>
 					</CardContent>
 				</Card>
@@ -408,32 +428,32 @@ export default function HrApplicationReview() {
 
 						{/* Application Header Info */}
 						<div className="flex-1 min-w-0">
-			<h1 className="mb-1 flex flex-wrap items-center gap-2 text-2xl font-bold text-foreground">
-				{memberProfilePath && memberProfileState ? (
-					<Link
-						to={memberProfilePath}
-						state={memberProfileState}
-						className="truncate text-left transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
-					>
-						{application.characterName}
-					</Link>
-				) : (
-					<span className="min-w-0 truncate">{application.characterName}</span>
-				)}
-				{application.isFirstApplication !== undefined && (
-					<Badge
-						variant={application.isFirstApplication ? 'success' : 'default'}
-						className="h-5 shrink-0 px-1.5 text-[10px] font-semibold leading-none"
-					>
-						{application.isFirstApplication ? 'First' : 'Repeat'}
-					</Badge>
-				)}
-				{altCharacterIds.length > 0 && (
-					<span className="ml-2 text-lg font-normal text-muted-foreground">
-						(+{altCharacterIds.length} {altCharacterIds.length === 1 ? 'Alt' : 'Alts'})
-					</span>
-				)}
-			</h1>
+							<h1 className="mb-1 flex flex-wrap items-center gap-2 text-2xl font-bold text-foreground">
+								{memberProfilePath && memberProfileState ? (
+									<Link
+										to={memberProfilePath}
+										state={memberProfileState}
+										className="truncate text-left transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
+									>
+										{application.characterName}
+									</Link>
+								) : (
+									<span className="min-w-0 truncate">{application.characterName}</span>
+								)}
+								{application.isFirstApplication !== undefined && (
+									<Badge
+										variant={application.isFirstApplication ? 'success' : 'default'}
+										className="h-5 shrink-0 px-1.5 text-[10px] font-semibold leading-none"
+									>
+										{application.isFirstApplication ? 'First' : 'Repeat'}
+									</Badge>
+								)}
+								{altCharacterIds.length > 0 && (
+									<span className="ml-2 text-lg font-normal text-muted-foreground">
+										(+{altCharacterIds.length} {altCharacterIds.length === 1 ? 'Alt' : 'Alts'})
+									</span>
+								)}
+							</h1>
 							{application.corporationName && (
 								<p className="text-lg text-muted-foreground mb-3">
 									Applied to: <span className="font-medium">{application.corporationName}</span>
@@ -460,50 +480,32 @@ export default function HrApplicationReview() {
 			{/* Tabbed Content */}
 			<Tabs defaultValue={initialTab} className="space-y-6">
 				<TabsList className="w-full flex-wrap gap-2 sm:w-auto sm:flex-nowrap">
-					<TabsTrigger
-						value="details"
-						className={reviewTabTriggerClassName}
-					>
+					<TabsTrigger value="details" className={reviewTabTriggerClassName}>
 						Details
 					</TabsTrigger>
-					<TabsTrigger
-						value="alts"
-						className={reviewTabTriggerClassName}
-					>
+					<TabsTrigger value="alts" className={reviewTabTriggerClassName}>
 						Characters
 						{altCharacterIds.length > 0 && (
 							<span className="ml-1.5 text-xs opacity-70">({altCharacterIds.length})</span>
 						)}
 					</TabsTrigger>
-					<TabsTrigger
-						value="recommendations"
-						className={reviewTabTriggerClassName}
-					>
+					<TabsTrigger value="recommendations" className={reviewTabTriggerClassName}>
 						Recommendations
 						{recommendations && recommendations.length > 0 && (
 							<span className="ml-1.5 text-xs opacity-70">({recommendations.length})</span>
 						)}
 					</TabsTrigger>
-					<TabsTrigger
-						value="history"
-						className={reviewTabTriggerClassName}
-					>
+					<TabsTrigger value="history" className={reviewTabTriggerClassName}>
 						History
 					</TabsTrigger>
-					<TabsTrigger
-						value="messages"
-						className={reviewTabTriggerClassName}
-					>
+					<TabsTrigger value="messages" className={reviewTabTriggerClassName}>
 						Messages
 						{messageCount > 0 && (
 							<span className="ml-1.5 text-xs opacity-70">({messageCount})</span>
 						)}
 					</TabsTrigger>
 					{(user?.is_admin || permission?.hasPermission) && (
-						<TabsTrigger
-							value="staff-notes"
-							className={reviewTabTriggerClassName}
-						>
+						<TabsTrigger value="staff-notes" className={reviewTabTriggerClassName}>
 							Application Notes
 							{staffNotesCount > 0 && (
 								<span className="ml-1.5 text-xs opacity-70">({staffNotesCount})</span>
@@ -511,25 +513,16 @@ export default function HrApplicationReview() {
 						</TabsTrigger>
 					)}
 					{(user?.is_admin || permission?.hasPermission) && (
-						<TabsTrigger
-							value="global-notes"
-							className={reviewTabTriggerClassName}
-						>
+						<TabsTrigger value="global-notes" className={reviewTabTriggerClassName}>
 							Account Notes
 							<span className="ml-1.5 text-xs opacity-70">({globalUserNotesCount})</span>
 						</TabsTrigger>
 					)}
-					<TabsTrigger
-						value="prior-apps"
-						className={reviewTabTriggerClassName}
-					>
+					<TabsTrigger value="prior-apps" className={reviewTabTriggerClassName}>
 						Prior Apps
 					</TabsTrigger>
 					{canShowFulcrumTab && (
-						<TabsTrigger
-							value="fulcrum"
-							className={reviewTabTriggerClassName}
-						>
+						<TabsTrigger value="fulcrum" className={reviewTabTriggerClassName}>
 							Fulcrum
 						</TabsTrigger>
 					)}
@@ -554,8 +547,16 @@ export default function HrApplicationReview() {
 
 					{/* Review Information (shown for under_review, accepted, rejected) */}
 					{application.reviewedAt &&
-						(application.status === 'under_review' || application.status === 'accepted' || application.status === 'rejected') && (
-							<Card className={application.status === 'under_review' ? 'border-primary/30 bg-primary/5' : undefined}>
+						(application.status === 'under_review' ||
+							application.status === 'accepted' ||
+							application.status === 'rejected') && (
+							<Card
+								className={
+									application.status === 'under_review'
+										? 'border-primary/30 bg-primary/5'
+										: undefined
+								}
+							>
 								<CardHeader>
 									<CardTitle>Review Information</CardTitle>
 									<CardDescription>Details about the application review</CardDescription>
@@ -592,7 +593,7 @@ export default function HrApplicationReview() {
 					{/* HR Action Panel */}
 					<ApplicationActionPanel
 						application={application}
-						userRole={permission?.currentRole || null}
+						userRole={applicationActionRole}
 						onStatusChange={() => {
 							// Status change is handled by React Query cache invalidation
 							// No need to manually refetch
@@ -619,26 +620,28 @@ export default function HrApplicationReview() {
 					<Card>
 						<CardHeader>
 							<CardTitle>Main Character</CardTitle>
-							<CardDescription>
-								The primary character for this application
-							</CardDescription>
+							<CardDescription>The primary character for this application</CardDescription>
 						</CardHeader>
 						<CardContent>
 							<div className="card-gradient rounded-md border border-border/50 bg-card p-3 shadow-elevated">
-						<CharacterIdentitySummary
-							characterId={application.characterId}
-							characterName={application.characterName}
-							hasValidToken={esiStateByCharacterId[application.characterId]}
-							corporationId={hrCharacterById.get(application.characterId)?.corporationId ?? null}
-							corporationName={hrCharacterById.get(application.characterId)?.corporationName ?? null}
-							allianceId={hrCharacterById.get(application.characterId)?.allianceId ?? null}
-							allianceName={hrCharacterById.get(application.characterId)?.allianceName ?? null}
-							skillPoints={spByCharacterId[application.characterId]}
-							walletBalance={walletByCharacterId[application.characterId]}
-							isMetricsLoading={metricsLoadingByCharacterId[application.characterId]}
-							enableCopyName
-							isNameCopied={copiedCharacterIds.has(application.characterId)}
-							onCopyName={() =>
+								<CharacterIdentitySummary
+									characterId={application.characterId}
+									characterName={application.characterName}
+									hasValidToken={esiStateByCharacterId[application.characterId]}
+									corporationId={
+										hrCharacterById.get(application.characterId)?.corporationId ?? null
+									}
+									corporationName={
+										hrCharacterById.get(application.characterId)?.corporationName ?? null
+									}
+									allianceId={hrCharacterById.get(application.characterId)?.allianceId ?? null}
+									allianceName={hrCharacterById.get(application.characterId)?.allianceName ?? null}
+									skillPoints={spByCharacterId[application.characterId]}
+									walletBalance={walletByCharacterId[application.characterId]}
+									isMetricsLoading={metricsLoadingByCharacterId[application.characterId]}
+									enableCopyName
+									isNameCopied={copiedCharacterIds.has(application.characterId)}
+									onCopyName={() =>
 										void markCharacterNameCopied(application.characterId, application.characterName)
 									}
 								/>
@@ -662,28 +665,30 @@ export default function HrApplicationReview() {
 											key={charId}
 											className="card-gradient rounded-md border border-border/50 bg-card p-3 shadow-elevated"
 										>
-						<CharacterIdentitySummary
-							characterId={charId}
-							characterName={altCharacterNames[charId] ?? charId}
-							hasValidToken={esiStateByCharacterId[charId]}
-							corporationId={hrCharacterById.get(charId)?.corporationId ?? null}
-							corporationName={hrCharacterById.get(charId)?.corporationName ?? null}
-							allianceId={hrCharacterById.get(charId)?.allianceId ?? null}
-							allianceName={hrCharacterById.get(charId)?.allianceName ?? null}
-							skillPoints={spByCharacterId[charId]}
-							walletBalance={walletByCharacterId[charId]}
-							isMetricsLoading={metricsLoadingByCharacterId[charId]}
-							enableCopyName
-							isNameCopied={copiedCharacterIds.has(charId)}
-							onCopyName={() =>
-								void markCharacterNameCopied(charId, altCharacterNames[charId] ?? charId)
-							}
-						/>
+											<CharacterIdentitySummary
+												characterId={charId}
+												characterName={altCharacterNames[charId] ?? charId}
+												hasValidToken={esiStateByCharacterId[charId]}
+												corporationId={hrCharacterById.get(charId)?.corporationId ?? null}
+												corporationName={hrCharacterById.get(charId)?.corporationName ?? null}
+												allianceId={hrCharacterById.get(charId)?.allianceId ?? null}
+												allianceName={hrCharacterById.get(charId)?.allianceName ?? null}
+												skillPoints={spByCharacterId[charId]}
+												walletBalance={walletByCharacterId[charId]}
+												isMetricsLoading={metricsLoadingByCharacterId[charId]}
+												enableCopyName
+												isNameCopied={copiedCharacterIds.has(charId)}
+												onCopyName={() =>
+													void markCharacterNameCopied(charId, altCharacterNames[charId] ?? charId)
+												}
+											/>
 										</div>
 									))}
 								</div>
 							) : (
-								<p className="text-sm text-muted-foreground">No alt characters were included with this application.</p>
+								<p className="text-sm text-muted-foreground">
+									No alt characters were included with this application.
+								</p>
 							)}
 						</CardContent>
 					</Card>
@@ -702,7 +707,7 @@ export default function HrApplicationReview() {
 							<RecommendationList
 								applicationId={applicationId!}
 								currentUserId={user?.id}
-							// HR cannot add recommendations, only view them
+								// HR cannot add recommendations, only view them
 							/>
 						</CardContent>
 					</Card>
@@ -785,7 +790,8 @@ export default function HrApplicationReview() {
 									<CardTitle>Account Notes</CardTitle>
 								</div>
 								<CardDescription>
-									Private internal notes about this user across all applications. Only visible to HR staff.
+									Private internal notes about this user across all applications. Only visible to HR
+									staff.
 								</CardDescription>
 							</CardHeader>
 							<CardContent>
@@ -808,7 +814,8 @@ export default function HrApplicationReview() {
 						<CardHeader>
 							<CardTitle>Prior Applications</CardTitle>
 							<CardDescription>
-								Applications by this character (across all accounts) and other characters on this account
+								Applications by this character (across all accounts) and other characters on this
+								account
 							</CardDescription>
 						</CardHeader>
 						<CardContent>

--- a/apps/ui/src/client/features/applications/utils/application-action-role.ts
+++ b/apps/ui/src/client/features/applications/utils/application-action-role.ts
@@ -1,0 +1,33 @@
+import type { HrRoleType } from '../../hr/api'
+
+type CorporationAccessRole =
+	| 'CEO'
+	| 'Director'
+	| 'admin'
+	| 'hr_admin'
+	| 'hr_reviewer'
+	| 'hr_viewer'
+	| null
+
+interface ApplicationActionRoleInput {
+	isSiteAdmin: boolean
+	corporationRole: CorporationAccessRole | undefined
+	permissionRole: HrRoleType | null | undefined
+}
+
+/** Resolve the role used by the application action panel. */
+export function resolveApplicationActionRole({
+	isSiteAdmin,
+	corporationRole,
+	permissionRole,
+}: ApplicationActionRoleInput): HrRoleType | null {
+	if (isSiteAdmin || corporationRole === 'admin') return 'hr_admin'
+	return (
+		permissionRole ??
+		(corporationRole === 'hr_admin' ||
+		corporationRole === 'hr_reviewer' ||
+		corporationRole === 'hr_viewer'
+			? corporationRole
+			: null)
+	)
+}

--- a/apps/ui/src/client/features/corporations/hooks.ts
+++ b/apps/ui/src/client/features/corporations/hooks.ts
@@ -7,16 +7,18 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo } from 'react'
 
+import { useAuth } from '@/hooks/useAuth'
+
 import { myCorporationsApi } from './api'
 
 import type {
-	CorporationMemberAccountResponse,
 	CorporationAccessResult,
+	CorporationMemberAccountResponse,
 	CorporationMembersQuery,
 	CorporationMembersResponse,
+	CorporationScopedAccessResult,
 	CorporationUserSearchResult,
 	MyCorporation,
-	CorporationScopedAccessResult,
 } from './api'
 
 // ============================================================================
@@ -49,11 +51,15 @@ export const corporationKeys = {
  * This is optimized for speed and should be used in the sidebar
  */
 export function useHasCorporationAccess() {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
 	return useQuery({
-		queryKey: ['my-corporations', 'has-access'],
+		queryKey: ['my-corporations', 'has-access', userId],
 		queryFn: () => myCorporationsApi.hasAccess(),
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		gcTime: 1000 * 60 * 10, // 10 minutes
+		enabled: userId !== null,
 	})
 }
 
@@ -86,11 +92,15 @@ export function formatCorporationRoleLabel(
  * This returns the complete list of accessible corporations
  */
 export function useCorporationAccess() {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
 	return useQuery<CorporationAccessResult>({
-		queryKey: corporationKeys.access(),
+		queryKey: [...corporationKeys.access(), userId],
 		queryFn: () => myCorporationsApi.checkAccess(),
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		gcTime: 1000 * 60 * 10, // 10 minutes (formerly cacheTime)
+		enabled: userId !== null,
 	})
 }
 
@@ -98,11 +108,15 @@ export function useCorporationAccess() {
  * Hook to fetch user's corporations with leadership roles
  */
 export function useMyCorporations() {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
 	return useQuery<MyCorporation[]>({
-		queryKey: corporationKeys.list(),
+		queryKey: [...corporationKeys.list(), userId],
 		queryFn: () => myCorporationsApi.getMyCorporations(),
 		staleTime: 1000 * 60 * 2, // 2 minutes
 		gcTime: 1000 * 60 * 5, // 5 minutes
+		enabled: userId !== null,
 	})
 }
 
@@ -286,14 +300,19 @@ export function useCorporationMemberStats(corporationId: string) {
  * Hook to check access for a specific corporation.
  */
 export function useCanAccessCorporation(corporationId: string) {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
 	const {
 		data: access,
 		isLoading,
 		isFetching,
 	} = useQuery<CorporationScopedAccessResult>({
-		queryKey: corporationKeys.accessForCorporation(corporationId),
+		// The API derives the caller from the session, so access results must be
+		// isolated per authenticated user in the client cache.
+		queryKey: [...corporationKeys.accessForCorporation(corporationId), userId],
 		queryFn: () => myCorporationsApi.getCorporationAccess(corporationId),
-		enabled: Boolean(corporationId),
+		enabled: Boolean(corporationId) && userId !== null,
 		staleTime: 1000 * 60 * 5,
 		gcTime: 1000 * 60 * 10,
 		meta: {

--- a/apps/ui/src/client/features/hr/hooks.ts
+++ b/apps/ui/src/client/features/hr/hooks.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
+import { useAuth } from '@/hooks/useAuth'
+
 import { hrApi } from './api'
 
 import type {
@@ -40,13 +42,20 @@ export function useHrRoles(corporationId: string, options?: { enabled?: boolean 
  * @param request - Permission check request (userId derived from session)
  */
 export function useHrPermissionCheck(request: CheckHrPermissionRequest | null) {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
 	return useQuery({
-		queryKey: request ? hrKeys.permission(request.corporationId) : ['hr', 'permission', 'null'],
+		// The API derives the user from the session, so the session user and role
+		// requirement must be part of the client cache identity as well.
+		queryKey: request
+			? [...hrKeys.permission(request.corporationId), userId, request.requiredRole ?? null]
+			: ['hr', 'permission', 'null'],
 		queryFn: () => {
 			if (!request) throw new Error('No request provided')
 			return hrApi.checkHrPermission(request)
 		},
-		enabled: !!request,
+		enabled: !!request && userId !== null,
 		staleTime: 10 * 60 * 1000, // 10 minutes (HR roles change infrequently)
 	})
 }
@@ -55,11 +64,14 @@ export function useHrPermissionCheck(request: CheckHrPermissionRequest | null) {
  * Hook to list corporations where current user has HR access
  */
 export function useHrAccessibleCorporations(options?: { enabled?: boolean }) {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
 	return useQuery<HrAccessibleCorporation[]>({
-		queryKey: hrKeys.corporations(),
+		queryKey: [...hrKeys.corporations(), userId],
 		queryFn: () => hrApi.listAccessibleCorporations(),
 		staleTime: 5 * 60 * 1000,
-		enabled: options?.enabled ?? true,
+		enabled: (options?.enabled ?? true) && userId !== null,
 	})
 }
 

--- a/apps/ui/src/test/unit/features/applications/application-action-role.unit.test.ts
+++ b/apps/ui/src/test/unit/features/applications/application-action-role.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveApplicationActionRole } from '../../../../client/features/applications/utils/application-action-role'
+
+describe('resolveApplicationActionRole', () => {
+	it('gives site admins HR admin actions without a permission request result', () => {
+		expect(
+			resolveApplicationActionRole({
+				isSiteAdmin: true,
+				corporationRole: 'admin',
+				permissionRole: null,
+			})
+		).toBe('hr_admin')
+	})
+
+	it('uses the corporation access role when the permission result is unavailable', () => {
+		expect(
+			resolveApplicationActionRole({
+				isSiteAdmin: false,
+				corporationRole: 'hr_reviewer',
+				permissionRole: null,
+			})
+		).toBe('hr_reviewer')
+	})
+
+	it('preserves the permission result for regular HR roles', () => {
+		expect(
+			resolveApplicationActionRole({
+				isSiteAdmin: false,
+				corporationRole: 'CEO',
+				permissionRole: 'hr_admin',
+			})
+		).toBe('hr_admin')
+	})
+
+	it('does not grant actions to leadership without an HR role', () => {
+		expect(
+			resolveApplicationActionRole({
+				isSiteAdmin: false,
+				corporationRole: 'Director',
+				permissionRole: null,
+			})
+		).toBeNull()
+	})
+})

--- a/packages/db-utils/src/client.ts
+++ b/packages/db-utils/src/client.ts
@@ -13,9 +13,10 @@ import type { NeonDatabase } from 'drizzle-orm/neon-serverless'
  */
 export function createDbClient<TSchema extends Record<string, unknown>>(
 	databaseUrl: string,
-	schema: TSchema
+	schema: TSchema,
+	options?: { fetchOptions?: Record<string, unknown> }
 ): NeonHttpDatabase<TSchema> {
-	const sql = neon(databaseUrl)
+	const sql = neon(databaseUrl, options)
 	return drizzle(sql, { schema })
 }
 
@@ -24,8 +25,11 @@ export function createDbClient<TSchema extends Record<string, unknown>>(
  * @param databaseUrl - The Neon database connection URL
  * @returns A configured Drizzle database instance
  */
-export function createDbClientRaw(databaseUrl: string) {
-	const sql = neon(databaseUrl)
+export function createDbClientRaw(
+	databaseUrl: string,
+	options?: { fetchOptions?: Record<string, unknown> }
+) {
+	const sql = neon(databaseUrl, options)
 	return drizzle(sql)
 }
 

--- a/packages/eve-corporation-data-db-schema/src/index.ts
+++ b/packages/eve-corporation-data-db-schema/src/index.ts
@@ -1,5 +1,16 @@
-import { index, unique } from 'drizzle-orm/pg-core'
-import { boolean, integer, jsonb, numeric, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import {
+	boolean,
+	foreignKey,
+	index,
+	integer,
+	jsonb,
+	numeric,
+	pgTable,
+	text,
+	timestamp,
+	unique,
+	uuid,
+} from 'drizzle-orm/pg-core'
 
 import { managedCorporations } from '@repo/core-db-schema'
 
@@ -7,9 +18,7 @@ export const corporationStructures = pgTable(
 	'corporation_structures',
 	{
 		id: uuid('id').defaultRandom().primaryKey(),
-		corporationId: text('corporation_id')
-			.notNull()
-			.references(() => managedCorporations.corporationId),
+		corporationId: text('corporation_id').notNull(),
 		structureId: text('structure_id').notNull(),
 		name: text('name'),
 		typeId: text('type_id').notNull(),
@@ -34,7 +43,9 @@ export const corporationStructures = pgTable(
 		stateTimerStart: timestamp('state_timer_start', { withTimezone: true }),
 		unanchorsAt: timestamp('unanchors_at', { withTimezone: true }),
 		lowPower: boolean('low_power').notNull().default(false),
-		syncStatus: text('sync_status', { enum: ['ok', 'warning', 'error'] }).notNull().default('ok'),
+		syncStatus: text('sync_status', { enum: ['ok', 'warning', 'error'] })
+			.notNull()
+			.default('ok'),
 		syncFailureReason: text('sync_failure_reason'),
 		lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }),
 		services: jsonb('services').$type<
@@ -48,6 +59,30 @@ export const corporationStructures = pgTable(
 	(table) => [unique().on(table.structureId)]
 )
 
+export const corporationStructureInventorySnapshots = pgTable(
+	'corporation_structure_inventory_snapshots',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		corporationId: text('corporation_id')
+			.notNull()
+			.references(() => managedCorporations.corporationId),
+		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+		activatedAt: timestamp('activated_at', { withTimezone: true }),
+	},
+	(table) => [
+		foreignKey({
+			columns: [table.corporationId],
+			foreignColumns: [managedCorporations.corporationId],
+			name: 'corp_inv_snapshots_corp_fk',
+		}),
+		index('corporation_structure_inventory_snapshots_corp_activated_idx').on(
+			table.corporationId,
+			table.activatedAt,
+			table.createdAt
+		),
+	]
+)
+
 export const corporationStructureInventory = pgTable(
 	'corporation_structure_inventory',
 	{
@@ -55,6 +90,7 @@ export const corporationStructureInventory = pgTable(
 		corporationId: text('corporation_id')
 			.notNull()
 			.references(() => managedCorporations.corporationId),
+		snapshotId: uuid('snapshot_id').notNull(),
 		structureId: text('structure_id')
 			.notNull()
 			.references(() => corporationStructures.structureId, { onDelete: 'cascade' }),
@@ -67,8 +103,18 @@ export const corporationStructureInventory = pgTable(
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
 	(table) => [
-		unique().on(table.corporationId, table.itemId),
+		foreignKey({
+			columns: [table.snapshotId],
+			foreignColumns: [corporationStructureInventorySnapshots.id],
+			name: 'corp_inv_snapshot_fk',
+		}).onDelete('cascade'),
+		unique('corp_inv_snapshot_item_uniq').on(table.corporationId, table.snapshotId, table.itemId),
 		index('corporation_structure_inventory_corp_structure_idx').on(
+			table.corporationId,
+			table.structureId
+		),
+		index('corporation_structure_inventory_snapshot_structure_idx').on(
+			table.snapshotId,
 			table.corporationId,
 			table.structureId
 		),
@@ -100,6 +146,7 @@ export const structureFuelLog = pgTable(
 
 export const schema = {
 	corporationStructures,
+	corporationStructureInventorySnapshots,
 	corporationStructureInventory,
 	structureFuelLog,
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
A grab-bag of post-maintenance bug fixes across bills, core, EVE corporation data, EVE token store, structures, and the UI. Most changes address correctness issues found after the recent maintenance pass (durable-object query timeouts, cron overloading, stale/racy data, cache-key leakage) rather than adding new features.

## Changes
- **Bills workflow**: give the bills DB client a configurable query timeout (`AbortSignal.timeout`) so a stalled Neon request can't outlive its Workflow step; consolidate the payment-status-check workflow's steps (`reconcile-payment-data`, `finalize-payment-state`, `sync-bill-effects`) so retrying the timestamp step no longer re-runs (and loses) the payment/overdue transition results; dedupe new-payment lookups directly in SQL (`NOT EXISTS` + capped batch) instead of a per-row existence check; drop redundant `handle-success`/`handle-failure` steps from the schedule-executor workflow.
- **Core worker**: split the single overloaded cron trigger (previously firing four unrelated jobs on one schedule) into independent cron entries for Discord refresh, tempop expiry, market reconciliation, and export cleanup, each on its own cadence.
- **EVE corporation data**: rework structure inventory storage to use immutable, activated "snapshots" (new `corporation_structure_inventory_snapshots` table/migrations) instead of delete-then-insert in place, so readers never see a partially-rebuilt/empty inventory; paginate the asset scan used to rebuild inventory instead of loading everything at once; clean up stale snapshots after activation; bump the background refresh cron/drain limit from 5 min/20 to 10 min/30.
- **EVE token store**: fix ESI cache invalidation to avoid SQLite `LIKE` wildcard queries (which SQLite can reject as too complex) in favor of `substr` prefix comparisons; downgrade expected "skipping refresh" cooldown/retry logs from `warn` to `info`.
- **Structures**: scope structure inventory reads to the corporation's currently-active snapshot, matching the new snapshot model.
- **UI**: fix HR application action permissions so site admins and corporation admins/leadership get proper action-panel access even without an explicit HR permission record (`resolveApplicationActionRole`); fix React Query cache-key collisions in corporation-access and HR hooks by including the current user id in the query key (and gating on a loaded user), preventing stale access data from leaking across a user switch.
- Db-utils' `createDbClient`/`createDbClientRaw` now accept an optional `fetchOptions` passed through to `neon()`, backing the new per-call query timeout.
- Broad Prettier reformatting (line wrapping, import ordering) across touched files with no functional change.

## Testing
- Updated/added unit tests for the bill payment-status-check workflow (step consolidation and retry behavior), background refresh scheduling (new cron cadence/drain limit), structures inventory snapshot lookups, and the new `resolveApplicationActionRole` helper.
<!-- claude:end -->