### PR TITLE
try to fix bills workflow lifecycle error

### DIFF
--- a/apps/bills/src/db/index.ts
+++ b/apps/bills/src/db/index.ts
@@ -4,30 +4,13 @@ import * as schema from './schema'
 
 import type { DbClient } from '@repo/db-utils'
 
-export interface CreateDbOptions {
-	queryTimeoutMs?: number
-}
-
 /**
  * Create a database client instance
  * @param databaseUrl - The Neon database connection URL
  * @returns A configured Drizzle database client
  */
-export function createDb(
-	databaseUrl: string,
-	options: CreateDbOptions = {}
-): DbClient<typeof schema> {
-	return createDbClient(
-		databaseUrl,
-		schema,
-		options.queryTimeoutMs === undefined
-			? undefined
-			: {
-					// Neon HTTP requests otherwise have no application-level deadline. Keep a
-					// stalled request from outliving the Workflow step that owns this client.
-					fetchOptions: { signal: AbortSignal.timeout(options.queryTimeoutMs) },
-				}
-	)
+export function createDb(databaseUrl: string): DbClient<typeof schema> {
+	return createDbClient(databaseUrl, schema)
 }
 
 export type BillsDb = ReturnType<typeof createDb>

--- a/apps/bills/src/workflows/bill-payment-status-check.ts
+++ b/apps/bills/src/workflows/bill-payment-status-check.ts
@@ -15,8 +15,6 @@ import type { BillStatus } from '@repo/bills'
 import type { Env } from '../context'
 import type { WorkflowContext } from './context'
 
-const DATABASE_QUERY_TIMEOUT_MS = 25_000
-
 const TAX_SYNC_ACTOR = 'system:bills:payment-status-check'
 type CorporationTaxSyncStub = {
 	syncBillStatus(
@@ -72,7 +70,7 @@ export class BillPaymentStatusCheckWorkflow extends WorkflowEntrypoint<Env, Work
 	 * MUST be called inside step.do() callbacks since services don't survive hibernation.
 	 */
 	private createContext(billId: string, workflowInstanceId: string): WorkflowContext {
-		const db = createDb(this.env.DATABASE_URL, { queryTimeoutMs: DATABASE_QUERY_TIMEOUT_MS })
+		const db = createDb(this.env.DATABASE_URL)
 		return {
 			env: this.env,
 			workflowInstanceId,


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Reverts the per-query database timeout mechanism added in #591 for the bills payment-status-check workflow, since it's causing a Workflow lifecycle error.

## Changes
- Removed `CreateDbOptions`/`queryTimeoutMs` from `createDb()` in `apps/bills/src/db/index.ts`; it now calls `createDbClient()` with no extra fetch options.
- Removed the `AbortSignal.timeout(...)`-based `fetchOptions` deadline that was passed to Neon's HTTP driver.
- Removed the now-unused `DATABASE_QUERY_TIMEOUT_MS` constant and stopped passing `queryTimeoutMs` when creating the DB client in `BillPaymentStatusCheckWorkflow.createContext()`.
<!-- claude:end -->