### PR TITLE
optimize billing payments check

### DIFF
--- a/apps/bills/src/db/schema.ts
+++ b/apps/bills/src/db/schema.ts
@@ -95,6 +95,7 @@ export const bills = pgTable(
 		groupBillId: uuid('group_bill_id'), // nullable — links all sub-bills of a group bill together
 		createdAt: timestamp('created_at').notNull().defaultNow(),
 		updatedAt: timestamp('updated_at').notNull().defaultNow(),
+		// Completed payment-window watermark. It advances only after the full lookbehind is drained.
 		paymentLastCheckedAt: timestamp('payment_last_checked_at', { withTimezone: true }),
 	},
 	(table) => [
@@ -186,7 +187,11 @@ export const billNotificationEvents = pgTable(
 		index('bill_notification_events_event_type_idx').on(table.eventType),
 		index('bill_notification_events_status_idx').on(table.status),
 		index('bill_notification_events_first_eligible_at_idx').on(table.firstEligibleAt),
-		unique('bill_notification_events_unique').on(table.billId, table.recipientUserId, table.eventType),
+		unique('bill_notification_events_unique').on(
+			table.billId,
+			table.recipientUserId,
+			table.eventType
+		),
 	]
 )
 

--- a/apps/bills/src/services/bill.service.ts
+++ b/apps/bills/src/services/bill.service.ts
@@ -50,6 +50,13 @@ function parseISKToMinorUnits(value: string): bigint | null {
 	}
 }
 
+export interface WalletPaymentInput {
+	amount: bigint
+	paidById: string
+	paidByType: EntityType
+	esiTransactionId: string
+}
+
 /**
  * Bill Service
  *
@@ -137,8 +144,9 @@ export class BillService {
 		}
 
 		const first = rows[0]
-		const groupId =
-			(first.externalMetadata as Record<string, unknown> | null)?.groupId as string | undefined
+		const groupId = (first.externalMetadata as Record<string, unknown> | null)?.groupId as
+			| string
+			| undefined
 
 		const billEntries: GroupBillEntry[] = rows.map((b) => {
 			const totalDue = Number(b.amount) + Number(b.lateFee)
@@ -146,7 +154,7 @@ export class BillService {
 			return {
 				billId: b.id,
 				payerId: b.payerId,
-				status: b.status as import('@repo/bills').BillStatus,
+				status: b.status as BillStatus,
 				amount: b.amount,
 				lateFee: b.lateFee,
 				totalDue: totalDue.toString(),
@@ -679,6 +687,153 @@ export class BillService {
 	}
 
 	/**
+	 * Record wallet payments in bounded, idempotent batches.
+	 */
+	async recordWalletPayments(
+		billId: string,
+		payments: readonly WalletPaymentInput[]
+	): Promise<number> {
+		const uniquePayments = Array.from(
+			new Map(payments.map((payment) => [payment.esiTransactionId, payment])).values()
+		)
+		if (uniquePayments.length === 0) {
+			return 0
+		}
+
+		const bill = await this.db.query.bills.findFirst({
+			where: eq(bills.id, billId),
+		})
+
+		if (!bill) {
+			throw new Error('Bill not found')
+		}
+
+		if (bill.status === 'paid') {
+			throw new Error('Bill is already paid')
+		}
+
+		if (bill.status === 'cancelled') {
+			throw new Error('Bill has been cancelled')
+		}
+
+		if (bill.status === 'draft') {
+			throw new Error('Bill has not been issued yet')
+		}
+
+		// Late fees and the issued-to-overdue transition only need to be evaluated once for the
+		// batch. Each batch insert below is atomic with its payment-recorded events.
+		const updatedBill = await this.updateLateFeeIfNeeded(bill)
+		let insertedCount = 0
+		const batchSize = 50
+
+		for (let offset = 0; offset < uniquePayments.length; offset += batchSize) {
+			insertedCount += await this.insertWalletPaymentBatch(
+				updatedBill,
+				uniquePayments.slice(offset, offset + batchSize)
+			)
+		}
+
+		return insertedCount
+	}
+
+	private async insertWalletPaymentBatch(
+		bill: typeof bills.$inferSelect,
+		payments: readonly WalletPaymentInput[]
+	): Promise<number> {
+		const inputValues = sql.join(
+			payments.map((payment) => {
+				const paymentId = generateUuidV7()
+				const eventId = generateUuidV7()
+				const paidAt = new Date()
+
+				return sql`(
+					${paymentId}::uuid,
+					${eventId}::uuid,
+					${bill.id}::uuid,
+					${bill.paymentToken},
+					${payment.esiTransactionId},
+					${payment.amount.toString()},
+					${payment.paidById},
+					${payment.paidByType}::bill_entity_type,
+					${paidAt}
+				)`
+			}),
+			sql`, `
+		)
+
+		const result = await this.db.execute<{ insertedCount: number | string }>(sql`
+			with payment_input (
+				payment_id,
+				event_id,
+				bill_id,
+				payment_token,
+				esi_transaction_id,
+				amount,
+				paid_by_id,
+				paid_by_type,
+				paid_at
+			) as (
+				values ${inputValues}
+			), inserted_payments as (
+				insert into bill_payments (
+					id,
+					bill_id,
+					payment_token,
+					esi_transaction_id,
+					amount,
+					paid_by_id,
+					paid_by_type,
+					paid_at
+				)
+				select
+					payment_id,
+					bill_id,
+					payment_token,
+					esi_transaction_id,
+					amount,
+					paid_by_id,
+					paid_by_type,
+					paid_at
+				from payment_input
+				on conflict (esi_transaction_id) do nothing
+				returning bill_id, esi_transaction_id, amount, paid_by_id, paid_by_type
+			), inserted_events as (
+				insert into bill_status_events (
+					id,
+					bill_id,
+					event_type,
+					from_status,
+					to_status,
+					actor_user_id,
+					metadata
+				)
+				select
+					payment_input.event_id,
+					inserted_payments.bill_id,
+					'payment_recorded'::bill_status_event_type,
+					null::bill_status,
+					null::bill_status,
+					null,
+					jsonb_build_object(
+						'amount', inserted_payments.amount,
+						'paidById', inserted_payments.paid_by_id,
+						'paidByType', inserted_payments.paid_by_type,
+						'esiTransactionId', inserted_payments.esi_transaction_id
+					)
+				from inserted_payments
+				inner join payment_input
+					on payment_input.bill_id = inserted_payments.bill_id
+					and payment_input.esi_transaction_id = inserted_payments.esi_transaction_id
+				returning id
+			)
+			select count(*)::int as "insertedCount"
+			from inserted_payments
+		`)
+
+		return Number(result.rows[0]?.insertedCount ?? 0)
+	}
+
+	/**
 	 * Pay a bill using payment token
 	 */
 	async payBill(
@@ -833,7 +988,10 @@ export class BillService {
 	/**
 	 * Issue all eligible (draft) sub-bills sharing a groupBillId
 	 */
-	async issueGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult> {
+	async issueGroupBill(
+		actorUserId: string,
+		groupBillId: string
+	): Promise<GroupBillOperationResult> {
 		const subBills = await this.db.query.bills.findMany({
 			where: eq(bills.groupBillId, groupBillId),
 		})
@@ -853,7 +1011,10 @@ export class BillService {
 	/**
 	 * Cancel all eligible sub-bills sharing a groupBillId
 	 */
-	async cancelGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult> {
+	async cancelGroupBill(
+		actorUserId: string,
+		groupBillId: string
+	): Promise<GroupBillOperationResult> {
 		const subBills = await this.db.query.bills.findMany({
 			where: eq(bills.groupBillId, groupBillId),
 		})
@@ -900,7 +1061,10 @@ export class BillService {
 	/**
 	 * Delete all eligible (draft) sub-bills sharing a groupBillId
 	 */
-	async deleteGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult> {
+	async deleteGroupBill(
+		actorUserId: string,
+		groupBillId: string
+	): Promise<GroupBillOperationResult> {
 		const subBills = await this.db.query.bills.findMany({
 			where: eq(bills.groupBillId, groupBillId),
 		})
@@ -947,9 +1111,6 @@ export class BillService {
 	async checkBillBalancePaid(billId: string): Promise<boolean> {
 		const bill = await this.db.query.bills.findFirst({
 			where: eq(bills.id, billId),
-			with: {
-				payments: true,
-			},
 		})
 
 		if (!bill) {
@@ -961,13 +1122,16 @@ export class BillService {
 			throw new Error('Bill amount or late fee is invalid')
 		}
 
-		const paidAmount = bill.payments.reduce((acc, payment) => {
-			const paymentAmount = parseISKToMinorUnits(payment.amount)
-			if (paymentAmount === null) {
-				throw new Error(`Invalid payment amount for bill ${billId}`)
-			}
-			return acc + paymentAmount
-		}, BigInt(0))
+		const [paymentTotal] = await this.db
+			.select({
+				paidAmount: sql<string>`coalesce(sum(${billPayments.amount}::numeric), 0)`,
+			})
+			.from(billPayments)
+			.where(eq(billPayments.billId, billId))
+		const paidAmount = parseISKToMinorUnits(paymentTotal?.paidAmount ?? '0')
+		if (paidAmount === null) {
+			throw new Error(`Invalid payment amount for bill ${billId}`)
+		}
 
 		return paidAmount >= totalAmount + lateFeeAmount
 	}
@@ -989,9 +1153,6 @@ export class BillService {
 			throw new Error('Cannot mark a cancelled bill as paid')
 		}
 
-		const existingPayments = await this.db.query.billPayments.findMany({
-			where: eq(billPayments.billId, billId),
-		})
 		const paidAt = new Date()
 
 		const transitioned = await this.applyStatusTransitionAtomic({

--- a/apps/bills/src/test/unit/services/bill.service.test.ts
+++ b/apps/bills/src/test/unit/services/bill.service.test.ts
@@ -10,21 +10,24 @@ function createService(overrides?: {
 		payments: Array<{ amount: string }>
 	}
 }) {
-	const bill =
-		overrides?.bill ?? {
-			id: 'bill-1',
-			amount: '100.00',
-			lateFee: '12.50',
-			payments: [],
-		}
+	const bill = overrides?.bill ?? {
+		id: 'bill-1',
+		amount: '100.00',
+		lateFee: '12.50',
+		payments: [],
+	}
 
 	const findFirst = vi.fn().mockResolvedValue(bill)
+	const paidAmount = bill.payments.reduce((total, payment) => total + Number(payment.amount), 0)
+	const where = vi.fn().mockResolvedValue([{ paidAmount: String(paidAmount) }])
+	const from = vi.fn().mockReturnValue({ where })
 	const db = {
 		query: {
 			bills: {
 				findFirst,
 			},
 		},
+		select: vi.fn().mockReturnValue({ from }),
 	} as unknown as ConstructorParameters<typeof BillService>[0]
 
 	return { service: new BillService(db), findFirst }
@@ -35,12 +38,7 @@ describe('BillService.checkBillBalancePaid', () => {
 		const { service, findFirst } = createService()
 
 		await expect(service.checkBillBalancePaid('bill-1')).resolves.toBe(false)
-		expect(findFirst).toHaveBeenCalledWith({
-			where: expect.anything(),
-			with: {
-				payments: true,
-			},
-		})
+		expect(findFirst).toHaveBeenCalledWith({ where: expect.anything() })
 	})
 
 	it('counts payment amounts against the total due including late fee', async () => {
@@ -54,5 +52,53 @@ describe('BillService.checkBillBalancePaid', () => {
 		})
 
 		await expect(service.checkBillBalancePaid('bill-1')).resolves.toBe(true)
+	})
+})
+
+describe('BillService.recordWalletPayments', () => {
+	it('deduplicates journal IDs and records the batch with one SQL statement', async () => {
+		const findFirst = vi.fn().mockResolvedValue({
+			id: 'bill-1',
+			paymentToken: 'PAYTOKEN',
+			status: 'issued',
+			dueDate: new Date(Date.now() + 60_000),
+			amount: '100',
+			lateFee: '0',
+			lateFeeType: 'none',
+			lateFeeAmount: '0',
+			lateFeeCompounding: 'none',
+		})
+		const execute = vi.fn().mockResolvedValue({ rows: [{ insertedCount: 2 }] })
+		const service = new BillService({
+			query: { bills: { findFirst } },
+			select: vi.fn(),
+			execute,
+		} as unknown as ConstructorParameters<typeof BillService>[0])
+
+		await expect(
+			service.recordWalletPayments('bill-1', [
+				{
+					amount: 100n,
+					paidById: 'character-1',
+					paidByType: 'character',
+					esiTransactionId: 'journal-1',
+				},
+				{
+					amount: 200n,
+					paidById: 'character-2',
+					paidByType: 'character',
+					esiTransactionId: 'journal-1',
+				},
+				{
+					amount: 300n,
+					paidById: 'character-3',
+					paidByType: 'character',
+					esiTransactionId: 'journal-2',
+				},
+			])
+		).resolves.toBe(2)
+
+		expect(findFirst).toHaveBeenCalledTimes(1)
+		expect(execute).toHaveBeenCalledTimes(1)
 	})
 })

--- a/apps/bills/src/test/unit/workflows/bill-payment-status-check.test.ts
+++ b/apps/bills/src/test/unit/workflows/bill-payment-status-check.test.ts
@@ -154,7 +154,9 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 				externalSourceType: 'corporation_tax_assessment',
 			},
 		})
-		findPaymentsForBillMock.mockResolvedValue({ newPaymentsRecorded: 0 })
+		findPaymentsForBillMock.mockResolvedValue({
+			newPaymentsRecorded: 0,
+		})
 		checkPaymentStatusMock.mockResolvedValue({
 			markedPaid: false,
 			statusBefore: 'issued',
@@ -164,7 +166,9 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 	})
 
 	it('syncs tax status when payment is newly recorded', async () => {
-		findPaymentsForBillMock.mockResolvedValueOnce({ newPaymentsRecorded: 1 })
+		findPaymentsForBillMock.mockResolvedValueOnce({
+			newPaymentsRecorded: 1,
+		})
 		const { workflow, taxSyncMock } = createWorkflowAndContext()
 		const { step, executedStepNames } = createStep()
 
@@ -173,7 +177,6 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 		expect(executedStepNames).toEqual([
 			'reconcile-payment-data',
 			'finalize-payment-state',
-			'update-check-timestamp',
 			'sync-bill-effects',
 		])
 		expect(taxSyncMock).toHaveBeenCalledWith('system:bills:payment-status-check', {
@@ -194,7 +197,6 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 		expect(noPaymentStep.executedStepNames).toEqual([
 			'reconcile-payment-data',
 			'finalize-payment-state',
-			'update-check-timestamp',
 		])
 
 		vi.clearAllMocks()
@@ -205,7 +207,9 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 				externalSourceType: 'corporation_tax_assessment',
 			},
 		})
-		findPaymentsForBillMock.mockResolvedValue({ newPaymentsRecorded: 2 })
+		findPaymentsForBillMock.mockResolvedValue({
+			newPaymentsRecorded: 2,
+		})
 		checkPaymentStatusMock.mockResolvedValue({
 			markedPaid: false,
 			statusBefore: 'issued',
@@ -223,7 +227,6 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 		expect(withPaymentStep.executedStepNames).toEqual([
 			'reconcile-payment-data',
 			'finalize-payment-state',
-			'update-check-timestamp',
 			'sync-bill-effects',
 		])
 	})
@@ -240,7 +243,7 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 
 		await workflow.run({ payload: { billId: 'bill-1' }, instanceId: 'wf-1' } as never, step)
 
-		expect(doMock).toHaveBeenCalledTimes(4)
+		expect(doMock).toHaveBeenCalledTimes(3)
 		expect(taxSyncMock).toHaveBeenCalledWith('system:bills:payment-status-check', {
 			id: 'bill-1',
 			status: 'paid',
@@ -286,7 +289,9 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 				externalSourceType: 'manual',
 			},
 		})
-		findPaymentsForBillMock.mockResolvedValue({ newPaymentsRecorded: 2 })
+		findPaymentsForBillMock.mockResolvedValue({
+			newPaymentsRecorded: 2,
+		})
 		checkPaymentStatusMock.mockResolvedValue({
 			markedPaid: false,
 			statusBefore: 'issued',
@@ -305,26 +310,31 @@ describe('BillPaymentStatusCheckWorkflow', () => {
 		expect(secondStep.executedStepNames).toEqual([
 			'reconcile-payment-data',
 			'finalize-payment-state',
-			'update-check-timestamp',
 		])
 	})
 
-	it('does not recompute transition flags when the timestamp step retries', async () => {
-		checkPaymentStatusMock.mockResolvedValueOnce({
-			markedPaid: true,
-			statusBefore: 'issued',
-			statusAfter: 'paid',
-		})
+	it('retries the finalization step when timestamp persistence fails', async () => {
+		checkPaymentStatusMock
+			.mockResolvedValueOnce({
+				markedPaid: true,
+				statusBefore: 'issued',
+				statusAfter: 'paid',
+			})
+			.mockResolvedValue({
+				markedPaid: true,
+				statusBefore: 'issued',
+				statusAfter: 'paid',
+			})
 		updateCheckTimestampMock
 			.mockRejectedValueOnce(new Error('temporary timestamp failure'))
 			.mockResolvedValueOnce({ updated: true })
 
 		const { workflow } = createWorkflowAndContext()
-		const { step } = createStep(['update-check-timestamp'])
+		const { step } = createStep(['finalize-payment-state'])
 
 		await workflow.run({ payload: { billId: 'bill-1' }, instanceId: 'wf-1' } as never, step)
 
-		expect(checkPaymentStatusMock).toHaveBeenCalledTimes(1)
+		expect(checkPaymentStatusMock).toHaveBeenCalledTimes(2)
 		expect(updateCheckTimestampMock).toHaveBeenCalledTimes(2)
 	})
 })

--- a/apps/bills/src/test/unit/workflows/find-payments.test.ts
+++ b/apps/bills/src/test/unit/workflows/find-payments.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { findPaymentsForBill } from '../../../workflows/steps/find-payments/find-payments'
+
+function createContext(overrides?: { rows?: unknown[]; pages?: unknown[][] }) {
+	const execute = vi.fn()
+	if (overrides?.pages) {
+		for (const page of overrides.pages) {
+			execute.mockResolvedValueOnce({ rows: page })
+		}
+	} else {
+		execute.mockResolvedValue({ rows: overrides?.rows ?? [] })
+	}
+	const recordWalletPayments = vi.fn().mockResolvedValue(1)
+
+	return {
+		ctx: {
+			db: { execute },
+			env: {},
+			workflowInstanceId: 'workflow-1',
+			billId: 'bill-1',
+			billService: { recordWalletPayments },
+		},
+		execute,
+		recordWalletPayments,
+	}
+}
+
+describe('findPaymentsForBill', () => {
+	it('validates candidates and records them in one batch', async () => {
+		const { ctx, recordWalletPayments } = createContext({
+			pages: [
+				[
+					{
+						journalId: 'journal-1',
+						amount: '100',
+						firstPartyId: 'character-1',
+						entryDate: new Date(),
+					},
+					{
+						journalId: 'journal-invalid-amount',
+						amount: 'not-a-number',
+						firstPartyId: 'character-1',
+						entryDate: new Date(),
+					},
+					{
+						journalId: 'journal-missing-payer',
+						amount: '100',
+						firstPartyId: null,
+						entryDate: new Date(),
+					},
+				],
+				[],
+			],
+		})
+
+		const result = await findPaymentsForBill(ctx as never, {
+			id: 'bill-1',
+			status: 'issued',
+			payeeId: '987',
+			payeeType: 'corporation',
+			payerType: 'character',
+			paymentToken: 'PAYTOKEN',
+			paymentStartAt: new Date(0).toISOString(),
+			paymentLastCheckedAt: null,
+			externalSourceType: null,
+		})
+
+		expect(result).toEqual({ newPaymentsRecorded: 1 })
+		expect(recordWalletPayments).toHaveBeenCalledTimes(1)
+		expect(recordWalletPayments).toHaveBeenCalledWith('bill-1', [
+			{
+				amount: 100n,
+				paidById: 'character-1',
+				paidByType: 'corporation',
+				esiTransactionId: 'journal-1',
+			},
+		])
+	})
+
+	it('drains every payment page within the lookbehind boundary', async () => {
+		const firstPage = Array.from({ length: 100 }, (_, index) => ({
+			journalId: `journal-${index}`,
+			amount: '100',
+			firstPartyId: 'character-1',
+			entryDate: new Date(1_000 + index),
+		}))
+		const secondPage = [
+			{
+				journalId: 'journal-100',
+				amount: '100',
+				firstPartyId: 'character-1',
+				entryDate: new Date(2_000),
+			},
+		]
+		const { ctx, recordWalletPayments, execute } = createContext({
+			pages: [firstPage, secondPage, []],
+		})
+		recordWalletPayments.mockResolvedValueOnce(100).mockResolvedValueOnce(1)
+
+		const result = await findPaymentsForBill(ctx as never, {
+			id: 'bill-1',
+			status: 'issued',
+			payeeId: '987',
+			payeeType: 'corporation',
+			payerType: 'character',
+			paymentToken: 'PAYTOKEN',
+			paymentStartAt: new Date(0).toISOString(),
+			paymentLastCheckedAt: null,
+			externalSourceType: null,
+		})
+
+		expect(result).toEqual({ newPaymentsRecorded: 101 })
+		expect(execute).toHaveBeenCalledTimes(3)
+		expect(recordWalletPayments).toHaveBeenCalledTimes(2)
+		expect(recordWalletPayments.mock.calls[0][1]).toHaveLength(100)
+		expect(recordWalletPayments.mock.calls[1][1]).toHaveLength(1)
+	})
+})

--- a/apps/bills/src/workflows/bill-discord-notify.ts
+++ b/apps/bills/src/workflows/bill-discord-notify.ts
@@ -1,5 +1,5 @@
-import { WorkflowEntrypoint, WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
-import { and, eq, inArray, lte, sql } from 'drizzle-orm'
+import { WorkflowEntrypoint } from 'cloudflare:workers'
+import { eq, sql } from 'drizzle-orm'
 
 import { getStub } from '@repo/do-utils'
 import { formatISK } from '@repo/worker-utils'
@@ -7,6 +7,7 @@ import { formatISK } from '@repo/worker-utils'
 import { createDb } from '../db'
 import { billNotificationEvents, bills } from '../db/schema'
 
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
 import type { Discord, MessageContent } from '@repo/discord'
 import type { EsiTypeResolver } from '@repo/esi'
 import type { Env } from '../context'
@@ -182,12 +183,11 @@ export class BillDiscordNotifyWorkflow extends WorkflowEntrypoint<
 
 				const payeeName =
 					bill.payeeId && bill.payeeId.trim().length > 0
-						? (
-								(await getStub<EsiTypeResolver>(
-									this.env.ESI_TYPE_RESOLVER,
-									'global'
-								).resolveIds([bill.payeeId]))[bill.payeeId] ?? bill.payeeId
-							)
+						? ((
+								await getStub<EsiTypeResolver>(this.env.ESI_TYPE_RESOLVER, 'global').resolveIds([
+									bill.payeeId,
+								])
+							)[bill.payeeId] ?? bill.payeeId)
 						: 'Unknown'
 
 				const message = buildMessage({

--- a/apps/bills/src/workflows/bill-payment-status-check.ts
+++ b/apps/bills/src/workflows/bill-payment-status-check.ts
@@ -123,8 +123,8 @@ export class BillPaymentStatusCheckWorkflow extends WorkflowEntrypoint<Env, Work
 				status: paymentReconciliationResult.bill.status,
 			})
 
-			// Step 2: Normalize lifecycle state and evaluate payment status. Keep the transition
-			// result durable so a later timestamp retry cannot re-run it and lose its edge flags.
+			// Step 2: Normalize lifecycle state and evaluate payment status. The watermark write is
+			// deliberately last so failed finalization leaves the payment window eligible for retry.
 			const paymentStatusResult = await step.do(
 				'finalize-payment-state',
 				{
@@ -146,16 +146,12 @@ export class BillPaymentStatusCheckWorkflow extends WorkflowEntrypoint<Env, Work
 									billStatus: paymentReconciliationResult.bill.status,
 								}
 					const paymentStatus = await checkPaymentStatus(ctx)
+					// Advance the watermark only after payment reconciliation and lifecycle evaluation
+					// both succeed, without adding another workflow step.
+					await updateCheckTimestamp(ctx)
 					return { ...overdueRefreshResult, ...paymentStatus }
 				}
 			)
-
-			// Keep this independent from state transitions. If it retries, the durable
-			// paymentStatusResult above is reused instead of being recomputed.
-			await step.do('update-check-timestamp', () => {
-				const ctx = this.createContext(billId, workflowInstanceId)
-				return updateCheckTimestamp(ctx)
-			})
 
 			logger.log('[Workflow] Checked payment status', logContext)
 

--- a/apps/bills/src/workflows/context.ts
+++ b/apps/bills/src/workflows/context.ts
@@ -1,9 +1,8 @@
 import { logger } from '@repo/hono-helpers'
 
-import { BillService } from '../services/bill.service'
-
 import type { Env } from '../context'
 import type { createDb } from '../db'
+import type { BillService } from '../services/bill.service'
 
 /**
  * Workflow context

--- a/apps/bills/src/workflows/steps/check-payment-status/check-payment-status.ts
+++ b/apps/bills/src/workflows/steps/check-payment-status/check-payment-status.ts
@@ -1,5 +1,3 @@
-import { eq } from 'drizzle-orm'
-
 import { getWorkflowLogger } from '../../context'
 
 import type { WorkflowContext } from '../../context'

--- a/apps/bills/src/workflows/steps/fetch-bill-data/fetch-bill-data.ts
+++ b/apps/bills/src/workflows/steps/fetch-bill-data/fetch-bill-data.ts
@@ -1,6 +1,6 @@
-import { eq } from '@repo/db-utils'
+import { and, desc, eq } from '@repo/db-utils'
 
-import { bills } from '../../../db/schema'
+import { bills, billStatusEvents } from '../../../db/schema'
 import { getWorkflowLogger } from '../../context'
 
 import type { BillStatus, EntityType } from '@repo/bills'
@@ -13,7 +13,8 @@ export interface BillPaymentCheckData {
 	payeeType: EntityType | null
 	payerType: EntityType
 	paymentToken: string
-	createdAt: string
+	paymentStartAt: string
+	paymentLastCheckedAt: string | null
 	externalSourceType: string | null
 }
 
@@ -38,6 +39,12 @@ export async function fetchBillData(ctx: WorkflowContext): Promise<FetchBillData
 		throw new Error(`Bill not found: ${ctx.billId}`)
 	}
 
+	const issuedEvent = await ctx.db.query.billStatusEvents.findFirst({
+		where: and(eq(billStatusEvents.billId, bill.id), eq(billStatusEvents.eventType, 'issued')),
+		orderBy: desc(billStatusEvents.createdAt),
+		columns: { createdAt: true },
+	})
+
 	logger.info('[Workflow] Fetched bill data', {
 		billId: ctx.billId,
 		workflowInstanceId: ctx.workflowInstanceId,
@@ -52,7 +59,8 @@ export async function fetchBillData(ctx: WorkflowContext): Promise<FetchBillData
 			payeeType: bill.payeeType,
 			payerType: bill.payerType,
 			paymentToken: bill.paymentToken,
-			createdAt: bill.createdAt.toISOString(),
+			paymentStartAt: (issuedEvent?.createdAt ?? bill.createdAt).toISOString(),
+			paymentLastCheckedAt: bill.paymentLastCheckedAt?.toISOString() ?? null,
 			externalSourceType: bill.externalSourceType,
 		},
 	}

--- a/apps/bills/src/workflows/steps/find-payments/find-payments.ts
+++ b/apps/bills/src/workflows/steps/find-payments/find-payments.ts
@@ -2,10 +2,12 @@ import { sql } from '@repo/db-utils'
 
 import { getWorkflowLogger } from '../../context'
 
+import type { WalletPaymentInput } from '../../../services/bill.service'
 import type { WorkflowContext } from '../../context'
 import type { BillPaymentCheckData } from '../fetch-bill-data'
 
-const MAX_NEW_PAYMENT_TRANSACTIONS_PER_RUN = 100
+const PAYMENT_BATCH_SIZE = 100
+const PAYMENT_LOOKBEHIND_MS = 60 * 60 * 1000
 
 type CorporationWalletPaymentRow = {
 	journalId: string
@@ -19,6 +21,13 @@ type CharacterWalletPaymentRow = {
 	amount: string
 	firstPartyId: string | null
 	entryDate: Date
+}
+
+type WalletPaymentRow = CorporationWalletPaymentRow | CharacterWalletPaymentRow
+
+type PaymentCursor = {
+	entryDate: Date
+	journalId: string
 }
 
 function parseAmountToBigInt(rawAmount: string): bigint | null {
@@ -43,9 +52,50 @@ function parseAmountToBigInt(rawAmount: string): bigint | null {
 	}
 }
 
+function validatePaymentTransactions(
+	ctx: WorkflowContext,
+	rows: WalletPaymentRow[],
+	paidByType: WalletPaymentInput['paidByType']
+): WalletPaymentInput[] {
+	const logger = getWorkflowLogger(ctx, 'validate-payment-transactions')
+	const payments: WalletPaymentInput[] = []
+
+	for (const paymentTransaction of rows) {
+		const amount = parseAmountToBigInt(paymentTransaction.amount)
+		if (amount === null || amount <= 0n) {
+			logger.warn('[Workflow] Skipping wallet payment transaction with invalid amount', {
+				billId: ctx.billId,
+				workflowInstanceId: ctx.workflowInstanceId,
+				journalId: paymentTransaction.journalId,
+				amount: paymentTransaction.amount,
+			})
+			continue
+		}
+		if (!paymentTransaction.firstPartyId) {
+			logger.warn('[Workflow] Skipping wallet payment transaction with missing payer id', {
+				billId: ctx.billId,
+				workflowInstanceId: ctx.workflowInstanceId,
+				journalId: paymentTransaction.journalId,
+			})
+			continue
+		}
+
+		payments.push({
+			amount,
+			paidById: paymentTransaction.firstPartyId,
+			paidByType,
+			esiTransactionId: paymentTransaction.journalId,
+		})
+	}
+
+	return payments
+}
+
 async function findPaymentTransactionsForCorporationFromDb(
 	ctx: WorkflowContext,
-	billData: BillPaymentCheckData
+	billData: BillPaymentCheckData,
+	searchEnd: Date,
+	cursor?: PaymentCursor
 ): Promise<CorporationWalletPaymentRow[]> {
 	const logger = getWorkflowLogger(ctx, 'find-payment-transaction-for-corporation-db')
 
@@ -54,9 +104,9 @@ async function findPaymentTransactionsForCorporationFromDb(
 	logger.info('[Workflow] Finding payment transaction in persisted corporation wallet journal', {
 		billId: ctx.billId,
 		workflowInstanceId: ctx.workflowInstanceId,
-		corporationId: corporationId,
+		corporationId,
 		paymentToken: billData.paymentToken,
-		fromDate: billData.createdAt,
+		fromDate: billData.paymentStartAt,
 	})
 
 	if (!corporationId) {
@@ -70,7 +120,11 @@ async function findPaymentTransactionsForCorporationFromDb(
 		return []
 	}
 
-	const tokenNeedle = `%${billData.paymentToken}%`
+	const tokenPrefix = `${billData.paymentToken}%`
+	const paymentSearchStart = getPaymentSearchStart(billData)
+	const cursorCondition = cursor
+		? sql`date > ${cursor.entryDate} or (date = ${cursor.entryDate} and journal_id > ${cursor.journalId})`
+		: sql`true`
 	const results = await ctx.db.execute<CorporationWalletPaymentRow>(
 		sql`select
 			journal_id::text as "journalId",
@@ -79,24 +133,34 @@ async function findPaymentTransactionsForCorporationFromDb(
 			date as "entryDate"
 		from corporation_wallet_journal
 		where corporation_id = ${corporationId}
-			and date >= ${billData.createdAt}
-			and amount::numeric > 0
+			and date >= ${paymentSearchStart}
+			and date <= ${searchEnd}
+			and (${cursorCondition})
+			and (
+				case
+					when amount ~ '^[0-9]+(\\.[0-9]+)?$' then amount::numeric
+					else 0
+				end
+			) > 0
+			and first_party_id is not null
 			and reason is not null
-			and reason like ${tokenNeedle}
+			and reason like ${tokenPrefix}
 			and not exists (
 				select 1
 				from bill_payments
 				where bill_payments.esi_transaction_id = corporation_wallet_journal.journal_id::text
 			)
-		order by date asc
-		limit ${MAX_NEW_PAYMENT_TRANSACTIONS_PER_RUN}`
+		order by date asc, journal_id asc
+		limit ${PAYMENT_BATCH_SIZE}`
 	)
 	return results.rows ?? []
 }
 
 async function findPaymentTransactionsForCharacterFromDb(
 	ctx: WorkflowContext,
-	billData: BillPaymentCheckData
+	billData: BillPaymentCheckData,
+	searchEnd: Date,
+	cursor?: PaymentCursor
 ): Promise<CharacterWalletPaymentRow[]> {
 	const logger = getWorkflowLogger(ctx, 'find-payment-transaction-for-character-db')
 
@@ -107,7 +171,7 @@ async function findPaymentTransactionsForCharacterFromDb(
 		workflowInstanceId: ctx.workflowInstanceId,
 		characterId,
 		paymentToken: billData.paymentToken,
-		fromDate: billData.createdAt,
+		fromDate: billData.paymentStartAt,
 	})
 
 	if (!characterId) {
@@ -121,7 +185,11 @@ async function findPaymentTransactionsForCharacterFromDb(
 		return []
 	}
 
-	const tokenNeedle = `%${billData.paymentToken}%`
+	const tokenPrefix = `${billData.paymentToken}%`
+	const paymentSearchStart = getPaymentSearchStart(billData)
+	const cursorCondition = cursor
+		? sql`date > ${cursor.entryDate} or (date = ${cursor.entryDate} and journal_id > ${cursor.journalId})`
+		: sql`true`
 	const results = await ctx.db.execute<CharacterWalletPaymentRow>(
 		sql`select
 			journal_id::text as "journalId",
@@ -130,19 +198,69 @@ async function findPaymentTransactionsForCharacterFromDb(
 			date as "entryDate"
 		from character_wallet_journal
 		where character_id = ${characterId}
-			and date >= ${billData.createdAt}
-			and amount::numeric > 0
+			and date >= ${paymentSearchStart}
+			and date <= ${searchEnd}
+			and (${cursorCondition})
+			and (
+				case
+					when amount ~ '^[0-9]+(\\.[0-9]+)?$' then amount::numeric
+					else 0
+				end
+			) > 0
+			and first_party_id is not null
 			and reason is not null
-			and reason like ${tokenNeedle}
+			and reason like ${tokenPrefix}
 			and not exists (
 				select 1
 				from bill_payments
 				where bill_payments.esi_transaction_id = character_wallet_journal.journal_id::text
 			)
-		order by date asc
-		limit ${MAX_NEW_PAYMENT_TRANSACTIONS_PER_RUN}`
+		order by date asc, journal_id asc
+		limit ${PAYMENT_BATCH_SIZE}`
 	)
 	return results.rows ?? []
+}
+
+function getPaymentSearchStart(billData: BillPaymentCheckData): Date {
+	const paymentStartAt = new Date(billData.paymentStartAt)
+	const lastCheckedAt = billData.paymentLastCheckedAt
+		? new Date(billData.paymentLastCheckedAt).getTime() - PAYMENT_LOOKBEHIND_MS
+		: paymentStartAt.getTime()
+
+	return new Date(Math.max(paymentStartAt.getTime(), lastCheckedAt))
+}
+
+function getPaymentCursor(row: WalletPaymentRow): PaymentCursor {
+	return {
+		entryDate: row.entryDate,
+		journalId: row.journalId,
+	}
+}
+
+async function processPaymentPages<T extends WalletPaymentRow>(
+	ctx: WorkflowContext,
+	findPage: (cursor?: PaymentCursor) => Promise<T[]>,
+	paidByType: WalletPaymentInput['paidByType']
+): Promise<{ newPaymentsRecorded: number; pageCount: number }> {
+	let cursor: PaymentCursor | undefined
+	let newPaymentsRecorded = 0
+	let pageCount = 0
+
+	while (true) {
+		const paymentTransactions = await findPage(cursor)
+		if (paymentTransactions.length === 0) {
+			break
+		}
+
+		const payments = validatePaymentTransactions(ctx, paymentTransactions, paidByType)
+		if (payments.length > 0) {
+			newPaymentsRecorded += await ctx.billService.recordWalletPayments(ctx.billId, payments)
+		}
+		pageCount += 1
+		cursor = getPaymentCursor(paymentTransactions[paymentTransactions.length - 1])
+	}
+
+	return { newPaymentsRecorded, pageCount }
 }
 
 export async function findPaymentsForBill(
@@ -150,7 +268,7 @@ export async function findPaymentsForBill(
 	billData: BillPaymentCheckData
 ): Promise<{ newPaymentsRecorded: number }> {
 	const logger = getWorkflowLogger(ctx, 'check-character-payment-status')
-	let newPaymentsRecorded = 0
+	const searchEnd = new Date()
 
 	logger.info('[Workflow] Checking payment status for bill', {
 		billId: ctx.billId,
@@ -167,112 +285,63 @@ export async function findPaymentsForBill(
 			workflowInstanceId: ctx.workflowInstanceId,
 			payeeId: billData.payeeId,
 		})
-		return { newPaymentsRecorded }
+		return { newPaymentsRecorded: 0 }
 	}
 
 	if (payeeType === 'corporation') {
-		const paymentTransactions = await findPaymentTransactionsForCorporationFromDb(ctx, billData)
-		if (paymentTransactions.length === 0) {
+		const result = await processPaymentPages(
+			ctx,
+			(cursor) => findPaymentTransactionsForCorporationFromDb(ctx, billData, searchEnd, cursor),
+			'corporation'
+		)
+		if (result.pageCount === 0) {
 			logger.info('[Workflow] No payment transactions found for corporation in persisted data', {
 				billId: ctx.billId,
 				workflowInstanceId: ctx.workflowInstanceId,
 				corporationId: billData.payeeId,
 				paymentToken: billData.paymentToken,
-				fromDate: billData.createdAt,
+				fromDate: billData.paymentStartAt,
 			})
-			return { newPaymentsRecorded }
-		}
-		for (const paymentTransaction of paymentTransactions) {
-			const amount = parseAmountToBigInt(paymentTransaction.amount)
-			if (amount === null || amount <= 0n) {
-				logger.warn('[Workflow] Skipping corporation payment transaction with invalid amount', {
-					billId: ctx.billId,
-					workflowInstanceId: ctx.workflowInstanceId,
-					journalId: paymentTransaction.journalId,
-					amount: paymentTransaction.amount,
-				})
-				continue
-			}
-			if (!paymentTransaction.firstPartyId) {
-				logger.warn('[Workflow] Skipping corporation payment transaction with missing payer id', {
-					billId: ctx.billId,
-					workflowInstanceId: ctx.workflowInstanceId,
-					journalId: paymentTransaction.journalId,
-				})
-				continue
-			}
-			await ctx.billService.payBill(billData.paymentToken, {
-				amount,
-				paidById: paymentTransaction.firstPartyId,
-				paidByType: 'corporation',
-				esiTransactionId: paymentTransaction.journalId,
-			})
-			newPaymentsRecorded += 1
 		}
 		logger.info('[Workflow] Processed corporation payment transactions from persisted data', {
 			billId: ctx.billId,
 			workflowInstanceId: ctx.workflowInstanceId,
 			corporationId: billData.payeeId,
-			count: paymentTransactions.length,
+			pageCount: result.pageCount,
+			newPaymentsRecorded: result.newPaymentsRecorded,
 		})
-		return { newPaymentsRecorded }
+		return { newPaymentsRecorded: result.newPaymentsRecorded }
 	}
 
 	if (payeeType === 'character') {
-		const paymentTransactions = await findPaymentTransactionsForCharacterFromDb(ctx, billData)
-		if (paymentTransactions.length === 0) {
+		const result = await processPaymentPages(
+			ctx,
+			(cursor) => findPaymentTransactionsForCharacterFromDb(ctx, billData, searchEnd, cursor),
+			billData.payerType ?? 'character'
+		)
+		if (result.pageCount === 0) {
 			logger.info('[Workflow] No payment transactions found for character in persisted data', {
 				billId: ctx.billId,
 				workflowInstanceId: ctx.workflowInstanceId,
 				characterId: billData.payeeId,
 				paymentToken: billData.paymentToken,
-				fromDate: billData.createdAt,
+				fromDate: billData.paymentStartAt,
 			})
-			return { newPaymentsRecorded }
 		}
-
-		for (const paymentTransaction of paymentTransactions) {
-			const amount = parseAmountToBigInt(paymentTransaction.amount)
-			if (amount === null || amount <= 0n) {
-				logger.warn('[Workflow] Skipping character payment transaction with invalid amount', {
-					billId: ctx.billId,
-					workflowInstanceId: ctx.workflowInstanceId,
-					journalId: paymentTransaction.journalId,
-					amount: paymentTransaction.amount,
-				})
-				continue
-			}
-			if (!paymentTransaction.firstPartyId) {
-				logger.warn('[Workflow] Skipping character payment transaction with missing payer id', {
-					billId: ctx.billId,
-					workflowInstanceId: ctx.workflowInstanceId,
-					journalId: paymentTransaction.journalId,
-				})
-				continue
-			}
-			await ctx.billService.payBill(billData.paymentToken, {
-				amount,
-				paidById: paymentTransaction.firstPartyId,
-				paidByType: billData.payerType ?? 'character',
-				esiTransactionId: paymentTransaction.journalId,
-			})
-			newPaymentsRecorded += 1
-		}
-
 		logger.info('[Workflow] Processed character payment transactions from persisted data', {
 			billId: ctx.billId,
 			workflowInstanceId: ctx.workflowInstanceId,
 			characterId: billData.payeeId,
-			count: paymentTransactions.length,
+			pageCount: result.pageCount,
+			newPaymentsRecorded: result.newPaymentsRecorded,
 		})
-		return { newPaymentsRecorded }
-	} else {
-		logger.info('[Workflow] Skipping payment transaction lookup for unsupported payee type', {
-			billId: ctx.billId,
-			workflowInstanceId: ctx.workflowInstanceId,
-			payeeType,
-		})
+		return { newPaymentsRecorded: result.newPaymentsRecorded }
 	}
 
-	return { newPaymentsRecorded }
+	logger.info('[Workflow] Skipping payment transaction lookup for unsupported payee type', {
+		billId: ctx.billId,
+		workflowInstanceId: ctx.workflowInstanceId,
+		payeeType,
+	})
+	return { newPaymentsRecorded: 0 }
 }

--- a/apps/bills/src/workflows/steps/update-check-timestamp/update-check-timestamp.ts
+++ b/apps/bills/src/workflows/steps/update-check-timestamp/update-check-timestamp.ts
@@ -37,4 +37,3 @@ export async function updateCheckTimestamp(
 		updated: true,
 	}
 }
-

--- a/apps/eve-character-data/.migrations/0007_shiny_shadowcat.sql
+++ b/apps/eve-character-data/.migrations/0007_shiny_shadowcat.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "character_wallet_journal_character_date_idx" ON "character_wallet_journal" USING btree ("character_id","date");--> statement-breakpoint
+CREATE INDEX "character_wallet_journal_character_reason_date_idx" ON "character_wallet_journal" USING btree ("character_id","reason","date");

--- a/apps/eve-character-data/.migrations/meta/0007_snapshot.json
+++ b/apps/eve-character-data/.migrations/meta/0007_snapshot.json
@@ -1,0 +1,1256 @@
+{
+  "id": "21031a4d-e66a-4513-8cc7-42e54b13887f",
+  "prevId": "36fd29c0-1c88-4416-a452-7293f552eaa7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_assets": {
+      "name": "character_assets",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_value": {
+          "name": "total_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_count": {
+          "name": "asset_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_assets_character_id_character_public_info_character_id_fk": {
+          "name": "character_assets_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_assets",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_attributes": {
+      "name": "character_attributes",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intelligence": {
+          "name": "intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perception": {
+          "name": "perception",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory": {
+          "name": "memory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "willpower": {
+          "name": "willpower",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charisma": {
+          "name": "charisma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accrued_remap_cooldown_date": {
+          "name": "accrued_remap_cooldown_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bonus_remaps": {
+          "name": "bonus_remaps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_remap_date": {
+          "name": "last_remap_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_attributes_character_id_character_public_info_character_id_fk": {
+          "name": "character_attributes_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_attributes",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_corporation_history": {
+      "name": "character_corporation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_corporation_history_character_id_character_public_info_character_id_fk": {
+          "name": "character_corporation_history_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_corporation_history",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_corporation_history_character_id_record_id_unique": {
+          "name": "character_corporation_history_character_id_record_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id",
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_killmails": {
+      "name": "character_killmails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_id": {
+          "name": "killmail_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_hash": {
+          "name": "killmail_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_time": {
+          "name": "killmail_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_loss": {
+          "name": "is_loss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_name": {
+          "name": "ship_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_value": {
+          "name": "total_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solar_system_name": {
+          "name": "solar_system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_character_id": {
+          "name": "victim_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killmail_data": {
+          "name": "killmail_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_killmails_character_id_character_public_info_character_id_fk": {
+          "name": "character_killmails_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_killmails",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_killmails_character_id_killmail_id_unique": {
+          "name": "character_killmails_character_id_killmail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id",
+            "killmail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_location": {
+      "name": "character_location",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "solar_system_id": {
+          "name": "solar_system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_location_character_id_character_public_info_character_id_fk": {
+          "name": "character_location_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_location",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_market_orders": {
+      "name": "character_market_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy_order": {
+          "name": "is_buy_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_total": {
+          "name": "volume_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_remain": {
+          "name": "volume_remain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued": {
+          "name": "issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_volume": {
+          "name": "min_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escrow": {
+          "name": "escrow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_market_orders_character_id_character_public_info_character_id_fk": {
+          "name": "character_market_orders_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_market_orders",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_market_orders_character_id_order_id_unique": {
+          "name": "character_market_orders_character_id_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id",
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_market_transactions": {
+      "name": "character_market_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy": {
+          "name": "is_buy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_ref_id": {
+          "name": "journal_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_market_transactions_character_id_character_public_info_character_id_fk": {
+          "name": "character_market_transactions_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_market_transactions",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_market_transactions_character_id_transaction_id_unique": {
+          "name": "character_market_transactions_character_id_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id",
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_public_info": {
+      "name": "character_public_info",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "race_id": {
+          "name": "race_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bloodline_id": {
+          "name": "bloodline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_status": {
+          "name": "security_status",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_skill_queue": {
+      "name": "character_skill_queue",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_skill_queue_character_id_character_public_info_character_id_fk": {
+          "name": "character_skill_queue_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_skill_queue",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_skills": {
+      "name": "character_skills",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_sp": {
+          "name": "total_sp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unallocated_sp": {
+          "name": "unallocated_sp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_skills_character_id_character_public_info_character_id_fk": {
+          "name": "character_skills_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_skills",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_status": {
+      "name": "character_status",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "online": {
+          "name": "online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_logout": {
+          "name": "last_logout",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logins_count": {
+          "name": "logins_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_status_character_id_character_public_info_character_id_fk": {
+          "name": "character_status_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_status",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_wallet": {
+      "name": "character_wallet",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_wallet_character_id_character_public_info_character_id_fk": {
+          "name": "character_wallet_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_wallet",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_wallet_journal": {
+      "name": "character_wallet_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_receiver_id": {
+          "name": "tax_receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id_type": {
+          "name": "context_id_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_wallet_journal_character_date_idx": {
+          "name": "character_wallet_journal_character_date_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "character_wallet_journal_character_reason_date_idx": {
+          "name": "character_wallet_journal_character_reason_date_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_wallet_journal_character_id_character_public_info_character_id_fk": {
+          "name": "character_wallet_journal_character_id_character_public_info_character_id_fk",
+          "tableFrom": "character_wallet_journal",
+          "tableTo": "character_public_info",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "character_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_wallet_journal_character_id_journal_id_unique": {
+          "name": "character_wallet_journal_character_id_journal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "character_id",
+            "journal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/eve-character-data/.migrations/meta/_journal.json
+++ b/apps/eve-character-data/.migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776368351158,
       "tag": "0006_dry_captain_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785598517674,
+      "tag": "0007_shiny_shadowcat",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/eve-character-data/src/db/schema.ts
+++ b/apps/eve-character-data/src/db/schema.ts
@@ -1,5 +1,6 @@
 import {
 	boolean,
+	index,
 	integer,
 	jsonb,
 	pgTable,
@@ -200,7 +201,15 @@ export const characterWalletJournal = pgTable(
 		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
-	(table) => [unique().on(table.characterId, table.journalId)]
+	(table) => [
+		unique().on(table.characterId, table.journalId),
+		index('character_wallet_journal_character_date_idx').on(table.characterId, table.date),
+		index('character_wallet_journal_character_reason_date_idx').on(
+			table.characterId,
+			table.reason,
+			table.date
+		),
+	]
 )
 
 /**

--- a/apps/eve-corporation-data/.migrations/0035_salty_dragon_man.sql
+++ b/apps/eve-corporation-data/.migrations/0035_salty_dragon_man.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "corporation_wallet_journal_corporation_date_idx" ON "corporation_wallet_journal" USING btree ("corporation_id","date");--> statement-breakpoint
+CREATE INDEX "corporation_wallet_journal_corporation_reason_date_idx" ON "corporation_wallet_journal" USING btree ("corporation_id","reason","date");

--- a/apps/eve-corporation-data/.migrations/meta/0035_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0035_snapshot.json
@@ -1,0 +1,3928 @@
+{
+  "id": "c0a763ea-e8ea-448d-a4d9-b57563fb791d",
+  "prevId": "ebef1847-e147-45a6-bb71-b3fab4a3ddf7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_corporation_roles": {
+      "name": "character_corporation_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_at_hq": {
+          "name": "roles_at_hq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_base": {
+          "name": "roles_at_base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_other": {
+          "name": "roles_at_other",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "character_corporation_roles",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_corporation_roles_corporation_id_character_id_unique": {
+          "name": "character_corporation_roles_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_assets": {
+      "name": "corporation_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_blueprint_copy": {
+          "name": "is_blueprint_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_assets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_assets_corporation_id_item_id_unique": {
+          "name": "corporation_assets_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_config": {
+      "name": "corporation_config",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "corporation_type": {
+          "name": "corporation_type",
+          "type": "corporation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "members_last_sync": {
+          "name": "members_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_tracking_last_sync": {
+          "name": "member_tracking_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets_last_sync": {
+          "name": "wallets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_journal_last_sync": {
+          "name": "wallet_journal_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_transactions_last_sync": {
+          "name": "wallet_transactions_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assets_last_sync": {
+          "name": "assets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structures_last_sync": {
+          "name": "structures_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_last_sync": {
+          "name": "orders_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contracts_last_sync": {
+          "name": "contracts_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_jobs_last_sync": {
+          "name": "industry_jobs_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killmails_last_sync": {
+          "name": "killmails_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_config_include_in_background_refresh_idx": {
+          "name": "corporation_config_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_include_in_structure_asset_sync_idx": {
+          "name": "corporation_config_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_corporation_type_idx": {
+          "name": "corporation_config_corporation_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_member_tracking_last_sync_idx": {
+          "name": "corporation_config_member_tracking_last_sync_idx",
+          "columns": [
+            {
+              "expression": "member_tracking_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallets_last_sync_idx": {
+          "name": "corporation_config_wallets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_assets_last_sync_idx": {
+          "name": "corporation_config_assets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "assets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_structures_last_sync_idx": {
+          "name": "corporation_config_structures_last_sync_idx",
+          "columns": [
+            {
+              "expression": "structures_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_orders_last_sync_idx": {
+          "name": "corporation_config_orders_last_sync_idx",
+          "columns": [
+            {
+              "expression": "orders_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_contracts_last_sync_idx": {
+          "name": "corporation_config_contracts_last_sync_idx",
+          "columns": [
+            {
+              "expression": "contracts_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_industry_jobs_last_sync_idx": {
+          "name": "corporation_config_industry_jobs_last_sync_idx",
+          "columns": [
+            {
+              "expression": "industry_jobs_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_killmails_last_sync_idx": {
+          "name": "corporation_config_killmails_last_sync_idx",
+          "columns": [
+            {
+              "expression": "killmails_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_members_last_sync_idx": {
+          "name": "corporation_config_members_last_sync_idx",
+          "columns": [
+            {
+              "expression": "members_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_transactions_last_sync_idx": {
+          "name": "corporation_config_wallet_transactions_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_transactions_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_journal_last_sync_idx": {
+          "name": "corporation_config_wallet_journal_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_journal_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_contracts": {
+      "name": "corporation_contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptor_id": {
+          "name": "acceptor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyout": {
+          "name": "buyout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collateral": {
+          "name": "collateral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_accepted": {
+          "name": "date_accepted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_expired": {
+          "name": "date_expired",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_to_complete": {
+          "name": "days_to_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_location_id": {
+          "name": "end_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_corporation": {
+          "name": "for_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_corporation_id": {
+          "name": "issuer_corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward": {
+          "name": "reward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_location_id": {
+          "name": "start_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_contracts_leaderboard_all_time_idx": {
+          "name": "corporation_contracts_leaderboard_all_time_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_contracts_leaderboard_period_idx": {
+          "name": "corporation_contracts_leaderboard_period_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_contracts_contract_id_unique": {
+          "name": "corporation_contracts_contract_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contract_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_directors": {
+      "name": "corporation_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_healthy": {
+          "name": "is_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permanent_failure_at": {
+          "name": "permanent_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_directors_corp_healthy_idx": {
+          "name": "corporation_directors_corp_healthy_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_healthy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_next_retry_idx": {
+          "name": "corporation_directors_corp_next_retry_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_permanent_failure_idx": {
+          "name": "corporation_directors_corp_permanent_failure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permanent_failure_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_last_used_idx": {
+          "name": "corporation_directors_last_used_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_directors",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_directors_corporation_id_character_id_unique": {
+          "name": "corporation_directors_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_industry_jobs": {
+      "name": "corporation_industry_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_id": {
+          "name": "installer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_type_id": {
+          "name": "blueprint_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_location_id": {
+          "name": "blueprint_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_location_id": {
+          "name": "output_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs": {
+          "name": "runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_runs": {
+          "name": "licensed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_type_id": {
+          "name": "product_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_date": {
+          "name": "pause_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_character_id": {
+          "name": "completed_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successful_runs": {
+          "name": "successful_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_industry_jobs",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_industry_jobs_corporation_id_job_id_unique": {
+          "name": "corporation_industry_jobs_corporation_id_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_killmails": {
+      "name": "corporation_killmails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_id": {
+          "name": "killmail_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_hash": {
+          "name": "killmail_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_time": {
+          "name": "killmail_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_killmails",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_killmails_corporation_id_killmail_id_unique": {
+          "name": "corporation_killmails_corporation_id_killmail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "killmail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_member_tracking": {
+      "name": "corporation_member_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoff_date": {
+          "name": "logoff_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logon_date": {
+          "name": "logon_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_member_tracking",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_member_tracking_corporation_id_character_id_unique": {
+          "name": "corporation_member_tracking_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_members": {
+      "name": "corporation_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_members_character_id_idx": {
+          "name": "corporation_members_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_members",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_members_corporation_id_character_id_unique": {
+          "name": "corporation_members_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_orders": {
+      "name": "corporation_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escrow": {
+          "name": "escrow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_buy_order": {
+          "name": "is_buy_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issued": {
+          "name": "issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_volume": {
+          "name": "min_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_remain": {
+          "name": "volume_remain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_total": {
+          "name": "volume_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_division": {
+          "name": "wallet_division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_orders",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_orders_corporation_id_order_id_unique": {
+          "name": "corporation_orders_corporation_id_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_public_info": {
+      "name": "corporation_public_info",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ceo_id": {
+          "name": "ceo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_founded": {
+          "name": "date_founded",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_station_id": {
+          "name": "home_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "war_eligible": {
+          "name": "war_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory": {
+      "name": "corporation_structure_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_corp_structure_idx": {
+          "name": "corporation_structure_inventory_corp_structure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_structure_inventory_snapshot_structure_idx": {
+          "name": "corporation_structure_inventory_snapshot_structure_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+          "name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corp_inv_snapshot_fk": {
+          "name": "corp_inv_snapshot_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structure_inventory_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corp_inv_snapshot_item_uniq": {
+          "name": "corp_inv_snapshot_item_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "snapshot_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory_snapshots": {
+      "name": "corporation_structure_inventory_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_snapshots_corp_activated_idx": {
+          "name": "corporation_structure_inventory_snapshots_corp_activated_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corp_inv_snapshots_corp_fk": {
+          "name": "corp_inv_snapshots_corp_fk",
+          "tableFrom": "corporation_structure_inventory_snapshots",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structures": {
+      "name": "corporation_structures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_expires": {
+          "name": "fuel_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_amount": {
+          "name": "fuel_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_burn_rate": {
+          "name": "fuel_burn_rate",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refilled_at": {
+          "name": "last_refilled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_apply": {
+          "name": "next_reinforce_apply",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_hour": {
+          "name": "next_reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforce_hour": {
+          "name": "reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_timer_end": {
+          "name": "state_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_timer_start": {
+          "name": "state_timer_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unanchors_at": {
+          "name": "unanchors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_power": {
+          "name": "low_power",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structures_last_synced_at_idx": {
+          "name": "corporation_structures_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structures",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structures_structure_id_unique": {
+          "name": "corporation_structures_structure_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "structure_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_journal": {
+      "name": "corporation_wallet_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id_type": {
+          "name": "context_id_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_receiver_id": {
+          "name": "tax_receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_wallet_journal_corporation_date_idx": {
+          "name": "corporation_wallet_journal_corporation_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_journal_corporation_reason_date_idx": {
+          "name": "corporation_wallet_journal_corporation_reason_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_journal",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+          "name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "journal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_transactions": {
+      "name": "corporation_wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy": {
+          "name": "is_buy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "journal_ref_id": {
+          "name": "journal_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_transactions",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+          "name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallets": {
+      "name": "corporation_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallets_corporation_id_division_unique": {
+          "name": "corporation_wallets_corporation_id_division_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_fuel_log": {
+      "name": "structure_fuel_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_block_units": {
+          "name": "fuel_block_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_fuel_log_corp_structure_observed_idx": {
+          "name": "structure_fuel_log_corp_structure_observed_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_mining_citadel_extractions": {
+      "name": "structure_mining_citadel_extractions",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_start_time": {
+          "name": "extraction_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_arrival_time": {
+          "name": "chunk_arrival_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "natural_decay_time": {
+          "name": "natural_decay_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_mining_citadel_extractions_corporation_id_idx": {
+          "name": "structure_mining_citadel_extractions_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_citadel_extractions_last_synced_at_idx": {
+          "name": "structure_mining_citadel_extractions_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_drills": {
+      "name": "structure_moon_drills",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_drills_corporation_id_idx": {
+          "name": "structure_moon_drills_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_drills_last_synced_at_idx": {
+          "name": "structure_moon_drills_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_geographies": {
+      "name": "structure_moon_geographies",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_name": {
+          "name": "moon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_geographies_corporation_id_idx": {
+          "name": "structure_moon_geographies_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_moon_id_idx": {
+          "name": "structure_moon_geographies_moon_id_idx",
+          "columns": [
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_planet_id_idx": {
+          "name": "structure_moon_geographies_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_system_id_idx": {
+          "name": "structure_moon_geographies_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_last_synced_at_idx": {
+          "name": "structure_moon_geographies_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhook_reagents": {
+      "name": "structure_skyhook_reagents",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "magmatic_gas_secured_stock": {
+          "name": "magmatic_gas_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_unsecured_stock": {
+          "name": "magmatic_gas_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_last_cycle": {
+          "name": "magmatic_gas_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superionic_ice_secured_stock": {
+          "name": "superionic_ice_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_unsecured_stock": {
+          "name": "superionic_ice_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_last_cycle": {
+          "name": "superionic_ice_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhook_reagents_corporation_id_idx": {
+          "name": "structure_skyhook_reagents_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhooks": {
+      "name": "structure_skyhooks",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "effective_workforce": {
+          "name": "effective_workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforcement_timer_end": {
+          "name": "reinforcement_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_start": {
+          "name": "theft_vulnerability_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_end": {
+          "name": "theft_vulnerability_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhooks_corporation_id_idx": {
+          "name": "structure_skyhooks_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_planet_id_idx": {
+          "name": "structure_skyhooks_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_system_id_idx": {
+          "name": "structure_skyhooks_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_type_id_idx": {
+          "name": "structure_skyhooks_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_last_synced_at_idx": {
+          "name": "structure_skyhooks_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_hubs": {
+      "name": "structure_sovereignty_hubs",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_access_list_id": {
+          "name": "fuel_access_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_id": {
+          "name": "controller_alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_name": {
+          "name": "controller_alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay_last_updated": {
+          "name": "reagent_bay_last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay": {
+          "name": "reagent_bay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+        },
+        "upgrades": {
+          "name": "upgrades",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_transport": {
+          "name": "workforce_transport",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_hubs_corporation_id_idx": {
+          "name": "structure_sovereignty_hubs_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_system_id_idx": {
+          "name": "structure_sovereignty_hubs_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_type_id_idx": {
+          "name": "structure_sovereignty_hubs_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_last_synced_at_idx": {
+          "name": "structure_sovereignty_hubs_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_hubs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_systems": {
+      "name": "structure_sovereignty_systems",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_claimant_id": {
+          "name": "corporation_claimant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_since": {
+          "name": "claimed_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sovereignty_hub_structure_id": {
+          "name": "sovereignty_hub_structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capital_system": {
+          "name": "is_capital_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_defense_multiplier": {
+          "name": "activity_defense_multiplier",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "military_level": {
+          "name": "military_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industrial_level": {
+          "name": "industrial_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategic_level": {
+          "name": "strategic_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_systems_corporation_id_idx": {
+          "name": "structure_sovereignty_systems_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_region_id_idx": {
+          "name": "structure_sovereignty_systems_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_alliance_id_idx": {
+          "name": "structure_sovereignty_systems_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+          "name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+          "columns": [
+            {
+              "expression": "sovereignty_hub_structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_last_synced_at_idx": {
+          "name": "structure_sovereignty_systems_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_systems",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.corporation_type": {
+      "name": "corporation_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "alt",
+        "special_purpose",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/eve-corporation-data/.migrations/meta/_journal.json
+++ b/apps/eve-corporation-data/.migrations/meta/_journal.json
@@ -1,251 +1,258 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1761099619236,
-			"tag": "0000_dazzling_natasha_romanoff",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1761110912747,
-			"tag": "0001_mature_legion",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1761111712115,
-			"tag": "0002_amused_starbolt",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1761111737470,
-			"tag": "0003_natural_rage",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1761160474761,
-			"tag": "0004_clean_tinkerer",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1761744369304,
-			"tag": "0005_stormy_captain_flint",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1761747572400,
-			"tag": "0006_uneven_ricochet",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1761747676930,
-			"tag": "0007_famous_unicorn",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1762957583759,
-			"tag": "0008_curved_gamma_corps",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1762957633914,
-			"tag": "0009_brown_the_hunter",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1762957839616,
-			"tag": "0010_redundant_susan_delgado",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1762965216030,
-			"tag": "0011_melodic_punisher",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1763040426490,
-			"tag": "0012_tiny_exodus",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1763040690210,
-			"tag": "0013_quiet_jazinda",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1763331803557,
-			"tag": "0014_dazzling_monster_badoon",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1779900405297,
-			"tag": "0015_woozy_human_robot",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1781300366548,
-			"tag": "0016_numerous_molly_hayes",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1781388311665,
-			"tag": "0017_stormy_queen_noir",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1781388451291,
-			"tag": "0018_lame_risque",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1781407594809,
-			"tag": "0019_free_lethal_legion",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1781594825288,
-			"tag": "0020_flippant_vapor",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1781634026073,
-			"tag": "0021_dry_korg",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1783949372726,
-			"tag": "0022_striped_tempest",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1783975959015,
-			"tag": "0023_left_young_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1784085393701,
-			"tag": "0024_kind_sir_ram",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1784112964441,
-			"tag": "0025_mysterious_lady_mastermind",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1784260492391,
-			"tag": "0026_shiny_revanche",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1784616356949,
-			"tag": "0027_unusual_korath",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1784768869865,
-			"tag": "0028_wakeful_juggernaut",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1784788914282,
-			"tag": "0029_brainy_killraven",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1784827578420,
-			"tag": "0030_curious_clea",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1784916519807,
-			"tag": "0031_lively_mariko_yashida",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1785538247429,
-			"tag": "0032_inventory_snapshot_expand",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1785538256449,
-			"tag": "0033_inventory_snapshot_backfill",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1785538275535,
-			"tag": "0034_inventory_snapshot_contract",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1761099619236,
+      "tag": "0000_dazzling_natasha_romanoff",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1761110912747,
+      "tag": "0001_mature_legion",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1761111712115,
+      "tag": "0002_amused_starbolt",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1761111737470,
+      "tag": "0003_natural_rage",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1761160474761,
+      "tag": "0004_clean_tinkerer",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1761744369304,
+      "tag": "0005_stormy_captain_flint",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1761747572400,
+      "tag": "0006_uneven_ricochet",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1761747676930,
+      "tag": "0007_famous_unicorn",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1762957583759,
+      "tag": "0008_curved_gamma_corps",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1762957633914,
+      "tag": "0009_brown_the_hunter",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1762957839616,
+      "tag": "0010_redundant_susan_delgado",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1762965216030,
+      "tag": "0011_melodic_punisher",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1763040426490,
+      "tag": "0012_tiny_exodus",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1763040690210,
+      "tag": "0013_quiet_jazinda",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1763331803557,
+      "tag": "0014_dazzling_monster_badoon",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1779900405297,
+      "tag": "0015_woozy_human_robot",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1781300366548,
+      "tag": "0016_numerous_molly_hayes",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1781388311665,
+      "tag": "0017_stormy_queen_noir",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1781388451291,
+      "tag": "0018_lame_risque",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1781407594809,
+      "tag": "0019_free_lethal_legion",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1781594825288,
+      "tag": "0020_flippant_vapor",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1781634026073,
+      "tag": "0021_dry_korg",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1783949372726,
+      "tag": "0022_striped_tempest",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1783975959015,
+      "tag": "0023_left_young_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1784085393701,
+      "tag": "0024_kind_sir_ram",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1784112964441,
+      "tag": "0025_mysterious_lady_mastermind",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1784260492391,
+      "tag": "0026_shiny_revanche",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1784616356949,
+      "tag": "0027_unusual_korath",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1784768869865,
+      "tag": "0028_wakeful_juggernaut",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1784788914282,
+      "tag": "0029_brainy_killraven",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1784827578420,
+      "tag": "0030_curious_clea",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1784916519807,
+      "tag": "0031_lively_mariko_yashida",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1785538247429,
+      "tag": "0032_inventory_snapshot_expand",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1785538256449,
+      "tag": "0033_inventory_snapshot_backfill",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1785538275535,
+      "tag": "0034_inventory_snapshot_contract",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1785598539248,
+      "tag": "0035_salty_dragon_man",
+      "breakpoints": true
+    }
+  ]
 }

--- a/apps/eve-corporation-data/src/db/schema.ts
+++ b/apps/eve-corporation-data/src/db/schema.ts
@@ -304,7 +304,15 @@ export const corporationWalletJournal = pgTable(
 		taxReceiverId: text('tax_receiver_id'),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
-	(table) => [unique().on(table.corporationId, table.division, table.journalId)]
+	(table) => [
+		unique().on(table.corporationId, table.division, table.journalId),
+		index('corporation_wallet_journal_corporation_date_idx').on(table.corporationId, table.date),
+		index('corporation_wallet_journal_corporation_reason_date_idx').on(
+			table.corporationId,
+			table.reason,
+			table.date
+		),
+	]
 )
 
 /**


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Optimizes and hardens the bill payment-checking workflow: wallet journal lookups are now indexed and paginated, matched payments are recorded in bulk via a single idempotent batch SQL statement (instead of one `payBill` call per transaction), and outstanding-balance checks are computed with a SQL aggregate instead of loading every payment row into memory.

## Changes
- Add `recordWalletPayments`/`insertWalletPaymentBatch` to `BillService`, inserting up to 50 payments per batch in one CTE-based `INSERT ... ON CONFLICT DO NOTHING` statement (deduped by `esiTransactionId`) and emitting matching `payment_recorded` status events atomically.
- Rework `findPaymentsForBill` to page through corporation/character wallet journals with a cursor (`entryDate`, `journalId`) instead of a single 100-row cap, validate/dedupe rows, and hand each page to `recordWalletPayments` in bulk.
- Bound the wallet journal scan to a payment window: search starts at the bill's `issued` status-event timestamp (`paymentStartAt`, falling back to `createdAt`) and re-scans a 1-hour lookbehind (`PAYMENT_LOOKBEHIND_MS`) before the last completed watermark (`paymentLastCheckedAt`), bounded by a fixed `searchEnd` snapshot per run.
- Match on a `reason LIKE 'token%'` prefix instead of a `%token%` substring, and only consider rows with a numeric `amount` and non-null `first_party_id`.
- `checkBillBalancePaid` now sums payments via a SQL `coalesce(sum(...))` query instead of fetching all `billPayments` rows through the `bills.payments` relation.
- Simplify `BillPaymentStatusCheckWorkflow`: fold the separate `update-check-timestamp` step into `finalize-payment-state` so the watermark only advances after payment reconciliation and status evaluation both succeed (one fewer workflow step).
- Add composite indexes `(character_id, date)` / `(character_id, reason, date)` and `(corporation_id, date)` / `(corporation_id, reason, date)` on the wallet journal tables to support the new lookups (new migrations in `eve-character-data` and `eve-corporation-data`).
- Minor cleanup: drop unused imports, fix formatting, use the imported `BillStatus`/`EntityType` types instead of inline `import(...)`.

## Testing
- Updated/added unit tests for `BillService.checkBillBalancePaid` and `BillService.recordWalletPayments`, plus new tests for `findPaymentsForBill` covering validation, batching, and pagination across multiple pages.
- Updated `BillPaymentStatusCheckWorkflow` tests to reflect the collapsed workflow steps and retry behavior.
<!-- claude:end -->