### PR TITLE
fix terminal SRP fetch workflow statuses

### DIFF
--- a/apps/srp/src/recent-loss-refresh-coordinator.ts
+++ b/apps/srp/src/recent-loss-refresh-coordinator.ts
@@ -11,9 +11,17 @@ import type {
 } from '@repo/srp'
 import type { Env } from './context'
 
-export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implements RecentLossRefreshCoordinator {
+export class RecentLossRefreshCoordinatorDO
+	extends DurableObject<Env>
+	implements RecentLossRefreshCoordinator
+{
 	private static readonly COOLDOWN_MS = 15 * 60 * 1000
-	private static readonly STATUS_RETENTION_MS = 10 * 60 * 1000
+	private static readonly STATUS_RETENTION_MS = 60 * 60 * 1000
+	private static readonly STATUS_ALARM_RECHECK_MS = 5 * 60 * 1000
+	// A character refresh can spend several minutes in retry backoff. Only use this
+	// fallback when the workflow instance cannot be inspected, so a slow refresh is
+	// not mistaken for a dead one.
+	private static readonly ACTIVE_STATUS_STALE_MS = 60 * 60 * 1000
 	private static readonly COOLDOWN_KEY_PREFIX = 'recent-loss-refresh:'
 	private static readonly STATUS_KEY_PREFIX = 'recent-loss-refresh-status:'
 
@@ -29,23 +37,153 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 		return lastTriggeredAtMs + RecentLossRefreshCoordinatorDO.COOLDOWN_MS
 	}
 
+	private getStatusActivityMs(status: RecentLossRefreshStatusRecord): number {
+		const timestamps = [status.queuedAt, status.startedAt, status.updatedAt]
+			.map((timestamp) => (timestamp ? Date.parse(timestamp) : Number.NaN))
+			.filter((timestamp) => Number.isFinite(timestamp))
+		return timestamps.length > 0 ? Math.max(...timestamps) : 0
+	}
+
+	private getStatusCleanupAtMs(status: RecentLossRefreshStatusRecord, now: number): number | null {
+		if (status.status === 'completed' || status.status === 'failed') {
+			const completedAtMs = status.completedAt ? Date.parse(status.completedAt) : Number.NaN
+			return Number.isFinite(completedAtMs)
+				? completedAtMs + RecentLossRefreshCoordinatorDO.STATUS_RETENTION_MS
+				: now
+		}
+
+		if (status.status !== 'queued' && status.status !== 'running') return null
+		const lastActivityMs = this.getStatusActivityMs(status)
+		if (lastActivityMs === 0) return now + RecentLossRefreshCoordinatorDO.STATUS_ALARM_RECHECK_MS
+
+		const staleAtMs = lastActivityMs + RecentLossRefreshCoordinatorDO.ACTIVE_STATUS_STALE_MS
+		return staleAtMs > now
+			? staleAtMs
+			: now + RecentLossRefreshCoordinatorDO.STATUS_ALARM_RECHECK_MS
+	}
+
+	private async markWorkflowFailed(
+		userId: string,
+		status: RecentLossRefreshStatusRecord,
+		message: string
+	): Promise<RecentLossRefreshStatusRecord> {
+		const now = new Date().toISOString()
+		const failedStatus: RecentLossRefreshStatusRecord = {
+			...status,
+			status: 'failed',
+			updatedAt: now,
+			completedAt: now,
+			currentCharacterId: undefined,
+			currentCharacterName: undefined,
+			lastError: message,
+		}
+		await this.ctx.storage.put(this.buildStatusKey(userId), failedStatus)
+		return failedStatus
+	}
+
+	private async clearStaleWorkflowStatus(
+		userId: string,
+		status: RecentLossRefreshStatusRecord,
+		message: string
+	): Promise<RecentLossRefreshStatusRecord> {
+		const failedStatus = {
+			...status,
+			status: 'failed' as const,
+			updatedAt: new Date().toISOString(),
+			completedAt: new Date().toISOString(),
+			currentCharacterId: undefined,
+			currentCharacterName: undefined,
+			lastError: message,
+		}
+		await this.ctx.storage.delete(this.buildStatusKey(userId))
+		await this.rescheduleCleanup()
+		return failedStatus
+	}
+
+	private async reconcileActiveStatus(
+		userId: string,
+		status: RecentLossRefreshStatusRecord
+	): Promise<RecentLossRefreshStatusRecord> {
+		if (status.status !== 'queued' && status.status !== 'running') return status
+
+		try {
+			const workflowInstance = await this.env.SRP_RECENT_LOSS_REFRESH_WORKFLOW.get(
+				status.workflowInstanceId
+			)
+			const workflowStatus = await workflowInstance.status()
+
+			switch (workflowStatus.status) {
+				case 'complete': {
+					const completedAt = new Date().toISOString()
+					const completedStatus: RecentLossRefreshStatusRecord = {
+						...status,
+						status: 'completed',
+						updatedAt: completedAt,
+						completedAt,
+						currentCharacterId: undefined,
+						currentCharacterName: undefined,
+					}
+					await this.ctx.storage.put(this.buildStatusKey(userId), completedStatus)
+					return completedStatus
+				}
+				case 'errored':
+				case 'terminated':
+				case 'unknown':
+					return this.markWorkflowFailed(
+						userId,
+						status,
+						`Recent loss refresh workflow ended with status "${workflowStatus.status}".`
+					)
+				default:
+					return status
+			}
+		} catch {
+			const lastActivityMs = this.getStatusActivityMs(status)
+			if (
+				lastActivityMs === 0 ||
+				Date.now() - lastActivityMs <= RecentLossRefreshCoordinatorDO.ACTIVE_STATUS_STALE_MS
+			) {
+				return status
+			}
+
+			return this.clearStaleWorkflowStatus(
+				userId,
+				status,
+				'Recent loss refresh could not be confirmed as active and was cleared after the fallback timeout.'
+			)
+		}
+	}
+
 	private async readStatus(userId: string): Promise<RecentLossRefreshStatusRecord | null> {
-		const status = await this.ctx.storage.get<RecentLossRefreshStatusRecord>(this.buildStatusKey(userId))
+		const status = await this.ctx.storage.get<RecentLossRefreshStatusRecord>(
+			this.buildStatusKey(userId)
+		)
 		if (!status || typeof status !== 'object') return null
 		if (status.userId !== userId) return null
+		const reconciledStatus = await this.reconcileActiveStatus(userId, status)
 		if (
-			(status.status === 'completed' || status.status === 'failed') &&
-			status.completedAt &&
-			Date.now() - Date.parse(status.completedAt) > RecentLossRefreshCoordinatorDO.STATUS_RETENTION_MS
+			(reconciledStatus.status === 'completed' || reconciledStatus.status === 'failed') &&
+			reconciledStatus.completedAt
 		) {
-			await this.ctx.storage.delete(this.buildStatusKey(userId))
-			return null
+			const completedAtMs = Date.parse(reconciledStatus.completedAt)
+			if (
+				Number.isFinite(completedAtMs) &&
+				Date.now() - completedAtMs > RecentLossRefreshCoordinatorDO.STATUS_RETENTION_MS
+			) {
+				await this.ctx.storage.delete(this.buildStatusKey(userId))
+				return null
+			}
 		}
-		return status
+		if (reconciledStatus.status === 'completed' || reconciledStatus.status === 'failed') {
+			await this.rescheduleCleanup()
+		}
+		return reconciledStatus
 	}
 
 	private async readCooldownUntil(userId: string): Promise<string | null> {
-		const record = await this.ctx.storage.get<{ lastTriggeredAtMs?: number }>(this.buildCooldownKey(userId))
+		const record = await this.ctx.storage.get<{ lastTriggeredAtMs?: number }>(
+			this.buildCooldownKey(userId)
+		)
 		const lastTriggeredAtMs =
 			typeof record?.lastTriggeredAtMs === 'number' && Number.isFinite(record.lastTriggeredAtMs)
 				? record.lastTriggeredAtMs
@@ -60,9 +198,13 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 		const entries = await this.ctx.storage.list<{ lastTriggeredAtMs?: number }>({
 			prefix: RecentLossRefreshCoordinatorDO.COOLDOWN_KEY_PREFIX,
 		})
+		const statusEntries = await this.ctx.storage.list<RecentLossRefreshStatusRecord>({
+			prefix: RecentLossRefreshCoordinatorDO.STATUS_KEY_PREFIX,
+		})
 
 		let nextExpiryMs: number | null = null
 		const now = Date.now()
+		const expiredStatusKeys: string[] = []
 
 		for (const record of entries.values()) {
 			const lastTriggeredAtMs =
@@ -75,6 +217,27 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 			if (nextExpiryMs === null || expiryMs < nextExpiryMs) {
 				nextExpiryMs = expiryMs
 			}
+		}
+
+		for (const [key, status] of statusEntries) {
+			if (!status || typeof status !== 'object' || typeof status.userId !== 'string') {
+				expiredStatusKeys.push(key)
+				continue
+			}
+
+			const cleanupAtMs = this.getStatusCleanupAtMs(status, now)
+			if (cleanupAtMs === null) continue
+			if (cleanupAtMs <= now) {
+				expiredStatusKeys.push(key)
+				continue
+			}
+			if (nextExpiryMs === null || cleanupAtMs < nextExpiryMs) {
+				nextExpiryMs = cleanupAtMs
+			}
+		}
+
+		if (expiredStatusKeys.length > 0) {
+			await this.ctx.storage.delete(expiredStatusKeys)
 		}
 
 		if (nextExpiryMs === null) {
@@ -98,7 +261,8 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 			this.buildCooldownKey(userId)
 		)
 		const existingTriggeredAtMs =
-			typeof cooldownEntry?.lastTriggeredAtMs === 'number' && Number.isFinite(cooldownEntry.lastTriggeredAtMs)
+			typeof cooldownEntry?.lastTriggeredAtMs === 'number' &&
+			Number.isFinite(cooldownEntry.lastTriggeredAtMs)
 				? cooldownEntry.lastTriggeredAtMs
 				: null
 		const activeStatus = await this.readStatus(userId)
@@ -116,7 +280,11 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 			}
 		}
 
-		if (!bypassCooldown && existingTriggeredAtMs !== null && now - existingTriggeredAtMs < cooldownMs) {
+		if (
+			!bypassCooldown &&
+			existingTriggeredAtMs !== null &&
+			now - existingTriggeredAtMs < cooldownMs
+		) {
 			const retryAfterMs = Math.max(0, cooldownMs - (now - existingTriggeredAtMs))
 			return {
 				allowed: false,
@@ -174,7 +342,10 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 	}
 
 	async getRecentLossRefreshStatus(userId: string): Promise<RecentLossRefreshStatusResponse> {
-		const [status, cooldownUntil] = await Promise.all([this.readStatus(userId), this.readCooldownUntil(userId)])
+		const [status, cooldownUntil] = await Promise.all([
+			this.readStatus(userId),
+			this.readCooldownUntil(userId),
+		])
 		return { status, cooldownUntil }
 	}
 
@@ -186,6 +357,7 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 			throw new Error('Recent loss refresh status user mismatch')
 		}
 		await this.ctx.storage.put(this.buildStatusKey(userId), status)
+		await this.rescheduleCleanup()
 	}
 
 	async alarm(): Promise<void> {
@@ -195,7 +367,6 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 		})
 
 		const expiredKeys: string[] = []
-		let nextExpiryMs: number | null = null
 
 		for (const [key, record] of entries) {
 			const lastTriggeredAtMs =
@@ -212,21 +383,20 @@ export class RecentLossRefreshCoordinatorDO extends DurableObject<Env> implement
 				expiredKeys.push(key)
 				continue
 			}
-
-			if (nextExpiryMs === null || expiryMs < nextExpiryMs) {
-				nextExpiryMs = expiryMs
-			}
 		}
 
 		if (expiredKeys.length > 0) {
 			await this.ctx.storage.delete(expiredKeys)
 		}
 
-		if (nextExpiryMs === null) {
-			await this.ctx.storage.deleteAlarm()
-			return
+		const statusEntries = await this.ctx.storage.list<RecentLossRefreshStatusRecord>({
+			prefix: RecentLossRefreshCoordinatorDO.STATUS_KEY_PREFIX,
+		})
+		for (const status of statusEntries.values()) {
+			if (!status || typeof status !== 'object' || typeof status.userId !== 'string') continue
+			await this.readStatus(status.userId)
 		}
 
-		await this.ctx.storage.setAlarm(nextExpiryMs)
+		await this.rescheduleCleanup()
 	}
 }

--- a/apps/srp/src/test/unit/recent-loss-refresh-coordinator.unit.test.ts
+++ b/apps/srp/src/test/unit/recent-loss-refresh-coordinator.unit.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RecentLossRefreshCoordinatorDO } from '../../recent-loss-refresh-coordinator'
+
+vi.mock('cloudflare:workers', () => ({
+	DurableObject: class {},
+}))
+vi.mock('@repo/workflow-utils', () => ({
+	createWorkflow: vi.fn(),
+}))
+
+const USER_ID = 'user-1'
+const WORKFLOW_ID = 'workflow-1'
+const STATUS_KEY = `recent-loss-refresh-status:${USER_ID}`
+
+interface StoredValueMap {
+	get: ReturnType<typeof vi.fn>
+	put: ReturnType<typeof vi.fn>
+	delete: ReturnType<typeof vi.fn>
+	list: ReturnType<typeof vi.fn>
+	setAlarm: ReturnType<typeof vi.fn>
+	deleteAlarm: ReturnType<typeof vi.fn>
+	values: Map<string, unknown>
+}
+
+function createStorage(initialStatus: Record<string, unknown>): StoredValueMap {
+	const values = new Map<string, unknown>([[STATUS_KEY, initialStatus]])
+	const storage: StoredValueMap = {
+		get: vi.fn(async (key: string) => values.get(key)),
+		put: vi.fn(async (key: string, value: unknown) => {
+			values.set(key, value)
+		}),
+		delete: vi.fn(async (key: string | string[]) => {
+			for (const storageKey of Array.isArray(key) ? key : [key]) values.delete(storageKey)
+		}),
+		list: vi.fn(async ({ prefix }: { prefix: string }) => {
+			return new Map([...values.entries()].filter(([key]) => key.startsWith(prefix)))
+		}),
+		setAlarm: vi.fn(),
+		deleteAlarm: vi.fn(),
+		values,
+	}
+	return storage
+}
+
+function createStatus(overrides: Record<string, unknown> = {}) {
+	return {
+		userId: USER_ID,
+		workflowInstanceId: WORKFLOW_ID,
+		status: 'running',
+		totalCharacters: 1,
+		processedCharacters: 0,
+		successfulCharacters: 0,
+		failedCharacters: 0,
+		queuedAt: '2026-08-04T00:00:00.000Z',
+		updatedAt: '2026-08-04T00:00:00.000Z',
+		failures: [],
+		maxLossAgeDays: 30,
+		...overrides,
+	}
+}
+
+function createCoordinator(
+	status: Record<string, unknown>,
+	workflowStatus: { status: string } | Error
+): { coordinator: RecentLossRefreshCoordinatorDO; storage: StoredValueMap } {
+	const storage = createStorage(status)
+	const workflow = {
+		get: vi.fn(async () => {
+			if (workflowStatus instanceof Error) throw workflowStatus
+			return { status: vi.fn(async () => workflowStatus) }
+		}),
+	}
+	const coordinator = Object.create(
+		RecentLossRefreshCoordinatorDO.prototype
+	) as RecentLossRefreshCoordinatorDO
+	Object.assign(coordinator, {
+		ctx: { storage },
+		env: { SRP_RECENT_LOSS_REFRESH_WORKFLOW: workflow },
+	})
+	return { coordinator, storage }
+}
+
+describe('RecentLossRefreshCoordinatorDO workflow reconciliation', () => {
+	beforeEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('marks a persisted active status completed when the workflow has completed', async () => {
+		const { coordinator, storage } = createCoordinator(createStatus(), { status: 'complete' })
+
+		const result = await coordinator.getRecentLossRefreshStatus(USER_ID)
+
+		expect(result.status?.status).toBe('completed')
+		expect(result.status?.completedAt).toEqual(expect.any(String))
+		expect(storage.put).toHaveBeenCalledWith(
+			STATUS_KEY,
+			expect.objectContaining({ status: 'completed' })
+		)
+	})
+
+	it('keeps the active status when the workflow is still running', async () => {
+		const { coordinator, storage } = createCoordinator(createStatus(), { status: 'running' })
+
+		const result = await coordinator.getRecentLossRefreshStatus(USER_ID)
+
+		expect(result.status?.status).toBe('running')
+		expect(storage.put).not.toHaveBeenCalled()
+	})
+
+	it('marks the status failed when the workflow has terminated', async () => {
+		const { coordinator, storage } = createCoordinator(createStatus(), { status: 'terminated' })
+
+		const result = await coordinator.getRecentLossRefreshStatus(USER_ID)
+
+		expect(result.status?.status).toBe('failed')
+		expect(result.status?.lastError).toContain('terminated')
+		expect(storage.put).toHaveBeenCalledWith(
+			STATUS_KEY,
+			expect.objectContaining({ status: 'failed' })
+		)
+	})
+
+	it('clears an active status after the fallback timeout when the workflow cannot be inspected', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-08-04T02:00:00.000Z'))
+		const { coordinator, storage } = createCoordinator(
+			createStatus({
+				queuedAt: '2026-08-04T00:00:00.000Z',
+				updatedAt: '2026-08-04T00:30:00.000Z',
+			}),
+			new Error('workflow lookup unavailable')
+		)
+
+		const result = await coordinator.getRecentLossRefreshStatus(USER_ID)
+
+		expect(result.status?.status).toBe('failed')
+		expect(result.status?.lastError).toContain('fallback timeout')
+		expect(storage.values.has(STATUS_KEY)).toBe(false)
+		expect(storage.delete).toHaveBeenCalledWith(STATUS_KEY)
+	})
+
+	it('evicts dormant terminal status during the coordinator alarm', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-08-04T02:00:00.000Z'))
+		const { coordinator, storage } = createCoordinator(
+			createStatus({
+				status: 'completed',
+				completedAt: '2026-08-04T00:00:00.000Z',
+			}),
+			{ status: 'complete' }
+		)
+
+		await coordinator.alarm()
+
+		expect(storage.values.has(STATUS_KEY)).toBe(false)
+		expect(storage.deleteAlarm).toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes stale/stuck status records in `RecentLossRefreshCoordinatorDO` by reconciling persisted "queued"/"running" statuses against the actual state of the underlying Cloudflare Workflow instance, instead of trusting whatever was last written to storage.

## Changes
- Added `reconcileActiveStatus` to look up the workflow instance's real status and update the stored record accordingly: `complete` → `completed`, `errored`/`terminated`/`unknown` → `failed` (via new `markWorkflowFailed`).
- Added a fallback path (`clearStaleWorkflowStatus`) that clears an active status if the workflow instance can't be inspected and no activity has been recorded for over `ACTIVE_STATUS_STALE_MS` (1 hour), avoiding a status being stuck forever if the workflow is unreachable.
- `readStatus` now runs reconciliation before applying terminal-status retention/cleanup logic, and increased `STATUS_RETENTION_MS` from 10 minutes to 1 hour.
- Added `getStatusActivityMs`/`getStatusCleanupAtMs` helpers and reworked the alarm scheduling (`rescheduleCleanup`) so the DO alarm reconciles and evicts dormant status entries in addition to cooldown records, rather than only tracking cooldown expiry.
- `alarm()` now also re-reads (and thus reconciles) all stored status entries, delegating alarm rescheduling to the new `rescheduleCleanup` helper.
- Reformatted the file to satisfy Prettier line-length/formatting rules (multi-line class declaration, wrapped conditionals, etc.).

## Testing
- Added `apps/srp/src/test/unit/recent-loss-refresh-coordinator.unit.test.ts`, covering: marking a status completed/failed based on workflow status, keeping a running status untouched, clearing a status after the fallback timeout when the workflow can't be inspected, and evicting dormant terminal statuses during the alarm.
<!-- claude:end -->