### PR TITLE
force sov systems re-fetch no-store

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -208,6 +208,7 @@ const CORPORATION_MEMBERSHIP_SCOPE = 'esi-corporations.read_corporation_membersh
 const NPC_CORPORATION_ID_MIN = 1_000_000
 const NPC_CORPORATION_ID_MAX = 1_999_999
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY = 'shared:sovereignty-systems:observed-at'
+const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY = 'shared:sovereignty-systems:count'
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX = 'shared:sovereignty-systems:row:'
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS = 60 * 60
 const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY = 'shared:sovereignty-systems:refresh-lease'
@@ -3438,6 +3439,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				await txn.delete([...existing.keys()])
 			}
 			await txn.put(SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY, observedAt)
+			await txn.put(SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY, systems.length)
 			if (systems.length > 0) {
 				await txn.put(rowEntries)
 			}
@@ -3482,40 +3484,34 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 	}
 
-	/**
-	 * Get shared sovereignty system snapshots for the requested system IDs if they are still within TTL.
-	 */
-	async getSharedSovereigntySystemsByIds(
-		systemIds: string[],
+	async getSharedSovereigntySystemsForCorporation(
+		corporationId: string,
 		maxAgeSeconds = SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS
 	): Promise<EsiSovereigntySystem[] | null> {
 		const observedAtRaw = await this.state.storage.get<string>(
 			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
 		)
-		if (!observedAtRaw) {
+		const cachedSystemCount = await this.state.storage.get<number>(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY
+		)
+		if (!observedAtRaw || cachedSystemCount === undefined) {
 			return null
 		}
 
 		const observedAt = parseDateOrNull(observedAtRaw)
-		if (!observedAt) {
+		if (!observedAt || Date.now() - observedAt.getTime() > maxAgeSeconds * 1000) {
 			return null
 		}
 
-		const ageMs = Date.now() - observedAt.getTime()
-		if (ageMs > maxAgeSeconds * 1000) {
+		const rows = await this.state.storage.list<EsiSovereigntySystem>({
+			prefix: SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX,
+		})
+		if (rows.size !== cachedSystemCount) {
 			return null
 		}
-
-		const uniqueSystemIds = [...new Set(systemIds.filter((systemId) => Boolean(systemId)))]
-		if (uniqueSystemIds.length === 0) {
-			return []
-		}
-
-		const rows = await this.state.storage.get<EsiSovereigntySystem>(
-			uniqueSystemIds.map((systemId) => `${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX}${systemId}`)
+		return [...rows.values()].filter(
+			(system) => system.claim_type === 'alliance' && system.corporation_id === corporationId
 		)
-
-		return [...rows.values()]
 	}
 
 	async getSharedSovereigntySystemsSnapshot(
@@ -3524,7 +3520,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const observedAtRaw = await this.state.storage.get<string>(
 			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
 		)
-		if (!observedAtRaw) {
+		const cachedSystemCount = await this.state.storage.get<number>(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY
+		)
+		if (!observedAtRaw || cachedSystemCount === undefined) {
 			return null
 		}
 
@@ -3541,6 +3540,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const rows = await this.state.storage.list<EsiSovereigntySystem>({
 			prefix: SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX,
 		})
+		if (rows.size !== cachedSystemCount) {
+			return null
+		}
 		return [...rows.values()]
 	}
 
@@ -3550,7 +3552,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const observedAtRaw = await this.state.storage.get<string>(
 			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
 		)
-		if (!observedAtRaw) {
+		const cachedSystemCount = await this.state.storage.get<number>(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY
+		)
+		if (!observedAtRaw || cachedSystemCount === undefined) {
 			return false
 		}
 

--- a/apps/eve-corporation-data/src/scheduled.ts
+++ b/apps/eve-corporation-data/src/scheduled.ts
@@ -6,7 +6,7 @@ import {
 	enrichQueueEntry,
 	selectPriorityDrain,
 } from './workflows/utils/background-refresh-batching'
-import { refreshSharedSovereigntySystems } from './workflows/utils/sovereignty-systems-cache'
+import { ensureSharedSovereigntySystems } from './workflows/utils/sovereignty-systems-cache'
 
 import type { Env } from './context'
 import type {
@@ -96,12 +96,15 @@ async function runScheduledRefresh(event: ScheduledEvent, env: Env): Promise<voi
 		// Corp workflows read this from the global corporation-data DO instead of
 		// refetching the same system map independently.
 		try {
-			await refreshSharedSovereigntySystems(env)
-			logger.info('[BackgroundRefresh] Warmed shared sovereignty systems cache')
+			await ensureSharedSovereigntySystems(env)
+			logger.info('[BackgroundRefresh] Ensured shared sovereignty systems cache freshness')
 		} catch (error) {
-			logger.error('[BackgroundRefresh] Failed to warm shared sovereignty systems cache', {
-				error: error instanceof Error ? error.message : String(error),
-			})
+			logger.error(
+				'[BackgroundRefresh] Failed to ensure shared sovereignty systems cache freshness',
+				{
+					error: error instanceof Error ? error.message : String(error),
+				}
+			)
 		}
 
 		const corporationsById = new Map(

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -6,7 +6,7 @@ const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 
 const mocks = vi.hoisted(() => {
 	const fetchSovereigntyHubsMock = vi.fn()
-	const readSharedSovereigntySystemsByIdsMock = vi.fn()
+	const readSharedSovereigntySystemsForCorporationMock = vi.fn()
 	const refreshSharedSovereigntySystemsMock = vi.fn()
 	const resolveSolarSystemsByIdsMock = vi.fn()
 	const getSovereigntyHubSyncPrioritiesMock = vi.fn()
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => {
 
 	return {
 		fetchSovereigntyHubsMock,
-		readSharedSovereigntySystemsByIdsMock,
+		readSharedSovereigntySystemsForCorporationMock,
 		refreshSharedSovereigntySystemsMock,
 		resolveSolarSystemsByIdsMock,
 		getSovereigntyHubSyncPrioritiesMock,
@@ -56,8 +56,8 @@ vi.mock('../../../workflows/utils/services', () => ({
 }))
 
 vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
-	readSharedSovereigntySystemsByIds: (...args: unknown[]) =>
-		mocks.readSharedSovereigntySystemsByIdsMock(...args),
+	readSharedSovereigntySystemsForCorporation: (...args: unknown[]) =>
+		mocks.readSharedSovereigntySystemsForCorporationMock(...args),
 	refreshSharedSovereigntySystems: (...args: unknown[]) =>
 		mocks.refreshSharedSovereigntySystemsMock(...args),
 }))
@@ -84,7 +84,7 @@ describe('fetchSovereigntyEnrichment', () => {
 			},
 			pages: 1,
 		})
-		mocks.readSharedSovereigntySystemsByIdsMock.mockResolvedValue([
+		mocks.readSharedSovereigntySystemsForCorporationMock.mockResolvedValue([
 			{
 				system_id: '30000142',
 				claim_type: 'alliance',
@@ -169,11 +169,11 @@ describe('fetchSovereigntyEnrichment', () => {
 				pruneCandidateIds: ['departed-hub'],
 			}
 		)
-		expect(mocks.readSharedSovereigntySystemsByIdsMock).toHaveBeenCalledWith(
+		expect(mocks.readSharedSovereigntySystemsForCorporationMock).toHaveBeenCalledWith(
 			{
 				UNIVERSE: {},
 			},
-			['30000142']
+			'corp-1'
 		)
 		expect(mocks.getStubMock).toHaveBeenCalledWith({}, 'default')
 		expect(mocks.resolveSolarSystemsByIdsMock).toHaveBeenCalledWith(['30000142'])
@@ -193,6 +193,7 @@ describe('fetchSovereigntyEnrichment', () => {
 			pruneCandidateIds: [],
 			syncPriorities: [],
 		})
+		mocks.readSharedSovereigntySystemsForCorporationMock.mockResolvedValue([])
 		mocks.fetchEsiMock.mockRejectedValue(
 			new Error(
 				'ESI request failed: 401 Unauthorized - {"error":"missing scope"} | metadata={"status":401,"path":"/corporations/123/structures/sovereignty-hubs/"}'

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -5,7 +5,7 @@ import * as esiFetch from '../../../services/esi-fetch'
 import { buildPriorityQueuedEntries } from '../../../services/structure-priority'
 import { createTokenStore, getCorporationDataStub } from '../../utils/services'
 import {
-	readSharedSovereigntySystemsByIds,
+	readSharedSovereigntySystemsForCorporation,
 	refreshSharedSovereigntySystems,
 } from '../../utils/sovereignty-systems-cache'
 import {
@@ -127,6 +127,20 @@ export async function fetchSovereigntyEnrichment(
 	try {
 		const corpData = getCorporationDataStub(env, corporationId)
 		const tokenStore = createTokenStore(env)
+		let sovereigntySystems = await readSharedSovereigntySystemsForCorporation(env, corporationId)
+		if (!sovereigntySystems) {
+			logger.warn(
+				'[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache',
+				{
+					corporationId,
+				}
+			)
+			await refreshSharedSovereigntySystems(env)
+			sovereigntySystems = await readSharedSovereigntySystemsForCorporation(env, corporationId)
+			if (!sovereigntySystems) {
+				throw new Error('Complete shared sovereignty snapshot was unavailable after refresh')
+			}
+		}
 		const sovereigntyHubListing = await fetchStructureListing(
 			(page) =>
 				tokenStore.fetchEsi<{ sovereignty_hubs: Array<{ id: number; solar_system_id: number }> }>(
@@ -165,7 +179,7 @@ export async function fetchSovereigntyEnrichment(
 
 		if (collectedHubs.length === 0) {
 			return {
-				sovereigntySystems: null,
+				sovereigntySystems,
 				sovereigntyHubs: [],
 				pruneCandidateIds: [...sovereigntyHubResult.pruneCandidateIds],
 				failures: sovereigntyHubResult.failures,
@@ -179,27 +193,6 @@ export async function fetchSovereigntyEnrichment(
 		const systemGeography = await universe.resolveSolarSystemsByIds([
 			...new Set(collectedHubs.map((hub) => hub.system_id)),
 		])
-		let sovereigntySystems = await readSharedSovereigntySystemsByIds(
-			env,
-			collectedHubs.map((hub) => hub.system_id)
-		)
-		if (!sovereigntySystems) {
-			logger.warn(
-				'[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache',
-				{
-					corporationId,
-				}
-			)
-			await refreshSharedSovereigntySystems(env)
-			sovereigntySystems = await readSharedSovereigntySystemsByIds(
-				env,
-				collectedHubs.map((hub) => hub.system_id)
-			)
-			if (!sovereigntySystems) {
-				throw new Error('Shared sovereignty snapshot was unavailable after refresh')
-			}
-		}
-
 		const allianceBySystemId = buildSovereigntyAllianceBySystemId(sovereigntySystems)
 		const enrichedSovereigntyHubs = collectedHubs.map((hub) => ({
 			...hub,
@@ -209,7 +202,7 @@ export async function fetchSovereigntyEnrichment(
 
 		logger.debug('[StructuresStep] Fetched sovereignty structure enrichment', {
 			corporationId,
-			sovereigntySystems: sovereigntySystems?.length ?? 0,
+			sovereigntySystems: sovereigntySystems.length,
 			sovereigntyHubs: collectedHubs.length,
 			failureCount,
 		})
@@ -329,6 +322,7 @@ export async function storeSovereigntyEnrichment(
 	enrichment: SovereigntyEnrichmentData
 ): Promise<void> {
 	const corpData = getCorporationDataStub(env, corporationId)
+
 	await Promise.all([
 		enrichment.sovereigntySystems
 			? corpData.storeSovereigntySystems(corporationId, enrichment.sovereigntySystems)

--- a/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
@@ -14,15 +14,15 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Read the shared sovereignty snapshot subset for the requested system IDs if it is still fresh enough.
+ * Read the complete sovereignty-system slice owned by a corporation if the shared snapshot is fresh.
  */
-export async function readSharedSovereigntySystemsByIds(
+export async function readSharedSovereigntySystemsForCorporation(
 	env: Env,
-	systemIds: string[]
+	corporationId: string
 ): Promise<EsiSovereigntySystem[] | null> {
 	const globalCorpData = getGlobalCorporationDataStub(env)
-	return await globalCorpData.getSharedSovereigntySystemsByIds(
-		systemIds,
+	return await globalCorpData.getSharedSovereigntySystemsForCorporation(
+		corporationId,
 		SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
 	)
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"check:deps": "runx check --deps",
 		"check:format": "runx check --format",
 		"check:lint:all": "run-eslint",
+		"diagnose:sovereignty-alliance": "node scripts/diagnose-sovereignty-alliance.mjs",
 		"test": "vitest",
 		"test:ci": "run-vitest-ci"
 	},

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -1379,10 +1379,10 @@ export interface EveCorporationData {
 	releaseSharedSovereigntySystemsRefreshLease(leaseToken: string): Promise<void>
 
 	/**
-	 * Read a subset of the shared sovereignty system snapshot by system ID if it is still fresh.
+	 * Read the complete fresh shared sovereignty snapshot slice owned by a corporation.
 	 */
-	getSharedSovereigntySystemsByIds(
-		systemIds: string[],
+	getSharedSovereigntySystemsForCorporation(
+		corporationId: string,
 		maxAgeSeconds?: number
 	): Promise<EsiSovereigntySystem[] | null>
 

--- a/scripts/diagnose-sovereignty-alliance.mjs
+++ b/scripts/diagnose-sovereignty-alliance.mjs
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_ALLIANCE_ID = 498125261
+const DEFAULT_BASE_URL = 'https://esi.evetech.net'
+const DEFAULT_COMPATIBILITY_DATE = '2026-05-19'
+const EVE_OAUTH_METADATA_URL = 'https://login.eveonline.com/.well-known/oauth-authorization-server'
+const USER_AGENT = 'pleaseignore.app sovereignty diagnostic'
+
+function parseId(value) {
+	const id = Number(value)
+	if (!Number.isSafeInteger(id) || id <= 0) {
+		throw new Error(`Invalid owner ID: ${value}`)
+	}
+
+	return id
+}
+
+function parseArgs(args) {
+	const options = {
+		baseUrl: DEFAULT_BASE_URL,
+		compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
+		checkStructures: false,
+		json: false,
+		ownerId: DEFAULT_ALLIANCE_ID,
+		ownerType: 'alliance',
+	}
+
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index]
+		switch (argument) {
+			case '--alliance-id':
+				if (!args[index + 1]) {
+					throw new Error('--alliance-id requires a value')
+				}
+				if (options.ownerType === 'corporation') {
+					throw new Error('--alliance-id and --corporation-id cannot be used together')
+				}
+				options.ownerType = 'alliance'
+				options.ownerId = parseId(args[++index])
+				break
+			case '--corporation-id':
+				if (!args[index + 1]) {
+					throw new Error('--corporation-id requires a value')
+				}
+				if (options.ownerType === 'alliance' && options.ownerId !== DEFAULT_ALLIANCE_ID) {
+					throw new Error('--alliance-id and --corporation-id cannot be used together')
+				}
+				options.ownerType = 'corporation'
+				options.ownerId = parseId(args[++index])
+				break
+			case '--base-url':
+				if (!args[index + 1]) {
+					throw new Error('--base-url requires a value')
+				}
+				options.baseUrl = args[++index].replace(/\/+$/, '')
+				break
+			case '--compatibility-date':
+				if (!args[index + 1]) {
+					throw new Error('--compatibility-date requires a value')
+				}
+				options.compatibilityDate = args[++index]
+				break
+			case '--check-structures':
+				options.checkStructures = true
+				break
+			case '--json':
+				options.json = true
+				break
+			case '--help':
+				console.log(`Usage: node scripts/diagnose-sovereignty-alliance.mjs [options]
+
+Count sovereignty systems owned by an alliance or corporation using ESI's public endpoint.
+
+Options:
+  --alliance-id <id>  Alliance to inspect (default: ${DEFAULT_ALLIANCE_ID})
+  --corporation-id <id>
+                      Corporation to inspect instead of an alliance
+  --base-url <url>    ESI base URL (default: ${DEFAULT_BASE_URL})
+  --compatibility-date <date>
+                      ESI compatibility date (default: ${DEFAULT_COMPATIBILITY_DATE})
+  --check-structures  Refresh the ESI token and list/enrich all corporation sovereignty hubs
+  --json              Print structured JSON, including matching system IDs
+  --help              Show this help text`)
+				process.exit(0)
+			default:
+				throw new Error(`Unknown argument: ${argument}`)
+		}
+	}
+
+	return options
+}
+
+function isRecord(value) {
+	return typeof value === 'object' && value !== null
+}
+
+function parseEnvValue(rawValue) {
+	let value = ''
+	let quote = null
+
+	for (let index = 0; index < rawValue.length; index += 1) {
+		const character = rawValue[index]
+		if (quote) {
+			if (character === quote) {
+				quote = null
+			} else {
+				value += character
+			}
+			continue
+		}
+
+		if (character === '"' || character === "'") {
+			quote = character
+		} else if (character === '#' && (index === 0 || /\s/.test(rawValue[index - 1]))) {
+			break
+		} else {
+			value += character
+		}
+	}
+
+	return value.trim()
+}
+
+function loadEnvFile() {
+	const envPath = resolve(dirname(fileURLToPath(import.meta.url)), '../.env')
+
+	try {
+		const envContent = readFileSync(envPath, 'utf8')
+		for (const line of envContent.split('\n')) {
+			const trimmed = line.trim()
+			if (!trimmed || trimmed.startsWith('#')) continue
+
+			const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/)
+			if (!match) continue
+
+			const key = match[1].trim()
+			const value = parseEnvValue(match[2])
+
+			if (!process.env[key]) process.env[key] = value
+		}
+	} catch {
+		// The environment file is optional when the public-only check is used.
+	}
+}
+
+function getRequiredEnv(name) {
+	const value = process.env[name]?.trim()
+	if (!value) throw new Error(`Missing ${name} in .env or the process environment`)
+	return value
+}
+
+async function fetchJson(url, init, label) {
+	const response = await fetch(url, init)
+	if (!response.ok) {
+		const body = await response.text()
+		throw new Error(`${label} failed: ${response.status} ${response.statusText} - ${body}`)
+	}
+
+	return {
+		data: await response.json(),
+		headers: response.headers,
+	}
+}
+
+async function refreshAccessToken() {
+	const metadataResult = await fetchJson(
+		EVE_OAUTH_METADATA_URL,
+		{
+			headers: {
+				Accept: 'application/json',
+				'User-Agent': USER_AGENT,
+			},
+		},
+		'GET /.well-known/oauth-authorization-server'
+	)
+	if (!isRecord(metadataResult.data) || typeof metadataResult.data.token_endpoint !== 'string') {
+		throw new Error('OAuth metadata did not include a token endpoint')
+	}
+
+	const clientId = getRequiredEnv('DIAGNOSTIC_EVE_SSO_CLIENT_ID')
+	const clientSecret = getRequiredEnv('DIAGNOSTIC_EVE_SSO_CLIENT_SECRET')
+	const refreshToken = getRequiredEnv('DIAGNOSTIC_EVE_SSO_REFRESH_TOKEN')
+	const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+	const response = await fetch(metadataResult.data.token_endpoint, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			Authorization: `Basic ${credentials}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'User-Agent': USER_AGENT,
+		},
+		body: new URLSearchParams({
+			grant_type: 'refresh_token',
+			refresh_token: refreshToken,
+		}),
+	})
+
+	if (!response.ok) {
+		const body = await response.text()
+		throw new Error(`Refresh token exchange failed: ${response.status} ${response.statusText} - ${body}`)
+	}
+
+	const payload = await response.json()
+	if (!isRecord(payload) || typeof payload.access_token !== 'string') {
+		throw new Error('Refresh token exchange did not return an access token')
+	}
+
+	return payload.access_token
+}
+
+async function fetchCorporationSovereigntyHubs(corporationId, accessToken, baseUrl, compatibilityDate) {
+	const headers = {
+		Accept: 'application/json',
+		Authorization: `Bearer ${accessToken}`,
+		'User-Agent': USER_AGENT,
+		'X-Compatibility-Date': compatibilityDate,
+	}
+	const firstPage = await fetchJson(
+		`${baseUrl}/corporations/${corporationId}/structures/sovereignty-hubs?page=1`,
+		{ headers },
+		'GET /corporations/{corporation_id}/structures/sovereignty-hubs?page=1'
+	)
+
+	if (!isRecord(firstPage.data) || !Array.isArray(firstPage.data.sovereignty_hubs)) {
+		throw new Error('ESI returned an unexpected sovereignty hubs listing response')
+	}
+
+	const totalPages = Number(firstPage.headers.get('X-Pages') ?? '1')
+	if (!Number.isSafeInteger(totalPages) || totalPages < 1) {
+		throw new Error(`ESI returned an invalid sovereignty hubs page count: ${totalPages}`)
+	}
+
+	const listing = [...firstPage.data.sovereignty_hubs]
+	for (let page = 2; page <= totalPages; page += 1) {
+		const pageResult = await fetchJson(
+			`${baseUrl}/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
+			{ headers },
+			`GET /corporations/{corporation_id}/structures/sovereignty-hubs?page=${page}`
+		)
+		if (!isRecord(pageResult.data) || !Array.isArray(pageResult.data.sovereignty_hubs)) {
+			throw new Error(`ESI returned an unexpected response for sovereignty hubs page ${page}`)
+		}
+		listing.push(...pageResult.data.sovereignty_hubs)
+	}
+
+	if (
+		!listing.every(
+			(hub) =>
+				isRecord(hub) &&
+				Number.isSafeInteger(hub.id) &&
+				Number.isSafeInteger(hub.solar_system_id)
+		)
+	) {
+		throw new Error(
+			'ESI returned a sovereignty hub listing entry without valid structure and solar-system IDs'
+		)
+	}
+
+	return { listing, pages: totalPages }
+}
+
+async function enrichCorporationSovereigntyHubs(
+	corporationId,
+	accessToken,
+	baseUrl,
+	compatibilityDate,
+	hubs
+) {
+	const headers = {
+		Accept: 'application/json',
+		Authorization: `Bearer ${accessToken}`,
+		'User-Agent': USER_AGENT,
+		'X-Compatibility-Date': compatibilityDate,
+	}
+
+	const results = await Promise.all(
+		hubs.map(async (hub) => {
+			try {
+				const result = await fetchJson(
+					`${baseUrl}/corporations/${corporationId}/structures/sovereignty-hubs/${hub.id}`,
+					{ headers },
+					`GET /corporations/{corporation_id}/structures/sovereignty-hubs/${hub.id}`
+				)
+				const detail = result.data
+				return {
+					detail:
+						isRecord(detail) && Number.isSafeInteger(detail.id)
+							? {
+								id: detail.id,
+								solarSystemId: detail.solar_system_id,
+								controllerAllianceId: detail.controller_alliance_id ?? null,
+							}
+							: null,
+					hubId: hub.id,
+					error: null,
+				}
+			} catch (error) {
+				return {
+					detail: null,
+					hubId: hub.id,
+					error: error instanceof Error ? error.message : String(error),
+				}
+			}
+		})
+	)
+
+	return {
+		attemptedCount: results.length,
+		succeededCount: results.filter((result) => result.detail !== null).length,
+		failedCount: results.filter((result) => result.error !== null || result.detail === null).length,
+		details: results.flatMap((result) => (result.detail ? [result.detail] : [])),
+		failures: results
+			.filter((result) => result.error !== null || result.detail === null)
+			.map(({ hubId, error }) => ({ hubId, error: error ?? 'Invalid detail response' })),
+	}
+}
+
+async function main() {
+	loadEnvFile()
+	const options = parseArgs(process.argv.slice(2))
+	if (options.checkStructures && options.ownerType !== 'corporation') {
+		throw new Error('--check-structures requires --corporation-id')
+	}
+
+	const baseUrl = options.baseUrl.replace(/\/+$/, '')
+	const endpoint = `${baseUrl}/sovereignty/systems/`
+	const response = await fetch(endpoint, {
+		headers: {
+			Accept: 'application/json',
+			'X-Compatibility-Date': options.compatibilityDate,
+			'User-Agent': USER_AGENT,
+		},
+	})
+
+	if (!response.ok) {
+		throw new Error(`ESI request failed: ${response.status} ${response.statusText}`)
+	}
+
+	const payload = await response.json()
+	if (!isRecord(payload) || !Array.isArray(payload.solar_systems)) {
+		throw new Error('ESI returned an unexpected sovereignty systems response')
+	}
+
+	const matchingSystems = payload.solar_systems.filter(
+		(system) =>
+			isRecord(system) &&
+			isRecord(system.claim) &&
+			isRecord(system.claim.alliance) &&
+			system.claim.alliance[`${options.ownerType}_id`] === options.ownerId
+	)
+	const systemIds = matchingSystems.map((system) => system.solar_system_id)
+
+	if (!systemIds.every((systemId) => Number.isSafeInteger(systemId))) {
+		throw new Error('ESI returned a matching sovereignty system without a valid system ID')
+	}
+
+	systemIds.sort((left, right) => left - right)
+
+	const result = {
+		ownerId: options.ownerId,
+		ownerType: options.ownerType,
+		ownedSystemCount: matchingSystems.length,
+		systemIds,
+	}
+
+	if (options.checkStructures) {
+		const corporationId = options.ownerId
+		const accessToken = await refreshAccessToken()
+		const hubsListing = await fetchCorporationSovereigntyHubs(
+			corporationId,
+			accessToken,
+			baseUrl,
+			options.compatibilityDate
+		)
+		const enrichment = await enrichCorporationSovereigntyHubs(
+			corporationId,
+			accessToken,
+			baseUrl,
+			options.compatibilityDate,
+			hubsListing.listing
+		)
+		const publicSystemIdSet = new Set(systemIds)
+		const hubSystemIds = hubsListing.listing.map((hub) => hub.solar_system_id)
+		const hubSystemIdSet = new Set(hubSystemIds)
+		const missingFromHubListing = systemIds.filter((systemId) => !hubSystemIdSet.has(systemId))
+		const missingFromPublicListing = hubSystemIds.filter(
+			(systemId) => !publicSystemIdSet.has(systemId)
+		)
+
+		result.structures = {
+			pages: hubsListing.pages,
+			listedCount: hubsListing.listing.length,
+			listedIds: hubsListing.listing.map((hub) => hub.id),
+			listedSystemIds: [...hubSystemIdSet].sort((left, right) => left - right),
+			systemListingMatch: {
+				matches:
+					missingFromHubListing.length === 0 &&
+					missingFromPublicListing.length === 0 &&
+					publicSystemIdSet.size === systemIds.length &&
+					hubSystemIdSet.size === hubSystemIds.length,
+				publicSystemCount: publicSystemIdSet.size,
+				hubSystemCount: hubSystemIdSet.size,
+				missingFromHubListing,
+				missingFromPublicListing,
+			},
+			...enrichment,
+		}
+	}
+
+	if (options.json) {
+		console.log(JSON.stringify(result, null, 2))
+		return
+	}
+
+	const ownerLabel = options.ownerType === 'alliance' ? 'Alliance' : 'Corporation'
+	console.log(`${ownerLabel} ${result.ownerId} owns ${result.ownedSystemCount} sovereignty systems.`)
+	if (systemIds.length > 0) {
+		console.log(`System IDs: ${systemIds.join(', ')}`)
+	}
+	if (result.structures) {
+		console.log(
+			`Sovereignty hub listing: ${result.structures.listedCount} structures across ${result.structures.pages} page(s).`
+		)
+		const systemListingMatch = result.structures.systemListingMatch
+		console.log(
+			`Sovereignty system listing match: ${systemListingMatch.matches ? 'yes' : 'no'} (${systemListingMatch.publicSystemCount} public, ${systemListingMatch.hubSystemCount} hub).`
+		)
+		if (!systemListingMatch.matches) {
+			console.log(
+				`Missing from hub listing: ${JSON.stringify(systemListingMatch.missingFromHubListing)}`
+			)
+			console.log(
+				`Missing from public listing: ${JSON.stringify(systemListingMatch.missingFromPublicListing)}`
+			)
+		}
+		console.log(
+			`Sovereignty hub enrichment: ${result.structures.succeededCount}/${result.structures.attemptedCount} succeeded.`
+		)
+		if (result.structures.failedCount > 0) {
+			console.log(`Enrichment failures: ${JSON.stringify(result.structures.failures)}`)
+		}
+	}
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : error)
+	process.exitCode = 1
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes incomplete/incorrect sovereignty data for corporations by making the shared sovereignty-systems cache detect partial writes, and by scoping structure enrichment lookups to a corporation's full sovereignty slice instead of a system-ID subset. Also adds a standalone diagnostic script for verifying an alliance's/corporation's sovereignty ownership against ESI.

## Changes
- Track a `SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY` alongside the existing cache metadata, and validate that the number of stored rows matches the expected count before treating the shared sovereignty cache as fresh (`getSharedSovereigntySystemsForCorporation`, `getSharedSovereigntySystemsSnapshot`, `hasFreshSharedSovereigntySystems`) — guards against reading a stale/partial cache.
- Replace `getSharedSovereigntySystemsByIds`/`readSharedSovereigntySystemsByIds` (lookup by a list of system IDs) with `getSharedSovereigntySystemsForCorporation`/`readSharedSovereigntySystemsForCorporation`, which returns all `alliance`-claimed sovereignty systems owned by a given corporation from the shared snapshot.
- Update `fetchSovereigntyEnrichment` to fetch the corporation's sovereignty slice up front (rewarming the shared cache if missing/stale) before resolving sovereignty hubs, rather than looking up by hub system IDs after fetching structures.
- Route the scheduled background refresh through `ensureSharedSovereigntySystems`, which only refreshes the shared cache when it isn't already fresh, instead of calling `refreshSharedSovereigntySystems` unconditionally.
- Add `scripts/diagnose-sovereignty-alliance.mjs` (and a `diagnose:sovereignty-alliance` root package script) to independently query ESI's public sovereignty-systems endpoint and, optionally, a corporation's authenticated sovereignty-hub structures, to cross-check ownership counts and surface listing mismatches.

## Testing
- Updated `structure-enrichment.test.ts` unit tests to mock `readSharedSovereigntySystemsForCorporation` (called with the corporation ID) instead of the old by-system-IDs lookup.
<!-- claude:end -->