### PR TITLE
Fix/paginate admin corps page

### DIFF
--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -1,19 +1,23 @@
-import type { AdminWorker as IAdminWorker, ThirdPartyAppsAdminWorker as IThirdPartyAppsAdminWorker } from '@repo/admin'
+import type {
+	AdminWorker as IAdminWorker,
+	ThirdPartyAppsAdminWorker as IThirdPartyAppsAdminWorker,
+} from '@repo/admin'
+import type { UserProfileDTO } from '@repo/core'
 import type { EveCharacterData } from '@repo/eve-character-data'
+import type { EveCorporationDataWorker as IEveCorporationDataWorker } from '@repo/eve-corporation-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Groups } from '@repo/groups'
 import type { HonoApp } from '@repo/hono-helpers'
 import type { SharedHonoEnv, SharedHonoVariables } from '@repo/hono-helpers/src/types'
-import type { StructuresWorker } from '@repo/structures'
-import type { Skills } from '@repo/skills'
 import type { PasteWorker } from '@repo/paste'
-import type { UserProfileDTO } from '@repo/core'
+import type { Skills } from '@repo/skills'
+import type { StructuresWorker } from '@repo/structures'
 import type { createDb } from './db'
 import type { CsvExportWorkflowParams } from './workflows/csv-export.workflow'
-import type { UserDiscordRefreshWorkflowParams } from './workflows/user-discord-refresh.workflow'
-import type { UserMumbleRefreshWorkflowParams } from './workflows/user-mumble-refresh.workflow'
 import type { DiscordMemberAuditWorkflowParams } from './workflows/discord-member-audit.workflow'
 import type { ServiceAccessAuditWorkflowParams } from './workflows/service-access-audit.workflow'
+import type { UserDiscordRefreshWorkflowParams } from './workflows/user-discord-refresh.workflow'
+import type { UserMumbleRefreshWorkflowParams } from './workflows/user-mumble-refresh.workflow'
 import type { UserRefreshWorkflowParams } from './workflows/user-refresh.workflow'
 
 export type Env = SharedHonoEnv & {
@@ -28,6 +32,8 @@ export type Env = SharedHonoEnv & {
 	EVE_CHARACTER_DATA: DurableObjectNamespace
 	/** EVE Corporation Data Durable Object binding */
 	EVE_CORPORATION_DATA: DurableObjectNamespace
+	/** EVE Corporation Data worker service binding */
+	EVE_CORPORATION_DATA_WORKER: IEveCorporationDataWorker
 	/** Groups Durable Object binding */
 	GROUPS: DurableObjectNamespace
 	/** Discord Durable Object binding */

--- a/apps/core/src/routes/__tests__/corporations.list.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporations.list.route.test.ts
@@ -1,30 +1,22 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getStub } from '@repo/do-utils'
-
 import corporationsRoutes from '../corporations'
 
 import type { SessionUser } from '../../context'
 
-vi.mock('@repo/do-utils', () => ({
-	getStub: vi.fn(),
-}))
-
 vi.mock('../../middleware/session', () => ({
 	requireAuth:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 	requireAdmin:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 }))
-
-const getStubMock = vi.mocked(getStub)
 
 function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 	return {
@@ -61,6 +53,9 @@ function createApp(user: SessionUser, db: any) {
 describe('corporations list route', () => {
 	const env = {
 		EVE_CORPORATION_DATA: { name: 'EVE_CORPORATION_DATA' },
+		EVE_CORPORATION_DATA_WORKER: {
+			getHealthyDirectorCounts: vi.fn(),
+		},
 		DATABASE_URL: 'postgres://test',
 	} as any
 
@@ -69,60 +64,113 @@ describe('corporations list route', () => {
 	})
 
 	it('keeps the persisted verification flag while surfacing live healthy director counts', async () => {
+		const findMany = vi.fn().mockResolvedValue([
+			{
+				corporationId: 'corp-1',
+				name: 'Test Corp',
+				ticker: 'TST',
+				assignedCharacterId: null,
+				assignedCharacterName: null,
+				isActive: true,
+				includeInBackgroundRefresh: true,
+				includeInStructureAssetSync: false,
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+				isRecruiting: false,
+				shortDescription: null,
+				fullDescription: null,
+				lastSync: null,
+				lastVerified: null,
+				isVerified: false,
+				healthyDirectorCount: 0,
+				configuredBy: null,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		])
 		const db = {
 			query: {
 				managedCorporations: {
-					findMany: vi.fn().mockResolvedValue([
-						{
-							corporationId: 'corp-1',
-							name: 'Test Corp',
-							ticker: 'TST',
-							assignedCharacterId: null,
-							assignedCharacterName: null,
-							isActive: true,
-							includeInBackgroundRefresh: true,
-							includeInStructureAssetSync: false,
-							isMemberCorporation: true,
-							isAltCorp: false,
-							isSpecialPurpose: false,
-							isRecruiting: false,
-							shortDescription: null,
-							fullDescription: null,
-							lastSync: null,
-							lastVerified: null,
-							isVerified: false,
-							healthyDirectorCount: 0,
-							configuredBy: null,
-							createdAt: new Date().toISOString(),
-							updatedAt: new Date().toISOString(),
-						},
-					]),
+					findMany,
 				},
 			},
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn().mockResolvedValue([{ count: 1 }]),
+				})),
+			})),
 		}
-		const corpStub = {
-			getHealthyDirectors: vi.fn().mockResolvedValue([
-				{ directorId: 'dir-1' },
-				{ directorId: 'dir-2' },
-			]),
-		}
-
-		getStubMock.mockImplementation((binding: unknown) => {
-			if (binding === env.EVE_CORPORATION_DATA) return corpStub as any
-			throw new Error('Unexpected binding')
-		})
+		env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts.mockResolvedValue({ 'corp-1': 2 })
 
 		const app = createApp(makeUser(), db)
 		const response = await app.request('/api/corporations', {}, env)
 
 		expect(response.status).toBe(200)
-		expect(await response.json()).toEqual([
+		expect(await response.json()).toEqual({
+			data: [
+				expect.objectContaining({
+					corporationId: 'corp-1',
+					isVerified: false,
+					healthyDirectorCount: 2,
+				}),
+			],
+			pagination: {
+				page: 1,
+				pageSize: 25,
+				totalCount: 1,
+				totalPages: 1,
+				hasNextPage: false,
+				hasPreviousPage: false,
+			},
+		})
+		expect(findMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				corporationId: 'corp-1',
-				isVerified: false,
-				healthyDirectorCount: 2,
-			}),
+				limit: 25,
+				offset: 0,
+			})
+		)
+		expect(env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts).toHaveBeenCalledWith([
+			'corp-1',
 		])
-		expect(corpStub.getHealthyDirectors).toHaveBeenCalledWith('corp-1')
+	})
+
+	it('passes requested SQL pagination to the corporation query', async () => {
+		const findMany = vi.fn().mockResolvedValue([])
+		const db = {
+			query: { managedCorporations: { findMany } },
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn().mockResolvedValue([{ count: 125 }]),
+				})),
+			})),
+		}
+
+		const app = createApp(makeUser(), db)
+		const response = await app.request(
+			'/api/corporations?corporationType=alt&search=alpha&page=2&pageSize=100',
+			{},
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toMatchObject({
+			data: [],
+			pagination: {
+				page: 2,
+				pageSize: 100,
+				totalCount: 125,
+				totalPages: 2,
+				hasNextPage: false,
+				hasPreviousPage: true,
+			},
+		})
+		expect(findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				limit: 100,
+				offset: 100,
+			})
+		)
+		expect(env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts).not.toHaveBeenCalled()
 	})
 })

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -1,14 +1,15 @@
 import { Hono } from 'hono'
 
-import { and, desc, eq, ilike, inArray, or, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, gte, ilike, inArray, lt, not, or, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
+import { buildCsvLine } from '@repo/worker-utils'
 
 import { managedCorporations, userCharacters, users } from '../../db/schema'
 import { isNpcCorporationId } from '../../lib/corporation-id'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 import { requireAdmin, requireAuth } from '../../middleware/session'
-import { buildCsvLine } from '@repo/worker-utils'
+import { CoreRpcService } from '../../services/core-rpc.service'
 import corporationsAlertsRoutes from './alerts-routes'
 import corporationsDirectorsRoutes from './directors-routes'
 import corporationsDiscordRoutes from './discord-routes'
@@ -23,7 +24,6 @@ import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Groups } from '@repo/groups'
 import type { Hr } from '@repo/hr'
 import type { App } from '../../context'
-import { CoreRpcService } from '../../services/core-rpc.service'
 
 const app = new Hono<App>()
 const MS_PER_DAY = 86_400_000
@@ -100,7 +100,7 @@ async function resolveCorporationMembersAccess(
 		const hasHrAccess = managedCorp?.isMemberCorporation
 			? await hr.checkPermission(user.id, corporationId, 'hr_viewer')
 			: false
-		const isAuditor = !hasHrAccess && await isHrAuditorUser(c)
+		const isAuditor = !hasHrAccess && (await isHrAuditorUser(c))
 		if (!hasHrAccess && !isAuditor) {
 			throw new Error(
 				'Access denied. Corporation CEO, Director, site admin, HR role, or HR auditor permission required.'
@@ -110,7 +110,8 @@ async function resolveCorporationMembersAccess(
 			return 'hr_viewer'
 		}
 		const isHrAdmin = await hr.checkPermission(user.id, corporationId, 'hr_admin')
-		const isHrReviewer = !isHrAdmin && await hr.checkPermission(user.id, corporationId, 'hr_reviewer')
+		const isHrReviewer =
+			!isHrAdmin && (await hr.checkPermission(user.id, corporationId, 'hr_reviewer'))
 		return isHrAdmin ? 'hr_admin' : isHrReviewer ? 'hr_reviewer' : 'hr_viewer'
 	}
 }
@@ -268,7 +269,7 @@ type CorporationMemberCoverageSummary = {
 	totalCharacters: number
 }
 
-function countDistinctLinkedUsers(members: { authUserId?: string | null }[]): number {
+function countDistinctLinkedUsers(members: Array<{ authUserId?: string | null }>): number {
 	return new Set(
 		members
 			.map((member) => member.authUserId)
@@ -437,7 +438,7 @@ function parseMembersQuery(c: Context<App>): MembersQuery {
 		authFilterRaw === 'linked_valid' ||
 		authFilterRaw === 'linked_invalid' ||
 		authFilterRaw === 'linked_unknown'
-		? authFilterRaw
+			? authFilterRaw
 			: 'all'
 	const coverageFilter: MembersCoverageFilter =
 		coverageFilterRaw === 'full' ||
@@ -447,7 +448,9 @@ function parseMembersQuery(c: Context<App>): MembersQuery {
 			? coverageFilterRaw
 			: 'all'
 	const activityFilter: MembersActivityFilter =
-		activityFilterRaw === 'active' || activityFilterRaw === 'inactive' || activityFilterRaw === 'unknown'
+		activityFilterRaw === 'active' ||
+		activityFilterRaw === 'inactive' ||
+		activityFilterRaw === 'unknown'
 			? activityFilterRaw
 			: 'all'
 	const roleFilter: MembersRoleFilter =
@@ -456,12 +459,12 @@ function parseMembersQuery(c: Context<App>): MembersQuery {
 			: 'all'
 	const sortField: MembersSortField =
 		sortFieldRaw === 'name' ||
-			sortFieldRaw === 'role' ||
-			sortFieldRaw === 'hrRole' ||
-			sortFieldRaw === 'auth' ||
-			sortFieldRaw === 'activity' ||
-			sortFieldRaw === 'lastLogin' ||
-			sortFieldRaw === 'joinDate'
+		sortFieldRaw === 'role' ||
+		sortFieldRaw === 'hrRole' ||
+		sortFieldRaw === 'auth' ||
+		sortFieldRaw === 'activity' ||
+		sortFieldRaw === 'lastLogin' ||
+		sortFieldRaw === 'joinDate'
 			? sortFieldRaw
 			: 'role'
 	const sortOrder: MembersSortOrder = sortOrderRaw === 'desc' ? 'desc' : 'asc'
@@ -546,7 +549,9 @@ function filterSortAndPaginateMembers(
 				return member.hasAuthAccount && member.hasValidToken === false
 			}
 			if (query.authFilter === 'linked_unknown') {
-				return member.hasAuthAccount && member.hasValidToken !== true && member.hasValidToken !== false
+				return (
+					member.hasAuthAccount && member.hasValidToken !== true && member.hasValidToken !== false
+				)
 			}
 			return true
 		})
@@ -705,7 +710,9 @@ function filterSortMembers(
 				return member.hasAuthAccount && member.hasValidToken === false
 			}
 			if (query.authFilter === 'linked_unknown') {
-				return member.hasAuthAccount && member.hasValidToken !== true && member.hasValidToken !== false
+				return (
+					member.hasAuthAccount && member.hasValidToken !== true && member.hasValidToken !== false
+				)
 			}
 			return true
 		})
@@ -772,7 +779,9 @@ function filterSortMembers(
 	return filtered
 }
 
-function getEsiStatusLabel(member: Pick<CorporationMemberListItem, 'hasAuthAccount' | 'hasValidToken'>) {
+function getEsiStatusLabel(
+	member: Pick<CorporationMemberListItem, 'hasAuthAccount' | 'hasValidToken'>
+) {
 	if (!member.hasAuthAccount) return 'Unlinked'
 	if (member.hasValidToken === true) return 'ESI Valid'
 	if (member.hasValidToken === false) return 'ESI Invalid'
@@ -839,8 +848,8 @@ async function hydrateCorporationMembers(
 	const linkedCharacters =
 		memberCharacterIds.length > 0
 			? await db.query.userCharacters.findMany({
-				where: inArray(userCharacters.characterId, memberCharacterIds),
-			})
+					where: inArray(userCharacters.characterId, memberCharacterIds),
+				})
 			: []
 	const linkedCharacterMap = new Map(linkedCharacters.map((row) => [row.characterId, row]))
 	const directors = await corpStub.getDirectors(corporationId)
@@ -851,8 +860,8 @@ async function hydrateCorporationMembers(
 	const linkedUsers =
 		linkedUserIds.length > 0
 			? await db.query.users.findMany({
-				where: inArray(users.id, linkedUserIds),
-			})
+					where: inArray(users.id, linkedUserIds),
+				})
 			: []
 	const mainCharacterIds = linkedUsers.map((user) => user.mainCharacterId)
 	const mainCharacterNameMap =
@@ -860,7 +869,9 @@ async function hydrateCorporationMembers(
 	const userIdToMainCharacterName = new Map(
 		linkedUsers.map((user) => [user.id, mainCharacterNameMap[user.mainCharacterId] || 'Unknown'])
 	)
-	const userIdToMainCharacterId = new Map(linkedUsers.map((user) => [user.id, user.mainCharacterId]))
+	const userIdToMainCharacterId = new Map(
+		linkedUsers.map((user) => [user.id, user.mainCharacterId])
+	)
 	const hrStub = getStub<Hr>(c.env.HR, 'default')
 	const blacklistStatuses =
 		memberCharacterIds.length > 0 ? await hrStub.checkCharactersBlacklisted(memberCharacterIds) : {}
@@ -886,8 +897,12 @@ async function hydrateCorporationMembers(
 			hasAuthAccount: !!linkedChar,
 			hasValidToken: linkedChar ? (linkedChar.hasValidToken ?? null) : null,
 			authUserId: linkedChar?.userId,
-			mainCharacterId: linkedChar?.userId ? userIdToMainCharacterId.get(linkedChar.userId) : undefined,
-			mainCharacterName: linkedChar?.userId ? userIdToMainCharacterName.get(linkedChar.userId) : undefined,
+			mainCharacterId: linkedChar?.userId
+				? userIdToMainCharacterId.get(linkedChar.userId)
+				: undefined,
+			mainCharacterName: linkedChar?.userId
+				? userIdToMainCharacterName.get(linkedChar.userId)
+				: undefined,
 			status: linkedChar?.status,
 			joinDate: tracking?.startDate?.toISOString() || member.updatedAt.toISOString(),
 			lastEsiUpdate: member.updatedAt.toISOString(),
@@ -1003,7 +1018,9 @@ async function checkCorporationAccess(
 
 	// Fast path: use persisted core.user_characters corporation affiliation.
 	// This avoids expensive per-character DO reads on interactive member-search requests.
-	const inCorpByPersistedAffiliation = userChars.filter((character) => character.corporationId === corporationId)
+	const inCorpByPersistedAffiliation = userChars.filter(
+		(character) => character.corporationId === corporationId
+	)
 	for (const character of inCorpByPersistedAffiliation) {
 		if (corpInfo && String(corpInfo.ceoId) === character.characterId) {
 			logger.info('[Corporation Access] CEO access granted', {
@@ -1103,6 +1120,9 @@ async function isHrAuditorUser(c: Context<App>): Promise<boolean> {
  * Query parameters:
  *   isMember: boolean - filter by member corporation status
  *   isAlt: boolean - filter by alt corporation status
+ *   search: string - search corporation name or ticker
+ *   page: number - page number, starting at 1 (default 1)
+ *   pageSize: 25|50|100 - results per page (default 25)
  */
 app.get('/', requireAuth(), requireAdmin(), async (c) => {
 	const db = c.get('db')
@@ -1112,59 +1132,100 @@ app.get('/', requireAuth(), requireAdmin(), async (c) => {
 	}
 
 	try {
+		const parsedPage = Number.parseInt(c.req.query('page') ?? '1', 10)
+		const page = Number.isFinite(parsedPage) ? Math.max(parsedPage, 1) : 1
+		const requestedPageSize = Number.parseInt(c.req.query('pageSize') ?? '25', 10)
+		const pageSize = [25, 50, 100].includes(requestedPageSize) ? requestedPageSize : null
+		if (pageSize === null) {
+			return c.json({ error: 'pageSize must be one of 25, 50, or 100' }, 400)
+		}
+
 		const corporationType = c.req.query('corporationType') as
 			| 'member'
 			| 'alt'
 			| 'special'
 			| 'other'
 			| undefined
+		const search = c.req.query('search')?.trim()
 
-		// Build where conditions based on corporation type
-		let whereCondition
+		// Keep the NPC safety filter in SQL so the count and page contain the same rows.
+		const conditions = [
+			not(
+				and(
+					gte(managedCorporations.corporationId, '1000000'),
+					lt(managedCorporations.corporationId, '2000000')
+				)!
+			),
+		]
 		if (corporationType === 'member') {
-			whereCondition = eq(managedCorporations.isMemberCorporation, true)
+			conditions.push(eq(managedCorporations.isMemberCorporation, true))
 		} else if (corporationType === 'alt') {
-			whereCondition = eq(managedCorporations.isAltCorp, true)
+			conditions.push(eq(managedCorporations.isAltCorp, true))
 		} else if (corporationType === 'special') {
-			whereCondition = eq(managedCorporations.isSpecialPurpose, true)
+			conditions.push(eq(managedCorporations.isSpecialPurpose, true))
 		} else if (corporationType === 'other') {
 			// "Other" corporations are those that are not member, alt, or special purpose
-			whereCondition = and(
-				eq(managedCorporations.isMemberCorporation, false),
-				eq(managedCorporations.isAltCorp, false),
-				eq(managedCorporations.isSpecialPurpose, false)
+			conditions.push(
+				and(
+					eq(managedCorporations.isMemberCorporation, false),
+					eq(managedCorporations.isAltCorp, false),
+					eq(managedCorporations.isSpecialPurpose, false)
+				)!
 			)
 		}
-		// If corporationType is undefined, no filter (show all)
+		if (search) {
+			const searchPattern = `%${search}%`
+			conditions.push(
+				or(
+					ilike(managedCorporations.name, searchPattern),
+					ilike(managedCorporations.ticker, searchPattern)
+				)!
+			)
+		}
+		const whereCondition = and(...conditions)!
 
+		const countRows = await db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(managedCorporations)
+			.where(whereCondition)
+		const totalCount = countRows[0]?.count ?? 0
 		const corporations = await db.query.managedCorporations.findMany({
 			where: whereCondition,
-			orderBy: desc(managedCorporations.updatedAt),
+			orderBy: [asc(managedCorporations.name), asc(managedCorporations.corporationId)],
+			limit: pageSize,
+			offset: (page - 1) * pageSize,
 		})
 
-		// Safety filter: never expose NPC corporations as managed corporations in admin views.
-		const managed = corporations.filter((corp) => !isNpcCorporationId(corp.corporationId))
-		const enriched = await Promise.all(
-			managed.map(async (corp) => {
-				try {
-					const stub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corp.corporationId)
-					const healthyDirectors = await stub.getHealthyDirectors(corp.corporationId)
-					const healthyDirectorCount = healthyDirectors.length
-					return {
-						...corp,
-						healthyDirectorCount,
-					}
-				} catch (error) {
-					logger.warn('[Corporations] Failed to enrich live director health for list item', {
-						corporationId: corp.corporationId,
-						error: error instanceof Error ? error.message : String(error),
-					})
-					return corp
-				}
-			})
-		)
+		let healthyDirectorCounts: Record<string, number | null> = {}
+		if (corporations.length > 0) {
+			try {
+				healthyDirectorCounts = await c.env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts(
+					corporations.map((corp) => corp.corporationId)
+				)
+			} catch (error) {
+				logger.warn('[Corporations] Failed to batch-enrich live director health', {
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+		}
 
-		return c.json(enriched)
+		const enriched = corporations.map((corp) => {
+			const healthyDirectorCount = healthyDirectorCounts[corp.corporationId]
+			return typeof healthyDirectorCount === 'number' ? { ...corp, healthyDirectorCount } : corp
+		})
+
+		const totalPages = totalCount === 0 ? 0 : Math.ceil(totalCount / pageSize)
+		return c.json({
+			data: enriched,
+			pagination: {
+				page,
+				pageSize,
+				totalCount,
+				totalPages,
+				hasNextPage: page < totalPages,
+				hasPreviousPage: page > 1 && totalPages > 0,
+			},
+		})
 	} catch (error) {
 		logger.error('Error fetching corporations:', error)
 		return c.json({ error: 'Failed to fetch corporations' }, 500)
@@ -1327,9 +1388,9 @@ app.get('/browse/:corporationId', requireAuth(), async (c) => {
 			where: hasManagementAccess
 				? eq(managedCorporations.corporationId, corporationId)
 				: and(
-					eq(managedCorporations.corporationId, corporationId),
-					eq(managedCorporations.isRecruiting, true)
-				),
+						eq(managedCorporations.corporationId, corporationId),
+						eq(managedCorporations.isRecruiting, true)
+					),
 		})
 
 		if (!corporation) {
@@ -1388,7 +1449,10 @@ app.patch('/:corporationId/settings', requireAuth(), async (c) => {
 			'hr_admin'
 		)
 		if (!hasHrAdmin) {
-			return c.json({ error: 'Access denied. Corporation CEO, site admin, or HR admin required.' }, 403)
+			return c.json(
+				{ error: 'Access denied. Corporation CEO, site admin, or HR admin required.' },
+				403
+			)
 		}
 	}
 
@@ -1780,9 +1844,7 @@ app.put('/:corporationId', requireAuth(), requireAdmin(), async (c) => {
 				if (uniqueUserIds.length > 0) {
 					const coreStub = getStub<Core>(c.env.CORE, 'default')
 					const queueResult = await coreStub.addPendingDiscordRefreshes(uniqueUserIds, {
-						source: isMemberCorporation
-							? 'corp-member-flag-enabled'
-							: 'corp-member-flag-disabled',
+						source: isMemberCorporation ? 'corp-member-flag-enabled' : 'corp-member-flag-disabled',
 						force: true,
 					})
 					logger.info('[Corporations] Queued Discord refresh after member-corp status change', {
@@ -1795,11 +1857,14 @@ app.put('/:corporationId', requireAuth(), requireAdmin(), async (c) => {
 					})
 				}
 			} catch (error) {
-				logger.error('[Corporations] Failed to queue Discord refresh after member-corp status change', {
-					corporationId,
-					isMemberCorporation,
-					error: error instanceof Error ? error.message : String(error),
-				})
+				logger.error(
+					'[Corporations] Failed to queue Discord refresh after member-corp status change',
+					{
+						corporationId,
+						isMemberCorporation,
+						error: error instanceof Error ? error.message : String(error),
+					}
+				)
 				// Non-fatal: setting update should still complete.
 			}
 		}
@@ -1915,7 +1980,7 @@ app.post('/:corporationId/verify', requireAuth(), requireAdmin(), async (c) => {
 		logger.info('[Corporations] Verifying corporation access', { corporationId })
 		const verification = await stub.verifyAccess(corporationId)
 
-		const healthyDirectorCount = (await stub.getHealthyDirectors(corporationId)).length
+		const healthyDirectorCount = await stub.getHealthyDirectorCount(corporationId)
 
 		await db
 			.update(managedCorporations)
@@ -1941,7 +2006,7 @@ app.post('/:corporationId/verify', requireAuth(), requireAdmin(), async (c) => {
 			})
 		}
 
-		return c.json(verification)
+		return c.json({ ...verification, healthyDirectorCount })
 	} catch (error) {
 		logger.error('[Corporations] Error verifying corporation access', {
 			corporationId,
@@ -2134,29 +2199,29 @@ app.get('/:corporationId/data', requireAuth(), requireAdmin(), async (c) => {
 			publicInfo,
 			coreData: coreData
 				? {
-					memberCount: coreData.members.length,
-					trackingCount: coreData.memberTracking.length,
-				}
+						memberCount: coreData.members.length,
+						trackingCount: coreData.memberTracking.length,
+					}
 				: null,
 			financialData: financialData
 				? {
-					walletCount: financialData.wallets.length,
-					journalCount: financialData.journalEntries.length,
-					transactionCount: financialData.transactions.length,
-				}
+						walletCount: financialData.wallets.length,
+						journalCount: financialData.journalEntries.length,
+						transactionCount: financialData.transactions.length,
+					}
 				: null,
 			assetsData: assetsData
 				? {
-					assetCount: assetsData.assets.length,
-					structureCount: assetsData.structures.length,
-				}
+						assetCount: assetsData.assets.length,
+						structureCount: assetsData.structures.length,
+					}
 				: null,
 			marketData: marketData
 				? {
-					orderCount: marketData.orders.length,
-					contractCount: marketData.contracts.length,
-					industryJobCount: marketData.industryJobs.length,
-				}
+						orderCount: marketData.orders.length,
+						contractCount: marketData.contracts.length,
+						industryJobCount: marketData.industryJobs.length,
+					}
 				: null,
 			killmailCount: killmails.length,
 		}
@@ -2224,8 +2289,10 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
 		const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
 		const hrStub = getStub<Hr>(c.env.HR, 'default')
-		const hrRoles = query.sortField === 'hrRole' ? await hrStub.getCorporationRoles(corporationId, true) : []
-		const hrRoleMap = hrRoles.length > 0 ? new Map(hrRoles.map((role) => [role.userId, role.role])) : undefined
+		const hrRoles =
+			query.sortField === 'hrRole' ? await hrStub.getCorporationRoles(corporationId, true) : []
+		const hrRoleMap =
+			hrRoles.length > 0 ? new Map(hrRoles.map((role) => [role.userId, role.role])) : undefined
 
 		const useBackendPagination =
 			!returnUnpaginated &&
@@ -2271,8 +2338,8 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 			const linkedCharacters =
 				pageCharacterIds.length > 0
 					? await db.query.userCharacters.findMany({
-						where: inArray(userCharacters.characterId, pageCharacterIds),
-					})
+							where: inArray(userCharacters.characterId, pageCharacterIds),
+						})
 					: []
 			const linkedCharacterMap = new Map(linkedCharacters.map((row) => [row.characterId, row]))
 			const characterNameMap =
@@ -2282,8 +2349,8 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 			const linkedUsers =
 				linkedUserIds.length > 0
 					? await db.query.users.findMany({
-						where: inArray(users.id, linkedUserIds),
-					})
+							where: inArray(users.id, linkedUserIds),
+						})
 					: []
 			const mainCharacterIds = linkedUsers.map((u) => u.mainCharacterId)
 			const mainCharacterNameMap =
@@ -2294,9 +2361,7 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 			const userIdToMainCharacterId = new Map(linkedUsers.map((u) => [u.id, u.mainCharacterId]))
 
 			const blacklistStatuses =
-				pageCharacterIds.length > 0
-					? await hrStub.checkCharactersBlacklisted(pageCharacterIds)
-					: {}
+				pageCharacterIds.length > 0 ? await hrStub.checkCharactersBlacklisted(pageCharacterIds) : {}
 
 			// These are lightweight member-summary fields used by list/search pages.
 			// They intentionally stop short of private character hydration so they
@@ -2312,7 +2377,9 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 					hasAuthAccount: !!linkedChar,
 					hasValidToken: linkedChar ? (linkedChar.hasValidToken ?? null) : null,
 					authUserId: linkedChar?.userId,
-					mainCharacterId: linkedChar?.userId ? userIdToMainCharacterId.get(linkedChar.userId) : undefined,
+					mainCharacterId: linkedChar?.userId
+						? userIdToMainCharacterId.get(linkedChar.userId)
+						: undefined,
 					mainCharacterName: linkedChar?.userId
 						? userIdToMainCharacterName.get(linkedChar.userId)
 						: undefined,
@@ -2362,8 +2429,8 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 				const coverageLinkedCharacters =
 					coverageMemberIds.length > 0
 						? await db.query.userCharacters.findMany({
-							where: inArray(userCharacters.characterId, coverageMemberIds),
-						})
+								where: inArray(userCharacters.characterId, coverageMemberIds),
+							})
 						: []
 				const coverageLinkedCharacterMap = new Map(
 					coverageLinkedCharacters.map((row) => [row.characterId, row])
@@ -2433,8 +2500,8 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		const linkedCharacters =
 			memberCharacterIds.length > 0
 				? await db.query.userCharacters.findMany({
-					where: inArray(userCharacters.characterId, memberCharacterIds),
-				})
+						where: inArray(userCharacters.characterId, memberCharacterIds),
+					})
 				: []
 
 		const linkedCharacterMap = new Map(linkedCharacters.map((c) => [c.characterId, c]))
@@ -2459,8 +2526,8 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		const linkedUsers =
 			linkedUserIds.length > 0
 				? await db.query.users.findMany({
-					where: inArray(users.id, linkedUserIds),
-				})
+						where: inArray(users.id, linkedUserIds),
+					})
 				: []
 
 		// Resolve main character IDs to character names
@@ -2518,7 +2585,9 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 					hasAuthAccount,
 					hasValidToken: linkedChar ? (linkedChar.hasValidToken ?? null) : null,
 					authUserId: linkedChar?.userId,
-					mainCharacterId: linkedChar?.userId ? userIdToMainCharacterId.get(linkedChar.userId) : undefined,
+					mainCharacterId: linkedChar?.userId
+						? userIdToMainCharacterId.get(linkedChar.userId)
+						: undefined,
 					mainCharacterName: linkedChar?.userId
 						? userIdToMainCharacterName.get(linkedChar.userId)
 						: undefined,
@@ -2617,16 +2686,23 @@ app.get('/:corporationId/members/export', requireAuth(), async (c) => {
 		const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
 		const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
 		const hrStub = getStub<Hr>(c.env.HR, 'default')
-		const members = await hydrateCorporationMembers(c, corporationId, managedCorp, corpStub, tokenStoreStub)
+		const members = await hydrateCorporationMembers(
+			c,
+			corporationId,
+			managedCorp,
+			corpStub,
+			tokenStoreStub
+		)
 		const hrRoles = await hrStub.getCorporationRoles(corporationId, true)
 		const hrRoleMap = new Map(hrRoles.map((role) => [role.userId, role.role]))
 		const filteredMembers = filterSortMembers(members, query, hrRoleMap)
 		const csv = buildCorporationMembersCsv(filteredMembers, hrRoleMap)
-		const safeFileName = managedCorp.name
-			.trim()
-			.replace(/[^a-zA-Z0-9._-]+/g, '-')
-			.replace(/^-+|-+$/g, '')
-			.toLowerCase() || 'corporation'
+		const safeFileName =
+			managedCorp.name
+				.trim()
+				.replace(/[^a-zA-Z0-9._-]+/g, '-')
+				.replace(/^-+|-+$/g, '')
+				.toLowerCase() || 'corporation'
 
 		return new Response(csv, {
 			status: 200,
@@ -2778,10 +2854,13 @@ app.get('/:corporationId/members/:accountId', requireAuth(), async (c) => {
 			const hasHrAccess = managedCorp.isMemberCorporation
 				? await hr.checkPermission(user.id, corporationId, 'hr_viewer')
 				: false
-			const isAuditor = !hasHrAccess && await isHrAuditorUser(c)
+			const isAuditor = !hasHrAccess && (await isHrAuditorUser(c))
 			if (!hasHrAccess && !isAuditor) {
 				return c.json(
-					{ error: 'Access denied. Corporation CEO, Director, site admin, HR role, or HR auditor permission required.' },
+					{
+						error:
+							'Access denied. Corporation CEO, Director, site admin, HR role, or HR auditor permission required.',
+					},
 					403
 				)
 			}
@@ -2828,14 +2907,12 @@ app.get('/:corporationId/members/:accountId', requireAuth(), async (c) => {
 		})
 		const discordUsername =
 			linkedUser?.discordUserId && accountId
-				? (
-						await getStub<Discord>(c.env.DISCORD, 'default').getDiscordUserStatus(accountId)
-				  )?.username ?? null
+				? ((await getStub<Discord>(c.env.DISCORD, 'default').getDiscordUserStatus(accountId))
+						?.username ?? null)
 				: null
-		const mainCharacterNameMap =
-			linkedUser?.mainCharacterId
-				? await tokenStoreStub.resolveIds([linkedUser.mainCharacterId])
-				: {}
+		const mainCharacterNameMap = linkedUser?.mainCharacterId
+			? await tokenStoreStub.resolveIds([linkedUser.mainCharacterId])
+			: {}
 		const mainCharacterName = linkedUser?.mainCharacterId
 			? (mainCharacterNameMap[linkedUser.mainCharacterId] ?? undefined)
 			: undefined
@@ -2886,9 +2963,10 @@ app.get('/:corporationId/members/:accountId', requireAuth(), async (c) => {
 
 		const rows = memberRows
 		const mainName =
-			rows.find((row) => row.mainCharacterName)?.mainCharacterName ?? rows[0]?.characterName ?? 'Unknown'
-		const representative =
-			rows.find((row) => row.characterName === mainName) ?? rows[0]
+			rows.find((row) => row.mainCharacterName)?.mainCharacterName ??
+			rows[0]?.characterName ??
+			'Unknown'
+		const representative = rows.find((row) => row.characterName === mainName) ?? rows[0]
 		const roleRank: Record<'CEO' | 'Director' | 'Member', number> = {
 			CEO: 0,
 			Director: 1,

--- a/apps/core/src/services/corporation-auto-register.service.ts
+++ b/apps/core/src/services/corporation-auto-register.service.ts
@@ -183,6 +183,8 @@ export async function autoRegisterDirectorCorporation(
 					assignedCharacterId: characterId,
 					assignedCharacterName: characterName,
 					isActive: true,
+					includeInBackgroundRefresh: false,
+					includeInStructureAssetSync: false,
 					isVerified: false,
 					healthyDirectorCount: 0,
 					configuredBy: userId,

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -230,6 +230,11 @@
 			"binding": "PASTE",
 			"service": "paste",
 			"entrypoint": "PasteWorkerEntrypoint"
+		},
+		{
+			"binding": "EVE_CORPORATION_DATA_WORKER",
+			"service": "eve-corporation-data",
+			"entrypoint": "EveCorporationDataWorker"
 		}
 	],
 	"migrations": [

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -1535,6 +1535,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	}
 
 	/**
+	 * Get the number of healthy directors without loading director rows.
+	 */
+	async getHealthyDirectorCount(corporationId: string): Promise<number> {
+		const directorManager = this.createDirectorManager(corporationId)
+		return await directorManager.getHealthyDirectorsCount()
+	}
+
+	/**
 	 * Verify health of a specific director
 	 */
 	async verifyDirectorHealth(corporationId: string, directorId: string): Promise<boolean> {

--- a/apps/eve-corporation-data/src/index.ts
+++ b/apps/eve-corporation-data/src/index.ts
@@ -19,13 +19,11 @@ import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { App, Env } from './context'
 
 const app = new Hono<App>()
-	.use(
-		'*',
-		(c, next) =>
-			withWorkersLogger(c.env.NAME, {
-				environment: c.env.ENVIRONMENT,
-				release: c.env.SENTRY_RELEASE,
-			})(c, next)
+	.use('*', (c, next) =>
+		withWorkersLogger(c.env.NAME, {
+			environment: c.env.ENVIRONMENT,
+			release: c.env.SENTRY_RELEASE,
+		})(c, next)
 	)
 
 	.onError(withOnError())
@@ -38,7 +36,7 @@ const app = new Hono<App>()
 // Export default worker with fetch, queue, and scheduled handlers
 export default {
 	fetch: app.fetch.bind(app),
-	async queue(batch: MessageBatch, env: Env, ctx: ExecutionContext): Promise<void> {
+	async queue(batch: MessageBatch, env: Env, _ctx: ExecutionContext): Promise<void> {
 		await withWorkerLogContext('eve-corporation-data-queue', env, async () => {
 			// No queue consumers anymore - this handler exists only because
 			// we have the hr-member-departed producer binding which requires
@@ -62,6 +60,36 @@ export { EveCorporationDataDO as EveCorporationData }
  * Exposes workflow dispatch methods for internal callers.
  */
 export class EveCorporationDataWorker extends WorkerEntrypoint<Env> {
+	/**
+	 * Read healthy director counts for a page of corporations. Corporation
+	 * Durable Objects are independent, so keep the internal fan-out bounded.
+	 */
+	async getHealthyDirectorCounts(corporationIds: string[]): Promise<Record<string, number | null>> {
+		const uniqueCorporationIds = [...new Set(corporationIds)]
+		const counts: Record<string, number | null> = {}
+		const BATCH_CONCURRENCY = 4
+
+		for (let i = 0; i < uniqueCorporationIds.length; i += BATCH_CONCURRENCY) {
+			const batch = uniqueCorporationIds.slice(i, i + BATCH_CONCURRENCY)
+			await Promise.all(
+				batch.map(async (corporationId) => {
+					try {
+						const stub = getStub<EveCorporationData>(this.env.EVE_CORPORATION_DATA, corporationId)
+						counts[corporationId] = await stub.getHealthyDirectorCount(corporationId)
+					} catch (error) {
+						logger.warn('[EveCorporationDataWorker] Failed to read director health count', {
+							corporationId,
+							error: error instanceof Error ? error.message : String(error),
+						})
+						counts[corporationId] = null
+					}
+				})
+			)
+		}
+
+		return counts
+	}
+
 	/**
 	 * Trigger corporation sync workflows in batches.
 	 */

--- a/apps/eve-corporation-data/src/services/director-manager.ts
+++ b/apps/eve-corporation-data/src/services/director-manager.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from '@repo/db-utils'
+import { and, asc, eq, sql } from '@repo/db-utils'
 import { logger } from '@repo/hono-helpers'
 import {
 	classifyEsiCredentialFailure,
@@ -914,8 +914,17 @@ export class DirectorManager {
 	 * Get count of healthy directors
 	 */
 	async getHealthyDirectorsCount(): Promise<number> {
-		const directors = await this.getHealthyDirectors()
-		return directors.length
+		const [result] = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(corporationDirectors)
+			.where(
+				and(
+					eq(corporationDirectors.corporationId, this.corporationId),
+					eq(corporationDirectors.isHealthy, true)
+				)
+			)
+
+		return result?.count ?? 0
 	}
 
 	/**

--- a/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
@@ -434,6 +434,11 @@ describe('DirectorManager.recordFailure', () => {
 				},
 			},
 			update,
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn().mockResolvedValue([{ count: 0 }]),
+				})),
+			})),
 		}
 		const onHealthSnapshotChanged = vi.fn().mockResolvedValue(undefined)
 		const manager = new DirectorManager(
@@ -454,6 +459,20 @@ describe('DirectorManager.recordFailure', () => {
 			healthyDirectorCount: 0,
 			isVerified: false,
 		})
+	})
+})
+
+describe('DirectorManager.getHealthyDirectorsCount', () => {
+	it('uses a database count query instead of loading director rows', async () => {
+		const where = vi.fn().mockResolvedValue([{ count: 3 }])
+		const from = vi.fn().mockReturnValue({ where })
+		const select = vi.fn().mockReturnValue({ from })
+		const manager = new DirectorManager({ select } as never, '98000001', {} as never)
+
+		await expect(manager.getHealthyDirectorsCount()).resolves.toBe(3)
+		expect(select).toHaveBeenCalledTimes(1)
+		expect(from).toHaveBeenCalledTimes(1)
+		expect(where).toHaveBeenCalledTimes(1)
 	})
 })
 

--- a/apps/eve-corporation-data/src/test/unit/worker-entrypoint.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/worker-entrypoint.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { EveCorporationDataWorker } from '../../index'
+
+const { getStubMock } = vi.hoisted(() => ({
+	getStubMock: vi.fn(),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: getStubMock,
+}))
+
+describe('EveCorporationDataWorker', () => {
+	it('returns per-corporation counts while isolating failed lookups', async () => {
+		const corporationStubs = new Map([
+			[
+				'corp-1',
+				{
+					getHealthyDirectorCount: vi.fn().mockResolvedValue(2),
+				},
+			],
+			[
+				'corp-2',
+				{
+					getHealthyDirectorCount: vi.fn().mockRejectedValue(new Error('DO unavailable')),
+				},
+			],
+		])
+		getStubMock.mockImplementation((_binding: unknown, corporationId: string) => {
+			return corporationStubs.get(corporationId)
+		})
+
+		const worker = new EveCorporationDataWorker({} as never, { EVE_CORPORATION_DATA: {} } as never)
+
+		await expect(worker.getHealthyDirectorCounts(['corp-1', 'corp-1', 'corp-2'])).resolves.toEqual({
+			'corp-1': 2,
+			'corp-2': null,
+		})
+		expect(getStubMock).toHaveBeenCalledTimes(2)
+		expect(getStubMock).toHaveBeenNthCalledWith(1, expect.anything(), 'corp-1')
+		expect(getStubMock).toHaveBeenNthCalledWith(2, expect.anything(), 'corp-2')
+		expect(corporationStubs.get('corp-1')?.getHealthyDirectorCount).toHaveBeenCalledWith('corp-1')
+		expect(corporationStubs.get('corp-2')?.getHealthyDirectorCount).toHaveBeenCalledWith('corp-2')
+	})
+})

--- a/apps/ui/src/client/hooks/useCorporations.ts
+++ b/apps/ui/src/client/hooks/useCorporations.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api } from '@/lib/api'
 
@@ -7,6 +7,8 @@ import type {
 	CorporationsFilters,
 	CreateCorporationRequest,
 	FetchCorporationDataRequest,
+	ManagedCorporation,
+	PaginatedResponse,
 	UpdateCorporationRequest,
 	UpdateDirectorPriorityRequest,
 } from '@/lib/api'
@@ -50,7 +52,9 @@ export function useCorporations(filters?: CorporationsFilters) {
 	return useQuery({
 		queryKey: corporationKeys.list(filters),
 		queryFn: () => api.getCorporations(filters),
+		placeholderData: keepPreviousData,
 		staleTime: 1000 * 60, // 1 minute
+		gcTime: 1000 * 60 * 60, // Keep recently viewed pages available for one hour
 	})
 }
 
@@ -173,7 +177,30 @@ export function useVerifyCorporationAccess() {
 
 	return useMutation({
 		mutationFn: (corporationId: string) => api.verifyCorporationAccess(corporationId),
-		onSuccess: (_, corporationId) => {
+		onSuccess: (verification, corporationId) => {
+			const lastVerified = verification.lastVerified
+				? new Date(verification.lastVerified).toISOString()
+				: null
+			queryClient.setQueriesData<PaginatedResponse<ManagedCorporation>>(
+				{ queryKey: corporationKeys.lists() },
+				(previous) => {
+					if (!previous) return previous
+					return {
+						...previous,
+						data: previous.data.map((corporation) =>
+							corporation.corporationId === corporationId
+								? {
+										...corporation,
+										isVerified: verification.healthyDirectorCount > 0,
+										healthyDirectorCount: verification.healthyDirectorCount,
+										lastVerified: lastVerified ?? corporation.lastVerified,
+									}
+								: corporation
+						),
+					}
+				}
+			)
+
 			// Batch invalidations for this specific corporation
 			void queryClient.invalidateQueries({
 				queryKey: corporationKeys.detail(corporationId),

--- a/apps/ui/src/client/hooks/useCorporations.ts
+++ b/apps/ui/src/client/hooks/useCorporations.ts
@@ -130,18 +130,41 @@ export function useUpdateCorporation() {
 			corporationId: string
 			data: UpdateCorporationRequest
 		}) => api.updateCorporation(corporationId, data),
-		onSuccess: (updatedCorporation) => {
+		onSuccess: (updatedCorporation, { data }) => {
 			// Update detail cache first (immediate update)
 			queryClient.setQueryData(
 				corporationKeys.detail(updatedCorporation.corporationId),
 				updatedCorporation
 			)
 
-			// Then invalidate list to show updated data
-			void queryClient.invalidateQueries({
-				queryKey: corporationKeys.lists(),
-				refetchType: 'active',
-			})
+			// Patch every cached page so sync toggles update only the affected row.
+			queryClient.setQueriesData<PaginatedResponse<ManagedCorporation>>(
+				{ queryKey: corporationKeys.lists() },
+				(previous) => {
+					if (!previous) return previous
+					return {
+						...previous,
+						data: previous.data.map((corporation) =>
+							corporation.corporationId === updatedCorporation.corporationId
+								? updatedCorporation
+								: corporation
+						),
+					}
+				}
+			)
+
+			const isSyncOnlyUpdate =
+				Object.keys(data).length > 0 &&
+				Object.keys(data).every(
+					(key) => key === 'includeInBackgroundRefresh' || key === 'includeInStructureAssetSync'
+				)
+			if (!isSyncOnlyUpdate) {
+				// Other updates can change filtering or ordering, so reconcile all active pages.
+				void queryClient.invalidateQueries({
+					queryKey: corporationKeys.lists(),
+					refetchType: 'active',
+				})
+			}
 		},
 	})
 }
@@ -201,15 +224,9 @@ export function useVerifyCorporationAccess() {
 				}
 			)
 
-			// Batch invalidations for this specific corporation
+			// Reconcile the detailed corporation view without refetching every list row.
 			void queryClient.invalidateQueries({
 				queryKey: corporationKeys.detail(corporationId),
-				refetchType: 'active',
-			})
-
-			// Also invalidate list, but less aggressively
-			void queryClient.invalidateQueries({
-				queryKey: corporationKeys.lists(),
 				refetchType: 'active',
 			})
 		},

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -15,41 +15,38 @@ import type { InventoryDisplayBay as SharedInventoryDisplayBay } from '@repo/inv
 import type { UpdateSRPConfig } from '@repo/srp'
 import type {
 	StructureCitadelListQuery as RepoStructureCitadelListQuery,
-	StructureMoonStructureListFilterOptions as RepoStructureMoonStructureListFilterOptions,
-	StructureMoonDrillListItem as RepoStructureMoonDrillListItem,
-	StructureMoonDrillListQuery as RepoStructureMoonDrillListQuery,
-	StructureMoonDrillListResponse as RepoStructureMoonDrillListResponse,
-	StructureMoonStructureListSortBy as RepoStructureMoonStructureListSortBy,
+	StructureCommonListFilterOptions as RepoStructureCommonListFilterOptions,
+	StructureCommonListQuery as RepoStructureCommonListQuery,
+	StructureCommonListSortBy as RepoStructureCommonListSortBy,
+	StructureListSummary as RepoStructureListSummary,
 	StructureMiningCitadelListItem as RepoStructureMiningCitadelListItem,
 	StructureMiningCitadelListQuery as RepoStructureMiningCitadelListQuery,
 	StructureMiningCitadelListResponse as RepoStructureMiningCitadelListResponse,
-	StructureNavigationListQuery as RepoStructureNavigationListQuery,
-	StructureListSummary as RepoStructureListSummary,
-	StructureCommonListQuery as RepoStructureCommonListQuery,
-	StructureCommonListFilterOptions as RepoStructureCommonListFilterOptions,
-	StructureCommonListSortBy as RepoStructureCommonListSortBy,
-	StructureSkyhookListItem as RepoStructureSkyhookListItem,
-	StructureSkyhookListFilterOptions as RepoStructureSkyhookListFilterOptions,
-	StructureSkyhookListSortBy as RepoStructureSkyhookListSortBy,
-	StructureSkyhookListResponse as RepoStructureSkyhookListResponse,
-	StructureSkyhookListQuery as RepoStructureSkyhookListQuery,
-	StructureSovereigntyListFilterOptions as RepoStructureSovereigntyListFilterOptions,
-	StructureSovereigntyListFilterOption as RepoStructureSovereigntyListFilterOption,
-	StructureSovereigntyListItem as RepoStructureSovereigntyListItem,
-	StructureSovereigntyListResponse as RepoStructureSovereigntyListResponse,
-	StructureSovereigntyListSummary as RepoStructureSovereigntyListSummary,
-	StructureSovereigntyListQuery as RepoStructureSovereigntyListQuery,
-	StructureSovereigntyListSortBy as RepoStructureSovereigntyListSortBy,
-	StructureMoonDrillSummary as RepoStructureMoonDrillSummary,
 	StructureMiningCitadelSummary as RepoStructureMiningCitadelSummary,
+	StructureMoonDrillListItem as RepoStructureMoonDrillListItem,
+	StructureMoonDrillListQuery as RepoStructureMoonDrillListQuery,
+	StructureMoonDrillListResponse as RepoStructureMoonDrillListResponse,
+	StructureMoonDrillSummary as RepoStructureMoonDrillSummary,
+	StructureMoonStructureListFilterOptions as RepoStructureMoonStructureListFilterOptions,
+	StructureMoonStructureListSortBy as RepoStructureMoonStructureListSortBy,
+	StructureNavigationListQuery as RepoStructureNavigationListQuery,
+	StructureSkyhookListFilterOptions as RepoStructureSkyhookListFilterOptions,
+	StructureSkyhookListItem as RepoStructureSkyhookListItem,
+	StructureSkyhookListQuery as RepoStructureSkyhookListQuery,
+	StructureSkyhookListResponse as RepoStructureSkyhookListResponse,
+	StructureSkyhookListSortBy as RepoStructureSkyhookListSortBy,
+	StructureSovereigntyListFilterOption as RepoStructureSovereigntyListFilterOption,
+	StructureSovereigntyListFilterOptions as RepoStructureSovereigntyListFilterOptions,
+	StructureSovereigntyListItem as RepoStructureSovereigntyListItem,
+	StructureSovereigntyListQuery as RepoStructureSovereigntyListQuery,
+	StructureSovereigntyListResponse as RepoStructureSovereigntyListResponse,
+	StructureSovereigntyListSortBy as RepoStructureSovereigntyListSortBy,
+	StructureSovereigntyListSummary as RepoStructureSovereigntyListSummary,
 	StructureSovereigntyReagent,
 	StructureSovereigntyTransportState,
 } from '@repo/structures'
 import type { TrackingSession } from '../features/fleet-tracking/types'
-import type {
-	RecentLossesResponse,
-	RequestListResponse,
-} from '../features/srp/types'
+import type { RecentLossesResponse, RequestListResponse } from '../features/srp/types'
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 const API_REQUEST_TIMEOUT_MS = 30_000
@@ -635,6 +632,9 @@ export interface UpdateCorporationRequest {
 
 export interface CorporationsFilters {
 	corporationType?: 'member' | 'alt' | 'special' | 'other'
+	search?: string
+	page?: number
+	pageSize?: 25 | 50 | 100
 }
 
 export interface CorporationAccessVerification {
@@ -644,6 +644,7 @@ export interface CorporationAccessVerification {
 	verifiedRoles: string[]
 	missingRoles?: string[]
 	lastVerified: Date | null
+	healthyDirectorCount: number
 }
 
 export interface CorporationDataSummary {
@@ -845,8 +846,7 @@ export interface StructureListFilterOptions extends RepoStructureCommonListFilte
 
 export type StructureOperationalListFilterOptions = RepoStructureCommonListFilterOptions
 
-export interface StructureSkyhookListFilterOptions
-	extends RepoStructureSkyhookListFilterOptions {}
+export interface StructureSkyhookListFilterOptions extends RepoStructureSkyhookListFilterOptions {}
 
 export interface StructureMoonStructureListFilterOptions
 	extends RepoStructureMoonStructureListFilterOptions {}
@@ -3382,10 +3382,15 @@ export class ApiClient {
 
 	// ===== Corporations API Methods =====
 
-	async getCorporations(filters?: CorporationsFilters): Promise<ManagedCorporation[]> {
+	async getCorporations(
+		filters?: CorporationsFilters
+	): Promise<PaginatedResponse<ManagedCorporation>> {
 		const params = new URLSearchParams()
 		if (filters?.corporationType !== undefined)
 			params.set('corporationType', filters.corporationType)
+		if (filters?.search) params.set('search', filters.search)
+		if (filters?.page !== undefined) params.set('page', String(filters.page))
+		if (filters?.pageSize !== undefined) params.set('pageSize', String(filters.pageSize))
 
 		const query = params.toString()
 		return this.get(`/corporations${query ? `?${query}` : ''}`)
@@ -4249,7 +4254,9 @@ export class ApiClient {
 		return this.get(`/admin/activity-log${query ? `?${query}` : ''}`)
 	}
 
-	async triggerDiscordJoin(userId: string): Promise<{ status: 'queued'; workflowInstanceId: string }> {
+	async triggerDiscordJoin(
+		userId: string
+	): Promise<{ status: 'queued'; workflowInstanceId: string }> {
 		return this.post(`/admin/users/${userId}/discord/join-servers`)
 	}
 
@@ -4642,7 +4649,10 @@ export class ApiClient {
 	/**
 	 * Get recent losses for all user's characters with SRP status
 	 */
-	async getRecentLosses(params?: { limit?: number; offset?: number }): Promise<RecentLossesResponse> {
+	async getRecentLosses(params?: {
+		limit?: number
+		offset?: number
+	}): Promise<RecentLossesResponse> {
 		const searchParams = new URLSearchParams()
 		if (params?.limit !== undefined) searchParams.set('limit', String(params.limit))
 		if (params?.offset !== undefined) searchParams.set('offset', String(params.offset))
@@ -4678,7 +4688,11 @@ export class ApiClient {
 	/**
 	 * Get user's own SRP requests (paginated)
 	 */
-	async getMyRequests(params?: { limit?: number; offset?: number; status?: string }): Promise<RequestListResponse> {
+	async getMyRequests(params?: {
+		limit?: number
+		offset?: number
+		status?: string
+	}): Promise<RequestListResponse> {
 		const searchParams = new URLSearchParams()
 		if (params?.limit) searchParams.set('limit', String(params.limit))
 		if (params?.offset) searchParams.set('offset', String(params.offset))

--- a/apps/ui/src/client/routes/admin/corporations.tsx
+++ b/apps/ui/src/client/routes/admin/corporations.tsx
@@ -9,9 +9,10 @@ import {
 	Trash2,
 	X,
 } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router'
 
+import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -36,6 +37,7 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import {
 	useCorporations,
 	useCreateCorporation,
@@ -52,9 +54,40 @@ export default function CorporationsPage() {
 	usePageTitle('Admin - Corporations')
 
 	// Filter state
-	const [filters, setFilters] = useState<CorporationsFilters>({ corporationType: 'member' })
+	const [filters, setFilters] = useState<CorporationsFilters>({
+		corporationType: 'member',
+		page: 1,
+		pageSize: 25,
+	})
+	const [searchQuery, setSearchQuery] = useState('')
+	const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
 
-	const { data: corporations, isLoading } = useCorporations(filters)
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedSearchQuery(searchQuery.trim())
+			setFilters((current) => ({ ...current, page: 1 }))
+		}, 300)
+
+		return () => clearTimeout(timer)
+	}, [searchQuery])
+
+	const { data, isLoading, isFetching, error } = useCorporations({
+		...filters,
+		search: debouncedSearchQuery || undefined,
+	})
+	const corporations = data?.data ?? []
+	const pagination = data?.pagination
+	const isInitialLoading = isLoading && !data
+	const isSoftLoading = Boolean(data) && isFetching
+
+	useEffect(() => {
+		const totalPages = pagination?.totalPages ?? 0
+		const currentPage = filters.page ?? 1
+		if (totalPages > 0 && currentPage > totalPages) {
+			setFilters((current) => ({ ...current, page: totalPages }))
+		}
+	}, [filters.page, pagination?.totalPages])
+
 	const createCorporation = useCreateCorporation()
 	const deleteCorporation = useDeleteCorporation()
 	const updateCorporation = useUpdateCorporation()
@@ -79,30 +112,19 @@ export default function CorporationsPage() {
 		includeInStructureAssetSync: false,
 	})
 
-	// Search state
-	const [searchQuery, setSearchQuery] = useState('')
-
-	// Memoize filtered and sorted corporations to prevent unnecessary processing on every render
-	const filteredCorporations = useMemo(() => {
-		if (!corporations) return undefined
-
-		const query = searchQuery.trim().toLowerCase()
-		const filtered = query
-			? corporations.filter(
-					(corp) =>
-						corp.name.toLowerCase().includes(query) || corp.ticker.toLowerCase().includes(query)
-				)
-			: corporations
-
-		return [...filtered].sort((a, b) => a.name.localeCompare(b.name))
-	}, [corporations, searchQuery])
-
 	// Check if any filters are active (different from default)
-	const hasActiveFilters = filters.corporationType !== 'member'
+	const hasActiveFilters = filters.corporationType !== 'member' || searchQuery.trim().length > 0
 
 	// Clear all filters (reset to default)
 	const clearFilters = () => {
-		setFilters({ corporationType: 'member' })
+		setSearchQuery('')
+		setDebouncedSearchQuery('')
+		setFilters({ corporationType: 'member', page: 1, pageSize: filters.pageSize ?? 25 })
+	}
+
+	const handlePageSizeChange = (pageSize: number) => {
+		if (pageSize !== 25 && pageSize !== 50 && pageSize !== 100) return
+		setFilters((current) => ({ ...current, page: 1, pageSize }))
 	}
 
 	// Handlers
@@ -289,6 +311,8 @@ export default function CorporationsPage() {
 												value === 'all'
 													? undefined
 													: (value as 'member' | 'alt' | 'special' | 'other'),
+											page: 1,
+											pageSize: filters.pageSize ?? 25,
 										})
 									}}
 									inputId="corporation-type-filter"
@@ -310,113 +334,160 @@ export default function CorporationsPage() {
 			{/* Corporations Table */}
 			<Card>
 				<CardHeader>
-					<CardTitle>Managed Corporations ({filteredCorporations?.length || 0})</CardTitle>
-					<CardDescription>Corporations configured for data collection</CardDescription>
+					<div className="space-y-4">
+						<div>
+							<CardTitle>Managed Corporations ({pagination?.totalCount ?? 0})</CardTitle>
+							<CardDescription>Corporations configured for data collection</CardDescription>
+						</div>
+						<UserSearchPaginationControls
+							totalCount={pagination?.totalCount ?? 0}
+							page={filters.page ?? 1}
+							pageSize={filters.pageSize ?? 25}
+							onPageChange={(page) => setFilters((current) => ({ ...current, page }))}
+							onPageSizeChange={handlePageSizeChange}
+							itemLabel="corporations"
+							nextButtonLoading={isFetching}
+						/>
+					</div>
 				</CardHeader>
 				<CardContent>
-					{isLoading ? (
-						<div className="flex justify-center py-8">
-							<LoadingSpinner label="Loading corporations..." />
-						</div>
-					) : !filteredCorporations || filteredCorporations.length === 0 ? (
-						<div className="text-center py-8">
-							<Building2 className="mx-auto h-12 w-12 text-muted-foreground" />
-							<h3 className="mt-4 text-lg font-medium">No corporations found</h3>
-							<p className="text-muted-foreground mt-2">
-								{searchQuery
-									? 'Try adjusting your search'
-									: 'Add your first corporation to get started'}
-							</p>
-						</div>
-					) : (
-						<div className="rounded-md border bg-card">
-							<Table>
-								<TableHeader>
-									<TableRow>
-										<TableHead>Corporation</TableHead>
-										<TableHead>Directors</TableHead>
-										<TableHead>Status</TableHead>
-										<TableHead>Auto-Sync</TableHead>
-										<TableHead>Asset Sync</TableHead>
-										<TableHead>Last Sync</TableHead>
-										<TableHead>Last Verified</TableHead>
-										<TableHead className="text-right">Actions</TableHead>
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{filteredCorporations.map((corp) => (
-										<TableRow key={corp.corporationId}>
-											<TableCell>
-												<div>
-													<Link
-														to={`/admin/corporations/${corp.corporationId}`}
-														className="font-medium hover:underline"
-													>
-														{corp.name}
-													</Link>
-													<div className="text-sm text-muted-foreground">[{corp.ticker}]</div>
-												</div>
-											</TableCell>
-											<TableCell>
-													<div className="text-sm">
-														<div>{`${corp.healthyDirectorCount} healthy`}</div>
-														{corp.healthyDirectorCount === 0 && (
-															<div className="text-amber-600 text-xs">Needs verification</div>
-														)}
-												</div>
-											</TableCell>
-											<TableCell>{getVerificationBadge(corp)}</TableCell>
-											<TableCell>
-												<Switch
-													checked={corp.includeInBackgroundRefresh}
-													onCheckedChange={(checked) =>
-														handleToggleBackgroundRefresh(corp.corporationId, checked)
-													}
-													disabled={updateCorporation.isPending}
-												/>
-											</TableCell>
-											<TableCell>
-												<Switch
-													checked={corp.includeInStructureAssetSync}
-													onCheckedChange={(checked) =>
-														handleToggleStructureAssetSync(corp.corporationId, checked)
-													}
-													disabled={updateCorporation.isPending}
-												/>
-											</TableCell>
-											<TableCell>
-												<span className="text-sm">{formatDate(corp.lastSync)}</span>
-											</TableCell>
-											<TableCell>
-												<span className="text-sm">{formatDate(corp.lastVerified)}</span>
-											</TableCell>
-											<TableCell className="text-right">
-												<div className="flex justify-end gap-2">
-													{corp.assignedCharacterId && (
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() => handleVerify(corp.corporationId)}
-															disabled={verifyAccess.isPending}
-														>
-															<RefreshCw className="h-4 w-4" />
-														</Button>
-													)}
-													<Button
-														variant="ghost"
-														size="sm"
-														onClick={() => openDeleteDialog(corp.corporationId)}
-													>
-														<Trash2 className="h-4 w-4 text-destructive" />
-													</Button>
-												</div>
-											</TableCell>
-										</TableRow>
-									))}
-								</TableBody>
-							</Table>
-						</div>
-					)}
+					<TableRefreshFrame
+						isRefreshing={isSoftLoading}
+						refreshMessage="Loading corporations..."
+						errorMessage={
+							error && data
+								? error instanceof Error
+									? error.message
+									: 'Failed to refresh corporations.'
+								: null
+						}
+					>
+						{error && !data ? (
+							<div className="rounded-lg border border-destructive/40 bg-destructive/10 p-8 text-center text-sm text-destructive">
+								<div className="font-medium">Failed to load corporations.</div>
+								<div className="mt-1 text-destructive/80">
+									{error instanceof Error ? error.message : 'Please try again.'}
+								</div>
+							</div>
+						) : isInitialLoading ? (
+							<div className="flex justify-center py-8">
+								<LoadingSpinner label="Loading corporations..." />
+							</div>
+						) : corporations.length === 0 ? (
+							<div className="text-center py-8">
+								<Building2 className="mx-auto h-12 w-12 text-muted-foreground" />
+								<h3 className="mt-4 text-lg font-medium">No corporations found</h3>
+								<p className="text-muted-foreground mt-2">
+									{searchQuery
+										? 'Try adjusting your search'
+										: 'Add your first corporation to get started'}
+								</p>
+							</div>
+						) : (
+							<>
+								<div className="rounded-md border bg-card">
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Corporation</TableHead>
+												<TableHead>Directors</TableHead>
+												<TableHead>Status</TableHead>
+												<TableHead>Auto-Sync</TableHead>
+												<TableHead>Asset Sync</TableHead>
+												<TableHead>Last Sync</TableHead>
+												<TableHead>Last Verified</TableHead>
+												<TableHead className="text-right">Actions</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{corporations.map((corp) => (
+												<TableRow key={corp.corporationId}>
+													<TableCell>
+														<div>
+															<Link
+																to={`/admin/corporations/${corp.corporationId}`}
+																className="font-medium hover:underline"
+															>
+																{corp.name}
+															</Link>
+															<div className="text-sm text-muted-foreground">[{corp.ticker}]</div>
+														</div>
+													</TableCell>
+													<TableCell>
+														<div className="text-sm">
+															<div>{`${corp.healthyDirectorCount} healthy`}</div>
+															{corp.healthyDirectorCount === 0 && (
+																<div className="text-amber-600 text-xs">Needs verification</div>
+															)}
+														</div>
+													</TableCell>
+													<TableCell>{getVerificationBadge(corp)}</TableCell>
+													<TableCell>
+														<Switch
+															checked={corp.includeInBackgroundRefresh}
+															onCheckedChange={(checked) =>
+																handleToggleBackgroundRefresh(corp.corporationId, checked)
+															}
+															disabled={updateCorporation.isPending}
+														/>
+													</TableCell>
+													<TableCell>
+														<Switch
+															checked={corp.includeInStructureAssetSync}
+															onCheckedChange={(checked) =>
+																handleToggleStructureAssetSync(corp.corporationId, checked)
+															}
+															disabled={updateCorporation.isPending}
+														/>
+													</TableCell>
+													<TableCell>
+														<span className="text-sm">{formatDate(corp.lastSync)}</span>
+													</TableCell>
+													<TableCell>
+														<span className="text-sm">{formatDate(corp.lastVerified)}</span>
+													</TableCell>
+													<TableCell className="text-right">
+														<div className="flex justify-end gap-2">
+															{corp.assignedCharacterId && (
+																<Button
+																	variant="ghost"
+																	size="sm"
+																	onClick={() => handleVerify(corp.corporationId)}
+																	disabled={verifyAccess.isPending}
+																>
+																	<RefreshCw className="h-4 w-4" />
+																</Button>
+															)}
+															<Button
+																variant="ghost"
+																size="sm"
+																onClick={() => openDeleteDialog(corp.corporationId)}
+															>
+																<Trash2 className="h-4 w-4 text-destructive" />
+															</Button>
+														</div>
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								</div>
+								{pagination && pagination.totalPages > 1 ? (
+									<div className="mt-4 border-t border-border pt-4">
+										<UserSearchPaginationControls
+											totalCount={pagination.totalCount}
+											page={filters.page ?? 1}
+											pageSize={filters.pageSize ?? 25}
+											onPageChange={(page) => setFilters((current) => ({ ...current, page }))}
+											onPageSizeChange={handlePageSizeChange}
+											itemLabel="corporations"
+											nextButtonLoading={isFetching}
+										/>
+									</div>
+								) : null}
+							</>
+						)}
+					</TableRefreshFrame>
 				</CardContent>
 			</Card>
 
@@ -493,22 +564,22 @@ export default function CorporationsPage() {
 								/>
 							</div>
 							<div className="space-y-2">
-									<div className="flex items-center space-x-2">
-										<Switch
-											id="includeInBackgroundRefresh"
-											checked={formData.includeInBackgroundRefresh ?? false}
-											onCheckedChange={(checked) =>
-												setFormData({ ...formData, includeInBackgroundRefresh: checked })
-											}
-										/>
-										<Label htmlFor="includeInBackgroundRefresh" className="cursor-pointer">
-											Include in Background Refresh
-										</Label>
-									</div>
-									<p className="text-sm text-muted-foreground">
-										Automatically fetch and sync corporation data on a regular schedule
-									</p>
+								<div className="flex items-center space-x-2">
+									<Switch
+										id="includeInBackgroundRefresh"
+										checked={formData.includeInBackgroundRefresh ?? false}
+										onCheckedChange={(checked) =>
+											setFormData({ ...formData, includeInBackgroundRefresh: checked })
+										}
+									/>
+									<Label htmlFor="includeInBackgroundRefresh" className="cursor-pointer">
+										Include in Background Refresh
+									</Label>
 								</div>
+								<p className="text-sm text-muted-foreground">
+									Automatically fetch and sync corporation data on a regular schedule
+								</p>
+							</div>
 							<div className="space-y-2">
 								<div className="flex items-center space-x-2">
 									<Switch
@@ -531,7 +602,8 @@ export default function CorporationsPage() {
 							<Button variant="cancel" type="button" onClick={() => setCreateDialogOpen(false)}>
 								Cancel
 							</Button>
-							<Button variant="confirm"
+							<Button
+								variant="confirm"
 								type="submit"
 								loading={createCorporation.isPending}
 								loadingText="Adding..."
@@ -553,8 +625,11 @@ export default function CorporationsPage() {
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel" onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
-						<Button variant="destructive"
+						<Button variant="cancel" onClick={() => setDeleteDialogOpen(false)}>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
 							onClick={handleDelete}
 							loading={deleteCorporation.isPending}
 							loadingText="Removing..."

--- a/apps/ui/src/client/routes/admin/corporations.tsx
+++ b/apps/ui/src/client/routes/admin/corporations.tsx
@@ -454,6 +454,8 @@ export default function CorporationsPage() {
 																	size="sm"
 																	onClick={() => handleVerify(corp.corporationId)}
 																	disabled={verifyAccess.isPending}
+																	title="Verify corporation access"
+																	aria-label="Verify corporation access"
 																>
 																	<RefreshCw className="h-4 w-4" />
 																</Button>

--- a/apps/ui/src/client/routes/admin/user-detail.tsx
+++ b/apps/ui/src/client/routes/admin/user-detail.tsx
@@ -7,26 +7,27 @@ import {
 	ChevronDown,
 	ExternalLink,
 	History,
-	Mic,
 	LogOut,
 	MessageSquare,
 	MessageSquarePlus,
+	Mic,
 	RefreshCw,
+	Server,
 	Shield,
 	ShieldBan,
 	ShieldOff,
 	Trash2,
 	Users,
-	Server,
 	XCircle,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 
+import { IpHistoryCard } from '@/components/ip-history-card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { IpHistoryCard } from '@/components/ip-history-card'
+import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
 import {
 	Dialog,
 	DialogContent,
@@ -35,7 +36,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog'
-import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
 import { Label } from '@/components/ui/label'
 import {
 	Table,
@@ -50,28 +50,28 @@ import { AddHRNoteDialog } from '@/features/applications/components/add-hr-note-
 import { HRNoteCard } from '@/features/applications/components/hr-note-card'
 import { useHRNotes } from '@/features/applications/hooks'
 import { useMumbleFeatureEnabled } from '@/features/mumble/feature'
-import { useAuth } from '@/hooks/useAuth'
 import {
 	useAdminMumbleAccount,
 	useAdminUser,
 	useAdminUserIpHistory,
-	useDeleteAdminMumbleAccount,
 	useClearUserSessions,
+	useDeleteAdminMumbleAccount,
 	useDeleteUserCharacter,
 	useRevokeDiscordLink,
 	useSetUserAdmin,
 	useSetUserPrimaryCharacter,
-	useSyncUser,
 	useSyncAdminMumbleGroups,
+	useSyncUser,
 	useUnlinkDiscordAccount,
 	useUpdateDiscordAccess,
 } from '@/hooks/useAdminUsers'
+import { useAuth } from '@/hooks/useAuth'
+import { useBreadcrumb } from '@/hooks/useBreadcrumb'
 import { useCorporations } from '@/hooks/useCorporations'
 import { usePageTitle } from '@/hooks/usePageTitle'
-import { useBreadcrumb } from '@/hooks/useBreadcrumb'
 import { api } from '@/lib/api'
-import { characterPortraitUrl } from '@/lib/eve-images'
 import { formatDateTime, formatRelativeTime } from '@/lib/date-utils'
+import { characterPortraitUrl } from '@/lib/eve-images'
 import { cn } from '@/lib/utils'
 
 import type { BlacklistTargetType, DiscordRefreshOutput } from '@/lib/api'
@@ -113,7 +113,8 @@ export default function UserDetailPage() {
 	const updateDiscordAccess = useUpdateDiscordAccess()
 	const syncMumbleGroups = useSyncAdminMumbleGroups()
 	const deleteMumbleAccount = useDeleteAdminMumbleAccount()
-	const { data: managedCorporations = [] } = useCorporations()
+	const { data: managedCorporationData } = useCorporations({ page: 1, pageSize: 100 })
+	const managedCorporations = managedCorporationData?.data ?? []
 	const managedCorporationIds = new Set(managedCorporations.map((corp) => corp.corporationId))
 
 	// Blacklist data
@@ -163,7 +164,9 @@ export default function UserDetailPage() {
 	const [removeBlacklistDialogOpen, setRemoveBlacklistDialogOpen] = useState(false)
 	const [blacklistReason, setBlacklistReason] = useState('')
 	const [addNoteDialogOpen, setAddNoteDialogOpen] = useState(false)
-	const [discordUpdateResults, setDiscordUpdateResults] = useState<DiscordRefreshOutput | null>(null)
+	const [discordUpdateResults, setDiscordUpdateResults] = useState<DiscordRefreshOutput | null>(
+		null
+	)
 	const [selectedCharacter, setSelectedCharacter] = useState<string | null>(null)
 
 	// Message state
@@ -177,9 +180,10 @@ export default function UserDetailPage() {
 	const primaryCharacter =
 		user?.characters.find((character) => character.is_primary) ?? user?.characters[0] ?? null
 	const primaryCharacterName = primaryCharacter?.characterName || 'this user'
-	const corporationLinkForCurrentUser = sessionUser?.is_admin === true
-		? (corporationId: string) => `/admin/corporations/${corporationId}`
-		: (corporationId: string) => `/corporations/${corporationId}/members`
+	const corporationLinkForCurrentUser =
+		sessionUser?.is_admin === true
+			? (corporationId: string) => `/admin/corporations/${corporationId}`
+			: (corporationId: string) => `/corporations/${corporationId}/members`
 
 	useEffect(() => {
 		if (!userId) return
@@ -586,9 +590,7 @@ export default function UserDetailPage() {
 							<div className="flex items-start justify-between">
 								<div>
 									<div className="flex items-center justify-between gap-2">
-										<h2 className="text-2xl font-bold">
-											{primaryCharacterName || 'Unknown'}
-										</h2>
+										<h2 className="text-2xl font-bold">{primaryCharacterName || 'Unknown'}</h2>
 										{user.is_admin && (
 											<Badge variant="default">
 												<Shield className="h-3 w-3 mr-1" />
@@ -606,7 +608,8 @@ export default function UserDetailPage() {
 										</Badge>
 									)}
 									{user.is_admin ? (
-										<Button variant="destructive"
+										<Button
+											variant="destructive"
 											onClick={() => setAdminDialogOpen(true)}
 											disabled={setUserAdmin.isPending}
 											size="sm"
@@ -616,7 +619,8 @@ export default function UserDetailPage() {
 											Revoke Admin
 										</Button>
 									) : (
-										<Button variant="destructive"
+										<Button
+											variant="destructive"
 											onClick={() => setAdminDialogOpen(true)}
 											disabled={setUserAdmin.isPending}
 											size="sm"
@@ -636,7 +640,8 @@ export default function UserDetailPage() {
 											Remove from Blocklist
 										</Button>
 									) : (
-										<Button variant="destructive"
+										<Button
+											variant="destructive"
 											onClick={() => setBlacklistDialogOpen(true)}
 											disabled={createBlacklist.isPending}
 											size="sm"
@@ -662,7 +667,8 @@ export default function UserDetailPage() {
 											</span>
 										</Button>
 									)}
-									<Button variant="destructive"
+									<Button
+										variant="destructive"
 										onClick={() => setClearSessionsDialogOpen(true)}
 										disabled={clearSessions.isPending}
 										size="sm"
@@ -671,14 +677,13 @@ export default function UserDetailPage() {
 										<LogOut className="h-4 w-4" />
 										Clear Sessions
 									</Button>
-									<Button variant="primary"
+									<Button
+										variant="primary"
 										onClick={() => setSyncUserDialogOpen(true)}
 										disabled={syncUser.isPending}
 										size="sm"
 									>
-										<RefreshCw
-											className={cn('h-4 w-4', syncUser.isPending && 'animate-spin')}
-										/>
+										<RefreshCw className={cn('h-4 w-4', syncUser.isPending && 'animate-spin')} />
 										Sync User
 									</Button>
 								</div>
@@ -738,9 +743,7 @@ export default function UserDetailPage() {
 						<summary className="flex cursor-pointer list-none items-center justify-between px-6 py-4">
 							<div>
 								<CardTitle>Account Notes ({hrNotes.length})</CardTitle>
-								<CardDescription className="mt-1">
-									Private notes about this user
-								</CardDescription>
+								<CardDescription className="mt-1">Private notes about this user</CardDescription>
 							</div>
 							<div className="pointer-events-auto flex items-center gap-3">
 								<Button
@@ -788,20 +791,19 @@ export default function UserDetailPage() {
 							<div className="flex items-center gap-2">
 								{!user.discord.authRevoked && (
 									<>
-										<Button variant="primary"
+										<Button
+											variant="primary"
 											onClick={handleUpdateDiscordAccess}
 											disabled={updateDiscordAccess.isPending}
 											size="sm"
 										>
 											<RefreshCw
-												className={cn(
-													'h-4 w-4',
-													updateDiscordAccess.isPending && 'animate-spin'
-												)}
+												className={cn('h-4 w-4', updateDiscordAccess.isPending && 'animate-spin')}
 											/>
 											Update Discord Access
 										</Button>
-										<Button variant="destructive"
+										<Button
+											variant="destructive"
 											onClick={() => setRevokeDiscordDialogOpen(true)}
 											disabled={revokeDiscord.isPending}
 											size="sm"
@@ -812,7 +814,8 @@ export default function UserDetailPage() {
 										</Button>
 									</>
 								)}
-								<Button variant="destructive"
+								<Button
+									variant="destructive"
 									onClick={() => setUnlinkDiscordDialogOpen(true)}
 									disabled={unlinkDiscord.isPending}
 									size="sm"
@@ -852,7 +855,9 @@ export default function UserDetailPage() {
 									<div className="flex items-start gap-2">
 										<ShieldBan className="h-4 w-4 text-destructive mt-0.5 flex-shrink-0" />
 										<div>
-											<p className="text-sm text-destructive font-medium">Discord Account Blocklisted</p>
+											<p className="text-sm text-destructive font-medium">
+												Discord Account Blocklisted
+											</p>
 											<p className="text-sm text-destructive/90 mt-1">
 												This Discord account is blocked from accessing the platform.
 												{activeDiscordBlacklist.isAutoBlacklist && (
@@ -886,13 +891,9 @@ export default function UserDetailPage() {
 									<div className="text-sm text-muted-foreground">Authorization Status</div>
 									<div className="text-sm font-medium">
 										{user.discord.authRevoked ? (
-											<Badge variant="destructive">
-												Revoked
-											</Badge>
+											<Badge variant="destructive">Revoked</Badge>
 										) : (
-											<Badge variant="success">
-												Active
-											</Badge>
+											<Badge variant="success">Active</Badge>
 										)}
 									</div>
 								</div>
@@ -911,118 +912,118 @@ export default function UserDetailPage() {
 			)}
 
 			{/* Mumble Services */}
-			{isMumbleFeatureEnabled && !isLoadingMumbleFeature && !isLoadingMumbleAccount && mumbleAccountData?.account && (
-				<Card>
-					<CardHeader>
-						<CardTitle>Services</CardTitle>
-						<CardDescription>Mumble account status and admin controls</CardDescription>
-					</CardHeader>
-					<CardContent>
-						<Card variant="flat" className="border-border/50">
-							<CardContent className="p-4">
-								<div className="flex flex-col gap-4">
-									<div className="flex items-start justify-between gap-4">
-										<div className="flex items-center gap-3 min-w-0">
-											<div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-												<Mic className="h-6 w-6 text-muted-foreground" />
-											</div>
-											<div className="min-w-0">
-												<div className="flex flex-wrap items-center gap-2">
-													<p className="font-semibold text-lg">Mumble</p>
-													<Badge
-														variant="default"
-														className={cn(
-															'text-xs',
-															mumbleAccountData.account.enabled
-																? 'bg-green-500/20 text-green-500'
-																: 'bg-muted text-muted-foreground'
-														)}
-													>
-														{mumbleAccountData.account.enabled ? 'Active' : 'Disabled'}
-													</Badge>
+			{isMumbleFeatureEnabled &&
+				!isLoadingMumbleFeature &&
+				!isLoadingMumbleAccount &&
+				mumbleAccountData?.account && (
+					<Card>
+						<CardHeader>
+							<CardTitle>Services</CardTitle>
+							<CardDescription>Mumble account status and admin controls</CardDescription>
+						</CardHeader>
+						<CardContent>
+							<Card variant="flat" className="border-border/50">
+								<CardContent className="p-4">
+									<div className="flex flex-col gap-4">
+										<div className="flex items-start justify-between gap-4">
+											<div className="flex items-center gap-3 min-w-0">
+												<div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+													<Mic className="h-6 w-6 text-muted-foreground" />
 												</div>
-												<p className="text-sm text-muted-foreground">
-													Login: {mumbleAccountData.account.loginName}
-												</p>
-												<p className="text-xs text-muted-foreground">
-													Display: {mumbleAccountData.account.displayName}
-												</p>
+												<div className="min-w-0">
+													<div className="flex flex-wrap items-center gap-2">
+														<p className="font-semibold text-lg">Mumble</p>
+														<Badge
+															variant="default"
+															className={cn(
+																'text-xs',
+																mumbleAccountData.account.enabled
+																	? 'bg-green-500/20 text-green-500'
+																	: 'bg-muted text-muted-foreground'
+															)}
+														>
+															{mumbleAccountData.account.enabled ? 'Active' : 'Disabled'}
+														</Badge>
+													</div>
+													<p className="text-sm text-muted-foreground">
+														Login: {mumbleAccountData.account.loginName}
+													</p>
+													<p className="text-xs text-muted-foreground">
+														Display: {mumbleAccountData.account.displayName}
+													</p>
+												</div>
+											</div>
+											<div className="flex items-center gap-2">
+												<Button
+													variant="primary"
+													size="sm"
+													onClick={handleSyncMumbleGroups}
+													disabled={syncMumbleGroups.isPending}
+													showIcon={false}
+												>
+													<RefreshCw
+														className={cn('h-4 w-4', syncMumbleGroups.isPending && 'animate-spin')}
+													/>
+													Sync Groups
+												</Button>
+												<Button
+													variant="destructive"
+													size="sm"
+													onClick={() => setDeleteMumbleDialogOpen(true)}
+													disabled={deleteMumbleAccount.isPending}
+													showIcon={false}
+												>
+													<Trash2 className="h-4 w-4" />
+													Delete Account
+												</Button>
 											</div>
 										</div>
-										<div className="flex items-center gap-2">
-											<Button
-												variant="primary"
-												size="sm"
-												onClick={handleSyncMumbleGroups}
-												disabled={syncMumbleGroups.isPending}
-												showIcon={false}
-											>
-												<RefreshCw
-													className={cn(
-														'h-4 w-4',
-														syncMumbleGroups.isPending && 'animate-spin'
-													)}
-												/>
-												Sync Groups
-											</Button>
-											<Button
-												variant="destructive"
-												size="sm"
-												onClick={() => setDeleteMumbleDialogOpen(true)}
-												disabled={deleteMumbleAccount.isPending}
-												showIcon={false}
-											>
-												<Trash2 className="h-4 w-4" />
-												Delete Account
-											</Button>
-										</div>
-									</div>
 
-									<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-										<div>
-											<div className="text-xs uppercase tracking-wide text-muted-foreground">
-												Status
+										<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+											<div>
+												<div className="text-xs uppercase tracking-wide text-muted-foreground">
+													Status
+												</div>
+												<div className="text-sm font-medium mt-1">
+													{mumbleAccountData.account.enabled ? 'Enabled' : 'Disabled'}
+												</div>
 											</div>
-											<div className="text-sm font-medium mt-1">
-												{mumbleAccountData.account.enabled ? 'Enabled' : 'Disabled'}
+											<div>
+												<div className="text-xs uppercase tracking-wide text-muted-foreground">
+													Groups
+												</div>
+												<div className="text-sm font-medium mt-1">
+													{mumbleAccountData.account.groups.length}
+												</div>
 											</div>
-										</div>
-										<div>
-											<div className="text-xs uppercase tracking-wide text-muted-foreground">
-												Groups
+											<div>
+												<div className="text-xs uppercase tracking-wide text-muted-foreground">
+													Connection
+												</div>
+												<div className="text-sm font-medium mt-1 flex items-center gap-1">
+													<Server className="h-3.5 w-3.5 text-muted-foreground" />
+													<span>
+														{mumbleAccountData.connection.host}:{mumbleAccountData.connection.port}
+													</span>
+												</div>
 											</div>
-											<div className="text-sm font-medium mt-1">
-												{mumbleAccountData.account.groups.length}
-											</div>
-										</div>
-										<div>
-											<div className="text-xs uppercase tracking-wide text-muted-foreground">
-												Connection
-											</div>
-											<div className="text-sm font-medium mt-1 flex items-center gap-1">
-												<Server className="h-3.5 w-3.5 text-muted-foreground" />
-												<span>
-													{mumbleAccountData.connection.host}:{mumbleAccountData.connection.port}
-												</span>
-											</div>
-										</div>
-										<div>
-											<div className="text-xs uppercase tracking-wide text-muted-foreground">
-												Last Auth
-											</div>
-											<div className="text-sm font-medium mt-1">
-												{mumbleAccountData.account.lastAuthenticatedAt
-													? formatRelativeTime(mumbleAccountData.account.lastAuthenticatedAt)
-													: 'Never'}
+											<div>
+												<div className="text-xs uppercase tracking-wide text-muted-foreground">
+													Last Auth
+												</div>
+												<div className="text-sm font-medium mt-1">
+													{mumbleAccountData.account.lastAuthenticatedAt
+														? formatRelativeTime(mumbleAccountData.account.lastAuthenticatedAt)
+														: 'Never'}
+												</div>
 											</div>
 										</div>
 									</div>
-								</div>
-							</CardContent>
-						</Card>
-					</CardContent>
-				</Card>
-			)}
+								</CardContent>
+							</Card>
+						</CardContent>
+					</Card>
+				)}
 
 			{/* Blacklist Information */}
 			{activeBlacklist && (
@@ -1061,9 +1062,7 @@ export default function UserDetailPage() {
 												Auto-Blocklisted
 											</Badge>
 										) : (
-											<Badge variant="destructive">
-												Manual Blocklist
-											</Badge>
+											<Badge variant="destructive">Manual Blocklist</Badge>
 										)}
 									</div>
 								</div>
@@ -1084,10 +1083,7 @@ export default function UserDetailPage() {
 														{TARGET_TYPE_LABELS[triggeringEntry.targetType]}
 													</span>{' '}
 													blocklist on{' '}
-													<span className="font-mono">
-														{triggeringEntry.targetValue}
-													</span>
-													.{' '}
+													<span className="font-mono">{triggeringEntry.targetValue}</span>.{' '}
 													<Link to="/admin/blacklist" className="underline hover:text-orange-400">
 														View blocklist
 													</Link>
@@ -1128,7 +1124,7 @@ export default function UserDetailPage() {
 						</TableHeader>
 						<TableBody>
 							{user.characters.map((character) => (
-													<TableRow
+								<TableRow
 									key={character.characterId}
 									className="cursor-pointer"
 									onClick={() =>
@@ -1141,62 +1137,54 @@ export default function UserDetailPage() {
 										})
 									}
 								>
-										<TableCell>
-											<div className="flex items-center gap-3">
-												<img
+									<TableCell>
+										<div className="flex items-center gap-3">
+											<img
 												src={characterPortraitUrl(character.characterId, 64)}
 												alt={character.characterName}
 												className="h-10 w-10 rounded-full"
 											/>
-												<div>
-													<div className="font-medium">{character.characterName}</div>
-													<div className="text-xs text-muted-foreground">{character.characterId}</div>
-													<div className="mt-1 flex gap-2">
-														{character.is_primary && (
-															<Badge variant="default">Primary</Badge>
-														)}
-														{character.isBlacklisted && (
-															<Badge variant="destructive">
-																<ShieldBan className="h-3 w-3 mr-1" />
-																Blocklisted
-															</Badge>
-														)}
-													</div>
+											<div>
+												<div className="font-medium">{character.characterName}</div>
+												<div className="text-xs text-muted-foreground">{character.characterId}</div>
+												<div className="mt-1 flex gap-2">
+													{character.is_primary && <Badge variant="default">Primary</Badge>}
+													{character.isBlacklisted && (
+														<Badge variant="destructive">
+															<ShieldBan className="h-3 w-3 mr-1" />
+															Blocklisted
+														</Badge>
+													)}
 												</div>
 											</div>
-										</TableCell>
-										<TableCell>
-											<div className="text-sm">
-												{character.corporationId &&
-												managedCorporationIds.has(character.corporationId) ? (
-													<Link
-														to={corporationLinkForCurrentUser(character.corporationId)}
-														className="font-medium underline-offset-2 hover:underline"
-													>
-														{character.corporationName || 'Unknown'}
-													</Link>
-												) : (
-													<div className="font-medium">
-														{character.corporationName || 'Unknown'}
-													</div>
-												)}
-												{character.corporationId && (
-													<div className="text-xs text-muted-foreground">
-														{character.corporationId}
-													</div>
-												)}
-											</div>
-										</TableCell>
+										</div>
+									</TableCell>
+									<TableCell>
+										<div className="text-sm">
+											{character.corporationId &&
+											managedCorporationIds.has(character.corporationId) ? (
+												<Link
+													to={corporationLinkForCurrentUser(character.corporationId)}
+													className="font-medium underline-offset-2 hover:underline"
+												>
+													{character.corporationName || 'Unknown'}
+												</Link>
+											) : (
+												<div className="font-medium">{character.corporationName || 'Unknown'}</div>
+											)}
+											{character.corporationId && (
+												<div className="text-xs text-muted-foreground">
+													{character.corporationId}
+												</div>
+											)}
+										</div>
+									</TableCell>
 									<TableCell>
 										<div className="text-sm">
 											{character.hasValidToken ? (
-												<Badge variant="success">
-													Valid
-												</Badge>
+												<Badge variant="success">Valid</Badge>
 											) : (
-												<Badge variant="destructive">
-													Invalid
-												</Badge>
+												<Badge variant="destructive">Invalid</Badge>
 											)}
 										</div>
 									</TableCell>
@@ -1275,14 +1263,16 @@ export default function UserDetailPage() {
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => setAdminDialogOpen(false)}
 							disabled={setUserAdmin.isPending}
 						>
 							Cancel
 						</Button>
 						{user.is_admin ? (
-							<Button variant="destructive"
+							<Button
+								variant="destructive"
 								onClick={handleToggleAdmin}
 								loading={setUserAdmin.isPending}
 								showIcon={false}
@@ -1292,7 +1282,8 @@ export default function UserDetailPage() {
 								Revoke Admin
 							</Button>
 						) : (
-							<Button variant="confirm"
+							<Button
+								variant="confirm"
 								onClick={handleToggleAdmin}
 								loading={setUserAdmin.isPending}
 								loadingText="Granting..."
@@ -1312,19 +1303,20 @@ export default function UserDetailPage() {
 					<DialogHeader>
 						<DialogTitle>Revoke Discord Authorization</DialogTitle>
 						<DialogDescription>
-							Are you sure you want to revoke Discord authorization for{' '}
-							{primaryCharacterName}? This will
-							mark their Discord account as unauthorized and they will need to re-link it.
+							Are you sure you want to revoke Discord authorization for {primaryCharacterName}? This
+							will mark their Discord account as unauthorized and they will need to re-link it.
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => setRevokeDiscordDialogOpen(false)}
 							disabled={revokeDiscord.isPending}
 						>
 							Cancel
 						</Button>
-						<Button variant="destructive"
+						<Button
+							variant="destructive"
 							onClick={handleRevokeDiscordConfirm}
 							loading={revokeDiscord.isPending}
 							loadingText="Revoking..."
@@ -1344,8 +1336,7 @@ export default function UserDetailPage() {
 						<DialogTitle>Unlink Discord Account</DialogTitle>
 						<DialogDescription>
 							Are you sure you want to completely unlink the Discord account for{' '}
-							{primaryCharacterName}? This action
-							will:
+							{primaryCharacterName}? This action will:
 							<ul className="list-disc list-inside mt-2 space-y-1">
 								<li>Remove the Discord link from their account</li>
 								<li>Delete all Discord tokens</li>
@@ -1357,13 +1348,15 @@ export default function UserDetailPage() {
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => setUnlinkDiscordDialogOpen(false)}
 							disabled={unlinkDiscord.isPending}
 						>
 							Cancel
 						</Button>
-						<Button variant="destructive"
+						<Button
+							variant="destructive"
 							onClick={handleUnlinkDiscordConfirm}
 							loading={unlinkDiscord.isPending}
 							loadingText="Unlinking..."
@@ -1394,19 +1387,20 @@ export default function UserDetailPage() {
 					<DialogHeader>
 						<DialogTitle>Clear All Sessions</DialogTitle>
 						<DialogDescription>
-							Are you sure you want to clear all active sessions for{' '}
-							{primaryCharacterName}? This will
-							force them to re-authenticate on all devices.
+							Are you sure you want to clear all active sessions for {primaryCharacterName}? This
+							will force them to re-authenticate on all devices.
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => setClearSessionsDialogOpen(false)}
 							disabled={clearSessions.isPending}
 						>
 							Cancel
 						</Button>
-						<Button variant="destructive"
+						<Button
+							variant="destructive"
 							onClick={handleClearSessionsConfirm}
 							loading={clearSessions.isPending}
 							loadingText="Clearing..."
@@ -1425,20 +1419,21 @@ export default function UserDetailPage() {
 					<DialogHeader>
 						<DialogTitle>Sync User Data</DialogTitle>
 						<DialogDescription>
-							Are you sure you want to trigger a data sync for{' '}
-							{primaryCharacterName}? This will
+							Are you sure you want to trigger a data sync for {primaryCharacterName}? This will
 							refresh all character data, authenticated data, and role assignments. The sync runs in
 							the background and may take a few minutes to complete.
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => setSyncUserDialogOpen(false)}
 							disabled={syncUser.isPending}
 						>
 							Cancel
 						</Button>
-						<Button variant="confirm"
+						<Button
+							variant="confirm"
 							onClick={handleSyncUserConfirm}
 							loading={syncUser.isPending}
 							loadingText="Triggering..."
@@ -1468,7 +1463,8 @@ export default function UserDetailPage() {
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => {
 								setDeleteDialogOpen(false)
 								setSelectedCharacter(null)
@@ -1477,7 +1473,8 @@ export default function UserDetailPage() {
 						>
 							Cancel
 						</Button>
-						<Button variant="destructive"
+						<Button
+							variant="destructive"
 							onClick={handleDeleteCharacterConfirm}
 							loading={deleteCharacter.isPending}
 							loadingText="Deleting..."
@@ -1497,13 +1494,13 @@ export default function UserDetailPage() {
 						<DialogTitle>Set Primary Character</DialogTitle>
 						<DialogDescription>
 							Are you sure you want to set "{selectedCharacterData?.characterName}" as the primary
-							character for{' '}
-							{primaryCharacterName}? This will
-							change the user's main character and update their display name throughout the system.
+							character for {primaryCharacterName}? This will change the user's main character and
+							update their display name throughout the system.
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => {
 								setPrimaryDialogOpen(false)
 								setSelectedCharacter(null)
@@ -1512,7 +1509,8 @@ export default function UserDetailPage() {
 						>
 							Cancel
 						</Button>
-						<Button variant="confirm"
+						<Button
+							variant="confirm"
 							onClick={handleSetPrimaryConfirm}
 							loading={setPrimaryCharacter.isPending}
 							loadingText="Setting..."
@@ -1531,8 +1529,7 @@ export default function UserDetailPage() {
 					<DialogHeader>
 						<DialogTitle>Discord Access Update Results</DialogTitle>
 						<DialogDescription>
-							Results of updating Discord server access for{' '}
-							{primaryCharacterName}
+							Results of updating Discord server access for {primaryCharacterName}
 						</DialogDescription>
 					</DialogHeader>
 					{discordUpdateResults && (
@@ -1655,9 +1652,8 @@ export default function UserDetailPage() {
 					<DialogHeader>
 						<DialogTitle>Blocklist User</DialogTitle>
 						<DialogDescription>
-							Blocklist {primaryCharacterName}.
-							This will immediately disable all services and prevent login. This action can be
-							reversed.
+							Blocklist {primaryCharacterName}. This will immediately disable all services and
+							prevent login. This action can be reversed.
 						</DialogDescription>
 					</DialogHeader>
 					<div className="space-y-4 py-4">
@@ -1676,7 +1672,8 @@ export default function UserDetailPage() {
 						</div>
 					</div>
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => {
 								setBlacklistDialogOpen(false)
 								setBlacklistReason('')
@@ -1685,7 +1682,8 @@ export default function UserDetailPage() {
 						>
 							Cancel
 						</Button>
-						<Button variant="destructive"
+						<Button
+							variant="destructive"
 							onClick={handleBlacklistConfirm}
 							loading={createBlacklist.isPending}
 							loadingText="Blocklisting..."
@@ -1704,9 +1702,8 @@ export default function UserDetailPage() {
 					<DialogHeader>
 						<DialogTitle>Remove from Blocklist</DialogTitle>
 						<DialogDescription>
-							Are you sure you want to remove{' '}
-							{primaryCharacterName} from the
-							blocklist? They will regain access to all services immediately.
+							Are you sure you want to remove {primaryCharacterName} from the blocklist? They will
+							regain access to all services immediately.
 						</DialogDescription>
 					</DialogHeader>
 					{activeBlacklist && (
@@ -1716,13 +1713,15 @@ export default function UserDetailPage() {
 						</div>
 					)}
 					<DialogFooter>
-						<Button variant="cancel"
+						<Button
+							variant="cancel"
 							onClick={() => setRemoveBlacklistDialogOpen(false)}
 							disabled={removeBlacklist.isPending}
 						>
 							Cancel
 						</Button>
-						<Button variant="confirm"
+						<Button
+							variant="confirm"
 							onClick={handleRemoveBlacklistConfirm}
 							loading={removeBlacklist.isPending}
 							loadingText="Removing..."

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -1190,6 +1190,13 @@ export interface EveCorporationData {
 	getHealthyDirectors(corporationId: string): Promise<DirectorHealth[]>
 
 	/**
+	 * Get the number of healthy directors for this corporation
+	 * @param corporationId - The corporation ID
+	 * @returns Number of healthy directors
+	 */
+	getHealthyDirectorCount(corporationId: string): Promise<number>
+
+	/**
 	 * Verify health of a specific director
 	 * @param corporationId - The corporation ID
 	 * @param directorId - The director's character ID
@@ -1956,4 +1963,15 @@ export interface EveCorporationData {
 		corporationId: string,
 		updates: { includeInBackgroundRefresh?: boolean; includeInStructureAssetSync?: boolean }
 	): Promise<void>
+}
+
+/**
+ * RPC service methods exposed by the Eve Corporation Data worker entrypoint.
+ */
+export interface EveCorporationDataWorker {
+	/**
+	 * Read healthy director counts for a page of corporations with bounded
+	 * concurrency and per-corporation failure isolation.
+	 */
+	getHealthyDirectorCounts(corporationIds: string[]): Promise<Record<string, number | null>>
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds server-side pagination and search to the admin corporations list, batches director-health lookups instead of fetching them one Durable Object at a time, and stops newly auto-registered director corporations from being auto-synced until an admin opts them in.

## Changes
- `GET /api/corporations` now supports `page`, `pageSize` (25/50/100), and `search` (name/ticker) query params; the NPC-corp safety filter and result count are computed in SQL, and results are ordered by name.
- Added `EVE_CORPORATION_DATA_WORKER` service binding and a new `EveCorporationDataWorker.getHealthyDirectorCounts()` RPC that fans out to per-corporation Durable Objects with bounded concurrency (4) instead of the route calling `getStub`/`getHealthyDirectors` once per corp.
- Added `EveCorporationDataDO.getHealthyDirectorCount()` and reworked `DirectorManager.getHealthyDirectorsCount()` to run a SQL `count(*)` instead of loading and counting all director rows.
- `POST /:corporationId/verify` now returns `healthyDirectorCount` using the new count method.
- Admin Corporations UI (`apps/ui/src/client/routes/admin/corporations.tsx`) now drives pagination/search through the API (debounced search, `keepPreviousData`, `UserSearchPaginationControls`, soft-loading via `TableRefreshFrame`) instead of client-side filtering of a full list.
- `useVerifyCorporationAccess` optimistically updates the cached corporation list with the verification result.
- `autoRegisterDirectorCorporation` now sets `includeInBackgroundRefresh: false` and `includeInStructureAssetSync: false` for newly auto-added corporations, so they aren't auto-synced by default.

## Testing
- Updated/added unit tests for the corporations list route covering paginated responses and batched director-health counts (`apps/core/src/routes/__tests__/corporations.list.route.test.ts`).
- Added unit tests for `EveCorporationDataWorker.getHealthyDirectorCounts` (per-corp isolation of failures) and `DirectorManager.getHealthyDirectorsCount` (SQL count query).
<!-- claude:end -->