### PR TITLE
add SRP type from broadcast for srpfleet command

### DIFF
--- a/apps/broadcasts/src/durable-object.ts
+++ b/apps/broadcasts/src/durable-object.ts
@@ -752,6 +752,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 			.select({
 				content: broadcasts.content,
 				srpToken: broadcastSessionLinks.srpToken,
+				srpMode: broadcastSessionLinks.srpMode,
 				doctrineId: broadcastSessionLinks.doctrineId,
 				fleetSessionId: broadcastSessionLinks.fleetSessionId,
 			})
@@ -772,6 +773,7 @@ export class BroadcastsDO extends DurableObject<Env> implements Broadcasts {
 		return {
 			content: row.content as Record<string, unknown>,
 			srpToken: row.srpToken,
+			srpMode: row.srpMode,
 			doctrineId: row.doctrineId,
 			fleetSessionId: row.fleetSessionId,
 		}

--- a/apps/core/src/services/discord-programmatic-commands/__tests__/srpfleet.test.ts
+++ b/apps/core/src/services/discord-programmatic-commands/__tests__/srpfleet.test.ts
@@ -6,6 +6,7 @@ import type { DiscordEmbed } from '@repo/discord'
 import type { ProgrammaticCommandContext, ProgrammaticCommandEnv } from '../types'
 
 const hoisted = vi.hoisted(() => ({
+	select: vi.fn(),
 	getConfig: vi.fn(),
 	getSrpFleetBroadcastByToken: vi.fn(),
 	getSrpFleetSessionDetails: vi.fn(),
@@ -14,6 +15,10 @@ const hoisted = vi.hoisted(() => ({
 	wasSessionMemberAt: vi.fn(),
 	sendMessage: vi.fn(),
 	getCachedUserPermissions: vi.fn(),
+}))
+
+vi.mock('../../../db', () => ({
+	createDb: vi.fn(() => ({ select: hoisted.select })),
 }))
 
 vi.mock('@repo/do-utils', () => ({
@@ -39,6 +44,7 @@ function ctx(overrides: Partial<ProgrammaticCommandContext> = {}): ProgrammaticC
 		isAdmin: false,
 		env: {
 			GROUPS: {},
+			DATABASE_URL: 'database-url',
 			DISCORD: {},
 			PREDICTION_MARKETS: {},
 			BROADCASTS: {},
@@ -65,6 +71,7 @@ describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
 		})
 		hoisted.getSrpFleetBroadcastByToken.mockResolvedValue({
 			fleetSessionId: 'session-1',
+			srpMode: 'blanket',
 			doctrineId: null,
 			srpToken: 'FleetToken',
 			content: {
@@ -91,6 +98,15 @@ describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
 		})
 		hoisted.wasSessionMemberAt.mockResolvedValue(true)
 		hoisted.getCachedUserPermissions.mockResolvedValue([{ urn: 'urn:srp:reviewer' }])
+		hoisted.select.mockReturnValue({
+			from: () => ({
+				innerJoin: () => ({
+					where: () => ({
+						limit: () => Promise.resolve([{ characterName: 'Commanding Main' }]),
+					}),
+				}),
+			}),
+		})
 		hoisted.sendMessage.mockResolvedValue({ success: true, messageId: 'message-1' })
 	})
 
@@ -108,16 +124,22 @@ describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
 		expect(result.data?.content).toContain('posted')
 		const embed = hoisted.sendMessage.mock.calls[0]?.[2]?.embeds?.[0] as DiscordEmbed | undefined
 		expect(embed?.title).toContain('Standing Fleet')
-		expect(embed?.fields?.find((field) => field.name === 'MOTD')?.value).toContain('Comms\nStanding')
+		expect(embed?.fields?.find((field) => field.name === 'MOTD')?.value).toContain(
+			'Comms\nStanding'
+		)
 		expect(embed?.fields?.find((field) => field.name === 'SRP Token')?.value).toBe('FleetToken')
+		expect(embed?.fields?.find((field) => field.name === 'SRP Type')?.value).toBe('Blanket')
+		expect(embed?.fields?.find((field) => field.name === 'Requested By')?.value).toBe(
+			'Commanding Main'
+		)
 		expect(embed?.fields?.find((field) => field.name === 'Eligibility Check')?.value).toContain(
 			'Member of fleet at loss: Yes'
 		)
 		expect(hoisted.wasSessionMemberAt).toHaveBeenCalledWith(
-		'session-1',
-		'300',
-		'2026-01-01T11:00:00.000Z'
-	)
+			'session-1',
+			'300',
+			'2026-01-01T11:00:00.000Z'
+		)
 	})
 
 	it('rejects an invocation from the wrong channel before looking up the token', async () => {
@@ -127,6 +149,7 @@ describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
 
 		expect(result.data?.content).toContain('configured SRP channel')
 		expect(hoisted.getSrpFleetBroadcastByToken).not.toHaveBeenCalled()
+		expect(hoisted.select).not.toHaveBeenCalled()
 		expect(hoisted.sendMessage).not.toHaveBeenCalled()
 	})
 
@@ -141,6 +164,7 @@ describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
 	it('resolves the linked doctrine name without loading doctrine fittings', async () => {
 		hoisted.getSrpFleetBroadcastByToken.mockResolvedValue({
 			fleetSessionId: 'session-1',
+			srpMode: 'military',
 			doctrineId: 'doctrine-1',
 			srpToken: 'FleetToken',
 			content: { fleetName: 'Standing Fleet' },
@@ -152,5 +176,6 @@ describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
 		expect(hoisted.getDoctrineName).toHaveBeenCalledWith('doctrine-1')
 		const embed = hoisted.sendMessage.mock.calls[0]?.[2]?.embeds?.[0] as DiscordEmbed | undefined
 		expect(embed?.fields?.find((field) => field.name === 'Doctrine')?.value).toBe('Armor HAC')
+		expect(embed?.fields?.find((field) => field.name === 'SRP Type')?.value).toBe('Military')
 	})
 })

--- a/apps/core/src/services/discord-programmatic-commands/srpfleet.ts
+++ b/apps/core/src/services/discord-programmatic-commands/srpfleet.ts
@@ -1,11 +1,14 @@
+import { eq } from '@repo/db-utils'
 import { DISCORD_SLASH_COMMAND_OPTION_TYPE } from '@repo/discord'
 import { getStub } from '@repo/do-utils'
-
-import { getCachedUserPermissions } from '../../lib/groups-cache'
-import { ephemeralCommandResponse } from './types'
 import { parseDateOrNull } from '@repo/worker-utils'
 
-import type { Broadcasts } from '@repo/broadcasts'
+import { createDb } from '../../db'
+import { userCharacters, users } from '../../db/schema'
+import { getCachedUserPermissions } from '../../lib/groups-cache'
+import { ephemeralCommandResponse } from './types'
+
+import type { Broadcasts, BroadcastSrpMode } from '@repo/broadcasts'
 import type { Discord, DiscordEmbed } from '@repo/discord'
 import type { Doctrines } from '@repo/doctrines'
 import type { Fleets } from '@repo/fleets'
@@ -54,6 +57,29 @@ function buildComparisonError(message: string): string {
 	return `Eligibility comparison unavailable: ${message}`
 }
 
+function srpTypeLabel(mode: BroadcastSrpMode | null | undefined): string {
+	if (mode === 'blanket') return 'Blanket'
+	if (mode === 'military') return 'Military'
+	if (mode === 'coalition') return 'Coalition'
+	if (mode === 'disabled') return 'None'
+	return 'Unavailable'
+}
+
+async function getInvokerMainCharacterName(
+	databaseUrl: string,
+	userId: string
+): Promise<string | null> {
+	const db = createDb(databaseUrl)
+	const [row] = await db
+		.select({ characterName: userCharacters.characterName })
+		.from(users)
+		.innerJoin(userCharacters, eq(userCharacters.characterId, users.mainCharacterId))
+		.where(eq(users.id, userId))
+		.limit(1)
+
+	return row?.characterName ?? null
+}
+
 export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 	name: 'srpfleet',
 	description: 'Show SRP fleet details for a fleet broadcast token.',
@@ -81,7 +107,9 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 		if (!isAdmin) {
 			const permissions = await getCachedUserPermissions(env, coreUserId)
 			if (!permissions.some((permission) => SRP_STAFF_URNS.has(permission.urn))) {
-				return ephemeralCommandResponse('You need SRP reviewer, payer, or manager permissions to use this command.')
+				return ephemeralCommandResponse(
+					'You need SRP reviewer, payer, or manager permissions to use this command.'
+				)
 			}
 		}
 
@@ -93,7 +121,9 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 			return ephemeralCommandResponse('The SRP Discord channel is not configured.')
 		}
 		if (input.guildId !== configuredGuildId || input.channelId !== configuredChannelId) {
-			return ephemeralCommandResponse('This command can only be used in the configured SRP channel.')
+			return ephemeralCommandResponse(
+				'This command can only be used in the configured SRP channel.'
+			)
 		}
 
 		const token = optionValues.token?.trim()
@@ -106,11 +136,15 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 		}
 
 		const fleets = getStub<Fleets>(env.FLEETS, 'default')
-		const details = await fleets.getSrpFleetSessionDetails(broadcast.fleetSessionId)
+		const [details, invokerMainCharacterName] = await Promise.all([
+			fleets.getSrpFleetSessionDetails(broadcast.fleetSessionId),
+			getInvokerMainCharacterName(env.DATABASE_URL, coreUserId).catch(() => null),
+		])
 		if (!details) return ephemeralCommandResponse('The fleet session could not be found.')
 
 		const content = broadcast.content ?? {}
-		const fleetName = textValue(content.fleetName) ?? textValue(content.fleet_name) ?? details.sessionName
+		const fleetName =
+			textValue(content.fleetName) ?? textValue(content.fleet_name) ?? details.sessionName
 		let doctrine = textValue(content.doctrine) ?? textValue(content.doctrineName)
 		if (!doctrine && broadcast.doctrineId) {
 			try {
@@ -123,7 +157,12 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 		doctrine ??= 'Unavailable'
 		const commanders = details.commanderCharacterIds.map((id, index) => {
 			const name = details.commanderCharacterNames[id] ?? id
-			const label = index === 0 ? 'Initial Commander' : index === details.commanderCharacterIds.length - 1 ? 'Final Commander' : 'Commander Handoff'
+			const label =
+				index === 0
+					? 'Initial Commander'
+					: index === details.commanderCharacterIds.length - 1
+						? 'Final Commander'
+						: 'Commander Handoff'
 			return `${label}: ${name}`
 		})
 
@@ -136,7 +175,9 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 				} else {
 					const request = await srp.getRequestEligibilityData(comparisonId)
 					if (!request) {
-						comparison = buildComparisonError(`no SRP request was found for Killmail ID ${comparisonId}.`)
+						comparison = buildComparisonError(
+							`no SRP request was found for Killmail ID ${comparisonId}.`
+						)
 					} else {
 						const memberAtLoss = await fleets.wasSessionMemberAt(
 							details.sessionId,
@@ -159,8 +200,10 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 		const fields: NonNullable<DiscordEmbed['fields']> = [
 			{ name: 'Fleet Commander(s)', value: truncate(commanders.join('\n') || 'Unavailable') },
 			{ name: 'Doctrine', value: truncate(doctrine) },
+			{ name: 'SRP Type', value: srpTypeLabel(broadcast.srpMode) },
 			{ name: 'MOTD', value: sanitizeMotd(details.motd) },
 			{ name: 'SRP Token', value: truncate(token) },
+			{ name: 'Requested By', value: truncate(invokerMainCharacterName ?? 'Unavailable') },
 			{
 				name: 'Fleet Period',
 				value: `${discordTimestamp(details.startedAt, 'Unknown start')} - ${discordTimestamp(details.endedAt, 'Ongoing')}`,
@@ -185,7 +228,9 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 			allowEveryone: false,
 		})
 		if (!sent.success) {
-			return ephemeralCommandResponse('The fleet details could not be posted to the configured SRP channel.')
+			return ephemeralCommandResponse(
+				'The fleet details could not be posted to the configured SRP channel.'
+			)
 		}
 		return ephemeralCommandResponse('Fleet details posted to the configured SRP channel.')
 	},

--- a/packages/broadcasts/src/index.ts
+++ b/packages/broadcasts/src/index.ts
@@ -113,6 +113,7 @@ export interface BroadcastWithDetails extends Broadcast {
 export interface SrpFleetBroadcastLookup {
 	content: Record<string, unknown>
 	srpToken: string
+	srpMode: 'blanket' | 'military' | 'coalition' | 'disabled' | null
 	doctrineId: string | null
 	fleetSessionId: string | null
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Enriches the `/srpfleet` Discord command's embed with the broadcast's SRP mode ("SRP Type") and the invoking user's main character name ("Requested By"), so reviewers can see the fleet's SRP coverage and who requested the post directly from the embed.

## Changes
- Added `srpMode` to `SrpFleetBroadcastLookup` (`packages/broadcasts/src/index.ts`) and populated it in the `BroadcastsDO` query/return value (`apps/broadcasts/src/durable-object.ts`).
- Added `srpTypeLabel()` to map `BroadcastSrpMode` values (`blanket`, `military`, `coalition`, `disabled`, or missing) to display labels in `srpfleet.ts`.
- Added `getInvokerMainCharacterName()`, which looks up the invoking user's main character name via a DB join on `users`/`userCharacters`, fetched in parallel with the fleet session details.
- Added "SRP Type" and "Requested By" fields to the posted embed.
- Reformatted several long lines/ternaries in `srpfleet.ts` to satisfy Prettier line-width rules.

## Testing
- Updated `srpfleet.test.ts` to mock the new `../../db` `createDb`/`select` chain and assert the new "SRP Type" and "Requested By" embed fields for both the blanket and military SRP modes, and to verify the DB is not queried when the command is rejected for the wrong channel.
<!-- claude:end -->