### PR TITLE
fix missing corps from admin listing and enhance caching

### DIFF
--- a/apps/core/src/lib/corporation-list-cache.ts
+++ b/apps/core/src/lib/corporation-list-cache.ts
@@ -1,0 +1,60 @@
+import { TimeCache } from '@repo/hono-helpers'
+
+import type { managedCorporations } from '../db/schema'
+
+type CorporationRow = typeof managedCorporations.$inferSelect
+
+export type CorporationStaticRow = Omit<
+	CorporationRow,
+	'lastSync' | 'lastVerified' | 'isVerified' | 'healthyDirectorCount'
+>
+export type CorporationDirectorStatus = Pick<
+	CorporationRow,
+	'lastVerified' | 'isVerified' | 'healthyDirectorCount'
+>
+export type CorporationSyncStatus = Pick<CorporationRow, 'lastSync'>
+
+export type CorporationListCacheEntry = {
+	data: CorporationStaticRow[]
+	totalCount: number
+}
+
+// Static corporation metadata changes infrequently. Mutations clear the affected
+// page cache, while this TTL remains a backstop for writes from other processes.
+export const CORPORATION_LIST_CACHE_TTL_MS = 60 * 60 * 1000
+export const CORPORATION_STATUS_CACHE_TTL_MS = 15 * 60 * 1000
+
+export const corporationListCache = new TimeCache<CorporationListCacheEntry>(
+	CORPORATION_LIST_CACHE_TTL_MS,
+	250
+)
+export const corporationDirectorStatusCache = new TimeCache<CorporationDirectorStatus>(
+	CORPORATION_STATUS_CACHE_TTL_MS,
+	1000
+)
+export const corporationSyncStatusCache = new TimeCache<CorporationSyncStatus>(
+	CORPORATION_STATUS_CACHE_TTL_MS,
+	1000
+)
+export const corporationHealthCache = new TimeCache<number | null>(
+	CORPORATION_STATUS_CACHE_TTL_MS,
+	1000
+)
+
+export function clearCorporationListCache(): void {
+	corporationListCache.clear()
+}
+
+export function clearCorporationDirectorHealthCache(corporationId: string): void {
+	corporationDirectorStatusCache.delete(corporationId)
+	corporationHealthCache.delete(corporationId)
+}
+
+export function clearCorporationSyncStatusCache(corporationId: string): void {
+	corporationSyncStatusCache.delete(corporationId)
+}
+
+export function clearCorporationStatusCache(corporationId: string): void {
+	clearCorporationDirectorHealthCache(corporationId)
+	clearCorporationSyncStatusCache(corporationId)
+}

--- a/apps/core/src/routes/__tests__/corporations.list.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporations.list.route.test.ts
@@ -173,4 +173,56 @@ describe('corporations list route', () => {
 		)
 		expect(env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts).not.toHaveBeenCalled()
 	})
+
+	it('reuses cached page and per-corporation health data', async () => {
+		const findMany = vi.fn().mockResolvedValue([
+			{
+				corporationId: 'corp-cache-1',
+				name: 'Cached Corp',
+				ticker: 'CAC',
+				assignedCharacterId: null,
+				assignedCharacterName: null,
+				isActive: true,
+				includeInBackgroundRefresh: false,
+				includeInStructureAssetSync: false,
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+				isRecruiting: false,
+				shortDescription: null,
+				fullDescription: null,
+				lastSync: null,
+				lastVerified: null,
+				isVerified: false,
+				healthyDirectorCount: 1,
+				configuredBy: null,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		])
+		const db = {
+			query: { managedCorporations: { findMany } },
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn().mockResolvedValue([{ count: 1 }]),
+				})),
+			})),
+		}
+		env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts.mockResolvedValue({
+			'corp-cache-1': 4,
+		})
+
+		const app = createApp(makeUser(), db)
+		const firstResponse = await app.request('/api/corporations?search=cache-test', {}, env)
+		const secondResponse = await app.request('/api/corporations?search=cache-test', {}, env)
+
+		expect(firstResponse.status).toBe(200)
+		expect(secondResponse.status).toBe(200)
+		const secondBody = (await secondResponse.json()) as {
+			data: Array<{ healthyDirectorCount: number }>
+		}
+		expect(secondBody.data[0]?.healthyDirectorCount).toBe(4)
+		expect(findMany).toHaveBeenCalledTimes(1)
+		expect(env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts).toHaveBeenCalledTimes(1)
+	})
 })

--- a/apps/core/src/routes/corporations/directors-routes.ts
+++ b/apps/core/src/routes/corporations/directors-routes.ts
@@ -5,6 +5,10 @@ import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { managedCorporations, userCharacters } from '../../db/schema'
+import {
+	clearCorporationDirectorHealthCache,
+	clearCorporationListCache,
+} from '../../lib/corporation-list-cache'
 import { requireAdmin, requireAuth } from '../../middleware/session'
 
 import type { EveCorporationData } from '@repo/eve-corporation-data'
@@ -29,6 +33,7 @@ async function syncManagedCorporationDirectorHealth(
 			updatedAt: new Date(),
 		})
 		.where(eq(managedCorporations.corporationId, corporationId))
+	clearCorporationDirectorHealthCache(corporationId)
 
 	return healthyDirectorCount
 }
@@ -70,7 +75,16 @@ function toAdminUnhealthyReason(lastFailureReason: string | null | undefined): {
 		? missingRolesMatch[1].split('|').filter(Boolean)
 		: null
 
-	if (!step && !status && !path && !hint && !reasonCode && !detailCode && !requiredRoles && !missingRoles) {
+	if (
+		!step &&
+		!status &&
+		!path &&
+		!hint &&
+		!reasonCode &&
+		!detailCode &&
+		!requiredRoles &&
+		!missingRoles
+	) {
 		const lower = lastFailureReason.toLowerCase()
 		let summary = 'Director authentication failed'
 		if (lower.includes('no token')) {
@@ -207,6 +221,7 @@ app.post('/:corporationId/directors', requireAuth(), requireAdmin(), async (c) =
 					updatedAt: new Date(),
 				})
 				.where(eq(managedCorporations.corporationId, corporationId))
+			clearCorporationListCache()
 		}
 
 		return c.json({ success: true, characterId, characterName, priority })

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -1,12 +1,21 @@
 import { Hono } from 'hono'
 
-import { and, asc, desc, eq, gte, ilike, inArray, lt, not, or, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, ilike, inArray, or, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { buildCsvLine } from '@repo/worker-utils'
 
 import { managedCorporations, userCharacters, users } from '../../db/schema'
 import { isNpcCorporationId } from '../../lib/corporation-id'
+import {
+	clearCorporationListCache,
+	clearCorporationStatusCache,
+	clearCorporationSyncStatusCache,
+	corporationDirectorStatusCache,
+	corporationHealthCache,
+	corporationListCache,
+	corporationSyncStatusCache,
+} from '../../lib/corporation-list-cache'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 import { requireAdmin, requireAuth } from '../../middleware/session'
 import { CoreRpcService } from '../../services/core-rpc.service'
@@ -35,7 +44,6 @@ const ACTIVE_MEMBER_THRESHOLD_MS = 7 * MS_PER_DAY
 const CACHE_TTL = 5 * 60 // 5 minutes in seconds
 const MEMBERS_ACCESS_DENIED_MESSAGE =
 	'Access denied. Corporation CEO, Director, site admin, HR role, or HR auditor permission required.'
-
 /**
  * Helper to get cache instance
  */
@@ -1148,14 +1156,12 @@ app.get('/', requireAuth(), requireAdmin(), async (c) => {
 			| undefined
 		const search = c.req.query('search')?.trim()
 
-		// Keep the NPC safety filter in SQL so the count and page contain the same rows.
+		// Corporation IDs are stored as text. Cast before applying the NPC range so
+		// valid player corporations such as 1018389948 are not excluded by a
+		// lexicographic comparison with 2000000.
+		const corporationId = managedCorporations.corporationId
 		const conditions = [
-			not(
-				and(
-					gte(managedCorporations.corporationId, '1000000'),
-					lt(managedCorporations.corporationId, '2000000')
-				)!
-			),
+			sql`(${corporationId}::bigint < 1000000 OR ${corporationId}::bigint >= 2000000)`,
 		]
 		if (corporationType === 'member') {
 			conditions.push(eq(managedCorporations.isMemberCorporation, true))
@@ -1183,25 +1189,82 @@ app.get('/', requireAuth(), requireAdmin(), async (c) => {
 			)
 		}
 		const whereCondition = and(...conditions)!
+		const cacheKey = [
+			corporationType ?? 'all',
+			search?.toLocaleLowerCase() ?? '',
+			page,
+			pageSize,
+		].join(':')
+		const response = await corporationListCache.getOrSet(cacheKey, async () => {
+			const countRows = await db
+				.select({ count: sql<number>`count(*)::int` })
+				.from(managedCorporations)
+				.where(whereCondition)
+			const totalCount = countRows[0]?.count ?? 0
+			const corporations = await db.query.managedCorporations.findMany({
+				where: whereCondition,
+				// Keep the page order stable and alphabetical across requests.
+				orderBy: [asc(managedCorporations.name), asc(managedCorporations.corporationId)],
+				limit: pageSize,
+				offset: (page - 1) * pageSize,
+			})
 
-		const countRows = await db
-			.select({ count: sql<number>`count(*)::int` })
-			.from(managedCorporations)
-			.where(whereCondition)
-		const totalCount = countRows[0]?.count ?? 0
-		const corporations = await db.query.managedCorporations.findMany({
-			where: whereCondition,
-			orderBy: [asc(managedCorporations.name), asc(managedCorporations.corporationId)],
-			limit: pageSize,
-			offset: (page - 1) * pageSize,
+			return {
+				data: corporations.map(
+					({ lastSync, lastVerified, isVerified, healthyDirectorCount, ...corp }) => {
+						corporationDirectorStatusCache.set(corp.corporationId, {
+							lastVerified,
+							isVerified,
+							healthyDirectorCount,
+						})
+						corporationSyncStatusCache.set(corp.corporationId, { lastSync })
+						return corp
+					}
+				),
+				totalCount,
+			}
 		})
 
-		let healthyDirectorCounts: Record<string, number | null> = {}
-		if (corporations.length > 0) {
+		const corporationIds = response.data.map((corporation) => corporation.corporationId)
+		const missingDirectorStatusIds = corporationIds.filter(
+			(corporationId) => !corporationDirectorStatusCache.has(corporationId)
+		)
+		const missingSyncStatusIds = corporationIds.filter(
+			(corporationId) => !corporationSyncStatusCache.has(corporationId)
+		)
+		const missingStatusIds = [...new Set([...missingDirectorStatusIds, ...missingSyncStatusIds])]
+
+		if (missingStatusIds.length > 0) {
+			const statusRows = await db.query.managedCorporations.findMany({
+				where: inArray(managedCorporations.corporationId, missingStatusIds),
+				columns: {
+					corporationId: true,
+					lastSync: true,
+					lastVerified: true,
+					isVerified: true,
+					healthyDirectorCount: true,
+				},
+			})
+			for (const row of statusRows) {
+				corporationDirectorStatusCache.set(row.corporationId, {
+					lastVerified: row.lastVerified,
+					isVerified: row.isVerified,
+					healthyDirectorCount: row.healthyDirectorCount,
+				})
+				corporationSyncStatusCache.set(row.corporationId, { lastSync: row.lastSync })
+			}
+		}
+
+		const missingHealthIds = corporationIds.filter(
+			(corporationId) => !corporationHealthCache.has(corporationId)
+		)
+		if (missingHealthIds.length > 0) {
 			try {
-				healthyDirectorCounts = await c.env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts(
-					corporations.map((corp) => corp.corporationId)
-				)
+				const healthyDirectorCounts =
+					await c.env.EVE_CORPORATION_DATA_WORKER.getHealthyDirectorCounts(missingHealthIds)
+				for (const corporationId of missingHealthIds) {
+					corporationHealthCache.set(corporationId, healthyDirectorCounts[corporationId] ?? null)
+				}
 			} catch (error) {
 				logger.warn('[Corporations] Failed to batch-enrich live director health', {
 					error: error instanceof Error ? error.message : String(error),
@@ -1209,18 +1272,27 @@ app.get('/', requireAuth(), requireAdmin(), async (c) => {
 			}
 		}
 
-		const enriched = corporations.map((corp) => {
-			const healthyDirectorCount = healthyDirectorCounts[corp.corporationId]
-			return typeof healthyDirectorCount === 'number' ? { ...corp, healthyDirectorCount } : corp
+		const data = response.data.map((corporation) => {
+			const directorStatus = corporationDirectorStatusCache.get(corporation.corporationId)
+			const syncStatus = corporationSyncStatusCache.get(corporation.corporationId)
+			const liveHealthyDirectorCount = corporationHealthCache.get(corporation.corporationId)
+			return {
+				...corporation,
+				...directorStatus,
+				...syncStatus,
+				healthyDirectorCount:
+					typeof liveHealthyDirectorCount === 'number'
+						? liveHealthyDirectorCount
+						: (directorStatus?.healthyDirectorCount ?? 0),
+			}
 		})
-
-		const totalPages = totalCount === 0 ? 0 : Math.ceil(totalCount / pageSize)
+		const totalPages = response.totalCount === 0 ? 0 : Math.ceil(response.totalCount / pageSize)
 		return c.json({
-			data: enriched,
+			data,
 			pagination: {
 				page,
 				pageSize,
-				totalCount,
+				totalCount: response.totalCount,
 				totalPages,
 				hasNextPage: page < totalPages,
 				hasPreviousPage: page > 1 && totalPages > 0,
@@ -1518,6 +1590,7 @@ app.patch('/:corporationId/settings', requireAuth(), async (c) => {
 			.set(updateData)
 			.where(eq(managedCorporations.corporationId, corporationId))
 			.returning()
+		clearCorporationListCache()
 
 		logger.info('[Corporations] Settings updated', {
 			corporationId,
@@ -1599,6 +1672,7 @@ app.post('/', requireAuth(), requireAdmin(), async (c) => {
 				configuredBy: user.id,
 			})
 			.returning()
+		clearCorporationListCache()
 
 		// Configure the Durable Object
 		try {
@@ -1888,6 +1962,7 @@ app.put('/:corporationId', requireAuth(), requireAdmin(), async (c) => {
 			})
 			.where(eq(managedCorporations.corporationId, corporationId))
 			.returning()
+		clearCorporationListCache()
 
 		// Update Durable Object if character assignment changed
 		if (assignedCharacterId && assignedCharacterName) {
@@ -1951,6 +2026,7 @@ app.delete('/:corporationId', requireAuth(), requireAdmin(), async (c) => {
 
 	try {
 		await db.delete(managedCorporations).where(eq(managedCorporations.corporationId, corporationId))
+		clearCorporationListCache()
 
 		return c.json({ success: true })
 	} catch (error) {
@@ -1991,6 +2067,7 @@ app.post('/:corporationId/verify', requireAuth(), requireAdmin(), async (c) => {
 				updatedAt: new Date(),
 			})
 			.where(eq(managedCorporations.corporationId, corporationId))
+		clearCorporationStatusCache(corporationId)
 
 		if (verification.hasAccess) {
 			logger.info('[Corporations] Corporation access verified', {
@@ -2103,6 +2180,7 @@ app.post('/:corporationId/fetch', requireAuth(), requireAdmin(), async (c) => {
 				updatedAt: new Date(),
 			})
 			.where(eq(managedCorporations.corporationId, corporationId))
+		clearCorporationStatusCache(corporationId)
 
 		logger.info('[Corporations] Fetch successful', { corporationId, category })
 		return c.json({ success: true, category })
@@ -3061,6 +3139,7 @@ app.post('/:corporationId/members/refresh', requireAuth(), async (c) => {
 				updatedAt: new Date(),
 			})
 			.where(eq(managedCorporations.corporationId, corporationId))
+		clearCorporationSyncStatusCache(corporationId)
 
 		logger.info('[Corporations] Members refresh completed', { corporationId, userId: user.id })
 		return c.json({ success: true })

--- a/apps/core/src/services/core-rpc.service.ts
+++ b/apps/core/src/services/core-rpc.service.ts
@@ -1,7 +1,12 @@
 import { and, asc, desc, eq, gt, ilike, inArray, or, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
 
 import { discordServers, userCharacters, users } from '../db/schema'
+import {
+	clearCorporationDirectorHealthCache,
+	clearCorporationSyncStatusCache,
+} from '../lib/corporation-list-cache'
 import { validateAndSyncCharacterTokenValidityBatchTransitions } from '../lib/token-validity'
 import * as discordService from '../services/discord.service'
 import * as mumbleService from '../services/mumble.service'
@@ -22,7 +27,6 @@ import type { Groups } from '@repo/groups'
 import type { Hr } from '@repo/hr'
 import type { Env } from '../context'
 import type { DbClient, schema } from '../db'
-import { logger } from '@repo/hono-helpers'
 
 /**
  * Core RPC Service - Business logic for user/character management operations
@@ -369,14 +373,15 @@ export class CoreRpcService {
 		const tokenValidityByCharacterId = new Map<string, boolean | null>()
 		if (chars.length > 0) {
 			try {
-				const tokenValidityTransitions = await validateAndSyncCharacterTokenValidityBatchTransitions({
-					db: this.db,
-					tokenStore: eveTokenStore,
-					characters: chars.map((char) => ({
-						characterId: char.characterId,
-						hasValidToken: char.hasValidToken ?? null,
-					})),
-				})
+				const tokenValidityTransitions =
+					await validateAndSyncCharacterTokenValidityBatchTransitions({
+						db: this.db,
+						tokenStore: eveTokenStore,
+						characters: chars.map((char) => ({
+							characterId: char.characterId,
+							hasValidToken: char.hasValidToken ?? null,
+						})),
+					})
 				for (const transition of tokenValidityTransitions) {
 					tokenValidityByCharacterId.set(transition.characterId, transition.nextHasValidToken)
 				}
@@ -394,7 +399,8 @@ export class CoreRpcService {
 			allianceName: char.allianceName,
 			is_primary: char.is_primary,
 			linkedAt: char.linkedAt,
-			hasValidToken: tokenValidityByCharacterId.get(char.characterId) ?? (char.hasValidToken === true),
+			hasValidToken:
+				tokenValidityByCharacterId.get(char.characterId) ?? char.hasValidToken === true,
 			isBlacklisted: blacklistStatuses[char.characterId] || false,
 		}))
 
@@ -449,7 +455,9 @@ export class CoreRpcService {
 			refreshSucceeded: boolean
 		}>
 	> {
-		const normalizedCharacterIds = [...new Set(input.characterIds.map((id) => String(id).trim()))].filter(Boolean)
+		const normalizedCharacterIds = [
+			...new Set(input.characterIds.map((id) => String(id).trim())),
+		].filter(Boolean)
 		if (normalizedCharacterIds.length === 0) {
 			return []
 		}
@@ -705,10 +713,7 @@ export class CoreRpcService {
 		return characters.map((character) => character.characterId)
 	}
 
-	async listUsersWithActiveCharactersPage(input: {
-		limit: number
-		offset: number
-	}): Promise<{
+	async listUsersWithActiveCharactersPage(input: { limit: number; offset: number }): Promise<{
 		users: Array<{ userId: string; characterIds: string[] }>
 		totalCount: number
 	}> {
@@ -741,15 +746,15 @@ export class CoreRpcService {
 		}
 
 		const pageCharacters = await this.db.query.userCharacters.findMany({
-			where: and(
-				inArray(userCharacters.userId, userIds),
-				eq(userCharacters.isDeleted, false)
-			),
+			where: and(inArray(userCharacters.userId, userIds), eq(userCharacters.isDeleted, false)),
 			columns: {
 				userId: true,
 				characterId: true,
 			},
-			orderBy: (table, operators) => [operators.asc(table.userId), operators.asc(table.characterId)],
+			orderBy: (table, operators) => [
+				operators.asc(table.userId),
+				operators.asc(table.characterId),
+			],
 		})
 
 		const characterIdsByUserId = new Map<string, string[]>()
@@ -909,6 +914,7 @@ export class CoreRpcService {
 				updatedAt: now,
 			})
 			.where(eq(managedCorporations.corporationId, corporationId))
+		clearCorporationSyncStatusCache(corporationId)
 	}
 
 	async updateCorporationAuthHealth(
@@ -930,6 +936,7 @@ export class CoreRpcService {
 				updatedAt: new Date(),
 			})
 			.where(eq(managedCorporations.corporationId, corporationId))
+		clearCorporationDirectorHealthCache(corporationId)
 	}
 
 	/**

--- a/apps/core/src/services/corporation-auto-register.service.ts
+++ b/apps/core/src/services/corporation-auto-register.service.ts
@@ -4,6 +4,7 @@ import { logger } from '@repo/hono-helpers'
 
 import { managedCorporations } from '../db/schema'
 import { isNpcCorporationId } from '../lib/corporation-id'
+import { clearCorporationListCache } from '../lib/corporation-list-cache'
 
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
@@ -189,6 +190,7 @@ export async function autoRegisterDirectorCorporation(
 					healthyDirectorCount: 0,
 					configuredBy: userId,
 				})
+				clearCorporationListCache()
 
 				wasNew = true
 			} catch (error) {

--- a/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
+++ b/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
@@ -19,11 +19,11 @@ import {
 } from 'lucide-react'
 import { useCallback, useState } from 'react'
 
-import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { EsiStatusBadge, getEsiStatusBadgeState } from '@/components/esi-status-badge'
+import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
-import { EsiStatusBadge, getEsiStatusBadgeState } from '@/components/esi-status-badge'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select } from '@/components/ui/select'
@@ -35,6 +35,7 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { useMessage } from '@/hooks/useMessage'
 import { characterPortraitUrl } from '@/lib/eve-images'
 import { cn } from '@/lib/utils'
@@ -49,18 +50,19 @@ import {
 import { myCorporationsApi } from '../api'
 import { EmeritusConfirmationDialog } from './emeritus-confirmation-dialog'
 
+import type { SetStateAction } from 'react'
+import type { HrRoleType } from '../../hr'
 import type {
 	CorporationMember,
 	CorporationMembersQuery,
 	CorporationMembersResponse,
 	CorporationMembersSortField,
 } from '../api'
-import type { HrRoleType } from '../../hr'
-import type { SetStateAction } from 'react'
 
 interface CorporationMembersTableProps {
 	members: CorporationMember[]
 	loading?: boolean
+	isRefreshing?: boolean
 	onMemberClick?: (member: CorporationMember) => void
 	showActions?: boolean
 	canManageHrRoles?: boolean
@@ -83,7 +85,9 @@ interface CorporationMembersTableProps {
 
 type SortField = CorporationMembersSortField
 
-export function getAuthStatusBadge(member: Pick<CorporationMember, 'hasAuthAccount' | 'hasValidToken'>): {
+export function getAuthStatusBadge(
+	member: Pick<CorporationMember, 'hasAuthAccount' | 'hasValidToken'>
+): {
 	variant: 'success' | 'destructive' | 'warning'
 	label: 'ESI Valid' | 'ESI Invalid' | 'ESI Unknown' | 'Unlinked'
 } {
@@ -154,6 +158,7 @@ function ActionsMenu({ items }: { items: ActionItem[] }) {
 export default function CorporationMembersTable({
 	members,
 	loading,
+	isRefreshing = false,
 	onMemberClick,
 	showActions = true,
 	canManageHrRoles = false,
@@ -446,185 +451,193 @@ export default function CorporationMembersTable({
 			</Card>
 
 			{/* Table */}
-			<Card>
-				{renderPaginationControls()}
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<SortableHead field="name" label="Member" />
-							<SortableHead field="role" label="Role" />
-							{canManageHrRoles && <SortableHead field="hrRole" label="HR Role" />}
-							<SortableHead field="auth" label="Auth Account" />
-							<SortableHead field="activity" label="Activity" />
-							<SortableHead field="lastLogin" label="Last Login" />
-							<SortableHead field="joinDate" label="Join Date" />
-							{showActions && (
-								<TableHead className="sticky right-0 z-20 bg-card text-right">
-									Actions
-								</TableHead>
-							)}
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{paginatedMembers.map((member) => (
-							<TableRow
-								key={member.characterId}
-								className={cn(
-									'hover:bg-muted/50 cursor-pointer',
-									!member.hasAuthAccount && 'bg-yellow-500/5'
+			<TableRefreshFrame isRefreshing={isRefreshing} refreshMessage="Loading members...">
+				<Card>
+					{renderPaginationControls()}
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<SortableHead field="name" label="Member" />
+								<SortableHead field="role" label="Role" />
+								{canManageHrRoles && <SortableHead field="hrRole" label="HR Role" />}
+								<SortableHead field="auth" label="Auth Account" />
+								<SortableHead field="activity" label="Activity" />
+								<SortableHead field="lastLogin" label="Last Login" />
+								<SortableHead field="joinDate" label="Join Date" />
+								{showActions && (
+									<TableHead className="sticky right-0 z-20 bg-card text-right">Actions</TableHead>
 								)}
-								onClick={() => onMemberClick?.(member)}
-							>
-								<TableCell>
-									<div className="flex items-center gap-3">
-										<img
-											src={characterPortraitUrl(member.characterId, 64)}
-											alt={`${member.characterName}'s portrait`}
-											loading="lazy"
-											onError={(e) => {
-												; (e.currentTarget as HTMLImageElement).src =
-													'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"%3E%3Crect fill="%23404040" width="64" height="64"/%3E%3Ctext x="50%25" y="50%25" font-family="Arial" font-size="24" fill="%23bfbfbf" text-anchor="middle" dominant-baseline="middle"%3E?%3C/text%3E%3C/svg%3E'
-											}}
-											className="w-8 h-8 rounded-full border border-border"
-										/>
-										<div>
-											<div className="font-medium">{member.characterName}</div>
-											{member.locationSystem && (
-												<div className="text-xs text-muted-foreground">{member.locationSystem}</div>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{paginatedMembers.map((member) => (
+								<TableRow
+									key={member.characterId}
+									className={cn(
+										'hover:bg-muted/50 cursor-pointer',
+										!member.hasAuthAccount && 'bg-yellow-500/5'
+									)}
+									onClick={() => onMemberClick?.(member)}
+								>
+									<TableCell>
+										<div className="flex items-center gap-3">
+											<img
+												src={characterPortraitUrl(member.characterId, 64)}
+												alt={`${member.characterName}'s portrait`}
+												loading="lazy"
+												onError={(e) => {
+													;(e.currentTarget as HTMLImageElement).src =
+														'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"%3E%3Crect fill="%23404040" width="64" height="64"/%3E%3Ctext x="50%25" y="50%25" font-family="Arial" font-size="24" fill="%23bfbfbf" text-anchor="middle" dominant-baseline="middle"%3E?%3C/text%3E%3C/svg%3E'
+												}}
+												className="w-8 h-8 rounded-full border border-border"
+											/>
+											<div>
+												<div className="font-medium">{member.characterName}</div>
+												{member.locationSystem && (
+													<div className="text-xs text-muted-foreground">
+														{member.locationSystem}
+													</div>
+												)}
+											</div>
+										</div>
+									</TableCell>
+									<TableCell>
+										<div className="flex gap-2 flex-wrap">
+											{member.role === 'CEO' && (
+												<Badge variant="destructive" icon={Star}>
+													CEO
+												</Badge>
+											)}
+											{member.role === 'Director' && (
+												<Badge variant="warning" icon={Shield}>
+													Director
+												</Badge>
+											)}
+											{member.role === 'Member' && (
+												<Badge variant="default" icon={User}>
+													Member
+												</Badge>
+											)}
+											{member.status === 'emeritus' && (
+												<Badge variant="special" icon={Heart}>
+													Emeritus
+												</Badge>
+											)}
+											{member.isBlacklisted && (
+												<Badge variant="destructive" icon={ShieldBan}>
+													Blocklisted
+												</Badge>
 											)}
 										</div>
-									</div>
-								</TableCell>
-								<TableCell>
-									<div className="flex gap-2 flex-wrap">
-										{member.role === 'CEO' && (
-											<Badge variant="destructive" icon={Star}>CEO</Badge>
-										)}
-										{member.role === 'Director' && (
-											<Badge variant="warning" icon={Shield}>Director</Badge>
-										)}
-										{member.role === 'Member' && (
-											<Badge variant="default" icon={User}>Member</Badge>
-										)}
-										{member.status === 'emeritus' && (
-											<Badge variant="special" icon={Heart}>Emeritus</Badge>
-										)}
-										{member.isBlacklisted && (
-											<Badge variant="destructive" icon={ShieldBan}>Blocklisted</Badge>
-										)}
-									</div>
-								</TableCell>
-								{canManageHrRoles && (
-									<TableCell>
-										{member.hrRole ? (
-											<HrRoleBadge role={member.hrRole} />
-										) : (
-											<span className="text-xs text-muted-foreground">None</span>
-										)}
 									</TableCell>
-								)}
-								<TableCell>
-									<div className="space-y-1">
-										<EsiStatusBadge
-											hasAuthAccount={member.hasAuthAccount}
-											hasValidToken={member.hasValidToken}
-											className="text-[10px]"
-										/>
-										{member.mainCharacterName && (
-											<div className="text-xs text-muted-foreground">
-												{member.mainCharacterName}
-											</div>
+									{canManageHrRoles && (
+										<TableCell>
+											{member.hrRole ? (
+												<HrRoleBadge role={member.hrRole} />
+											) : (
+												<span className="text-xs text-muted-foreground">None</span>
+											)}
+										</TableCell>
+									)}
+									<TableCell>
+										<div className="space-y-1">
+											<EsiStatusBadge
+												hasAuthAccount={member.hasAuthAccount}
+												hasValidToken={member.hasValidToken}
+												className="text-[10px]"
+											/>
+											{member.mainCharacterName && (
+												<div className="text-xs text-muted-foreground">
+													{member.mainCharacterName}
+												</div>
+											)}
+										</div>
+									</TableCell>
+									<TableCell>
+										{member.activityStatus === 'active' && <Badge variant="success">Active</Badge>}
+										{member.activityStatus === 'inactive' && (
+											<Badge variant="warning">Inactive</Badge>
 										)}
-									</div>
-								</TableCell>
-								<TableCell>
-									{member.activityStatus === 'active' && (
-										<Badge variant="success">Active</Badge>
+										{member.activityStatus === 'unknown' && <Badge variant="ghost">Unknown</Badge>}
+									</TableCell>
+									<TableCell>
+										<div className="text-sm">{formatDate(member.lastLogin)}</div>
+									</TableCell>
+									<TableCell>
+										<div className="text-sm">{formatDate(member.joinDate)}</div>
+									</TableCell>
+									{showActions && (
+										<TableCell
+											className="sticky right-0 z-10 bg-card text-right"
+											onClick={(e) => e.stopPropagation()}
+										>
+											<ActionsMenu
+												items={[
+													{
+														label: 'View Profile',
+														intent: 'muted',
+														onClick: () => onMemberClick?.(member),
+													},
+													{
+														label: 'Grant HR Role',
+														intent: 'confirm',
+														hidden: !canManageHrRoles || !member.hasAuthAccount || !!member.hrRole,
+														onClick: () => setGrantDialogMember(member),
+													},
+													{
+														label: 'Revoke HR Role',
+														intent: 'destructive',
+														hidden:
+															!canManageHrRoles ||
+															!member.hrRole ||
+															(!canRevokeHrAdmin && member.hrRole.role === 'hr_admin'),
+														onClick: () => setRevokeDialogMember(member),
+													},
+													{
+														label: 'Mark as Emeritus',
+														intent: 'secondary',
+														hidden:
+															!canManageEmeritus ||
+															!member.hasAuthAccount ||
+															member.role === 'CEO' ||
+															member.status === 'emeritus',
+														onClick: () => {
+															setEmeritusAction('mark')
+															setEmeritusDialogMember(member)
+														},
+													},
+													{
+														label: 'Remove Emeritus',
+														intent: 'secondary',
+														hidden: !canManageEmeritus || member.status !== 'emeritus',
+														onClick: () => {
+															setEmeritusAction('remove')
+															setEmeritusDialogMember(member)
+														},
+													},
+												]}
+											/>
+										</TableCell>
 									)}
-									{member.activityStatus === 'inactive' && (
-										<Badge variant="warning">Inactive</Badge>
-									)}
-									{member.activityStatus === 'unknown' && (
-										<Badge variant="ghost">Unknown</Badge>
-									)}
-								</TableCell>
-								<TableCell>
-									<div className="text-sm">{formatDate(member.lastLogin)}</div>
-								</TableCell>
-								<TableCell>
-									<div className="text-sm">{formatDate(member.joinDate)}</div>
-								</TableCell>
-								{showActions && (
-								<TableCell
-									className="sticky right-0 z-10 bg-card text-right"
-									onClick={(e) => e.stopPropagation()}
-								>
-									<ActionsMenu
-										items={[
-											{
-												label: 'View Profile',
-												intent: 'muted',
-												onClick: () => onMemberClick?.(member),
-											},
-											{
-												label: 'Grant HR Role',
-												intent: 'confirm',
-												hidden: !canManageHrRoles || !member.hasAuthAccount || !!member.hrRole,
-												onClick: () => setGrantDialogMember(member),
-											},
-											{
-												label: 'Revoke HR Role',
-												intent: 'destructive',
-												hidden:
-													!canManageHrRoles ||
-													!member.hrRole ||
-													(!canRevokeHrAdmin && member.hrRole.role === 'hr_admin'),
-												onClick: () => setRevokeDialogMember(member),
-											},
-											{
-												label: 'Mark as Emeritus',
-												intent: 'secondary',
-												hidden:
-													!canManageEmeritus ||
-													!member.hasAuthAccount ||
-													member.role === 'CEO' ||
-													member.status === 'emeritus',
-												onClick: () => {
-													setEmeritusAction('mark')
-													setEmeritusDialogMember(member)
-												},
-											},
-											{
-												label: 'Remove Emeritus',
-												intent: 'secondary',
-												hidden: !canManageEmeritus || member.status !== 'emeritus',
-												onClick: () => {
-													setEmeritusAction('remove')
-													setEmeritusDialogMember(member)
-												},
-											},
-										]}
-									/>
-								</TableCell>
+								</TableRow>
+							))}
+							{paginatedMembers.length === 0 && (
+								<TableRow>
+									<TableCell
+										colSpan={showActions ? (canManageHrRoles ? 8 : 7) : canManageHrRoles ? 7 : 6}
+										className="py-8 text-center text-sm text-muted-foreground"
+									>
+										No members found for the current filters.
+									</TableCell>
+								</TableRow>
 							)}
-							</TableRow>
-						))}
-						{paginatedMembers.length === 0 && (
-							<TableRow>
-								<TableCell
-									colSpan={showActions ? (canManageHrRoles ? 8 : 7) : (canManageHrRoles ? 7 : 6)}
-									className="py-8 text-center text-sm text-muted-foreground"
-								>
-									No members found for the current filters.
-								</TableCell>
-							</TableRow>
-						)}
-					</TableBody>
-				</Table>
+						</TableBody>
+					</Table>
 
-				{/* Pagination */}
-				{renderPaginationControls()}
-			</Card>
+					{/* Pagination */}
+					{renderPaginationControls()}
+				</Card>
+			</TableRefreshFrame>
 
 			{/* HR Role Dialogs */}
 			{canManageHrRoles && corporationId && (

--- a/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
+++ b/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
@@ -25,6 +25,7 @@ import {
 	BreadcrumbPage,
 	BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { LoadingSpinner } from '@/components/ui/loading'
@@ -39,15 +40,14 @@ import { useHrRoles } from '../../hr'
 import { buildCorporationMembersExportUrl, myCorporationsApi } from '../api'
 import { CorporationUserSearchDialog } from '../components/corporation-user-search-dialog'
 import {
-	useCanAccessCorporation,
 	formatCorporationRoleLabel,
+	useCanAccessCorporation,
 	useCorporationManager,
 	useCorporationMembers,
 	useMyCorporation,
 } from '../hooks'
 
 import type { CorporationMember, CorporationMembersQuery } from '../api'
-import { Button } from '@/components/ui/button'
 
 // Lazy load the members table for code splitting
 const CorporationMembersTable = lazy(() => import('../components/corporation-members-table'))
@@ -99,6 +99,7 @@ export default function CorporationMembers() {
 	const {
 		data: membersResponse,
 		isLoading: membersLoading,
+		isFetching: membersFetching,
 		error,
 	} = useCorporationMembers(corporationId!, effectiveMembersQuery, { enabled: canAccess })
 
@@ -107,7 +108,8 @@ export default function CorporationMembers() {
 	const isHrAdmin = userRole === 'hr_admin'
 	const isHrOnly =
 		userRole === 'hr_admin' || userRole === 'hr_reviewer' || userRole === 'hr_viewer' || isAuditor
-	const isMemberCorporation = corporation?.isMemberCorporation ?? accessCorp?.isMemberCorporation ?? false
+	const isMemberCorporation =
+		corporation?.isMemberCorporation ?? accessCorp?.isMemberCorporation ?? false
 
 	// Can refresh data: CEO/Director/admin only
 	const canRefresh = isLeadership
@@ -119,8 +121,7 @@ export default function CorporationMembers() {
 	// Can manage HR roles: member corp only, with CEO/admin/hr_admin access
 	const canManageHrRoles = useMemo(() => {
 		return (
-			isMemberCorporation &&
-			(userRole === 'CEO' || userRole === 'admin' || userRole === 'hr_admin')
+			isMemberCorporation && (userRole === 'CEO' || userRole === 'admin' || userRole === 'hr_admin')
 		)
 	}, [isMemberCorporation, userRole])
 	const { data: hrRoles, isLoading: hrRolesLoading } = useHrRoles(corporationId!, {
@@ -141,10 +142,12 @@ export default function CorporationMembers() {
 	)
 
 	// Can manage emeritus status: site admins or member corporations only, CEO/site admin
-	const canManageEmeritus = user?.is_admin === true || (isMemberCorporation && (userRole === 'CEO' || userRole === 'admin'))
+	const canManageEmeritus =
+		user?.is_admin === true || (isMemberCorporation && (userRole === 'CEO' || userRole === 'admin'))
 
 	// Can access settings: site admins or member corporations only
-	const canAccessSettings = user?.is_admin === true || (isMemberCorporation && (isLeadership || isHrAdmin))
+	const canAccessSettings =
+		user?.is_admin === true || (isMemberCorporation && (isLeadership || isHrAdmin))
 	const canUseHrTools = isMemberCorporation
 
 	// Enhance members with HR role data
@@ -302,8 +305,8 @@ export default function CorporationMembers() {
 						<AlertCircle className="h-16 w-16 mx-auto text-red-500 mb-4" />
 						<CardTitle className="text-2xl text-red-900 dark:text-red-100">Access Denied</CardTitle>
 						<CardDescription className="mt-2 text-red-700 dark:text-red-300">
-							You don't have permission to view members of this corporation. CEO, director, or
-							HR role access is required.
+							You don't have permission to view members of this corporation. CEO, director, or HR
+							role access is required.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="text-center">
@@ -381,13 +384,13 @@ export default function CorporationMembers() {
 							{corpName} Members
 						</h1>
 						<p className="text-muted-foreground mt-2">
-							View and manage all members of{' '}
-							{corpTicker ? `[${corpTicker}]` : 'this corporation'}
+							View and manage all members of {corpTicker ? `[${corpTicker}]` : 'this corporation'}
 							{corpAllianceName && ` • Alliance: ${corpAllianceName}`}
 						</p>
 						{userRole && (
 							<p className="text-sm text-muted-foreground mt-1">
-								Your role: <span className="font-medium">{formatCorporationRoleLabel(userRole)}</span>
+								Your role:{' '}
+								<span className="font-medium">{formatCorporationRoleLabel(userRole)}</span>
 							</p>
 						)}
 					</div>
@@ -472,8 +475,8 @@ export default function CorporationMembers() {
 										HR tools unavailable
 									</div>
 									<p className="text-sm text-muted-foreground">
-										{corpTypeLabel} corporations do not expose HR management tools. You can still review
-										member details and ESI coverage here.
+										{corpTypeLabel} corporations do not expose HR management tools. You can still
+										review member details and ESI coverage here.
 									</p>
 								</div>
 							</div>
@@ -498,7 +501,9 @@ export default function CorporationMembers() {
 										: 'bg-background/80 hover:border-success/50 hover:bg-background/95'
 								)}
 							>
-								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">Full</div>
+								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+									Full
+								</div>
 								<div className="text-base font-bold text-success leading-none">
 									{esiCoverage.full}
 								</div>
@@ -517,7 +522,9 @@ export default function CorporationMembers() {
 										: 'bg-background/80 hover:border-warning/50 hover:bg-background/95'
 								)}
 							>
-								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">Partial</div>
+								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+									Partial
+								</div>
 								<div className="text-base font-bold text-warning leading-none">
 									{esiCoverage.partial}
 								</div>
@@ -536,7 +543,9 @@ export default function CorporationMembers() {
 										: 'bg-background/80 hover:border-destructive/50 hover:bg-background/95'
 								)}
 							>
-								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">None</div>
+								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+									None
+								</div>
 								<div className="text-base font-bold text-destructive leading-none">
 									{esiCoverage.none}
 								</div>
@@ -555,7 +564,9 @@ export default function CorporationMembers() {
 										: 'bg-background/80 hover:border-muted-foreground/50 hover:bg-background/95'
 								)}
 							>
-								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">Unlinked</div>
+								<div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+									Unlinked
+								</div>
 								<div className="text-base font-bold text-muted-foreground leading-none">
 									{esiCoverage.unlinked}
 								</div>
@@ -578,13 +589,14 @@ export default function CorporationMembers() {
 					</Card>
 				}
 			>
-					<CorporationMembersTable
-						members={membersWithHrRoles ?? []}
-						loading={membersLoading && !membersResponse}
-						onMemberClick={handleMemberClick}
-						showActions={true}
-						canManageHrRoles={canManageHrRoles}
-						grantableHrRoles={[...grantableHrRoles]}
+				<CorporationMembersTable
+					members={membersWithHrRoles ?? []}
+					loading={membersLoading && !membersResponse}
+					isRefreshing={membersFetching && Boolean(membersResponse)}
+					onMemberClick={handleMemberClick}
+					showActions={true}
+					canManageHrRoles={canManageHrRoles}
+					grantableHrRoles={[...grantableHrRoles]}
 					canRevokeHrAdmin={canRevokeHrAdmin}
 					canManageEmeritus={canManageEmeritus}
 					corporationId={corporationId!}
@@ -602,7 +614,6 @@ export default function CorporationMembers() {
 					onOpenChange={setIsUserSearchOpen}
 				/>
 			)}
-
 		</Container>
 	)
 }

--- a/apps/ui/src/client/routes/admin/corporations.tsx
+++ b/apps/ui/src/client/routes/admin/corporations.tsx
@@ -56,25 +56,25 @@ export default function CorporationsPage() {
 	// Filter state
 	const [filters, setFilters] = useState<CorporationsFilters>({
 		corporationType: 'member',
+		search: undefined,
 		page: 1,
 		pageSize: 25,
 	})
 	const [searchQuery, setSearchQuery] = useState('')
-	const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
 
 	useEffect(() => {
 		const timer = setTimeout(() => {
-			setDebouncedSearchQuery(searchQuery.trim())
-			setFilters((current) => ({ ...current, page: 1 }))
+			const search = searchQuery.trim() || undefined
+			setFilters((current) => {
+				if (current.search === search && current.page === 1) return current
+				return { ...current, search, page: 1 }
+			})
 		}, 300)
 
 		return () => clearTimeout(timer)
 	}, [searchQuery])
 
-	const { data, isLoading, isFetching, error } = useCorporations({
-		...filters,
-		search: debouncedSearchQuery || undefined,
-	})
+	const { data, isLoading, isFetching, error } = useCorporations(filters)
 	const corporations = data?.data ?? []
 	const pagination = data?.pagination
 	const isInitialLoading = isLoading && !data
@@ -118,8 +118,12 @@ export default function CorporationsPage() {
 	// Clear all filters (reset to default)
 	const clearFilters = () => {
 		setSearchQuery('')
-		setDebouncedSearchQuery('')
-		setFilters({ corporationType: 'member', page: 1, pageSize: filters.pageSize ?? 25 })
+		setFilters({
+			corporationType: 'member',
+			search: undefined,
+			page: 1,
+			pageSize: filters.pageSize ?? 25,
+		})
 	}
 
 	const handlePageSizeChange = (pageSize: number) => {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a bug where valid player corporations (e.g. IDs like `1018389948`) were incorrectly excluded from the admin corporations listing due to a lexicographic string comparison, and adds a caching layer to reduce database/RPC load on that listing endpoint.

## Changes
- Fixed the NPC-corporation filter in `GET /api/corporations`: it previously used `gte`/`lt` string comparisons on the text `corporationId` column, which excluded valid corporation IDs that sort lexicographically within the NPC range (`1000000`–`2000000`). Now casts to `::bigint` for a correct numeric comparison.
- Added `apps/core/src/lib/corporation-list-cache.ts` with `TimeCache`-backed caches for the corporation list page, director status, sync status, and live director-health lookups, each with its own TTL.
- Wired cache population/lookup into the corporations list route, only fetching per-corporation status/health data for cache misses.
- Added cache invalidation (`clearCorporationListCache`, `clearCorporationStatusCache`, `clearCorporationDirectorHealthCache`, `clearCorporationSyncStatusCache`) to all corporation mutation paths (create, update, delete, verify, fetch, settings update, director add, members refresh) across `corporations/index.ts`, `directors-routes.ts`, `core-rpc.service.ts`, and `corporation-auto-register.service.ts`.
- UI: `CorporationMembersTable` now wraps its content in `TableRefreshFrame` and accepts an `isRefreshing` prop, driven by the members query's `isFetching` state in `corporation-members.tsx`.
- UI: simplified the admin corporations page's search-debounce logic by storing `search` directly in filter state instead of a separate `debouncedSearchQuery` state variable.
- Assorted Prettier formatting/import-order fixups in `core-rpc.service.ts` and other touched files.

## Testing
- Added an integration test (`corporations.list.route.test.ts`) verifying that a second request with the same query reuses the cached page and per-corporation health data instead of re-querying the DB or the EVE corporation data worker.
<!-- claude:end -->