### PR TITLE
improve mumble sync timing and host/port copying.

### DIFF
--- a/apps/core/src/routes/__tests__/mumble.route.test.ts
+++ b/apps/core/src/routes/__tests__/mumble.route.test.ts
@@ -10,6 +10,7 @@ import type { App, SessionUser } from '../../context'
 
 const {
 	getMumbleAccountMock,
+	syncMumbleAccountIfDueMock,
 	provisionMumbleAccountMock,
 	resetMumblePasswordMock,
 	getMumbleConnectionInfoMock,
@@ -17,6 +18,7 @@ const {
 	featuresStub,
 } = vi.hoisted(() => ({
 	getMumbleAccountMock: vi.fn(),
+	syncMumbleAccountIfDueMock: vi.fn(),
 	provisionMumbleAccountMock: vi.fn(),
 	resetMumblePasswordMock: vi.fn(),
 	getMumbleConnectionInfoMock: vi.fn(() => ({ host: 'voice.test', port: 64738 })),
@@ -28,6 +30,7 @@ const {
 
 vi.mock('../../services/mumble.service', () => ({
 	getMumbleAccount: getMumbleAccountMock,
+	syncMumbleAccountIfDue: syncMumbleAccountIfDueMock,
 	provisionMumbleAccount: provisionMumbleAccountMock,
 	resetMumblePassword: resetMumblePasswordMock,
 	getMumbleConnectionInfo: getMumbleConnectionInfoMock,
@@ -71,6 +74,7 @@ function makeApp(user?: SessionUser) {
 beforeEach(() => {
 	vi.clearAllMocks()
 	getMumbleConnectionInfoMock.mockReturnValue({ host: 'voice.test', port: 64738 })
+	syncMumbleAccountIfDueMock.mockResolvedValue(undefined)
 	getStubMock.mockImplementation((namespace: any) => {
 		if (namespace === env.FEATURES) return featuresStub as any
 		throw new Error('Unexpected namespace')
@@ -79,10 +83,12 @@ beforeEach(() => {
 })
 
 describe('GET /api/mumble/account', () => {
+	const executionContext = { waitUntil: vi.fn() } as any
+
 	it('returns 404 when the mumble feature flag is disabled', async () => {
 		featuresStub.checkFlag.mockResolvedValue(false)
 
-		const res = await makeApp(makeUser()).request('/api/mumble/account', {}, env)
+		const res = await makeApp(makeUser()).request('/api/mumble/account', {}, env, executionContext)
 
 		expect(res.status).toBe(404)
 	})
@@ -100,12 +106,22 @@ describe('GET /api/mumble/account', () => {
 	it('returns account and connection info', async () => {
 		getMumbleAccountMock.mockResolvedValue({ subjectId: 'u1', loginName: 'pilot' })
 
-		const res = await makeApp(makeUser()).request('/api/mumble/account', {}, env)
+		const res = await makeApp(makeUser()).request('/api/mumble/account', {}, env, executionContext)
 
 		expect(res.status).toBe(200)
 		const body = (await res.json()) as any
 		expect(body.account.loginName).toBe('pilot')
 		expect(body.connection).toEqual({ host: 'voice.test', port: 64738 })
+		expect(syncMumbleAccountIfDueMock).toHaveBeenCalledWith(env, makeUser().id)
+	})
+
+	it('does not start a sync when no Mumble account exists', async () => {
+		getMumbleAccountMock.mockResolvedValue(null)
+
+		const res = await makeApp(makeUser()).request('/api/mumble/account', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(syncMumbleAccountIfDueMock).not.toHaveBeenCalled()
 	})
 
 	it('falls back to an empty state when the Mumble RPC transport is unavailable', async () => {

--- a/apps/core/src/routes/mumble.ts
+++ b/apps/core/src/routes/mumble.ts
@@ -1,12 +1,12 @@
 import { Hono } from 'hono'
 
+import { MUMBLE_FEATURE_FLAG_KEY } from '@repo/features'
 import { logger } from '@repo/hono-helpers'
 import { parseMumbleError } from '@repo/mumble'
-import { MUMBLE_FEATURE_FLAG_KEY } from '@repo/features'
 
 import { requireAllianceMember } from '../middleware/session'
-import { resolveFlag } from './flags'
 import * as mumbleService from '../services/mumble.service'
+import { resolveFlag } from './flags'
 
 import type { Context } from 'hono'
 import type { App } from '../context'
@@ -62,6 +62,16 @@ mumble.get('/account', async (c) => {
 
 	try {
 		const account = await mumbleService.getMumbleAccount(c.env, user.id)
+		if (account) {
+			c.executionCtx.waitUntil(
+				mumbleService.syncMumbleAccountIfDue(c.env, user.id).catch((error) => {
+					logger.warn('[Mumble] On-demand account sync failed', {
+						userId: user.id,
+						error: error instanceof Error ? error.message : String(error),
+					})
+				})
+			)
+		}
 		return c.json({
 			account,
 			connection: mumbleService.getMumbleConnectionInfo(c.env),

--- a/apps/core/src/services/mumble.service.ts
+++ b/apps/core/src/services/mumble.service.ts
@@ -5,10 +5,10 @@ import { logger } from '@repo/hono-helpers'
 import { parseMumbleError } from '@repo/mumble'
 
 import { createDb } from '../db'
+import { mumbleTempopGuests, mumbleTempops, userCharacters, users } from '../db/schema'
 import { getCachedUserRoles } from '../lib/groups-cache'
 import { isMumbleFeatureEnabled } from '../lib/mumble-feature'
 import { hasMemberCorporationAttachment } from '../lib/service-eligibility'
-import { mumbleTempopGuests, mumbleTempops, userCharacters, users } from '../db/schema'
 
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
@@ -43,6 +43,8 @@ const ALLIANCE_MEMBER_MUMBLE_GROUP = 'Test Alliance'
 export const TEMPOP_GROUP_NAME = 'TempOp'
 const USER_GROUP_LOOKUP_CONCURRENCY = 5
 const USER_PROFILE_LOOKUP_CONCURRENCY = 5
+const ON_DEMAND_SYNC_COOLDOWN_MS = 5 * 60 * 1000
+const ON_DEMAND_SYNC_LEASE_MS = 60 * 1000
 interface MumbleIdentity {
 	characterName: string
 	displayName: string
@@ -75,7 +77,10 @@ export function deriveLoginName(characterName: string, userId: string): string {
 }
 
 function normalizeMumbleTicker(ticker?: string | null): string | null {
-	const normalized = ticker?.trim().toUpperCase().replace(/[^A-Z0-9]/g, '')
+	const normalized = ticker
+		?.trim()
+		.toUpperCase()
+		.replace(/[^A-Z0-9]/g, '')
 	if (!normalized) {
 		return null
 	}
@@ -123,10 +128,7 @@ async function buildMumbleIdentity(env: Env, userId: string): Promise<MumbleIden
 	const [corpTicker, groupTickers] = await Promise.all([
 		corporationId
 			? (async () => {
-					const corpStub = getStub<EveCorporationData>(
-						env.EVE_CORPORATION_DATA,
-						corporationId
-					)
+					const corpStub = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, corporationId)
 					const corpInfo = await corpStub.getCorporationInfo(corporationId)
 					return normalizeMumbleTicker(corpInfo?.ticker)
 				})()
@@ -257,6 +259,40 @@ export async function getMumbleAccount(
 	userId: string
 ): Promise<MumbleAccountStatus | null> {
 	return getMumbleStub(env).getAccount(env.MUMBLE_SERVER_ID, userId)
+}
+
+/**
+ * Refresh a provisioned user's Mumble groups and profile at account-view time.
+ * The Mumble DO owns the cooldown and short lease so concurrent requests and
+ * separate Core isolates cannot fan out duplicate refreshes.
+ */
+export async function syncMumbleAccountIfDue(env: Env, userId: string): Promise<void> {
+	const mumble = getMumbleStub(env)
+	const lease = await mumble.tryClaimUserSync(
+		env.MUMBLE_SERVER_ID,
+		userId,
+		ON_DEMAND_SYNC_COOLDOWN_MS,
+		ON_DEMAND_SYNC_LEASE_MS
+	)
+	if (!lease) return
+
+	try {
+		await Promise.all([
+			syncUsersMumbleGroups(env, [userId], 'account-view'),
+			syncUsersMumbleProfiles(env, [userId]),
+		])
+		await mumble.completeUserSync(env.MUMBLE_SERVER_ID, userId, lease.token)
+	} catch (error) {
+		await mumble
+			.releaseUserSync(env.MUMBLE_SERVER_ID, userId, lease.token)
+			.catch((releaseError) => {
+				logger.error('[Mumble] Failed to release on-demand sync lease', {
+					userId,
+					error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+				})
+			})
+		throw error
+	}
 }
 
 /**

--- a/apps/mumble/src/durable-object.ts
+++ b/apps/mumble/src/durable-object.ts
@@ -39,6 +39,19 @@ const PENDING_DELETE_PREFIX = 'pending-delete:'
 /** Retry interval for pending deletions */
 const PENDING_DELETE_RETRY_MS = 5 * 60 * 1000
 
+/** Durable state prefix for on-demand user sync cooldown leases. */
+const USER_SYNC_PREFIX = 'user-sync:'
+/** Keep temporary sync state only until the cooldown has elapsed. */
+const USER_SYNC_DEFAULT_COOLDOWN_MS = 5 * 60 * 1000
+
+interface UserSyncState {
+	completedAt: number
+	cooldownMs: number
+	leaseToken: string | null
+	leaseUntil: number
+	cleanupAt: number
+}
+
 /**
  * Assignments at or below this count are existence-checked per subject;
  * larger batches use a single full user-state read instead.
@@ -263,6 +276,123 @@ export class MumbleDO extends DurableObject<Env> implements Mumble {
 		} catch (error) {
 			this.handleError(error, 'getAccount', serverId)
 		}
+	}
+
+	private userSyncKey(subjectId: string): string {
+		return `${USER_SYNC_PREFIX}${subjectId}`
+	}
+
+	async tryClaimUserSync(
+		_serverId: string,
+		subjectId: string,
+		cooldownMs: number,
+		leaseMs: number,
+		nowMs = Date.now()
+	): Promise<{ token: string } | null> {
+		if (cooldownMs < 0 || leaseMs <= 0) {
+			throw new Error('User sync cooldown and lease must be non-negative and positive respectively')
+		}
+
+		return this.serialize(async () => {
+			const key = this.userSyncKey(subjectId)
+			const current = (await this.state.storage.get<UserSyncState>(key)) ?? {
+				completedAt: 0,
+				cooldownMs,
+				leaseToken: null,
+				leaseUntil: 0,
+				cleanupAt: 0,
+			}
+			const cleanupAt =
+				current.cleanupAt > 0
+					? current.cleanupAt
+					: current.completedAt > 0
+						? current.completedAt + (current.cooldownMs || cooldownMs)
+						: current.leaseUntil
+
+			if (current.leaseToken && current.leaseUntil > nowMs) {
+				return null
+			}
+			if (cleanupAt > nowMs) {
+				return null
+			}
+
+			const token = crypto.randomUUID()
+			await this.state.storage.put(key, {
+				completedAt: current.completedAt,
+				cooldownMs,
+				leaseToken: token,
+				leaseUntil: nowMs + leaseMs,
+				cleanupAt: nowMs + leaseMs,
+			})
+			await this.scheduleUserSyncAlarm(nowMs + leaseMs)
+			return { token }
+		})
+	}
+
+	async completeUserSync(
+		_serverId: string,
+		subjectId: string,
+		token: string,
+		nowMs = Date.now()
+	): Promise<void> {
+		await this.serialize(async () => {
+			const key = this.userSyncKey(subjectId)
+			const current = await this.state.storage.get<UserSyncState>(key)
+			if (current?.leaseToken !== token) return
+			await this.state.storage.put(key, {
+				completedAt: nowMs,
+				cooldownMs: current.cooldownMs || USER_SYNC_DEFAULT_COOLDOWN_MS,
+				leaseToken: null,
+				leaseUntil: 0,
+				cleanupAt: nowMs + (current.cooldownMs || USER_SYNC_DEFAULT_COOLDOWN_MS),
+			})
+			await this.scheduleUserSyncAlarm(
+				nowMs + (current.cooldownMs || USER_SYNC_DEFAULT_COOLDOWN_MS)
+			)
+		})
+	}
+
+	async releaseUserSync(_serverId: string, subjectId: string, token: string): Promise<void> {
+		await this.serialize(async () => {
+			const key = this.userSyncKey(subjectId)
+			const current = await this.state.storage.get<UserSyncState>(key)
+			if (current?.leaseToken !== token) return
+			await this.state.storage.delete(key)
+		})
+	}
+
+	private async scheduleUserSyncAlarm(scheduledAt: number): Promise<void> {
+		const existingAlarm = await this.state.storage.getAlarm()
+		const nowMs = Date.now()
+		if (existingAlarm === null || existingAlarm <= nowMs || existingAlarm > scheduledAt) {
+			await this.state.storage.setAlarm(scheduledAt)
+		}
+	}
+
+	private async cleanupUserSyncStates(nowMs: number): Promise<number | null> {
+		const entries = await this.state.storage.list<UserSyncState>({ prefix: USER_SYNC_PREFIX })
+		let nextCleanupAt: number | null = null
+		const expiredKeys: string[] = []
+
+		for (const [key, state] of entries) {
+			const cleanupAt =
+				state.cleanupAt > 0
+					? state.cleanupAt
+					: state.completedAt > 0
+						? state.completedAt + (state.cooldownMs || USER_SYNC_DEFAULT_COOLDOWN_MS)
+						: state.leaseUntil
+			if (cleanupAt <= nowMs) {
+				expiredKeys.push(key)
+			} else if (nextCleanupAt === null || cleanupAt < nextCleanupAt) {
+				nextCleanupAt = cleanupAt
+			}
+		}
+
+		if (expiredKeys.length > 0) {
+			await this.state.storage.delete(expiredKeys)
+		}
+
+		return nextCleanupAt
 	}
 
 	/**
@@ -494,7 +624,16 @@ export class MumbleDO extends DurableObject<Env> implements Mumble {
 		const pendingEntries = await this.state.storage.list<number>({
 			prefix: PENDING_DELETE_PREFIX,
 		})
-		if (pendingEntries.size === 0) return
+		const nowMs = Date.now()
+		const nextUserSyncCleanupAt = await this.cleanupUserSyncStates(nowMs)
+		if (pendingEntries.size === 0) {
+			if (nextUserSyncCleanupAt === null) {
+				await this.state.storage.deleteAlarm()
+			} else {
+				await this.state.storage.setAlarm(nextUserSyncCleanupAt)
+			}
+			return
+		}
 
 		// Group queued subjects by serverId. subjectIds are UUIDs (no colons),
 		// so the last colon separates serverId from subjectId.
@@ -520,6 +659,19 @@ export class MumbleDO extends DurableObject<Env> implements Mumble {
 					resolved.map((subjectId) => `${PENDING_DELETE_PREFIX}${serverId}:${subjectId}`)
 				)
 			}
+		}
+
+		const remainingPendingEntries = await this.state.storage.list<number>({
+			prefix: PENDING_DELETE_PREFIX,
+		})
+		if (remainingPendingEntries.size === 0) {
+			if (nextUserSyncCleanupAt === null) {
+				await this.state.storage.deleteAlarm()
+			} else {
+				await this.state.storage.setAlarm(nextUserSyncCleanupAt)
+			}
+		} else if (nextUserSyncCleanupAt !== null) {
+			await this.scheduleUserSyncAlarm(nextUserSyncCleanupAt)
 		}
 	}
 }

--- a/apps/mumble/src/test/durable-object.test.ts
+++ b/apps/mumble/src/test/durable-object.test.ts
@@ -53,11 +53,16 @@ function makeFakeStorage() {
 	const data = new Map<string, unknown>()
 	return {
 		data,
-		put: vi.fn(async (entries: Record<string, unknown>) => {
-			for (const [key, value] of Object.entries(entries)) data.set(key, value)
+		get: vi.fn(async (key: string) => data.get(key)),
+		put: vi.fn(async (keyOrEntries: string | Record<string, unknown>, value?: unknown) => {
+			if (typeof keyOrEntries === 'string') {
+				data.set(keyOrEntries, value)
+				return
+			}
+			for (const [key, entryValue] of Object.entries(keyOrEntries)) data.set(key, entryValue)
 		}),
-		delete: vi.fn(async (keys: string[]) => {
-			for (const key of keys) data.delete(key)
+		delete: vi.fn(async (keys: string | string[]) => {
+			for (const key of typeof keys === 'string' ? [keys] : keys) data.delete(key)
 		}),
 		list: vi.fn(async ({ prefix }: { prefix: string }) => {
 			const result = new Map<string, unknown>()
@@ -68,6 +73,7 @@ function makeFakeStorage() {
 		}),
 		getAlarm: vi.fn(async () => null),
 		setAlarm: vi.fn(async () => undefined),
+		deleteAlarm: vi.fn(async () => undefined),
 	}
 }
 
@@ -84,6 +90,9 @@ function makeFakeThis(client: FakeClient, overrides: Record<string, unknown> = {
 		takeToken: proto.takeToken,
 		handleError: proto.handleError,
 		resolveLoginName: proto.resolveLoginName,
+		userSyncKey: proto.userSyncKey,
+		scheduleUserSyncAlarm: proto.scheduleUserSyncAlarm,
+		cleanupUserSyncStates: proto.cleanupUserSyncStates,
 		findProvisionedSubjects: proto.findProvisionedSubjects,
 		deleteAccountsInner: proto.deleteAccountsInner,
 		queuePendingDeletes: proto.queuePendingDeletes,
@@ -188,6 +197,93 @@ describe('MumbleDO.provisionAccount', () => {
 			'busy'
 		)
 		expect(client.getLocalAccount).not.toHaveBeenCalled()
+	})
+})
+
+describe('MumbleDO user sync leases', () => {
+	it('allows one claim and suppresses concurrent claims', async () => {
+		const client = makeFakeClient()
+		const state = makeFakeThis(client) as any
+
+		const first = await MumbleDO.prototype.tryClaimUserSync.call(
+			state,
+			'srv',
+			'user-1',
+			300_000,
+			60_000,
+			1_000
+		)
+		const second = await MumbleDO.prototype.tryClaimUserSync.call(
+			state,
+			'srv',
+			'user-1',
+			300_000,
+			60_000,
+			1_001
+		)
+
+		expect(first).toEqual({ token: expect.any(String) })
+		expect(second).toBeNull()
+	})
+
+	it('starts a new claim after completion and cooldown expiry', async () => {
+		const client = makeFakeClient()
+		const state = makeFakeThis(client) as any
+
+		const first = await MumbleDO.prototype.tryClaimUserSync.call(
+			state,
+			'srv',
+			'user-1',
+			300_000,
+			60_000,
+			1_000
+		)
+		await MumbleDO.prototype.completeUserSync.call(state, 'srv', 'user-1', first!.token, 1_001)
+
+		const duringCooldown = await MumbleDO.prototype.tryClaimUserSync.call(
+			state,
+			'srv',
+			'user-1',
+			300_000,
+			60_000,
+			299_999
+		)
+		const afterCooldown = await MumbleDO.prototype.tryClaimUserSync.call(
+			state,
+			'srv',
+			'user-1',
+			300_000,
+			60_000,
+			301_001
+		)
+
+		expect(duringCooldown).toBeNull()
+		expect(afterCooldown).toEqual({ token: expect.any(String) })
+	})
+
+	it('releases a failed claim so it can be retried immediately', async () => {
+		const client = makeFakeClient()
+		const state = makeFakeThis(client) as any
+
+		const first = await MumbleDO.prototype.tryClaimUserSync.call(
+			state,
+			'srv',
+			'user-1',
+			300_000,
+			60_000,
+			1_000
+		)
+		await MumbleDO.prototype.releaseUserSync.call(state, 'srv', 'user-1', first!.token)
+		const retry = await MumbleDO.prototype.tryClaimUserSync.call(
+			state,
+			'srv',
+			'user-1',
+			300_000,
+			60_000,
+			1_001
+		)
+
+		expect(retry).toEqual({ token: expect.any(String) })
 	})
 })
 
@@ -347,6 +443,32 @@ describe('MumbleDO.deleteAccounts', () => {
 })
 
 describe('MumbleDO.alarm', () => {
+	it('cleans up completed and abandoned user sync state', async () => {
+		const client = makeFakeClient()
+		const fakeThis = makeFakeThis(client)
+		const now = Date.now()
+		fakeThis.state.storage.data.set('user-sync:completed', {
+			completedAt: now - 301_000,
+			cooldownMs: 300_000,
+			leaseToken: null,
+			leaseUntil: 0,
+			cleanupAt: now - 1,
+		})
+		fakeThis.state.storage.data.set('user-sync:abandoned', {
+			completedAt: 0,
+			cooldownMs: 300_000,
+			leaseToken: 'stale-lease',
+			leaseUntil: now - 1,
+			cleanupAt: now - 1,
+		})
+
+		await (MumbleDO.prototype.alarm as () => Promise<void>).call(fakeThis as any)
+
+		expect(fakeThis.state.storage.data.has('user-sync:completed')).toBe(false)
+		expect(fakeThis.state.storage.data.has('user-sync:abandoned')).toBe(false)
+		expect(fakeThis.state.storage.deleteAlarm).toHaveBeenCalledTimes(1)
+	})
+
 	it('retries queued deletions and clears confirmed entries', async () => {
 		const client = makeFakeClient()
 		client.getLocalAccount.mockResolvedValue(SNAPSHOT)

--- a/apps/ui/src/client/features/mumble/components/credentials-card.tsx
+++ b/apps/ui/src/client/features/mumble/components/credentials-card.tsx
@@ -68,14 +68,11 @@ export function useCopyField() {
 }
 
 /** One-time credentials card shown after provisioning or a password reset. */
-export function OneTimeCredentialsCard({
-	credentials,
-}: {
-	credentials: MumbleOneTimeCredentials
-}) {
+export function OneTimeCredentialsCard({ credentials }: { credentials: MumbleOneTimeCredentials }) {
 	const { copiedField, copyToClipboard } = useCopyField()
 	const mumbleUrl = buildMumbleUrl(credentials)
-	const server = `${credentials.connection.host}:${credentials.connection.port}`
+	const server = credentials.connection.host
+	const port = String(credentials.connection.port)
 
 	return (
 		<Card variant="default" className="border-amber-500/50">
@@ -85,8 +82,8 @@ export function OneTimeCredentialsCard({
 					Your Mumble credentials
 				</CardTitle>
 				<CardDescription>
-					The password below is shown only once and cannot be recovered. Save the server,
-					username, and password somewhere safe before you leave this page.
+					The password below is shown only once and cannot be recovered. Save the server, username,
+					and password somewhere safe before you leave this page.
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-3">
@@ -111,6 +108,12 @@ export function OneTimeCredentialsCard({
 					value={server}
 					copied={copiedField === 'server'}
 					onCopy={() => copyToClipboard(server, 'server', 'Server')}
+				/>
+				<CopyRow
+					label="Port"
+					value={port}
+					copied={copiedField === 'port'}
+					onCopy={() => copyToClipboard(port, 'port', 'Port')}
 				/>
 				<div className="pt-3">
 					<Button asChild variant="primary" className="justify-center gap-2">

--- a/apps/ui/src/client/features/mumble/hooks.ts
+++ b/apps/ui/src/client/features/mumble/hooks.ts
@@ -1,14 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { mumbleKeys } from './query-keys'
 import { apiClient } from '@/lib/api'
+
+import { mumbleKeys } from './query-keys'
 
 /** Current user's Mumble account status + connection info. */
 export function useMumbleAccount(enabled = true) {
 	return useQuery({
 		queryKey: mumbleKeys.account(),
 		queryFn: () => apiClient.getMumbleAccount(),
-		staleTime: 1000 * 30,
+		// The API performs a best-effort on-demand sync with its own durable
+		// cooldown. Do not turn tab focus into a recurring sync trigger.
+		staleTime: 1000 * 60 * 5,
+		refetchOnWindowFocus: false,
 		enabled,
 	})
 }

--- a/apps/ui/src/test/unit/features/mumble/credentials-card.unit.test.tsx
+++ b/apps/ui/src/test/unit/features/mumble/credentials-card.unit.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { OneTimeCredentialsCard } from '@/features/mumble/components/credentials-card'
+
+describe('OneTimeCredentialsCard', () => {
+	it('renders copyable connection fields in Mumble form order', () => {
+		const html = renderToStaticMarkup(
+			<OneTimeCredentialsCard
+				credentials={{
+					loginName: 'Pilot One',
+					password: 'secret',
+					connection: { host: 'voice.example.test', port: 64738 },
+				}}
+			/>
+		)
+
+		const usernameIndex = html.indexOf('Pilot One')
+		const passwordIndex = html.indexOf('secret')
+		const serverIndex = html.indexOf('voice.example.test')
+		const portIndex = html.indexOf('64738')
+
+		expect(usernameIndex).toBeGreaterThan(-1)
+		expect(passwordIndex).toBeGreaterThan(usernameIndex)
+		expect(serverIndex).toBeGreaterThan(passwordIndex)
+		expect(portIndex).toBeGreaterThan(serverIndex)
+	})
+})

--- a/packages/mumble/src/index.ts
+++ b/packages/mumble/src/index.ts
@@ -116,6 +116,11 @@ export interface MumbleSyncProfilesResult {
 	skipped: string[]
 }
 
+/** A short-lived lease used to coalesce on-demand account refreshes. */
+export interface MumbleUserSyncLease {
+	token: string
+}
+
 export interface MumbleDeleteResult {
 	/** Subjects deleted from murmur-control */
 	deleted: string[]
@@ -160,6 +165,24 @@ export interface Mumble extends DurableObject {
 
 	/** Get account status, or null if the subject has no account. */
 	getAccount(serverId: string, subjectId: string): Promise<MumbleAccountStatus | null>
+
+	/** Claim the right to perform a user refresh when its cooldown has elapsed. */
+	tryClaimUserSync(
+		serverId: string,
+		subjectId: string,
+		cooldownMs: number,
+		leaseMs: number,
+		nowMs?: number
+	): Promise<MumbleUserSyncLease | null>
+
+	/** Complete or release a previously claimed on-demand user refresh. */
+	completeUserSync(
+		serverId: string,
+		subjectId: string,
+		token: string,
+		nowMs?: number
+	): Promise<void>
+	releaseUserSync(serverId: string, subjectId: string, token: string): Promise<void>
 
 	/**
 	 * Replace group sets for the given subjects (batch-first; pass 1 or N).


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a best-effort, server-side on-demand sync of Mumble groups/profile when a user views their Mumble account, and splits the connection info in the UI credentials card into separate copyable Server and Port fields.

## Changes
- GET /api/mumble/account now kicks off a background sync via syncMumbleAccountIfDue when the user already has a Mumble account.
- mumble.service.ts adds syncMumbleAccountIfDue, which claims a short-lived lease from the Mumble Durable Object, runs group and profile sync, then completes or releases the lease on failure.
- MumbleDO adds tryClaimUserSync, completeUserSync, and releaseUserSync RPC methods that track a per-user cooldown and lease so concurrent requests or isolates cannot fan out duplicate syncs.
- MumbleDO alarm handler now also cleans up expired or abandoned user-sync state alongside its existing pending-delete handling.
- packages/mumble adds the MumbleUserSyncLease type and the new DO interface methods.
- UI OneTimeCredentialsCard now renders separate Server and Port copy rows instead of a combined host:port string.
- useMumbleAccount hook increases staleTime to 5 minutes and disables refetchOnWindowFocus, since refresh is now driven server side on account view.
- Minor import ordering cleanups with no behavior change.

## Testing
- Added unit tests for MumbleDO lease claim, complete, release, and cooldown behavior, plus alarm-driven cleanup of user-sync state.
- Updated route tests for the mumble account endpoint to verify sync is triggered when an account exists and skipped otherwise.
- Added a UI test asserting the credentials card renders username, password, server, and port in the expected order.
<!-- claude:end -->
