### PR TITLE
fix SMB display on SRP requests

### DIFF
--- a/apps/core/src/lib/__tests__/srp-killmail-item-names.test.ts
+++ b/apps/core/src/lib/__tests__/srp-killmail-item-names.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { collectKillmailItemTypeIds } from '@repo/srp'
+
+describe('collectKillmailItemTypeIds', () => {
+	it('collects ship maintenance bay contents for visible item metadata', () => {
+		const ids = collectKillmailItemTypeIds([
+			{
+				flag: 90,
+				item_type_id: 11400,
+				items: [{ flag: 27, item_type_id: 4292 }],
+			},
+		] as never)
+
+		expect(ids).toEqual(['11400', '4292'])
+	})
+})

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -2,19 +2,18 @@ import { DurableObject } from 'cloudflare:workers'
 
 import { and, asc, desc, eq, gte, ilike, inArray, lte, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import type { CharacterKillmailBasic } from '@repo/esi'
 import { buildPublicEsiUserKey, EsiRateLimitGuard, EsiRateLimitStore } from '@repo/esi-rate-limit'
 import { createEveRegionId, createEveTypeId } from '@repo/eve-types'
+import { logger } from '@repo/hono-helpers'
 import {
 	buildKillmailItemMetadata,
 	collectKillmailItemTypeIds,
-	roundToMillion,
 	MAX_SRP_LOSS_AGE_DAYS,
+	roundToMillion,
 } from '@repo/srp'
 import { parseJsonResponse } from '@repo/worker-utils'
 
 import { createDb } from './db'
-import { buildKillmailDetailFromCachedLoss } from './lib/cached-killmail'
 import {
 	srpComments,
 	srpConfig,
@@ -24,27 +23,76 @@ import {
 	srpRequestHistory,
 	srpRequests,
 } from './db/schema'
+import { buildKillmailDetailFromCachedLoss } from './lib/cached-killmail'
 import { buildEquippedByType } from './lib/equipment'
+import { formatSrpRequest, formatSrpRequestSummary } from './lib/format-request'
 import { SrpKillmailEsiClient, SrpKillmailNotFoundError } from './lib/killmail-esi'
 import {
 	doesRecentLossCacheCoverCutoff,
-	mergeRecentLosses,
 	isRecentLossRequestable,
-	selectRecentKillmailsUntilKnown,
+	mergeRecentLosses,
 	ROOKIE_SHIP_TYPE_IDS,
-	type RecentLossCacheRecord,
-	type RecentLossCacheStorageRecord,
+	selectRecentKillmailsUntilKnown,
 } from './lib/recent-loss-cache'
 import {
 	DEFAULT_NON_POD_SLOT_CAPACITIES,
 	DEFAULT_POD_SLOT_CAPACITIES,
 	parseShipSlotCapacitiesFromDogmaAttributes,
 } from './lib/ship-slot-capacities'
-import { formatSrpRequest, formatSrpRequestSummary } from './lib/format-request'
 
+import type { CharacterKillmailBasic } from '@repo/esi'
+import type {
+	CharacterKillmailData,
+	CharacterLossData,
+	CharacterLossItemData,
+	EveCharacterData,
+} from '@repo/eve-character-data'
+import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { EveTokenStore } from '@repo/eve-token-store'
+import type { LatestMarketPrice, Markets } from '@repo/markets'
+import type {
+	CreateSRPPolicy,
+	RecentLossesResponse,
+	RecentLossRefreshCharacterFailure,
+	RecentLossRefreshCharacterInput,
+	RecentLossRefreshCharacterResult,
+	RequestStatus,
+	Srp,
+	SRPCommentResponse,
+	SRPConfigResponse,
+	SRPPaymentMismatchAlert,
+	SRPPolicy,
+	SRPPolicyConfig,
+	SRPPublicRequestSummaryResponse,
+	SrpRequestEligibilityData,
+	SRPRequestResponse,
+	SRPReviewSubmission,
+	SRPStatsResponse,
+	SRPValuationPreview,
+	UpdateSRPConfig,
+} from '@repo/srp'
+import type { KillmailDetail, Universe } from '@repo/universe'
+import type { Env } from './context'
 import type { srpRequests as srpRequestsTable } from './db/schema'
+import type { RecentLossCacheRecord, RecentLossCacheStorageRecord } from './lib/recent-loss-cache'
 
 type KillmailDataJson = NonNullable<typeof srpRequestsTable.$inferInsert.killmailData>
+
+type RawVictimItem = {
+	item_type_id?: number | string
+	flag?: number
+	quantity_destroyed?: number
+	quantity_dropped?: number
+	items?: RawVictimItem[]
+}
+
+type PreviewVictimItem = {
+	typeId: string
+	flag: number
+	quantityDestroyed: number
+	quantityDropped: number
+	items?: PreviewVictimItem[]
+}
 
 const srpRequestListColumns = {
 	id: srpRequests.id,
@@ -92,40 +140,6 @@ const srpPaymentListColumns = {
 	createdAt: srpRequests.createdAt,
 	updatedAt: srpRequests.updatedAt,
 }
-
-import type {
-	CharacterKillmailData,
-	CharacterLossData,
-	CharacterLossItemData,
-	EveCharacterData,
-} from '@repo/eve-character-data'
-import type { EveCorporationData } from '@repo/eve-corporation-data'
-import type { EveTokenStore } from '@repo/eve-token-store'
-import type { LatestMarketPrice, Markets } from '@repo/markets'
-import type {
-	CreateSRPPolicy,
-	RecentLossRefreshCharacterFailure,
-	RecentLossRefreshCharacterInput,
-	RecentLossRefreshCharacterResult,
-	RecentLossesResponse,
-	RequestStatus,
-	Srp,
-	SRPCommentResponse,
-	SRPConfigResponse,
-	SrpRequestEligibilityData,
-	SRPPaymentMismatchAlert,
-	SRPPolicy,
-	SRPPolicyConfig,
-	SRPRequestResponse,
-	SRPPublicRequestSummaryResponse,
-	SRPReviewSubmission,
-	SRPStatsResponse,
-	SRPValuationPreview,
-	UpdateSRPConfig,
-} from '@repo/srp'
-import type { KillmailDetail, Universe } from '@repo/universe'
-import type { Env } from './context'
-import { logger } from '@repo/hono-helpers'
 
 const SRP_REQUIRED_KILLMAIL_SCOPES = ['esi-killmails.read_killmails.v1']
 
@@ -241,14 +255,14 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		const { characterName, shipTypeName, solarSystemName, dateFrom, dateTo } = options
 
 		const startDate = dateFrom
-			? (dateFrom.includes('T')
+			? dateFrom.includes('T')
 				? new Date(dateFrom)
-				: new Date(`${dateFrom}T00:00:00.000Z`))
+				: new Date(`${dateFrom}T00:00:00.000Z`)
 			: null
 		const endDate = dateTo
-			? (dateTo.includes('T')
+			? dateTo.includes('T')
 				? new Date(dateTo)
-				: new Date(`${dateTo}T23:59:59.999Z`))
+				: new Date(`${dateTo}T23:59:59.999Z`)
 			: null
 
 		const conditions =
@@ -290,7 +304,10 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		if (cached && cached.expiresAt > now) return cached.value
 
 		const { where } = this.buildReviewQueueConditions(status, options)
-		const [row] = await this.db.select({ count: sql<number>`count(*)::int` }).from(srpRequests).where(where)
+		const [row] = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(srpRequests)
+			.where(where)
 		const count = row?.count ?? 0
 		this.reviewQueueCountCache.set(cacheKey, {
 			value: count,
@@ -299,7 +316,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		return count
 	}
 
-	private convertKillmailDetailToLoss(killmail: KillmailDetail & { killmail_hash?: string }): CharacterLossData | null {
+	private convertKillmailDetailToLoss(
+		killmail: KillmailDetail & { killmail_hash?: string }
+	): CharacterLossData | null {
 		if (!killmail.killmail_hash) return null
 		const victimCharacterId = killmail.victim.character_id
 		if (!victimCharacterId) return null
@@ -321,7 +340,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	}
 
 	private async readRecentLossCache(characterId: string): Promise<RecentLossCacheRecord | null> {
-		const record = await this.storage.get<RecentLossCacheStorageRecord>(this.buildRecentLossCacheKey(characterId))
+		const record = await this.storage.get<RecentLossCacheStorageRecord>(
+			this.buildRecentLossCacheKey(characterId)
+		)
 		if (!record || !Array.isArray(record.losses)) {
 			return null
 		}
@@ -365,7 +386,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 							items?: CharacterLossItemData[]
 						}
 						solar_system_id?: number | string
-				  })
+					})
 				: null
 		const victim = killmailData?.victim
 		const shipTypeId = row.shipTypeId ?? victim?.ship_type_id
@@ -390,10 +411,16 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		}
 	}
 
-	private async readRecentLossRows(characterIds: string[], cutoffMs: number): Promise<RecentLossDbRow[]> {
+	private async readRecentLossRows(
+		characterIds: string[],
+		cutoffMs: number
+	): Promise<RecentLossDbRow[]> {
 		if (characterIds.length === 0) return []
 
-		const characterIdList = sql.join(characterIds.map((id) => sql`${id}`), sql`, `)
+		const characterIdList = sql.join(
+			characterIds.map((id) => sql`${id}`),
+			sql`, `
+		)
 		const cutoff = new Date(cutoffMs)
 
 		const result = await this.db.execute<RecentLossDbRow>(sql`
@@ -435,7 +462,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 					? new Date(entry.loss.killmailTime).getTime() >= cutoffMs
 					: true
 			)
-			.sort((a, b) => new Date(b.loss.killmailTime).getTime() - new Date(a.loss.killmailTime).getTime())
+			.sort(
+				(a, b) => new Date(b.loss.killmailTime).getTime() - new Date(a.loss.killmailTime).getTime()
+			)
 
 		if (persistable.length === 0) return
 
@@ -482,13 +511,16 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 					type_id?: number | string
 					typeId?: number | string
 					items?: any[]
-			  }>)
+				}>)
 			: []
 		if (itemPrices.length === 0 && killmailItems.length === 0) return
 		if (!request?.id) return
 
 		const existingKillmailItemNames = (request.killmailItemNames ?? {}) as Record<string, string>
-		const existingKillmailItemGroupIds = (request.killmailItemGroupIds ?? {}) as Record<string, string>
+		const existingKillmailItemGroupIds = (request.killmailItemGroupIds ?? {}) as Record<
+			string,
+			string
+		>
 		const missingPriceTypeIds = itemPrices
 			.filter((item) => Boolean(item.typeId) && (!item.typeName || item.typeName === item.typeId))
 			.map((item) => String(item.typeId))
@@ -542,7 +574,10 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 					...resolvedKillmailItemMetadata.killmailItemGroupIds,
 				}
 			: existingKillmailItemGroupIds
-		const isSameStringMap = (left?: Record<string, string> | null, right?: Record<string, string>) => {
+		const isSameStringMap = (
+			left?: Record<string, string> | null,
+			right?: Record<string, string>
+		) => {
 			const leftEntries = Object.entries(left ?? {})
 			const rightEntries = Object.entries(right ?? {})
 			if (leftEntries.length !== rightEntries.length) return false
@@ -568,7 +603,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 				killmailItemNames:
 					Object.keys(nextKillmailItemNames).length > 0 ? (nextKillmailItemNames as any) : null,
 				killmailItemGroupIds:
-					Object.keys(nextKillmailItemGroupIds).length > 0 ? (nextKillmailItemGroupIds as any) : null,
+					Object.keys(nextKillmailItemGroupIds).length > 0
+						? (nextKillmailItemGroupIds as any)
+						: null,
 				updatedAt: new Date(),
 			})
 			.where(eq(srpRequests.id, request.id))
@@ -624,63 +661,30 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		)
 	}
 
-	private flattenVictimItemsForPreview(
-		items: Array<{
-			item_type_id?: number | string
-			flag?: number
-			quantity_destroyed?: number
-			quantity_dropped?: number
-			items?: any[]
-		}>,
-		inheritedFlag?: number
-	): Array<{
-		typeId: string
-		flag: number
-		quantityDestroyed: number
-		quantityDropped: number
-	}> {
-		const flattened: Array<{
-			typeId: string
-			flag: number
-			quantityDestroyed: number
-			quantityDropped: number
-		}> = []
+	private serializeVictimItemsForPreview(items: RawVictimItem[]): PreviewVictimItem[] {
+		const serialized: PreviewVictimItem[] = []
 
 		for (const item of items) {
 			const itemTypeId = item.item_type_id
 			const flag = item.flag
 			if (itemTypeId != null && flag != null) {
-				const displayFlag = inheritedFlag ?? flag
-				flattened.push({
+				serialized.push({
 					typeId: String(itemTypeId),
-					flag: displayFlag,
+					flag,
 					quantityDestroyed: item.quantity_destroyed ?? 0,
 					quantityDropped: item.quantity_dropped ?? 0,
+					items: item.items?.length ? this.serializeVictimItemsForPreview(item.items) : undefined,
 				})
-
-				if (item.items?.length) {
-					flattened.push(...this.flattenVictimItemsForPreview(item.items, displayFlag))
-				}
-				continue
-			}
-
-			if (item.items?.length) {
-				flattened.push(...this.flattenVictimItemsForPreview(item.items, inheritedFlag))
 			}
 		}
 
-		return flattened
+		return serialized
 	}
 
-	private collectVictimItemTypeIds(
-		items: Array<{
-			item_type_id?: number | string
-			items?: any[]
-		}>
-	): string[] {
+	private collectVictimItemTypeIds(items: RawVictimItem[]): string[] {
 		const typeIds = new Set<string>()
 
-		const walk = (rows: Array<{ item_type_id?: number | string; items?: any[] }>) => {
+		const walk = (rows: RawVictimItem[]) => {
 			for (const row of rows) {
 				if (row.item_type_id != null) {
 					typeIds.add(String(row.item_type_id))
@@ -704,10 +708,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		}
 
 		const losses: HydratedRecentLoss[] = []
-		const concurrency = Math.min(
-			SrpDO.RECENT_LOSS_DETAIL_CONCURRENCY,
-			killmails.length
-		)
+		const concurrency = Math.min(SrpDO.RECENT_LOSS_DETAIL_CONCURRENCY, killmails.length)
 		let nextIndex = 0
 
 		const worker = async () => {
@@ -836,25 +837,27 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 					killmailHash,
 					cachedLoss
 				) as KillmailDataJson
-				void charInstance.upsertCharacterKillmails([
-					{
-						killmailId: normalizedKillmailId,
-						killmailHash,
-						killmailTime: cachedLoss.killmailTime,
-						isLoss: true,
-						shipTypeId: cachedLoss.shipTypeId,
-						totalValue: cachedLoss.totalValue,
-						solarSystemId: cachedLoss.solarSystemId,
-						victimCharacterId: cachedLoss.victimCharacterId,
-						killmailData,
-					},
-				]).catch((error) => {
-					logger.warn('[createRequest] Failed to backfill cached killmail into character data', {
-						characterId,
-						killmailId: normalizedKillmailId,
-						error: error instanceof Error ? error.message : String(error),
+				void charInstance
+					.upsertCharacterKillmails([
+						{
+							killmailId: normalizedKillmailId,
+							killmailHash,
+							killmailTime: cachedLoss.killmailTime,
+							isLoss: true,
+							shipTypeId: cachedLoss.shipTypeId,
+							totalValue: cachedLoss.totalValue,
+							solarSystemId: cachedLoss.solarSystemId,
+							victimCharacterId: cachedLoss.victimCharacterId,
+							killmailData,
+						},
+					])
+					.catch((error) => {
+						logger.warn('[createRequest] Failed to backfill cached killmail into character data', {
+							characterId,
+							killmailId: normalizedKillmailId,
+							error: error instanceof Error ? error.message : String(error),
+						})
 					})
-				})
 			}
 		}
 
@@ -878,17 +881,17 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 
 		const victim = killmailData.victim as any
 		const universeStub = getStub<Universe>(this.env.UNIVERSE, 'default')
-		const killmailItemTypeIds = collectKillmailItemTypeIds((victim.items ?? []) as Array<{
-			item_type_id?: number | string
-			type_id?: number | string
-			typeId?: number | string
-			items?: any[]
-		}>)
+		const killmailItemTypeIds = collectKillmailItemTypeIds(
+			(victim.items ?? []) as Array<{
+				item_type_id?: number | string
+				type_id?: number | string
+				typeId?: number | string
+				items?: any[]
+			}>
+		)
 		const [typeMap, systemMap] = await Promise.all([
 			universeStub
-				.resolveTypeNamesByIds(
-					[...new Set([String(victim.ship_type_id), ...killmailItemTypeIds])]
-				)
+				.resolveTypeNamesByIds([...new Set([String(victim.ship_type_id), ...killmailItemTypeIds])])
 				.catch(() => ({}) as Record<string, null>),
 			solarSystemId
 				? universeStub
@@ -926,7 +929,12 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		}
 		let valuation: Awaited<ReturnType<typeof this.calculateSrpValuation>> = null
 		try {
-			valuation = await this.calculateSrpValuation(killmailData as any, lossDate, String(victim.ship_type_id), config)
+			valuation = await this.calculateSrpValuation(
+				killmailData as any,
+				lossDate,
+				String(victim.ship_type_id),
+				config
+			)
 		} catch (err) {
 			// Non-fatal — request is still created, valuation fields will be null
 			logger.error('[createRequest] SRP valuation failed:', err)
@@ -1007,11 +1015,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 							items: cachedVictimItems as any,
 						},
 					} as any)
-				: await this.killmailEsi.fetchCharacterKillmailDetail(
-						characterId,
-						killmailId,
-						killmailHash
-					)
+				: await this.killmailEsi.fetchCharacterKillmailDetail(characterId, killmailId, killmailHash)
 		}
 
 		const victim = killmailData.victim as any
@@ -1037,16 +1041,15 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			.map((item) => item.typeId)
 
 		const rawItems = victim.items ?? []
-		const victimItems = this.flattenVictimItemsForPreview(rawItems)
+		const victimItems = this.serializeVictimItemsForPreview(rawItems)
 
 		const allTypeIds = [
-			...new Set([
-				String(victim.ship_type_id),
-				...this.collectVictimItemTypeIds(rawItems),
-			]),
+			...new Set([String(victim.ship_type_id), ...this.collectVictimItemTypeIds(rawItems)]),
 		]
 		const universeStub = getStub<Universe>(this.env.UNIVERSE, 'default')
-		const typeMap = await universeStub.resolveTypeNamesByIds(allTypeIds).catch(() => ({}) as Record<string, null>)
+		const typeMap = await universeStub
+			.resolveTypeNamesByIds(allTypeIds)
+			.catch(() => ({}) as Record<string, null>)
 		const itemNames: Record<string, string> = {}
 		for (const [id, type] of Object.entries(typeMap)) {
 			if (type?.typeName) itemNames[id] = type.typeName
@@ -1079,12 +1082,12 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	): Promise<SRPRequestResponse | null> {
 		const request = await this.db.query.srpRequests.findFirst({
 			where: eq(srpRequests.id, requestId),
-				with: {
-					history: {
-						orderBy: asc(srpRequestHistory.timestamp),
-						limit: 50,
-					},
+			with: {
+				history: {
+					orderBy: asc(srpRequestHistory.timestamp),
+					limit: 50,
 				},
+			},
 		})
 
 		if (!request) return null
@@ -1224,11 +1227,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		for (const [index, character] of characters.entries()) {
 			const storedLosses = recentLossesByCharacter.get(character.characterId) ?? []
 			const cached = cachedRecords[index]
-			const mergedCharacterLosses = mergeRecentLosses(
-				storedLosses,
-				cached?.losses ?? [],
-				cutoffMs
-			)
+			const mergedCharacterLosses = mergeRecentLosses(storedLosses, cached?.losses ?? [], cutoffMs)
 
 			if (mergedCharacterLosses.length === 0) {
 				if (cached?.complete === true) {
@@ -1277,8 +1276,9 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			}
 		}
 
-		const mergedLosses = [...allLosses.values()]
-			.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime())
+		const mergedLosses = [...allLosses.values()].sort(
+			(a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime()
+		)
 		const total = mergedLosses.length
 		const effectiveLimit = typeof limit === 'number' ? Math.max(1, limit) : total
 		const effectiveOffset = typeof offset === 'number' ? Math.max(0, offset) : 0
@@ -1324,7 +1324,10 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			where: and(eq(srpRequests.userId, userId), inArray(srpRequests.id, killmailIds)),
 		})
 		const dismissedLosses = await this.db.query.srpDismissedLosses.findMany({
-			where: and(eq(srpDismissedLosses.userId, userId), inArray(srpDismissedLosses.killmailId, killmailIds)),
+			where: and(
+				eq(srpDismissedLosses.userId, userId),
+				inArray(srpDismissedLosses.killmailId, killmailIds)
+			),
 			columns: { killmailId: true },
 		})
 		const dismissedKillmailIds = new Set(dismissedLosses.map((row) => row.killmailId))
@@ -1366,35 +1369,35 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 
 		// Annotate losses with SRP status and sort by time descending
 		const annotatedLosses = mergedLosses
-				.filter((loss) => !dismissedKillmailIds.has(String(loss.killmailId)))
-				.filter((loss) => !legacyPaidKillmailIds.has(String(loss.killmailId)))
-				.filter((loss) => {
-					const shipTypeId = String(loss.shipTypeId)
-					const marketGroupId = typeMetaMap[shipTypeId]?.marketGroupId ?? null
-					const shipTypeName = resolved[shipTypeId] ?? ''
-					const looksLikeShuttleByName = shipTypeName.toLowerCase().includes('shuttle')
-					return !(this.isShuttleMarketGroupId(marketGroupId) || looksLikeShuttleByName)
-				})
-				.map((loss) => {
-					const lossKillmailId = String(loss.killmailId)
-					const request = requestMap.get(lossKillmailId)
-					return {
-						killmailId: lossKillmailId,
-						killmailHash: loss.killmailHash ?? '',
-						killmailTime: new Date(loss.killmailTime).toISOString(),
-						shipTypeId: loss.shipTypeId,
-						shipTypeName: resolved[String(loss.shipTypeId)],
-						totalValue: loss.totalValue ?? '0',
-						solarSystemId: loss.solarSystemId,
-						solarSystemName: resolved[String(loss.solarSystemId)],
-						victimCharacterId: String(loss.victimCharacterId ?? ''),
-						victimItems: loss.victimItems,
-						hasSRPRequest: !!request,
-						srpRequestId: request?.id,
-						srpRequestStatus: request?.status,
-					}
-				})
-				.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime())
+			.filter((loss) => !dismissedKillmailIds.has(String(loss.killmailId)))
+			.filter((loss) => !legacyPaidKillmailIds.has(String(loss.killmailId)))
+			.filter((loss) => {
+				const shipTypeId = String(loss.shipTypeId)
+				const marketGroupId = typeMetaMap[shipTypeId]?.marketGroupId ?? null
+				const shipTypeName = resolved[shipTypeId] ?? ''
+				const looksLikeShuttleByName = shipTypeName.toLowerCase().includes('shuttle')
+				return !(this.isShuttleMarketGroupId(marketGroupId) || looksLikeShuttleByName)
+			})
+			.map((loss) => {
+				const lossKillmailId = String(loss.killmailId)
+				const request = requestMap.get(lossKillmailId)
+				return {
+					killmailId: lossKillmailId,
+					killmailHash: loss.killmailHash ?? '',
+					killmailTime: new Date(loss.killmailTime).toISOString(),
+					shipTypeId: loss.shipTypeId,
+					shipTypeName: resolved[String(loss.shipTypeId)],
+					totalValue: loss.totalValue ?? '0',
+					solarSystemId: loss.solarSystemId,
+					solarSystemName: resolved[String(loss.solarSystemId)],
+					victimCharacterId: String(loss.victimCharacterId ?? ''),
+					victimItems: loss.victimItems,
+					hasSRPRequest: !!request,
+					srpRequestId: request?.id,
+					srpRequestStatus: request?.status,
+				}
+			})
+			.sort((a, b) => new Date(b.killmailTime).getTime() - new Date(a.killmailTime).getTime())
 
 		return {
 			losses: annotatedLosses.slice(effectiveOffset, effectiveOffset + effectiveLimit),
@@ -1643,13 +1646,13 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 
 		if (!request) throw new Error('Request not found')
 
-			const comments = await this.db.query.srpComments.findMany({
+		const comments = await this.db.query.srpComments.findMany({
 			where: and(
 				eq(srpComments.requestId, requestId),
 				includeInternal ? undefined : eq(srpComments.visibility, 'public')
 			),
-				orderBy: asc(srpComments.createdAt),
-			})
+			orderBy: asc(srpComments.createdAt),
+		})
 
 		return comments.map((c) => ({
 			id: c.id,
@@ -1871,7 +1874,8 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 				? metadata.srpDiscordGuildId.trim()
 				: undefined
 		const srpDiscordChannelId =
-			typeof metadata.srpDiscordChannelId === 'string' && metadata.srpDiscordChannelId.trim().length > 0
+			typeof metadata.srpDiscordChannelId === 'string' &&
+			metadata.srpDiscordChannelId.trim().length > 0
 				? metadata.srpDiscordChannelId.trim()
 				: undefined
 
@@ -1897,10 +1901,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	/**
 	 * Update SRP configuration
 	 */
-	async updateConfig(
-		userId: string,
-		updates: UpdateSRPConfig
-	): Promise<SRPConfigResponse> {
+	async updateConfig(userId: string, updates: UpdateSRPConfig): Promise<SRPConfigResponse> {
 		// Get current config
 		const current = await this.getConfig()
 
@@ -2116,7 +2117,14 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		priceSnapshotTime: Date | null
 		pricingSource: 'historic' | 'fallback'
 		insuranceSource?: 'historic' | 'fallback'
-		itemPrices: Array<{ typeId: string; typeName: string; quantity: number; unitPrice: string; lineTotal: string; isConsumable?: boolean }>
+		itemPrices: Array<{
+			typeId: string
+			typeName: string
+			quantity: number
+			unitPrice: string
+			lineTotal: string
+			isConsumable?: boolean
+		}>
 	} | null> {
 		const equippedByType = buildEquippedByType(killmailData?.victim?.items ?? [])
 
@@ -2132,16 +2140,17 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 			atTime: lossDate,
 		})
 
-		const priceMap = new Map(
-			prices.map((p: LatestMarketPrice) => [p.typeId, p.bestSellPrice])
-		)
+		const priceMap = new Map(prices.map((p: LatestMarketPrice) => [p.typeId, p.bestSellPrice]))
 		const priceSnapshotTime = prices[0]?.snapshotTime ?? null
 		let pricingSource: 'historic' | 'fallback' = prices.length > 0 ? 'historic' : 'fallback'
 
 		// Fill in any types missing from daily history using the DB-first/cache-fallback RPC
 		if (missingTypeIds.length > 0) {
 			try {
-				const cached = await marketsStub.getMarketPricesForTypes(missingTypeIds.map(String), priceDate)
+				const cached = await marketsStub.getMarketPricesForTypes(
+					missingTypeIds.map(String),
+					priceDate
+				)
 				for (const p of cached) {
 					const avg = p.averagePrice
 					if (avg && avg > 0) {
@@ -2160,13 +2169,15 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		const allTypeIds = [...equippedByType.keys()]
 		const [typeNameMap, typeMetaMap] = await Promise.all([
 			universeStub.resolveTypeNamesByIds(allTypeIds).catch(() => ({}) as Record<string, null>),
-			universeStub.resolveTypeMetadataByIds(allTypeIds).catch(
-				() =>
-					({}) as Record<
-						string,
-						{ categoryName: string; marketGroupId: string | null; marketGroupName: string | null }
-					>
-			),
+			universeStub
+				.resolveTypeMetadataByIds(allTypeIds)
+				.catch(
+					() =>
+						({}) as Record<
+							string,
+							{ categoryName: string; marketGroupId: string | null; marketGroupName: string | null }
+						>
+				),
 		])
 
 		// Build per-item breakdown
@@ -2483,7 +2494,13 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		const rows = await this.db
 			.selectDistinct({ solarSystemName: srpRequests.solarSystemName })
 			.from(srpRequests)
-			.where(and(statusCond, ilike(srpRequests.solarSystemName!, `%${query}%`), sql`${srpRequests.solarSystemName} is not null`))
+			.where(
+				and(
+					statusCond,
+					ilike(srpRequests.solarSystemName!, `%${query}%`),
+					sql`${srpRequests.solarSystemName} is not null`
+				)
+			)
 			.limit(20)
 		return rows.map((r) => ({ value: r.solarSystemName! }))
 	}
@@ -2509,16 +2526,18 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		let capPolicy: typeof srpPolicies.$inferSelect | null = null
 
 		if (data.appliedModifierPolicyId) {
-			modifierPolicy = await this.db.query.srpPolicies.findFirst({
-				where: eq(srpPolicies.id, data.appliedModifierPolicyId),
-			}) ?? null
+			modifierPolicy =
+				(await this.db.query.srpPolicies.findFirst({
+					where: eq(srpPolicies.id, data.appliedModifierPolicyId),
+				})) ?? null
 			if (!modifierPolicy) throw new Error('Modifier policy not found')
 		}
 
 		if (data.appliedCapPolicyId) {
-			capPolicy = await this.db.query.srpPolicies.findFirst({
-				where: eq(srpPolicies.id, data.appliedCapPolicyId),
-			}) ?? null
+			capPolicy =
+				(await this.db.query.srpPolicies.findFirst({
+					where: eq(srpPolicies.id, data.appliedCapPolicyId),
+				})) ?? null
 			if (!capPolicy) throw new Error('Cap policy not found')
 		}
 
@@ -2530,9 +2549,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 
 		if (data.reviewerOverrideMillions != null) {
 			// Override replaces the entire calculation
-			approvedAmount = roundToMillion(
-				String(BigInt(data.reviewerOverrideMillions) * 1_000_000n)
-			)
+			approvedAmount = roundToMillion(String(BigInt(data.reviewerOverrideMillions) * 1_000_000n))
 		} else {
 			approvedAmount = this.computeReviewPayout(request, data, modifierPolicy, capPolicy)
 		}
@@ -2604,12 +2621,24 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 
 		// Auto-post feedback as public comment
 		if (data.feedbackText) {
-			await this.addComment(requestId, reviewerUserId, reviewerCharacterName, data.feedbackText, 'public')
+			await this.addComment(
+				requestId,
+				reviewerUserId,
+				reviewerCharacterName,
+				data.feedbackText,
+				'public'
+			)
 		}
 
 		// Auto-post review notes as internal comment
 		if (data.reviewNotes) {
-			await this.addComment(requestId, reviewerUserId, reviewerCharacterName, data.reviewNotes, 'internal')
+			await this.addComment(
+				requestId,
+				reviewerUserId,
+				reviewerCharacterName,
+				data.reviewNotes,
+				'internal'
+			)
 		}
 
 		return await this.formatRequestWithShipSlotCapacities(updated[0])
@@ -2626,7 +2655,10 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		let current = parseFloat(request.srpEquipmentValue ?? '0')
 
 		// Step 1: Insurance delta — applied by default unless policy explicitly disables it
-		const modifierConfig = modifierPolicy?.config as { rate?: string; applyInsuranceDelta?: boolean } | null
+		const modifierConfig = modifierPolicy?.config as {
+			rate?: string
+			applyInsuranceDelta?: boolean
+		} | null
 		const applyInsuranceDelta = modifierConfig?.applyInsuranceDelta ?? true
 		if (applyInsuranceDelta) {
 			const netInsurance = parseFloat(request.srpNetInsurance ?? '0')
@@ -2641,7 +2673,8 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		// Step 3: Ad-hoc modifiers in order
 		for (const mod of data.appliedModifiers) {
 			if (mod.mode === 'percentage') {
-				const factor = mod.modifierType === 'deduction' ? 1 - mod.amount / 100 : 1 + mod.amount / 100
+				const factor =
+					mod.modifierType === 'deduction' ? 1 - mod.amount / 100 : 1 + mod.amount / 100
 				current = current * factor
 			} else {
 				const delta = mod.amount * 1_000_000
@@ -2689,7 +2722,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 							paymentDate: new Date(),
 							paymentCharacterName: actorCharacterName,
 							paymentScanCursorDate: null,
-					  }
+						}
 					: {}),
 				updatedAt: new Date(),
 			})
@@ -2764,10 +2797,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 		return rows.map(this.formatPolicy)
 	}
 
-	async createPolicy(
-		userId: string,
-		data: CreateSRPPolicy
-	): Promise<SRPPolicy> {
+	async createPolicy(userId: string, data: CreateSRPPolicy): Promise<SRPPolicy> {
 		const [row] = await this.db
 			.insert(srpPolicies)
 			.values({

--- a/apps/srp/src/lib/slot-flags.ts
+++ b/apps/srp/src/lib/slot-flags.ts
@@ -17,7 +17,8 @@
 export function isEquippedSlot(flag: number): boolean {
 	return (
 		(flag >= 11 && flag <= 34) || // Low + Mid + High slots
-		(flag >= 89 && flag <= 99) || // Implants (89) + Rig slots (92–99)
+		flag === 89 || // Implant slot
+		(flag >= 92 && flag <= 99) || // Rig slots
 		(flag >= 125 && flag <= 132) // Subsystems (T3)
 	)
 }

--- a/apps/srp/src/test/unit/equipment.unit.test.ts
+++ b/apps/srp/src/test/unit/equipment.unit.test.ts
@@ -17,14 +17,13 @@ describe('buildEquippedByType', () => {
 	it('filters out cargo and non-equipped flags', () => {
 		const result = buildEquippedByType([
 			{ flag: FLAG_CARGO, item_type_id: 100, quantity_destroyed: 1 },
+			{ flag: 90, item_type_id: 101, quantity_destroyed: 1 },
 		])
 		expect(result.size).toBe(0)
 	})
 
 	it('filters out items with missing flag', () => {
-		const result = buildEquippedByType([
-			{ flag: 0, item_type_id: 100, quantity_destroyed: 1 },
-		])
+		const result = buildEquippedByType([{ flag: 0, item_type_id: 100, quantity_destroyed: 1 }])
 		expect(result.size).toBe(0)
 	})
 
@@ -71,9 +70,7 @@ describe('buildEquippedByType', () => {
 	})
 
 	it('defaults missing quantity fields to 0', () => {
-		const result = buildEquippedByType([
-			{ flag: FLAG_LOW_0, item_type_id: 301 },
-		])
+		const result = buildEquippedByType([{ flag: FLAG_LOW_0, item_type_id: 301 }])
 		expect(result.get('301')).toBe(0)
 	})
 

--- a/apps/srp/src/test/unit/slot-flags.unit.test.ts
+++ b/apps/srp/src/test/unit/slot-flags.unit.test.ts
@@ -33,8 +33,8 @@ describe('isEquippedSlot', () => {
 
 	describe('Implant slot (89)', () => {
 		it('includes flag 89 (Implant)', () => expect(isEquippedSlot(89)).toBe(true))
-		it('includes flag 90 (in implant+rig range)', () => expect(isEquippedSlot(90)).toBe(true))
-		it('includes flag 91 (in implant+rig range)', () => expect(isEquippedSlot(91)).toBe(true))
+		it('excludes flag 90 (Ship Maintenance Bay)', () => expect(isEquippedSlot(90)).toBe(false))
+		it('excludes flag 91 (not an equipped slot)', () => expect(isEquippedSlot(91)).toBe(false))
 	})
 
 	describe('Rig slots (92–99)', () => {

--- a/apps/ui/src/client/features/srp/components/CreateRequestForm.tsx
+++ b/apps/ui/src/client/features/srp/components/CreateRequestForm.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
-import toast from '@/lib/toast'
 import { z } from 'zod'
 
 import { Button } from '@/components/ui/button'
@@ -9,12 +8,18 @@ import { Card } from '@/components/ui/card'
 import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import toast from '@/lib/toast'
 
 import { useCreateRequest } from '../hooks'
-import type { RecentLossVictimItem } from '../types'
 import { getKillmailUrl } from '../utils'
-import { transformKillmailToCargoItems, transformKillmailToFittingItems } from '../utils/fitting'
+import {
+	transformKillmailToCargoItems,
+	transformKillmailToFittingItems,
+	transformKillmailToShipMaintenanceBayShips,
+} from '../utils/fitting'
 import { SRPFittingDisplay } from './SRPFittingDisplay'
+
+import type { RecentLossVictimItem } from '../types'
 
 const createRequestSchema = z.object({
 	killmailId: z.string().min(1),
@@ -25,13 +30,16 @@ const createRequestSchema = z.object({
 
 type CreateRequestFormData = z.infer<typeof createRequestSchema>
 
+type PreviewVictimItem = {
+	typeId: string
+	flag: number
+	quantityDestroyed: number
+	quantityDropped: number
+	items?: PreviewVictimItem[]
+}
+
 interface KillmailPreview {
-	victimItems: Array<{
-		typeId: string
-		flag: number
-		quantityDestroyed: number
-		quantityDropped: number
-	}>
+	victimItems: PreviewVictimItem[]
 	itemPrices: Array<{
 		typeId: string
 		quantity: number
@@ -72,12 +80,15 @@ function normalizeVictimItems(items: RecentLossVictimItem[]): NormalizedVictimIt
 	}))
 }
 
-function normalizePreviewVictimItems(items: KillmailPreview['victimItems']): NormalizedVictimItem[] {
+function normalizePreviewVictimItems(
+	items: KillmailPreview['victimItems']
+): NormalizedVictimItem[] {
 	return items.map((item) => ({
 		item_type_id: Number(item.typeId),
 		flag: item.flag,
 		quantity_destroyed: item.quantityDestroyed,
 		quantity_dropped: item.quantityDropped,
+		items: item.items?.length ? normalizePreviewVictimItems(item.items) : undefined,
 	}))
 }
 
@@ -100,12 +111,11 @@ export function CreateRequestForm({
 		defaultValues: { killmailId, killmailHash, characterId, contextText: '' },
 	})
 
-	const displayVictimItems =
-		lossVictimItems?.length
-			? normalizeVictimItems(lossVictimItems)
-			: preview?.victimItems?.length
-				? normalizePreviewVictimItems(preview.victimItems)
-				: []
+	const displayVictimItems = lossVictimItems?.length
+		? normalizeVictimItems(lossVictimItems)
+		: preview?.victimItems?.length
+			? normalizePreviewVictimItems(preview.victimItems)
+			: []
 	const fittingItems = transformKillmailToFittingItems(
 		displayVictimItems,
 		preview?.itemPrices?.map((p) => ({
@@ -115,7 +125,8 @@ export function CreateRequestForm({
 		})) ?? [],
 		preview?.itemNames ?? {}
 	)
-	const cargoItems = transformKillmailToCargoItems(
+	const cargoItems = transformKillmailToCargoItems(displayVictimItems, preview?.itemNames ?? {})
+	const shipMaintenanceBayShips = transformKillmailToShipMaintenanceBayShips(
 		displayVictimItems,
 		preview?.itemNames ?? {}
 	)
@@ -190,6 +201,7 @@ export function CreateRequestForm({
 				shipTypeName={shipTypeName}
 				fittingItems={fittingItems}
 				cargoItems={cargoItems}
+				shipMaintenanceBayShips={shipMaintenanceBayShips}
 				showPricing={false}
 				panelLoading={previewLoading}
 			/>

--- a/apps/ui/src/client/features/srp/components/ReviewRequestForm.tsx
+++ b/apps/ui/src/client/features/srp/components/ReviewRequestForm.tsx
@@ -1,6 +1,5 @@
 import { Plus, X } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import toast from '@/lib/toast'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -9,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import toast from '@/lib/toast'
 
 import {
 	useDoctrineFittingsForShip,
@@ -18,7 +18,11 @@ import {
 	useUpdateReviewState,
 } from '../hooks'
 import { formatISK } from '../utils'
-import { transformKillmailToCargoItems, transformKillmailToFittingItems } from '../utils/fitting'
+import {
+	transformKillmailToCargoItems,
+	transformKillmailToFittingItems,
+	transformKillmailToShipMaintenanceBayShips,
+} from '../utils/fitting'
 import { SRPFittingDisplay } from './SRPFittingDisplay'
 
 import type { ReactNode } from 'react'
@@ -733,7 +737,8 @@ export function ReviewRequestForm({
 			return
 		}
 		const hasSelected =
-			selectedCapPolicyId !== null && capPolicies.some((policy) => policy.id === selectedCapPolicyId)
+			selectedCapPolicyId !== null &&
+			capPolicies.some((policy) => policy.id === selectedCapPolicyId)
 
 		if (!hasInitializedCapPolicyDefault.current && selectedCapPolicyId === null) {
 			setSelectedCapPolicyId(capPolicies[0].id)
@@ -804,6 +809,10 @@ export function ReviewRequestForm({
 		itemNames
 	)
 	const cargoItems = transformKillmailToCargoItems(request.killmailItems ?? [], itemNames)
+	const shipMaintenanceBayShips = transformKillmailToShipMaintenanceBayShips(
+		request.killmailItems ?? [],
+		itemNames
+	)
 
 	const sortedDoctrineFittings = useMemo(
 		() =>
@@ -858,9 +867,7 @@ export function ReviewRequestForm({
 				0,
 				Math.min(
 					SHIP_SLOT_ARC_MAX[slot],
-					requestedCapacity > 0
-						? requestedCapacity
-						: Math.max(observedCapacity, doctrineCapacity)
+					requestedCapacity > 0 ? requestedCapacity : Math.max(observedCapacity, doctrineCapacity)
 				)
 			)
 		}
@@ -947,16 +954,16 @@ export function ReviewRequestForm({
 			delta = mod.amount * 1_000_000
 		}
 		const signed = mod.modifierType === 'deduction' ? -delta : delta
-			const percentSuffix =
-				mod.mode === 'percentage'
-					? ` (${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(mod.amount)}%)`
-					: ''
-			modifierLines.push({
-				label: mod.reason,
-				percentSuffix: percentSuffix || undefined,
-				amount: signed,
-				modifierType: mod.modifierType,
-			})
+		const percentSuffix =
+			mod.mode === 'percentage'
+				? ` (${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(mod.amount)}%)`
+				: ''
+		modifierLines.push({
+			label: mod.reason,
+			percentSuffix: percentSuffix || undefined,
+			amount: signed,
+			modifierType: mod.modifierType,
+		})
 		afterModifiers = afterModifiers + signed
 	}
 	afterModifiers = Math.max(0, afterModifiers)
@@ -1073,6 +1080,7 @@ export function ReviewRequestForm({
 					shipTypeName={request.shipTypeName}
 					fittingItems={fittingItems}
 					cargoItems={cargoItems}
+					shipMaintenanceBayShips={shipMaintenanceBayShips}
 					slotHighlights={slotHighlights}
 					slotCapacities={slotCapacities}
 					middleContent={
@@ -1192,19 +1200,19 @@ export function ReviewRequestForm({
 							value={applyInsurance ? afterInsurance : equipmentValue}
 							bold
 						/>
-							{coverageRate !== null && (
-								<>
-									<div className="flex justify-between text-xs text-muted-foreground">
-										<span>× Coverage Rate</span>
-										<span>{Math.round(coverageRate * 100)}%</span>
-									</div>
-									{coverageReduction > 0 && (
-										<MathRow label="− Coverage Reduction" value={-coverageReduction} dim />
-									)}
-									<div className="my-1 border-t border-border/50" />
-									<MathRow label="After Coverage" value={afterCoverage} bold />
-								</>
-							)}
+						{coverageRate !== null && (
+							<>
+								<div className="flex justify-between text-xs text-muted-foreground">
+									<span>× Coverage Rate</span>
+									<span>{Math.round(coverageRate * 100)}%</span>
+								</div>
+								{coverageReduction > 0 && (
+									<MathRow label="− Coverage Reduction" value={-coverageReduction} dim />
+								)}
+								<div className="my-1 border-t border-border/50" />
+								<MathRow label="After Coverage" value={afterCoverage} bold />
+							</>
+						)}
 						{modifierLines.map((line, i) => (
 							<div key={i} className="flex justify-between text-xs text-muted-foreground">
 								<span className="inline-flex items-center gap-2">
@@ -1216,13 +1224,13 @@ export function ReviewRequestForm({
 									>
 										{line.modifierType === 'deduction' ? 'Deduction' : 'Bonus'}
 									</Badge>
-										<span>
-											{line.label}
-											{line.percentSuffix && (
-												<span className="font-semibold">{line.percentSuffix}</span>
-											)}
-										</span>
+									<span>
+										{line.label}
+										{line.percentSuffix && (
+											<span className="font-semibold">{line.percentSuffix}</span>
+										)}
 									</span>
+								</span>
 								<span className={line.amount >= 0 ? 'text-green-400' : 'text-destructive'}>
 									{line.amount >= 0 ? '+' : '-'}
 									{formatISK(String(Math.round(Math.abs(line.amount))))}
@@ -1238,13 +1246,13 @@ export function ReviewRequestForm({
 						{capPolicy && (
 							<div className="flex justify-between text-xs text-muted-foreground">
 								<span>Cap ({selectedCapPolicy?.name})</span>
-									<span className={isCapped ? 'text-amber-500' : ''}>
-										{isCapped
-											? `→ ${formatISK(String(capPolicy.maxPayoutMillions * 1_000_000))}`
-											: 'not applicable'}
-									</span>
-								</div>
-							)}
+								<span className={isCapped ? 'text-amber-500' : ''}>
+									{isCapped
+										? `→ ${formatISK(String(capPolicy.maxPayoutMillions * 1_000_000))}`
+										: 'not applicable'}
+								</span>
+							</div>
+						)}
 						<div className="my-1 border-t-2 border-border" />
 						<div className="flex justify-between font-bold">
 							<span
@@ -1278,12 +1286,12 @@ export function ReviewRequestForm({
 					<Card className="p-4">
 						<h4 className="mb-3 text-sm font-semibold">Payout Modifier Policy</h4>
 						<div className="space-y-2">
-								<PolicyRadio
-									label="No Modifier Policy"
-									selected={selectedModifierPolicyId === null}
-									onSelect={() => setSelectedModifierPolicyId(null)}
-									detail="No policy applied"
-								/>
+							<PolicyRadio
+								label="No Modifier Policy"
+								selected={selectedModifierPolicyId === null}
+								onSelect={() => setSelectedModifierPolicyId(null)}
+								detail="No policy applied"
+							/>
 							{modifierPolicies.map((p) => {
 								const cfg = isPayoutModifierConfig(p.config) ? p.config : null
 								return (
@@ -1338,32 +1346,32 @@ export function ReviewRequestForm({
 					<h4 className="mb-3 text-sm font-semibold">Ad-hoc Modifiers</h4>
 					<div className="space-y-2">
 						{predefinedModifierOptions.length > 0 && (
-								<Select
-									value={selectedPredefinedModifierValue}
-									onValueChange={(value) => {
-										setSelectedPredefinedModifierValue(value)
-										addPredefinedModifier(value)
-									}}
-									options={predefinedModifierOptions}
-									placeholder="Apply modifier template"
-									searchable
-									emptyText="No predefined modifiers"
-								/>
-							)}
+							<Select
+								value={selectedPredefinedModifierValue}
+								onValueChange={(value) => {
+									setSelectedPredefinedModifierValue(value)
+									addPredefinedModifier(value)
+								}}
+								options={predefinedModifierOptions}
+								placeholder="Apply modifier template"
+								searchable
+								emptyText="No predefined modifiers"
+							/>
+						)}
 						{modifiers.map((mod) => (
 							<div
 								key={mod.id}
 								className="flex items-center gap-2 rounded-md border border-border/40 p-2"
 							>
 								<div className="w-32">
-										<Select
-											value={mod.modifierType}
-											onValueChange={(v) => updateModifier(mod.id, { modifierType: v as any })}
-											options={[
-												{ value: 'deduction', label: 'Deduction' },
-												{ value: 'bonus', label: 'Bonus' },
-											]}
-										/>
+									<Select
+										value={mod.modifierType}
+										onValueChange={(v) => updateModifier(mod.id, { modifierType: v as any })}
+										options={[
+											{ value: 'deduction', label: 'Deduction' },
+											{ value: 'bonus', label: 'Bonus' },
+										]}
+									/>
 								</div>
 								<div className="w-24">
 									<Select

--- a/apps/ui/src/client/features/srp/components/SRPFittingDisplay.tsx
+++ b/apps/ui/src/client/features/srp/components/SRPFittingDisplay.tsx
@@ -1,3 +1,6 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { typeIconUrl } from '@/lib/eve-images'
@@ -5,19 +8,22 @@ import { typeIconUrl } from '@/lib/eve-images'
 import { SRPFittingPanel } from './SRPFittingPanel'
 import { SRPFittingSlotList } from './SRPFittingSlotList'
 
+import type { ReactNode } from 'react'
 import type {
 	SRPCargoItem,
 	SRPFittingItem,
+	SRPShipMaintenanceBayContent,
+	SRPShipMaintenanceBayShip,
 	SRPShipSlotCapacities,
 	SRPSlotHighlightMap,
 } from '../utils/fitting'
-import type { ReactNode } from 'react'
 
 interface SRPFittingDisplayProps {
 	shipTypeId: string
 	shipTypeName?: string
 	fittingItems: SRPFittingItem[]
 	cargoItems?: SRPCargoItem[]
+	shipMaintenanceBayShips?: SRPShipMaintenanceBayShip[]
 	slotHighlights?: SRPSlotHighlightMap
 	slotCapacities?: SRPShipSlotCapacities
 	showPricing?: boolean
@@ -30,6 +36,7 @@ export function SRPFittingDisplay({
 	shipTypeName,
 	fittingItems,
 	cargoItems,
+	shipMaintenanceBayShips,
 	slotHighlights,
 	slotCapacities,
 	showPricing = true,
@@ -98,6 +105,111 @@ export function SRPFittingDisplay({
 						</div>
 					)}
 				</Card>
+			)}
+
+			{shipMaintenanceBayShips && shipMaintenanceBayShips.length > 0 && (
+				<ShipMaintenanceBayCard ships={shipMaintenanceBayShips} />
+			)}
+		</div>
+	)
+}
+
+function ShipMaintenanceBayCard({ ships }: { ships: SRPShipMaintenanceBayShip[] }) {
+	const [expandedShips, setExpandedShips] = useState<Set<string>>(new Set())
+
+	const toggleShip = (key: string) => {
+		setExpandedShips((current) => {
+			const next = new Set(current)
+			if (next.has(key)) next.delete(key)
+			else next.add(key)
+			return next
+		})
+	}
+
+	return (
+		<Card className="p-4">
+			<h4 className="mb-3 font-semibold text-sm">Ship Maintenance Bay</h4>
+			<div className="space-y-1 rounded-md border border-border/40 bg-muted/10 p-1">
+				{ships.map((ship, index) => {
+					const key = `${ship.typeId}-${index}`
+					const isExpanded = expandedShips.has(key)
+
+					return (
+						<div key={key} className="rounded border border-border/30">
+							<button
+								type="button"
+								onClick={() => toggleShip(key)}
+								aria-expanded={isExpanded}
+								className="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-1 text-left hover:bg-muted/20"
+							>
+								{isExpanded ? (
+									<ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+								) : (
+									<ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+								)}
+								<img
+									src={typeIconUrl(ship.typeId, 32)}
+									alt={ship.typeName}
+									className="h-8 w-8 shrink-0 rounded border border-border/40 object-contain"
+									loading="lazy"
+								/>
+								<span className="min-w-0 flex-1 truncate text-sm font-medium">
+									{ship.typeName}
+									{ship.quantity > 1 && (
+										<span className="ml-1.5 text-primary">x{ship.quantity.toLocaleString()}</span>
+									)}
+								</span>
+								<span className="text-xs text-muted-foreground">
+									{ship.contents.length} item{ship.contents.length === 1 ? '' : 's'}
+								</span>
+							</button>
+							{isExpanded && <MaintenanceBayContents contents={ship.contents} />}
+						</div>
+					)
+				})}
+			</div>
+		</Card>
+	)
+}
+
+function MaintenanceBayContents({
+	contents,
+	depth = 0,
+}: {
+	contents: SRPShipMaintenanceBayContent[]
+	depth?: number
+}) {
+	return (
+		<div className="border-t border-border/30 px-3 py-2">
+			{contents.length === 0 ? (
+				<p className="text-xs text-muted-foreground">No contents recorded.</p>
+			) : (
+				<div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1 text-xs">
+					{contents.map((item, index) => (
+						<div key={`${item.typeId}-${index}`} className="contents">
+							<div
+								className="flex min-w-0 items-center gap-2"
+								style={{ paddingLeft: `${depth * 1.25}rem` }}
+							>
+								<img
+									src={typeIconUrl(item.typeId, 32)}
+									alt={item.typeName}
+									className="h-6 w-6 shrink-0 rounded border border-border/30 object-contain"
+									loading="lazy"
+								/>
+								<span className="truncate">{item.typeName}</span>
+							</div>
+							<span className="text-right text-muted-foreground">
+								x{item.quantity.toLocaleString()}
+							</span>
+							{item.items?.length ? (
+								<div className="col-span-2">
+									<MaintenanceBayContents contents={item.items} depth={depth + 1} />
+								</div>
+							) : null}
+						</div>
+					))}
+				</div>
 			)}
 		</div>
 	)

--- a/apps/ui/src/client/features/srp/utils/fitting.ts
+++ b/apps/ui/src/client/features/srp/utils/fitting.ts
@@ -1,3 +1,5 @@
+import { SHIP_MAINTENANCE_BAY_FLAG } from '@repo/srp'
+
 import type {
 	FittingShipSlotType,
 	FittingSlotCapacities,
@@ -30,14 +32,14 @@ const EQUIPPED_FLAG_RANGES: Array<{ min: number; max: number; type: SlotType; ba
 	{ min: 11, max: 18, type: 'low', base: 11 },
 	{ min: 19, max: 26, type: 'mid', base: 19 },
 	{ min: 27, max: 34, type: 'high', base: 27 },
-	{ min: 89, max: 98, type: 'implant', base: 89 },
+	{ min: 89, max: 89, type: 'implant', base: 89 },
 	{ min: 92, max: 99, type: 'rig', base: 92 },
 	{ min: 125, max: 132, type: 'sub', base: 125 },
 ]
 
-// Rigs overlap with implants in flag range — rigs take priority (92-99 over implants 89-98)
+// Rigs are checked first so their flags remain unambiguous if EVE adds adjacent flags.
 function flagToSlot(flag: number): { slotType: SlotType; slotIndex: number } | null {
-	// Check rigs first (92-99) before implants (89-98) due to overlap
+	// Check rigs first so their flags remain unambiguous if EVE adds adjacent flags.
 	if (flag >= 92 && flag <= 99) return { slotType: 'rig', slotIndex: flag - 92 }
 	for (const range of EQUIPPED_FLAG_RANGES) {
 		if (flag >= range.min && flag <= range.max) {
@@ -62,6 +64,21 @@ export interface SRPCargoItem {
 	flag: number
 }
 
+export interface SRPShipMaintenanceBayContent {
+	typeId: string
+	typeName: string
+	quantity: number
+	flag: number
+	items?: SRPShipMaintenanceBayContent[]
+}
+
+export interface SRPShipMaintenanceBayShip {
+	typeId: string
+	typeName: string
+	quantity: number
+	contents: SRPShipMaintenanceBayContent[]
+}
+
 interface SRPItemPrice {
 	typeId: string
 	price: string
@@ -70,23 +87,29 @@ interface SRPItemPrice {
 
 function flattenKillmailItemsForDisplay(
 	items: KillmailItem[],
-	inheritedFlag?: number
+	inheritedFlag?: number,
+	includeContainedShips = true
 ): KillmailItem[] {
 	const flattened: KillmailItem[] = []
 
 	for (const item of items) {
 		const slot = flagToSlot(item.flag)
-		const displayFlag = slot ? item.flag : (inheritedFlag ?? item.flag)
+		const isContainedShip = item.flag === SHIP_MAINTENANCE_BAY_FLAG
+		const displayFlag = isContainedShip ? 5 : slot ? item.flag : (inheritedFlag ?? item.flag)
 
-		flattened.push({
-			item_type_id: item.item_type_id,
-			flag: displayFlag,
-			quantity_destroyed: item.quantity_destroyed,
-			quantity_dropped: item.quantity_dropped,
-		})
+		if (!isContainedShip || includeContainedShips) {
+			flattened.push({
+				item_type_id: item.item_type_id,
+				flag: displayFlag,
+				quantity_destroyed: item.quantity_destroyed,
+				quantity_dropped: item.quantity_dropped,
+			})
+		}
 
-		if (item.items?.length) {
-			flattened.push(...flattenKillmailItemsForDisplay(item.items, displayFlag))
+		if (!isContainedShip && item.items?.length) {
+			flattened.push(
+				...flattenKillmailItemsForDisplay(item.items, displayFlag, includeContainedShips)
+			)
 		}
 	}
 
@@ -144,7 +167,7 @@ export function transformKillmailToCargoItems(
 	itemNames: Record<string, string> = {}
 ): SRPCargoItem[] {
 	const byType = new Map<string, SRPCargoItem>()
-	const flattenedItems = flattenKillmailItemsForDisplay(killmailItems)
+	const flattenedItems = flattenKillmailItemsForDisplay(killmailItems, undefined, false)
 
 	for (const item of flattenedItems) {
 		if (item.flag !== 5) continue
@@ -164,6 +187,33 @@ export function transformKillmailToCargoItems(
 	}
 
 	return [...byType.values()].sort((left, right) => left.typeName.localeCompare(right.typeName))
+}
+
+function transformMaintenanceBayContents(
+	items: KillmailItem[] | undefined,
+	itemNames: Record<string, string>
+): SRPShipMaintenanceBayContent[] {
+	return (items ?? []).map((item) => ({
+		typeId: String(item.item_type_id),
+		typeName: itemNames[String(item.item_type_id)] ?? String(item.item_type_id),
+		quantity: (item.quantity_destroyed ?? 0) + (item.quantity_dropped ?? 0) || 1,
+		flag: item.flag,
+		items: item.items?.length ? transformMaintenanceBayContents(item.items, itemNames) : undefined,
+	}))
+}
+
+export function transformKillmailToShipMaintenanceBayShips(
+	killmailItems: KillmailItem[],
+	itemNames: Record<string, string> = {}
+): SRPShipMaintenanceBayShip[] {
+	return killmailItems
+		.filter((item) => item.flag === SHIP_MAINTENANCE_BAY_FLAG)
+		.map((item) => ({
+			typeId: String(item.item_type_id),
+			typeName: itemNames[String(item.item_type_id)] ?? String(item.item_type_id),
+			quantity: (item.quantity_destroyed ?? 0) + (item.quantity_dropped ?? 0) || 1,
+			contents: transformMaintenanceBayContents(item.items, itemNames),
+		}))
 }
 
 export const POD_TYPE_IDS = new Set(['670', '33328'])

--- a/apps/ui/src/test/unit/features/srp/fitting.unit.test.ts
+++ b/apps/ui/src/test/unit/features/srp/fitting.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	transformKillmailToCargoItems,
+	transformKillmailToFittingItems,
+	transformKillmailToShipMaintenanceBayShips,
+} from '@/features/srp/utils/fitting'
+
+describe('SRP killmail fitting transforms', () => {
+	it('renders a ship maintenance bay ship as cargo without its nested contents', () => {
+		const items = [
+			{ flag: 27, item_type_id: 4292, quantity_dropped: 1 },
+			{
+				flag: 90,
+				item_type_id: 11400,
+				quantity_dropped: 1,
+				items: [{ flag: 27, item_type_id: 4027, quantity_dropped: 1 }],
+			},
+		]
+
+		expect(transformKillmailToFittingItems(items, [])).toEqual([
+			expect.objectContaining({ typeId: '4292', slotType: 'high' }),
+		])
+		expect(transformKillmailToCargoItems(items)).toEqual([])
+		expect(transformKillmailToShipMaintenanceBayShips(items)).toEqual([
+			expect.objectContaining({
+				typeId: '11400',
+				quantity: 1,
+				contents: [expect.objectContaining({ typeId: '4027', quantity: 1 })],
+			}),
+		])
+	})
+})

--- a/packages/srp/src/index.ts
+++ b/packages/srp/src/index.ts
@@ -9,6 +9,7 @@ import { z } from 'zod'
 export {
 	buildKillmailItemMetadata,
 	collectKillmailItemTypeIds,
+	SHIP_MAINTENANCE_BAY_FLAG,
 	type KillmailItemNode,
 	type KillmailItemTypeMeta,
 } from './lib/killmail-item-names'
@@ -64,11 +65,7 @@ export interface RecentLossCacheBackfillResult {
 	persistedLosses: number
 }
 
-export type RecentLossRefreshStatus =
-	| 'queued'
-	| 'running'
-	| 'completed'
-	| 'failed'
+export type RecentLossRefreshStatus = 'queued' | 'running' | 'completed' | 'failed'
 
 export interface RecentLossRefreshStatusRecord {
 	userId: string
@@ -138,7 +135,11 @@ export interface Srp {
 		actorCharacterName: string,
 		notes?: string
 	): Promise<SRPRequestResponse>
-	getRequest(requestId: string, userId: string, includeShipSlotCapacities?: boolean): Promise<SRPRequestResponse | null>
+	getRequest(
+		requestId: string,
+		userId: string,
+		includeShipSlotCapacities?: boolean
+	): Promise<SRPRequestResponse | null>
 	getRequestEligibilityData(requestId: string): Promise<SrpRequestEligibilityData | null>
 	getPublicRequestSummary(requestId: string): Promise<SRPPublicRequestSummaryResponse | null>
 	getUserRequests(
@@ -286,7 +287,6 @@ export interface Srp {
 		actorUserId: string,
 		actorCharacterName: string
 	): Promise<SRPPaymentMismatchAlert>
-
 
 	// Statistics
 	getStats(startDate?: string, endDate?: string, corporationId?: string): Promise<SRPStatsResponse>
@@ -459,14 +459,7 @@ export const SRPReviewSubmissionSchema = z.object({
  * Schema for changing request state
  */
 export const UpdateReviewStateSchema = z.object({
-	newState: z.enum([
-		'pending',
-		'needs_context',
-		'approved',
-		'payment_pending',
-		'rejected',
-		'paid',
-	]),
+	newState: z.enum(['pending', 'needs_context', 'approved', 'payment_pending', 'rejected', 'paid']),
 	notes: z.string().max(2000).optional(),
 })
 
@@ -496,8 +489,16 @@ export const UpdateSRPConfigSchema = z.object({
 	maxLossAgeDays: z.number().int().positive().max(MAX_SRP_LOSS_AGE_DAYS).optional(),
 	paymentProcessorCorporationId: z.string().nullable().optional(),
 	srpGroupId: z.string().nullable().optional(),
-	srpDiscordGuildId: z.string().regex(/^\d{17,20}$/).nullable().optional(),
-	srpDiscordChannelId: z.string().regex(/^\d{17,20}$/).nullable().optional(),
+	srpDiscordGuildId: z
+		.string()
+		.regex(/^\d{17,20}$/)
+		.nullable()
+		.optional(),
+	srpDiscordChannelId: z
+		.string()
+		.regex(/^\d{17,20}$/)
+		.nullable()
+		.optional(),
 	metadata: z.record(z.string(), z.unknown()).optional(),
 	predefinedAdhocModifiers: z.array(PredefinedAdhocModifierSchema).optional(),
 })
@@ -740,18 +741,28 @@ export interface SRPValuationPreview {
 	pricingSource: 'historic' | 'fallback'
 	/** Whether insurance prices came from stored daily history or live ESI cache fallback. Absent for pod losses. */
 	insuranceSource?: 'historic' | 'fallback'
-	itemPrices: Array<{ typeId: string; typeName: string; quantity: number; unitPrice: string; lineTotal: string; isConsumable?: boolean }>
-	/** Raw victim items from the killmail — used to render the fitting panel. */
-	victimItems: Array<{
+	itemPrices: Array<{
 		typeId: string
-		flag: number
-		quantityDestroyed: number
-		quantityDropped: number
+		typeName: string
+		quantity: number
+		unitPrice: string
+		lineTotal: string
+		isConsumable?: boolean
 	}>
+	/** Raw victim items from the killmail — used to render the fitting panel. */
+	victimItems: SRPValuationPreviewVictimItem[]
 	/** Resolved type names for all item and ship type IDs in this killmail. */
 	itemNames: Record<string, string>
 	/** Type IDs that had no market data at the loss date (priced at 0). */
 	missingPriceTypeIds: string[]
+}
+
+export interface SRPValuationPreviewVictimItem {
+	typeId: string
+	flag: number
+	quantityDestroyed: number
+	quantityDropped: number
+	items?: SRPValuationPreviewVictimItem[]
 }
 
 /**

--- a/packages/srp/src/lib/killmail-item-names.ts
+++ b/packages/srp/src/lib/killmail-item-names.ts
@@ -1,4 +1,5 @@
 export interface KillmailItemNode {
+	flag?: number
 	item_type_id?: number | string
 	type_id?: number | string
 	typeId?: number | string
@@ -29,6 +30,9 @@ export function collectKillmailItemTypeIds(items: readonly KillmailItemNode[]): 
 	walk(items)
 	return [...typeIds]
 }
+
+/** ESI flag used for a ship stored in another ship's ship maintenance bay. */
+export const SHIP_MAINTENANCE_BAY_FLAG = 90
 
 export function buildKillmailItemMetadata(
 	items: readonly KillmailItemNode[],


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes incorrect SRP display of ships stored in a lost ship's Ship Maintenance Bay (SMB): they were being misclassified as fitted implants (or dropped/flattened) instead of being shown as their own contained ships with nested cargo.

## Changes
- `isEquippedSlot` (`apps/srp/src/lib/slot-flags.ts`) and `flagToSlot` (`apps/ui/.../srp/utils/fitting.ts`) no longer treat flags 90/91 as implant slots — the old `89–98` range overlapped with the SMB flag (90), causing SMB contents to render as fitted implants.
- Added `SHIP_MAINTENANCE_BAY_FLAG` (90) constant and `flag` field on `KillmailItemNode` in `@repo/srp`.
- Killmail item flattening in the SRP durable object now preserves nested item hierarchy (`serializeVictimItemsForPreview` replaces the old `flattenVictimItemsForPreview`) so SMB contents keep their parent/child structure instead of being flattened into a single list.
- Added `transformKillmailToShipMaintenanceBayShips` plus `SRPShipMaintenanceBayShip`/`SRPShipMaintenanceBayContent` types to build a dedicated SMB item tree, and excluded SMB ships from the cargo transform.
- Added a new `ShipMaintenanceBayCard` (collapsible, per-ship contents) to `SRPFittingDisplay`, and wired `shipMaintenanceBayShips` through `CreateRequestForm` and `ReviewRequestForm`.
- `SRPValuationPreview.victimItems` is now recursive (`SRPValuationPreviewVictimItem`) to carry nested SMB contents through the API.
- Incidental Prettier formatting cleanup in `apps/srp/src/durable-object.ts` and `ReviewRequestForm.tsx` (no behavior change).

## Testing
- Added/updated unit tests: `collectKillmailItemTypeIds` (new `srp-killmail-item-names.test.ts`), `isEquippedSlot` (flags 89–91 in `slot-flags.unit.test.ts`), `buildEquippedByType` (`equipment.unit.test.ts`), and the new fitting transforms (`apps/ui/src/test/unit/features/srp/fitting.unit.test.ts`) covering SMB ships being excluded from fittings/cargo and rendered with their nested contents.
<!-- claude:end -->