### PR TITLE
add temp role assignment interaction button

### DIFF
--- a/apps/core/src/lib/__tests__/temporary-role-panel.test.ts
+++ b/apps/core/src/lib/__tests__/temporary-role-panel.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildDiscordWebhookMessagePayload } from '@repo/discord'
+
+import {
+	buildTemporaryRolePanelMessage,
+	parseTemporaryRolePanelAction,
+	TEMPORARY_ROLE_PANEL_DEFAULT_MESSAGE,
+	TEMPORARY_ROLE_PANEL_DEFAULT_TITLE,
+} from '../temporary-role-panel'
+
+describe('temporary role panel', () => {
+	it('builds a non-mentioning panel with join and leave buttons', () => {
+		const message = buildTemporaryRolePanelMessage()
+
+		expect(message.allowEveryone).toBe(false)
+		expect(message.embeds?.[0]?.title).toBe(TEMPORARY_ROLE_PANEL_DEFAULT_TITLE)
+		expect(message.embeds?.[0]?.description).toBe(TEMPORARY_ROLE_PANEL_DEFAULT_MESSAGE)
+		expect(message.components?.[0]?.components).toEqual([
+			expect.objectContaining({ label: 'Join', custom_id: 'tmp-role-panel:join' }),
+			expect.objectContaining({ label: 'Leave', custom_id: 'tmp-role-panel:leave' }),
+		])
+		expect(buildDiscordWebhookMessagePayload(message)).toMatchObject({
+			components: message.components,
+			allowed_mentions: { parse: [] },
+		})
+	})
+
+	it('accepts custom panel instructions and rejects oversized content', () => {
+		const message = buildTemporaryRolePanelMessage(' Custom title ', ' Custom instructions ')
+		expect(message.embeds?.[0]?.title).toBe('Custom title')
+		expect(message.embeds?.[0]?.description).toBe('Custom instructions')
+		expect(() => buildTemporaryRolePanelMessage('x'.repeat(257))).toThrow('title')
+		expect(() => buildTemporaryRolePanelMessage(undefined, 'x'.repeat(4001))).toThrow('description')
+	})
+
+	it('parses only known panel actions', () => {
+		expect(parseTemporaryRolePanelAction('tmp-role-panel:join')).toBe('join')
+		expect(parseTemporaryRolePanelAction('tmp-role-panel:leave')).toBe('leave')
+		expect(parseTemporaryRolePanelAction('tmp-role-panel:unknown')).toBeNull()
+	})
+})

--- a/apps/core/src/lib/temporary-role-panel.ts
+++ b/apps/core/src/lib/temporary-role-panel.ts
@@ -1,0 +1,66 @@
+import { DISCORD_BUTTON_STYLE, DISCORD_COMPONENT_TYPE } from '@repo/discord'
+
+import type { MessageContent } from '@repo/discord'
+
+export const TEMPORARY_ROLE_PANEL_DEFAULT_TITLE = 'Temporary Roles'
+
+export const TEMPORARY_ROLE_PANEL_DEFAULT_MESSAGE =
+	'Click Join to choose a temporary role. When you are done, click Leave or use /leave to remove it.'
+
+export const TEMPORARY_ROLE_PANEL_CUSTOM_IDS = {
+	join: 'tmp-role-panel:join',
+	leave: 'tmp-role-panel:leave',
+} as const
+
+const MAX_EMBED_DESCRIPTION_LENGTH = 4000
+const MAX_EMBED_TITLE_LENGTH = 256
+
+export function buildTemporaryRolePanelMessage(
+	title?: string,
+	description?: string
+): MessageContent {
+	const embedTitle = title?.trim() || TEMPORARY_ROLE_PANEL_DEFAULT_TITLE
+	const message = description?.trim() || TEMPORARY_ROLE_PANEL_DEFAULT_MESSAGE
+	if (embedTitle.length > MAX_EMBED_TITLE_LENGTH) {
+		throw new Error('The panel title is too long for a Discord embed.')
+	}
+	if (message.length > MAX_EMBED_DESCRIPTION_LENGTH) {
+		throw new Error('The panel description is too long for a Discord embed.')
+	}
+
+	return {
+		content: '\u200b',
+		embeds: [
+			{
+				title: embedTitle,
+				description: message,
+			},
+		],
+		components: [
+			{
+				type: DISCORD_COMPONENT_TYPE.ACTION_ROW,
+				components: [
+					{
+						type: DISCORD_COMPONENT_TYPE.BUTTON,
+						style: DISCORD_BUTTON_STYLE.SUCCESS,
+						label: 'Join',
+						custom_id: TEMPORARY_ROLE_PANEL_CUSTOM_IDS.join,
+					},
+					{
+						type: DISCORD_COMPONENT_TYPE.BUTTON,
+						style: DISCORD_BUTTON_STYLE.DANGER,
+						label: 'Leave',
+						custom_id: TEMPORARY_ROLE_PANEL_CUSTOM_IDS.leave,
+					},
+				],
+			},
+		],
+		allowEveryone: false,
+	}
+}
+
+export function parseTemporaryRolePanelAction(customId: string): 'join' | 'leave' | null {
+	if (customId === TEMPORARY_ROLE_PANEL_CUSTOM_IDS.join) return 'join'
+	if (customId === TEMPORARY_ROLE_PANEL_CUSTOM_IDS.leave) return 'leave'
+	return null
+}

--- a/apps/core/src/services/__tests__/discord-components.temporary-roles.test.ts
+++ b/apps/core/src/services/__tests__/discord-components.temporary-roles.test.ts
@@ -6,6 +6,7 @@ import type { ExecuteComponentInput, ExecuteModalSubmitInput } from '../discord-
 
 const hoisted = vi.hoisted(() => ({
 	findCommandRoleById: vi.fn(),
+	listSelfAssignableRolesForUser: vi.fn(),
 	assignTemporaryRole: vi.fn(),
 	removeTemporaryRole: vi.fn(),
 	hasAllianceMemberRole: vi.fn(),
@@ -15,6 +16,7 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock('../discord-temporary-roles.service', () => ({
 	findCommandRoleById: hoisted.findCommandRoleById,
+	listSelfAssignableRolesForUser: hoisted.listSelfAssignableRolesForUser,
 	assignTemporaryRole: hoisted.assignTemporaryRole,
 	removeTemporaryRole: hoisted.removeTemporaryRole,
 	hasAllianceMemberRole: hoisted.hasAllianceMemberRole,
@@ -91,6 +93,7 @@ describe('temporary role component/modal flow', () => {
 			getGuildMemberByDiscordUserId: vi.fn().mockResolvedValue({ isMember: true, roleIds: [] }),
 		})
 		hoisted.findCommandRoleById.mockResolvedValue(role)
+		hoisted.listSelfAssignableRolesForUser.mockResolvedValue([role])
 		hoisted.assignTemporaryRole.mockResolvedValue({
 			...role,
 			expiresAt: Date.now() + 302400000,
@@ -99,6 +102,51 @@ describe('temporary role component/modal flow', () => {
 		assignmentStub.listActiveAssignments.mockResolvedValue([])
 		db.query.users.findFirst.mockResolvedValue({ id: 'core-admin', is_admin: true })
 		hoisted.hasAllianceMemberRole.mockResolvedValue(true)
+	})
+
+	it('uses the shared join command behavior when a panel button is clicked', async () => {
+		const result = await executeDiscordComponent(
+			db,
+			env as never,
+			componentInput({ customId: 'tmp-role-panel:join', values: [] })
+		)
+
+		expect(result.reason).toBe('role-selection')
+		expect(result.response.type).toBe(9)
+		expect(result.response.data.components).toHaveLength(1)
+		expect(hoisted.listSelfAssignableRolesForUser).toHaveBeenCalledWith(
+			env,
+			db,
+			'guild-1',
+			'admin-discord',
+			'join',
+			undefined
+		)
+	})
+
+	it('uses the shared leave command behavior for a single panel role', async () => {
+		hoisted.listSelfAssignableRolesForUser.mockResolvedValue([role])
+
+		const result = await executeDiscordComponent(
+			db,
+			env as never,
+			componentInput({ customId: 'tmp-role-panel:leave', values: [] })
+		)
+
+		expect(result.reason).toBe('ok')
+		expect(result.response.data.content).toContain('Removed')
+		expect(hoisted.removeTemporaryRole).toHaveBeenCalledWith(
+			env,
+			db,
+			expect.objectContaining({
+				guildId: 'guild-1',
+				discordUserId: 'admin-discord',
+				coreUserId: 'core-admin',
+				role,
+				reason: 'part',
+				onlySelf: true,
+			})
+		)
 	})
 
 	it('assigns a selected self-assignable role from the join modal submission', async () => {
@@ -173,7 +221,9 @@ describe('temporary role component/modal flow', () => {
 			{ roleId: 'role-1', assignmentSource: 'self' },
 		])
 		hoisted.getDiscordStub.mockReturnValue({
-			getGuildMemberByDiscordUserId: vi.fn().mockResolvedValue({ isMember: true, roleIds: ['role-1'] }),
+			getGuildMemberByDiscordUserId: vi
+				.fn()
+				.mockResolvedValue({ isMember: true, roleIds: ['role-1'] }),
 		})
 		const result = await executeDiscordComponent(
 			db,
@@ -204,7 +254,9 @@ describe('temporary role component/modal flow', () => {
 			{ roleId: 'role-1', assignmentSource: 'self' },
 		])
 		hoisted.getDiscordStub.mockReturnValue({
-			getGuildMemberByDiscordUserId: vi.fn().mockResolvedValue({ isMember: true, roleIds: ['role-1'] }),
+			getGuildMemberByDiscordUserId: vi
+				.fn()
+				.mockResolvedValue({ isMember: true, roleIds: ['role-1'] }),
 		})
 
 		const result = await executeDiscordModalSubmit(

--- a/apps/core/src/services/__tests__/discord-programmatic-roles.test.ts
+++ b/apps/core/src/services/__tests__/discord-programmatic-roles.test.ts
@@ -18,6 +18,7 @@ const hoisted = vi.hoisted(() => ({
 	assignTemporaryRole: vi.fn(),
 	removeTemporaryRole: vi.fn(),
 	createDb: vi.fn(() => ({})),
+	getStub: vi.fn(),
 }))
 
 vi.mock('../discord-temporary-roles.service', () => ({
@@ -28,6 +29,8 @@ vi.mock('../discord-temporary-roles.service', () => ({
 }))
 
 vi.mock('../../db', () => ({ createDb: hoisted.createDb }))
+
+vi.mock('@repo/do-utils', () => ({ getStub: hoisted.getStub }))
 
 const role = {
 	roleDbId: 'role-db-1',
@@ -69,11 +72,14 @@ describe('temporary role programmatic commands', () => {
 			expiresAt: Date.now() + 3600000,
 		})
 		hoisted.removeTemporaryRole.mockResolvedValue(true)
+		hoisted.getStub.mockReturnValue({
+			sendMessage: vi.fn().mockResolvedValue({ success: true, messageId: 'message-1' }),
+		})
 	})
 
 	it('registers every live role command', () => {
 		expect(PROGRAMMATIC_COMMAND_DEFINITIONS.map((definition) => definition.name)).toEqual(
-			expect.arrayContaining(['join', 'part', 'leave'])
+			expect.arrayContaining(['join', 'part', 'leave', 'roles'])
 		)
 		expect(
 			[
@@ -82,6 +88,41 @@ describe('temporary role programmatic commands', () => {
 				DISCORD_LEAVE_PROGRAMMATIC_COMMAND,
 			].map((definition) => definition.name)
 		).toEqual(expect.arrayContaining(['join', 'part', 'leave']))
+	})
+
+	it('allows only site admins to post a temporary role panel', async () => {
+		const rolesCommand = PROGRAMMATIC_COMMAND_DEFINITIONS.find(
+			(definition) => definition.name === 'roles'
+		)
+		expect(rolesCommand).toBeDefined()
+		expect(rolesCommand!.options?.map((option) => option.name)).toEqual(['title', 'message'])
+
+		const response = await rolesCommand!.handler(
+			ctx({
+				isAdmin: true,
+				optionValues: { title: 'Fleet Roles', message: 'Pick a role.' },
+				input: {
+					commandName: 'roles',
+					discordUserId: 'discord-1',
+					guildId: 'guild-1',
+					channelId: 'channel-1',
+				},
+			})
+		)
+
+		expect(response.data?.content).toContain('message-1')
+		const sendMessage = hoisted.getStub.mock.results[0]?.value.sendMessage
+		expect(sendMessage).toHaveBeenCalledWith(
+			'guild-1',
+			'channel-1',
+			expect.objectContaining({
+				embeds: [expect.objectContaining({ title: 'Fleet Roles', description: 'Pick a role.' })],
+				components: [expect.objectContaining({ type: 1 })],
+			})
+		)
+
+		const denied = await rolesCommand!.handler(ctx({ isAdmin: false }))
+		expect(denied.data?.content).toContain('Only site admins')
 	})
 
 	it('rejects self-assignment when the caller lacks alliance member permission', async () => {

--- a/apps/core/src/services/discord-components.service.ts
+++ b/apps/core/src/services/discord-components.service.ts
@@ -12,18 +12,11 @@
  */
 
 import { eq } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
 import { getDiscordStub } from '@repo/discord'
+import { getStub } from '@repo/do-utils'
 import { captureException, logger } from '@repo/hono-helpers'
 
 import { users } from '../db/schema'
-import { TEMPORARY_ROLE_INTERACTION_REPLAY_ERROR } from '../temporary-role-assignments-do'
-import {
-	assignTemporaryRole,
-	findCommandRoleById,
-	hasAllianceMemberRole,
-	removeTemporaryRole,
-} from './discord-temporary-roles.service'
 import {
 	BET_AMOUNT_INPUT_ID,
 	customIdAction,
@@ -35,6 +28,8 @@ import {
 } from '../lib/market-custom-id'
 import { formatMarketPoints } from '../lib/market-embed'
 import { hasMarketPermission } from '../lib/market-permissions'
+import { parseTemporaryRolePanelAction } from '../lib/temporary-role-panel'
+import { TEMPORARY_ROLE_INTERACTION_REPLAY_ERROR } from '../temporary-role-assignments-do'
 import {
 	announceMarketClosed,
 	announceMarketResolved,
@@ -45,8 +40,15 @@ import {
 	applyMarketPostStatus,
 	updateMarketPostFromDetail,
 } from './discord-market-post.service'
+import {
+	assignTemporaryRole,
+	findCommandRoleById,
+	hasAllianceMemberRole,
+	removeTemporaryRole,
+} from './discord-temporary-roles.service'
+import { executeTemporaryRoleCommand } from './temporary-role-command.service'
 
-import type { Discord, DiscordActionRow, DiscordEmbed } from '@repo/discord'
+import type { Discord, DiscordInteractionResponse } from '@repo/discord'
 import type { PredictionMarkets } from '@repo/prediction-markets'
 import type { Env } from '../context'
 import type { createDb } from '../db'
@@ -82,17 +84,12 @@ function temporaryRoleFailureMessage(
 /** Bindings the component/modal path needs (money DO, Discord DO, groups for the tier gate). */
 export type ComponentEnv = Pick<
 	Env,
-	| 'DISCORD'
-	| 'PREDICTION_MARKETS'
-	| 'GROUPS'
-	| 'PM_FORUM_GUILD_ID'
-	| 'TEMPORARY_ROLE_ASSIGNMENTS'
+	'DISCORD' | 'PREDICTION_MARKETS' | 'GROUPS' | 'PM_FORUM_GUILD_ID' | 'TEMPORARY_ROLE_ASSIGNMENTS'
 >
 
 export interface DiscordComponentResult {
-	response: {
-		type: number
-		data: { content: string; flags?: number; embeds?: DiscordEmbed[]; components?: DiscordActionRow[] }
+	response: Omit<DiscordInteractionResponse, 'data'> & {
+		data: NonNullable<DiscordInteractionResponse['data']>
 	}
 	coreUserId: string | null
 	reason: string
@@ -203,7 +200,11 @@ async function handleTemporaryRoleSelection(
 	const user = await resolveUser(db, discordUserId)
 	if (!user) return ephemeral(NOT_LINKED, 'not-linked')
 	if (!user.is_admin && !(await hasAllianceMemberRole(env, user.id))) {
-		return ephemeral('You need alliance member permission to use this command.', 'permission', user.id)
+		return ephemeral(
+			'You need alliance member permission to use this command.',
+			'permission',
+			user.id
+		)
 	}
 	const selectedRoleValue =
 		roleValue ?? firstSelectedValue(selectValues, `tmp-role:${mode}:role`) ?? null
@@ -261,7 +262,9 @@ async function handleTemporaryRoleSelection(
 			onlySelf: true,
 		})
 		return ephemeral(
-			removed ? `Left **${role.displayName}**.` : `You do not currently have **${role.displayName}**.`,
+			removed
+				? `Left **${role.displayName}**.`
+				: `You do not currently have **${role.displayName}**.`,
 			'ok',
 			user.id
 		)
@@ -297,6 +300,49 @@ async function executeTemporaryRoleComponent(
 		input.selectValues,
 		input.interactionId
 	)
+}
+
+async function executeTemporaryRolePanelComponent(
+	db: ReturnType<typeof createDb>,
+	env: ComponentEnv,
+	input: ExecuteComponentInput,
+	mode: 'join' | 'leave'
+): Promise<DiscordComponentResult> {
+	if (!input.guildId)
+		return ephemeral('This action can only be used in a Discord server.', 'no-guild')
+	const user = await resolveUser(db, input.discordUserId)
+	if (!user) return ephemeral(NOT_LINKED, 'not-linked')
+
+	try {
+		const response = await executeTemporaryRoleCommand({
+			db,
+			env,
+			guildId: input.guildId,
+			discordUserId: input.discordUserId,
+			coreUserId: user.id,
+			isAdmin: user.is_admin,
+			memberRoleIds: input.memberRoleIds,
+			mode,
+		})
+		return {
+			response: response as DiscordComponentResult['response'],
+			coreUserId: user.id,
+			reason: response.type === 9 ? 'role-selection' : 'ok',
+		}
+	} catch (error) {
+		if (error instanceof Error && error.name === 'ProgrammaticCommandPermissionError') {
+			return ephemeral(error.message, 'permission', user.id)
+		}
+		return ephemeral(
+			temporaryRoleFailureMessage(error, {
+				guildId: input.guildId,
+				discordUserId: input.discordUserId,
+				roleValue: `panel:${mode}`,
+			}),
+			'role-error',
+			user.id
+		)
+	}
 }
 
 /** Pull the underlying driver error off a Drizzle "Failed query: …" wrapper (the real cause). */
@@ -441,7 +487,12 @@ async function announceSettlement(
 		const settlement = await prediction.getMarketSettlement(marketId)
 		if (!settlement) return undefined
 		const discord = getStub<Discord>(env.DISCORD, 'default')
-		const posted = await announceMarketResolved(discord, env.PM_FORUM_GUILD_ID ?? '', market, settlement)
+		const posted = await announceMarketResolved(
+			discord,
+			env.PM_FORUM_GUILD_ID ?? '',
+			market,
+			settlement
+		)
 		// Post failed → leave the flag NULL so the reconcile sweep re-posts (and re-DMs) later; don't
 		// half-notify by DMing now against a market whose public result never landed.
 		if (!posted) return undefined
@@ -495,6 +546,10 @@ export async function executeDiscordComponent(
 	env: ComponentEnv,
 	input: ExecuteComponentInput
 ): Promise<DiscordComponentResult> {
+	const panelAction = parseTemporaryRolePanelAction(input.customId)
+	if (panelAction) {
+		return executeTemporaryRolePanelComponent(db, env, input, panelAction)
+	}
 	if (input.customId.startsWith('tmp-role:')) {
 		return executeTemporaryRoleComponent(db, env, input)
 	}
@@ -560,7 +615,10 @@ export async function executeDiscordModalSubmit(
 			input.guildId,
 			input.discordUserId,
 			parseTemporaryRoleMode(input.customId) ?? 'join',
-			firstSelectedValue(input.selectValues, `tmp-role:${parseTemporaryRoleMode(input.customId) ?? 'join'}:role`) ??
+			firstSelectedValue(
+				input.selectValues,
+				`tmp-role:${parseTemporaryRoleMode(input.customId) ?? 'join'}:role`
+			) ??
 				input.values?.[0] ??
 				null,
 			input.selectValues,

--- a/apps/core/src/services/discord-programmatic-commands/index.ts
+++ b/apps/core/src/services/discord-programmatic-commands/index.ts
@@ -7,6 +7,7 @@ import {
 	DISCORD_JOIN_PROGRAMMATIC_COMMAND,
 	DISCORD_LEAVE_PROGRAMMATIC_COMMAND,
 	DISCORD_PART_PROGRAMMATIC_COMMAND,
+	DISCORD_ROLES_PROGRAMMATIC_COMMAND,
 } from './temporary-roles'
 
 import type { ProgrammaticCommandDefinition } from './types'
@@ -20,6 +21,7 @@ export {
 	DISCORD_JOIN_PROGRAMMATIC_COMMAND,
 	DISCORD_LEAVE_PROGRAMMATIC_COMMAND,
 	DISCORD_PART_PROGRAMMATIC_COMMAND,
+	DISCORD_ROLES_PROGRAMMATIC_COMMAND,
 } from './temporary-roles'
 export type { DeferralMode, ProgrammaticCommandDefinition } from './types'
 
@@ -32,6 +34,7 @@ export const PROGRAMMATIC_COMMAND_DEFINITIONS: ProgrammaticCommandDefinition[] =
 	DISCORD_JOIN_PROGRAMMATIC_COMMAND,
 	DISCORD_PART_PROGRAMMATIC_COMMAND,
 	DISCORD_LEAVE_PROGRAMMATIC_COMMAND,
+	DISCORD_ROLES_PROGRAMMATIC_COMMAND,
 ]
 
 export const programmaticCommandDefinitionByName = new Map(

--- a/apps/core/src/services/discord-programmatic-commands/temporary-roles.ts
+++ b/apps/core/src/services/discord-programmatic-commands/temporary-roles.ts
@@ -1,122 +1,39 @@
-import { createDb } from '../../db'
-import {
-	hasAllianceMemberRole,
-	listSelfAssignableRolesForUser,
-	removeTemporaryRole,
-} from '../discord-temporary-roles.service'
-import {
-	ephemeralCommandResponse,
-	modalCommandResponse,
-	ProgrammaticCommandPermissionError,
-} from './types'
+import { DISCORD_SLASH_COMMAND_OPTION_TYPE } from '@repo/discord'
+import { getStub } from '@repo/do-utils'
 
+import { createDb } from '../../db'
+import { buildTemporaryRolePanelMessage } from '../../lib/temporary-role-panel'
+import { executeTemporaryRoleCommand } from '../temporary-role-command.service'
+
+import type { Discord } from '@repo/discord'
 import type { ProgrammaticCommandContext, ProgrammaticCommandDefinition } from './types'
 
 const ALLIANCE_MEMBER_ACCESS = ['Alliance member']
 
-type TemporaryRoleCommandRole = {
-	roleDbId: string
-	roleName: string
-	displayName: string
-}
-
-const MAX_DISCORD_SELECT_LABEL_LENGTH = 100
-
-function buildRoleSelectModalResponse(mode: 'join' | 'leave', roles: TemporaryRoleCommandRole[]) {
-	if (
-		roles.length > 25 ||
-		roles.some(
-			(role) =>
-				role.displayName.length > MAX_DISCORD_SELECT_LABEL_LENGTH ||
-				role.roleName.length > MAX_DISCORD_SELECT_LABEL_LENGTH
-		)
-	) {
-		return ephemeralCommandResponse(
-			roles.length > 25
-				? 'Too many self-assignable roles are configured for this server.'
-				: 'A configured role name is too long for Discord selection.'
-		)
-	}
-	return modalCommandResponse(
-		mode === 'join' ? 'Choose a role to join.' : 'Choose a role to leave.',
-		`tmp-role:${mode}`,
-		[
-			{
-				type: 18 as const,
-				label: mode === 'join' ? 'Available roles' : 'Assigned roles',
-				description: mode === 'join' ? 'Select a role to join.' : 'Select a role to leave.',
-				component: {
-					type: 3 as const,
-					custom_id: `tmp-role:${mode}:role`,
-					options: roles.map((role) => ({
-						label: role.displayName,
-						value: role.roleDbId,
-						description: role.roleName,
-					})),
-					placeholder: mode === 'join' ? 'Select a role to join' : 'Select a role to leave',
-					max_values: 1,
-				},
-			},
-		]
-	)
-}
-
-async function assertMemberAccess(ctx: ProgrammaticCommandContext): Promise<void> {
-	if (ctx.isAdmin) return
-	if (!(await hasAllianceMemberRole(ctx.env, ctx.coreUserId))) {
-		throw new ProgrammaticCommandPermissionError(
-			'You need alliance member permission to use this command.'
-		)
-	}
-}
-
 async function handleSelfAssignment(ctx: ProgrammaticCommandContext) {
-	await assertMemberAccess(ctx)
-	const guildId = ctx.input.guildId
-	if (!guildId) throw new Error('This command can only be used in a Discord server.')
-	const db = createDb(ctx.env.DATABASE_URL)
-	const roles = await listSelfAssignableRolesForUser(
-		ctx.env,
-		db,
-		guildId,
-		ctx.input.discordUserId,
-		'join',
-		ctx.input.memberRoleIds
-	)
-	if (roles.length === 0) return ephemeralCommandResponse('You have no available roles to join.')
-	return buildRoleSelectModalResponse('join', roles)
+	return executeTemporaryRoleCommand({
+		db: createDb(ctx.env.DATABASE_URL),
+		env: ctx.env,
+		guildId: ctx.input.guildId,
+		discordUserId: ctx.input.discordUserId,
+		coreUserId: ctx.coreUserId,
+		isAdmin: ctx.isAdmin,
+		memberRoleIds: ctx.input.memberRoleIds,
+		mode: 'join',
+	})
 }
 
 async function handleSelfRemoval(ctx: ProgrammaticCommandContext) {
-	await assertMemberAccess(ctx)
-	const guildId = ctx.input.guildId
-	if (!guildId) throw new Error('This command can only be used in a Discord server.')
-	const db = createDb(ctx.env.DATABASE_URL)
-	const roles = await listSelfAssignableRolesForUser(
-		ctx.env,
-		db,
-		guildId,
-		ctx.input.discordUserId,
-		'leave',
-		ctx.input.memberRoleIds
-	)
-	if (roles.length === 0)
-		return ephemeralCommandResponse('You have no self-assigned roles to leave.')
-	if (roles.length > 1) return buildRoleSelectModalResponse('leave', roles)
-	const role = roles[0]
-	const removed = await removeTemporaryRole(ctx.env, db, {
-		guildId,
+	return executeTemporaryRoleCommand({
+		db: createDb(ctx.env.DATABASE_URL),
+		env: ctx.env,
+		guildId: ctx.input.guildId,
 		discordUserId: ctx.input.discordUserId,
 		coreUserId: ctx.coreUserId,
-		role,
-		reason: 'part',
-		onlySelf: true,
+		isAdmin: ctx.isAdmin,
+		memberRoleIds: ctx.input.memberRoleIds,
+		mode: 'leave',
 	})
-	return ephemeralCommandResponse(
-		removed
-			? `Removed **${role.displayName}**.`
-			: `You do not currently have **${role.displayName}** self-assigned.`
-	)
 }
 
 export const DISCORD_JOIN_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
@@ -147,4 +64,83 @@ export const DISCORD_LEAVE_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition =
 	options: undefined,
 	deferral: 'sync',
 	handler: handleSelfRemoval,
+}
+
+export const DISCORD_ROLES_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
+	name: 'roles',
+	description: 'Post a temporary role selection panel in this channel.',
+	categoryName: 'Roles Management',
+	immutableAccessRequirements: [],
+	options: [
+		{
+			type: DISCORD_SLASH_COMMAND_OPTION_TYPE.STRING,
+			name: 'title',
+			description: 'Optional title for the panel embed.',
+			required: false,
+			max_length: 256,
+		},
+		{
+			type: DISCORD_SLASH_COMMAND_OPTION_TYPE.STRING,
+			name: 'message',
+			description: 'Optional instructions to show in the panel.',
+			required: false,
+			max_length: 4000,
+		},
+	],
+	deferral: 'sync',
+	handler: async ({ optionValues, isAdmin, env, input }) => {
+		if (!isAdmin) {
+			return {
+				type: 4,
+				data: {
+					content: 'Only site admins can post a temporary role panel.',
+					flags: 1 << 6,
+				},
+			}
+		}
+		if (!input.guildId || !input.channelId) {
+			return {
+				type: 4,
+				data: {
+					content: 'This command can only be used in a Discord server channel.',
+					flags: 1 << 6,
+				},
+			}
+		}
+
+		try {
+			const discord = getStub<Discord>(env.DISCORD, 'default')
+			const result = await discord.sendMessage(
+				input.guildId,
+				input.channelId,
+				buildTemporaryRolePanelMessage(optionValues.title, optionValues.message)
+			)
+			if (!result.success) {
+				return {
+					type: 4,
+					data: {
+						content: `Could not post the temporary role panel: ${result.error ?? 'Discord rejected the message.'}`,
+						flags: 1 << 6,
+					},
+				}
+			}
+			return {
+				type: 4,
+				data: {
+					content: result.messageId
+						? `Temporary role panel posted in <#${input.channelId}> (message ${result.messageId}).`
+						: `Temporary role panel posted in <#${input.channelId}>.`,
+					flags: 1 << 6,
+				},
+			}
+		} catch {
+			return {
+				type: 4,
+				data: {
+					content: 'Could not post the temporary role panel. Please try again later.',
+					flags: 1 << 6,
+				},
+			}
+		}
+	},
 }

--- a/apps/core/src/services/temporary-role-command.service.ts
+++ b/apps/core/src/services/temporary-role-command.service.ts
@@ -1,0 +1,121 @@
+import {
+	ephemeralCommandResponse,
+	modalCommandResponse,
+	ProgrammaticCommandPermissionError,
+} from './discord-programmatic-commands/types'
+import {
+	hasAllianceMemberRole,
+	listSelfAssignableRolesForUser,
+	removeTemporaryRole,
+} from './discord-temporary-roles.service'
+
+import type { DiscordInteractionResponse } from '@repo/discord'
+import type { Env } from '../context'
+import type { createDb } from '../db'
+
+export type TemporaryRoleCommandMode = 'join' | 'leave'
+
+export type TemporaryRoleCommandRole = {
+	roleDbId: string
+	roleName: string
+	displayName: string
+}
+
+export type TemporaryRoleCommandEnv = Pick<Env, 'GROUPS' | 'TEMPORARY_ROLE_ASSIGNMENTS' | 'DISCORD'>
+
+const MAX_DISCORD_SELECT_LABEL_LENGTH = 100
+
+export function buildTemporaryRoleSelectModalResponse(
+	mode: TemporaryRoleCommandMode,
+	roles: TemporaryRoleCommandRole[]
+): DiscordInteractionResponse {
+	if (
+		roles.length > 25 ||
+		roles.some(
+			(role) =>
+				role.displayName.length > MAX_DISCORD_SELECT_LABEL_LENGTH ||
+				role.roleName.length > MAX_DISCORD_SELECT_LABEL_LENGTH
+		)
+	) {
+		return ephemeralCommandResponse(
+			roles.length > 25
+				? 'Too many self-assignable roles are configured for this server.'
+				: 'A configured role name is too long for Discord selection.'
+		)
+	}
+
+	return modalCommandResponse(
+		mode === 'join' ? 'Choose a role to join.' : 'Choose a role to leave.',
+		`tmp-role:${mode}`,
+		[
+			{
+				type: 18,
+				label: mode === 'join' ? 'Available roles' : 'Assigned roles',
+				description: mode === 'join' ? 'Select a role to join.' : 'Select a role to leave.',
+				component: {
+					type: 3,
+					custom_id: `tmp-role:${mode}:role`,
+					options: roles.map((role) => ({
+						label: role.displayName,
+						value: role.roleDbId,
+						description: role.roleName,
+					})),
+					placeholder: mode === 'join' ? 'Select a role to join' : 'Select a role to leave',
+					max_values: 1,
+				},
+			},
+		]
+	)
+}
+
+export async function executeTemporaryRoleCommand(input: {
+	db: ReturnType<typeof createDb>
+	env: TemporaryRoleCommandEnv
+	guildId: string | null | undefined
+	discordUserId: string
+	coreUserId: string
+	isAdmin: boolean
+	memberRoleIds?: string[]
+	mode: TemporaryRoleCommandMode
+}): Promise<DiscordInteractionResponse> {
+	if (!input.isAdmin && !(await hasAllianceMemberRole(input.env, input.coreUserId))) {
+		throw new ProgrammaticCommandPermissionError(
+			'You need alliance member permission to use this command.'
+		)
+	}
+	if (!input.guildId) throw new Error('This command can only be used in a Discord server.')
+
+	const roles = await listSelfAssignableRolesForUser(
+		input.env,
+		input.db,
+		input.guildId,
+		input.discordUserId,
+		input.mode,
+		input.memberRoleIds
+	)
+	if (roles.length === 0) {
+		return ephemeralCommandResponse(
+			input.mode === 'join'
+				? 'You have no available roles to join.'
+				: 'You have no self-assigned roles to leave.'
+		)
+	}
+	if (input.mode === 'join' || roles.length > 1) {
+		return buildTemporaryRoleSelectModalResponse(input.mode, roles)
+	}
+
+	const role = roles[0]
+	const removed = await removeTemporaryRole(input.env, input.db, {
+		guildId: input.guildId,
+		discordUserId: input.discordUserId,
+		coreUserId: input.coreUserId,
+		role,
+		reason: 'part',
+		onlySelf: true,
+	})
+	return ephemeralCommandResponse(
+		removed
+			? `Removed **${role.displayName}**.`
+			: `You do not currently have **${role.displayName}** self-assigned.`
+	)
+}

--- a/apps/discord/src/durable-object.ts
+++ b/apps/discord/src/durable-object.ts
@@ -2,6 +2,7 @@ import { DurableObject } from 'cloudflare:workers'
 
 import { and, eq, ilike, isNotNull, sql } from '@repo/db-utils'
 import {
+	buildDiscordWebhookMessagePayload,
 	DISCORD_CHANNEL_TYPE,
 	DISCORD_EXCLUDED_AUTH_GIGACHAD_ROLE_ID,
 	DiscordAPIError,
@@ -1489,31 +1490,7 @@ export class DiscordDO extends DurableObject<Env> implements Discord {
 		try {
 			const proxyUrl = this.getDiscordProxyUrl()
 
-			// Build the message payload
-			const payload: any = {
-				content: message.content,
-			}
-
-			// Add embeds if provided
-			if (message.embeds && message.embeds.length > 0) {
-				payload.embeds = message.embeds
-			}
-
-			// Handle mention permissions
-			if (message.allowEveryone === false) {
-				payload.allowed_mentions = {
-					parse: [], // Don't parse any mentions
-				}
-			} else if (message.allowEveryone === true) {
-				payload.allowed_mentions = {
-					parse: ['everyone', 'roles', 'users'],
-				}
-			} else {
-				// Default: allow user and role mentions but not @everyone/@here
-				payload.allowed_mentions = {
-					parse: ['roles', 'users'],
-				}
-			}
+			const payload = buildDiscordWebhookMessagePayload(message)
 
 			// Send message via Discord API (with retry on rate limit)
 			const url = `https://discord.com/api/v10/channels/${channelId}/messages`

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -1,9 +1,15 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
-import { getStub } from '@repo/do-utils'
 import { z } from 'zod'
 
-import { logger, withNotFound, withOnError, withSentry, withWorkersLogger } from '@repo/hono-helpers'
+import { getStub } from '@repo/do-utils'
+import {
+	logger,
+	withNotFound,
+	withOnError,
+	withSentry,
+	withWorkersLogger,
+} from '@repo/hono-helpers'
 
 import { DiscordDO, DiscordGatewayDO } from './durable-object'
 import * as discordService from './services/discord.service'
@@ -87,9 +93,12 @@ async function getInteractionRouting(env: App['Bindings']): Promise<DiscordInter
 				routingCache.loadedAtMs = Date.now()
 				return routing
 			} catch (error) {
-				logger.warn('[DiscordInteractions] Failed to load interaction routing; defaulting to sync', {
-					error: error instanceof Error ? error.message : String(error),
-				})
+				logger.warn(
+					'[DiscordInteractions] Failed to load interaction routing; defaulting to sync',
+					{
+						error: error instanceof Error ? error.message : String(error),
+					}
+				)
 				return routingCache.value ?? { commands: {} }
 			} finally {
 				routingCache.loading = null
@@ -272,10 +281,10 @@ async function runDeferredComponent(
 		})
 		const content = execution.response.data?.content ?? '​'
 		const stub = getStub<Discord>(env.DISCORD, 'default')
-			const result = await stub.editOriginalInteractionResponse(ctx.token, {
-				content,
-				components: execution.response.data?.components as DiscordActionRow[] | undefined,
-			})
+		const result = await stub.editOriginalInteractionResponse(ctx.token, {
+			content,
+			components: execution.response.data?.components as DiscordActionRow[] | undefined,
+		})
 		if (!result.success) {
 			logger.error('[DiscordInteractions] Failed to deliver component response', {
 				interactionId: ctx.interactionId,
@@ -302,11 +311,7 @@ async function runDeferredComponent(
 
 type ModalComponentInput = DiscordModalLabelComponent
 
-function buildModalResponse(
-	customId: string,
-	title: string,
-	components: ModalComponentInput[]
-) {
+function buildModalResponse(customId: string, title: string, components: ModalComponentInput[]) {
 	return {
 		type: DISCORD_RESPONSE_MODAL,
 		data: {
@@ -350,7 +355,6 @@ function collectModalSubmissionData(
 	}
 }
 
-
 function hexToBytes(hex: unknown): Uint8Array | null {
 	if (typeof hex !== 'string') return null
 	const normalized = hex.trim()
@@ -389,13 +393,11 @@ async function verifyDiscordInteractionSignature(
 }
 
 const app = new Hono<App>()
-	.use(
-		'*',
-		(c, next) =>
-			withWorkersLogger(c.env.NAME ?? 'discord', {
-				environment: c.env.ENVIRONMENT ?? 'development',
-				release: c.env.SENTRY_RELEASE ?? 'unknown',
-			})(c, next)
+	.use('*', (c, next) =>
+		withWorkersLogger(c.env.NAME ?? 'discord', {
+			environment: c.env.ENVIRONMENT ?? 'development',
+			release: c.env.SENTRY_RELEASE ?? 'unknown',
+		})(c, next)
 	)
 
 	.onError(withOnError())
@@ -453,7 +455,10 @@ const app = new Hono<App>()
 		}
 
 		if (interaction.type === DISCORD_INTERACTION_PING) {
-			logger.info('[DiscordInteractions] Ping interaction', { requestId, interactionId: interaction.id })
+			logger.info('[DiscordInteractions] Ping interaction', {
+				requestId,
+				interactionId: interaction.id,
+			})
 			return c.json({ type: DISCORD_INTERACTION_PING })
 		}
 
@@ -464,6 +469,21 @@ const app = new Hono<App>()
 			const parts = customId.split(':')
 			const componentUserId = interaction.member?.user?.id ?? interaction.user?.id ?? null
 			const memberRoleIds = interaction.member?.roles ?? []
+
+			// Temporary role panels reuse the same command executor as /join and /leave. The executor
+			// may return a role-selection modal, so this path must remain synchronous for Discord's ACK.
+			if (parts[0] === 'tmp-role-panel' && componentUserId) {
+				const execution = await c.env.CORE.executeDiscordComponent({
+					customId,
+					discordUserId: componentUserId,
+					interactionId: interaction.id,
+					guildId: interaction.guild_id ?? null,
+					channelId: interaction.channel_id ?? null,
+					memberRoleIds,
+					values: interaction.data?.values ?? [],
+				})
+				return c.json(execution.response)
+			}
 
 			if (parts[0] === 'tmp-role' && componentUserId) {
 				c.executionCtx.waitUntil(
@@ -510,18 +530,18 @@ const app = new Hono<App>()
 				const [, action, marketId] = parts
 				if (action === 'resolve') {
 					return c.json(
-					buildModalResponse(`resolvemodal:${marketId}`, 'Resolve market', [
-						{
-							type: 18,
-							label: 'Winning outcome number',
-							component: {
-								type: 4,
-								custom_id: 'outcome',
-								style: 1,
-								required: true,
-								min_length: 1,
-								max_length: 3,
-								placeholder: '1',
+						buildModalResponse(`resolvemodal:${marketId}`, 'Resolve market', [
+							{
+								type: 18,
+								label: 'Winning outcome number',
+								component: {
+									type: 4,
+									custom_id: 'outcome',
+									style: 1,
+									required: true,
+									min_length: 1,
+									max_length: 3,
+									placeholder: '1',
 								},
 							},
 						])
@@ -529,18 +549,18 @@ const app = new Hono<App>()
 				}
 				if (action === 'void') {
 					return c.json(
-					buildModalResponse(`voidmodal:${marketId}`, 'Void market', [
-						{
-							type: 18,
-							label: 'Void reason',
-							component: {
-								type: 4,
-								custom_id: 'reason',
-								style: 2,
-								required: true,
-								min_length: 3,
-								max_length: 500,
-								placeholder: 'Why is this market being voided?',
+						buildModalResponse(`voidmodal:${marketId}`, 'Void market', [
+							{
+								type: 18,
+								label: 'Void reason',
+								component: {
+									type: 4,
+									custom_id: 'reason',
+									style: 2,
+									required: true,
+									min_length: 3,
+									max_length: 500,
+									placeholder: 'Why is this market being voided?',
 								},
 							},
 						])
@@ -848,7 +868,11 @@ const app = new Hono<App>()
 
 const sentryApp = withSentry(app)
 
-	async function scheduled(event: ScheduledEvent, _env: App['Bindings'], _ctx: ExecutionContext): Promise<void> {
+async function scheduled(
+	event: ScheduledEvent,
+	_env: App['Bindings'],
+	_ctx: ExecutionContext
+): Promise<void> {
 	// Intentionally stubbed: the Discord gateway listener has been disabled because
 	// the always-on websocket bootstrap caused unacceptable hosting cost inflation.
 	// We keep the scheduled entrypoint and gateway DO stub in place so the feature can

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -133,6 +133,8 @@ export interface MessageContent {
 	content: string
 	/** Message embeds */
 	embeds?: DiscordEmbed[]
+	/** Interactive message components */
+	components?: DiscordActionRow[]
 	/** Whether to allow @everyone and @here mentions */
 	allowEveryone?: boolean
 }
@@ -144,6 +146,7 @@ export interface DiscordWebhookAllowedMentions {
 export interface DiscordWebhookMessagePayload {
 	content: string
 	embeds?: DiscordEmbed[]
+	components?: DiscordActionRow[]
 	allowed_mentions?: DiscordWebhookAllowedMentions
 }
 
@@ -156,6 +159,10 @@ export function buildDiscordWebhookMessagePayload(
 
 	if (message.embeds && message.embeds.length > 0) {
 		payload.embeds = message.embeds
+	}
+
+	if (message.components && message.components.length > 0) {
+		payload.components = message.components
 	}
 
 	if (message.allowEveryone === false) {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a `/roles` admin command that posts an interactive Discord panel with **Join**/**Leave** buttons, letting members self-assign or remove temporary roles without running slash commands. The panel button handlers reuse the same permission checks and role-selection logic as the existing `/join` and `/leave` commands.

## Changes
- Add `apps/core/src/lib/temporary-role-panel.ts` to build the panel embed/button message (`buildTemporaryRolePanelMessage`) and parse panel button clicks (`parseTemporaryRolePanelAction`), with validation for oversized titles/descriptions.
- Extract shared join/leave logic from the programmatic `/join` and `/leave` commands into a new `apps/core/src/services/temporary-role-command.service.ts` (`executeTemporaryRoleCommand`), used by both the slash commands and the new panel buttons.
- Add `DISCORD_ROLES_PROGRAMMATIC_COMMAND` (`/roles`, admin-only) which posts the panel message to a channel via the Discord DO's `sendMessage`.
- Wire panel button interactions (`tmp-role-panel:join` / `tmp-role-panel:leave`) into `executeDiscordComponent` and handle them synchronously in the Discord worker's interaction route, since role selection may return a modal.
- Extract `buildDiscordWebhookMessagePayload` in `@repo/discord` (used by both the DO webhook sender and the new panel message) and add `components` support to `MessageContent`/`DiscordWebhookMessagePayload`.
- Various formatting-only diffs from Prettier re-wrapping touched lines.

## Testing
- Added unit tests for `temporary-role-panel.ts` (panel message shape, title/description length limits, action parsing).
- Extended `discord-components.temporary-roles.test.ts` and `discord-programmatic-roles.test.ts` with cases covering panel button join/leave flows and the admin-only `/roles` command (including permission denial for non-admins).
<!-- claude:end -->