### PR TITLE
fix workflow issues with timeouts and harden director health

### DIFF
--- a/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
+++ b/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
@@ -13,6 +13,14 @@ vi.mock('@repo/do-utils', () => ({
 
 const getStubMock = vi.mocked(getStub)
 
+function makeRpcResult<T extends object>(
+	value: T
+): { value: T; dispose: ReturnType<typeof vi.fn> } {
+	const dispose = vi.fn()
+	Object.defineProperty(value, Symbol.dispose, { value: dispose })
+	return { value, dispose }
+}
+
 function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 	return {
 		id: 'user-1',
@@ -121,28 +129,32 @@ describe('users corporation access', () => {
 			},
 		}
 		hrStub = {
-			getUserHrCorporations: vi.fn().mockResolvedValue(['1001', '2001', '3001']),
-			getUserRoles: vi.fn().mockResolvedValue([
-				{
-					id: 'role-1',
-					corporationId: '1001',
-					role: 'hr_viewer',
-					isActive: true,
-				},
-				{
-					id: 'role-2',
-					corporationId: '2001',
-					role: 'hr_admin',
-					isActive: true,
-				},
-			]),
+			getUserHrCorporations: vi
+				.fn()
+				.mockResolvedValue(makeRpcResult(['1001', '2001', '3001']).value),
+			getUserRoles: vi.fn().mockResolvedValue(
+				makeRpcResult([
+					{
+						id: 'role-1',
+						corporationId: '1001',
+						role: 'hr_viewer',
+						isActive: true,
+					},
+					{
+						id: 'role-2',
+						corporationId: '2001',
+						role: 'hr_admin',
+						isActive: true,
+					},
+				]).value
+			),
 		}
 		charStub = {
 			getCharacterInfo: vi.fn(),
 		}
 		corpStub = {
-			getCorporationInfo: vi.fn().mockResolvedValue({ ceoId: '9999' } as any),
-			getDirectors: vi.fn().mockResolvedValue([]),
+			getCorporationInfo: vi.fn().mockResolvedValue(makeRpcResult({ ceoId: '9999' }).value as any),
+			getDirectors: vi.fn().mockResolvedValue(makeRpcResult([]).value),
 			getMembers: vi.fn(),
 		}
 
@@ -184,12 +196,14 @@ describe('users corporation access', () => {
 				{ characterId: '2002', userId: 'user-a', status: 'active', hasValidToken: true },
 				{ characterId: '2003', userId: 'user-b', status: 'active', hasValidToken: true },
 			] as any)
-		corpStub.getMembers.mockResolvedValue([
-			{ characterId: '2001' },
-			{ characterId: '2002' },
-			{ characterId: '2003' },
-			{ characterId: '2004' },
-		] as any)
+		corpStub.getMembers.mockResolvedValue(
+			makeRpcResult([
+				{ characterId: '2001' },
+				{ characterId: '2002' },
+				{ characterId: '2003' },
+				{ characterId: '2004' },
+			] as any).value
+		)
 
 		const app = createApp({ user: makeUser(), db: dbStub })
 		const res = await app.request('/api/users/corporation-access', {}, env)
@@ -224,9 +238,9 @@ describe('users corporation access', () => {
 	it('returns all managed corporations for site admins without character lookups', async () => {
 		dbStub.query.userCharacters.findMany.mockResolvedValue([] as any)
 		corpStub.getMembers
-			.mockResolvedValueOnce([{ characterId: '1001' }] as any)
-			.mockResolvedValueOnce([{ characterId: '2001' }] as any)
-			.mockResolvedValueOnce([{ characterId: '3001' }] as any)
+			.mockResolvedValueOnce(makeRpcResult([{ characterId: '1001' }] as any).value)
+			.mockResolvedValueOnce(makeRpcResult([{ characterId: '2001' }] as any).value)
+			.mockResolvedValueOnce(makeRpcResult([{ characterId: '3001' }] as any).value)
 
 		const app = createApp({ user: makeUser({ is_admin: true }), db: dbStub })
 		const res = await app.request('/api/users/corporation-access', {}, env)
@@ -286,5 +300,35 @@ describe('users corporation access', () => {
 		expect(corpStub.getCorporationInfo).not.toHaveBeenCalled()
 		expect(corpStub.getDirectors).not.toHaveBeenCalled()
 		expect(corpStub.getMembers).toHaveBeenCalledTimes(3)
+	})
+
+	it('disposes RPC results when checking quick corporation access', async () => {
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{
+				characterId: '2001',
+				characterName: 'Alpha One',
+				corporationId: '1001',
+				status: 'active',
+				hasValidToken: true,
+			},
+		] as any)
+		const characterResult = makeRpcResult({ corporationId: '1001' })
+		const corporationResult = makeRpcResult({ ceoId: '9999' })
+		const directorsResult = makeRpcResult([])
+		const hrCorporationsResult = makeRpcResult(['1001'])
+		charStub.getCharacterInfo.mockResolvedValue(characterResult.value)
+		corpStub.getCorporationInfo.mockResolvedValue(corporationResult.value)
+		corpStub.getDirectors.mockResolvedValue(directorsResult.value)
+		hrStub.getUserHrCorporations.mockResolvedValue(hrCorporationsResult.value)
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/users/has-corporation-access', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ hasAccess: true })
+		expect(characterResult.dispose).toHaveBeenCalledOnce()
+		expect(corporationResult.dispose).toHaveBeenCalledOnce()
+		expect(directorsResult.dispose).toHaveBeenCalledOnce()
+		expect(hrCorporationsResult.dispose).toHaveBeenCalledOnce()
 	})
 })

--- a/apps/core/src/routes/users.ts
+++ b/apps/core/src/routes/users.ts
@@ -438,9 +438,9 @@ users.get('/has-corporation-access', async (c) => {
 		// Fetch corporation IDs for ALL characters (not just first 10)
 		// This ensures we check all managed corporations the user has characters in
 		const charCorpPromises = characters.map(async (character) => {
+			const charStub = getStub<Rpc.Provider<EveCharacterData>>(c.env.EVE_CHARACTER_DATA, 'default')
 			try {
-				const charStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
-				const charData = await charStub.getCharacterInfo(character.characterId)
+				using charData = await charStub.getCharacterInfo(character.characterId)
 				return charData ? String(charData.corporationId) : null
 			} catch {
 				return null
@@ -455,11 +455,20 @@ users.get('/has-corporation-access', async (c) => {
 			const managedCorp = managedCorps.find((c) => c.corporationId === corpId)
 			if (managedCorp) {
 				// Found a managed corp - quick check for any role
+				const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
+					c.env.EVE_CORPORATION_DATA,
+					corpId
+				)
 				try {
-					const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corpId)
 					const [corpInfo, directors] = await Promise.all([
-						corpStub.getCorporationInfo(corpId),
-						corpStub.getDirectors(corpId),
+						(async () => {
+							using result = await corpStub.getCorporationInfo(corpId)
+							return result ? { ceoId: result.ceoId } : null
+						})(),
+						(async () => {
+							using result = await corpStub.getDirectors(corpId)
+							return result.map((director) => ({ characterId: director.characterId }))
+						})(),
 					])
 
 					// Check if any character is CEO or director
@@ -481,9 +490,9 @@ users.get('/has-corporation-access', async (c) => {
 		}
 
 		// Also check if user has any HR roles
+		const hrStub = getStub<Rpc.Provider<Hr>>(c.env.HR, 'default')
 		try {
-			const hrStub = getStub<Hr>(c.env.HR, 'default')
-			const hrCorpIds = await hrStub.getUserHrCorporations(user.id)
+			using hrCorpIds = await hrStub.getUserHrCorporations(user.id)
 			if (hrCorpIds.length > 0) {
 				return c.json({ hasAccess: true })
 			}
@@ -586,7 +595,9 @@ users.get('/corporation-access', async (c) => {
 			// Only fall back to the corporation-data worker for rows that are missing it.
 			const characterCorpMap = new Map<string, string>() // characterId -> corporationId
 			const missingCharacterIds: string[] = []
-			const charactersById = new Map(characters.map((character) => [character.characterId, character]))
+			const charactersById = new Map(
+				characters.map((character) => [character.characterId, character])
+			)
 
 			for (const character of characters) {
 				if (character.corporationId) {
@@ -602,10 +613,11 @@ users.get('/corporation-access', async (c) => {
 				})
 
 				try {
-					const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, 'default')
-					const missingCorpMap = await corpStub.getCorporationIdsByCharacterIds(
-						missingCharacterIds
+					const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
+						c.env.EVE_CORPORATION_DATA,
+						'default'
 					)
+					using missingCorpMap = await corpStub.getCorporationIdsByCharacterIds(missingCharacterIds)
 
 					for (const [characterId, corporationId] of Object.entries(missingCorpMap)) {
 						characterCorpMap.set(characterId, corporationId)
@@ -646,15 +658,22 @@ users.get('/corporation-access', async (c) => {
 			// Process corporations in parallel instead of sequential loop
 			const corpCheckPromises = relevantCorps.map(async (corp) => {
 				try {
-					const corpStub = getStub<EveCorporationData>(
+					const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
 						c.env.EVE_CORPORATION_DATA,
 						corp.corporationId
 					)
 
-					// Get corporation info and directors in parallel
+					// Get corporation info and directors in parallel while disposing each result
+					// within the async scope that owns it.
 					const [corpInfo, directors] = await Promise.all([
-						corpStub.getCorporationInfo(corp.corporationId),
-						corpStub.getDirectors(corp.corporationId),
+						(async () => {
+							using result = await corpStub.getCorporationInfo(corp.corporationId)
+							return result ? { ceoId: result.ceoId } : null
+						})(),
+						(async () => {
+							using result = await corpStub.getDirectors(corp.corporationId)
+							return result.map((director) => ({ characterId: director.characterId }))
+						})(),
 					])
 
 					// Create director lookup Set for O(1) checks
@@ -753,8 +772,8 @@ users.get('/corporation-access', async (c) => {
 		// Also check HR roles across member corporations only (non-admin users only).
 		if (!user.is_admin) {
 			const accessibleCorpIds = new Set(accessibleCorporations.map((c) => c.corporationId))
-			const hrStub = getStub<Hr>(c.env.HR, 'default')
-			const hrCorpIds = await hrStub.getUserHrCorporations(user.id)
+			const hrStub = getStub<Rpc.Provider<Hr>>(c.env.HR, 'default')
+			using hrCorpIds = await hrStub.getUserHrCorporations(user.id)
 			const managedCorpById = new Map(managedCorps.map((corp) => [corp.corporationId, corp]))
 			const uniqueHrCorpIds = [...new Set(hrCorpIds)].filter((id) => {
 				if (accessibleCorpIds.has(id)) return false
@@ -767,7 +786,7 @@ users.get('/corporation-access', async (c) => {
 					hr_reviewer: 2,
 					hr_viewer: 1,
 				}
-				const explicitHrRoles = await hrStub.getUserRoles(user.id)
+				using explicitHrRoles = await hrStub.getUserRoles(user.id)
 				const highestExplicitRoleByCorp = new Map<
 					string,
 					'hr_admin' | 'hr_reviewer' | 'hr_viewer'
@@ -813,11 +832,16 @@ users.get('/corporation-access', async (c) => {
 		const accessibleCorpData = await Promise.all(
 			accessibleCorporations.map(async (corp) => {
 				try {
-					const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corp.corporationId)
-					const members = await corpStub.getMembers(corp.corporationId)
+					const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
+						c.env.EVE_CORPORATION_DATA,
+						corp.corporationId
+					)
+					using members = await corpStub.getMembers(corp.corporationId)
 					return {
 						corporationId: corp.corporationId,
-						members,
+						members: members.map((member) => ({
+							characterId: String(member.characterId),
+						})),
 					}
 				} catch (error) {
 					logger.warn('[Corporation Access] Failed to hydrate corporation stats', {
@@ -950,11 +974,11 @@ users.get('/my-corporations', async (c) => {
 			// Fetch all corporation data in parallel
 			const corpDataPromises = managedCorps.map(async (corp) => {
 				try {
-					const corpStub = getStub<EveCorporationData>(
+					const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
 						c.env.EVE_CORPORATION_DATA,
 						corp.corporationId
 					)
-					const coreData = await corpStub.getCoreData(corp.corporationId)
+					using coreData = await corpStub.getCoreData(corp.corporationId)
 					const linkedChars =
 						coreData?.members && coreData.members.length > 0
 							? await db.query.userCharacters.findMany({
@@ -1033,16 +1057,18 @@ users.get('/my-corporations', async (c) => {
 		}
 
 		// STEP 2: Create stubs ONCE (outside loops)
-		const charStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
+		const charStub = getStub<Rpc.Provider<EveCharacterData>>(c.env.EVE_CHARACTER_DATA, 'default')
 
 		// STEP 3: Batch fetch all character data in parallel
 		const characterDataMap = new Map<string, any>()
 		await Promise.all(
 			characters.map(async (char) => {
 				try {
-					const charData = await charStub.getCharacterInfo(char.characterId)
+					using charData = await charStub.getCharacterInfo(char.characterId)
 					if (charData) {
-						characterDataMap.set(char.characterId, charData)
+						characterDataMap.set(char.characterId, {
+							corporationId: charData.corporationId,
+						})
 					}
 				} catch (error) {
 					logger.warn('Error fetching character data:', {
@@ -1069,13 +1095,31 @@ users.get('/my-corporations', async (c) => {
 		// STEP 6: Batch fetch all corporation data in parallel
 		const corpDataPromises = relevantCorps.map(async (corp) => {
 			try {
-				const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corp.corporationId)
+				const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
+					c.env.EVE_CORPORATION_DATA,
+					corp.corporationId
+				)
 
 				// Fetch all corp data in parallel for each corporation
 				const [corpInfo, directors, coreData] = await Promise.all([
-					corpStub.getCorporationInfo(corp.corporationId),
-					corpStub.getDirectors(corp.corporationId),
-					corpStub.getCoreData(corp.corporationId),
+					(async () => {
+						using result = await corpStub.getCorporationInfo(corp.corporationId)
+						return result ? { ceoId: result.ceoId, allianceId: result.allianceId } : null
+					})(),
+					(async () => {
+						using result = await corpStub.getDirectors(corp.corporationId)
+						return result.map((director) => ({ characterId: director.characterId }))
+					})(),
+					(async () => {
+						using result = await corpStub.getCoreData(corp.corporationId)
+						return result
+							? {
+									members: result.members?.map((member) => ({
+										characterId: member.characterId,
+									})),
+								}
+							: null
+					})(),
 				])
 
 				return { corp, corpInfo, directors, coreData }

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -2394,21 +2394,36 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			const UPDATE_BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 			for (let i = 0; i < estimatedFuelBurnRateRows.length; i += UPDATE_BATCH_SIZE) {
 				const batch = estimatedFuelBurnRateRows.slice(i, i + UPDATE_BATCH_SIZE)
+				const structureIds = batch.map(([structureId]) => structureId)
+				if (batch.every(([, burnRate]) => burnRate === null)) {
+					await db
+						.update(corporationStructures)
+						.set({ fuelBurnRate: null })
+						.where(
+							and(
+								eq(corporationStructures.corporationId, corporationId),
+								inArray(corporationStructures.structureId, structureIds)
+							)
+						)
+					continue
+				}
+
 				await db
 					.update(corporationStructures)
 					.set({
 						fuelBurnRate: sql`case ${corporationStructures.structureId} ${sql.join(
-							batch.map(([structureId, burnRate]) => sql`when ${structureId} then ${burnRate}`),
+							batch.map(([structureId, burnRate]) =>
+								burnRate === null
+									? sql`when ${structureId} then null`
+									: sql`when ${structureId} then cast(${burnRate} as numeric)`
+							),
 							sql` `
 						)} else null end`,
 					})
 					.where(
 						and(
 							eq(corporationStructures.corporationId, corporationId),
-							inArray(
-								corporationStructures.structureId,
-								batch.map(([structureId]) => structureId)
-							)
+							inArray(corporationStructures.structureId, structureIds)
 						)
 					)
 			}

--- a/apps/eve-corporation-data/src/services/director-manager.ts
+++ b/apps/eve-corporation-data/src/services/director-manager.ts
@@ -1,12 +1,12 @@
 import { and, asc, eq } from '@repo/db-utils'
 import { logger } from '@repo/hono-helpers'
-import { parseEsiErrorMetadata, retryWithBackoff } from '@repo/workflow-utils'
-
 import {
-	characterCorporationRoles,
-	corporationConfig,
-	corporationDirectors,
-} from '../db/schema'
+	classifyEsiCredentialFailure,
+	parseEsiErrorMetadata,
+	retryWithBackoff,
+} from '@repo/workflow-utils'
+
+import { characterCorporationRoles, corporationConfig, corporationDirectors } from '../db/schema'
 
 import type { CorporationRole, EsiCharacterRoles } from '@repo/eve-corporation-data'
 import type {
@@ -54,6 +54,7 @@ const FAILURE_THRESHOLD = 3
  */
 const _RECOVERY_THRESHOLD = 3
 const PERMANENT_FAILURE_PREFIX = '[PERMANENT]'
+const DIRECTOR_DEPENDENCY_FAILURE_PREFIX = 'Director dependency failure'
 const INVALID_STALE_PERMANENT_MS = 7 * 24 * 60 * 60 * 1000
 const TRANSIENT_DIRECTOR_COOLDOWN_MS = 10 * 60 * 1000
 
@@ -67,7 +68,7 @@ const FULL_SYNC_REQUIRED_ROLE_SETS: CorporationRole[][] = [
 
 function describeTokenValidationFailure(validation: TokenValidationResult): string {
 	if (validation.status === 'missing_scopes' && validation.missingScopes.length > 0) {
-		return `Director token is missing required ESI scopes: ${validation.missingScopes.join(', ')}`
+		return `Director permission failure: Director token is missing required ESI scopes: ${validation.missingScopes.join(', ')}`
 	}
 
 	if (validation.error) {
@@ -240,7 +241,9 @@ export class DirectorManager {
 	 * Select the next healthy director using round-robin with priority
 	 * Returns null if no healthy directors available
 	 */
-	async selectDirector(options?: { requiredRoleSets?: CorporationRole[][] }): Promise<SelectedDirector | null> {
+	async selectDirector(options?: {
+		requiredRoleSets?: CorporationRole[][]
+	}): Promise<SelectedDirector | null> {
 		try {
 			const now = Date.now()
 			const healthyDirectors = (await this.getHealthyDirectors()).filter(
@@ -274,24 +277,22 @@ export class DirectorManager {
 							)
 							continue
 						}
-							const refreshResult = await this.tokenStore.refreshTokenWithResult(
-								candidate.characterId
+						const refreshResult = await this.tokenStore.refreshTokenWithResult(
+							candidate.characterId
+						)
+						if (!refreshResult.success) {
+							const reason =
+								refreshResult.status === 'transient_error'
+									? `Director token refresh transient failure: ${refreshResult.error ?? 'unknown'}`
+									: (refreshResult.error ?? 'Director token expired and refresh failed')
+							await this.safeRecordFailure(
+								candidate.directorId,
+								reason,
+								refreshResult.status === 'transient_error' ? undefined : { forceUnhealthy: true }
 							)
-							if (!refreshResult.success) {
-								const reason =
-									refreshResult.status === 'transient_error'
-										? `Director token refresh transient failure: ${refreshResult.error ?? 'unknown'}`
-										: refreshResult.error ?? 'Director token expired and refresh failed'
-								await this.safeRecordFailure(
-									candidate.directorId,
-									reason,
-									refreshResult.status === 'transient_error'
-										? undefined
-										: { forceUnhealthy: true }
-								)
-								continue
-							}
+							continue
 						}
+					}
 
 					const affiliationCheck = await this.checkAffiliation(candidate.characterId)
 					if (!affiliationCheck.matches) {
@@ -314,14 +315,17 @@ export class DirectorManager {
 								),
 							{
 								onRetry: (attempt, error, delayMs) => {
-									logger.warn('[DirectorManager] Retrying director role lookup after ESI throttling', {
-										corporationId: this.corporationId,
-										directorId: candidate.directorId,
-										characterId: candidate.characterId,
-										attempt,
-										delayMs,
-										error: error.message,
-									})
+									logger.warn(
+										'[DirectorManager] Retrying director role lookup after ESI throttling',
+										{
+											corporationId: this.corporationId,
+											directorId: candidate.directorId,
+											characterId: candidate.characterId,
+											attempt,
+											delayMs,
+											error: error.message,
+										}
+									)
 								},
 							}
 						)
@@ -331,7 +335,7 @@ export class DirectorManager {
 						if (missingRoleSets.length > 0) {
 							await this.safeRecordFailure(
 								candidate.directorId,
-								`Director missing required roles for selection: ${missingRoleSets.map((set) => `[${set.join('|')}]`).join(', ')}`,
+								`Director permission failure: Director missing required roles for selection: ${missingRoleSets.map((set) => `[${set.join('|')}]`).join(', ')}`,
 								{ forceUnhealthy: true }
 							)
 							continue
@@ -346,10 +350,12 @@ export class DirectorManager {
 						characterName: candidate.characterName,
 					}
 				} catch (error) {
-					await this.safeRecordFailure(
-						candidate.directorId,
-						this.buildDirectorAuthFailureReason('select-director', error)
-					)
+					const reason = classifyEsiCredentialFailure(error)
+						? this.buildDirectorCredentialFailureReason('select-director', error)
+						: this.isDirectorLookupNotFoundFailure(error)
+							? this.buildDirectorLookupFailureReason('select-director', error)
+							: this.buildDirectorDependencyFailureReason('select-director', error)
+					await this.safeRecordFailure(candidate.directorId, reason)
 				}
 			}
 
@@ -405,13 +411,16 @@ export class DirectorManager {
 				() => this.tokenStore.fetchCharacterAffiliations([characterId]),
 				{
 					onRetry: (attempt, error, delayMs) => {
-						logger.warn('[DirectorManager] Retrying character affiliation lookup after ESI throttling', {
-							corporationId: this.corporationId,
-							characterId,
-							attempt,
-							delayMs,
-							error: error.message,
-						})
+						logger.warn(
+							'[DirectorManager] Retrying character affiliation lookup after ESI throttling',
+							{
+								corporationId: this.corporationId,
+								characterId,
+								attempt,
+								delayMs,
+								error: error.message,
+							}
+						)
 					},
 				}
 			)
@@ -429,11 +438,11 @@ export class DirectorManager {
 				`Director affiliation lookup returned no affiliations for character ${characterId}`
 			)
 		}
-		const affiliation = affiliations.find((entry) => entry.character_id === Number.parseInt(characterId, 10))
+		const affiliation = affiliations.find(
+			(entry) => entry.character_id === Number.parseInt(characterId, 10)
+		)
 		if (!affiliation) {
-			throw new Error(
-				`Director affiliation lookup did not include character ${characterId}`
-			)
+			throw new Error(`Director affiliation lookup did not include character ${characterId}`)
 		}
 
 		const corporationId = String(affiliation.corporation_id)
@@ -512,10 +521,7 @@ export class DirectorManager {
 		])
 	}
 
-	private satisfiesAnyRequiredRoles(
-		roleSet: Set<string>,
-		anyOf: CorporationRole[]
-	): boolean {
+	private satisfiesAnyRequiredRoles(roleSet: Set<string>, anyOf: CorporationRole[]): boolean {
 		return anyOf.some((role) => roleSet.has(role))
 	}
 
@@ -583,19 +589,21 @@ export class DirectorManager {
 				})
 				return
 			}
-		} catch (error) {
+		} catch {
 			return
 		}
 	}
 
-	private buildDirectorAuthFailureReason(
+	private buildDirectorCredentialFailureReason(
 		stepName: string,
 		error: unknown,
 		requiredRoles?: CorporationRole[]
 	): string {
 		const rawMessage = error instanceof Error ? error.message : String(error)
 		const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
-		const status = typeof metadata?.status === 'number' ? metadata.status : null
+		const credentialFailureKind = classifyEsiCredentialFailure(error)
+		const metadataStatus = typeof metadata?.status === 'number' ? metadata.status : null
+		const status = metadataStatus ?? (credentialFailureKind === 'permission' ? 403 : 401)
 		const path = typeof metadata?.path === 'string' ? metadata.path : null
 		const lower = rawMessage.toLowerCase()
 		const roleHint = lower.includes('required role') ? 'required_roles_missing' : null
@@ -645,9 +653,32 @@ export class DirectorManager {
 			detailCode ? `detailCode=${detailCode}` : null,
 			roleHint ? `hint=${roleHint}` : null,
 			requiredRoles && requiredRoles.length > 0 ? `requiredRoles=${requiredRoles.join('|')}` : null,
-			roleHint && requiredRoles && requiredRoles.length > 0 ? `missingRoles=unknown_from_esi` : null,
+			roleHint && requiredRoles && requiredRoles.length > 0
+				? `missingRoles=unknown_from_esi`
+				: null,
 		].filter((part): part is string => Boolean(part))
-		return `Director auth failure (${parts.join(', ')})`
+		const failureLabel =
+			credentialFailureKind === 'permission'
+				? 'Director permission failure'
+				: 'Director authentication failure'
+		return `${failureLabel} (${parts.join(', ')})`
+	}
+
+	private isDirectorLookupNotFoundFailure(error: unknown): boolean {
+		if (!(error instanceof Error)) return false
+		const metadata = parseEsiErrorMetadata(error.message)
+		if (metadata?.status !== 404) return false
+		return /ESI request failed:|Director affiliation lookup/i.test(error.message)
+	}
+
+	private buildDirectorLookupFailureReason(stepName: string, error: unknown): string {
+		const rawMessage = error instanceof Error ? error.message : String(error)
+		return `Director lookup failure (step=${stepName}, reasonCode=lookup_not_found): ${rawMessage}`
+	}
+
+	private buildDirectorDependencyFailureReason(stepName: string, error: unknown): string {
+		const rawMessage = error instanceof Error ? error.message : String(error)
+		return `${DIRECTOR_DEPENDENCY_FAILURE_PREFIX} (${stepName}): ${rawMessage}`
 	}
 
 	private isTransientEsiFailure(reason: string): boolean {
@@ -662,6 +693,7 @@ export class DirectorManager {
 		if (lower.includes('timeout')) return true
 		if (lower.includes('temporarily unavailable')) return true
 		if (lower.includes('token refresh transient failure')) return true
+		if (lower.includes(DIRECTOR_DEPENDENCY_FAILURE_PREFIX.toLowerCase())) return true
 
 		return false
 	}
@@ -675,7 +707,10 @@ export class DirectorManager {
 		permanentFailureAt?: Date | null
 		lastFailureReason: string | null
 	}): boolean {
-		return Boolean(director.permanentFailureAt) || this.isPermanentFailureReason(director.lastFailureReason)
+		return (
+			Boolean(director.permanentFailureAt) ||
+			this.isPermanentFailureReason(director.lastFailureReason)
+		)
 	}
 
 	private asPermanentFailureReason(reason: string): string {
@@ -719,7 +754,8 @@ export class DirectorManager {
 	}): boolean {
 		if (director.isHealthy) return false
 		if (this.isPermanentlyFailed(director)) return false
-		if (director.lastFailureReason && this.isTransientEsiFailure(director.lastFailureReason)) return false
+		if (director.lastFailureReason && this.isTransientEsiFailure(director.lastFailureReason))
+			return false
 		if (director.nextRetryAt && director.nextRetryAt.getTime() > Date.now()) return false
 
 		const anchor = director.lastHealthCheck ?? director.updatedAt
@@ -851,12 +887,15 @@ export class DirectorManager {
 						)
 					)
 			} catch (error) {
-				logger.warn('[DirectorManager] Failed to clear stale director role cache after unhealthy transition', {
-					corporationId: this.corporationId,
-					directorId,
-					characterId: director.characterId,
-					error: error instanceof Error ? error.message : String(error),
-				})
+				logger.warn(
+					'[DirectorManager] Failed to clear stale director role cache after unhealthy transition',
+					{
+						corporationId: this.corporationId,
+						directorId,
+						characterId: director.characterId,
+						error: error instanceof Error ? error.message : String(error),
+					}
+				)
 			}
 			await this.syncHealthSnapshot()
 		}
@@ -944,14 +983,17 @@ export class DirectorManager {
 					),
 				{
 					onRetry: (attempt, error, delayMs) => {
-						logger.warn('[DirectorManager] Retrying director health role check after ESI throttling', {
-							corporationId: this.corporationId,
-							directorId,
-							characterId: director.characterId,
-							attempt,
-							delayMs,
-							error: error.message,
-						})
+						logger.warn(
+							'[DirectorManager] Retrying director health role check after ESI throttling',
+							{
+								corporationId: this.corporationId,
+								directorId,
+								characterId: director.characterId,
+								attempt,
+								delayMs,
+								error: error.message,
+							}
+						)
 					},
 				}
 			)
@@ -1001,7 +1043,7 @@ export class DirectorManager {
 			await this.syncHealthSnapshot()
 
 			if (missingRoleSets.length > 0) {
-				const reason = `Director missing required roles: ${missingRoleSets
+				const reason = `Director permission failure: Director missing required roles: ${missingRoleSets
 					.map((set) => `[${set.join('|')}]`)
 					.join(', ')}`
 				await this.recordFailure(directorId, reason, { forceUnhealthy: true })
@@ -1023,7 +1065,12 @@ export class DirectorManager {
 				error: errorMessage,
 			})
 
-			await this.recordFailure(directorId, errorMessage)
+			const failureReason = classifyEsiCredentialFailure(error)
+				? this.buildDirectorCredentialFailureReason('verify-director-health', error)
+				: this.isDirectorLookupNotFoundFailure(error)
+					? this.buildDirectorLookupFailureReason('verify-director-health', error)
+					: this.buildDirectorDependencyFailureReason('verify-director-health', error)
+			await this.recordFailure(directorId, failureReason)
 			return false
 		}
 	}
@@ -1142,8 +1189,14 @@ export class DirectorManager {
 					error: lastError.message,
 				})
 
-				// Record failure
-				await this.recordFailure(director.directorId, lastError.message)
+				// Preserve director health for dependency failures; only ESI auth failures
+				// should be eligible for permanent director failover.
+				const failureReason = classifyEsiCredentialFailure(lastError)
+					? this.buildDirectorCredentialFailureReason('execute-with-failover', lastError)
+					: this.isDirectorLookupNotFoundFailure(lastError)
+						? this.buildDirectorLookupFailureReason('execute-with-failover', lastError)
+						: this.buildDirectorDependencyFailureReason('execute-with-failover', lastError)
+				await this.recordFailure(director.directorId, failureReason)
 
 				// Continue to next director
 			}

--- a/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
@@ -87,11 +87,7 @@ describe('DirectorManager.selectDirector', () => {
 					},
 				}),
 		}
-		const manager = new DirectorManager(
-			{} as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager({} as never, '98000001', tokenStore as never)
 
 		vi.spyOn(manager as any, 'getHealthyDirectors').mockResolvedValue([
 			{
@@ -158,11 +154,7 @@ describe('DirectorManager.selectDirector', () => {
 				error: 'Network timeout while refreshing token',
 			}),
 		}
-		const manager = new DirectorManager(
-			{} as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager({} as never, '98000001', tokenStore as never)
 
 		vi.spyOn(manager as any, 'getHealthyDirectors').mockResolvedValue([
 			{
@@ -220,11 +212,7 @@ describe('DirectorManager.selectDirector', () => {
 			getTokenInfo: vi.fn().mockResolvedValue({ isExpired: false }),
 			refreshToken: vi.fn().mockResolvedValue(true),
 		}
-		const manager = new DirectorManager(
-			{} as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager({} as never, '98000001', tokenStore as never)
 
 		vi.spyOn(manager as any, 'getHealthyDirectors').mockResolvedValue([
 			{
@@ -265,15 +253,11 @@ describe('DirectorManager.checkAffiliation', () => {
 
 	it('uses token store affiliation RPC and matches corporation', async () => {
 		const tokenStore = {
-			fetchCharacterAffiliations: vi.fn().mockResolvedValue([
-				{ character_id: 111, corporation_id: 98000001 },
-			]),
+			fetchCharacterAffiliations: vi
+				.fn()
+				.mockResolvedValue([{ character_id: 111, corporation_id: 98000001 }]),
 		}
-		const manager = new DirectorManager(
-			{} as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager({} as never, '98000001', tokenStore as never)
 
 		const result = await (manager as any).checkAffiliation('111')
 
@@ -285,11 +269,7 @@ describe('DirectorManager.checkAffiliation', () => {
 		const tokenStore = {
 			fetchCharacterAffiliations: vi.fn().mockResolvedValue([]),
 		}
-		const manager = new DirectorManager(
-			{} as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager({} as never, '98000001', tokenStore as never)
 
 		await expect((manager as any).checkAffiliation('111')).rejects.toThrow(
 			'Director affiliation lookup returned no affiliations for character 111'
@@ -299,17 +279,15 @@ describe('DirectorManager.checkAffiliation', () => {
 
 	it('throws a hard error when the affiliation lookup returns 404', async () => {
 		const tokenStore = {
-			fetchCharacterAffiliations: vi.fn().mockRejectedValue(
-				new Error(
-					'ESI request failed: 404 Not Found - not found | metadata={"status":404,"path":"/characters/affiliation"}'
-				)
-			),
+			fetchCharacterAffiliations: vi
+				.fn()
+				.mockRejectedValue(
+					new Error(
+						'ESI request failed: 404 Not Found - not found | metadata={"status":404,"path":"/characters/affiliation"}'
+					)
+				),
 		}
-		const manager = new DirectorManager(
-			{} as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager({} as never, '98000001', tokenStore as never)
 
 		await expect((manager as any).checkAffiliation('111')).rejects.toThrow(
 			'Director affiliation lookup returned 404 for character 111'
@@ -343,11 +321,7 @@ describe('DirectorManager.recordFailure', () => {
 			delete: deleteBuilder,
 			update,
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			{} as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', {} as never)
 		vi.spyOn(manager, 'getHealthyDirectorsCount').mockResolvedValue(1)
 
 		await manager.recordFailure('dir-1', 'ESI request failed: 403 Forbidden', {
@@ -387,11 +361,7 @@ describe('DirectorManager.recordFailure', () => {
 			delete: deleteBuilder,
 			update,
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			{} as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', {} as never)
 		vi.spyOn(manager, 'getHealthyDirectorsCount').mockResolvedValue(0)
 
 		await manager.recordFailure('dir-1', 'Director missing required roles: [Station_Manager]')
@@ -427,11 +397,7 @@ describe('DirectorManager.recordFailure', () => {
 			delete: deleteBuilder,
 			update,
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			{} as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', {} as never)
 
 		await manager.recordFailure(
 			'dir-1',
@@ -525,9 +491,9 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 				refreshSucceeded: false,
 				status: 'valid',
 			}),
-			fetchCharacterAffiliations: vi.fn().mockResolvedValue([
-				{ character_id: 111, corporation_id: 98000001 },
-			]),
+			fetchCharacterAffiliations: vi
+				.fn()
+				.mockResolvedValue([{ character_id: 111, corporation_id: 98000001 }]),
 			fetchEsi: vi.fn().mockResolvedValue({
 				data: {
 					roles: ['Trader'],
@@ -535,11 +501,7 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 				},
 			}),
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', tokenStore as never)
 
 		const result = await manager.verifyDirectorHealth('dir-1', {
 			requiredRoleSets: [['Station_Manager'], ['Trader', 'Accountant']],
@@ -597,20 +559,16 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 				refreshSucceeded: false,
 				status: 'valid',
 			}),
-			fetchCharacterAffiliations: vi.fn().mockResolvedValue([
-				{ character_id: 111, corporation_id: 98000001 },
-			]),
+			fetchCharacterAffiliations: vi
+				.fn()
+				.mockResolvedValue([{ character_id: 111, corporation_id: 98000001 }]),
 			fetchEsi: vi.fn().mockResolvedValue({
 				data: {
 					roles: ['Trader'],
 				},
 			}),
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', tokenStore as never)
 		const recordFailure = vi.spyOn(manager, 'recordFailure').mockResolvedValue(undefined)
 
 		const result = await manager.verifyDirectorHealth('dir-1', {
@@ -648,11 +606,7 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 				error: 'Network timeout while refreshing token',
 			}),
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', tokenStore as never)
 		const recordFailure = vi.spyOn(manager, 'recordFailure').mockResolvedValue(undefined)
 
 		const result = await manager.verifyDirectorHealth('dir-1')
@@ -662,6 +616,35 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 			'dir-1',
 			expect.stringContaining('transient failure')
 		)
+	})
+
+	it('does not classify Durable Object failures as director auth failures', async () => {
+		const db = {
+			query: {
+				corporationDirectors: {
+					findFirst: vi.fn().mockResolvedValue({
+						id: 'dir-1',
+						characterId: '111',
+					}),
+				},
+			},
+		}
+		const tokenStore = {
+			validateToken: vi
+				.fn()
+				.mockRejectedValue(new Error('Durable Object storage operation exceeded timeout')),
+		}
+		const manager = new DirectorManager(db as never, '98000001', tokenStore as never)
+		const recordFailure = vi.spyOn(manager, 'recordFailure').mockResolvedValue(undefined)
+
+		const result = await manager.verifyDirectorHealth('dir-1')
+
+		expect(result).toBe(false)
+		expect(recordFailure).toHaveBeenCalledWith(
+			'dir-1',
+			expect.stringContaining('Director dependency failure (verify-director-health)')
+		)
+		expect(recordFailure.mock.calls[0]?.[1]).not.toContain('Director auth failure')
 	})
 
 	it('records failure when ESI role fetch throws', async () => {
@@ -685,22 +668,21 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 				refreshSucceeded: false,
 				status: 'valid',
 			}),
-			fetchCharacterAffiliations: vi.fn().mockResolvedValue([
-				{ character_id: 111, corporation_id: 98000001 },
-			]),
+			fetchCharacterAffiliations: vi
+				.fn()
+				.mockResolvedValue([{ character_id: 111, corporation_id: 98000001 }]),
 			fetchEsi: vi.fn().mockRejectedValue(new Error('ESI request failed: 403 Forbidden')),
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', tokenStore as never)
 		const recordFailure = vi.spyOn(manager, 'recordFailure').mockResolvedValue(undefined)
 
 		const result = await manager.verifyDirectorHealth('dir-1')
 
 		expect(result).toBe(false)
-		expect(recordFailure).toHaveBeenCalledWith('dir-1', 'ESI request failed: 403 Forbidden')
+		expect(recordFailure).toHaveBeenCalledWith(
+			'dir-1',
+			expect.stringContaining('Director permission failure')
+		)
 	})
 
 	it('records failure when the director token is missing required scopes', async () => {
@@ -727,11 +709,7 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 			fetchCharacterAffiliations: vi.fn(),
 			fetchEsi: vi.fn(),
 		}
-		const manager = new DirectorManager(
-			db as never,
-			'98000001',
-			tokenStore as never
-		)
+		const manager = new DirectorManager(db as never, '98000001', tokenStore as never)
 		const recordFailure = vi.spyOn(manager, 'recordFailure').mockResolvedValue(undefined)
 		const removeDirector = vi.spyOn(manager, 'removeDirector').mockResolvedValue(undefined)
 
@@ -771,9 +749,9 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 				refreshSucceeded: false,
 				status: 'valid',
 			}),
-			fetchCharacterAffiliations: vi.fn().mockResolvedValue([
-				{ character_id: 111, corporation_id: 98000002 },
-			]),
+			fetchCharacterAffiliations: vi
+				.fn()
+				.mockResolvedValue([{ character_id: 111, corporation_id: 98000002 }]),
 			fetchEsi: vi.fn(),
 		}
 		const manager = new DirectorManager(
@@ -808,11 +786,7 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 		const where = vi.fn().mockResolvedValue(undefined)
 		const set = vi.fn().mockReturnValue({ where })
 		const update = vi.fn().mockReturnValue({ set })
-		const manager = new DirectorManager(
-			{ update } as never,
-			'98000001',
-			{} as never
-		)
+		const manager = new DirectorManager({ update } as never, '98000001', {} as never)
 
 		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue([
 			{
@@ -856,11 +830,7 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 		const where = vi.fn().mockResolvedValue(undefined)
 		const set = vi.fn().mockReturnValue({ where })
 		const update = vi.fn().mockReturnValue({ set })
-		const manager = new DirectorManager(
-			{ update } as never,
-			'98000001',
-			{} as never
-		)
+		const manager = new DirectorManager({ update } as never, '98000001', {} as never)
 
 		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue([
 			{
@@ -891,11 +861,7 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 		const where = vi.fn().mockResolvedValue(undefined)
 		const set = vi.fn().mockReturnValue({ where })
 		const update = vi.fn().mockReturnValue({ set })
-		const manager = new DirectorManager(
-			{ update } as never,
-			'98000001',
-			{} as never
-		)
+		const manager = new DirectorManager({ update } as never, '98000001', {} as never)
 		const verifyDirectorHealth = vi.spyOn(manager, 'verifyDirectorHealth').mockResolvedValue(true)
 
 		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue([
@@ -934,13 +900,8 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 			.fn()
 			.mockReturnValueOnce({ set: directorSet })
 			.mockReturnValueOnce({ set: corpSet })
-		const manager = new DirectorManager(
-			{ update } as never,
-			'98000001',
-			{} as never
-		)
-		vi.spyOn(manager, 'verifyDirectorHealth')
-			.mockResolvedValueOnce(false)
+		const manager = new DirectorManager({ update } as never, '98000001', {} as never)
+		vi.spyOn(manager, 'verifyDirectorHealth').mockResolvedValueOnce(false)
 		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue([
 			{
 				directorId: 'dir-1',
@@ -974,11 +935,7 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 		const where = vi.fn().mockResolvedValue(undefined)
 		const set = vi.fn().mockReturnValue({ where })
 		const update = vi.fn().mockReturnValue({ set })
-		const manager = new DirectorManager(
-			{ update } as never,
-			'98000001',
-			{} as never
-		)
+		const manager = new DirectorManager({ update } as never, '98000001', {} as never)
 
 		const verifyDirectorHealth = vi.spyOn(manager, 'verifyDirectorHealth').mockResolvedValue(true)
 
@@ -991,7 +948,8 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 				lastHealthCheck: null,
 				lastUsed: null,
 				failureCount: 3,
-				lastFailureReason: '[PERMANENT] Director affiliation mismatch: expected corporation 98000001, got 98000002',
+				lastFailureReason:
+					'[PERMANENT] Director affiliation mismatch: expected corporation 98000001, got 98000002',
 				nextRetryAt: null,
 				permanentFailureAt: new Date(),
 				priority: 1,
@@ -1044,7 +1002,8 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 				lastHealthCheck: null,
 				lastUsed: null,
 				failureCount: 3,
-				lastFailureReason: '[PERMANENT] Director token expired and could not be refreshed. Re-authenticate this character.',
+				lastFailureReason:
+					'[PERMANENT] Director token expired and could not be refreshed. Re-authenticate this character.',
 				nextRetryAt: null,
 				permanentFailureAt: new Date(),
 				priority: 1,

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -59,6 +59,7 @@ vi.mock('@repo/do-utils', () => ({
 vi.mock('@repo/workflow-utils', () => ({
 	NonRetryableError: class NonRetryableError extends Error {},
 	esiRetryOptions: {},
+	classifyEsiCredentialFailure: () => null,
 	parseEsiErrorMetadata: (message: string) => parseEsiErrorMetadataMock(message),
 	withEsiRetryClassification: async (_label: string, fn: () => Promise<unknown> | unknown) =>
 		await fn(),
@@ -70,8 +71,10 @@ vi.mock('../../../workflows/steps/assets', () => ({
 
 vi.mock('../../../workflows/steps/common', () => ({
 	clearTaxProjectionRetryIntent: (...args: unknown[]) => clearTaxProjectionRetryIntentMock(...args),
-	recordTaxProjectionRetryIntent: (...args: unknown[]) => recordTaxProjectionRetryIntentMock(...args),
-	replayTaxProjectionRetryIntent: (...args: unknown[]) => replayTaxProjectionRetryIntentMock(...args),
+	recordTaxProjectionRetryIntent: (...args: unknown[]) =>
+		recordTaxProjectionRetryIntentMock(...args),
+	replayTaxProjectionRetryIntent: (...args: unknown[]) =>
+		replayTaxProjectionRetryIntentMock(...args),
 	sendHrDepartedMessages: (...args: unknown[]) => sendHrDepartedMessagesMock(...args),
 	triggerTaxProjectionRefresh: (...args: unknown[]) => triggerTaxProjectionRefreshMock(...args),
 	updateCoreLastSync: (...args: unknown[]) => updateCoreLastSyncMock(...args),
@@ -105,14 +108,16 @@ vi.mock('../../../workflows/steps/structures', () => ({
 
 function createStep() {
 	const executedStepNames: string[] = []
-	const doMock = vi.fn(async (name: string, optionsOrHandler: unknown, maybeHandler?: () => unknown) => {
-		executedStepNames.push(name)
-		const handler =
-			typeof optionsOrHandler === 'function'
-				? (optionsOrHandler as () => unknown)
-				: (maybeHandler as () => unknown)
-		return await handler()
-	})
+	const doMock = vi.fn(
+		async (name: string, optionsOrHandler: unknown, maybeHandler?: () => unknown) => {
+			executedStepNames.push(name)
+			const handler =
+				typeof optionsOrHandler === 'function'
+					? (optionsOrHandler as () => unknown)
+					: (maybeHandler as () => unknown)
+			return await handler()
+		}
+	)
 
 	return {
 		executedStepNames,
@@ -201,7 +206,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		const workflow = new EveCorporationSyncWorkflow({} as ExecutionContext, env)
-		const { step } = createStep()
+		const { step, executedStepNames } = createStep()
 
 		await expect(
 			workflow.run(
@@ -223,17 +228,14 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
+		expect(executedStepNames.filter((name) => name === 'sync-assets')).toHaveLength(1)
 		expect(markStructureSyncFailureReasonMock).toHaveBeenCalledWith(
 			env,
 			'693378155',
 			'structures',
 			'Station Manager access required'
 		)
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
-			env,
-			'693378155',
-			['assets', 'skyhooks']
-		)
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets', 'skyhooks'])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
 	})
@@ -312,11 +314,7 @@ describe('EveCorporationSyncWorkflow', () => {
 			'structures',
 			'Station Manager access required'
 		)
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
-			env,
-			'693378155',
-			['assets', 'skyhooks']
-		)
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets', 'skyhooks'])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
 	})
@@ -387,11 +385,11 @@ describe('EveCorporationSyncWorkflow', () => {
 			trigger: 'cron',
 		})
 
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
-			env,
-			'693378155',
-			['assets', 'structures', 'skyhooks']
-		)
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [
+			'assets',
+			'structures',
+			'skyhooks',
+		])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
 	})
@@ -537,11 +535,11 @@ describe('EveCorporationSyncWorkflow', () => {
 			},
 		])
 		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
-			env,
-			'693378155',
-			['assets', 'structures', 'skyhooks']
-		)
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [
+			'assets',
+			'structures',
+			'skyhooks',
+		])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 
@@ -974,11 +972,11 @@ describe('EveCorporationSyncWorkflow', () => {
 		expect(fetchSkyhookEnrichmentMock).toHaveBeenCalled()
 		expect(storeSkyhookEnrichmentMock).toHaveBeenCalled()
 		expect(fetchMiningExtractionEnrichmentMock).toHaveBeenCalled()
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(
-			env,
-			'693378155',
-			['assets', 'structures', 'skyhooks']
-		)
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [
+			'assets',
+			'structures',
+			'skyhooks',
+		])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
 })

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -3,12 +3,14 @@ import { WorkflowEntrypoint } from 'cloudflare:workers'
 import { getStub } from '@repo/do-utils'
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
 import {
+	classifyEsiCredentialFailure,
 	esiRetryOptions,
 	NonRetryableError,
 	parseEsiErrorMetadata,
 	withEsiRetryClassification,
 } from '@repo/workflow-utils'
 
+import { buildPriorityQueuedEntries } from '../services/structure-priority'
 import { syncAssets } from './steps/assets'
 import {
 	clearTaxProjectionRetryIntent,
@@ -45,14 +47,11 @@ import {
 	storeSovereigntyEnrichment,
 	storeStructures,
 } from './steps/structures'
-import { buildPriorityQueuedEntries } from '../services/structure-priority'
-import {
-	StructureEnrichmentScopeMismatchError,
-} from './utils/structure-enrichment-auth'
 import { syncWalletJournal } from './steps/wallet-journal'
 import { syncWalletTransactions } from './steps/wallet-transactions'
 import { fetchWallets, storeWallets } from './steps/wallets'
 import { createShouldSyncPredicate } from './utils/should-sync'
+import { StructureEnrichmentScopeMismatchError } from './utils/structure-enrichment-auth'
 import { dispatchTaxProjectionRefresh } from './utils/tax-projection-dispatch'
 import {
 	buildTaxProjectionRefreshInput,
@@ -62,9 +61,9 @@ import {
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
 import type {
 	CorporationRole,
+	EsiCorporationStructure,
 	EveCorporationData,
 	EveCorporationSyncDataType,
-	EsiCorporationStructure,
 	StructureSyncPriorityTarget,
 } from '@repo/eve-corporation-data'
 import type { Env } from '../context'
@@ -202,7 +201,10 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 					requestedDataTypes: dataTypes ?? 'all',
 					structureAssetSyncEnabled,
 				}
-				logger.info('[EveCorporationSyncWorkflow] Asset sync skipped by corporation configuration', assetSyncLog)
+				logger.info(
+					'[EveCorporationSyncWorkflow] Asset sync skipped by corporation configuration',
+					assetSyncLog
+				)
 			}
 
 			await step.do(
@@ -272,24 +274,6 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			const shouldSyncAuthenticated = (type: EveCorporationSyncDataType) =>
 				director !== null && shouldSync(type)
 
-			const isDirectorAuthFailure = (error: unknown): boolean => {
-				if (error instanceof Error) {
-					const metadata = parseEsiErrorMetadata(error.message)
-					const status = metadata?.status
-					if (status === 401 || status === 403) {
-						return true
-					}
-				}
-				const message =
-					error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
-				return (
-					message.includes('esi request failed: 403') ||
-					message.includes('esi request failed: 401') ||
-					message.includes('forbidden') ||
-					message.includes('unauthorized')
-				)
-			}
-
 			const buildDirectorFailureReason = (
 				stepName: string,
 				error: unknown,
@@ -297,7 +281,9 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			): string => {
 				const rawMessage = error instanceof Error ? error.message : String(error)
 				const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
-				const status = typeof metadata?.status === 'number' ? metadata.status : null
+				const credentialFailureKind = classifyEsiCredentialFailure(error)
+				const metadataStatus = typeof metadata?.status === 'number' ? metadata.status : null
+				const status = metadataStatus ?? (credentialFailureKind === 'permission' ? 403 : 401)
 				const path = typeof metadata?.path === 'string' ? metadata.path : null
 				const lower = rawMessage.toLowerCase()
 				const roleHint = lower.includes('required role') ? 'required_roles_missing' : null
@@ -347,7 +333,11 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						? `missingRoles=unknown_from_esi`
 						: null,
 				].filter((part): part is string => Boolean(part))
-				return `Director auth failure (${parts.join(', ')})`
+				const failureLabel =
+					credentialFailureKind === 'permission'
+						? 'Director permission failure'
+						: 'Director authentication failure'
+				return `${failureLabel} (${parts.join(', ')})`
 			}
 
 			const runDirectorStepWithFailover = async <T>(params: {
@@ -364,18 +354,22 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 				const stepOptions = { ...STEP_RETRY_OPTIONS, timeout: params.timeout }
 				const persistResult = params.persistResult ?? true
 				const execute = async (): Promise<T> =>
-					((await withEsiRetryClassification(params.stepName, () =>
+					(await withEsiRetryClassification(params.stepName, () =>
 						params.run(director!.characterId)
-					)) as T)
+					)) as T
 
 				try {
 					if (!persistResult) {
 						return await execute()
 					}
 
-					return (await step.do(params.stepName, stepOptions, async () => (await execute()) as any)) as T
+					return (await step.do(
+						params.stepName,
+						stepOptions,
+						async () => (await execute()) as any
+					)) as T
 				} catch (error) {
-					if (!isDirectorAuthFailure(error)) {
+					if (!classifyEsiCredentialFailure(error)) {
 						throw error
 					}
 
@@ -386,7 +380,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						params.requiredRoles
 					)
 					logger.warn(
-						'[EveCorporationSyncWorkflow] Director auth failure on authenticated step, failing over',
+						'[EveCorporationSyncWorkflow] Director credential failure on authenticated step, failing over',
 						{
 							corporationId,
 							stepName: params.stepName,
@@ -481,14 +475,14 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 							)
 					)
 				} catch (error) {
-					if (!director || !isDirectorAuthFailure(error)) {
+					if (!director || !classifyEsiCredentialFailure(error)) {
 						throw error
 					}
 
 					const errorMessage = error instanceof Error ? error.message : String(error)
 					const failureReason = buildDirectorFailureReason('fetch-members', error, ['Director'])
 					logger.warn(
-						'[EveCorporationSyncWorkflow] Director auth failure on fetch-members, failing over',
+						'[EveCorporationSyncWorkflow] Director credential failure on fetch-members, failing over',
 						{
 							corporationId,
 							directorId: director.directorId,
@@ -567,7 +561,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 							)
 					)
 				} catch (error) {
-					if (!director || !isDirectorAuthFailure(error)) {
+					if (!director || !classifyEsiCredentialFailure(error)) {
 						throw error
 					}
 
@@ -576,7 +570,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						'Director',
 					])
 					logger.warn(
-						'[EveCorporationSyncWorkflow] Director auth failure on fetch-member-tracking, failing over',
+						'[EveCorporationSyncWorkflow] Director credential failure on fetch-member-tracking, failing over',
 						{
 							corporationId,
 							directorId: director.directorId,
@@ -643,327 +637,318 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 			}
 
 			if (shouldSyncAuthenticated('wallet-journal')) {
-				walletJournalSync = await step.do(
-					'sync-wallet-journal',
-					{ ...STEP_RETRY_OPTIONS, timeout: '5 minutes' },
-					async () => {
-						const walletJournalResult = await runDirectorStepWithFailover({
-							stepName: 'sync-wallet-journal',
-							timeout: '5 minutes',
-							requiredRoles: ['Accountant', 'Junior_Accountant'],
-							run: (directorCharacterId) =>
-								syncWalletJournal(this.env, corporationId, directorCharacterId),
-						})
-						return {
-							dataType: 'wallet-journal' as const,
-							stats: {
-								walletJournalFetchedCount: walletJournalResult.totalEntries,
-								walletJournalPersistedNewRows: walletJournalResult.persistedNewRows,
-								walletJournalMaxId: walletJournalResult.maxJournalId,
-								walletJournalMaxDate: walletJournalResult.maxJournalDate,
-							},
-						}
-					}
-				)
+				const walletJournalResult = await runDirectorStepWithFailover({
+					stepName: 'sync-wallet-journal',
+					timeout: '5 minutes',
+					requiredRoles: ['Accountant', 'Junior_Accountant'],
+					run: (directorCharacterId) =>
+						syncWalletJournal(this.env, corporationId, directorCharacterId),
+				})
+				walletJournalSync = {
+					dataType: 'wallet-journal',
+					stats: {
+						walletJournalFetchedCount: walletJournalResult.totalEntries,
+						walletJournalPersistedNewRows: walletJournalResult.persistedNewRows,
+						walletJournalMaxId: walletJournalResult.maxJournalId,
+						walletJournalMaxDate: walletJournalResult.maxJournalDate,
+					},
+				}
 			}
 
 			if (shouldSyncAuthenticated('wallet-transactions')) {
-				walletTransactionsSync = await step.do(
-					'sync-wallet-transactions',
-					{ ...STEP_RETRY_OPTIONS, timeout: '5 minutes' },
-					async () => {
-						const walletTransactionsResult = await runDirectorStepWithFailover({
-							stepName: 'sync-wallet-transactions',
-							timeout: '5 minutes',
-							requiredRoles: ['Accountant', 'Junior_Accountant'],
-							run: (directorCharacterId) =>
-								syncWalletTransactions(this.env, corporationId, directorCharacterId),
-						})
-						return {
-							dataType: 'wallet-transactions' as const,
-							stats: {
-								walletTransactionsFetchedCount: walletTransactionsResult.totalTransactions,
-								walletTransactionsPersistedNewRows: walletTransactionsResult.persistedNewRows,
-								walletTransactionsMaxId: walletTransactionsResult.maxTransactionId,
-								walletTransactionsMaxDate: walletTransactionsResult.maxTransactionDate,
-							},
-						}
-					}
-				)
+				const walletTransactionsResult = await runDirectorStepWithFailover({
+					stepName: 'sync-wallet-transactions',
+					timeout: '5 minutes',
+					requiredRoles: ['Accountant', 'Junior_Accountant'],
+					run: (directorCharacterId) =>
+						syncWalletTransactions(this.env, corporationId, directorCharacterId),
+				})
+				walletTransactionsSync = {
+					dataType: 'wallet-transactions',
+					stats: {
+						walletTransactionsFetchedCount: walletTransactionsResult.totalTransactions,
+						walletTransactionsPersistedNewRows: walletTransactionsResult.persistedNewRows,
+						walletTransactionsMaxId: walletTransactionsResult.maxTransactionId,
+						walletTransactionsMaxDate: walletTransactionsResult.maxTransactionDate,
+					},
+				}
 			}
 
 			if (shouldSyncAuthenticated('structures')) {
 				// Keep the structure refresh from blocking the asset projection refresh.
 				// The inventory path can fall back to the DB or refresh structures on its own.
-				structuresSync = await step.do('sync-structures', {}, async () => {
-					let structureSyncHadFailure = false
-					let structuresCount = 0
-					let sovereigntySystemsCount = 0
-					let sovereigntyHubsCount = 0
-					let miningExtractionsCount = 0
-					const corpData = getStub<EveCorporationData>(this.env.EVE_CORPORATION_DATA, corporationId)
-
-					try {
-						const structures = await runDirectorStepWithFailover({
-							stepName: 'fetch-structures',
-							timeout: '5 minutes',
-							requiredRoles: ['Station_Manager'],
-							persistResult: false,
-							run: (directorCharacterId) =>
-								fetchStructures(this.env, corporationId, directorCharacterId),
-						})
-						structuresCount = structures.length
-
-						await storeStructures(this.env, corporationId, structures)
-
-						const miningCitadelStructureIds = new Set(
-							structures
-								.filter((structure) => isMiningCitadelStructure(structure))
-								.map((structure) => String(structure.structure_id))
+				structuresSync = await step.do(
+					'sync-structures',
+					{ ...STEP_RETRY_OPTIONS, timeout: '20 minutes' },
+					async () => {
+						let structureSyncHadFailure = false
+						let structuresCount = 0
+						let sovereigntySystemsCount = 0
+						let sovereigntyHubsCount = 0
+						let miningExtractionsCount = 0
+						const corpData = getStub<EveCorporationData>(
+							this.env.EVE_CORPORATION_DATA,
+							corporationId
 						)
 
-						if (miningCitadelStructureIds.size > 0) {
-							try {
-								const miningCitadelPriorities =
-									await corpData.getMiningCitadelSyncPriorities(corporationId)
-								const newMiningCitadelStructureIds =
-									await corpData.getMissingStructureIdsForPriorityQueue(
-										corporationId,
-										'mining-extractions' as StructureSyncPriorityTarget,
-										[...miningCitadelStructureIds]
-									)
-								const prioritizedMiningCitadelQueue = buildPriorityQueuedEntries(
-									[...miningCitadelStructureIds].map((structureId) => ({
-										id: structureId,
-									})),
-									newMiningCitadelStructureIds,
-									miningCitadelPriorities
-								)
-								const prioritizedMiningCitadelIds = prioritizedMiningCitadelQueue.entries.map(
-									({ entry }) => entry.id
-								)
+						try {
+							const structures = await runDirectorStepWithFailover({
+								stepName: 'fetch-structures',
+								timeout: '5 minutes',
+								requiredRoles: ['Station_Manager'],
+								persistResult: false,
+								run: (directorCharacterId) =>
+									fetchStructures(this.env, corporationId, directorCharacterId),
+							})
+							structuresCount = structures.length
 
-								const fetchedMiningExtractions = await runDirectorStepWithFailover({
-									stepName: 'fetch-structure-mining-extraction-enrichment',
-									timeout: '10 minutes',
-									requiredRoles: ['Station_Manager'],
-									persistResult: false,
-									run: (directorCharacterId) =>
-										fetchMiningExtractionEnrichment(
-											this.env,
-											corporationId,
-											directorCharacterId
-										),
-								})
-								const miningExtractionByStructureId = new Map(
-									fetchedMiningExtractions.map((extraction) => [
-										String(extraction.structure_id),
-										extraction,
-									])
-								)
-								const prioritizedMiningExtractions = prioritizedMiningCitadelIds
-									.map((structureId) => miningExtractionByStructureId.get(structureId) ?? null)
-									.filter(
-										(
-											extraction
-										): extraction is (typeof fetchedMiningExtractions)[number] =>
-											extraction !== null
-									)
-								miningExtractionsCount = prioritizedMiningExtractions.length
+							await storeStructures(this.env, corporationId, structures)
 
-								for (let index = 0; index < prioritizedMiningExtractions.length; index += 100) {
-									const batch = prioritizedMiningExtractions.slice(index, index + 100)
-									if (batch.length === 0) continue
-									await storeMiningExtractionEnrichment(this.env, corporationId, batch)
-								}
-							} catch (error) {
-								const metadata =
-									error instanceof Error ? parseEsiErrorMetadata(error.message) : null
-								const isRateLimitError = metadata?.status === 429
-								structureSyncHadFailure ||= !isRateLimitError
-								if (!isRateLimitError) {
-									try {
-										await markStructureSyncFailureReason(
-											this.env,
+							const miningCitadelStructureIds = new Set(
+								structures
+									.filter((structure) => isMiningCitadelStructure(structure))
+									.map((structure) => String(structure.structure_id))
+							)
+
+							if (miningCitadelStructureIds.size > 0) {
+								try {
+									const miningCitadelPriorities =
+										await corpData.getMiningCitadelSyncPriorities(corporationId)
+									const newMiningCitadelStructureIds =
+										await corpData.getMissingStructureIdsForPriorityQueue(
 											corporationId,
-											'mining-extractions',
-											error instanceof Error ? error.message : String(error)
+											'mining-extractions' as StructureSyncPriorityTarget,
+											[...miningCitadelStructureIds]
 										)
-									} catch (markError) {
-										logger.warn(
-											'[EveCorporationSyncWorkflow] Mining extraction failure reason could not be persisted',
-											{
-												corporationId,
-												error: markError instanceof Error ? markError.message : String(markError),
-											}
+									const prioritizedMiningCitadelQueue = buildPriorityQueuedEntries(
+										[...miningCitadelStructureIds].map((structureId) => ({
+											id: structureId,
+										})),
+										newMiningCitadelStructureIds,
+										miningCitadelPriorities
+									)
+									const prioritizedMiningCitadelIds = prioritizedMiningCitadelQueue.entries.map(
+										({ entry }) => entry.id
+									)
+
+									const fetchedMiningExtractions = await runDirectorStepWithFailover({
+										stepName: 'fetch-structure-mining-extraction-enrichment',
+										timeout: '10 minutes',
+										requiredRoles: ['Station_Manager'],
+										persistResult: false,
+										run: (directorCharacterId) =>
+											fetchMiningExtractionEnrichment(this.env, corporationId, directorCharacterId),
+									})
+									const miningExtractionByStructureId = new Map(
+										fetchedMiningExtractions.map((extraction) => [
+											String(extraction.structure_id),
+											extraction,
+										])
+									)
+									const prioritizedMiningExtractions = prioritizedMiningCitadelIds
+										.map((structureId) => miningExtractionByStructureId.get(structureId) ?? null)
+										.filter(
+											(extraction): extraction is (typeof fetchedMiningExtractions)[number] =>
+												extraction !== null
 										)
+									miningExtractionsCount = prioritizedMiningExtractions.length
+
+									for (let index = 0; index < prioritizedMiningExtractions.length; index += 100) {
+										const batch = prioritizedMiningExtractions.slice(index, index + 100)
+										if (batch.length === 0) continue
+										await storeMiningExtractionEnrichment(this.env, corporationId, batch)
 									}
+								} catch (error) {
+									const metadata =
+										error instanceof Error ? parseEsiErrorMetadata(error.message) : null
+									const isRateLimitError = metadata?.status === 429
+									structureSyncHadFailure ||= !isRateLimitError
+									if (!isRateLimitError) {
+										try {
+											await markStructureSyncFailureReason(
+												this.env,
+												corporationId,
+												'mining-extractions',
+												error instanceof Error ? error.message : String(error)
+											)
+										} catch (markError) {
+											logger.warn(
+												'[EveCorporationSyncWorkflow] Mining extraction failure reason could not be persisted',
+												{
+													corporationId,
+													error: markError instanceof Error ? markError.message : String(markError),
+												}
+											)
+										}
+									}
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Mining extraction enrichment failed; continuing without it',
+										{
+											corporationId,
+											error: error instanceof Error ? error.message : String(error),
+											isRateLimitError,
+										}
+									)
+								}
+							}
+						} catch (error) {
+							const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
+							const isRateLimitError = metadata?.status === 429
+							structureSyncHadFailure ||= !isRateLimitError
+							if (!isRateLimitError) {
+								try {
+									await markStructureSyncFailureReason(
+										this.env,
+										corporationId,
+										'structures',
+										error instanceof Error ? error.message : String(error)
+									)
+								} catch (markError) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Structure sync failure reason could not be persisted',
+										{
+											corporationId,
+											error: markError instanceof Error ? markError.message : String(markError),
+										}
+									)
+								}
+							}
+							logger.warn(
+								'[EveCorporationSyncWorkflow] Structure sync failed; continuing to asset sync',
+								{
+									corporationId,
+									error: error instanceof Error ? error.message : String(error),
+									isRateLimitError,
+								}
+							)
+						}
+
+						try {
+							const sovereigntyEnrichment = await runDirectorStepWithFailover({
+								stepName: 'fetch-structure-sovereignty-enrichment',
+								timeout: '10 minutes',
+								requiredRoles: ['Station_Manager'],
+								persistResult: false,
+								run: (directorCharacterId) =>
+									fetchSovereigntyEnrichment(this.env, corporationId, directorCharacterId),
+							})
+
+							if (sovereigntyEnrichment) {
+								await storeSovereigntyEnrichment(this.env, corporationId, sovereigntyEnrichment)
+								sovereigntySystemsCount = sovereigntyEnrichment.sovereigntySystems?.length ?? 0
+								sovereigntyHubsCount = sovereigntyEnrichment.sovereigntyHubs.length
+
+								if (sovereigntyEnrichment.nonRateLimitFailureCount > 0) {
+									structureSyncHadFailure = true
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Sovereignty enrichment completed with partial non-rate-limit failures',
+										{
+											corporationId,
+											successCount: sovereigntyEnrichment.sovereigntyHubs.length,
+											failureCount: sovereigntyEnrichment.failureCount,
+											rateLimitFailureCount: sovereigntyEnrichment.rateLimitFailureCount,
+											nonRateLimitFailureCount: sovereigntyEnrichment.nonRateLimitFailureCount,
+										}
+									)
+								} else if (sovereigntyEnrichment.rateLimitFailureCount > 0) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Sovereignty enrichment completed with rate-limit pressure; preserving successful rows',
+										{
+											corporationId,
+											successCount: sovereigntyEnrichment.sovereigntyHubs.length,
+											rateLimitFailureCount: sovereigntyEnrichment.rateLimitFailureCount,
+										}
+									)
+								}
+							}
+						} catch (error) {
+							const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
+							const isRateLimitError = metadata?.status === 429
+							structureSyncHadFailure ||= !isRateLimitError
+
+							if (error instanceof StructureEnrichmentScopeMismatchError) {
+								try {
+									await markStructureEnrichmentSyncFailure(
+										this.env,
+										corporationId,
+										error.target,
+										error.message
+									)
+								} catch (markError) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch could not be persisted',
+										{
+											corporationId,
+											error: markError instanceof Error ? markError.message : String(markError),
+										}
+									)
 								}
 								logger.warn(
-									'[EveCorporationSyncWorkflow] Mining extraction enrichment failed; continuing without it',
+									'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch; marking sync failure',
+									{
+										corporationId,
+										error: error.message,
+									}
+								)
+							} else if (isRateLimitError) {
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Sovereignty enrichment hit rate limit; preserving previously synced rows',
 									{
 										corporationId,
 										error: error instanceof Error ? error.message : String(error),
-										isRateLimitError,
+									}
+								)
+							} else {
+								try {
+									await markStructureSyncFailureReason(
+										this.env,
+										corporationId,
+										'sovereignty',
+										error instanceof Error ? error.message : String(error)
+									)
+								} catch (markError) {
+									logger.warn(
+										'[EveCorporationSyncWorkflow] Sovereignty failure reason could not be persisted',
+										{
+											corporationId,
+											error: markError instanceof Error ? markError.message : String(markError),
+										}
+									)
+								}
+								logger.warn(
+									'[EveCorporationSyncWorkflow] Sovereignty enrichment failed; continuing without it',
+									{
+										corporationId,
+										error: error instanceof Error ? error.message : String(error),
 									}
 								)
 							}
 						}
-					} catch (error) {
-						const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
-						const isRateLimitError = metadata?.status === 429
-						structureSyncHadFailure ||= !isRateLimitError
-						if (!isRateLimitError) {
-							try {
-								await markStructureSyncFailureReason(
-									this.env,
-									corporationId,
-									'structures',
-									error instanceof Error ? error.message : String(error)
-								)
-							} catch (markError) {
-								logger.warn(
-									'[EveCorporationSyncWorkflow] Structure sync failure reason could not be persisted',
-									{
-										corporationId,
-										error: markError instanceof Error ? markError.message : String(markError),
-									}
-								)
-							}
-						}
-						logger.warn('[EveCorporationSyncWorkflow] Structure sync failed; continuing to asset sync', {
-							corporationId,
-							error: error instanceof Error ? error.message : String(error),
-							isRateLimitError,
-						})
-					}
 
-					try {
-						const sovereigntyEnrichment = await runDirectorStepWithFailover({
-							stepName: 'fetch-structure-sovereignty-enrichment',
-							timeout: '10 minutes',
-							requiredRoles: ['Station_Manager'],
-							persistResult: false,
-							run: (directorCharacterId) =>
-								fetchSovereigntyEnrichment(this.env, corporationId, directorCharacterId),
-						})
-
-						if (sovereigntyEnrichment) {
-							await storeSovereigntyEnrichment(
-								this.env,
-								corporationId,
-								sovereigntyEnrichment
-							)
-							sovereigntySystemsCount = sovereigntyEnrichment.sovereigntySystems?.length ?? 0
-							sovereigntyHubsCount = sovereigntyEnrichment.sovereigntyHubs.length
-
-							if (sovereigntyEnrichment.nonRateLimitFailureCount > 0) {
-								structureSyncHadFailure = true
-								logger.warn(
-									'[EveCorporationSyncWorkflow] Sovereignty enrichment completed with partial non-rate-limit failures',
-									{
-										corporationId,
-										successCount: sovereigntyEnrichment.sovereigntyHubs.length,
-										failureCount: sovereigntyEnrichment.failureCount,
-										rateLimitFailureCount: sovereigntyEnrichment.rateLimitFailureCount,
-										nonRateLimitFailureCount: sovereigntyEnrichment.nonRateLimitFailureCount,
-									}
-								)
-							} else if (sovereigntyEnrichment.rateLimitFailureCount > 0) {
-								logger.warn(
-									'[EveCorporationSyncWorkflow] Sovereignty enrichment completed with rate-limit pressure; preserving successful rows',
-									{
-										corporationId,
-										successCount: sovereigntyEnrichment.sovereigntyHubs.length,
-										rateLimitFailureCount: sovereigntyEnrichment.rateLimitFailureCount,
-									}
-								)
-							}
-						}
-					} catch (error) {
-						const metadata = error instanceof Error ? parseEsiErrorMetadata(error.message) : null
-						const isRateLimitError = metadata?.status === 429
-						structureSyncHadFailure ||= !isRateLimitError
-
-						if (error instanceof StructureEnrichmentScopeMismatchError) {
-							try {
-								await markStructureEnrichmentSyncFailure(
-									this.env,
-									corporationId,
-									error.target,
-									error.message
-								)
-							} catch (markError) {
-								logger.warn(
-									'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch could not be persisted',
-									{
-										corporationId,
-										error: markError instanceof Error ? markError.message : String(markError),
-									}
-								)
-							}
-							logger.warn(
-								'[EveCorporationSyncWorkflow] Sovereignty enrichment scope mismatch; marking sync failure',
-								{
-									corporationId,
-									error: error.message,
-								}
-							)
-						} else if (isRateLimitError) {
-							logger.warn(
-								'[EveCorporationSyncWorkflow] Sovereignty enrichment hit rate limit; preserving previously synced rows',
-								{
-									corporationId,
-									error: error instanceof Error ? error.message : String(error),
-								}
-							)
-						} else {
-							try {
-								await markStructureSyncFailureReason(
-									this.env,
-									corporationId,
-									'sovereignty',
-									error instanceof Error ? error.message : String(error)
-								)
-							} catch (markError) {
-								logger.warn(
-									'[EveCorporationSyncWorkflow] Sovereignty failure reason could not be persisted',
-									{
-										corporationId,
-										error: markError instanceof Error ? markError.message : String(markError),
-									}
-								)
-							}
-							logger.warn(
-								'[EveCorporationSyncWorkflow] Sovereignty enrichment failed; continuing without it',
-								{
-									corporationId,
-									error: error instanceof Error ? error.message : String(error),
-								}
-							)
+						const completed = !structureSyncHadFailure
+						structureSyncCompleted = completed
+						return {
+							dataType: 'structures' as const,
+							stats: {
+								structuresCount,
+								sovereigntySystemsCount,
+								sovereigntyHubsCount,
+								miningExtractionsCount,
+							},
+							completed,
 						}
 					}
+				)
+			}
 
-					const completed = !structureSyncHadFailure
-					structureSyncCompleted = completed
-					return {
-						dataType: 'structures' as const,
-						stats: {
-							structuresCount,
-							sovereigntySystemsCount,
-							sovereigntyHubsCount,
-							miningExtractionsCount,
-						},
-						completed,
-					}
-				})
-				}
+			const shouldSyncSkyhooks =
+				shouldSyncAuthenticated('structures') || shouldSyncAuthenticated('skyhooks')
 
-				const shouldSyncSkyhooks =
-					shouldSyncAuthenticated('structures') || shouldSyncAuthenticated('skyhooks')
-
-				if (shouldSyncSkyhooks) {
-					skyhooksSync = await step.do('sync-skyhooks', {}, async () => {
+			if (shouldSyncSkyhooks) {
+				skyhooksSync = await step.do(
+					'sync-skyhooks',
+					{ ...STEP_RETRY_OPTIONS, timeout: '10 minutes' },
+					async () => {
 						let skyhooksCount = 0
 						let skyhooksReturnedCount = 0
 						let skyhooksPrunedCount = 0
@@ -1081,32 +1066,27 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 								skyhooksPrunedCount,
 							},
 						}
-					})
-				}
+					}
+				)
+			}
 
-				if (shouldSyncAuthenticated('assets')) {
+			if (shouldSyncAuthenticated('assets')) {
 				logger.info('[EveCorporationSyncWorkflow] Asset sync selected for this run', {
 					corporationId,
 					trigger,
 					hasDirector: director !== null,
 					structureAssetSyncEnabled,
 				})
-				assetsSync = await step.do(
-					'sync-assets',
-					{ ...STEP_RETRY_OPTIONS, timeout: '20 minutes' },
-					async () => {
-						const result: { assetsCount: number } = await runDirectorStepWithFailover({
-							stepName: 'sync-assets',
-							timeout: '20 minutes',
-							requiredRoles: ['Director'],
-							run: (directorCharacterId) => syncAssets(this.env, corporationId, directorCharacterId),
-						})
-						return {
-							dataType: 'assets' as const,
-							stats: { assetsCount: result.assetsCount },
-						}
-					}
-				)
+				const result = await runDirectorStepWithFailover({
+					stepName: 'sync-assets',
+					timeout: '20 minutes',
+					requiredRoles: ['Director'],
+					run: (directorCharacterId) => syncAssets(this.env, corporationId, directorCharacterId),
+				})
+				assetsSync = {
+					dataType: 'assets',
+					stats: { assetsCount: result.assetsCount },
+				}
 			}
 
 			if (shouldSyncAuthenticated('orders')) {

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -2,7 +2,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
 import * as z4 from 'zod/v4/core'
 
-import { and, asc, eq, gt, gte, inArray, isNull, lt, lte, or } from '@repo/db-utils'
+import { and, asc, eq, gt, inArray, isNull, lt, lte, or } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { EsiRequestClient } from '@repo/esi'
 import { buildEsiUserKey, buildPublicEsiUserKey, EsiRateLimitStore } from '@repo/esi-rate-limit'
@@ -87,6 +87,9 @@ const AUTH_ESI_ROUTE_WINDOW_LIMIT = 60
 const AUTH_ESI_RAMP_WINDOW_MS = 60 * 1000
 const TOKEN_REFRESH_COOLDOWN_PREFIX = 'token:refresh:cooldown:'
 const TOKEN_REFRESH_TRANSIENT_COOLDOWN_MS = 5 * 60 * 1000
+const TOKEN_REFRESH_ALARM_BATCH_SIZE = 10
+const TOKEN_REFRESH_ALARM_CONTINUE_DELAY_MS = 30 * 1000
+const TOKEN_REFRESH_ALARM_INTERVAL_MS = 5 * 60 * 1000
 
 type AccessTokenLookupResult =
 	| {
@@ -152,7 +155,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		})
 
 		// Load cached metadata from DO storage once on startup.
-		state.blockConcurrencyWhile(async () => {
+		void state.blockConcurrencyWhile(async () => {
 			this.metadata = (await state.storage.get<CachedEveMetadata>('eve:oauth:metadata')) ?? null
 
 			if (this.metadata) {
@@ -2024,7 +2027,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	): Promise<{
 		data: T[]
 		pages: number
-		responses: EsiResponse<T[]>[]
+		responses: Array<EsiResponse<T[]>>
 	}> {
 		const maxConcurrent = options?.maxConcurrent ?? 5
 		const cacheMode = options?.cacheMode ?? 'default'
@@ -2040,7 +2043,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		})
 
 		const totalPages = firstResponse.pages ?? 1
-		const responses: EsiResponse<T[]>[] = [firstResponse]
+		const responses: Array<EsiResponse<T[]>> = [firstResponse]
 
 		// If there's only one page, return early
 		if (totalPages === 1) {
@@ -2061,7 +2064,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		}
 
 		// Fetch with concurrency control
-		const remainingResponses: EsiResponse<T[]>[] = []
+		const remainingResponses: Array<EsiResponse<T[]>> = []
 		for (let i = 0; i < remainingPages.length; i += maxConcurrent) {
 			const batch = remainingPages.slice(i, i + maxConcurrent)
 			const batchResponses = await Promise.all(batch.map(fetchPage))
@@ -2093,7 +2096,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	): Promise<{
 		data: T[]
 		pages: number
-		responses: EsiResponse<T[]>[]
+		responses: Array<EsiResponse<T[]>>
 	}> {
 		const maxConcurrent = options?.maxConcurrent ?? 5
 
@@ -2106,7 +2109,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		const firstResponse = await this.fetchPublicEsi<T[]>(firstPagePath)
 
 		const totalPages = firstResponse.pages ?? 1
-		const responses: EsiResponse<T[]>[] = [firstResponse]
+		const responses: Array<EsiResponse<T[]>> = [firstResponse]
 
 		// If there's only one page, return early
 		if (totalPages === 1) {
@@ -2125,7 +2128,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		}
 
 		// Fetch with concurrency control
-		const remainingResponses: EsiResponse<T[]>[] = []
+		const remainingResponses: Array<EsiResponse<T[]>> = []
 		for (let i = 0; i < remainingPages.length; i += maxConcurrent) {
 			const batch = remainingPages.slice(i, i + maxConcurrent)
 			const batchResponses = await Promise.all(batch.map(fetchPage))
@@ -2187,8 +2190,6 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 
 					// Fetch and stream remaining pages with concurrency control
 					const remainingPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2)
-					let totalItems = firstResponse.data.length
-
 					for (let i = 0; i < remainingPages.length; i += maxConcurrent) {
 						const batch = remainingPages.slice(i, i + maxConcurrent)
 
@@ -2205,7 +2206,6 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 							for (const item of response.data) {
 								const line = JSON.stringify(item) + '\n'
 								controller.enqueue(encoder.encode(line))
-								totalItems++
 							}
 						}
 					}
@@ -2221,7 +2221,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 				}
 			},
 
-			cancel(reason) {
+			cancel(_reason) {
 				// Stream cancelled
 			},
 		})
@@ -2551,35 +2551,44 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	 * Alarm handler - automatically refresh tokens that are expiring soon
 	 */
 	async alarm(): Promise<void> {
+		let processedBatchSize = 0
 		try {
 			const now = new Date()
 			const fiveMinutesFromNow = new Date(Date.now() + 5 * 60 * 1000)
 
-			// Find tokens expiring within the next 5 minutes
-			const expiringTokens = await this.db.query.eveTokens.findMany({
-				where: and(
-					gt(eveTokens.expiresAt, now), // Not already expired
-					lte(eveTokens.expiresAt, fiveMinutesFromNow), // Expires within 5 minutes
-					or(isNull(eveTokens.nextRetryAt), lte(eveTokens.nextRetryAt, now))
-				),
-			})
+			// Process a bounded batch so one alarm cannot build an unbounded queue of
+			// Durable Object storage operations when many tokens expire together.
+			const expiringTokens = await this.db
+				.select({ characterId: eveCharacters.characterId })
+				.from(eveTokens)
+				.innerJoin(eveCharacters, eq(eveTokens.characterId, eveCharacters.id))
+				.where(
+					and(
+						gt(eveTokens.expiresAt, now),
+						lte(eveTokens.expiresAt, fiveMinutesFromNow),
+						isNull(eveCharacters.deletedAt),
+						isNull(eveTokens.permanentInvalidAt),
+						or(isNull(eveTokens.nextRetryAt), lte(eveTokens.nextRetryAt, now))
+					)
+				)
+				.orderBy(asc(eveTokens.expiresAt))
+				.limit(TOKEN_REFRESH_ALARM_BATCH_SIZE)
+
+			processedBatchSize = expiringTokens.length
 
 			// Refresh each token
-			for (const token of expiringTokens) {
-				const character = await this.db.query.eveCharacters.findFirst({
-					where: eq(eveCharacters.id, token.characterId),
-				})
-
-				if (character) {
-					await this.refreshToken(character.characterId)
-				}
+			for (const { characterId } of expiringTokens) {
+				await this.refreshToken(characterId)
 			}
 		} catch (error) {
 			logger.error(error)
 		}
 
-		// Schedule next alarm (5 minutes)
-		await this.state.storage.setAlarm(Date.now() + 5 * 60 * 1000)
+		const nextAlarmDelayMs =
+			processedBatchSize === TOKEN_REFRESH_ALARM_BATCH_SIZE
+				? TOKEN_REFRESH_ALARM_CONTINUE_DELAY_MS
+				: TOKEN_REFRESH_ALARM_INTERVAL_MS
+		await this.state.storage.setAlarm(Date.now() + nextAlarmDelayMs)
 	}
 
 	/**

--- a/packages/esi-rate-limit/src/index.test.ts
+++ b/packages/esi-rate-limit/src/index.test.ts
@@ -156,10 +156,38 @@ describe('EsiRateLimitStore', () => {
 		const kv = new DeferredKv()
 		const store = new EsiRateLimitStore(kv as never)
 
-		void store.rememberRouteGroup('/corporations/:id/wallets/:id/journal', 'corp-wallet')
+		const firstWrite = store.rememberRouteGroup(
+			'/corporations/:id/wallets/:id/journal',
+			'corp-wallet'
+		)
 		void store.rememberRouteGroup('/corporations/:id/wallets/:id/journal', 'corp-wallet')
 
 		await Promise.resolve()
 		expect(kv.peekPutCount()).toBe(1)
+		kv.resolveNextPut()
+		await firstWrite
+
+		await store.rememberRouteGroup('/corporations/:id/wallets/:id/journal', 'corp-wallet')
+		expect(kv.peekPutCount()).toBe(0)
+	})
+
+	it('backs off repeated route-group writes after KV throttling', async () => {
+		const kv = new DeferredKv()
+		const store = new EsiRateLimitStore(kv as never)
+
+		const firstWrite = store.rememberRouteGroup('/characters/:id/wallet', 'char-wallet')
+		await Promise.resolve()
+		kv.rejectNextPut(new Error('KV PUT failed: 429 Too Many Requests'))
+		await firstWrite
+
+		await store.rememberRouteGroup('/characters/:id/wallet', 'char-wallet')
+		expect(kv.peekPutCount()).toBe(0)
+
+		vi.advanceTimersByTime(60_000)
+		const retry = store.rememberRouteGroup('/characters/:id/wallet', 'char-wallet')
+		await Promise.resolve()
+		expect(kv.peekPutCount()).toBe(1)
+		kv.rejectNextPut(new Error('KV PUT failed: 429 Too Many Requests'))
+		await retry
 	})
 })

--- a/packages/esi-rate-limit/src/index.ts
+++ b/packages/esi-rate-limit/src/index.ts
@@ -13,11 +13,14 @@ const ESI_RATE_LIMIT_ROUTE_PREFIX = 'esi:rate-limit:route:'
 // long time and only refresh them opportunistically when ESI returns a new
 // group header.
 const ESI_RATE_LIMIT_ROUTE_GROUP_MAPPING_TTL_SECONDS = 180 * 24 * 60 * 60
+const ESI_RATE_LIMIT_ROUTE_GROUP_MAPPING_TTL_MS =
+	ESI_RATE_LIMIT_ROUTE_GROUP_MAPPING_TTL_SECONDS * 1000
 
 // We still cap transient bucket/cooldown records to avoid an upstream bug or a
 // malformed response pinning the limiter forever.
 const ESI_RATE_LIMIT_MAX_TTL_SECONDS = 6 * 60 * 60
 const ESI_RATE_LIMIT_MIN_TTL_SECONDS = 60
+const ESI_RATE_LIMIT_ROUTE_GROUP_RETRY_DELAY_MS = 60_000
 
 export type EsiRateLimitFamily = 'bucket' | 'error-limit' | 'route-breaker'
 
@@ -67,7 +70,9 @@ export interface EsiRateLimitResponseLike {
 	ok?: boolean
 }
 
-export interface EsiRateLimitRequestErrorContext<TResponse extends EsiRateLimitResponseLike = EsiRateLimitResponseLike> {
+export interface EsiRateLimitRequestErrorContext<
+	TResponse extends EsiRateLimitResponseLike = EsiRateLimitResponseLike,
+> {
 	path: string
 	routeKey: string
 	userKey: string
@@ -154,7 +159,9 @@ export function buildEsiRouteGroupMappingKey(routeKey: string): string {
 	return `${ESI_RATE_LIMIT_ROUTE_GROUP_PREFIX}${routeKey}`
 }
 
-export function parseEsiRateLimitWindow(limitHeader: string | null): { limit: number; windowSeconds: number } | null {
+export function parseEsiRateLimitWindow(
+	limitHeader: string | null
+): { limit: number; windowSeconds: number } | null {
 	if (!limitHeader) return null
 
 	const trimmed = limitHeader.trim()
@@ -172,7 +179,9 @@ export function parseEsiRateLimitWindow(limitHeader: string | null): { limit: nu
 	return { limit, windowSeconds }
 }
 
-export function parseEsiRateLimitHeaders(headers: EsiRateLimitHeadersLike): EsiRateLimitHeadersSnapshot {
+export function parseEsiRateLimitHeaders(
+	headers: EsiRateLimitHeadersLike
+): EsiRateLimitHeadersSnapshot {
 	const group = headers.get('X-Ratelimit-Group') ?? undefined
 	const limitInfo = parseEsiRateLimitWindow(headers.get('X-Ratelimit-Limit'))
 	const remaining = parseHeaderInteger(headers, 'X-Ratelimit-Remaining')
@@ -259,9 +268,12 @@ function summarizeBucketCharges(
 	const windowMs = windowSeconds * 1000
 	const used = charges.reduce((sum, charge) => sum + charge.cost, 0)
 	const remaining = Math.max(0, limit - used)
-	const expiresAtMs = charges.length > 0 ? charges[charges.length - 1]!.atMs + windowMs : nowMs + windowMs
+	const expiresAtMs =
+		charges.length > 0 ? charges[charges.length - 1]!.atMs + windowMs : nowMs + windowMs
 	const retryAfterSeconds =
-		used >= limit && charges.length > 0 ? Math.max(1, Math.ceil((charges[0]!.atMs + windowMs - nowMs) / 1000)) : undefined
+		used >= limit && charges.length > 0
+			? Math.max(1, Math.ceil((charges[0]!.atMs + windowMs - nowMs) / 1000))
+			: undefined
 
 	return {
 		charges,
@@ -291,6 +303,9 @@ export class EsiRateLimitStore {
 		{
 			flushPromise: Promise<void> | null
 			lastPersistedAtMs: number
+			lastPersistedGroup: string | null
+			lastAttemptedAtMs: number
+			lastAttemptedGroup: string | null
 			pendingGroup: string | null
 		}
 	>()
@@ -319,6 +334,9 @@ export class EsiRateLimitStore {
 	private getRouteGroupWriteState(key: string): {
 		flushPromise: Promise<void> | null
 		lastPersistedAtMs: number
+		lastPersistedGroup: string | null
+		lastAttemptedAtMs: number
+		lastAttemptedGroup: string | null
 		pendingGroup: string | null
 	} {
 		const existing = this.routeGroupWriteStates.get(key)
@@ -329,6 +347,9 @@ export class EsiRateLimitStore {
 		const created = {
 			flushPromise: null,
 			lastPersistedAtMs: 0,
+			lastPersistedGroup: null,
+			lastAttemptedAtMs: 0,
+			lastAttemptedGroup: null,
 			pendingGroup: null,
 		}
 		this.routeGroupWriteStates.set(key, created)
@@ -387,7 +408,11 @@ export class EsiRateLimitStore {
 			}
 			if (snapshot.family === 'bucket') {
 				const now = Date.now()
-				const normalizedCharges = normalizeBucketCharges(snapshot.charges, snapshot.windowSeconds ?? 0, now)
+				const normalizedCharges = normalizeBucketCharges(
+					snapshot.charges,
+					snapshot.windowSeconds ?? 0,
+					now
+				)
 				const blockedUntilMs =
 					typeof snapshot.blockedUntilMs === 'number' && snapshot.blockedUntilMs > now
 						? snapshot.blockedUntilMs
@@ -409,19 +434,26 @@ export class EsiRateLimitStore {
 					}
 				}
 
-					const summary = summarizeBucketCharges(normalizedCharges, snapshot.limit, snapshot.windowSeconds, now)
-					return {
-						...snapshot,
-						charges: summary.charges,
-						used: snapshot.used ?? summary.used,
-						remaining: snapshot.remaining ?? summary.remaining,
-						blockedUntilMs,
-						expiresAtMs: blockedUntilMs ? Math.max(summary.expiresAtMs, blockedUntilMs) : summary.expiresAtMs,
-						retryAfterSeconds: blockedUntilMs
-							? Math.max(1, Math.ceil((blockedUntilMs - now) / 1000))
-							: snapshot.retryAfterSeconds ?? summary.retryAfterSeconds,
-					}
+				const summary = summarizeBucketCharges(
+					normalizedCharges,
+					snapshot.limit,
+					snapshot.windowSeconds,
+					now
+				)
+				return {
+					...snapshot,
+					charges: summary.charges,
+					used: snapshot.used ?? summary.used,
+					remaining: snapshot.remaining ?? summary.remaining,
+					blockedUntilMs,
+					expiresAtMs: blockedUntilMs
+						? Math.max(summary.expiresAtMs, blockedUntilMs)
+						: summary.expiresAtMs,
+					retryAfterSeconds: blockedUntilMs
+						? Math.max(1, Math.ceil((blockedUntilMs - now) / 1000))
+						: (snapshot.retryAfterSeconds ?? summary.retryAfterSeconds),
 				}
+			}
 			return snapshot
 		} catch {
 			return null
@@ -436,11 +468,12 @@ export class EsiRateLimitStore {
 		}
 	}
 
-	private async persistRouteGroup(routeKey: string, group: string): Promise<void> {
+	private async persistRouteGroup(routeKey: string, group: string): Promise<boolean> {
 		try {
 			await this.kv.put(buildEsiRouteGroupMappingKey(routeKey), group, {
 				expirationTtl: ESI_RATE_LIMIT_ROUTE_GROUP_MAPPING_TTL_SECONDS,
 			})
+			return true
 		} catch (error) {
 			// Route-group mappings are best-effort limiter hints. If KV is briefly
 			// saturated, keep serving requests and let the in-memory state on this
@@ -450,6 +483,7 @@ export class EsiRateLimitStore {
 				group,
 				error: error instanceof Error ? error.message : String(error),
 			})
+			return false
 		}
 	}
 
@@ -473,13 +507,35 @@ export class EsiRateLimitStore {
 			}
 
 			state.pendingGroup = null
-			await this.persistRouteGroup(routeKey, nextGroup)
+			state.lastAttemptedAtMs = Date.now()
+			state.lastAttemptedGroup = nextGroup
+			const persisted = await this.persistRouteGroup(routeKey, nextGroup)
 			state.lastPersistedAtMs = Date.now()
+			if (persisted) {
+				state.lastPersistedGroup = nextGroup
+			}
 		}
 	}
 
 	async rememberRouteGroup(routeKey: string, group: string): Promise<void> {
 		const state = this.getRouteGroupWriteState(routeKey)
+		if (state.pendingGroup === group) {
+			return
+		}
+		if (
+			state.pendingGroup === null &&
+			state.lastPersistedGroup === group &&
+			Date.now() - state.lastPersistedAtMs < ESI_RATE_LIMIT_ROUTE_GROUP_MAPPING_TTL_MS
+		) {
+			return
+		}
+		if (
+			state.pendingGroup === null &&
+			state.lastAttemptedGroup === group &&
+			Date.now() - state.lastAttemptedAtMs < ESI_RATE_LIMIT_ROUTE_GROUP_RETRY_DELAY_MS
+		) {
+			return
+		}
 		state.pendingGroup = group
 
 		if (state.flushPromise) {
@@ -496,9 +552,6 @@ export class EsiRateLimitStore {
 			})
 			.finally(() => {
 				state.flushPromise = null
-				if (!state.pendingGroup) {
-					this.routeGroupWriteStates.delete(routeKey)
-				}
 			})
 
 		await state.flushPromise
@@ -514,16 +567,18 @@ export class EsiRateLimitStore {
 		return this.getSnapshot(key)
 	}
 
-	async putBucketSnapshot(params: Omit<EsiRateLimitSnapshot, 'family' | 'key' | 'observedAtMs' | 'expiresAtMs'> & {
-		group: string
-		userKey: string
-		status: number
-		observedAtMs: number
-		expiresAtMs: number
-	}): Promise<void> {
+	async putBucketSnapshot(
+		params: Omit<EsiRateLimitSnapshot, 'family' | 'key' | 'observedAtMs' | 'expiresAtMs'> & {
+			group: string
+			userKey: string
+			status: number
+			observedAtMs: number
+			expiresAtMs: number
+		}
+	): Promise<void> {
 		const key = buildEsiBucketKey(params.group, params.userKey)
 		const existing = await this.getSnapshot(key)
-		const existingCharges = existing?.family === 'bucket' ? existing.charges ?? [] : []
+		const existingCharges = existing?.family === 'bucket' ? (existing.charges ?? []) : []
 		const windowSeconds = params.windowSeconds ?? existing?.windowSeconds ?? 0
 		const charges = normalizeBucketCharges(existingCharges, windowSeconds, params.observedAtMs)
 		const responseCost = getBucketRequestCost(params.status)
@@ -559,7 +614,12 @@ export class EsiRateLimitStore {
 			return
 		}
 
-		const summary = summarizeBucketCharges(nextCharges, params.limit, params.windowSeconds, params.observedAtMs)
+		const summary = summarizeBucketCharges(
+			nextCharges,
+			params.limit,
+			params.windowSeconds,
+			params.observedAtMs
+		)
 		const snapshot: EsiRateLimitSnapshot = {
 			family: 'bucket',
 			key,
@@ -573,11 +633,13 @@ export class EsiRateLimitStore {
 			retryAfterSeconds:
 				blockedUntilMs !== undefined
 					? Math.max(1, Math.ceil((blockedUntilMs - params.observedAtMs) / 1000))
-					: params.retryAfterSeconds ?? summary.retryAfterSeconds,
+					: (params.retryAfterSeconds ?? summary.retryAfterSeconds),
 			charges: summary.charges,
 			blockedUntilMs,
 			observedAtMs: params.observedAtMs,
-			expiresAtMs: blockedUntilMs ? Math.max(summary.expiresAtMs, blockedUntilMs) : summary.expiresAtMs,
+			expiresAtMs: blockedUntilMs
+				? Math.max(summary.expiresAtMs, blockedUntilMs)
+				: summary.expiresAtMs,
 		}
 
 		const state = this.getBucketWriteState(key)
@@ -604,16 +666,21 @@ export class EsiRateLimitStore {
 		await state.flushPromise
 	}
 
-	async getRouteErrorLimit(routeKey: string, userKey: string): Promise<EsiRateLimitSnapshot | null> {
+	async getRouteErrorLimit(
+		routeKey: string,
+		userKey: string
+	): Promise<EsiRateLimitSnapshot | null> {
 		return this.getSnapshot(buildEsiRouteErrorKey(routeKey, userKey))
 	}
 
-	async putRouteErrorLimit(params: Omit<EsiRateLimitSnapshot, 'family' | 'key' | 'observedAtMs' | 'expiresAtMs'> & {
-		userKey: string
-		routeKey: string
-		observedAtMs: number
-		expiresAtMs: number
-	}): Promise<void> {
+	async putRouteErrorLimit(
+		params: Omit<EsiRateLimitSnapshot, 'family' | 'key' | 'observedAtMs' | 'expiresAtMs'> & {
+			userKey: string
+			routeKey: string
+			observedAtMs: number
+			expiresAtMs: number
+		}
+	): Promise<void> {
 		await this.persistSnapshot({
 			family: 'error-limit',
 			key: buildEsiRouteErrorKey(params.routeKey, params.userKey),
@@ -633,11 +700,13 @@ export class EsiRateLimitStore {
 		return this.getSnapshot(buildEsiRouteCooldownKey(routeKey, userKey))
 	}
 
-	async putRouteCooldown(params: Omit<EsiRateLimitSnapshot, 'family' | 'key' | 'observedAtMs' | 'expiresAtMs'> & {
-		userKey: string
-		observedAtMs: number
-		expiresAtMs: number
-	}): Promise<void> {
+	async putRouteCooldown(
+		params: Omit<EsiRateLimitSnapshot, 'family' | 'key' | 'observedAtMs' | 'expiresAtMs'> & {
+			userKey: string
+			observedAtMs: number
+			expiresAtMs: number
+		}
+	): Promise<void> {
 		await this.persistSnapshot({
 			family: 'route-breaker',
 			key: buildEsiRouteCooldownKey(params.routeKey, params.userKey),
@@ -666,42 +735,45 @@ export class EsiRateLimitGuard {
 		const now = Date.now()
 
 		const routeGroup = await this.store.getRouteGroup(routeKey)
-			if (routeGroup) {
-				const bucket = await this.store.getBucketSnapshot(routeGroup, userKey)
-				if (bucket && bucket.limit !== undefined) {
-					if (bucket.blockedUntilMs !== undefined && bucket.blockedUntilMs > now) {
-						const retryAfterSeconds = Math.max(1, Math.ceil((bucket.blockedUntilMs - now) / 1000))
+		if (routeGroup) {
+			const bucket = await this.store.getBucketSnapshot(routeGroup, userKey)
+			if (bucket && bucket.limit !== undefined) {
+				if (bucket.blockedUntilMs !== undefined && bucket.blockedUntilMs > now) {
+					const retryAfterSeconds = Math.max(1, Math.ceil((bucket.blockedUntilMs - now) / 1000))
 					throw this.buildPreflightError(path, routeKey, 'bucket', retryAfterSeconds, routeGroup, {
 						limit: bucket.limit,
 						remaining: bucket.remaining,
 						used: bucket.used ?? bucket.limit - (bucket.remaining ?? 0),
-							windowSeconds: bucket.windowSeconds,
-						})
-					}
+						windowSeconds: bucket.windowSeconds,
+					})
+				}
 
-					if (bucket.remaining !== undefined && bucket.remaining <= 0) {
-						const retryAfterSeconds = bucket.retryAfterSeconds ?? Math.max(1, Math.ceil((bucket.expiresAtMs - now) / 1000))
-						throw this.buildPreflightError(path, routeKey, 'bucket', retryAfterSeconds, routeGroup, {
-							limit: bucket.limit,
-							remaining: bucket.remaining,
-							used: bucket.used ?? bucket.limit - bucket.remaining,
-							windowSeconds: bucket.windowSeconds,
-						})
-					}
+				if (bucket.remaining !== undefined && bucket.remaining <= 0) {
+					const retryAfterSeconds =
+						bucket.retryAfterSeconds ?? Math.max(1, Math.ceil((bucket.expiresAtMs - now) / 1000))
+					throw this.buildPreflightError(path, routeKey, 'bucket', retryAfterSeconds, routeGroup, {
+						limit: bucket.limit,
+						remaining: bucket.remaining,
+						used: bucket.used ?? bucket.limit - bucket.remaining,
+						windowSeconds: bucket.windowSeconds,
+					})
 				}
 			}
+		}
 
 		const routeErrorLimit = await this.store.getRouteErrorLimit(routeKey, userKey)
 		if (routeErrorLimit) {
 			const retryAfterSeconds =
-				routeErrorLimit.retryAfterSeconds ?? Math.max(1, Math.ceil((routeErrorLimit.expiresAtMs - now) / 1000))
+				routeErrorLimit.retryAfterSeconds ??
+				Math.max(1, Math.ceil((routeErrorLimit.expiresAtMs - now) / 1000))
 			throw this.buildPreflightError(path, routeKey, 'error_limit', retryAfterSeconds)
 		}
 
 		const routeCooldown = await this.store.getRouteCooldown(routeKey, userKey)
 		if (routeCooldown) {
 			const retryAfterSeconds =
-				routeCooldown.retryAfterSeconds ?? Math.max(1, Math.ceil((routeCooldown.expiresAtMs - now) / 1000))
+				routeCooldown.retryAfterSeconds ??
+				Math.max(1, Math.ceil((routeCooldown.expiresAtMs - now) / 1000))
 			throw this.buildPreflightError(path, routeKey, 'route_breaker', retryAfterSeconds)
 		}
 	}
@@ -729,7 +801,9 @@ export class EsiRateLimitGuard {
 			routeGroup,
 			bucket,
 		})
-		return new Error(`ESI request failed: 429 Too Many Requests - {"error":"ESI rate limit active"} | metadata=${metadata}`)
+		return new Error(
+			`ESI request failed: 429 Too Many Requests - {"error":"ESI rate limit active"} | metadata=${metadata}`
+		)
 	}
 
 	private async updateState(
@@ -808,7 +882,9 @@ export class EsiRateLimitGuard {
 		contentType?: string | false
 		timeoutMs?: number
 	}): Record<string, unknown> {
-		const method = (options.method ?? (options.jsonBody !== undefined ? 'POST' : 'GET')).toUpperCase()
+		const method = (
+			options.method ?? (options.jsonBody !== undefined ? 'POST' : 'GET')
+		).toUpperCase()
 		const headers: Record<string, string> = {}
 
 		if (options.accessToken) {
@@ -838,9 +914,11 @@ export class EsiRateLimitGuard {
 		}
 
 		if (options.timeoutMs !== undefined) {
-			const abortSignal = (globalThis as unknown as {
-				AbortSignal?: { timeout(ms: number): unknown }
-			}).AbortSignal?.timeout(options.timeoutMs)
+			const abortSignal = (
+				globalThis as unknown as {
+					AbortSignal?: { timeout(ms: number): unknown }
+				}
+			).AbortSignal?.timeout(options.timeoutMs)
 			if (abortSignal) {
 				requestInit.signal = abortSignal
 			}
@@ -877,9 +955,11 @@ export class EsiRateLimitGuard {
 	}): Promise<TResult> {
 		await this.assertAllowance(options.path, options.userKey)
 		const requestInit = this.buildRequestInit(options)
-		const response = await (globalThis as unknown as {
-			fetch(input: string, init?: Record<string, unknown>): Promise<TResponse>
-		}).fetch(`https://esi.evetech.net${options.path}`, requestInit)
+		const response = await (
+			globalThis as unknown as {
+				fetch(input: string, init?: Record<string, unknown>): Promise<TResponse>
+			}
+		).fetch(`https://esi.evetech.net${options.path}`, requestInit)
 		await this.updateState(options.path, response.headers, response.status, options.userKey)
 
 		if (!this.isResponseOk(response)) {

--- a/packages/workflow-utils/eslint.config.ts
+++ b/packages/workflow-utils/eslint.config.ts
@@ -1,7 +1,19 @@
-import { defineConfig } from '@repo/eslint-config'
+import { defineConfig, getConfig } from '@repo/eslint-config'
 
-export default defineConfig({
-	typescript: {
-		project: './tsconfig.json',
+import type { Config } from '@repo/eslint-config'
+
+const config = getConfig(import.meta.url)
+
+export default defineConfig([
+	config,
+	{
+		files: ['vitest.config.ts'],
+		languageOptions: {
+			parserOptions: {
+				projectService: {
+					allowDefaultProject: ['vitest.config.ts'],
+				},
+			},
+		},
 	},
-})
+]) as Config

--- a/packages/workflow-utils/src/create-workflow.ts
+++ b/packages/workflow-utils/src/create-workflow.ts
@@ -117,7 +117,7 @@ export async function createWorkflow<PARAMS = unknown>(
  */
 export async function createWorkflowBatch<PARAMS = unknown>(
 	workflow: Workflow<PARAMS>,
-	batch: CreateWorkflowOptions<PARAMS>[]
+	batch: Array<CreateWorkflowOptions<PARAMS>>
 ): Promise<WorkflowInstance[]> {
 	return workflow.createBatch(batch.map((options) => withDefaultRetention(options)))
 }

--- a/packages/workflow-utils/src/esi-retry.ts
+++ b/packages/workflow-utils/src/esi-retry.ts
@@ -49,6 +49,26 @@ function getEsiStatusFromError(error: unknown): number | null {
 }
 
 /**
+ * Classify an ESI authentication or permission failure.
+ *
+ * Generic words such as "forbidden" are not sufficient because Durable
+ * Object, Worker, and Workflow errors can contain them without saying
+ * anything about the director token.
+ */
+export type EsiCredentialFailureKind = 'authentication' | 'permission'
+
+export function classifyEsiCredentialFailure(error: unknown): EsiCredentialFailureKind | null {
+	if (!(error instanceof Error)) return null
+
+	const match = error.message.match(/ESI request failed:\s*(401|403)\b/i)
+	if (!match) return null
+
+	const metadataStatus = getEsiStatusFromError(error)
+	if (metadataStatus !== null && metadataStatus !== Number(match[1])) return null
+	return match[1] === '401' ? 'authentication' : 'permission'
+}
+
+/**
  * Check if an error is a retriable ESI rate limit (420 or 429).
  */
 export function isEsiRateLimitError(error: unknown): boolean {
@@ -113,8 +133,12 @@ export function extractEsiRateLimitSleepSeconds(
 
 	if (metadata.status !== 429) return null
 
-	const retryAfter = typeof metadata.retryAfterSeconds === 'number' ? metadata.retryAfterSeconds : undefined
-	const errorLimitReset = typeof metadata.errorLimitResetSeconds === 'number' ? metadata.errorLimitResetSeconds : undefined
+	const retryAfter =
+		typeof metadata.retryAfterSeconds === 'number' ? metadata.retryAfterSeconds : undefined
+	const errorLimitReset =
+		typeof metadata.errorLimitResetSeconds === 'number'
+			? metadata.errorLimitResetSeconds
+			: undefined
 	const recommended = retryAfter ?? errorLimitReset ?? fallbackSeconds
 
 	return Math.max(1, Math.min(maxSeconds, recommended))
@@ -165,7 +189,11 @@ export async function withEsiRetryClassification<T>(
 		}
 
 		const message = error instanceof Error ? error.message : String(error)
-		const sleepSeconds = extractEsiRateLimitSleepSeconds(message, rateLimitFallbackSeconds, rateLimitMaxSeconds)
+		const sleepSeconds = extractEsiRateLimitSleepSeconds(
+			message,
+			rateLimitFallbackSeconds,
+			rateLimitMaxSeconds
+		)
 		if (sleepSeconds !== null) {
 			await new Promise((resolve) => setTimeout(resolve, sleepSeconds * 1000))
 		}

--- a/packages/workflow-utils/src/index.ts
+++ b/packages/workflow-utils/src/index.ts
@@ -98,6 +98,8 @@ export {
 	parseEsiErrorMetadata,
 	extractEsiRateLimitSleepSeconds,
 	isEsiRateLimitError,
+	classifyEsiCredentialFailure,
+	type EsiCredentialFailureKind,
 	isPermanentEsiFailure,
 	withJitter,
 	withEsiRetryClassification,

--- a/packages/workflow-utils/src/test/create-workflow.test.ts
+++ b/packages/workflow-utils/src/test/create-workflow.test.ts
@@ -14,7 +14,7 @@ function mockWorkflow<PARAMS = unknown>() {
 		id: 'instance-1',
 		options,
 	}))
-	const createBatch = vi.fn(async (batch: WorkflowInstanceCreateOptions<PARAMS>[]) =>
+	const createBatch = vi.fn(async (batch: Array<WorkflowInstanceCreateOptions<PARAMS>>) =>
 		batch.map((options, i) => ({ id: `instance-${i}`, options }))
 	)
 	return { create, createBatch } as unknown as Workflow<PARAMS> & {

--- a/packages/workflow-utils/src/test/index.test.ts
+++ b/packages/workflow-utils/src/test/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
 	calculateJsonSize,
+	classifyEsiCredentialFailure,
 	generateCleanupPrefix,
 	generateR2Key,
 	isEsiRateLimitError,
@@ -165,6 +166,28 @@ describe('workflow-utils', () => {
 				'request failed without explicit 429 text | metadata={"status":429,"path":"/x"}'
 			)
 			expect(isEsiRateLimitError(error)).toBe(true)
+		})
+
+		it('classifies canonical ESI authentication and permission failures separately', () => {
+			expect(classifyEsiCredentialFailure(new Error('ESI request failed: 401 Unauthorized'))).toBe(
+				'authentication'
+			)
+			expect(classifyEsiCredentialFailure(new Error('ESI request failed: 403 Forbidden'))).toBe(
+				'permission'
+			)
+			expect(
+				classifyEsiCredentialFailure(
+					new Error('fetch failed: ESI request failed: 401 Unauthorized | metadata={"status":401}')
+				)
+			).toBe('authentication')
+			expect(classifyEsiCredentialFailure(new Error('Worker failed: forbidden RPC response'))).toBe(
+				null
+			)
+			expect(
+				classifyEsiCredentialFailure(
+					new Error('ESI request failed: 403 Forbidden | metadata={"status":500,"path":"/x"}')
+				)
+			).toBe(null)
 		})
 	})
 })


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Fixes two reliability issues in the EVE corporation sync workflow: director health checks were misclassifying non-auth failures (e.g. Durable Object timeouts) as director authentication failures, causing healthy directors to be incorrectly failed over/removed, and some sync workflow steps had no timeout or were double-wrapped in `step.do`. Also adds proper disposal of RPC results in `apps/core` routes and hardens a few other durable object/rate-limit edge cases found along the way.

## Changes

- **Director health classification** (`director-manager.ts`, `sync-workflow.ts`, `workflow-utils/esi-retry.ts`): added a shared `classifyEsiCredentialFailure()` that only matches canonical `ESI request failed: 401/403` messages (instead of loose `includes('forbidden')`/`includes('unauthorized')` checks), so dependency/timeout errors are no longer misclassified as director auth failures. Non-credential failures are now recorded as "Director dependency failure" or "Director lookup failure" instead of "Director auth failure", and only credential failures are eligible for director failover/permanent removal.
- **Workflow step timeouts** (`sync-workflow.ts`): `sync-structures` and `sync-skyhooks` steps now have explicit timeouts (`20 minutes` / `10 minutes`) instead of `{}`; removed redundant `step.do` wrapping around `sync-wallet-journal`/`sync-wallet-transactions` (which already run inside `runDirectorStepWithFailover`'s own `step.do`).
- **RPC result disposal** (`apps/core/src/routes/users.ts`): stub calls now use `Rpc.Provider<T>` typing with `using` to dispose RPC results as soon as they're consumed, mapping results to plain objects before returning them from the disposal scope.
- **Token refresh alarm batching** (`eve-token-store/durable-object.ts`): the alarm handler now processes a bounded batch (10) of expiring tokens via a single joined query instead of an unbounded set with N+1 character lookups, and reschedules sooner when a full batch was processed vs. the normal 5-minute interval otherwise.
- **ESI rate limit route-group writes** (`esi-rate-limit/index.ts`): added backoff tracking (`lastPersistedGroup`/`lastAttemptedGroup` + timestamps) to avoid repeatedly retrying KV writes for the same route group, especially after a KV throttling error.
- **Fuel burn rate batch update** (`eve-corporation-data/durable-object.ts`): handles the case where an entire batch has `null` burn rates (skips the `CASE` SQL and just nulls the column) and casts non-null burn rates explicitly to `numeric`.
- Various Prettier-only reformatting across touched files.

## Testing

- Added/updated unit tests for director failure classification (`director-manager.test.ts`), including a new case asserting Durable Object timeout errors are not classified as director auth failures.
- Updated `sync-workflow.test.ts` to assert `sync-assets` only executes once (no double step wrapping).
- Added tests in `esi-rate-limit/index.test.ts` covering route-group write dedup and backoff after KV throttling.
- Updated `users.corporation-access.route.test.ts` with an RPC disposal helper and a new test asserting RPC results are disposed on the `has-corporation-access` path.
- Added a `classifyEsiCredentialFailure` unit test in `workflow-utils/src/test/index.test.ts`.
<!-- claude:end -->