### PR TITLE
fix structure workflow prioritization queue.

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -65,7 +65,6 @@ import {
 	projectStructureInventoryFromStoredAssets,
 	summarizeFuelBlockUnitsByStructure,
 } from './services/structure-inventory'
-import { buildPriorityQueuedEntries } from './services/structure-priority'
 
 import type { SQL } from 'drizzle-orm'
 import type {
@@ -304,6 +303,7 @@ type SkyhookStorageRow = {
 	theftVulnerabilityEnd: Date | null
 	syncStatus: 'ok' | 'warning' | 'error'
 	syncFailureReason: string | null
+	lastAttemptedSyncAt: Date
 	lastObservedAt: Date
 	sourceSyncAt: Date
 	lastSyncedAt: Date
@@ -450,6 +450,7 @@ export function buildSkyhookStorageRow(input: {
 		theftVulnerabilityEnd: parseDateOrNull(skyhook.theft_vulnerability?.end) ?? null,
 		syncStatus: 'ok',
 		syncFailureReason: null,
+		lastAttemptedSyncAt: observedAt,
 		lastObservedAt: observedAt,
 		sourceSyncAt: observedAt,
 		lastSyncedAt: observedAt,
@@ -2779,26 +2780,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			return
 		}
 
-		const syncPriorities = await this.getMoonDrillSyncPriorities(corporationId)
-		const liveMoonDrillIds = moonDrillStructures.map((structure) => structure.structureId)
-		const newMoonDrillIds = await this.getMissingStructureIdsForPriorityQueue(
-			corporationId,
-			'moon-drills',
-			liveMoonDrillIds
-		)
-		const prioritizedMoonDrillQueue = buildPriorityQueuedEntries(
-			moonDrillStructures.map((structure) => ({
-				id: structure.structureId,
-				structure,
-			})),
-			newMoonDrillIds,
-			syncPriorities
-		)
-		const prioritizedMoonDrillStructures = prioritizedMoonDrillQueue.entries.map(
-			({ entry }) => entry.structure
-		)
-
-		const synthesizedRows = prioritizedMoonDrillStructures
+		const synthesizedRows = moonDrillStructures
 			.map((structure) =>
 				buildMoonDrillStorageRow({
 					corporationId,
@@ -2809,28 +2791,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			.filter((row): row is MoonDrillStorageRow => row !== null)
 
 		if (synthesizedRows.length === 0) {
-			if (prioritizedMoonDrillStructures.length === 0) {
-				logger.info(
-					'[storeMoonDrills] No moon drill snapshot refresh was due; preserving existing snapshot',
-					{
-						corporationId,
-						structureCount: moonDrillStructures.length,
-						priorityCount: syncPriorities.length,
-						newStructureCount: newMoonDrillIds.length,
-					}
-				)
-			} else {
-				logger.warn('[storeMoonDrills] Could not synthesize eligible moon drill snapshot rows', {
-					corporationId,
-					structureCount: moonDrillStructures.length,
-					eligibleStructureCount: prioritizedMoonDrillStructures.length,
-				})
-			}
+			logger.warn('[storeMoonDrills] Could not synthesize moon drill snapshot rows', {
+				corporationId,
+				structureCount: moonDrillStructures.length,
+			})
 			return
 		}
 
-		const shouldPrune = synthesizedRows.length === moonDrillStructures.length
-		const pruneCandidateIds = prioritizedMoonDrillQueue.pruneCandidateIds
 		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 
 		for (let i = 0; i < synthesizedRows.length; i += BATCH_SIZE) {
@@ -2850,16 +2817,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				})
 		}
 
-		if (!shouldPrune) {
-			logger.warn('[storeMoonDrills] Skipping moon drill prune because synthesis was partial', {
-				corporationId,
-				synthesizedCount: synthesizedRows.length,
-				candidateCount: moonDrillStructures.length,
-			})
-			return
-		}
-
-		const departedStructureIds = pruneCandidateIds
+		const currentStructureIds = new Set(
+			moonDrillStructures.map((structure) => structure.structureId)
+		)
+		const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
 
 		await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
 			await this.getDb()
@@ -2899,11 +2860,35 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				updatedAt: true,
 			},
 		})
-		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
+		const existingStructureIds = new Set(existingRows.map((row) => row.structureId))
+		const newMoonGeographyStructures = moonGeographyStructures.filter(
+			(structure) => !existingStructureIds.has(structure.structureId)
+		)
 
+		if (moonGeographyStructures.length === 0) {
+			const departedStructureIds = filterPrunableStructureIds(existingRows, new Set<string>(), now)
+
+			await deleteIdsInBatches(
+				departedStructureIds,
+				STRUCTURE_CLEANUP_BATCH_SIZE,
+				async (batch) => {
+					await this.getDb()
+						.delete(structureMoonGeographies)
+						.where(
+							and(
+								eq(structureMoonGeographies.corporationId, corporationId),
+								inArray(structureMoonGeographies.structureId, batch)
+							)
+						)
+				}
+			)
+			return
+		}
+
+		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const synthesizedRows = (
 			await Promise.all(
-				moonGeographyStructures.map(async (structure) => {
+				newMoonGeographyStructures.map(async (structure) => {
 					if (!structure.structureInfo) {
 						return null
 					}
@@ -2932,43 +2917,18 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			)
 		).filter((row): row is MoonGeographyStorageRow => row !== null)
 
-		if (moonGeographyStructures.length === 0) {
-			const currentStructureIds = new Set<string>()
-			const departedStructureIds = filterPrunableStructureIds(
-				existingRows,
-				currentStructureIds,
-				now
-			)
-
-			await deleteIdsInBatches(
-				departedStructureIds,
-				STRUCTURE_CLEANUP_BATCH_SIZE,
-				async (batch) => {
-					await this.getDb()
-						.delete(structureMoonGeographies)
-						.where(
-							and(
-								eq(structureMoonGeographies.corporationId, corporationId),
-								inArray(structureMoonGeographies.structureId, batch)
-							)
-						)
-				}
-			)
-			return
-		}
-
-		if (synthesizedRows.length === 0) {
+		const synthesisComplete = synthesizedRows.length === newMoonGeographyStructures.length
+		if (!synthesisComplete) {
 			logger.warn(
 				'[storeMoonGeographies] Preserving existing moon geography snapshot because synthesis failed',
 				{
 					corporationId,
-					structureCount: moonGeographyStructures.length,
+					structureCount: newMoonGeographyStructures.length,
 				}
 			)
 			return
 		}
 
-		const shouldPrune = synthesizedRows.length === moonGeographyStructures.length
 		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 
 		for (let i = 0; i < synthesizedRows.length; i += BATCH_SIZE) {
@@ -2993,19 +2953,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				})
 		}
 
-		if (!shouldPrune) {
-			logger.warn(
-				'[storeMoonGeographies] Skipping moon geography prune because synthesis was partial',
-				{
-					corporationId,
-					synthesizedCount: synthesizedRows.length,
-					candidateCount: moonGeographyStructures.length,
-				}
-			)
-			return
-		}
-
-		const currentStructureIds = new Set(synthesizedRows.map((row) => row.structureId))
+		const currentStructureIds = new Set(
+			moonGeographyStructures.map((structure) => structure.structureId)
+		)
 		const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
 
 		await deleteIdsInBatches(departedStructureIds, STRUCTURE_CLEANUP_BATCH_SIZE, async (batch) => {
@@ -3494,19 +3444,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 	}
 
-	async clearSharedSovereigntySystems(): Promise<void> {
-		await this.state.storage.transaction(async (txn) => {
-			const existing = await txn.list<EsiSovereigntySystem>({
-				prefix: SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX,
-			})
-			if (existing.size > 0) {
-				await txn.delete([...existing.keys()])
-			}
-			await txn.delete(SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY)
-			await txn.delete(SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY)
-		})
-	}
-
 	async acquireSharedSovereigntySystemsRefreshLease(
 		leaseSeconds = SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS
 	): Promise<string | null> {
@@ -3607,6 +3544,24 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		return [...rows.values()]
 	}
 
+	async hasFreshSharedSovereigntySystems(
+		maxAgeSeconds = SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS
+	): Promise<boolean> {
+		const observedAtRaw = await this.state.storage.get<string>(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
+		)
+		if (!observedAtRaw) {
+			return false
+		}
+
+		const observedAt = parseDateOrNull(observedAtRaw)
+		if (!observedAt) {
+			return false
+		}
+
+		return Date.now() - observedAt.getTime() <= maxAgeSeconds * 1000
+	}
+
 	/**
 	 * Get a cached sovereignty system snapshot for a specific corporation if it is still within TTL.
 	 */
@@ -3678,21 +3633,43 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const pruneCandidateIds = [
 			...new Set((options.pruneCandidateIds ?? []).map((id) => String(id))),
 		]
+		const liveStructureIds = [...new Set(hubs.map((hub) => hub.structure_id))]
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		const controllerAllianceNames = await resolveAllianceNames(
 			tokenStore,
 			hubs.flatMap((hub) => (hub.controller_alliance_id ? [hub.controller_alliance_id] : []))
 		)
+		const existingRows =
+			liveStructureIds.length > 0
+				? await this.getDb().query.structureSovereigntyHubs.findMany({
+						where: and(
+							eq(structureSovereigntyHubs.corporationId, corporationId),
+							inArray(structureSovereigntyHubs.structureId, liveStructureIds)
+						),
+						columns: {
+							structureId: true,
+							systemId: true,
+							systemName: true,
+						},
+					})
+				: []
+		const existingByStructureId = new Map(existingRows.map((row) => [row.structureId, row]))
+		const newHubs = hubs.filter((hub) => !existingByStructureId.has(hub.structure_id))
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
-			hubs.length > 0
+			newHubs.length > 0
 				? ((await universe.resolveSolarSystemsByIds([
-						...new Set(hubs.map((hub) => hub.system_id)),
+						...new Set(newHubs.map((hub) => hub.system_id)),
 					])) ?? {})
 				: {}
 		const values: SovereigntyHubInsertRow[] = hubs.map((hub) => {
+			const existing = existingByStructureId.get(hub.structure_id)
+			const resolvedSystemId = existing?.systemId ?? hub.system_id
 			const resolvedSystemName =
-				systemGeography[hub.system_id]?.solarSystemName ?? hub.system_name ?? null
+				existing?.systemName ??
+				systemGeography[hub.system_id]?.solarSystemName ??
+				hub.system_name ??
+				null
 			const reagents = hub.reagent_bay.reagents.map((reagent) => ({
 				typeId: reagent.type_id,
 				typeName:
@@ -3708,7 +3685,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			return {
 				structureId: hub.structure_id,
 				corporationId,
-				systemId: hub.system_id,
+				systemId: resolvedSystemId,
 				systemName: resolvedSystemName,
 				typeId: hub.type_id,
 				fuelAccessListId: hub.fuel_access_list_id ?? null,
@@ -3749,9 +3726,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					target: structureSovereigntyHubs.structureId,
 					set: {
 						corporationId: sql`excluded.corporation_id`,
-						systemId: sql`excluded.system_id`,
-						systemName: sql`excluded.system_name`,
-						typeId: sql`excluded.type_id`,
 						fuelAccessListId: sql`excluded.fuel_access_list_id`,
 						controllerAllianceId: sql`excluded.controller_alliance_id`,
 						controllerAllianceName: sql`excluded.controller_alliance_name`,
@@ -3787,6 +3761,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	private async getTypeScopedStructureSyncPriorities(params: {
 		corporationId: string
 		targetTable: 'sovereignty' | 'skyhooks' | 'moon-drills' | 'mining-extractions'
+		structureIds?: readonly string[]
 	}): Promise<
 		Array<{
 			structureId: string
@@ -3794,7 +3769,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			lastSyncedAt: Date | null
 		}>
 	> {
-		const { corporationId, targetTable } = params
+		const { corporationId, targetTable, structureIds } = params
+		const liveStructureIds = structureIds
+			? [...new Set(structureIds.map((structureId) => String(structureId)))]
+			: null
+		if (liveStructureIds?.length === 0) {
+			return []
+		}
 		const now = new Date()
 		const successCutoff = new Date(now.getTime() - 60 * 60 * 1000)
 		const attemptCutoff = new Date(now.getTime() - 15 * 60 * 1000)
@@ -3810,7 +3791,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					? await this.getDb().query.structureSovereigntyHubs.findMany({
 							where: and(
 								eq(structureSovereigntyHubs.corporationId, corporationId),
-								sql`${structureSovereigntyHubs.lastSyncedAt} < ${successCutoff}`,
+								...(liveStructureIds
+									? [inArray(structureSovereigntyHubs.structureId, liveStructureIds)]
+									: []),
+								sql`(${structureSovereigntyHubs.lastSyncedAt} is null or ${structureSovereigntyHubs.lastSyncedAt} < ${successCutoff})`,
 								sql`coalesce(${structureSovereigntyHubs.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
 							),
 							orderBy: [
@@ -3826,12 +3810,16 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 								lastSyncedAt: true,
 							},
 							limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+							offset: rows.length,
 						})
 					: targetTable === 'skyhooks'
 						? await this.getDb().query.structureSkyhooks.findMany({
 								where: and(
 									eq(structureSkyhooks.corporationId, corporationId),
-									sql`${structureSkyhooks.lastSyncedAt} < ${successCutoff}`,
+									...(liveStructureIds
+										? [inArray(structureSkyhooks.structureId, liveStructureIds)]
+										: []),
+									sql`(${structureSkyhooks.lastSyncedAt} is null or ${structureSkyhooks.lastSyncedAt} < ${successCutoff})`,
 									sql`coalesce(${structureSkyhooks.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
 								),
 								orderBy: [
@@ -3845,12 +3833,16 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 									lastSyncedAt: true,
 								},
 								limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+								offset: rows.length,
 							})
 						: targetTable === 'moon-drills'
 							? await this.getDb().query.structureMoonDrills.findMany({
 									where: and(
 										eq(structureMoonDrills.corporationId, corporationId),
-										sql`${structureMoonDrills.lastSyncedAt} < ${successCutoff}`,
+										...(liveStructureIds
+											? [inArray(structureMoonDrills.structureId, liveStructureIds)]
+											: []),
+										sql`(${structureMoonDrills.lastSyncedAt} is null or ${structureMoonDrills.lastSyncedAt} < ${successCutoff})`,
 										sql`coalesce(${structureMoonDrills.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
 									),
 									orderBy: [
@@ -3864,11 +3856,15 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 										lastSyncedAt: true,
 									},
 									limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+									offset: rows.length,
 								})
 							: await this.getDb().query.structureMiningExtractions.findMany({
 									where: and(
 										eq(structureMiningExtractions.corporationId, corporationId),
-										sql`${structureMiningExtractions.lastSyncedAt} < ${successCutoff}`,
+										...(liveStructureIds
+											? [inArray(structureMiningExtractions.structureId, liveStructureIds)]
+											: []),
+										sql`(${structureMiningExtractions.lastSyncedAt} is null or ${structureMiningExtractions.lastSyncedAt} < ${successCutoff})`,
 										sql`coalesce(${structureMiningExtractions.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
 									),
 									orderBy: [
@@ -3884,6 +3880,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 										lastSyncedAt: true,
 									},
 									limit: STRUCTURE_ENRICHMENT_PRIORITY_LIMIT,
+									offset: rows.length,
 								})
 
 			if (batch.length === 0) {
@@ -3891,73 +3888,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			}
 
 			rows.push(...batch)
-
-			switch (targetTable) {
-				case 'sovereignty':
-					await this.getDb()
-						.update(structureSovereigntyHubs)
-						.set({
-							lastAttemptedSyncAt: now,
-						})
-						.where(
-							and(
-								eq(structureSovereigntyHubs.corporationId, corporationId),
-								inArray(
-									structureSovereigntyHubs.structureId,
-									batch.map((row) => row.structureId)
-								)
-							)
-						)
-					break
-				case 'skyhooks':
-					await this.getDb()
-						.update(structureSkyhooks)
-						.set({
-							lastAttemptedSyncAt: now,
-						})
-						.where(
-							and(
-								eq(structureSkyhooks.corporationId, corporationId),
-								inArray(
-									structureSkyhooks.structureId,
-									batch.map((row) => row.structureId)
-								)
-							)
-						)
-					break
-				case 'moon-drills':
-					await this.getDb()
-						.update(structureMoonDrills)
-						.set({
-							lastAttemptedSyncAt: now,
-						})
-						.where(
-							and(
-								eq(structureMoonDrills.corporationId, corporationId),
-								inArray(
-									structureMoonDrills.structureId,
-									batch.map((row) => row.structureId)
-								)
-							)
-						)
-					break
-				case 'mining-extractions':
-					await this.getDb()
-						.update(structureMiningExtractions)
-						.set({
-							lastAttemptedSyncAt: now,
-						})
-						.where(
-							and(
-								eq(structureMiningExtractions.corporationId, corporationId),
-								inArray(
-									structureMiningExtractions.structureId,
-									batch.map((row) => row.structureId)
-								)
-							)
-						)
-					break
-			}
 		}
 
 		return rows.map((row) => ({
@@ -3966,16 +3896,99 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}))
 	}
 
+	private async claimStructureSyncAttempts(params: {
+		corporationId: string
+		targetTable: 'sovereignty' | 'skyhooks' | 'moon-drills' | 'mining-extractions'
+		structureIds: readonly string[]
+	}): Promise<string[]> {
+		const { corporationId, targetTable, structureIds } = params
+		const uniqueStructureIds = [...new Set(structureIds.map((structureId) => String(structureId)))]
+		if (uniqueStructureIds.length === 0) {
+			return []
+		}
+
+		const now = new Date()
+		const successCutoff = new Date(now.getTime() - 60 * 60 * 1000)
+		const attemptCutoff = new Date(now.getTime() - 15 * 60 * 1000)
+		if (targetTable === 'sovereignty') {
+			const rows = await this.getDb()
+				.update(structureSovereigntyHubs)
+				.set({ lastAttemptedSyncAt: now })
+				.where(
+					and(
+						eq(structureSovereigntyHubs.corporationId, corporationId),
+						inArray(structureSovereigntyHubs.structureId, uniqueStructureIds),
+						sql`(${structureSovereigntyHubs.lastSyncedAt} is null or ${structureSovereigntyHubs.lastSyncedAt} < ${successCutoff})`,
+						sql`coalesce(${structureSovereigntyHubs.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+					)
+				)
+				.returning({ structureId: structureSovereigntyHubs.structureId })
+			return rows.map((row) => row.structureId)
+		}
+
+		if (targetTable === 'skyhooks') {
+			const rows = await this.getDb()
+				.update(structureSkyhooks)
+				.set({ lastAttemptedSyncAt: now })
+				.where(
+					and(
+						eq(structureSkyhooks.corporationId, corporationId),
+						inArray(structureSkyhooks.structureId, uniqueStructureIds),
+						sql`(${structureSkyhooks.lastSyncedAt} is null or ${structureSkyhooks.lastSyncedAt} < ${successCutoff})`,
+						sql`coalesce(${structureSkyhooks.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+					)
+				)
+				.returning({ structureId: structureSkyhooks.structureId })
+			return rows.map((row) => row.structureId)
+		}
+
+		if (targetTable === 'moon-drills') {
+			const rows = await this.getDb()
+				.update(structureMoonDrills)
+				.set({ lastAttemptedSyncAt: now })
+				.where(
+					and(
+						eq(structureMoonDrills.corporationId, corporationId),
+						inArray(structureMoonDrills.structureId, uniqueStructureIds),
+						sql`(${structureMoonDrills.lastSyncedAt} is null or ${structureMoonDrills.lastSyncedAt} < ${successCutoff})`,
+						sql`coalesce(${structureMoonDrills.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+					)
+				)
+				.returning({ structureId: structureMoonDrills.structureId })
+			return rows.map((row) => row.structureId)
+		}
+
+		const rows = await this.getDb()
+			.update(structureMiningExtractions)
+			.set({ lastAttemptedSyncAt: now })
+			.where(
+				and(
+					eq(structureMiningExtractions.corporationId, corporationId),
+					inArray(structureMiningExtractions.structureId, uniqueStructureIds),
+					sql`(${structureMiningExtractions.lastSyncedAt} is null or ${structureMiningExtractions.lastSyncedAt} < ${successCutoff})`,
+					sql`coalesce(${structureMiningExtractions.lastAttemptedSyncAt}, to_timestamp(0)) < ${attemptCutoff}`
+				)
+			)
+			.returning({ structureId: structureMiningExtractions.structureId })
+		return rows.map((row) => row.structureId)
+	}
+
 	private async getTypeScopedStructureIds(params: {
 		corporationId: string
 		targetTable: 'sovereignty' | 'skyhooks' | 'moon-drills' | 'mining-extractions'
+		updatedBefore?: Date
 	}): Promise<string[]> {
-		const { corporationId, targetTable } = params
+		const { corporationId, targetTable, updatedBefore } = params
 		switch (targetTable) {
 			case 'sovereignty':
 				return (
 					await this.getDb().query.structureSovereigntyHubs.findMany({
-						where: eq(structureSovereigntyHubs.corporationId, corporationId),
+						where: updatedBefore
+							? and(
+									eq(structureSovereigntyHubs.corporationId, corporationId),
+									sql`${structureSovereigntyHubs.updatedAt} < ${updatedBefore}`
+								)
+							: eq(structureSovereigntyHubs.corporationId, corporationId),
 						columns: {
 							structureId: true,
 						},
@@ -3984,7 +3997,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			case 'skyhooks':
 				return (
 					await this.getDb().query.structureSkyhooks.findMany({
-						where: eq(structureSkyhooks.corporationId, corporationId),
+						where: updatedBefore
+							? and(
+									eq(structureSkyhooks.corporationId, corporationId),
+									sql`${structureSkyhooks.updatedAt} < ${updatedBefore}`
+								)
+							: eq(structureSkyhooks.corporationId, corporationId),
 						columns: {
 							structureId: true,
 						},
@@ -3993,7 +4011,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			case 'moon-drills':
 				return (
 					await this.getDb().query.structureMoonDrills.findMany({
-						where: eq(structureMoonDrills.corporationId, corporationId),
+						where: updatedBefore
+							? and(
+									eq(structureMoonDrills.corporationId, corporationId),
+									sql`${structureMoonDrills.updatedAt} < ${updatedBefore}`
+								)
+							: eq(structureMoonDrills.corporationId, corporationId),
 						columns: {
 							structureId: true,
 						},
@@ -4002,7 +4025,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			case 'mining-extractions':
 				return (
 					await this.getDb().query.structureMiningExtractions.findMany({
-						where: eq(structureMiningExtractions.corporationId, corporationId),
+						where: updatedBefore
+							? and(
+									eq(structureMiningExtractions.corporationId, corporationId),
+									sql`${structureMiningExtractions.updatedAt} < ${updatedBefore}`
+								)
+							: eq(structureMiningExtractions.corporationId, corporationId),
 						columns: {
 							structureId: true,
 						},
@@ -4073,6 +4101,98 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 	}
 
+	async getStructurePriorityQueue(
+		corporationId: string,
+		targetTable: StructureSyncPriorityTarget,
+		structureIds: string[]
+	): Promise<{
+		newStructureIds: string[]
+		pruneCandidateIds: string[]
+		syncPriorities: Array<{
+			structureId: string
+			lastAttemptedSyncAt: Date | null
+			lastSyncedAt: Date | null
+		}>
+	}> {
+		const newStructureIds = await this.getTypeScopedMissingStructureIds({
+			corporationId,
+			targetTable,
+			structureIds,
+		})
+		const pruneCandidateIds = await this.getStructureIdsMissingFromLiveListing(
+			corporationId,
+			targetTable,
+			structureIds
+		)
+		const syncPriorities = await this.getTypeScopedStructureSyncPriorities({
+			corporationId,
+			targetTable,
+			structureIds,
+		})
+		const claimedStructureIds = new Set(
+			await this.claimStructureSyncAttempts({
+				corporationId,
+				targetTable,
+				structureIds: syncPriorities.map((priority) => priority.structureId),
+			})
+		)
+
+		return {
+			newStructureIds,
+			pruneCandidateIds,
+			syncPriorities: syncPriorities.filter((priority) =>
+				claimedStructureIds.has(priority.structureId)
+			),
+		}
+	}
+
+	async getStructureIdsMissingFromLiveListing(
+		corporationId: string,
+		targetTable: StructureSyncPriorityTarget,
+		structureIds: string[]
+	): Promise<string[]> {
+		const liveStructureIds = [...new Set(structureIds.map((structureId) => String(structureId)))]
+		const pruneBefore = new Date(Date.now() - STRUCTURE_PRUNE_GRACE_MS)
+		const targetTableRef =
+			targetTable === 'sovereignty'
+				? structureSovereigntyHubs
+				: targetTable === 'skyhooks'
+					? structureSkyhooks
+					: targetTable === 'moon-drills'
+						? structureMoonDrills
+						: structureMiningExtractions
+
+		if (liveStructureIds.length === 0) {
+			return await this.getTypeScopedStructureIds({
+				corporationId,
+				targetTable,
+				updatedBefore: pruneBefore,
+			})
+		}
+
+		const liveStructureRows = sql.join(
+			liveStructureIds.map((structureId) => sql`(${structureId})`),
+			sql`, `
+		)
+		const result = await this.getDb().execute<{ structureId: string }>(sql`
+			with live_ids(structure_id) as (
+				values ${liveStructureRows}
+			)
+			select ${targetTableRef.structureId} as "structureId"
+			from ${targetTableRef}
+			where ${targetTableRef.corporationId} = ${corporationId}
+				and ${targetTableRef.updatedAt} < ${pruneBefore}
+				and not exists (
+					select 1
+					from live_ids
+					where live_ids.structure_id = ${targetTableRef.structureId}
+				)
+			order by ${targetTableRef.structureId} asc
+		`)
+
+		return (result.rows ?? []).map((row) => row.structureId)
+	}
+
 	async getSovereigntyHubStructureIds(corporationId: string): Promise<string[]> {
 		return await this.getTypeScopedStructureIds({
 			corporationId,
@@ -4134,6 +4254,63 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		await this.markStructureSyncFailureReason(corporationId, mappedTarget, failureReason)
 	}
 
+	async markStructureEnrichmentFailures(
+		corporationId: string,
+		target: 'sovereignty-hubs' | 'skyhooks',
+		failures: Array<{ structureId: string; failureReason: string }>
+	): Promise<void> {
+		const uniqueFailures = [
+			...new Map(
+				failures.map((failure) => [String(failure.structureId), failure] as const)
+			).values(),
+		]
+		const now = new Date()
+
+		for (let index = 0; index < uniqueFailures.length; index += STRUCTURE_CLEANUP_BATCH_SIZE) {
+			const batch = uniqueFailures.slice(index, index + STRUCTURE_CLEANUP_BATCH_SIZE)
+			const failureCases = sql.join(
+				batch.map(
+					({ structureId, failureReason }) => sql`when ${String(structureId)} then ${failureReason}`
+				),
+				sql` `
+			)
+			const structureIds = batch.map(({ structureId }) => String(structureId))
+
+			if (target === 'sovereignty-hubs') {
+				await this.getDb()
+					.update(structureSovereigntyHubs)
+					.set({
+						syncStatus: 'warning',
+						syncFailureReason: sql<string>`case ${structureSovereigntyHubs.structureId} ${failureCases} else ${structureSovereigntyHubs.syncFailureReason} end`,
+						lastAttemptedSyncAt: now,
+						updatedAt: now,
+					})
+					.where(
+						and(
+							eq(structureSovereigntyHubs.corporationId, corporationId),
+							inArray(structureSovereigntyHubs.structureId, structureIds)
+						)
+					)
+				continue
+			}
+
+			await this.getDb()
+				.update(structureSkyhooks)
+				.set({
+					syncStatus: 'warning',
+					syncFailureReason: sql<string>`case ${structureSkyhooks.structureId} ${failureCases} else ${structureSkyhooks.syncFailureReason} end`,
+					lastAttemptedSyncAt: now,
+					updatedAt: now,
+				})
+				.where(
+					and(
+						eq(structureSkyhooks.corporationId, corporationId),
+						inArray(structureSkyhooks.structureId, structureIds)
+					)
+				)
+		}
+	}
+
 	async markStructureSyncFailureReason(
 		corporationId: string,
 		target: StructureSyncFailureTarget,
@@ -4191,38 +4368,50 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const pruneCandidateIds = [
 			...new Set((options.pruneCandidateIds ?? []).map((id) => String(id))),
 		]
+		const liveStructureIds = [...new Set(skyhooks.map((skyhook) => skyhook.structure_id))]
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
-		const existingRows = await this.getDb().query.structureSkyhooks.findMany({
-			where: eq(structureSkyhooks.corporationId, corporationId),
-			columns: {
-				structureId: true,
-				planetName: true,
-				systemName: true,
-				updatedAt: true,
-			},
-		})
+		const existingRows =
+			liveStructureIds.length > 0
+				? await this.getDb().query.structureSkyhooks.findMany({
+						where: and(
+							eq(structureSkyhooks.corporationId, corporationId),
+							inArray(structureSkyhooks.structureId, liveStructureIds)
+						),
+						columns: {
+							structureId: true,
+							planetName: true,
+							systemName: true,
+							updatedAt: true,
+						},
+					})
+				: []
 		const existingByStructureId = new Map(existingRows.map((row) => [row.structureId, row]))
-		const existingBaseStructures = await this.getDb().query.corporationStructures.findMany({
-			where: and(
-				eq(corporationStructures.corporationId, corporationId),
-				eq(corporationStructures.typeId, ORBITAL_SKYHOOK_TYPE_ID)
-			),
-			columns: {
-				structureId: true,
-				corporationId: true,
-				typeId: true,
-				systemId: true,
-				systemName: true,
-				regionId: true,
-				regionName: true,
-				updatedAt: true,
-			},
-		})
+		const existingBaseStructures =
+			liveStructureIds.length > 0
+				? await this.getDb().query.corporationStructures.findMany({
+						where: and(
+							eq(corporationStructures.corporationId, corporationId),
+							eq(corporationStructures.typeId, ORBITAL_SKYHOOK_TYPE_ID),
+							inArray(corporationStructures.structureId, liveStructureIds)
+						),
+						columns: {
+							structureId: true,
+							corporationId: true,
+							typeId: true,
+							systemId: true,
+							systemName: true,
+							regionId: true,
+							regionName: true,
+							updatedAt: true,
+						},
+					})
+				: []
 		const baseStructureById = new Map(existingBaseStructures.map((row) => [row.structureId, row]))
+		const newSkyhooks = skyhooks.filter((skyhook) => !baseStructureById.has(skyhook.structure_id))
 		const planetGeography: Awaited<ReturnType<Universe['resolvePlanetGeographyByIds']>> =
-			skyhooks.length > 0
+			newSkyhooks.length > 0
 				? await universe.resolvePlanetGeographyByIds([
-						...new Set(skyhooks.map((skyhook) => skyhook.planet_id)),
+						...new Set(newSkyhooks.map((skyhook) => skyhook.planet_id)),
 					])
 				: {}
 		const resolvedPlanetGeographies = Object.values(planetGeography).filter(
@@ -4246,7 +4435,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			.map((skyhook) => {
 				const existingBaseStructure = baseStructureById.get(skyhook.structure_id) ?? null
 				const existing = existingByStructureId.get(skyhook.structure_id) ?? null
-				const resolvedPlanet = planetGeography[skyhook.planet_id] ?? null
+				const isNewSkyhook = existingBaseStructure === null
+				const resolvedPlanet = isNewSkyhook ? (planetGeography[skyhook.planet_id] ?? null) : null
 				const resolvedSystem = resolvedPlanet?.solarSystemId
 					? (systemGeography[resolvedPlanet.solarSystemId] ?? null)
 					: null
@@ -4389,28 +4579,11 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					target: corporationStructures.structureId,
 					set: {
 						corporationId: sql`excluded.corporation_id`,
-						typeId: sql`excluded.type_id`,
-						typeName: sql`excluded.type_name`,
-						systemId: sql`excluded.system_id`,
-						systemName: sql`excluded.system_name`,
-						regionId: sql`excluded.region_id`,
-						regionName: sql`excluded.region_name`,
-						profileId: sql`excluded.profile_id`,
-						fuelExpires: sql`excluded.fuel_expires`,
-						fuelAmount: sql`excluded.fuel_amount`,
-						lastRefilledAt: sql`excluded.last_refilled_at`,
-						nextReinforceApply: sql`excluded.next_reinforce_apply`,
-						nextReinforceHour: sql`excluded.next_reinforce_hour`,
-						reinforceHour: sql`excluded.reinforce_hour`,
 						state: sql`excluded.state`,
 						stateTimerEnd: sql`excluded.state_timer_end`,
-						stateTimerStart: sql`excluded.state_timer_start`,
-						unanchorsAt: sql`excluded.unanchors_at`,
-						lowPower: sql`excluded.low_power`,
 						syncStatus: sql`excluded.sync_status`,
 						syncFailureReason: sql`excluded.sync_failure_reason`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
-						services: sql`excluded.services`,
 						updatedAt: sql`excluded.updated_at`,
 					},
 				})
@@ -4439,11 +4612,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					target: structureSkyhooks.structureId,
 					set: {
 						corporationId: sql`excluded.corporation_id`,
-						planetId: sql`excluded.planet_id`,
-						planetName: sql`excluded.planet_name`,
-						systemId: sql`excluded.system_id`,
-						systemName: sql`excluded.system_name`,
-						typeId: sql`excluded.type_id`,
 						state: sql`excluded.state`,
 						isActive: sql`excluded.is_active`,
 						effectiveWorkforce: sql`excluded.effective_workforce`,
@@ -4452,6 +4620,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						theftVulnerabilityEnd: sql`excluded.theft_vulnerability_end`,
 						syncStatus: sql`excluded.sync_status`,
 						syncFailureReason: sql`excluded.sync_failure_reason`,
+						lastAttemptedSyncAt: sql`excluded.last_attempted_sync_at`,
 						lastObservedAt: sql`excluded.last_observed_at`,
 						sourceSyncAt: sql`excluded.source_sync_at`,
 						lastSyncedAt: sql`excluded.last_synced_at`,
@@ -4506,16 +4675,22 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	 */
 	async storeMiningExtractions(
 		corporationId: string,
-		miningExtractions: EsiCorporationMiningExtraction[]
+		miningExtractions: EsiCorporationMiningExtraction[],
+		options: {
+			pruneCandidateIds?: readonly string[]
+		} = {}
 	): Promise<void> {
 		const now = new Date()
-		const existingRows = await this.getDb().query.structureMiningExtractions.findMany({
-			where: eq(structureMiningExtractions.corporationId, corporationId),
-			columns: {
-				structureId: true,
-				updatedAt: true,
-			},
-		})
+		const hasExplicitPruneCandidates = options.pruneCandidateIds !== undefined
+		const existingRows = hasExplicitPruneCandidates
+			? []
+			: await this.getDb().query.structureMiningExtractions.findMany({
+					where: eq(structureMiningExtractions.corporationId, corporationId),
+					columns: {
+						structureId: true,
+						updatedAt: true,
+					},
+				})
 
 		const values = miningExtractions.map((extraction) => {
 			return {
@@ -4532,33 +4707,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			}
 		})
 
-		if (values.length === 0) {
-			const currentStructureIds = new Set<string>()
-			const departedStructureIds = filterPrunableStructureIds(
-				existingRows,
-				currentStructureIds,
-				now
-			)
-
-			await deleteIdsInBatches(
-				departedStructureIds,
-				STRUCTURE_CLEANUP_BATCH_SIZE,
-				async (batch) => {
-					await this.getDb()
-						.delete(structureMiningExtractions)
-						.where(
-							and(
-								eq(structureMiningExtractions.corporationId, corporationId),
-								inArray(structureMiningExtractions.structureId, batch)
-							)
-						)
-				}
-			)
-			return
-		}
-
 		const currentStructureIds = new Set(values.map((row) => row.structureId))
-		const departedStructureIds = filterPrunableStructureIds(existingRows, currentStructureIds, now)
+		const departedStructureIds = hasExplicitPruneCandidates
+			? [...new Set(options.pruneCandidateIds?.map((structureId) => String(structureId)) ?? [])]
+			: filterPrunableStructureIds(existingRows, currentStructureIds, now)
 		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 		for (let i = 0; i < values.length; i += BATCH_SIZE) {
 			const batch = values.slice(i, i + BATCH_SIZE)

--- a/apps/eve-corporation-data/src/scheduled.ts
+++ b/apps/eve-corporation-data/src/scheduled.ts
@@ -96,10 +96,8 @@ async function runScheduledRefresh(event: ScheduledEvent, env: Env): Promise<voi
 		// Corp workflows read this from the global corporation-data DO instead of
 		// refetching the same system map independently.
 		try {
-			const sovereigntySystems = await refreshSharedSovereigntySystems(env)
-			logger.info('[BackgroundRefresh] Warmed shared sovereignty systems cache', {
-				count: sovereigntySystems.length,
-			})
+			await refreshSharedSovereigntySystems(env)
+			logger.info('[BackgroundRefresh] Warmed shared sovereignty systems cache')
 		} catch (error) {
 			logger.error('[BackgroundRefresh] Failed to warm shared sovereignty systems cache', {
 				error: error instanceof Error ? error.message : String(error),

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -13,6 +13,7 @@
 
 import { logger } from '@repo/hono-helpers'
 import { parseEsiErrorMetadata } from '@repo/workflow-utils'
+
 import {
 	transformAssets,
 	transformContracts,
@@ -35,21 +36,26 @@ import type {
 	EsiCorporationKillmail,
 	EsiCorporationMembers,
 	EsiCorporationMemberTracking,
-	EsiCorporationOrder,
 	EsiCorporationMiningExtraction,
+	EsiCorporationOrder,
 	EsiCorporationSkyhook,
 	EsiCorporationStructure,
-	EsiSovereigntyHub,
-	EsiSovereigntySystem,
 	EsiCorporationWallet,
 	EsiCorporationWalletJournalEntry,
 	EsiCorporationWalletTransaction,
+	EsiSovereigntyHub,
+	EsiSovereigntySystem,
 } from '@repo/eve-corporation-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 
 const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 const SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE = 4
 const SKYHOOK_DETAIL_BATCH_SIZE = 4
+
+export interface StructureEnrichmentFailure {
+	structureId: string
+	failureReason: string
+}
 
 // ========================================================================
 // PUBLIC DATA FETCHING
@@ -193,11 +199,9 @@ export async function fetchWalletTransactions(
 			type_id: number
 			unit_price: number
 		}>
-	>(
-		`/corporations/${corporationId}/wallets/${division}/transactions`,
-		characterId,
-		{ cacheMode: 'no-store' }
-	)
+	>(`/corporations/${corporationId}/wallets/${division}/transactions`, characterId, {
+		cacheMode: 'no-store',
+	})
 
 	return transformWalletTransactions(response.data)
 }
@@ -371,6 +375,7 @@ export async function fetchSovereigntyHubs(
 ): Promise<{
 	sovereigntyHubs: EsiSovereigntyHub[]
 	pruneCandidateIds: string[]
+	failures: StructureEnrichmentFailure[]
 	failureCount: number
 	rateLimitFailureCount: number
 	nonRateLimitFailureCount: number
@@ -408,15 +413,15 @@ export async function fetchSovereigntyHubs(
 		} | null
 		workforce_transport: {
 			configuration:
-			| {
-					import: {
-						sources: Array<{
-							solar_system_id: number
-						}>
-					}
-			  }
-			| {
-					export: {
+				| {
+						import: {
+							sources: Array<{
+								solar_system_id: number
+							}>
+						}
+				  }
+				| {
+						export: {
 							amount: number
 							solar_system_id?: number
 						}
@@ -425,14 +430,14 @@ export async function fetchSovereigntyHubs(
 						transit: boolean | null
 				  }
 			state:
-			| {
-					import: {
-						sources: Array<{
-							amount: number
-							solar_system_id: number
-						}>
-					}
-			  }
+				| {
+						import: {
+							sources: Array<{
+								amount: number
+								solar_system_id: number
+							}>
+						}
+				  }
 				| {
 						export: {
 							amount: number
@@ -450,6 +455,7 @@ export async function fetchSovereigntyHubs(
 		return {
 			sovereigntyHubs: [],
 			pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+			failures: [],
 			failureCount: 0,
 			rateLimitFailureCount: 0,
 			nonRateLimitFailureCount: 0,
@@ -463,6 +469,7 @@ export async function fetchSovereigntyHubs(
 
 	for (let index = 0; index < prioritizedHubs.length; index += SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE) {
 		const batch = prioritizedHubs.slice(index, index + SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE)
+		let rateLimitEncountered = false
 		const settled = await Promise.allSettled(
 			batch.map(async ({ entry }) => {
 				const detailResult = await tokenStore.fetchEsi<RawSovereigntyHubDetail>(
@@ -521,6 +528,7 @@ export async function fetchSovereigntyHubs(
 
 			if (isRateLimitEsiError(result.reason)) {
 				rateLimitFailureCount += 1
+				rateLimitEncountered = true
 			} else {
 				nonRateLimitFailureCount += 1
 			}
@@ -528,6 +536,10 @@ export async function fetchSovereigntyHubs(
 				structureId: String(source.entry.id),
 				error: result.reason instanceof Error ? result.reason.message : String(result.reason),
 			})
+		}
+
+		if (rateLimitEncountered) {
+			break
 		}
 	}
 
@@ -543,6 +555,10 @@ export async function fetchSovereigntyHubs(
 	return {
 		sovereigntyHubs: hubs.sort((a, b) => a.index - b.index).map((entry) => entry.hub),
 		pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+		failures: failures.map(({ structureId, error }) => ({
+			structureId,
+			failureReason: error.slice(0, 1000),
+		})),
 		failureCount: failures.length,
 		rateLimitFailureCount,
 		nonRateLimitFailureCount,
@@ -563,6 +579,7 @@ export async function fetchCorporationSkyhooks(
 ): Promise<{
 	skyhooks: EsiCorporationSkyhook[]
 	pruneCandidateIds: string[]
+	failures: StructureEnrichmentFailure[]
 	failureCount: number
 	rateLimitFailureCount: number
 	nonRateLimitFailureCount: number
@@ -594,6 +611,7 @@ export async function fetchCorporationSkyhooks(
 		return {
 			skyhooks: [],
 			pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+			failures: [],
 			failureCount: 0,
 			rateLimitFailureCount: 0,
 			nonRateLimitFailureCount: 0,
@@ -607,6 +625,7 @@ export async function fetchCorporationSkyhooks(
 
 	for (let index = 0; index < prioritizedListing.length; index += SKYHOOK_DETAIL_BATCH_SIZE) {
 		const batch = prioritizedListing.slice(index, index + SKYHOOK_DETAIL_BATCH_SIZE)
+		let rateLimitEncountered = false
 		const settled = await Promise.allSettled(
 			batch.map(async ({ entry }) => {
 				const detailResult = await tokenStore.fetchEsi<RawCorporationSkyhookDetail>(
@@ -655,6 +674,7 @@ export async function fetchCorporationSkyhooks(
 
 			if (isRateLimitEsiError(result.reason)) {
 				rateLimitFailureCount += 1
+				rateLimitEncountered = true
 			} else {
 				nonRateLimitFailureCount += 1
 			}
@@ -662,6 +682,10 @@ export async function fetchCorporationSkyhooks(
 				structureId: String(source.entry.id),
 				error: result.reason instanceof Error ? result.reason.message : String(result.reason),
 			})
+		}
+
+		if (rateLimitEncountered) {
+			break
 		}
 	}
 
@@ -677,6 +701,10 @@ export async function fetchCorporationSkyhooks(
 	return {
 		skyhooks: skyhooks.sort((a, b) => a.index - b.index).map((entry) => entry.skyhook),
 		pruneCandidateIds: [...(options.pruneCandidateIds ?? [])],
+		failures: failures.map(({ structureId, error }) => ({
+			structureId,
+			failureReason: error.slice(0, 1000),
+		})),
 		failureCount: failures.length,
 		rateLimitFailureCount,
 		nonRateLimitFailureCount,
@@ -783,11 +811,7 @@ export async function fetchContracts(
 			type: string
 			volume?: number
 		}>
-	>(
-		`/corporations/${corporationId}/contracts`,
-		characterId,
-		{ cacheMode: 'no-store' }
-	)
+	>(`/corporations/${corporationId}/contracts`, characterId, { cacheMode: 'no-store' })
 
 	return transformContracts(response.data)
 }
@@ -825,11 +849,7 @@ export async function fetchIndustryJobs(
 			completed_character_id?: number
 			successful_runs?: number
 		}>
-	>(
-		`/corporations/${corporationId}/industry/jobs`,
-		characterId,
-		{ cacheMode: 'no-store' }
-	)
+	>(`/corporations/${corporationId}/industry/jobs`, characterId, { cacheMode: 'no-store' })
 
 	return transformIndustryJobs(response.data)
 }

--- a/apps/eve-corporation-data/src/services/structure-priority.ts
+++ b/apps/eve-corporation-data/src/services/structure-priority.ts
@@ -10,16 +10,17 @@ export function buildPriorityQueuedEntries<
 >(
 	entries: readonly T[],
 	newStructureIds: readonly string[] = [],
-	syncPriorities: readonly P[] = []
+	syncPriorities: readonly P[] = [],
+	options: {
+		pruneCandidateIds: readonly string[]
+	}
 ): {
 	entries: Array<{ index: number; entry: T; priority: P | null }>
 	pruneCandidateIds: string[]
 } {
-	const liveStructureIds = new Set(entries.map((entry) => String(entry.id)))
 	const newStructureIdSet = new Set(newStructureIds.map((structureId) => String(structureId)))
-	const livePriorities = syncPriorities.filter((priority) => liveStructureIds.has(priority.structureId))
 	const priorityByStructureId = new Map(
-		livePriorities.map((priority) => [priority.structureId, priority] as const)
+		syncPriorities.map((priority) => [priority.structureId, priority] as const)
 	)
 	const mappedEntries = entries.map((entry, index) => ({
 		entry,
@@ -27,11 +28,9 @@ export function buildPriorityQueuedEntries<
 		priority: priorityByStructureId.get(String(entry.id)) ?? null,
 	}))
 
-	const newEntries = mappedEntries.filter(
-		(entry) => newStructureIdSet.has(String(entry.entry.id)) && entry.priority === null
-	)
+	const newEntries = mappedEntries.filter((entry) => newStructureIdSet.has(String(entry.entry.id)))
 	const prioritizedEntries = mappedEntries
-		.filter((entry) => entry.priority !== null)
+		.filter((entry) => entry.priority !== null && !newStructureIdSet.has(String(entry.entry.id)))
 		.sort((a, b) => {
 			const aPriority = a.priority!
 			const bPriority = b.priority!
@@ -39,18 +38,16 @@ export function buildPriorityQueuedEntries<
 			const bSynced = bPriority.lastSyncedAt?.getTime() ?? Number.NEGATIVE_INFINITY
 			if (aSynced !== bSynced) return aSynced - bSynced
 
-			const aAttempted =
-				aPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
-			const bAttempted =
-				bPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const aAttempted = aPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const bAttempted = bPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
 			if (aAttempted !== bAttempted) return aAttempted - bAttempted
 
 			return a.index - b.index
 		})
 
-	const pruneCandidateIds = syncPriorities
-		.filter((priority) => !liveStructureIds.has(priority.structureId))
-		.map((priority) => priority.structureId)
+	const pruneCandidateIds = [
+		...new Set(options.pruneCandidateIds.map((structureId) => String(structureId))),
+	]
 
 	return {
 		entries: [...newEntries, ...prioritizedEntries],
@@ -58,7 +55,10 @@ export function buildPriorityQueuedEntries<
 	}
 }
 
-export function buildPriorityOrderedEntries<T extends { id: string | number }, P extends SyncPriorityLike>(
+export function buildPriorityOrderedEntries<
+	T extends { id: string | number },
+	P extends SyncPriorityLike,
+>(
 	entries: readonly T[],
 	syncPriorities: readonly P[] = [],
 	options: {
@@ -69,9 +69,10 @@ export function buildPriorityOrderedEntries<T extends { id: string | number }, P
 	const knownStructureIds = options.knownStructureIds
 		? new Set(options.knownStructureIds.map((structureId) => String(structureId)))
 		: null
-	const livePriorities = syncPriorities.filter((priority) =>
-		liveStructureIds.has(priority.structureId) &&
-		(knownStructureIds === null || knownStructureIds.has(priority.structureId))
+	const livePriorities = syncPriorities.filter(
+		(priority) =>
+			liveStructureIds.has(priority.structureId) &&
+			(knownStructureIds === null || knownStructureIds.has(priority.structureId))
 	)
 	const priorityByStructureId = new Map(
 		livePriorities.map((priority) => [priority.structureId, priority] as const)
@@ -96,10 +97,8 @@ export function buildPriorityOrderedEntries<T extends { id: string | number }, P
 			const bSynced = bPriority.lastSyncedAt?.getTime() ?? Number.NEGATIVE_INFINITY
 			if (aSynced !== bSynced) return aSynced - bSynced
 
-			const aAttempted =
-				aPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
-			const bAttempted =
-				bPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const aAttempted = aPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
+			const bAttempted = bPriority.lastAttemptedSyncAt?.getTime() ?? Number.NEGATIVE_INFINITY
 			if (aAttempted !== bAttempted) return aAttempted - bAttempted
 
 			return a.index - b.index

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -29,10 +29,7 @@ describe('esi structure enrichment ownership handling', () => {
 
 		const structures = await fetchStructures(tokenStore as never, '98000001', '211')
 
-		expect(tokenStore.fetchEsi).toHaveBeenCalledWith(
-			'/corporations/98000001/structures',
-			'211'
-		)
+		expect(tokenStore.fetchEsi).toHaveBeenCalledWith('/corporations/98000001/structures', '211')
 		expect(structures).toHaveLength(1)
 		expect(structures[0]).toMatchObject({
 			structure_id: '1001',
@@ -123,11 +120,9 @@ describe('esi structure enrichment ownership handling', () => {
 			'211',
 			{ cacheMode: 'no-store' }
 		)
-		expect(tokenStore.fetchEsi).not.toHaveBeenCalledWith(
-			'/universe/structures/71001',
-			'211',
-			{ cacheMode: 'no-store' }
-		)
+		expect(tokenStore.fetchEsi).not.toHaveBeenCalledWith('/universe/structures/71001', '211', {
+			cacheMode: 'no-store',
+		})
 		expect(skyhookResult.failureCount).toBe(0)
 		expect(skyhookResult.skyhooks.map((skyhook) => skyhook.structure_id)).toEqual([
 			'71002',
@@ -218,19 +213,15 @@ describe('esi structure enrichment ownership handling', () => {
 			}),
 		}
 
-		const skyhookResult = await fetchCorporationSkyhooks(
-			tokenStore as never,
-			'98000001',
-			'211',
-			{
-				prioritizedEntries: [
-					{ index: 0, entry: { id: 40001, planet_id: 404 } },
-					{ index: 1, entry: { id: 30001, planet_id: 401 } },
-					{ index: 2, entry: { id: 10001, planet_id: 402 } },
-					{ index: 3, entry: { id: 20001, planet_id: 403 } },
-				],
-			}
-		)
+		const skyhookResult = await fetchCorporationSkyhooks(tokenStore as never, '98000001', '211', {
+			prioritizedEntries: [
+				{ index: 0, entry: { id: 40001, planet_id: 404 } },
+				{ index: 1, entry: { id: 30001, planet_id: 401 } },
+				{ index: 2, entry: { id: 10001, planet_id: 402 } },
+				{ index: 3, entry: { id: 20001, planet_id: 403 } },
+				{ index: 4, entry: { id: 50001, planet_id: 405 } },
+			],
+		})
 
 		expect(tokenStore.fetchEsi).toHaveBeenNthCalledWith(
 			1,
@@ -257,6 +248,12 @@ describe('esi structure enrichment ownership handling', () => {
 			{ cacheMode: 'no-store' }
 		)
 		expect(skyhookResult.failureCount).toBe(1)
+		expect(skyhookResult.failures).toEqual([
+			{
+				structureId: '30001',
+				failureReason: 'ESI request failed: 429 Too Many Requests',
+			},
+		])
 		expect(skyhookResult.skyhooks).toHaveLength(3)
 		expect(skyhookResult.skyhooks.map((skyhook) => skyhook.structure_id)).toEqual([
 			'40001',
@@ -503,43 +500,43 @@ describe('esi structure enrichment ownership handling', () => {
 	it('prioritizes stale sovereignty hubs first and keeps partial successes when one detail request fails', async () => {
 		const tokenStore = {
 			fetchEsi: vi.fn().mockImplementation(async (path: string) => {
-					if (path === '/corporations/98000001/structures/sovereignty-hubs?page=1') {
-						return {
-							data: {
-								sovereignty_hubs: [
-									{ id: 40001, solar_system_id: 404 },
-									{ id: 30001, solar_system_id: 401 },
-									{ id: 10001, solar_system_id: 402 },
-									{ id: 20001, solar_system_id: 403 },
-								],
-							},
-							pages: 1,
-						}
+				if (path === '/corporations/98000001/structures/sovereignty-hubs?page=1') {
+					return {
+						data: {
+							sovereignty_hubs: [
+								{ id: 40001, solar_system_id: 404 },
+								{ id: 30001, solar_system_id: 401 },
+								{ id: 10001, solar_system_id: 402 },
+								{ id: 20001, solar_system_id: 403 },
+							],
+						},
+						pages: 1,
 					}
+				}
 
-					if (path === '/corporations/98000001/structures/sovereignty-hubs/40001') {
-						return {
-							data: {
-								id: 40001,
-								solar_system_id: 404,
-								fuel_access_list_id: null,
-								reagent_bay: {
-									last_updated: '2026-07-23T00:00:00.000Z',
-									reagents: [],
-								},
-								resources: {
-									power: { allocated: 0, available: 0 },
-									workforce: { allocated: 0, available: 0 },
-								},
-								upgrades: [],
-								vulnerability_window: null,
-								workforce_transport: {
-									configuration: { transit: true },
-									state: { transit: true },
-								},
+				if (path === '/corporations/98000001/structures/sovereignty-hubs/40001') {
+					return {
+						data: {
+							id: 40001,
+							solar_system_id: 404,
+							fuel_access_list_id: null,
+							reagent_bay: {
+								last_updated: '2026-07-23T00:00:00.000Z',
+								reagents: [],
 							},
-						}
+							resources: {
+								power: { allocated: 0, available: 0 },
+								workforce: { allocated: 0, available: 0 },
+							},
+							upgrades: [],
+							vulnerability_window: null,
+							workforce_transport: {
+								configuration: { transit: true },
+								state: { transit: true },
+							},
+						},
 					}
+				}
 
 				if (path === '/corporations/98000001/structures/sovereignty-hubs/30001') {
 					throw new Error('ESI request failed: 429 Too Many Requests')
@@ -603,10 +600,13 @@ describe('esi structure enrichment ownership handling', () => {
 				{ index: 1, entry: { id: 30001, solar_system_id: 401 } },
 				{ index: 2, entry: { id: 10001, solar_system_id: 402 } },
 				{ index: 3, entry: { id: 20001, solar_system_id: 403 } },
+				{ index: 4, entry: { id: 50001, solar_system_id: 405 } },
 			],
 		})
 
 		expect(hubResult.failureCount).toBe(1)
+		expect(hubResult.failures).toHaveLength(1)
+		expect(hubResult.failures[0]).toMatchObject({ structureId: '30001' })
 		expect(hubResult.sovereigntyHubs.map((hub) => hub.structure_id)).toEqual([
 			'40001',
 			'10001',

--- a/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-mining-storage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { structureMiningExtractions } from '../../../db/schema'
+import { EveCorporationDataDO } from '../../../durable-object'
 
 const mocks = vi.hoisted(() => {
 	const findMany = vi.fn()
@@ -28,11 +29,11 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('../../../db', () => ({
 	createDb: vi.fn(() => ({
-			query: {
-				structureMiningExtractions: {
-					findMany: mocks.findMany,
-				},
+		query: {
+			structureMiningExtractions: {
+				findMany: mocks.findMany,
 			},
+		},
 		insert: mocks.insert,
 		update: vi.fn(() => ({
 			set: vi.fn(() => ({
@@ -46,8 +47,6 @@ vi.mock('../../../db', () => ({
 vi.mock('@repo/do-utils', () => ({
 	getStub: mocks.getStub,
 }))
-
-import { EveCorporationDataDO } from '../../../durable-object'
 
 describe('storeMiningExtractions', () => {
 	it('stamps mining snapshot rows with attempt and success timestamps on insert', async () => {
@@ -136,5 +135,39 @@ describe('storeMiningExtractions', () => {
 
 		expect(mocks.deleteMock).toHaveBeenCalledWith(structureMiningExtractions)
 		expect(mocks.values).not.toHaveBeenCalled()
+	})
+
+	it('uses the SQL-selected prune candidates for a partial priority refresh', async () => {
+		vi.clearAllMocks()
+
+		const doInstance = new EveCorporationDataDO(
+			{} as DurableObjectState,
+			{
+				DATABASE_URL: 'postgres://example',
+				UNIVERSE: {} as never,
+				EVE_TOKEN_STORE: {} as never,
+			} as never
+		)
+
+		await doInstance.storeMiningExtractions(
+			'corp-1',
+			[
+				{
+					structure_id: 'structure-1',
+					moon_id: 'moon-1',
+					extraction_start_time: '2026-07-01T00:00:00.000Z',
+					chunk_arrival_time: '2026-07-02T00:00:00.000Z',
+					natural_decay_time: '2026-07-03T00:00:00.000Z',
+					raw: {},
+				},
+			] as never,
+			{ pruneCandidateIds: [] }
+		)
+
+		expect(mocks.findMany).not.toHaveBeenCalled()
+		expect(mocks.deleteMock).not.toHaveBeenCalled()
+		expect(mocks.values).toHaveBeenCalledWith([
+			expect.objectContaining({ structureId: 'structure-1' }),
+		])
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/services/structure-priority.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-priority.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPriorityQueuedEntries } from '../../../services/structure-priority'
+
+describe('buildPriorityQueuedEntries', () => {
+	it('keeps new entries first and accepts pruning from a separate inventory query', () => {
+		const result = buildPriorityQueuedEntries(
+			[{ id: 'existing-due' }, { id: 'existing-cooldown' }, { id: 'new-structure' }],
+			['new-structure'],
+			[
+				{
+					structureId: 'existing-due',
+					lastAttemptedSyncAt: null,
+					lastSyncedAt: new Date('2026-07-22T00:00:00.000Z'),
+				},
+				{
+					structureId: 'departed-structure',
+					lastAttemptedSyncAt: null,
+					lastSyncedAt: new Date('2026-07-21T00:00:00.000Z'),
+				},
+			],
+			{ pruneCandidateIds: ['departed-structure'] }
+		)
+
+		expect(result.entries.map(({ entry }) => entry.id)).toEqual(['new-structure', 'existing-due'])
+		expect(result.pruneCandidateIds).toEqual(['departed-structure'])
+	})
+
+	it('does not queue persisted entries that are on cooldown', () => {
+		const result = buildPriorityQueuedEntries(
+			[{ id: 'live-due' }, { id: 'live-cooldown' }],
+			[],
+			[
+				{
+					structureId: 'live-due',
+					lastAttemptedSyncAt: null,
+					lastSyncedAt: new Date('2026-07-22T00:00:00.000Z'),
+				},
+			],
+			{ pruneCandidateIds: [] }
+		)
+
+		expect(result.entries.map(({ entry }) => entry.id)).toEqual(['live-due'])
+		expect(result.pruneCandidateIds).toEqual([])
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -45,7 +45,8 @@ vi.mock('@repo/do-utils', () => ({
 }))
 
 function makeDb() {
-	const where = vi.fn().mockResolvedValue(undefined)
+	const returning = vi.fn().mockResolvedValue([])
+	const where = vi.fn(() => ({ returning }))
 	const deleteMock = vi.fn(() => ({ where }))
 	const execute = vi.fn().mockResolvedValue({ rows: [] })
 	const set = vi.fn(() => ({ where }))
@@ -97,6 +98,7 @@ function makeDb() {
 		update,
 		insert,
 		_where: where,
+		_returning: returning,
 		_set: set,
 		_values: values,
 		_execute: execute,
@@ -119,24 +121,16 @@ function createDoInstance(db: ReturnType<typeof makeDb>) {
 }
 
 describe('structure prune cleanup', () => {
-	it('orders moon drill storage with new ids before stale priority rows', async () => {
+	it('stores all live moon drill rows from the corporation structure listing', async () => {
 		const db = makeDb()
 		const instance = createDoInstance(db)
-		db._execute.mockResolvedValue({
-			rows: [{ structureId: 'moon-1' }, { structureId: 'moon-2' }],
-		})
 
-		db.query.structureMoonDrills.findMany = vi
-			.fn()
-			.mockResolvedValueOnce([])
-			.mockResolvedValueOnce([
-				{
-					structureId: 'moon-2',
-					lastAttemptedSyncAt: new Date('2026-07-22T00:00:00.000Z'),
-					lastSyncedAt: new Date('2026-07-22T00:00:00.000Z'),
-				},
-			])
-			.mockResolvedValue([])
+		db.query.structureMoonDrills.findMany = vi.fn().mockResolvedValue([
+			{
+				structureId: 'stale-moon',
+				updatedAt: new Date('2026-07-22T00:00:00.000Z'),
+			},
+		])
 
 		await (instance as any).storeMoonDrills('corp-1', [
 			{
@@ -157,6 +151,7 @@ describe('structure prune cleanup', () => {
 		expect(
 			db._values.mock.calls[0][0].map((row: { structureId: string }) => row.structureId)
 		).toEqual(['moon-1', 'moon-2'])
+		expect(db.delete).toHaveBeenCalledWith(structureMoonDrills)
 	})
 
 	it('prunes stale skyhook and mining snapshots when structures disappear from a successful sync', async () => {
@@ -340,6 +335,43 @@ describe('structure prune cleanup', () => {
 		expect(db.delete).not.toHaveBeenCalled()
 	})
 
+	it('does not recalculate moon geography for an existing structure', async () => {
+		const db = makeDb()
+		db.query.structureMoonGeographies.findMany = vi.fn().mockResolvedValue([
+			{
+				structureId: 'moon-drill-1',
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		])
+		const resolveNearestMoonGeographyBySystemPosition = vi.fn()
+		mocks.getStub.mockReturnValue({
+			resolveNearestMoonGeographyBySystemPosition,
+		} as never)
+		const instance = createDoInstance(db)
+
+		await (instance as any).storeMoonGeographies('corp-1', [
+			{
+				structureId: 'moon-drill-1',
+				corporationId: 'corp-1',
+				typeId: '81826',
+				typeName: 'Metenox Moon Drill',
+				systemId: '30000142',
+				systemName: 'Jita',
+				structureInfo: {
+					position: {
+						x: 1,
+						y: 2,
+						z: 3,
+					},
+				},
+			},
+		])
+
+		expect(resolveNearestMoonGeographyBySystemPosition).not.toHaveBeenCalled()
+		expect(db.insert).not.toHaveBeenCalled()
+		expect(db.delete).not.toHaveBeenCalled()
+	})
+
 	it('stores sovereignty hub names using resolved solar system names', async () => {
 		const db = makeDb()
 		const instance = createDoInstance(db)
@@ -456,11 +488,12 @@ describe('structure prune cleanup', () => {
 		})
 	})
 
-	it('rebuilds sovereignty hubs without preserving stale hub names', async () => {
+	it('preserves existing sovereignty hub geography without re-resolving it', async () => {
 		const db = makeDb()
 		db.query.structureSovereigntyHubs.findMany = vi.fn().mockResolvedValue([
 			{
 				structureId: 'hub-1',
+				systemId: '30000142',
 				systemName: 'Stale Name',
 				name: 'Stale Hub',
 			},
@@ -468,12 +501,9 @@ describe('structure prune cleanup', () => {
 		const instance = createDoInstance(db)
 
 		mocks.getStub.mockReturnValueOnce({} as never)
+		const resolveSolarSystemsByIds = vi.fn()
 		mocks.getStub.mockReturnValueOnce({
-			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({
-				'30000142': {
-					solarSystemName: 'Jita',
-				},
-			}),
+			resolveSolarSystemsByIds,
 		} as never)
 
 		await instance.storeSovereigntyHubs('corp-1', [
@@ -514,8 +544,10 @@ describe('structure prune cleanup', () => {
 
 		expect(db._values).toHaveBeenCalled()
 		expect(db._values.mock.calls[0][0][0]).toMatchObject({
-			systemName: 'Jita',
+			systemId: '30000142',
+			systemName: 'Stale Name',
 		})
+		expect(resolveSolarSystemsByIds).not.toHaveBeenCalled()
 	})
 
 	it('preserves existing skyhook snapshots when upstream skyhooks cannot be synthesized', async () => {
@@ -558,6 +590,70 @@ describe('structure prune cleanup', () => {
 
 		expect(db.delete).not.toHaveBeenCalled()
 		expect(db.insert).not.toHaveBeenCalled()
+	})
+
+	it('preserves existing skyhook geography without re-resolving it', async () => {
+		const db = makeDb()
+		db.query.corporationStructures.findMany = vi.fn().mockResolvedValue([
+			{
+				structureId: 'skyhook-1',
+				corporationId: 'corp-1',
+				typeId: '81826',
+				systemId: '30000142',
+				systemName: 'Jita',
+				regionId: '10000002',
+				regionName: 'The Forge',
+				updatedAt: new Date('2026-07-12T19:36:46.834Z'),
+			},
+		])
+		db.query.structureSkyhooks.findMany = vi.fn().mockResolvedValue([
+			{
+				structureId: 'skyhook-1',
+				planetName: 'Planet One',
+				systemName: 'Jita',
+				updatedAt: new Date('2026-07-12T19:36:46.834Z'),
+			},
+		])
+		const resolvePlanetGeographyByIds = vi.fn()
+		const resolveSolarSystemsByIds = vi.fn()
+		const resolveRegionsByIds = vi.fn()
+		mocks.getStub.mockReturnValue({
+			resolvePlanetGeographyByIds,
+			resolveSolarSystemsByIds,
+			resolveRegionsByIds,
+			resolveNearestMoonGeographyBySystemPosition: vi.fn(),
+		} as never)
+
+		const instance = createDoInstance(db)
+
+		await instance.storeSkyhooks('corp-1', [
+			{
+				structure_id: 'skyhook-1',
+				planet_id: '401',
+				corporation_id: 'corp-1',
+				state: 'active',
+				is_active: true,
+				effective_workforce: 0,
+				reagents: [],
+				reinforcement_timer: null,
+				theft_vulnerability: null,
+				raw: { id: 1 },
+			} as never,
+		])
+
+		expect(resolvePlanetGeographyByIds).not.toHaveBeenCalled()
+		expect(resolveSolarSystemsByIds).not.toHaveBeenCalled()
+		expect(resolveRegionsByIds).not.toHaveBeenCalled()
+		expect(db._values.mock.calls[0][0][0]).toMatchObject({
+			systemId: '30000142',
+			systemName: 'Jita',
+			regionId: '10000002',
+			regionName: 'The Forge',
+		})
+		expect(db._values.mock.calls[1][0][0]).toMatchObject({
+			planetName: 'Planet One',
+			systemName: 'Jita',
+		})
 	})
 
 	it('does not prune skyhooks without explicit prune candidates when the upstream listing is empty', async () => {

--- a/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sovereignty-systems-cache.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+	ensureSharedSovereigntySystems,
+	refreshSharedSovereigntySystems,
+} from '../../../workflows/utils/sovereignty-systems-cache'
+
 const mocks = vi.hoisted(() => {
 	const fetchSovereigntySystemsMock = vi.fn()
 	const createTokenStoreMock = vi.fn()
@@ -22,175 +27,107 @@ vi.mock('../../../workflows/utils/services', () => ({
 		mocks.getGlobalCorporationDataStubMock(...args),
 }))
 
-import { refreshSharedSovereigntySystems } from '../../../workflows/utils/sovereignty-systems-cache'
+describe('ensureSharedSovereigntySystems', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('checks only the freshness metadata for an existing snapshot', async () => {
+		const hasFreshSharedSovereigntySystemsMock = vi.fn().mockResolvedValue(true)
+		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+			hasFreshSharedSovereigntySystems: hasFreshSharedSovereigntySystemsMock,
+		})
+
+		await expect(ensureSharedSovereigntySystems({} as never)).resolves.toBeUndefined()
+
+		expect(hasFreshSharedSovereigntySystemsMock).toHaveBeenCalledWith(60 * 60)
+	})
+
+	it('refreshes when the metadata is absent or stale', async () => {
+		const hasFreshSharedSovereigntySystemsMock = vi.fn().mockResolvedValue(false)
+		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue('lease-token')
+		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
+		const storeSharedSovereigntySystemsMock = vi.fn()
+
+		mocks.createTokenStoreMock.mockReturnValue({})
+		mocks.fetchSovereigntySystemsMock.mockResolvedValue([{ system_id: '30000142' }])
+		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+			hasFreshSharedSovereigntySystems: hasFreshSharedSovereigntySystemsMock,
+			acquireSharedSovereigntySystemsRefreshLease: acquireSharedSovereigntySystemsRefreshLeaseMock,
+			releaseSharedSovereigntySystemsRefreshLease: releaseSharedSovereigntySystemsRefreshLeaseMock,
+			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
+		})
+
+		await ensureSharedSovereigntySystems({} as never)
+
+		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
+		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
+		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000142' }])
+		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
+	})
+})
 
 describe('refreshSharedSovereigntySystems', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 	})
 
-	it('returns the fresh snapshot without acquiring a lease or fetching ESI', async () => {
-		const getSharedSovereigntySystemsSnapshotMock = vi.fn().mockResolvedValue([
-			{ system_id: '30000142' },
-		])
-		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue(
-			'lease-token'
-		)
-		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
-		const clearSharedSovereigntySystemsMock = vi.fn()
-		const storeSharedSovereigntySystemsMock = vi.fn()
-
-		mocks.createTokenStoreMock.mockReturnValue({})
-		mocks.fetchSovereigntySystemsMock.mockResolvedValue([{ system_id: '30000142' }])
-		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
-			acquireSharedSovereigntySystemsRefreshLease:
-				acquireSharedSovereigntySystemsRefreshLeaseMock,
-			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
-			releaseSharedSovereigntySystemsRefreshLease:
-				releaseSharedSovereigntySystemsRefreshLeaseMock,
-			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
-			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
-		})
-
-		const result = await refreshSharedSovereigntySystems({} as never)
-
-		expect(getSharedSovereigntySystemsSnapshotMock).not.toHaveBeenCalled()
-		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
-		expect(clearSharedSovereigntySystemsMock).toHaveBeenCalledWith()
-		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
-		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000142' }])
-		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
-		expect(result).toEqual([{ system_id: '30000142' }])
-	})
-
-	it('rebuilds the snapshot even if an existing snapshot is still fresh', async () => {
-		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
-		const clearSharedSovereigntySystemsMock = vi.fn()
-		const storeSharedSovereigntySystemsMock = vi.fn()
-		const getSharedSovereigntySystemsSnapshotMock = vi.fn().mockResolvedValue([
-			{ system_id: '30000142' },
-		])
+	it('refreshes under the lease without clearing the last good snapshot first', async () => {
 		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue('lease-token')
-
-		mocks.createTokenStoreMock.mockReturnValue({})
-		mocks.fetchSovereigntySystemsMock.mockResolvedValue([{ system_id: '30000999' }])
-		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
-			acquireSharedSovereigntySystemsRefreshLease:
-				acquireSharedSovereigntySystemsRefreshLeaseMock,
-			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
-			releaseSharedSovereigntySystemsRefreshLease:
-				releaseSharedSovereigntySystemsRefreshLeaseMock,
-			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
-			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
-		})
-
-		const result = await refreshSharedSovereigntySystems({} as never)
-
-		expect(getSharedSovereigntySystemsSnapshotMock).not.toHaveBeenCalled()
-		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
-		expect(clearSharedSovereigntySystemsMock).toHaveBeenCalledWith()
-		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
-		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000999' }])
-		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
-		expect(result).toEqual([{ system_id: '30000999' }])
-	})
-
-	it('uses the lease holder to refresh the snapshot and releases the lease afterward', async () => {
 		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
-		const clearSharedSovereigntySystemsMock = vi.fn()
 		const storeSharedSovereigntySystemsMock = vi.fn()
-		const getSharedSovereigntySystemsSnapshotMock = vi
-			.fn()
-			.mockResolvedValueOnce(null)
-			.mockResolvedValueOnce(null)
-		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi
-			.fn()
-			.mockResolvedValue('lease-token')
 
 		mocks.createTokenStoreMock.mockReturnValue({})
 		mocks.fetchSovereigntySystemsMock.mockResolvedValue([{ system_id: '30000142' }])
 		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
-			acquireSharedSovereigntySystemsRefreshLease:
-				acquireSharedSovereigntySystemsRefreshLeaseMock,
-			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
-			releaseSharedSovereigntySystemsRefreshLease:
-				releaseSharedSovereigntySystemsRefreshLeaseMock,
+			acquireSharedSovereigntySystemsRefreshLease: acquireSharedSovereigntySystemsRefreshLeaseMock,
+			releaseSharedSovereigntySystemsRefreshLease: releaseSharedSovereigntySystemsRefreshLeaseMock,
 			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
-			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
 		})
 
-		const result = await refreshSharedSovereigntySystems({} as never)
+		await expect(refreshSharedSovereigntySystems({} as never)).resolves.toBeUndefined()
 
-		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
-		expect(clearSharedSovereigntySystemsMock).toHaveBeenCalledWith()
-		expect(mocks.createTokenStoreMock).toHaveBeenCalledWith({})
 		expect(mocks.fetchSovereigntySystemsMock).toHaveBeenCalledWith({})
 		expect(storeSharedSovereigntySystemsMock).toHaveBeenCalledWith([{ system_id: '30000142' }])
 		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith('lease-token')
-		expect(result).toEqual([{ system_id: '30000142' }])
-		expect(clearSharedSovereigntySystemsMock.mock.invocationCallOrder[0]).toBeLessThan(
-			mocks.fetchSovereigntySystemsMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
-		)
 	})
 
-	it('falls back to the existing snapshot when another refresh already holds the lease', async () => {
-		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
-		const storeSharedSovereigntySystemsMock = vi.fn()
-		const clearSharedSovereigntySystemsMock = vi.fn()
-		const getSharedSovereigntySystemsSnapshotMock = vi
+	it('waits for the active lease holder using metadata-only checks', async () => {
+		const hasFreshSharedSovereigntySystemsMock = vi
 			.fn()
-			.mockResolvedValueOnce(null)
-			.mockResolvedValueOnce([{ system_id: '30000142' }])
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true)
 		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue(null)
 
-		mocks.createTokenStoreMock.mockReturnValue({})
 		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
-			acquireSharedSovereigntySystemsRefreshLease:
-				acquireSharedSovereigntySystemsRefreshLeaseMock,
-			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
-			releaseSharedSovereigntySystemsRefreshLease:
-				releaseSharedSovereigntySystemsRefreshLeaseMock,
-			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
-			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
+			hasFreshSharedSovereigntySystems: hasFreshSharedSovereigntySystemsMock,
+			acquireSharedSovereigntySystemsRefreshLease: acquireSharedSovereigntySystemsRefreshLeaseMock,
 		})
 
-		const result = await refreshSharedSovereigntySystems({} as never)
-
-		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
-		expect(clearSharedSovereigntySystemsMock).not.toHaveBeenCalled()
+		await expect(refreshSharedSovereigntySystems({} as never)).resolves.toBeUndefined()
+		expect(hasFreshSharedSovereigntySystemsMock).toHaveBeenCalledTimes(2)
 		expect(mocks.fetchSovereigntySystemsMock).not.toHaveBeenCalled()
-		expect(storeSharedSovereigntySystemsMock).not.toHaveBeenCalled()
-		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
-		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(2)
-		expect(result).toEqual([{ system_id: '30000142' }])
 	})
 
-	it('throws when it cannot produce a fresh snapshot after refresh attempts', async () => {
-		const releaseSharedSovereigntySystemsRefreshLeaseMock = vi.fn()
-		const clearSharedSovereigntySystemsMock = vi.fn()
-		const storeSharedSovereigntySystemsMock = vi.fn()
-		const getSharedSovereigntySystemsSnapshotMock = vi.fn().mockResolvedValue(null)
-		const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue(null)
+	it('fails after the lease holder does not publish a fresh snapshot', async () => {
+		vi.useFakeTimers()
+		try {
+			const hasFreshSharedSovereigntySystemsMock = vi.fn().mockResolvedValue(false)
+			const acquireSharedSovereigntySystemsRefreshLeaseMock = vi.fn().mockResolvedValue(null)
+			mocks.getGlobalCorporationDataStubMock.mockReturnValue({
+				hasFreshSharedSovereigntySystems: hasFreshSharedSovereigntySystemsMock,
+				acquireSharedSovereigntySystemsRefreshLease:
+					acquireSharedSovereigntySystemsRefreshLeaseMock,
+			})
 
-		mocks.getGlobalCorporationDataStubMock.mockReturnValue({
-			acquireSharedSovereigntySystemsRefreshLease:
-				acquireSharedSovereigntySystemsRefreshLeaseMock,
-			clearSharedSovereigntySystems: clearSharedSovereigntySystemsMock,
-			releaseSharedSovereigntySystemsRefreshLease:
-				releaseSharedSovereigntySystemsRefreshLeaseMock,
-			storeSharedSovereigntySystems: storeSharedSovereigntySystemsMock,
-			getSharedSovereigntySystemsSnapshot: getSharedSovereigntySystemsSnapshotMock,
-		})
+			const refreshAssertion = expect(refreshSharedSovereigntySystems({} as never)).rejects.toThrow(
+				'Failed to refresh shared sovereignty systems snapshot'
+			)
+			await vi.advanceTimersByTimeAsync(32_000)
 
-		await expect(refreshSharedSovereigntySystems({} as never)).rejects.toThrow(
-			'Failed to refresh shared sovereignty systems snapshot'
-		)
-
-		expect(acquireSharedSovereigntySystemsRefreshLeaseMock).toHaveBeenCalledWith()
-		expect(clearSharedSovereigntySystemsMock).not.toHaveBeenCalled()
-		expect(mocks.fetchSovereigntySystemsMock).not.toHaveBeenCalled()
-		expect(storeSharedSovereigntySystemsMock).not.toHaveBeenCalled()
-		expect(releaseSharedSovereigntySystemsRefreshLeaseMock).not.toHaveBeenCalled()
-		expect(getSharedSovereigntySystemsSnapshotMock).toHaveBeenCalledTimes(4)
+			await refreshAssertion
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+
+import { fetchSovereigntyEnrichment } from '../../../workflows/steps/structures'
+
 const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 
 const mocks = vi.hoisted(() => {
@@ -8,6 +11,8 @@ const mocks = vi.hoisted(() => {
 	const resolveSolarSystemsByIdsMock = vi.fn()
 	const getSovereigntyHubSyncPrioritiesMock = vi.fn()
 	const getMissingStructureIdsForPriorityQueueMock = vi.fn()
+	const getStructureIdsMissingFromLiveListingMock = vi.fn()
+	const getStructurePriorityQueueMock = vi.fn()
 	const fetchEsiMock = vi.fn()
 	const getStubMock = vi.fn(() => ({
 		resolveSolarSystemsByIds: resolveSolarSystemsByIdsMock,
@@ -21,6 +26,8 @@ const mocks = vi.hoisted(() => {
 		resolveSolarSystemsByIdsMock,
 		getSovereigntyHubSyncPrioritiesMock,
 		getMissingStructureIdsForPriorityQueueMock,
+		getStructureIdsMissingFromLiveListingMock,
+		getStructurePriorityQueueMock,
 		fetchEsiMock,
 		getStubMock,
 		createTokenStoreMock,
@@ -42,6 +49,9 @@ vi.mock('../../../workflows/utils/services', () => ({
 			mocks.getSovereigntyHubSyncPrioritiesMock(...args),
 		getMissingStructureIdsForPriorityQueue: (...args: unknown[]) =>
 			mocks.getMissingStructureIdsForPriorityQueueMock(...args),
+		getStructureIdsMissingFromLiveListing: (...args: unknown[]) =>
+			mocks.getStructureIdsMissingFromLiveListingMock(...args),
+		getStructurePriorityQueue: (...args: unknown[]) => mocks.getStructurePriorityQueueMock(...args),
 	})),
 }))
 
@@ -52,22 +62,22 @@ vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
 		mocks.refreshSharedSovereigntySystemsMock(...args),
 }))
 
-import { fetchSovereigntyEnrichment } from '../../../workflows/steps/structures'
-
 describe('fetchSovereigntyEnrichment', () => {
 	it('enriches sovereignty hub names from resolved solar systems before persistence', async () => {
 		mocks.createTokenStoreMock.mockReturnValue({
 			fetchEsi: mocks.fetchEsiMock,
 		})
-		mocks.getSovereigntyHubSyncPrioritiesMock
-			.mockResolvedValueOnce([
+		mocks.getStructurePriorityQueueMock.mockResolvedValueOnce({
+			newStructureIds: [],
+			pruneCandidateIds: ['departed-hub'],
+			syncPriorities: [
 				{
 					structureId: '1',
 					lastAttemptedSyncAt: null,
 					lastSyncedAt: new Date('2026-07-22T00:00:00.000Z'),
 				},
-			])
-		mocks.getMissingStructureIdsForPriorityQueueMock.mockResolvedValue([])
+			],
+		})
 		mocks.fetchEsiMock.mockResolvedValueOnce({
 			data: {
 				sovereignty_hubs: [{ id: 1, solar_system_id: 30000142 }],
@@ -119,6 +129,7 @@ describe('fetchSovereigntyEnrichment', () => {
 					raw: { detail: { id: 1 } },
 				},
 			],
+			failures: [],
 			failureCount: 0,
 			rateLimitFailureCount: 0,
 			nonRateLimitFailureCount: 0,
@@ -155,7 +166,7 @@ describe('fetchSovereigntyEnrichment', () => {
 						},
 					},
 				],
-				pruneCandidateIds: [],
+				pruneCandidateIds: ['departed-hub'],
 			}
 		)
 		expect(mocks.readSharedSovereigntySystemsByIdsMock).toHaveBeenCalledWith(
@@ -177,8 +188,11 @@ describe('fetchSovereigntyEnrichment', () => {
 		mocks.createTokenStoreMock.mockReturnValue({
 			fetchEsi: mocks.fetchEsiMock,
 		})
-		mocks.getSovereigntyHubSyncPrioritiesMock.mockResolvedValueOnce([])
-		mocks.getMissingStructureIdsForPriorityQueueMock.mockResolvedValue([])
+		mocks.getStructurePriorityQueueMock.mockResolvedValueOnce({
+			newStructureIds: [],
+			pruneCandidateIds: [],
+			syncPriorities: [],
+		})
 		mocks.fetchEsiMock.mockRejectedValue(
 			new Error(
 				'ESI request failed: 401 Unauthorized - {"error":"missing scope"} | metadata={"status":401,"path":"/corporations/123/structures/sovereignty-hubs/"}'
@@ -193,7 +207,9 @@ describe('fetchSovereigntyEnrichment', () => {
 			'character-1'
 		)
 
-		await expect(promise).rejects.toThrow('Sovereignty hub enrichment requires updated director scopes.')
+		await expect(promise).rejects.toThrow(
+			'Sovereignty hub enrichment requires updated director scopes.'
+		)
 		await promise.catch((error) => {
 			expect(error).toBeInstanceOf(Error)
 			expect((error as { target?: string }).target).toBe('sovereignty-hubs')

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -29,6 +29,7 @@ const recordTaxProjectionRetryIntentMock = vi.fn()
 const sendHrDepartedMessagesMock = vi.fn()
 const triggerTaxProjectionRefreshMock = vi.fn()
 const parseEsiErrorMetadataMock = vi.fn((_message: string) => null as { status: number } | null)
+const ensureSharedSovereigntySystemsMock = vi.fn().mockResolvedValue([])
 
 vi.mock('cloudflare:workers', () => {
 	class WorkflowEntrypoint<Env = unknown, Params = unknown> {
@@ -106,6 +107,11 @@ vi.mock('../../../workflows/steps/structures', () => ({
 		storeMiningExtractionEnrichmentMock(...args),
 }))
 
+vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
+	ensureSharedSovereigntySystems: (...args: unknown[]) =>
+		ensureSharedSovereigntySystemsMock(...args),
+}))
+
 function createStep() {
 	const executedStepNames: string[] = []
 	const doMock = vi.fn(
@@ -139,6 +145,12 @@ function createWorkflowEnv() {
 		getMiningCitadelSyncPriorities: vi.fn().mockResolvedValue([]),
 		getMiningCitadelStructureIds: vi.fn().mockResolvedValue([]),
 		getMissingStructureIdsForPriorityQueue: vi.fn().mockResolvedValue([]),
+		getStructureIdsMissingFromLiveListing: vi.fn().mockResolvedValue([]),
+		getStructurePriorityQueue: vi.fn().mockResolvedValue({
+			newStructureIds: [],
+			pruneCandidateIds: [],
+			syncPriorities: [],
+		}),
 		getSovereigntyHubSyncPriorities: vi.fn().mockResolvedValue([]),
 		getSovereigntyHubStructureIds: vi.fn().mockResolvedValue([]),
 		getSkyhookSyncPriorities: vi.fn().mockResolvedValue([]),
@@ -570,6 +582,7 @@ describe('EveCorporationSyncWorkflow', () => {
 					structure_id: 'skyhook-1',
 				},
 			],
+			failures: [],
 			failureCount: 0,
 			rateLimitFailureCount: 0,
 			nonRateLimitFailureCount: 0,
@@ -713,13 +726,17 @@ describe('EveCorporationSyncWorkflow', () => {
 	it('runs mining enrichment for mining citadels and still continues to asset sync', async () => {
 		vi.clearAllMocks()
 		const { env, corpDataStub, updateCorporationAuthHealth } = createWorkflowEnv()
-		corpDataStub.getMiningCitadelSyncPriorities.mockResolvedValue([
-			{
-				structureId: '1000001',
-				lastAttemptedSyncAt: null,
-				lastSyncedAt: new Date('2026-07-10T00:00:00.000Z'),
-			},
-		])
+		corpDataStub.getStructurePriorityQueue.mockResolvedValue({
+			newStructureIds: [],
+			pruneCandidateIds: [],
+			syncPriorities: [
+				{
+					structureId: '1000001',
+					lastAttemptedSyncAt: null,
+					lastSyncedAt: new Date('2026-07-10T00:00:00.000Z'),
+				},
+			],
+		})
 
 		verifyAllDirectorsHealthMock.mockResolvedValue({
 			verified: 1,
@@ -793,11 +810,16 @@ describe('EveCorporationSyncWorkflow', () => {
 
 		expect(fetchMiningExtractionEnrichmentMock).toHaveBeenCalledTimes(1)
 		expect(storeMiningExtractionEnrichmentMock).toHaveBeenCalledTimes(1)
-		expect(storeMiningExtractionEnrichmentMock).toHaveBeenCalledWith(env, '693378155', [
-			{
-				structure_id: '1000001',
-			},
-		])
+		expect(storeMiningExtractionEnrichmentMock).toHaveBeenCalledWith(
+			env,
+			'693378155',
+			[
+				{
+					structure_id: '1000001',
+				},
+			],
+			{ pruneCandidateIds: [] }
+		)
 		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 	})
@@ -919,6 +941,7 @@ describe('EveCorporationSyncWorkflow', () => {
 		storeSovereigntyEnrichmentMock.mockResolvedValue(undefined)
 		fetchSkyhookEnrichmentMock.mockResolvedValue({
 			skyhooks: [],
+			failures: [],
 			failureCount: 0,
 			rateLimitFailureCount: 0,
 			nonRateLimitFailureCount: 0,

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -1,26 +1,22 @@
-import { logger } from '@repo/hono-helpers'
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
 
 import * as esiFetch from '../../../services/esi-fetch'
-import {
-	createStructureEnrichmentScopeMismatchError,
-	shouldSuppressDirectorUnhealthyOnStructureEnrichmentAuthFailure,
-	type StructureEnrichmentSyncTarget,
-} from '../../utils/structure-enrichment-auth'
+import { buildPriorityQueuedEntries } from '../../../services/structure-priority'
 import { createTokenStore, getCorporationDataStub } from '../../utils/services'
 import {
 	readSharedSovereigntySystemsByIds,
 	refreshSharedSovereigntySystems,
 } from '../../utils/sovereignty-systems-cache'
-import type { Universe } from '@repo/universe'
-import type {
-	SkyhookStoreResult,
-	SovereigntyHubSyncPriority,
-	StructureSyncFailureTarget,
-} from '@repo/eve-corporation-data'
-import { buildPriorityQueuedEntries } from '../../../services/structure-priority'
+import {
+	createStructureEnrichmentScopeMismatchError,
+	shouldSuppressDirectorUnhealthyOnStructureEnrichmentAuthFailure,
+} from '../../utils/structure-enrichment-auth'
 
+import type { SkyhookStoreResult, StructureSyncFailureTarget } from '@repo/eve-corporation-data'
+import type { Universe } from '@repo/universe'
 import type { Env } from '../../../context'
+import type { StructureEnrichmentSyncTarget } from '../../utils/structure-enrichment-auth'
 
 export type StructuresData = Awaited<ReturnType<typeof esiFetch.fetchStructures>>
 export type SovereigntySystemsData = Awaited<ReturnType<typeof esiFetch.fetchSovereigntySystems>>
@@ -29,11 +25,13 @@ export type CorporationSkyhooksData = Awaited<ReturnType<typeof esiFetch.fetchCo
 export type MiningExtractionsData = Awaited<
 	ReturnType<typeof esiFetch.fetchCorporationMiningExtractions>
 >
+type StructureEnrichmentFailure = esiFetch.StructureEnrichmentFailure
 
 export interface SovereigntyEnrichmentData {
 	sovereigntySystems: SovereigntySystemsData | null
 	sovereigntyHubs: SovereigntyHubsData['sovereigntyHubs']
 	pruneCandidateIds: string[]
+	failures: StructureEnrichmentFailure[]
 	failureCount: number
 	rateLimitFailureCount: number
 	nonRateLimitFailureCount: number
@@ -42,9 +40,43 @@ export interface SovereigntyEnrichmentData {
 export interface SkyhookEnrichmentData {
 	skyhooks: CorporationSkyhooksData['skyhooks']
 	pruneCandidateIds: string[]
+	failures: StructureEnrichmentFailure[]
 	failureCount: number
 	rateLimitFailureCount: number
 	nonRateLimitFailureCount: number
+}
+
+type PaginatedEsiResponse<T> = {
+	data: T
+	pages?: number
+	page?: number
+}
+
+async function fetchStructureListing<T, E>(
+	fetchPage: (page: number) => Promise<PaginatedEsiResponse<T>>,
+	extractEntries: (data: T) => E[],
+	label: string
+): Promise<E[]> {
+	const firstResponse = await fetchPage(1)
+	const totalPages = firstResponse.pages ?? 1
+	const entries = [...extractEntries(firstResponse.data)]
+
+	for (let page = 2; page <= totalPages; page += 1) {
+		const response = await fetchPage(page)
+		if (response.pages !== undefined && response.pages !== totalPages) {
+			throw new Error(
+				`ESI ${label} listing changed page count while fetching: expected ${totalPages}, got ${response.pages}`
+			)
+		}
+		if (response.page !== undefined && response.page !== page) {
+			throw new Error(
+				`ESI ${label} listing returned page ${response.page} when page ${page} was requested`
+			)
+		}
+		entries.push(...extractEntries(response.data))
+	}
+
+	return entries
 }
 
 function buildSovereigntyAllianceBySystemId(
@@ -94,33 +126,28 @@ export async function fetchSovereigntyEnrichment(
 ): Promise<SovereigntyEnrichmentData | null> {
 	try {
 		const corpData = getCorporationDataStub(env, corporationId)
-		const syncPriorities: SovereigntyHubSyncPriority[] =
-			await corpData.getSovereigntyHubSyncPriorities(corporationId)
 		const tokenStore = createTokenStore(env)
-		const firstPass = await tokenStore.fetchEsi<{ sovereignty_hubs: Array<{ id: number; solar_system_id: number }> }>(
-			`/corporations/${corporationId}/structures/sovereignty-hubs?page=1`,
-			directorCharacterId,
-			{ cacheMode: 'no-store' }
+		const sovereigntyHubListing = await fetchStructureListing(
+			(page) =>
+				tokenStore.fetchEsi<{ sovereignty_hubs: Array<{ id: number; solar_system_id: number }> }>(
+					`/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
+					directorCharacterId,
+					{ cacheMode: 'no-store' }
+				),
+			(data) => data.sovereignty_hubs,
+			'sovereignty-hubs'
 		)
-		const sovereigntyHubListing = [...firstPass.data.sovereignty_hubs]
-		for (let page = 2; page <= (firstPass.pages ?? 1); page += 1) {
-			const pageResponse = await tokenStore.fetchEsi<{ sovereignty_hubs: Array<{ id: number; solar_system_id: number }> }>(
-				`/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
-				directorCharacterId,
-				{ cacheMode: 'no-store' }
-			)
-			sovereigntyHubListing.push(...pageResponse.data.sovereignty_hubs)
-		}
 		const liveStructureIds = sovereigntyHubListing.map((hub) => String(hub.id))
-		const newStructureIds = await corpData.getMissingStructureIdsForPriorityQueue(
+		const priorityQueue = await corpData.getStructurePriorityQueue(
 			corporationId,
 			'sovereignty',
 			liveStructureIds
 		)
 		const prioritizedQueue = buildPriorityQueuedEntries(
 			sovereigntyHubListing,
-			newStructureIds,
-			syncPriorities
+			priorityQueue.newStructureIds,
+			priorityQueue.syncPriorities,
+			{ pruneCandidateIds: priorityQueue.pruneCandidateIds }
 		)
 		const sovereigntyHubResult = await esiFetch.fetchSovereigntyHubs(
 			tokenStore,
@@ -141,6 +168,7 @@ export async function fetchSovereigntyEnrichment(
 				sovereigntySystems: null,
 				sovereigntyHubs: [],
 				pruneCandidateIds: [...sovereigntyHubResult.pruneCandidateIds],
+				failures: sovereigntyHubResult.failures,
 				failureCount,
 				rateLimitFailureCount,
 				nonRateLimitFailureCount,
@@ -148,17 +176,28 @@ export async function fetchSovereigntyEnrichment(
 		}
 
 		const universe = getStub<Universe>(env.UNIVERSE, 'default')
-		const systemGeography =
-			await universe.resolveSolarSystemsByIds([...new Set(collectedHubs.map((hub) => hub.system_id))])
+		const systemGeography = await universe.resolveSolarSystemsByIds([
+			...new Set(collectedHubs.map((hub) => hub.system_id)),
+		])
 		let sovereigntySystems = await readSharedSovereigntySystemsByIds(
 			env,
 			collectedHubs.map((hub) => hub.system_id)
 		)
 		if (!sovereigntySystems) {
-			logger.warn('[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache', {
-				corporationId,
-			})
-			sovereigntySystems = await refreshSharedSovereigntySystems(env)
+			logger.warn(
+				'[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache',
+				{
+					corporationId,
+				}
+			)
+			await refreshSharedSovereigntySystems(env)
+			sovereigntySystems = await readSharedSovereigntySystemsByIds(
+				env,
+				collectedHubs.map((hub) => hub.system_id)
+			)
+			if (!sovereigntySystems) {
+				throw new Error('Shared sovereignty snapshot was unavailable after refresh')
+			}
 		}
 
 		const allianceBySystemId = buildSovereigntyAllianceBySystemId(sovereigntySystems)
@@ -179,6 +218,7 @@ export async function fetchSovereigntyEnrichment(
 			sovereigntySystems,
 			sovereigntyHubs: enrichedSovereigntyHubs,
 			pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
+			failures: sovereigntyHubResult.failures,
 			failureCount,
 			rateLimitFailureCount,
 			nonRateLimitFailureCount,
@@ -198,29 +238,29 @@ export async function fetchSkyhookEnrichment(
 ): Promise<SkyhookEnrichmentData | null> {
 	try {
 		const corpData = getCorporationDataStub(env, corporationId)
-		const syncPriorities = await corpData.getSkyhookSyncPriorities(corporationId)
 		const tokenStore = createTokenStore(env)
-		const firstPass = await tokenStore.fetchEsi<{ skyhooks: Array<{ id: number; planet_id: number }> }>(
-			`/corporations/${corporationId}/structures/skyhooks`,
-			directorCharacterId,
-			{ cacheMode: 'no-store' }
+		const skyhookListing = await fetchStructureListing(
+			(page) =>
+				tokenStore.fetchEsi<{ skyhooks: Array<{ id: number; planet_id: number }> }>(
+					`/corporations/${corporationId}/structures/skyhooks${page === 1 ? '' : `?page=${page}`}`,
+					directorCharacterId,
+					{ cacheMode: 'no-store' }
+				),
+			(data) => data.skyhooks,
+			'skyhooks'
 		)
-		const skyhookListing = [...firstPass.data.skyhooks]
-		for (let page = 2; page <= (firstPass.pages ?? 1); page += 1) {
-			const pageResponse = await tokenStore.fetchEsi<{ skyhooks: Array<{ id: number; planet_id: number }> }>(
-				`/corporations/${corporationId}/structures/skyhooks?page=${page}`,
-				directorCharacterId,
-				{ cacheMode: 'no-store' }
-			)
-			skyhookListing.push(...pageResponse.data.skyhooks)
-		}
 		const liveStructureIds = skyhookListing.map((skyhook) => String(skyhook.id))
-		const newStructureIds = await corpData.getMissingStructureIdsForPriorityQueue(
+		const priorityQueue = await corpData.getStructurePriorityQueue(
 			corporationId,
 			'skyhooks',
 			liveStructureIds
 		)
-		const prioritizedQueue = buildPriorityQueuedEntries(skyhookListing, newStructureIds, syncPriorities)
+		const prioritizedQueue = buildPriorityQueuedEntries(
+			skyhookListing,
+			priorityQueue.newStructureIds,
+			priorityQueue.syncPriorities,
+			{ pruneCandidateIds: priorityQueue.pruneCandidateIds }
+		)
 		const skyhookResult = await esiFetch.fetchCorporationSkyhooks(
 			tokenStore,
 			corporationId,
@@ -244,6 +284,7 @@ export async function fetchSkyhookEnrichment(
 		return {
 			skyhooks,
 			pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
+			failures: skyhookResult.failures,
 			failureCount,
 			rateLimitFailureCount,
 			nonRateLimitFailureCount,
@@ -296,6 +337,13 @@ export async function storeSovereigntyEnrichment(
 			pruneCandidateIds: enrichment.pruneCandidateIds,
 		}),
 	])
+	if (enrichment.failures.length > 0) {
+		await corpData.markStructureEnrichmentFailures(
+			corporationId,
+			'sovereignty-hubs',
+			enrichment.failures
+		)
+	}
 
 	logger.info('[StructuresStep] Stored sovereignty enrichment', {
 		corporationId,
@@ -313,6 +361,9 @@ export async function storeSkyhookEnrichment(
 	const result = await corpData.storeSkyhooks(corporationId, enrichment.skyhooks, {
 		pruneCandidateIds: enrichment.pruneCandidateIds,
 	})
+	if (enrichment.failures.length > 0) {
+		await corpData.markStructureEnrichmentFailures(corporationId, 'skyhooks', enrichment.failures)
+	}
 
 	logger.info('[StructuresStep] Stored skyhook enrichment', {
 		corporationId,
@@ -346,10 +397,11 @@ export async function fetchMiningExtractionEnrichment(
 export async function storeMiningExtractionEnrichment(
 	env: Env,
 	corporationId: string,
-	enrichment: MiningExtractionsData
+	enrichment: MiningExtractionsData,
+	options: { pruneCandidateIds?: readonly string[] } = {}
 ): Promise<void> {
 	const corpData = getCorporationDataStub(env, corporationId)
-	await corpData.storeMiningExtractions(corporationId, enrichment)
+	await corpData.storeMiningExtractions(corporationId, enrichment, options)
 
 	logger.info('[StructuresStep] Stored mining extraction enrichment', {
 		corporationId,

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -51,6 +51,7 @@ import { syncWalletJournal } from './steps/wallet-journal'
 import { syncWalletTransactions } from './steps/wallet-transactions'
 import { fetchWallets, storeWallets } from './steps/wallets'
 import { createShouldSyncPredicate } from './utils/should-sync'
+import { ensureSharedSovereigntySystems } from './utils/sovereignty-systems-cache'
 import { StructureEnrichmentScopeMismatchError } from './utils/structure-enrichment-auth'
 import { dispatchTaxProjectionRefresh } from './utils/tax-projection-dispatch'
 import {
@@ -692,6 +693,8 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 						)
 
 						try {
+							await ensureSharedSovereigntySystems(this.env)
+
 							const structures = await runDirectorStepWithFailover({
 								stepName: 'fetch-structures',
 								timeout: '5 minutes',
@@ -712,25 +715,6 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 
 							if (miningCitadelStructureIds.size > 0) {
 								try {
-									const miningCitadelPriorities =
-										await corpData.getMiningCitadelSyncPriorities(corporationId)
-									const newMiningCitadelStructureIds =
-										await corpData.getMissingStructureIdsForPriorityQueue(
-											corporationId,
-											'mining-extractions' as StructureSyncPriorityTarget,
-											[...miningCitadelStructureIds]
-										)
-									const prioritizedMiningCitadelQueue = buildPriorityQueuedEntries(
-										[...miningCitadelStructureIds].map((structureId) => ({
-											id: structureId,
-										})),
-										newMiningCitadelStructureIds,
-										miningCitadelPriorities
-									)
-									const prioritizedMiningCitadelIds = prioritizedMiningCitadelQueue.entries.map(
-										({ entry }) => entry.id
-									)
-
 									const fetchedMiningExtractions = await runDirectorStepWithFailover({
 										stepName: 'fetch-structure-mining-extraction-enrichment',
 										timeout: '10 minutes',
@@ -739,25 +723,31 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 										run: (directorCharacterId) =>
 											fetchMiningExtractionEnrichment(this.env, corporationId, directorCharacterId),
 									})
-									const miningExtractionByStructureId = new Map(
-										fetchedMiningExtractions.map((extraction) => [
-											String(extraction.structure_id),
-											extraction,
-										])
+									const liveMiningExtractions = fetchedMiningExtractions.filter((extraction) =>
+										miningCitadelStructureIds.has(String(extraction.structure_id))
 									)
-									const prioritizedMiningExtractions = prioritizedMiningCitadelIds
-										.map((structureId) => miningExtractionByStructureId.get(structureId) ?? null)
-										.filter(
-											(extraction): extraction is (typeof fetchedMiningExtractions)[number] =>
-												extraction !== null
-										)
+									const priorityQueue = await corpData.getStructurePriorityQueue(
+										corporationId,
+										'mining-extractions' as StructureSyncPriorityTarget,
+										liveMiningExtractions.map((extraction) => String(extraction.structure_id))
+									)
+									const prioritizedMiningExtractions = buildPriorityQueuedEntries(
+										liveMiningExtractions.map((extraction) => ({
+											id: String(extraction.structure_id),
+											extraction,
+										})),
+										priorityQueue.newStructureIds,
+										priorityQueue.syncPriorities,
+										{ pruneCandidateIds: priorityQueue.pruneCandidateIds }
+									).entries.map(({ entry }) => entry.extraction)
 									miningExtractionsCount = prioritizedMiningExtractions.length
 
-									for (let index = 0; index < prioritizedMiningExtractions.length; index += 100) {
-										const batch = prioritizedMiningExtractions.slice(index, index + 100)
-										if (batch.length === 0) continue
-										await storeMiningExtractionEnrichment(this.env, corporationId, batch)
-									}
+									await storeMiningExtractionEnrichment(
+										this.env,
+										corporationId,
+										prioritizedMiningExtractions,
+										{ pruneCandidateIds: priorityQueue.pruneCandidateIds }
+									)
 								} catch (error) {
 									const metadata =
 										error instanceof Error ? parseEsiErrorMetadata(error.message) : null

--- a/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
@@ -5,7 +5,7 @@ import type { EsiSovereigntySystem } from '@repo/eve-corporation-data'
 import type { Env } from '../../context'
 
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS = 60 * 60
-const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_RETRY_DELAYS_MS = [250, 500, 1000]
+const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 16000]
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => {
@@ -28,41 +28,59 @@ export async function readSharedSovereigntySystemsByIds(
 }
 
 /**
+ * Ensure the full sovereignty snapshot is available before structure fanout.
+ */
+export async function ensureSharedSovereigntySystems(env: Env): Promise<void> {
+	const globalCorpData = getGlobalCorporationDataStub(env)
+	const isFresh = await globalCorpData.hasFreshSharedSovereigntySystems(
+		SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+	)
+	if (!isFresh) {
+		await refreshSharedSovereigntySystems(env)
+	}
+}
+
+/**
  * Fetch the live sovereignty snapshot and write it to the shared cache.
  */
-export async function refreshSharedSovereigntySystems(
-	env: Env
-): Promise<EsiSovereigntySystem[]> {
+export async function refreshSharedSovereigntySystems(env: Env): Promise<void> {
 	const globalCorpData = getGlobalCorporationDataStub(env)
 	const leaseToken = await globalCorpData.acquireSharedSovereigntySystemsRefreshLease()
 
 	if (leaseToken) {
 		try {
-			await globalCorpData.clearSharedSovereigntySystems()
 			const tokenStore = createTokenStore(env)
 			const sovereigntySystems = await esiFetch.fetchSovereigntySystems(tokenStore)
 			await globalCorpData.storeSharedSovereigntySystems(sovereigntySystems)
-			return sovereigntySystems
 		} finally {
 			await globalCorpData.releaseSharedSovereigntySystemsRefreshLease(leaseToken)
 		}
+		return
+	}
+
+	if (
+		await globalCorpData.hasFreshSharedSovereigntySystems(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+		)
+	) {
+		return
 	}
 
 	for (const delayMs of SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_RETRY_DELAYS_MS) {
-		const snapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
+		await sleep(delayMs)
+		const isFresh = await globalCorpData.hasFreshSharedSovereigntySystems(
 			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
 		)
-		if (snapshot) {
-			return snapshot
+		if (isFresh) {
+			return
 		}
-		await sleep(delayMs)
 	}
 
-	const snapshot = await globalCorpData.getSharedSovereigntySystemsSnapshot(
+	const isFresh = await globalCorpData.hasFreshSharedSovereigntySystems(
 		SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
 	)
-	if (snapshot) {
-		return snapshot
+	if (isFresh) {
+		return
 	}
 
 	throw new Error('Failed to refresh shared sovereignty systems snapshot')

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -251,7 +251,7 @@ export interface EsiSovereigntyHub {
 			  }
 			| {
 					transit: boolean | null
-			}
+			  }
 		state:
 			| {
 					import: {
@@ -454,6 +454,12 @@ export type MoonDrillSyncPriority = StructureSyncPriority
 
 export type MiningCitadelSyncPriority = StructureSyncPriority
 
+export interface StructurePriorityQueue {
+	newStructureIds: string[]
+	pruneCandidateIds: string[]
+	syncPriorities: StructureSyncPriority[]
+}
+
 export type StructureSyncFailureTarget =
 	| 'structures'
 	| 'sovereignty'
@@ -473,7 +479,9 @@ export type StructureSyncPriorityTarget =
 /**
  * A compact structure-priority queue entry used by enrichment batching.
  */
-export interface StructurePriorityQueueEntry<P extends StructureSyncPriority = StructureSyncPriority> {
+export interface StructurePriorityQueueEntry<
+	P extends StructureSyncPriority = StructureSyncPriority,
+> {
 	entry: { id: string | number }
 	index: number
 	priority: P | null
@@ -1360,17 +1368,10 @@ export interface EveCorporationData {
 	storeSharedSovereigntySystems(systems: EsiSovereigntySystem[]): Promise<void>
 
 	/**
-	 * Remove the shared sovereignty system snapshot before rebuilding it.
-	 */
-	clearSharedSovereigntySystems(): Promise<void>
-
-	/**
 	 * Acquire a short-lived refresh lease for the shared sovereignty snapshot.
 	 * Returns a token when acquired, or null when another refresh is already in progress.
 	 */
-	acquireSharedSovereigntySystemsRefreshLease(
-		leaseSeconds?: number
-	): Promise<string | null>
+	acquireSharedSovereigntySystemsRefreshLease(leaseSeconds?: number): Promise<string | null>
 
 	/**
 	 * Release a previously acquired shared sovereignty refresh lease.
@@ -1388,7 +1389,15 @@ export interface EveCorporationData {
 	/**
 	 * Read the entire shared sovereignty system snapshot if it is still fresh.
 	 */
-	getSharedSovereigntySystemsSnapshot(maxAgeSeconds?: number): Promise<EsiSovereigntySystem[] | null>
+	getSharedSovereigntySystemsSnapshot(
+		maxAgeSeconds?: number
+	): Promise<EsiSovereigntySystem[] | null>
+
+	/**
+	 * Check whether a completed shared sovereignty snapshot is still fresh.
+	 * This reads only the snapshot metadata, not the cached system rows.
+	 */
+	hasFreshSharedSovereigntySystems(maxAgeSeconds?: number): Promise<boolean>
 
 	/**
 	 * Get a cached sovereignty system snapshot if it is still fresh enough.
@@ -1428,6 +1437,28 @@ export interface EveCorporationData {
 	): Promise<string[]>
 
 	/**
+	 * Build the new, prune, and due-refresh sets from one complete live listing.
+	 */
+	getStructurePriorityQueue(
+		corporationId: string,
+		target: StructureSyncPriorityTarget,
+		structureIds: string[]
+	): Promise<StructurePriorityQueue>
+
+	/**
+	 * Return persisted structure IDs that are absent from a complete live listing.
+	 *
+	 * This is intentionally separate from the sync-priority queue: a structure
+	 * can be on cooldown and must not be treated as a prune candidate merely
+	 * because another structure was selected for enrichment.
+	 */
+	getStructureIdsMissingFromLiveListing(
+		corporationId: string,
+		target: StructureSyncPriorityTarget,
+		structureIds: string[]
+	): Promise<string[]>
+
+	/**
 	 * Read the current sovereignty hub structure IDs for a corporation.
 	 */
 	getSovereigntyHubStructureIds(corporationId: string): Promise<string[]>
@@ -1449,6 +1480,15 @@ export interface EveCorporationData {
 		corporationId: string,
 		target: StructureEnrichmentSyncTarget,
 		failureReason: string
+	): Promise<void>
+
+	/**
+	 * Mark individual live structure enrichment failures without overwriting their last good data.
+	 */
+	markStructureEnrichmentFailures(
+		corporationId: string,
+		target: Extract<StructureEnrichmentSyncTarget, 'sovereignty-hubs' | 'skyhooks'>,
+		failures: Array<{ structureId: string; failureReason: string }>
 	): Promise<void>
 
 	/**
@@ -1484,9 +1524,7 @@ export interface EveCorporationData {
 	/**
 	 * Read the current mining-citadel sync priority order for a corporation.
 	 */
-	getMiningCitadelSyncPriorities(
-		corporationId: string
-	): Promise<MiningCitadelSyncPriority[]>
+	getMiningCitadelSyncPriorities(corporationId: string): Promise<MiningCitadelSyncPriority[]>
 
 	/**
 	 * Read the current mining-citadel structure IDs for a corporation.
@@ -1498,7 +1536,8 @@ export interface EveCorporationData {
 	 */
 	storeMiningExtractions(
 		corporationId: string,
-		extractions: EsiCorporationMiningExtraction[]
+		extractions: EsiCorporationMiningExtraction[],
+		options?: { pruneCandidateIds?: readonly string[] }
 	): Promise<void>
 
 	/**


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Reworks the structure enrichment sync/priority pipeline in `eve-corporation-data` so that pruning, new-structure detection, and sync-priority selection are computed from one consistent live listing instead of ad-hoc, duplicated logic scattered across `storeMoonDrills`/`storeSovereigntyHubs`/`storeSkyhooks`/`storeMiningExtractions` and the sync workflow. This fixes cases where structures could be wrongly pruned or skipped when only a partial batch was selected for enrichment, and removes a race in the shared sovereignty systems cache where the cache was cleared before being rebuilt.

## Changes
- Adds `getStructurePriorityQueue` (new/prune/sync-priority in one DO call) and `getStructureIdsMissingFromLiveListing` (SQL `NOT EXISTS` against a full live listing, with a grace period) to replace scattered per-caller pruning logic.
- Adds `claimStructureSyncAttempts`, an atomic `UPDATE ... RETURNING` that stamps `lastAttemptedSyncAt` only for structures actually claimed for this pass, replacing the previous best-effort stamping baked into the priority query.
- `buildPriorityQueuedEntries` now takes explicit `pruneCandidateIds` instead of deriving prune candidates from the live entries it was given, so partial/priority-scoped batches don't cause otherwise-live structures to be pruned.
- Reworks the shared sovereignty systems cache: replaces "clear cache, then rebuild" with a metadata-only freshness check (`hasFreshSharedSovereigntySystems`) and a new `ensureSharedSovereigntySystems` warmup call, removing the `clearSharedSovereigntySystems` DO method and the window where readers could see an empty cache during refresh. Also extends the lease-wait retry/backoff schedule.
- Skips re-resolving Universe geography (solar systems, planets, regions, moon geography) for structures that already have persisted geography, only resolving it for newly-seen structures.
- Adds per-structure enrichment failure tracking (`markStructureEnrichmentFailures`) that marks `syncStatus`/`syncFailureReason` for individual failed structures without discarding their last good snapshot data.
- `fetchSovereigntyHubs`/`fetchCorporationSkyhooks` now return per-structure `failures` and stop fetching further batches once a rate limit is hit, instead of continuing to burn through remaining batches.
- Adds a paginated-listing helper (`fetchStructureListing`) that validates the ESI page count/number doesn't change mid-fetch.
- `storeMiningExtractions` accepts an explicit `pruneCandidateIds` option to skip an extra existing-rows lookup when the caller already knows the prune set.
- Narrows the upsert `set` clauses for sovereignty hubs, skyhooks, and corporation structures to only the fields that can actually change on resync, rather than overwriting all columns from `excluded`.

## Testing
Updated and added unit tests covering the new priority-queue/prune split (`structure-priority.test.ts`), structure prune/geography-reuse behavior (`structure-prune-cleanup.test.ts`), mining extraction storage with explicit prune candidates, the reworked sovereignty systems cache (`sovereignty-systems-cache.test.ts`), and the sync workflow and structure-enrichment step wiring for the new `getStructurePriorityQueue` API.
<!-- claude:end -->