### PR TITLE
change srpfleet embed layout and payment queue copy anim

### DIFF
--- a/apps/core/src/services/discord-programmatic-commands/__tests__/srpfleet.test.ts
+++ b/apps/core/src/services/discord-programmatic-commands/__tests__/srpfleet.test.ts
@@ -129,9 +129,10 @@ describe('SRPFLEET_PROGRAMMATIC_COMMAND', () => {
 		)
 		expect(embed?.fields?.find((field) => field.name === 'SRP Token')?.value).toBe('FleetToken')
 		expect(embed?.fields?.find((field) => field.name === 'SRP Type')?.value).toBe('Blanket')
-		expect(embed?.fields?.find((field) => field.name === 'Requested By')?.value).toBe(
-			'Commanding Main'
-		)
+		expect(embed?.fields?.[0]).toEqual({
+			name: 'Fleet Details Requested By',
+			value: 'Commanding Main',
+		})
 		expect(embed?.fields?.find((field) => field.name === 'Eligibility Check')?.value).toContain(
 			'Member of fleet at loss: Yes'
 		)

--- a/apps/core/src/services/discord-programmatic-commands/srpfleet.ts
+++ b/apps/core/src/services/discord-programmatic-commands/srpfleet.ts
@@ -198,12 +198,15 @@ export const SRPFLEET_PROGRAMMATIC_COMMAND: ProgrammaticCommandDefinition = {
 		}
 
 		const fields: NonNullable<DiscordEmbed['fields']> = [
+			{
+				name: 'Fleet Details Requested By',
+				value: truncate(invokerMainCharacterName ?? 'Unavailable'),
+			},
 			{ name: 'Fleet Commander(s)', value: truncate(commanders.join('\n') || 'Unavailable') },
 			{ name: 'Doctrine', value: truncate(doctrine) },
 			{ name: 'SRP Type', value: srpTypeLabel(broadcast.srpMode) },
 			{ name: 'MOTD', value: sanitizeMotd(details.motd) },
 			{ name: 'SRP Token', value: truncate(token) },
-			{ name: 'Requested By', value: truncate(invokerMainCharacterName ?? 'Unavailable') },
 			{
 				name: 'Fleet Period',
 				value: `${discordTimestamp(details.startedAt, 'Unknown start')} - ${discordTimestamp(details.endedAt, 'Ongoing')}`,

--- a/apps/ui/src/client/features/mumble/components/credentials-card.tsx
+++ b/apps/ui/src/client/features/mumble/components/credentials-card.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, ExternalLink, KeyRound } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -16,17 +16,32 @@ export function buildMumbleUrl(credentials: MumbleOneTimeCredentials): string {
 }
 
 /** A click-to-copy row used for credentials and generated links. */
-export function CopyRow({
-	label,
-	value,
-	copied,
-	onCopy,
-}: {
-	label: string
-	value: string
-	copied: boolean
-	onCopy: () => void
-}) {
+export function CopyRow({ label, value }: { label: string; value: string }) {
+	const [copied, setCopied] = useState(false)
+	const resetTimerRef = useRef<number | null>(null)
+
+	useEffect(() => {
+		return () => {
+			if (resetTimerRef.current !== null) {
+				window.clearTimeout(resetTimerRef.current)
+			}
+		}
+	}, [])
+
+	const onCopy = () => {
+		void navigator.clipboard.writeText(value).then(() => {
+			toast.success(`${label} copied`)
+			setCopied(true)
+			if (resetTimerRef.current !== null) {
+				window.clearTimeout(resetTimerRef.current)
+			}
+			resetTimerRef.current = window.setTimeout(() => {
+				setCopied(false)
+				resetTimerRef.current = null
+			}, 2000)
+		})
+	}
+
 	return (
 		<div className="flex items-center gap-2">
 			<span className="w-20 shrink-0 text-xs text-muted-foreground">{label}</span>
@@ -54,22 +69,8 @@ export function CopyRow({
 	)
 }
 
-/** Hook providing a copy-to-clipboard handler with transient "copied" state. */
-export function useCopyField() {
-	const [copiedField, setCopiedField] = useState<string | null>(null)
-	const copyToClipboard = (text: string, field: string, label: string) => {
-		void navigator.clipboard.writeText(text).then(() => {
-			toast.success(`${label} copied`)
-			setCopiedField(field)
-			setTimeout(() => setCopiedField(null), 2000)
-		})
-	}
-	return { copiedField, copyToClipboard }
-}
-
 /** One-time credentials card shown after provisioning or a password reset. */
 export function OneTimeCredentialsCard({ credentials }: { credentials: MumbleOneTimeCredentials }) {
-	const { copiedField, copyToClipboard } = useCopyField()
 	const mumbleUrl = buildMumbleUrl(credentials)
 	const server = credentials.connection.host
 	const port = String(credentials.connection.port)
@@ -91,30 +92,10 @@ export function OneTimeCredentialsCard({ credentials }: { credentials: MumbleOne
 					Once you close or refresh this page, the password will no longer be visible. If you lose
 					it, you will need to generate a new one.
 				</div>
-				<CopyRow
-					label="Username"
-					value={credentials.loginName}
-					copied={copiedField === 'username'}
-					onCopy={() => copyToClipboard(credentials.loginName, 'username', 'Username')}
-				/>
-				<CopyRow
-					label="Password"
-					value={credentials.password}
-					copied={copiedField === 'password'}
-					onCopy={() => copyToClipboard(credentials.password, 'password', 'Password')}
-				/>
-				<CopyRow
-					label="Server"
-					value={server}
-					copied={copiedField === 'server'}
-					onCopy={() => copyToClipboard(server, 'server', 'Server')}
-				/>
-				<CopyRow
-					label="Port"
-					value={port}
-					copied={copiedField === 'port'}
-					onCopy={() => copyToClipboard(port, 'port', 'Port')}
-				/>
+				<CopyRow label="Username" value={credentials.loginName} />
+				<CopyRow label="Password" value={credentials.password} />
+				<CopyRow label="Server" value={server} />
+				<CopyRow label="Port" value={port} />
 				<div className="pt-3">
 					<Button asChild variant="primary" className="justify-center gap-2">
 						<a href={mumbleUrl}>

--- a/apps/ui/src/client/features/mumble/components/tempop-section.tsx
+++ b/apps/ui/src/client/features/mumble/components/tempop-section.tsx
@@ -1,14 +1,13 @@
 import { Link2, Trash2, Users } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
-import { CopyRow, useCopyField } from './credentials-card'
-import { useCreateTempop, useDeleteTempop, useTempops } from '../tempop-hooks'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Select } from '@/components/ui/select'
 import {
 	Table,
 	TableBody,
@@ -17,9 +16,11 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
-import { Select } from '@/components/ui/select'
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import toast from '@/lib/toast'
+
+import { useCreateTempop, useDeleteTempop, useTempops } from '../tempop-hooks'
+import { CopyRow } from './credentials-card'
 
 import type { CreateTempopResponse, TempopListFilters, TempopListItem } from '@/lib/api'
 
@@ -60,12 +61,9 @@ function statusBadgeVariant(status: string): 'default' | 'secondary' | 'destruct
 /** Permission-gated create card. */
 function CreateTempopCard() {
 	const create = useCreateTempop()
-	const { copiedField, copyToClipboard } = useCopyField()
 	const [ttlMode, setTtlMode] = useState('1h')
 	const [customHours, setCustomHours] = useState('2')
-	const [generated, setGenerated] = useState<
-		(CreateTempopResponse & { url: string }) | null
-	>(null)
+	const [generated, setGenerated] = useState<(CreateTempopResponse & { url: string }) | null>(null)
 
 	const customHoursNumber = Number(customHours)
 	const customInvalid =
@@ -96,8 +94,8 @@ function CreateTempopCard() {
 				</CardTitle>
 				<CardDescription>
 					Generate a time-limited link that lets guests join voice after a quick EVE login. Guests
-					are placed in the <span className="font-mono">TempOp</span> group and disconnected when the
-					temp-op expires or is deleted.
+					are placed in the <span className="font-mono">TempOp</span> group and disconnected when
+					the temp-op expires or is deleted.
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
@@ -132,7 +130,9 @@ function CreateTempopCard() {
 				</div>
 
 				{customInvalid ? (
-					<p className="text-sm text-destructive">Custom duration must be between 1 and 12 hours.</p>
+					<p className="text-sm text-destructive">
+						Custom duration must be between 1 and 12 hours.
+					</p>
 				) : null}
 
 				{generated ? (
@@ -141,12 +141,7 @@ function CreateTempopCard() {
 							Share this link (code <span className="font-mono">{generated.shortCode}</span>). It
 							expires {new Date(generated.expiresAt).toLocaleString()}.
 						</p>
-						<CopyRow
-							label="Link"
-							value={generated.url}
-							copied={copiedField === 'tempop-link'}
-							onCopy={() => copyToClipboard(generated.url, 'tempop-link', 'Link')}
-						/>
+						<CopyRow label="Link" value={generated.url} />
 					</div>
 				) : null}
 			</CardContent>
@@ -329,12 +324,10 @@ export function TempopSection({
 									inputId="tempop-creator"
 									options={creatorOptions}
 									value={creatorId === '' ? ALL_CREATORS : creatorId}
-									onValueChange={(value) =>
-										{
-											setCreatorId(value === ALL_CREATORS ? '' : value)
-											resetPage()
-										}
-									}
+									onValueChange={(value) => {
+										setCreatorId(value === ALL_CREATORS ? '' : value)
+										resetPage()
+									}}
 									disabled={mine}
 									className="w-56"
 								/>

--- a/apps/ui/src/client/features/srp/routes/payments.tsx
+++ b/apps/ui/src/client/features/srp/routes/payments.tsx
@@ -1,7 +1,6 @@
 import { Check, Copy } from 'lucide-react'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Link, Navigate } from 'react-router'
-import toast from '@/lib/toast'
 
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -10,6 +9,7 @@ import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { PageHeader } from '@/components/ui/page-header'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
+import toast from '@/lib/toast'
 
 import { useMarkPaid, usePendingPayments, usePendingPayoutTotal } from '../hooks'
 import {
@@ -48,7 +48,10 @@ export default function PaymentsQueue() {
 
 	return (
 		<Container>
-			<PageHeader title="Payment Queue" description="Submit approved SRP payouts for payment validation" />
+			<PageHeader
+				title="Payment Queue"
+				description="Submit approved SRP payouts for payment validation"
+			/>
 			<div className="mt-section">
 				<PaymentStack />
 			</div>
@@ -180,7 +183,13 @@ function PaymentStack() {
 	}
 
 	const refreshButton = (
-		<Button variant="secondary" size="sm" onClick={() => void refetch()} loading={isFetching} loadingText="Refreshing...">
+		<Button
+			variant="secondary"
+			size="sm"
+			onClick={() => void refetch()}
+			loading={isFetching}
+			loadingText="Refreshing..."
+		>
 			Refresh Queue
 		</Button>
 	)
@@ -286,43 +295,20 @@ function PaymentCard({
 	isPendingRemoval?: boolean
 	registerCardRef: (el: HTMLDivElement | null) => void
 }) {
-	const [copiedField, setCopiedField] = useState<string | null>(null)
-
-	const copyToClipboard = (text: string, field: string, label: string) => {
-		void navigator.clipboard.writeText(text).then(() => {
-			toast.success(`${label} copied`)
-			setCopiedField(field)
-			setTimeout(() => setCopiedField(null), 2000)
-		})
-	}
-
 	const recipient = request.characterName
 	const amount = request.approvedAmount ?? '0'
 	const reason = `SRP - KM#${request.id}`
 
 	return (
-		<div ref={registerCardRef} className={`transition-opacity ${isPendingRemoval ? 'pointer-events-none opacity-0' : 'opacity-100'}`}>
+		<div
+			ref={registerCardRef}
+			className={`transition-opacity ${isPendingRemoval ? 'pointer-events-none opacity-0' : 'opacity-100'}`}
+		>
 			<Card className="p-4">
 				<div className="space-y-1.5">
-					<CopyRow
-						label="Recipient"
-						value={recipient}
-						copied={copiedField === 'recipient'}
-						onCopy={() => copyToClipboard(recipient, 'recipient', 'Recipient')}
-					/>
-					<CopyRow
-						label="Amount"
-						value={amount}
-						display={formatISK(amount)}
-						copied={copiedField === 'amount'}
-						onCopy={() => copyToClipboard(amount, 'amount', 'Amount')}
-					/>
-					<CopyRow
-						label="Reason"
-						value={reason}
-						copied={copiedField === 'reason'}
-						onCopy={() => copyToClipboard(reason, 'reason', 'Reason')}
-					/>
+					<CopyRow label="Recipient" value={recipient} />
+					<CopyRow label="Amount" value={amount} display={formatISK(amount)} />
+					<CopyRow label="Reason" value={reason} />
 				</div>
 
 				<div className="mt-3 flex items-center gap-3 border-t border-border/40 pt-3">
@@ -359,13 +345,7 @@ function PaymentCard({
 	)
 }
 
-function GhostPaymentCard({
-	request,
-	top,
-}: {
-	request: SRPRequestResponse
-	top: number
-}) {
+function GhostPaymentCard({ request, top }: { request: SRPRequestResponse; top: number }) {
 	const recipient = request.characterName
 	const amount = request.approvedAmount ?? '0'
 	const reason = `SRP - KM#${request.id}`
@@ -408,19 +388,32 @@ function GhostCopyRow({ label, value }: { label: string; value: string }) {
 	)
 }
 
-function CopyRow({
-	label,
-	value,
-	display,
-	copied,
-	onCopy,
-}: {
-	label: string
-	value: string
-	display?: string
-	copied: boolean
-	onCopy: () => void
-}) {
+function CopyRow({ label, value, display }: { label: string; value: string; display?: string }) {
+	const [copied, setCopied] = useState(false)
+	const resetTimerRef = useRef<number | null>(null)
+
+	useEffect(() => {
+		return () => {
+			if (resetTimerRef.current !== null) {
+				window.clearTimeout(resetTimerRef.current)
+			}
+		}
+	}, [])
+
+	const onCopy = () => {
+		void navigator.clipboard.writeText(value).then(() => {
+			toast.success(`${label} copied`)
+			setCopied(true)
+			if (resetTimerRef.current !== null) {
+				window.clearTimeout(resetTimerRef.current)
+			}
+			resetTimerRef.current = window.setTimeout(() => {
+				setCopied(false)
+				resetTimerRef.current = null
+			}, 2000)
+		})
+	}
+
 	return (
 		<div className="flex items-center gap-2">
 			<span className="w-20 shrink-0 text-xs text-muted-foreground">{label}</span>
@@ -428,7 +421,12 @@ function CopyRow({
 				role="button"
 				tabIndex={0}
 				onClick={onCopy}
-				onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCopy() } }}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault()
+						onCopy()
+					}
+				}}
 				className={`flex cursor-pointer items-center gap-2.5 rounded-md border-2 px-3 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
 					copied
 						? 'border-teal-500 bg-teal-500/30 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.18)]'


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Reorders the SRP fleet Discord embed so the requester is shown first (renamed to "Fleet Details Requested By"), and refactors the copy-to-clipboard UX on the mumble credentials/tempop cards and SRP payment queue into self-contained `CopyRow` components instead of a shared `useCopyField` hook.

## Changes
- `srpfleet.ts`: moved the "Requested By" field to the top of the embed and renamed it to "Fleet Details Requested By"; updated the corresponding test.
- `credentials-card.tsx`: removed the `useCopyField` hook; `CopyRow` now manages its own `copied` state and clipboard handler internally (with proper timeout cleanup on unmount), so callers only pass `label`/`value`.
- `tempop-section.tsx`: updated to use the simplified `CopyRow` API and cleaned up import ordering/formatting.
- `payments.tsx`: local `CopyRow` in the payment queue given the same self-contained copy/timeout logic as the mumble version, replacing per-card `copiedField` state; assorted formatting/import-order cleanup (no behavior change) in `PaymentsQueue`/`PaymentCard`.

## Testing
- Updated the existing `srpfleet` unit test to assert the new field order/name.
<!-- claude:end -->