### PR TITLE
add fleet tracking stats export and fix stats queries

### DIFF
--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -108,6 +108,8 @@ export type Env = SharedHonoEnv & {
 	SRP_EXPORTS: R2Bucket
 	/** Structure asset debug artifact bucket */
 	STRUCTURE_ASSETS_DEBUG_EXPORTS: R2Bucket
+	/** Fleet participation export artifact bucket */
+	FLEET_EXPORTS: R2Bucket
 	/** Markets Durable Object binding */
 	MARKETS: DurableObjectNamespace
 	/** Mumble Durable Object binding */

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -20,6 +20,7 @@ import { waitUntilWithTelemetry } from './lib/background-task'
 import { cleanupExpiredExportArtifacts } from './lib/export-retention'
 import { IMMUNITAS_ALERT_DRAIN_CRON } from './lib/immunitas-alerts'
 import { getStructureAssetsDebugBucket } from './lib/structure-assets-debug'
+import { getFleetParticipationExportBucket } from './lib/fleet-participation-export'
 import { TOKEN_INVALID_ALERT_DRAIN_CRON } from './lib/token-invalid-alerts'
 import { triggerDiscordRefreshWorkflow, triggerUserRefreshWorkflow } from './lib/workflow-triggers'
 import { csrfProtection } from './middleware/csrf'
@@ -255,11 +256,17 @@ export default {
 
 			if (event.cron === EXPORT_CLEANUP_CRON) {
 				ctx.waitUntil(
-					cleanupExpiredExportArtifacts(
-						getStructureAssetsDebugBucket(env),
-						'structure-assets-debug'
-					).catch((error) =>
-						captureException(error as Error, { tags: { job: 'structure-assets-debug-cleanup' } })
+					Promise.all([
+						cleanupExpiredExportArtifacts(
+							getStructureAssetsDebugBucket(env),
+							'structure-assets-debug'
+						),
+						cleanupExpiredExportArtifacts(
+							getFleetParticipationExportBucket(env),
+							'fleet-participation'
+						),
+					]).catch((error) =>
+						captureException(error as Error, { tags: { job: 'export-artifact-cleanup' } })
 					)
 				)
 			}

--- a/apps/core/src/lib/fleet-participation-export.ts
+++ b/apps/core/src/lib/fleet-participation-export.ts
@@ -1,0 +1,178 @@
+import { and, eq, inArray } from '@repo/db-utils'
+import { getStub } from '@repo/do-utils'
+import { buildCsvLine, createR2MultipartTextWriter } from '@repo/worker-utils'
+
+import { createDb, schema } from '../db'
+import { getExportArtifactExpiresAtIso } from './export-retention'
+
+import type { FleetParticipationExportPageRequest, Fleets } from '@repo/fleets'
+import type { Env } from '../context'
+
+export const FLEET_PARTICIPATION_EXPORT_BUCKET_PREFIX = 'fleet-participation'
+export const FLEET_PARTICIPATION_EXPORT_PAGE_SIZE = 500
+
+export type FleetParticipationExportParams = {
+	kind: 'fleet-corporation-participation'
+	userId: string
+	corporationId: string
+	dateFrom: string
+	dateTo: string
+}
+
+export function getFleetParticipationExportBucket(env: Pick<Env, 'FLEET_EXPORTS'>): R2Bucket {
+	return env.FLEET_EXPORTS
+}
+
+export function buildFleetParticipationExportKey(exportId: string): string {
+	return `${FLEET_PARTICIPATION_EXPORT_BUCKET_PREFIX}/${exportId}.csv`
+}
+
+export function buildFleetParticipationExportFileName(
+	corporationId: string,
+	dateFrom: string,
+	dateTo: string
+): string {
+	return `fleet-participation-${corporationId}-${dateFrom.slice(0, 10)}-${dateTo.slice(0, 10)}.csv`
+}
+
+function formatDuration(seconds: number): string {
+	let remaining = Math.max(0, Math.round(seconds))
+	const units: Array<[string, number]> = [
+		['d', 24 * 60 * 60],
+		['h', 60 * 60],
+		['m', 60],
+		['s', 1],
+	]
+	const parts: string[] = []
+	for (const [label, size] of units) {
+		if (parts.length >= 2) break
+		const value = Math.floor(remaining / size)
+		if (value > 0 || (label === 's' && parts.length === 0)) {
+			parts.push(`${value}${label}`)
+			remaining -= value * size
+		}
+	}
+	return parts.join(' ')
+}
+
+export async function writeFleetParticipationExportToBucket(args: {
+	env: Pick<Env, 'FLEETS' | 'DATABASE_URL' | 'FLEET_EXPORTS'>
+	exportId: string
+	corporationId: string
+	dateFrom: string
+	dateTo: string
+	fileName: string
+	expiresAt?: string
+}): Promise<{ rowCount: number; expiresAt: string }> {
+	const expiresAt = args.expiresAt ?? getExportArtifactExpiresAtIso()
+	const writer = await createR2MultipartTextWriter(
+		getFleetParticipationExportBucket(args.env),
+		buildFleetParticipationExportKey(args.exportId),
+		{
+			httpMetadata: { contentType: 'text/csv; charset=utf-8' },
+			customMetadata: { fileName: args.fileName, expiresAt },
+		}
+	)
+	const fleets = getStub<Fleets>(args.env.FLEETS, 'default')
+	const db = createDb(args.env.DATABASE_URL)
+	const ownershipCache = new Map<string, { userId: string; mainCharacterName: string } | null>()
+	let cursor: string | null = null
+	let rowCount = 0
+
+	try {
+		await writer.writeLine(
+			buildCsvLine([
+				'Date stamp',
+				'Core UserID',
+				'User Main Character Name',
+				'Fleet Character ID',
+				'Fleet Character Name',
+				'Fleet Session ID',
+				'Fleet Name',
+				'Role',
+				'Ships Flown',
+				'Duration',
+			])
+		)
+
+		do {
+			const request: FleetParticipationExportPageRequest = {
+				corporationId: args.corporationId,
+				from: args.dateFrom,
+				to: args.dateTo,
+				cursor,
+				limit: FLEET_PARTICIPATION_EXPORT_PAGE_SIZE,
+			}
+			const page = await fleets.getCorporationFleetParticipationPage(request)
+			const characterIds = page.items.map((row) => row.fleetCharacterId)
+			const linkedRows =
+				characterIds.length === 0
+					? []
+					: await db
+							.select({
+								characterId: schema.userCharacters.characterId,
+								userId: schema.userCharacters.userId,
+							})
+							.from(schema.userCharacters)
+							.where(
+								and(
+									inArray(schema.userCharacters.characterId, characterIds),
+									eq(schema.userCharacters.isDeleted, false)
+								)
+							)
+
+			const userIds = [...new Set(linkedRows.map((row) => row.userId))]
+			const primaryRows =
+				userIds.length === 0
+					? []
+					: await db
+							.select({
+								userId: schema.userCharacters.userId,
+								characterName: schema.userCharacters.characterName,
+							})
+							.from(schema.userCharacters)
+							.where(
+								and(
+									inArray(schema.userCharacters.userId, userIds),
+									eq(schema.userCharacters.is_primary, true),
+									eq(schema.userCharacters.isDeleted, false)
+								)
+							)
+			const primaryNames = new Map(primaryRows.map((row) => [row.userId, row.characterName]))
+			const linkedUsers = new Map(linkedRows.map((row) => [row.characterId, row.userId]))
+
+			for (const row of page.items) {
+				if (!ownershipCache.has(row.fleetCharacterId)) {
+					const userId = linkedUsers.get(row.fleetCharacterId)
+					ownershipCache.set(
+						row.fleetCharacterId,
+						userId ? { userId, mainCharacterName: primaryNames.get(userId) ?? '' } : null
+					)
+				}
+				const owner = ownershipCache.get(row.fleetCharacterId)
+				await writer.writeLine(
+					buildCsvLine([
+						row.dateStamp,
+						owner?.userId ?? '',
+						owner?.mainCharacterName ?? '',
+						row.fleetCharacterId,
+						row.fleetCharacterName ?? '',
+						row.fleetSessionId,
+						row.fleetName,
+						row.role,
+						row.shipCount,
+						formatDuration(row.durationSeconds),
+					])
+				)
+				rowCount += 1
+			}
+			cursor = page.nextCursor
+		} while (cursor)
+
+		await writer.close()
+		return { rowCount, expiresAt }
+	} catch (error) {
+		await writer.abort().catch(() => {})
+		throw error
+	}
+}

--- a/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
+++ b/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
@@ -2,10 +2,11 @@ import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStub } from '@repo/do-utils'
+import { createWorkflow } from '@repo/workflow-utils'
 
-import fleetsRoutes from '../fleets'
 import { createDb } from '../../db'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
+import fleetsRoutes from '../fleets'
 
 import type { SessionUser } from '../../context'
 import type * as DbModule from '../../db'
@@ -17,14 +18,18 @@ vi.mock('@repo/do-utils', () => ({
 vi.mock('../../middleware/session', () => ({
 	requireAuth:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 }))
 
 vi.mock('../../lib/groups-cache', () => ({
 	getCachedUserPermissions: vi.fn(),
 	getCachedCharacterPermissions: vi.fn(),
+}))
+
+vi.mock('@repo/workflow-utils', () => ({
+	createWorkflow: vi.fn(),
 }))
 
 // Preserve the real Drizzle `schema` (table definitions, no DB connection) but
@@ -37,6 +42,7 @@ vi.mock('../../db', async (importOriginal) => {
 const getStubMock = vi.mocked(getStub)
 const getCachedUserPermissionsMock = vi.mocked(getCachedUserPermissions)
 const createDbMock = vi.mocked(createDb)
+const createWorkflowMock = vi.mocked(createWorkflow)
 
 /**
  * Chainable Drizzle `select().from().where().limit()` stub that resolves to the
@@ -47,6 +53,7 @@ function makeDbStub(rows: unknown[]): any {
 		from: () => chain,
 		where: () => chain,
 		limit: () => Promise.resolve(rows),
+		then: (resolve: (value: unknown[]) => unknown) => Promise.resolve(rows).then(resolve),
 	}
 	return { select: () => chain }
 }
@@ -115,8 +122,13 @@ describe('fleets tracking routes', () => {
 		getSessionRoster: ReturnType<typeof vi.fn>
 		getSessionSummary: ReturnType<typeof vi.fn>
 		getStatsOverview: ReturnType<typeof vi.fn>
+		getCorpRollupForOverview: ReturnType<typeof vi.fn>
+		getStatsForCharacter: ReturnType<typeof vi.fn>
+		getCharacterFleetSessionsPage: ReturnType<typeof vi.fn>
+		getUserFleetSessionsPage: ReturnType<typeof vi.fn>
 		getCharactersByCorpInWindow: ReturnType<typeof vi.fn>
 		getStatsForCharacters: ReturnType<typeof vi.fn>
+		getCorporationFleetParticipationMonths: ReturnType<typeof vi.fn>
 	}
 	let broadcastsStub: {
 		getBroadcastByFleetSessionId: ReturnType<typeof vi.fn>
@@ -146,8 +158,23 @@ describe('fleets tracking routes', () => {
 			getSessionRoster: vi.fn(),
 			getSessionSummary: vi.fn(),
 			getStatsOverview: vi.fn(),
+			getCorpRollupForOverview: vi.fn().mockResolvedValue([]),
+			getStatsForCharacter: vi.fn().mockResolvedValue({
+				totals: {
+					fleetsJoined: 0,
+					minutesInFleet: 0,
+					timesFC: 0,
+					minutesAsFC: 0,
+					avgFleetDurationMinutes: null,
+				},
+				shipsFlown: [],
+				recentSessions: [],
+			}),
+			getCharacterFleetSessionsPage: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+			getUserFleetSessionsPage: vi.fn().mockResolvedValue({ items: [], total: 0 }),
 			getCharactersByCorpInWindow: vi.fn().mockResolvedValue([]),
 			getStatsForCharacters: vi.fn().mockResolvedValue({}),
+			getCorporationFleetParticipationMonths: vi.fn().mockResolvedValue([]),
 		}
 		broadcastsStub = {
 			getBroadcastByFleetSessionId: vi.fn().mockResolvedValue(null),
@@ -468,7 +495,11 @@ describe('fleets tracking routes', () => {
 			})
 		)
 
-		const res = await app.request('/api/fleets/tracking?userId=other-user&limit=25&offset=0', {}, env)
+		const res = await app.request(
+			'/api/fleets/tracking?userId=other-user&limit=25&offset=0',
+			{},
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(fleetsStub.listTrackingSessions).toHaveBeenCalledWith(
@@ -488,7 +519,11 @@ describe('fleets tracking routes', () => {
 		fleetsStub.listTrackingSessions.mockResolvedValue({ items: [], total: 0 })
 		const app = createApp(makeUser({ id: 'self-user' }))
 
-		const res = await app.request('/api/fleets/tracking?userId=other-user&limit=25&offset=0', {}, env)
+		const res = await app.request(
+			'/api/fleets/tracking?userId=other-user&limit=25&offset=0',
+			{},
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(fleetsStub.listTrackingSessions).toHaveBeenCalledWith(
@@ -710,7 +745,9 @@ describe('fleets tracking routes', () => {
 	})
 
 	it('returns live member locations for detailed viewers without mutating ship events', async () => {
-		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:view-fleets' }] as any)
+		getCachedUserPermissionsMock.mockResolvedValue([
+			{ urn: 'urn:fleet-tracking:view-fleets' },
+		] as any)
 		fleetsStub.getTrackingSession.mockResolvedValue({
 			id: 's-live',
 			status: 'active',
@@ -769,6 +806,34 @@ describe('fleets tracking routes', () => {
 
 		expect(res.status).toBe(400)
 		expect(fleetsStub.getStatsOverview).not.toHaveBeenCalled()
+	})
+
+	it('uses an epoch-start range for all-time stats', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:view-all' }] as any)
+		fleetsStub.getStatsOverview.mockResolvedValue({
+			totals: {
+				sessions: 0,
+				totalMinutes: 0,
+				uniquePilots: 0,
+				totalJoins: 0,
+				avgDurationMinutes: null,
+				avgPeakMembers: null,
+				largestFleetPeak: null,
+			},
+			topFCs: [],
+			topPilots: [],
+			topShips: [],
+			sessionsPerDay: [],
+		})
+
+		const app = createApp(makeUser({ id: 'all-time-viewer' }))
+		const res = await app.request('/api/fleets/tracking/stats/overview?allTime=true', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(fleetsStub.getStatsOverview).toHaveBeenCalledWith({
+			from: '1970-01-01T00:00:00.000Z',
+			to: expect.any(String),
+		})
 	})
 
 	it('hydrates linked broadcast SRP/doctrine on session detail', async () => {
@@ -914,5 +979,195 @@ describe('fleets tracking routes', () => {
 
 		expect(res.status).toBe(200)
 		expect(corpDataStub.getCorporationInfo).not.toHaveBeenCalled()
+	})
+
+	it('loads the requested character session page without changing aggregate stats', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:view-all' }] as any)
+		fleetsStub.getStatsForCharacter.mockResolvedValue({
+			totals: {
+				fleetsJoined: 22,
+				minutesInFleet: 320,
+				timesFC: 2,
+				minutesAsFC: 90,
+				avgFleetDurationMinutes: 15,
+			},
+			shipsFlown: [{ shipTypeId: 42, totalMinutes: 120 }],
+			recentSessions: [],
+		})
+		fleetsStub.getCharacterFleetSessionsPage.mockResolvedValue({
+			total: 22,
+			items: [
+				{
+					sessionId: 'session-2',
+					sessionName: 'Fleet 2',
+					fleetId: 'fleet-2',
+					wasFC: false,
+					startedAt: '2026-08-04T10:00:00.000Z',
+					endedAt: '2026-08-04T11:00:00.000Z',
+					totalMinutes: 60,
+					shipsFlown: 1,
+				},
+			],
+		})
+
+		const app = createApp(makeUser({ id: 'viewall-user' }))
+		const res = await app.request(
+			'/api/fleets/tracking/stats/characters/1514842406?from=2026-07-01T00:00:00.000Z&to=2026-08-05T00:00:00.000Z&limit=10&offset=10',
+			{},
+			env
+		)
+
+		expect(res.status).toBe(200)
+		await expect(res.json()).resolves.toMatchObject({
+			characterId: '1514842406',
+			totals: { fleetsJoined: 22 },
+			recentSessionsTotal: 22,
+			recentSessionsLimit: 10,
+			recentSessionsOffset: 10,
+			recentSessions: [{ sessionId: 'session-2' }],
+		})
+		expect(fleetsStub.getCharacterFleetSessionsPage).toHaveBeenCalledWith({
+			characterId: '1514842406',
+			range: {
+				from: '2026-07-01T00:00:00.000Z',
+				to: '2026-08-05T00:00:00.000Z',
+			},
+			limit: 10,
+			offset: 10,
+		})
+	})
+
+	it('loads all user fleet sessions through the batch page endpoint', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:fleet-tracking:view-all' }] as any)
+		createDbMock.mockReturnValue(
+			makeDbStub([
+				{
+					characterId: '1001',
+					characterName: 'Pilot One',
+					is_primary: true,
+					corporationId: null,
+					corporationName: null,
+				},
+			])
+		)
+		fleetsStub.getStatsForCharacters.mockResolvedValue({})
+		fleetsStub.getUserFleetSessionsPage.mockResolvedValue({
+			total: 31,
+			items: [
+				{
+					characterId: '1001',
+					sessionId: 'session-31',
+					sessionName: 'Fleet 31',
+					fleetId: 'fleet-31',
+					wasFC: false,
+					startedAt: '2026-08-04T10:00:00.000Z',
+					endedAt: '2026-08-04T11:00:00.000Z',
+					totalMinutes: 60,
+					shipsFlown: 1,
+				},
+			],
+		})
+
+		const app = createApp(makeUser({ id: 'viewall-user' }))
+		const res = await app.request(
+			'/api/fleets/tracking/stats/users/viewall-user?from=2026-07-01T00:00:00.000Z&to=2026-08-05T00:00:00.000Z&limit=10&offset=20',
+			{},
+			env
+		)
+
+		expect(res.status).toBe(200)
+		await expect(res.json()).resolves.toMatchObject({
+			recentSessionsTotal: 31,
+			recentSessionsLimit: 10,
+			recentSessionsOffset: 20,
+			recentSessions: [{ characterId: '1001', sessionId: 'session-31' }],
+		})
+		expect(fleetsStub.getUserFleetSessionsPage).toHaveBeenCalledWith({
+			characterIds: ['1001'],
+			range: {
+				from: '2026-07-01T00:00:00.000Z',
+				to: '2026-08-05T00:00:00.000Z',
+			},
+			limit: 10,
+			offset: 20,
+		})
+	})
+
+	it('uses the fleet DO for export month metadata without loading participation rows', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		fleetsStub.getCorporationFleetParticipationMonths.mockResolvedValue([
+			{ month: '2026-07', from: '2026-07-01T00:00:00.000Z', to: '2026-08-01T00:00:00.000Z' },
+		])
+		const app = createApp(makeUser({ id: 'admin-user', is_admin: true }))
+
+		const res = await app.request(
+			'/api/fleets/tracking/stats/corporations/505/export-months',
+			{},
+			env
+		)
+
+		expect(res.status).toBe(200)
+		await expect(res.json()).resolves.toEqual({
+			months: [
+				{ month: '2026-07', from: '2026-07-01T00:00:00.000Z', to: '2026-08-01T00:00:00.000Z' },
+			],
+		})
+		expect(fleetsStub.getCorporationFleetParticipationMonths).toHaveBeenCalledWith('505')
+	})
+
+	it('allows a corporation CEO to access export metadata under the same self-service gate', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '3001' })
+		corpDataStub.getDirectors.mockResolvedValue([])
+		charDataStub.getCharacterInfo.mockResolvedValue({ corporationId: '506' })
+		fleetsStub.getCorporationFleetParticipationMonths.mockResolvedValue([])
+
+		const app = createApp(makeLeaderUser('export-ceo-user', '3001'))
+		const res = await app.request(
+			'/api/fleets/tracking/stats/corporations/506/export-months',
+			{},
+			env
+		)
+
+		expect(res.status).toBe(200)
+		expect(fleetsStub.getCorporationFleetParticipationMonths).toHaveBeenCalledWith('506')
+	})
+
+	it('denies a plain corporation member from export metadata', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		corpDataStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' })
+		corpDataStub.getDirectors.mockResolvedValue([])
+		charDataStub.getCharacterInfo.mockResolvedValue({ corporationId: '507' })
+
+		const app = createApp(makeLeaderUser('export-member-user', '3002'))
+		const res = await app.request(
+			'/api/fleets/tracking/stats/corporations/507/export-months',
+			{},
+			env
+		)
+
+		expect(res.status).toBe(403)
+		expect(fleetsStub.getCorporationFleetParticipationMonths).not.toHaveBeenCalled()
+	})
+
+	it('validates the export range before creating a workflow', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([])
+		const app = createApp(makeUser({ id: 'admin-user', is_admin: true }))
+
+		const res = await app.request(
+			'/api/fleets/tracking/stats/corporations/505/export',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					dateFrom: '2026-08-01T00:00:00.000Z',
+					dateTo: '2026-07-01T00:00:00.000Z',
+				}),
+			},
+			env
+		)
+
+		expect(res.status).toBe(400)
+		expect(createWorkflowMock).not.toHaveBeenCalled()
 	})
 })

--- a/apps/core/src/routes/fleets.ts
+++ b/apps/core/src/routes/fleets.ts
@@ -1,20 +1,28 @@
 import { Hono } from 'hono'
-import type { Context } from 'hono'
 
 import { and, eq, ilike, inArray, or } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { createEveCharacterId } from '@repo/eve-types'
-import { StartTrackingSessionError } from '@repo/fleets'
+import { FLEET_NON_SHIP_TYPE_IDS, StartTrackingSessionError } from '@repo/fleets'
 import { logger, TimeCache } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb, schema } from '../db'
-import { getCachedCharacterPermissions, getCachedUserPermissions } from '../lib/groups-cache'
+import { isExportArtifactExpired } from '../lib/export-retention'
+import {
+	buildFleetParticipationExportFileName,
+	buildFleetParticipationExportKey,
+	getFleetParticipationExportBucket,
+} from '../lib/fleet-participation-export'
+import { getCachedUserPermissions } from '../lib/groups-cache'
 import { validatePagination } from '../lib/validation'
+import { normalizeWorkflowStatus } from '../lib/workflow-status'
 import { requireAuth } from '../middleware/session'
 import { hasCorporationSelfServiceAccess } from '../middleware/tax-permissions'
 
-import type { EsiTypeResolver } from '@repo/esi'
+import type { Context } from 'hono'
 import type { Broadcasts } from '@repo/broadcasts'
+import type { EsiTypeResolver } from '@repo/esi'
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type {
@@ -26,45 +34,6 @@ import type {
 } from '@repo/fleets'
 import type { Universe } from '@repo/universe'
 import type { App } from '../context'
-
-/**
- * Permission check cache - 15 second TTL
- * Caches the boolean result of permission checks
- */
-const permissionCache = new TimeCache<boolean>(15000)
-
-/**
- * Helper function to check if a character has a specific permission
- * Checks both user permissions and character permissions
- * Results are cached for 15 seconds to reduce load on Groups DO
- */
-async function hasCharacterPermission(
-	env: { GROUPS: DurableObjectNamespace },
-	userId: string,
-	characterId: string,
-	permissionUrn: string,
-	isAdmin: boolean
-): Promise<boolean> {
-	// Admins bypass permission checks
-	if (isAdmin) {
-		return true
-	}
-
-	// Check cache or fetch permissions
-	const cacheKey = `${userId}:${characterId}:${permissionUrn}`
-	return permissionCache.getOrSet(cacheKey, async () => {
-		// Check user group permissions first (cached)
-		const groupPermissions = await getCachedUserPermissions(env, userId)
-
-		if (groupPermissions.some((p) => p.urn === permissionUrn)) {
-			return true
-		}
-
-		// Check character permissions (cached)
-		const characterPermissions = await getCachedCharacterPermissions(env, characterId)
-		return characterPermissions.some((p) => p.urn === permissionUrn)
-	})
-}
 
 const app = new Hono<App>()
 
@@ -373,9 +342,7 @@ const FLEET_TRACKING_VIEW_ALL = 'urn:fleet-tracking:view-all'
  * Admin implies every perm. :view-all implies :view-fleets (stats viewers
  * always get session-detail visibility too).
  */
-async function resolveTrackingPerms(
-	c: Context<App>
-): Promise<{
+async function resolveTrackingPerms(c: Context<App>): Promise<{
 	canCreate: boolean
 	canViewFleets: boolean
 	canViewAll: boolean
@@ -460,9 +427,7 @@ app.post('/tracking', async (c) => {
 	const fleetsStub = getStub<Fleets>(c.env.FLEETS, 'default')
 	const eveCharacterId = createEveCharacterId(characterId)
 
-	let fleetInfo:
-		| Awaited<ReturnType<Fleets['getCharacterFleetInformation']>>
-		| null = null
+	let fleetInfo: Awaited<ReturnType<Fleets['getCharacterFleetInformation']>> | null = null
 	try {
 		fleetInfo = await fleetsStub.getCharacterFleetInformation(eveCharacterId)
 	} catch (error) {
@@ -509,8 +474,8 @@ app.post('/tracking', async (c) => {
 				error.code === 'not_in_fleet' || error.code === 'not_fleet_boss'
 					? 400
 					: error.code === 'character_session_active' || error.code === 'fleet_session_active'
-					? 409
-					: 502
+						? 409
+						: 502
 			if (error.code === 'fleet_session_active') {
 				const existingSession = fleetInfo?.fleet_id
 					? await fleetsStub.getActiveTrackingSessionByFleetId(fleetInfo.fleet_id)
@@ -676,7 +641,10 @@ app.get('/tracking', async (c) => {
 	const characterIds = Array.from(
 		new Set(
 			result.items
-				.flatMap((s) => [s.characterId, s.currentFleetBossCharacterId ?? s.currentCommanderCharacterId])
+				.flatMap((s) => [
+					s.characterId,
+					s.currentFleetBossCharacterId ?? s.currentCommanderCharacterId,
+				])
 				.filter((id): id is string => !!id)
 		)
 	)
@@ -688,14 +656,14 @@ app.get('/tracking', async (c) => {
 			...s,
 			characterName: names[s.characterId] ?? null,
 			currentFleetBossCharacterName: s.currentFleetBossCharacterId
-				? names[s.currentFleetBossCharacterId] ?? null
+				? (names[s.currentFleetBossCharacterId] ?? null)
 				: s.currentCommanderCharacterId
-					? names[s.currentCommanderCharacterId] ?? null
+					? (names[s.currentCommanderCharacterId] ?? null)
 					: null,
 			currentCommanderCharacterName: s.currentFleetBossCharacterId
-				? names[s.currentFleetBossCharacterId] ?? null
+				? (names[s.currentFleetBossCharacterId] ?? null)
 				: s.currentCommanderCharacterId
-					? names[s.currentCommanderCharacterId] ?? null
+					? (names[s.currentCommanderCharacterId] ?? null)
 					: null,
 		})),
 	})
@@ -714,7 +682,11 @@ async function resolveSessionAccess(
 	c: Context<App>,
 	sessionId: string
 ): Promise<
-	| { mode: 'allow'; session: NonNullable<Awaited<ReturnType<Fleets['getTrackingSession']>>>; canViewDetail: boolean }
+	| {
+			mode: 'allow'
+			session: NonNullable<Awaited<ReturnType<Fleets['getTrackingSession']>>>
+			canViewDetail: boolean
+	  }
 	| Response
 > {
 	const user = c.get('user')!
@@ -728,7 +700,11 @@ async function resolveSessionAccess(
 		? session.fleetBossCharacterIds
 		: session.commanderCharacterIds?.length
 			? session.commanderCharacterIds
-			: [session.currentFleetBossCharacterId ?? session.currentCommanderCharacterId ?? session.characterId]
+			: [
+					session.currentFleetBossCharacterId ??
+						session.currentCommanderCharacterId ??
+						session.characterId,
+				]
 	const isBoss =
 		canCreate &&
 		user.characters.some((character) => bossCharacterIds.includes(character.characterId.toString()))
@@ -747,7 +723,9 @@ function isCurrentFleetBossForUser(
 ): boolean {
 	const currentFleetBossCharacterId = session.currentFleetBossCharacterId ?? null
 	if (!currentFleetBossCharacterId) return false
-	return user.characters.some((character) => character.characterId.toString() === currentFleetBossCharacterId)
+	return user.characters.some(
+		(character) => character.characterId.toString() === currentFleetBossCharacterId
+	)
 }
 
 /**
@@ -803,14 +781,14 @@ app.get('/tracking/:sessionId', async (c) => {
 		...result.session,
 		characterName: names[result.session.characterId] ?? null,
 		currentFleetBossCharacterName: result.session.currentFleetBossCharacterId
-			? names[result.session.currentFleetBossCharacterId] ?? null
+			? (names[result.session.currentFleetBossCharacterId] ?? null)
 			: result.session.currentCommanderCharacterId
-				? names[result.session.currentCommanderCharacterId] ?? null
+				? (names[result.session.currentCommanderCharacterId] ?? null)
 				: null,
 		currentCommanderCharacterName: result.session.currentFleetBossCharacterId
-			? names[result.session.currentFleetBossCharacterId] ?? null
+			? (names[result.session.currentFleetBossCharacterId] ?? null)
 			: result.session.currentCommanderCharacterId
-				? names[result.session.currentCommanderCharacterId] ?? null
+				? (names[result.session.currentCommanderCharacterId] ?? null)
 				: null,
 		broadcast,
 	})
@@ -862,7 +840,7 @@ app.get('/tracking/:sessionId/current-members', async (c) => {
 	// Resolve ship type metadata via Universe DO to get type name + groupId.
 	const shipTypeIds = Array.from(new Set(members.map((m) => String(m.shipTypeId))))
 	const universe = getStub<Universe>(c.env.UNIVERSE, 'global')
-	let typeMeta: Record<string, { typeName: string; groupId: string } | null> = {}
+	const typeMeta: Record<string, { typeName: string; groupId: string } | null> = {}
 	try {
 		const raw = await universe.resolveTypeNamesByIds(shipTypeIds)
 		for (const [id, t] of Object.entries(raw)) {
@@ -882,7 +860,7 @@ app.get('/tracking/:sessionId/current-members', async (c) => {
 				.map((t) => t.groupId)
 		)
 	)
-	let groupNames: Record<string, string | null> = {}
+	const groupNames: Record<string, string | null> = {}
 	if (groupIds.length > 0) {
 		try {
 			const raw = await universe.resolveInvGroups(groupIds)
@@ -908,18 +886,14 @@ app.get('/tracking/:sessionId/current-members', async (c) => {
 			systemName: nameMap[String(m.solarSystemId)] ?? null,
 			stationId: m.stationId,
 			groupId,
-			groupName: groupId ? groupNames[groupId] ?? null : null,
+			groupName: groupId ? (groupNames[groupId] ?? null) : null,
 			sinceTime: m.sinceTime,
 		}
 	})
 
 	// Resolve system names for any systems we haven't seen yet.
 	const systemIds = Array.from(
-		new Set(
-			resolvedMembers
-				.filter((m) => !m.systemName)
-				.map((m) => String(m.solarSystemId))
-		)
+		new Set(resolvedMembers.filter((m) => !m.systemName).map((m) => String(m.solarSystemId)))
 	)
 	if (systemIds.length > 0) {
 		const sysNames = await resolveNames(c, systemIds)
@@ -1024,7 +998,7 @@ app.get('/tracking/:sessionId/timeline', async (c) => {
 				row.eventType === 'tracking_resumed' ||
 				row.eventType === 'tracking_ended'
 					? null
-					: row.shipTypeName ?? names[String(row.shipTypeId)] ?? null,
+					: (row.shipTypeName ?? names[String(row.shipTypeId)] ?? null),
 			systemName:
 				row.eventType === 'fleet_boss_change' ||
 				row.eventType === 'fleet_boss_initial' ||
@@ -1032,7 +1006,7 @@ app.get('/tracking/:sessionId/timeline', async (c) => {
 				row.eventType === 'tracking_resumed' ||
 				row.eventType === 'tracking_ended'
 					? null
-					: row.systemName ?? names[String(row.solarSystemId)] ?? null,
+					: (row.systemName ?? names[String(row.solarSystemId)] ?? null),
 			previousShipTypeName:
 				row.eventType === 'fleet_boss_change' ||
 				row.eventType === 'fleet_boss_initial' ||
@@ -1041,10 +1015,10 @@ app.get('/tracking/:sessionId/timeline', async (c) => {
 				row.eventType === 'tracking_ended'
 					? null
 					: row.previousShipTypeId != null
-						? names[String(row.previousShipTypeId)] ?? null
+						? (names[String(row.previousShipTypeId)] ?? null)
 						: null,
 			previousFleetBossCharacterName: row.previousFleetBossCharacterId
-				? names[row.previousFleetBossCharacterId] ?? null
+				? (names[row.previousFleetBossCharacterId] ?? null)
 				: null,
 		})),
 	})
@@ -1074,15 +1048,20 @@ app.get('/tracking/:sessionId/members/:characterId/ship-history', async (c) => {
 		if (row.stationId) ids.push(row.stationId)
 	}
 	const names = await resolveNames(c, ids)
+	const nonShipTypeIds = new Set<number>(FLEET_NON_SHIP_TYPE_IDS)
+	const shipsFlown = new Set(
+		rows.filter((row) => !nonShipTypeIds.has(row.shipTypeId)).map((row) => row.shipTypeId)
+	).size
 
 	return c.json({
 		characterId,
 		characterName: names[characterId] ?? null,
+		shipsFlown,
 		items: rows.map((row) => ({
 			...row,
 			shipTypeName: names[String(row.shipTypeId)] ?? null,
 			systemName: names[String(row.solarSystemId)] ?? null,
-			stationName: row.stationId ? names[String(row.stationId)] ?? null : null,
+			stationName: row.stationId ? (names[String(row.stationId)] ?? null) : null,
 		})),
 	})
 })
@@ -1163,7 +1142,7 @@ app.get('/tracking/:sessionId/commander-history', async (c) => {
 		items: events.map((event) => ({
 			...event,
 			previousCommanderCharacterName: event.previousCommanderCharacterId
-				? names[event.previousCommanderCharacterId] ?? null
+				? (names[event.previousCommanderCharacterId] ?? null)
 				: null,
 			commanderCharacterName: names[event.commanderCharacterId] ?? null,
 		})),
@@ -1175,23 +1154,35 @@ app.get('/tracking/:sessionId/commander-history', async (c) => {
 // ============================================================================
 
 /**
- * 5-minute response cache for stats endpoints.
+ * Short response caches for stats endpoints. Completed historical ranges use a
+ * longer TTL because their underlying rows do not normally change.
  * Key: scope:url. Different cache entries for :create-only vs :view-all viewers
  * because their visible session set differs (overview cares; per-character does
  * not since we already gated access by URL).
  */
 const fleetStatsCache = new TimeCache<unknown>(5 * 60 * 1000)
+const fleetHistoricalStatsCache = new TimeCache<unknown>(30 * 60 * 1000)
+
+function isHistoricalStatsRequest(c: Context<App>): boolean {
+	const to = c.req.query('to')
+	if (!to) return false
+	const timestamp = Date.parse(to)
+	return Number.isFinite(timestamp) && timestamp < Date.now() - 5 * 60 * 1000
+}
 
 /** Parse from/to from URL; default to last 30 days. */
-function parseStatsRange(c: Context<App>): { success: true; data: StatsRange } | { success: false; error: string } {
+function parseStatsRange(
+	c: Context<App>
+): { success: true; data: StatsRange } | { success: false; error: string } {
 	const url = new URL(c.req.url)
 	const now = new Date()
 	const defaultFrom = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
 
 	const fromParam = url.searchParams.get('from')
 	const toParam = url.searchParams.get('to')
+	const allTime = ['1', 'true'].includes(url.searchParams.get('allTime') ?? '')
 
-	const from = fromParam ? new Date(fromParam) : defaultFrom
+	const from = allTime ? new Date(0) : fromParam ? new Date(fromParam) : defaultFrom
 	const to = toParam ? new Date(toParam) : now
 	if (Number.isNaN(from.getTime())) {
 		return { success: false, error: 'Invalid from timestamp' }
@@ -1201,6 +1192,29 @@ function parseStatsRange(c: Context<App>): { success: true; data: StatsRange } |
 	}
 
 	return { success: true, data: { from: from.toISOString(), to: to.toISOString() } }
+}
+
+function parseFleetExportRange(dateFrom: unknown, dateTo: unknown): StatsRange | null {
+	if (typeof dateFrom !== 'string' || typeof dateTo !== 'string') return null
+	const from = new Date(dateFrom)
+	const to = new Date(dateTo)
+	if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from >= to) return null
+	if (to.getTime() - from.getTime() > 366 * 24 * 60 * 60 * 1000) return null
+	return { from: from.toISOString(), to: to.toISOString() }
+}
+
+async function canViewCorporationStats(c: Context<App>, corporationId: string): Promise<boolean> {
+	const { canViewAll } = await resolveTrackingPerms(c)
+	const user = c.get('user')!
+	return canViewAll || (await hasCorporationSelfServiceAccess(c.env, user, corporationId))
+}
+
+function getExecutionContextOrNull(c: { executionCtx?: Pick<ExecutionContext, 'waitUntil'> }) {
+	try {
+		return c.executionCtx ?? null
+	} catch {
+		return null
+	}
 }
 
 /** Cache key derived from the URL and viewer scope. */
@@ -1218,7 +1232,8 @@ async function withStatsCache<T>(
 	loader: () => Promise<T>
 ): Promise<T> {
 	const key = statsCacheKey(c, scope)
-	return (await fleetStatsCache.getOrSet(key, loader)) as T
+	const cache = isHistoricalStatsRequest(c) ? fleetHistoricalStatsCache : fleetStatsCache
+	return (await cache.getOrSet(key, loader)) as T
 }
 
 /**
@@ -1319,8 +1334,7 @@ app.get('/tracking/stats/overview', async (c) => {
 			pilots: r.pilotCount,
 		}))
 
-		const nameFor = (cid: string) =>
-			byCharacter[cid]?.characterName ?? resolverNames[cid] ?? null
+		const nameFor = (cid: string) => byCharacter[cid]?.characterName ?? resolverNames[cid] ?? null
 
 		return {
 			range,
@@ -1406,7 +1420,12 @@ app.get('/tracking/stats/search', async (c) => {
 							isPrimary: schema.userCharacters.is_primary,
 						})
 						.from(schema.userCharacters)
-						.where(inArray(schema.userCharacters.characterId, characters.map((c) => c.characterId)))
+						.where(
+							inArray(
+								schema.userCharacters.characterId,
+								characters.map((c) => c.characterId)
+							)
+						)
 				: []
 
 		const ownershipByCharacterId = new Map(
@@ -1468,11 +1487,22 @@ app.get('/tracking/stats/characters/:characterId', async (c) => {
 	const rangeResult = parseStatsRange(c)
 	if (!rangeResult.success) return c.json({ error: rangeResult.error }, 400)
 	const range = rangeResult.data
+	const pagination = validatePagination(c.req.query('limit'), c.req.query('offset'))
+	if (!pagination.success) {
+		return c.json({ error: pagination.error }, pagination.status)
+	}
+	const sessionPageSize = Math.min(pagination.data.limit, 100)
 	const scope = canViewAll || isAdmin ? 'view-all' : `self:${user.id}`
 	const fleetsStub = getStub<Fleets>(c.env.FLEETS, 'default')
 
 	const data = await withStatsCache(c, scope, async () => {
 		const stats = await fleetsStub.getStatsForCharacter(characterId, range)
+		const sessions = await fleetsStub.getCharacterFleetSessionsPage({
+			characterId,
+			range,
+			limit: sessionPageSize,
+			offset: pagination.data.offset,
+		})
 		const { byCharacter } = await resolveCharacterOwnership(c, [characterId])
 
 		const ids: Array<string | number> = [characterId]
@@ -1486,6 +1516,10 @@ app.get('/tracking/stats/characters/:characterId', async (c) => {
 			corporationId: byCharacter[characterId]?.corporationId ?? null,
 			corporationName: byCharacter[characterId]?.corporationName ?? null,
 			...stats,
+			recentSessions: sessions.items,
+			recentSessionsTotal: sessions.total,
+			recentSessionsLimit: sessionPageSize,
+			recentSessionsOffset: pagination.data.offset,
 			shipsFlown: stats.shipsFlown.map((s) => ({
 				...s,
 				shipTypeName: names[String(s.shipTypeId)] ?? null,
@@ -1512,6 +1546,9 @@ app.get('/tracking/stats/users/:userId', async (c) => {
 	const rangeResult = parseStatsRange(c)
 	if (!rangeResult.success) return c.json({ error: rangeResult.error }, 400)
 	const range = rangeResult.data
+	const pagination = validatePagination(c.req.query('limit'), c.req.query('offset'))
+	if (!pagination.success) return c.json({ error: pagination.error }, pagination.status)
+	const sessionPageSize = Math.min(pagination.data.limit, 100)
 	const scope = canViewAll || isAdmin ? 'view-all' : `self:${user.id}`
 	const fleetsStub = getStub<Fleets>(c.env.FLEETS, 'default')
 
@@ -1544,10 +1581,19 @@ app.get('/tracking/stats/users/:userId', async (c) => {
 				perCharacter: [],
 				shipsFlown: [],
 				recentSessions: [],
+				recentSessionsTotal: 0,
+				recentSessionsLimit: sessionPageSize,
+				recentSessionsOffset: pagination.data.offset,
 			}
 		}
 
 		const perCharStats = await fleetsStub.getStatsForCharacters(characterIds, range)
+		const sessionPage = await fleetsStub.getUserFleetSessionsPage({
+			characterIds,
+			range,
+			limit: sessionPageSize,
+			offset: pagination.data.offset,
+		})
 
 		// Sum totals
 		const totals = {
@@ -1558,7 +1604,6 @@ app.get('/tracking/stats/users/:userId', async (c) => {
 			avgFleetDurationMinutes: null as number | null,
 		}
 		const shipsAcc = new Map<number, { totalMinutes: number }>()
-		const allRecent: Array<{ characterId: string; row: ReturnType<typeof Object>['type'] }> = []
 		const perCharacter: Array<{
 			characterId: string
 			characterName: string
@@ -1590,9 +1635,6 @@ app.get('/tracking/stats/users/:userId', async (c) => {
 					totalMinutes: cur.totalMinutes + s.totalMinutes,
 				})
 			}
-			for (const r of stats.recentSessions) {
-				allRecent.push({ characterId: row.characterId, row: r as any })
-			}
 			perCharacter.push({
 				characterId: row.characterId,
 				characterName: row.characterName,
@@ -1611,17 +1653,11 @@ app.get('/tracking/stats/users/:userId', async (c) => {
 			.sort((a, b) => b.totalMinutes - a.totalMinutes)
 			.slice(0, 25)
 
-		const recentSessions = allRecent
-			.sort(
-				(a, b) =>
-					new Date((b.row as any).startedAt).getTime() -
-					new Date((a.row as any).startedAt).getTime()
-			)
-			.slice(0, 20)
-			.map((x) => ({ ...(x.row as object), characterId: x.characterId }))
-
 		// Resolve ship type names for the aggregated ship list
-		const shipNames = await resolveNames(c, shipsFlown.map((s) => s.shipTypeId))
+		const shipNames = await resolveNames(
+			c,
+			shipsFlown.map((s) => s.shipTypeId)
+		)
 
 		return {
 			range,
@@ -1632,7 +1668,10 @@ app.get('/tracking/stats/users/:userId', async (c) => {
 				...s,
 				shipTypeName: shipNames[String(s.shipTypeId)] ?? null,
 			})),
-			recentSessions,
+			recentSessions: sessionPage.items,
+			recentSessionsTotal: sessionPage.total,
+			recentSessionsLimit: sessionPageSize,
+			recentSessionsOffset: pagination.data.offset,
 		}
 	})
 
@@ -1643,6 +1682,118 @@ app.get('/tracking/stats/users/:userId', async (c) => {
  * GET /fleets/tracking/stats/corporations/:corpId
  * Per-corporation stats (current members). Requires :view-all.
  */
+app.get('/tracking/stats/corporations/:corpId/export-months', async (c) => {
+	const corporationId = c.req.param('corpId')
+	if (!(await canViewCorporationStats(c, corporationId))) {
+		return c.json({ error: 'Not authorized to view this corporation' }, 403)
+	}
+	const fleetsStub = getStub<Fleets>(c.env.FLEETS, 'default')
+	const months = await fleetsStub.getCorporationFleetParticipationMonths(corporationId)
+	return c.json({ months })
+})
+
+app.post('/tracking/stats/corporations/:corpId/export', async (c) => {
+	const corporationId = c.req.param('corpId')
+	if (!(await canViewCorporationStats(c, corporationId))) {
+		return c.json({ error: 'Not authorized to view this corporation' }, 403)
+	}
+	const body = await c.req.json<{ dateFrom?: unknown; dateTo?: unknown }>()
+	const range = parseFleetExportRange(body.dateFrom, body.dateTo)
+	if (!range) return c.json({ error: 'Invalid export date range' }, 400)
+
+	const workflow = await createWorkflow(c.env.EXPORT_WORKFLOW, {
+		params: {
+			kind: 'fleet-corporation-participation',
+			userId: c.get('user')!.id,
+			corporationId,
+			dateFrom: range.from,
+			dateTo: range.to,
+		},
+	})
+	return c.json(
+		{
+			workflowInstanceId: workflow.id,
+			exportId: workflow.id,
+			fileName: buildFleetParticipationExportFileName(corporationId, range.from, range.to),
+			status: 'queued',
+		},
+		202
+	)
+})
+
+async function getFleetExportWorkflowOutput(
+	c: Context<App>,
+	corporationId: string,
+	workflowInstanceId: string
+) {
+	const workflow = await c.env.EXPORT_WORKFLOW.get(workflowInstanceId)
+	const status = await workflow.status()
+	const output = status.output
+	const outputRecord =
+		output && typeof output === 'object' ? (output as Record<string, unknown>) : null
+	if (
+		outputRecord &&
+		(outputRecord.kind !== 'fleet-corporation-participation' ||
+			outputRecord.corporationId !== corporationId)
+	) {
+		return null
+	}
+	const outputStatus =
+		outputRecord && typeof outputRecord.status === 'string' ? outputRecord.status : undefined
+	return {
+		status: normalizeWorkflowStatus(status.status, outputStatus),
+		rawStatus: status.status,
+		output: output ?? null,
+	}
+}
+
+app.get('/tracking/stats/corporations/:corpId/export/:workflowInstanceId', async (c) => {
+	const corporationId = c.req.param('corpId')
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!(await canViewCorporationStats(c, corporationId))) {
+		return c.json({ error: 'Not authorized to view this corporation' }, 403)
+	}
+	if (!workflowInstanceId) return c.json({ error: 'workflowInstanceId is required' }, 400)
+	const workflowStatus = await getFleetExportWorkflowOutput(c, corporationId, workflowInstanceId)
+	if (!workflowStatus) return c.json({ error: 'Export not found' }, 404)
+	return c.json({ workflowInstanceId, ...workflowStatus })
+})
+
+app.get('/tracking/stats/corporations/:corpId/export/:workflowInstanceId/download', async (c) => {
+	const corporationId = c.req.param('corpId')
+	const workflowInstanceId = c.req.param('workflowInstanceId')
+	if (!(await canViewCorporationStats(c, corporationId))) {
+		return c.json({ error: 'Not authorized to view this corporation' }, 403)
+	}
+	if (!workflowInstanceId) return c.json({ error: 'workflowInstanceId is required' }, 400)
+	const workflowStatus = await getFleetExportWorkflowOutput(c, corporationId, workflowInstanceId)
+	if (!workflowStatus) return c.json({ error: 'Export not found' }, 404)
+
+	const bucket = getFleetParticipationExportBucket(c.env)
+	const exportKey = buildFleetParticipationExportKey(workflowInstanceId)
+	const object = await bucket.get(exportKey)
+	if (!object) return c.json({ error: 'Export not found' }, 404)
+	if (isExportArtifactExpired(object.customMetadata?.expiresAt)) {
+		await bucket.delete(exportKey).catch(() => {})
+		return c.json({ error: 'Export expired' }, 404)
+	}
+
+	const fileName = object.customMetadata?.fileName ?? `${workflowInstanceId}.csv`
+	const response = new Response(object.body, {
+		status: 200,
+		headers: {
+			'Content-Type': object.httpMetadata?.contentType ?? 'text/csv; charset=utf-8',
+			'Content-Disposition': `attachment; filename="${fileName}"`,
+			'Cache-Control': 'no-store',
+		},
+	})
+	const executionCtx = getExecutionContextOrNull(c)
+	const cleanup = bucket.delete(exportKey).catch(() => {})
+	if (executionCtx) executionCtx.waitUntil(cleanup)
+	else void cleanup
+	return response
+})
+
 app.get('/tracking/stats/corporations/:corpId', async (c) => {
 	const corpId = c.req.param('corpId')
 	const { canViewAll } = await resolveTrackingPerms(c)
@@ -1650,8 +1801,7 @@ app.get('/tracking/stats/corporations/:corpId', async (c) => {
 	// self-service (CEO/Director of this specific corp). The short-circuit
 	// keeps view-all viewers from paying the extra Durable Object lookups.
 	const user = c.get('user')!
-	const isCorpLeader =
-		canViewAll || (await hasCorporationSelfServiceAccess(c.env, user, corpId))
+	const isCorpLeader = canViewAll || (await hasCorporationSelfServiceAccess(c.env, user, corpId))
 	if (!isCorpLeader) {
 		return c.json({ error: 'Not authorized to view this corporation' }, 403)
 	}
@@ -1744,7 +1894,10 @@ app.get('/tracking/stats/corporations/:corpId', async (c) => {
 			.sort((a, b) => b.totalMinutes - a.totalMinutes)
 			.slice(0, 25)
 
-		const shipNames = await resolveNames(c, shipsFlown.map((s) => s.shipTypeId))
+		const shipNames = await resolveNames(
+			c,
+			shipsFlown.map((s) => s.shipTypeId)
+		)
 		const [corpRow] = await db
 			.select({ name: schema.managedCorporations.name })
 			.from(schema.managedCorporations)

--- a/apps/core/src/test/unit/workflows/csv-export.workflow.test.ts
+++ b/apps/core/src/test/unit/workflows/csv-export.workflow.test.ts
@@ -8,6 +8,7 @@ const getStubMock = vi.fn()
 const moonWriteMock = vi.fn()
 const srpPaidWriteMock = vi.fn()
 const srpWalletWriteMock = vi.fn()
+const fleetWriteMock = vi.fn()
 
 vi.mock('cloudflare:workers', () => {
 	class WorkflowEntrypoint<Env = unknown, Params = unknown> {
@@ -60,14 +61,21 @@ vi.mock('../../../routes/srp', () => ({
 	writeSrpWalletHistoryExportToBucket: (...args: unknown[]) => srpWalletWriteMock(...args),
 }))
 
+vi.mock('../../../lib/fleet-participation-export', () => ({
+	buildFleetParticipationExportFileName: () => 'fleet-participation.csv',
+	writeFleetParticipationExportToBucket: (...args: unknown[]) => fleetWriteMock(...args),
+}))
+
 function createStep() {
-	const doMock = vi.fn(async (_name: string, optionsOrHandler: unknown, maybeHandler?: () => unknown) => {
-		const handler =
-			typeof optionsOrHandler === 'function'
-				? (optionsOrHandler as () => unknown)
-				: (maybeHandler as () => unknown)
-		return await handler()
-	})
+	const doMock = vi.fn(
+		async (_name: string, optionsOrHandler: unknown, maybeHandler?: () => unknown) => {
+			const handler =
+				typeof optionsOrHandler === 'function'
+					? (optionsOrHandler as () => unknown)
+					: (maybeHandler as () => unknown)
+			return await handler()
+		}
+	)
 
 	return {
 		step: { do: doMock } as unknown as WorkflowStep,
@@ -102,23 +110,41 @@ describe('CsvExportWorkflow structure assets debug export', () => {
 		}
 
 		getStubMock.mockImplementation((binding: unknown) => {
-			if (binding && typeof binding === 'object' && 'name' in binding && binding.name === 'EVE_CORPORATION_DATA') {
+			if (
+				binding &&
+				typeof binding === 'object' &&
+				'name' in binding &&
+				binding.name === 'EVE_CORPORATION_DATA'
+			) {
 				return corpData
 			}
-			if (binding && typeof binding === 'object' && 'name' in binding && binding.name === 'UNIVERSE') {
+			if (
+				binding &&
+				typeof binding === 'object' &&
+				'name' in binding &&
+				binding.name === 'UNIVERSE'
+			) {
 				return universe
 			}
-			if (binding && typeof binding === 'object' && 'name' in binding && binding.name === 'STRUCTURE_ASSETS_DEBUG_EXPORTS') {
+			if (
+				binding &&
+				typeof binding === 'object' &&
+				'name' in binding &&
+				binding.name === 'STRUCTURE_ASSETS_DEBUG_EXPORTS'
+			) {
 				return bucket
 			}
 			return {}
 		})
 
-		const workflow = new CsvExportWorkflow({} as ExecutionContext, {
-			EVE_CORPORATION_DATA: { name: 'EVE_CORPORATION_DATA' },
-			UNIVERSE: { name: 'UNIVERSE' },
-			STRUCTURE_ASSETS_DEBUG_EXPORTS: bucket,
-		} as never)
+		const workflow = new CsvExportWorkflow(
+			{} as ExecutionContext,
+			{
+				EVE_CORPORATION_DATA: { name: 'EVE_CORPORATION_DATA' },
+				UNIVERSE: { name: 'UNIVERSE' },
+				STRUCTURE_ASSETS_DEBUG_EXPORTS: bucket,
+			} as never
+		)
 		const { step } = createStep()
 
 		const result = await workflow.run(
@@ -155,7 +181,7 @@ describe('CsvExportWorkflow structure assets debug export', () => {
 		const [exportKey, body, options] = bucketPut.mock.calls[0] as [
 			string,
 			string,
-			{ customMetadata?: { fileName?: string; expiresAt?: string } }
+			{ customMetadata?: { fileName?: string; expiresAt?: string } },
 		]
 		expect(exportKey).toBe('structure-assets-debug/workflow-1.json')
 		expect(options.customMetadata?.fileName).toBe('structure-assets-debug-workflow.json')
@@ -172,5 +198,47 @@ describe('CsvExportWorkflow structure assets debug export', () => {
 			itemCount: 1,
 		})
 		expect(artifact.items[0]?.typeName).toBe('Astrahus')
+	})
+})
+
+describe('CsvExportWorkflow fleet participation export', () => {
+	it('dispatches the bounded fleet export writer and preserves corporation metadata', async () => {
+		fleetWriteMock.mockResolvedValue({
+			rowCount: 12,
+			expiresAt: '2026-07-13T01:00:00.000Z',
+		})
+		const workflow = new CsvExportWorkflow({} as ExecutionContext, {} as never)
+		const { step } = createStep()
+
+		const result = await workflow.run(
+			{
+				payload: {
+					kind: 'fleet-corporation-participation',
+					userId: 'user-1',
+					corporationId: 'corp-1',
+					dateFrom: '2026-07-01T00:00:00.000Z',
+					dateTo: '2026-08-01T00:00:00.000Z',
+				},
+				instanceId: 'workflow-fleet-1',
+				timestamp: new Date('2026-07-13T00:00:00.000Z'),
+			} as never,
+			step
+		)
+
+		expect(result).toMatchObject({
+			status: 'completed',
+			kind: 'fleet-corporation-participation',
+			workflowInstanceId: 'workflow-fleet-1',
+			corporationId: 'corp-1',
+			rowCount: 12,
+		})
+		expect(fleetWriteMock).toHaveBeenCalledWith({
+			env: {},
+			exportId: 'workflow-fleet-1',
+			corporationId: 'corp-1',
+			dateFrom: '2026-07-01T00:00:00.000Z',
+			dateTo: '2026-08-01T00:00:00.000Z',
+			fileName: 'fleet-participation.csv',
+		})
 	})
 })

--- a/apps/core/src/workflows/__tests__/csv-export.workflow.test.ts
+++ b/apps/core/src/workflows/__tests__/csv-export.workflow.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { CsvExportWorkflow } from '../csv-export.workflow'
+
+import type { WorkflowStep } from 'cloudflare:workers'
+
+const writeExportMock = vi.fn()
+
+vi.mock('@repo/do-utils', () => ({ getStub: vi.fn() }))
+
+vi.mock('../../routes/moon-scan', () => ({
+	buildVerifiedMoonsExportFileName: vi.fn(),
+	buildVerifiedMoonsExportKey: vi.fn(),
+	getVerifiedMoonsExportBucket: vi.fn(),
+	buildVerifiedMoonSummaryRecords: vi.fn(),
+	writeVerifiedMoonsExportToBucket: vi.fn(),
+}))
+
+vi.mock('../../routes/srp', () => ({
+	buildSrpPaidRequestsExportFileName: vi.fn(),
+	buildSrpPaidRequestsExportKey: vi.fn(),
+	buildSrpWalletHistoryExportFileName: vi.fn(),
+	buildSrpWalletHistoryExportKey: vi.fn(),
+	getSrpExportBucket: vi.fn(),
+	parseSrpCsvExportDateRange: vi.fn(),
+	writeSrpPaidRequestsExportToBucket: vi.fn(),
+	writeSrpWalletHistoryExportToBucket: vi.fn(),
+}))
+
+vi.mock('../../lib/structure-assets-debug', () => ({
+	buildStructureAssetsDebugExportKey: vi.fn(),
+	buildStructureAssetsDebugFileName: vi.fn(),
+	enrichStructureAssetsDebugTypeNames: vi.fn(),
+	getStructureAssetsDebugBucket: vi.fn(),
+	getStructureAssetLocationLabel: vi.fn(),
+	writeStructureAssetsDebugArtifact: vi.fn(),
+}))
+
+vi.mock('cloudflare:workers', () => ({
+	WorkflowEntrypoint: class {
+		protected readonly env: unknown
+		constructor(_ctx: unknown, env: unknown) {
+			this.env = env
+		}
+	},
+}))
+
+vi.mock('../../lib/fleet-participation-export', () => ({
+	buildFleetParticipationExportFileName: () => 'fleet-participation.csv',
+	writeFleetParticipationExportToBucket: (...args: unknown[]) => writeExportMock(...args),
+}))
+
+function createStep(): WorkflowStep {
+	return {
+		do: vi.fn(async (_name: string, optionsOrHandler: unknown, maybeHandler?: () => unknown) => {
+			const handler =
+				typeof optionsOrHandler === 'function'
+					? optionsOrHandler
+					: maybeHandler
+			if (!handler) throw new Error('missing workflow step handler')
+			return await handler()
+		}),
+	} as unknown as WorkflowStep
+}
+
+describe('CsvExportWorkflow fleet participation export', () => {
+	it('writes a fleet participation artifact through the existing workflow step', async () => {
+		writeExportMock.mockResolvedValue({
+			rowCount: 2,
+			expiresAt: '2026-08-04T01:00:00.000Z',
+		})
+		const workflow = new CsvExportWorkflow({} as ExecutionContext, {} as never)
+
+		const result = await workflow.run(
+			{
+				payload: {
+					kind: 'fleet-corporation-participation',
+					userId: 'user-1',
+					corporationId: 'corp-1',
+					dateFrom: '2026-08-01T00:00:00.000Z',
+					dateTo: '2026-09-01T00:00:00.000Z',
+				},
+				instanceId: 'workflow-1',
+				timestamp: new Date('2026-08-04T00:00:00.000Z'),
+			} as never,
+			createStep()
+		)
+
+		expect(result).toMatchObject({
+			status: 'completed',
+			kind: 'fleet-corporation-participation',
+			corporationId: 'corp-1',
+			rowCount: 2,
+		})
+		expect(writeExportMock).toHaveBeenCalledWith({
+			env: {},
+			exportId: 'workflow-1',
+			corporationId: 'corp-1',
+			dateFrom: '2026-08-01T00:00:00.000Z',
+			dateTo: '2026-09-01T00:00:00.000Z',
+			fileName: 'fleet-participation.csv',
+		})
+	})
+})

--- a/apps/core/src/workflows/csv-export.workflow.ts
+++ b/apps/core/src/workflows/csv-export.workflow.ts
@@ -1,24 +1,26 @@
 import { WorkflowEntrypoint } from 'cloudflare:workers'
 
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
 
 import { getExportArtifactExpiresAtIso } from '../lib/export-retention'
+import {
+	buildFleetParticipationExportFileName,
+	writeFleetParticipationExportToBucket,
+} from '../lib/fleet-participation-export'
 import {
 	buildStructureAssetsDebugExportKey,
 	buildStructureAssetsDebugFileName,
 	enrichStructureAssetsDebugTypeNames,
-	getStructureAssetsDebugBucket,
 	getStructureAssetLocationLabel,
-	type StructureAssetsDebugWorkflowParams,
+	getStructureAssetsDebugBucket,
 	writeStructureAssetsDebugArtifact,
 } from '../lib/structure-assets-debug'
-
 import {
 	buildVerifiedMoonsExportFileName,
 	buildVerifiedMoonsExportKey,
-	getVerifiedMoonsExportBucket,
 	buildVerifiedMoonSummaryRecords,
-	type VerifiedMoonsExportQuery,
+	getVerifiedMoonsExportBucket,
 	writeVerifiedMoonsExportToBucket,
 } from '../routes/moon-scan'
 import {
@@ -37,7 +39,9 @@ import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { MoonScanDO } from '@repo/moon-scan'
 import type { Universe } from '@repo/universe'
 import type { Env } from '../context'
-import { logger } from '@repo/hono-helpers'
+import type { FleetParticipationExportParams } from '../lib/fleet-participation-export'
+import type { StructureAssetsDebugWorkflowParams } from '../lib/structure-assets-debug'
+import type { VerifiedMoonsExportQuery } from '../routes/moon-scan'
 
 export type CsvExportWorkflowParams =
 	| {
@@ -64,6 +68,7 @@ export type CsvExportWorkflowParams =
 			dateTo: string
 	  }
 	| StructureAssetsDebugWorkflowParams
+	| FleetParticipationExportParams
 
 export type CsvExportWorkflowKind = CsvExportWorkflowParams['kind']
 
@@ -81,6 +86,7 @@ export interface CsvExportWorkflowResult {
 		message: string
 		stack?: string
 	}
+	corporationId?: string
 }
 
 function chunkArray<T>(items: readonly T[], size: number): T[][] {
@@ -102,10 +108,7 @@ async function runStructureAssetsDebugExport(
 	const fileName = buildStructureAssetsDebugFileName(workflowInstanceId)
 	const bucket = getStructureAssetsDebugBucket(env)
 
-	const { assetsCount: fetchedAssetCount } = await corpData.fetchAssets(
-		params.corporationId,
-		true
-	)
+	const { assetsCount: fetchedAssetCount } = await corpData.fetchAssets(params.corporationId, true)
 	const rawItems = await corpData.searchAssets(params.corporationId, {
 		locationId: params.structureId,
 		locationType: 'item',
@@ -172,7 +175,9 @@ async function runMoonScanExport(
 			moonScan.getVerifiedMoonSummaryIds(),
 		])
 		const summaryMoonIdSet = new Set(summaryMoonIds)
-		const missingMoonIds = scanSummary.verifiedMoonIds.filter((moonId) => !summaryMoonIdSet.has(moonId))
+		const missingMoonIds = scanSummary.verifiedMoonIds.filter(
+			(moonId) => !summaryMoonIdSet.has(moonId)
+		)
 		if (missingMoonIds.length > 0) {
 			for (const missingMoonIdChunk of chunkArray(missingMoonIds, 250)) {
 				const missingCompositions = await moonScan.getVerifiedCompositions(missingMoonIdChunk)
@@ -271,6 +276,27 @@ async function runSrpWalletHistoryExport(
 	}
 }
 
+async function runFleetParticipationExport(
+	env: Env,
+	workflowInstanceId: string,
+	params: FleetParticipationExportParams
+): Promise<{ fileName: string; expiresAt: string; rowCount: number }> {
+	const fileName = buildFleetParticipationExportFileName(
+		params.corporationId,
+		params.dateFrom,
+		params.dateTo
+	)
+	const result = await writeFleetParticipationExportToBucket({
+		env,
+		exportId: workflowInstanceId,
+		corporationId: params.corporationId,
+		dateFrom: params.dateFrom,
+		dateTo: params.dateTo,
+		fileName,
+	})
+	return { fileName, expiresAt: result.expiresAt, rowCount: result.rowCount }
+}
+
 export class CsvExportWorkflow extends WorkflowEntrypoint<Env, CsvExportWorkflowParams> {
 	async run(
 		event: WorkflowEvent<CsvExportWorkflowParams>,
@@ -299,17 +325,15 @@ export class CsvExportWorkflow extends WorkflowEntrypoint<Env, CsvExportWorkflow
 				async () => {
 					switch (payload.kind) {
 						case 'moon-scan-verified':
-							return await runMoonScanExport(
-								this.env,
-								workflowInstanceId,
-								payload.query
-							)
+							return await runMoonScanExport(this.env, workflowInstanceId, payload.query)
 						case 'srp-paid-requests':
 							return await runSrpPaidRequestsExport(this.env, workflowInstanceId, payload)
 						case 'srp-wallet-history':
 							return await runSrpWalletHistoryExport(this.env, workflowInstanceId, payload)
 						case 'structure-assets-debug':
 							return await runStructureAssetsDebugExport(this.env, workflowInstanceId, payload)
+						case 'fleet-corporation-participation':
+							return await runFleetParticipationExport(this.env, workflowInstanceId, payload)
 					}
 				}
 			)
@@ -322,6 +346,9 @@ export class CsvExportWorkflow extends WorkflowEntrypoint<Env, CsvExportWorkflow
 				fileName: result.fileName,
 				expiresAt: result.expiresAt,
 				rowCount: result.rowCount,
+				...(payload.kind === 'fleet-corporation-participation'
+					? { corporationId: payload.corporationId }
+					: {}),
 			}
 		} catch (error) {
 			return {
@@ -332,6 +359,9 @@ export class CsvExportWorkflow extends WorkflowEntrypoint<Env, CsvExportWorkflow
 				fileName: workflowInstanceId,
 				expiresAt: null,
 				rowCount: 0,
+				...(payload.kind === 'fleet-corporation-participation'
+					? { corporationId: payload.corporationId }
+					: {}),
 				error: {
 					message: error instanceof Error ? error.message : String(error),
 					stack: error instanceof Error ? error.stack : undefined,

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -61,6 +61,10 @@
 		{
 			"binding": "STRUCTURE_ASSETS_DEBUG_EXPORTS",
 			"bucket_name": "structure-assets-debug-exports"
+		},
+		{
+			"binding": "FLEET_EXPORTS",
+			"bucket_name": "fleet-exports"
 		}
 	],
 	"durable_objects": {

--- a/apps/fleets/src/durable-object.ts
+++ b/apps/fleets/src/durable-object.ts
@@ -13,6 +13,7 @@ import {
 	isNull,
 	lt,
 	lte,
+	notInArray,
 	or,
 	sql,
 } from '@repo/db-utils'
@@ -23,6 +24,7 @@ import {
 	esiGetCharacterFleetInformationSchema,
 	esiGetFleetInformationSchema,
 	esiGetFleetMembersSchema,
+	FLEET_NON_SHIP_TYPE_IDS,
 	StartTrackingSessionError,
 } from '@repo/fleets'
 import { logger } from '@repo/hono-helpers'
@@ -45,6 +47,7 @@ import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { EveCharacterId } from '@repo/eve-types'
 import type {
+	CharacterFleetSessionsPage,
 	CharacterRecentSessionRow,
 	CharacterStatsResult,
 	CorpRollupRow,
@@ -56,6 +59,9 @@ import type {
 	FleetJoinResult,
 	FleetMonitor,
 	FleetMonitorState,
+	FleetParticipationExportMonth,
+	FleetParticipationExportPage,
+	FleetParticipationExportPageRequest,
 	Fleets,
 	KickTrackingSessionMemberResult,
 	QuickJoinCreationResult,
@@ -76,11 +82,19 @@ import type {
 	TrackingSession,
 	TrackingSessionListFilter,
 	TrackingSessionListResult,
+	UserFleetSessionsPage,
 } from '@repo/fleets'
 import type { Universe } from '@repo/universe'
 import type { Env } from './context'
 
 const LIVE_FLEET_ESI_OPTIONS = { cacheMode: 'no-store' } as const
+const MAX_FLEET_DURATION_MINUTES = 24 * 60
+const MAX_FLEET_DURATION_MS = MAX_FLEET_DURATION_MINUTES * 60_000
+const FLEET_NON_SHIP_TYPE_IDS_SQL = sql.join(
+	FLEET_NON_SHIP_TYPE_IDS.map((typeId) => sql`${typeId}`),
+	sql`, `
+)
+const FLEET_NON_SHIP_TYPE_ID_SET = new Set<number>(FLEET_NON_SHIP_TYPE_IDS)
 
 /**
  * Fleets Durable Object
@@ -170,9 +184,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 		})
 	}
 
-	private async getMonitorStateForFleet(
-		fleetId: string
-	): Promise<FleetMonitorState | null> {
+	private async getMonitorStateForFleet(fleetId: string): Promise<FleetMonitorState | null> {
 		try {
 			const monitorStub = getStub<FleetMonitor>(this.env.FLEET_MONITOR, `fleet-${fleetId}`)
 			const state = await monitorStub.getMonitorState()
@@ -1618,14 +1630,20 @@ export class FleetsDO extends DurableObject implements Fleets {
 				characterId: fleetTrackingSessions.characterId,
 				startedAt: fleetTrackingSessions.startedAt,
 				endedAt: fleetTrackingSessions.endedAt,
+				summaryEndedAt: fleetSummaries.endedAt,
 			})
 			.from(fleetTrackingSessions)
+			.leftJoin(fleetSummaries, eq(fleetTrackingSessions.id, fleetSummaries.trackingSessionId))
 			.where(
 				and(
 					lt(fleetTrackingSessions.startedAt, to),
 					or(
-						and(eq(fleetTrackingSessions.status, 'active'), isNull(fleetTrackingSessions.endedAt)),
-						and(isNotNull(fleetTrackingSessions.endedAt), gt(fleetTrackingSessions.endedAt, from))
+						and(
+							eq(fleetTrackingSessions.status, 'active'),
+							isNull(fleetTrackingSessions.endedAt),
+							isNull(fleetSummaries.endedAt)
+						),
+						gt(sql`coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt})`, from)
 					)
 				)
 			)
@@ -1737,7 +1755,11 @@ export class FleetsDO extends DurableObject implements Fleets {
 			let currentBossId = session.characterId
 			let cursor = session.startedAt.getTime()
 			const windowStart = from.getTime()
-			const windowEnd = Math.min(session.endedAt?.getTime() ?? to.getTime(), to.getTime())
+			const windowEnd = Math.min(
+				session.summaryEndedAt?.getTime() ?? session.endedAt?.getTime() ?? to.getTime(),
+				to.getTime(),
+				session.startedAt.getTime() + MAX_FLEET_DURATION_MS
+			)
 
 			for (const event of timeline) {
 				const eventTime = Math.max(event.observedAt.getTime(), session.startedAt.getTime())
@@ -1778,7 +1800,10 @@ export class FleetsDO extends DurableObject implements Fleets {
 		return {
 			startedAt: row.startedAt.toISOString(),
 			endedAt: row.endedAt.toISOString(),
-			durationMinutes: row.durationMinutes,
+			durationMinutes:
+				row.durationMinutes == null
+					? null
+					: Math.min(row.durationMinutes, MAX_FLEET_DURATION_MINUTES),
 			peakMemberCount: row.peakMemberCount,
 			finalMemberCount: row.finalMemberCount,
 			motd: row.motd,
@@ -2027,6 +2052,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 				const segDur = segEnd - seg.startedAt.getTime()
 				if (segDur > 0) totalMs += segDur
 			}
+			totalMs = Math.min(totalMs, MAX_FLEET_DURATION_MS)
 
 			// Did the pilot leave before session end?
 			// - If session is active: pilot left iff last segment is closed (endedAt set).
@@ -2054,7 +2080,11 @@ export class FleetsDO extends DurableObject implements Fleets {
 				}
 			}
 
-			const distinctShips = new Set(segments.map((s) => s.shipTypeId)).size
+			const distinctShips = new Set(
+				segments
+					.filter((segment) => !FLEET_NON_SHIP_TYPE_ID_SET.has(segment.shipTypeId))
+					.map((segment) => segment.shipTypeId)
+			).size
 
 			result.push({
 				characterId,
@@ -2195,10 +2225,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 		const sessionTotals = await this.db
 			.select({
 				sessions: sql<number>`count(*)::int`,
-				avgDuration: sql<number | null>`avg(${fleetSummaries.durationMinutes})::float`,
+				avgDuration: sql<
+					number | null
+				>`avg(least(${fleetSummaries.durationMinutes}, ${MAX_FLEET_DURATION_MINUTES}))::float`,
 				avgPeak: sql<number | null>`avg(${fleetSummaries.peakMemberCount})::float`,
 				maxPeak: sql<number | null>`max(${fleetSummaries.peakMemberCount})::int`,
-				totalMinutes: sql<number>`coalesce(sum(${fleetSummaries.durationMinutes}), 0)::int`,
+				totalMinutes: sql<number>`coalesce(sum(least(${fleetSummaries.durationMinutes}, ${MAX_FLEET_DURATION_MINUTES})), 0)::int`,
 			})
 			.from(fleetSummaries)
 			.where(and(gte(fleetSummaries.startedAt, from), lt(fleetSummaries.startedAt, to)))
@@ -2257,15 +2289,36 @@ export class FleetsDO extends DurableObject implements Fleets {
 				minutesInFleet: sql<number>`
 					sum(
 						extract(epoch from
-							least(coalesce(${fleetMemberShipEvents.endedAt}, ${to.toISOString()}::timestamp), ${to.toISOString()}::timestamp)
-							- greatest(${fleetMemberShipEvents.startedAt}, ${from.toISOString()}::timestamp)
+							least(
+								least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${to.toISOString()}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${to.toISOString()}::timestamp),
+									${to.toISOString()}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+								),
+								${to.toISOString()}::timestamp
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${from.toISOString()}::timestamp
+							)
 						) / 60
 					)::int
 				`,
 			})
 			.from(fleetMemberShipEvents)
+			.innerJoin(
+				fleetTrackingSessions,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetTrackingSessions.id)
+			)
+			.leftJoin(
+				fleetSummaries,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetSummaries.trackingSessionId)
+			)
 			.where(
 				and(
+					lt(fleetTrackingSessions.startedAt, to),
+					sql`(coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) IS NULL OR coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) > ${from})`,
 					lt(fleetMemberShipEvents.startedAt, to),
 					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`
 				)
@@ -2273,7 +2326,12 @@ export class FleetsDO extends DurableObject implements Fleets {
 			.groupBy(fleetMemberShipEvents.characterId)
 			.orderBy(
 				desc(
-					sql`sum(extract(epoch from least(coalesce(${fleetMemberShipEvents.endedAt}, ${to.toISOString()}::timestamp), ${to.toISOString()}::timestamp) - greatest(${fleetMemberShipEvents.startedAt}, ${from.toISOString()}::timestamp)))`
+					sql`sum(extract(epoch from least(
+							coalesce(${fleetMemberShipEvents.endedAt}, ${to.toISOString()}::timestamp),
+							coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${to.toISOString()}::timestamp),
+							${to.toISOString()}::timestamp,
+							${fleetTrackingSessions.startedAt} + interval '24 hours'
+						) - greatest(${fleetMemberShipEvents.startedAt}, ${fleetTrackingSessions.startedAt}, ${from.toISOString()}::timestamp)))`
 				)
 			)
 			.limit(10)
@@ -2290,17 +2348,39 @@ export class FleetsDO extends DurableObject implements Fleets {
 				totalMinutes: sql<number>`
 					sum(
 						extract(epoch from
-							least(coalesce(${fleetMemberShipEvents.endedAt}, ${toIsoOverview}::timestamp), ${toIsoOverview}::timestamp)
-							- greatest(${fleetMemberShipEvents.startedAt}, ${fromIsoOverview}::timestamp)
+							least(
+								least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${toIsoOverview}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${toIsoOverview}::timestamp),
+									${toIsoOverview}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+								),
+								${toIsoOverview}::timestamp
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${fromIsoOverview}::timestamp
+							)
 						) / 60
 					)::int
 				`,
 			})
 			.from(fleetMemberShipEvents)
+			.innerJoin(
+				fleetTrackingSessions,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetTrackingSessions.id)
+			)
+			.leftJoin(
+				fleetSummaries,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetSummaries.trackingSessionId)
+			)
 			.where(
 				and(
+					lt(fleetTrackingSessions.startedAt, to),
+					sql`(coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) IS NULL OR coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) > ${from})`,
 					lt(fleetMemberShipEvents.startedAt, to),
-					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`
+					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`,
+					notInArray(fleetMemberShipEvents.shipTypeId, [...FLEET_NON_SHIP_TYPE_IDS])
 				)
 			)
 			.groupBy(fleetMemberShipEvents.shipTypeId)
@@ -2308,8 +2388,19 @@ export class FleetsDO extends DurableObject implements Fleets {
 				desc(sql`
 					sum(
 						extract(epoch from
-							least(coalesce(${fleetMemberShipEvents.endedAt}, ${toIsoOverview}::timestamp), ${toIsoOverview}::timestamp)
-							- greatest(${fleetMemberShipEvents.startedAt}, ${fromIsoOverview}::timestamp)
+							least(
+								least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${toIsoOverview}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${toIsoOverview}::timestamp),
+									${toIsoOverview}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+								),
+								${toIsoOverview}::timestamp
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${fromIsoOverview}::timestamp
+							)
 						)
 					)
 				`)
@@ -2379,6 +2470,190 @@ export class FleetsDO extends DurableObject implements Fleets {
 		)
 	}
 
+	async getCharacterFleetSessionsPage(args: {
+		characterId: string
+		range: StatsRange
+		limit?: number
+		offset?: number
+	}): Promise<CharacterFleetSessionsPage> {
+		const limit = Math.min(Math.max(args.limit ?? 25, 1), 100)
+		const offset = Math.max(args.offset ?? 0, 0)
+		const from = new Date(args.range.from)
+		const to = new Date(args.range.to)
+		if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from >= to) {
+			throw new Error('Invalid character fleet sessions range')
+		}
+
+		const fromIso = from.toISOString()
+		const toIso = to.toISOString()
+		const bossAttributionBySession = await this.getFleetBossAttributionBySession(args.range)
+		const rows = await this.db
+			.select({
+				characterId: fleetMemberShipEvents.characterId,
+				sessionId: fleetMemberShipEvents.trackingSessionId,
+				sessionName: fleetTrackingSessions.name,
+				fleetId: fleetTrackingSessions.fleetId,
+				startedAt: fleetTrackingSessions.startedAt,
+				endedAt: fleetTrackingSessions.endedAt,
+				totalMinutes: sql<number>`
+						least(sum(
+							greatest(0, extract(epoch from
+								least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${toIso}::timestamp),
+									${toIso}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${fromIso}::timestamp
+							)) / 60)
+						), ${MAX_FLEET_DURATION_MINUTES})::int
+				`,
+				shipsFlown: sql<number>`count(distinct case when ${fleetMemberShipEvents.shipTypeId} not in (${FLEET_NON_SHIP_TYPE_IDS_SQL}) then ${fleetMemberShipEvents.shipTypeId} end)::int`,
+				total: sql<number>`count(*) over()::int`,
+			})
+			.from(fleetMemberShipEvents)
+			.innerJoin(
+				fleetTrackingSessions,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetTrackingSessions.id)
+			)
+			.leftJoin(
+				fleetSummaries,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetSummaries.trackingSessionId)
+			)
+			.where(
+				and(
+					eq(fleetMemberShipEvents.characterId, args.characterId),
+					lt(fleetTrackingSessions.startedAt, to),
+					sql`(coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) IS NULL OR coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) > ${from})`,
+					lt(fleetMemberShipEvents.startedAt, to),
+					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`
+				)
+			)
+			.groupBy(
+				fleetMemberShipEvents.characterId,
+				fleetMemberShipEvents.trackingSessionId,
+				fleetTrackingSessions.id,
+				fleetTrackingSessions.name,
+				fleetTrackingSessions.fleetId,
+				fleetTrackingSessions.startedAt,
+				fleetTrackingSessions.endedAt
+			)
+			.orderBy(desc(fleetTrackingSessions.startedAt), desc(fleetTrackingSessions.id))
+			.limit(limit)
+			.offset(offset)
+
+		return {
+			total: rows[0]?.total ?? 0,
+			items: rows.map((row) => ({
+				sessionId: row.sessionId,
+				sessionName: row.sessionName,
+				fleetId: row.fleetId,
+				wasFC:
+					(bossAttributionBySession.get(row.sessionId)?.get(args.characterId)?.minutes ?? 0) > 0,
+				startedAt: row.startedAt.toISOString(),
+				endedAt: row.endedAt ? row.endedAt.toISOString() : null,
+				totalMinutes: row.totalMinutes ?? 0,
+				shipsFlown: row.shipsFlown,
+			})),
+		}
+	}
+
+	async getUserFleetSessionsPage(args: {
+		characterIds: string[]
+		range: StatsRange
+		limit?: number
+		offset?: number
+	}): Promise<UserFleetSessionsPage> {
+		const characterIds = Array.from(new Set(args.characterIds))
+		if (characterIds.length === 0) return { items: [], total: 0 }
+
+		const limit = Math.min(Math.max(args.limit ?? 25, 1), 100)
+		const offset = Math.max(args.offset ?? 0, 0)
+		const from = new Date(args.range.from)
+		const to = new Date(args.range.to)
+		if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from >= to) {
+			throw new Error('Invalid user fleet sessions range')
+		}
+
+		const fromIso = from.toISOString()
+		const toIso = to.toISOString()
+		const bossAttributionBySession = await this.getFleetBossAttributionBySession(args.range)
+		const rows = await this.db
+			.select({
+				characterId: fleetMemberShipEvents.characterId,
+				sessionId: fleetMemberShipEvents.trackingSessionId,
+				sessionName: fleetTrackingSessions.name,
+				fleetId: fleetTrackingSessions.fleetId,
+				startedAt: fleetTrackingSessions.startedAt,
+				endedAt: fleetTrackingSessions.endedAt,
+				totalMinutes: sql<number>`
+					least(sum(
+						greatest(0, extract(epoch from
+							least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${toIso}::timestamp),
+									${toIso}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${fromIso}::timestamp
+						)) / 60)
+					), ${MAX_FLEET_DURATION_MINUTES})::int
+				`,
+				shipsFlown: sql<number>`count(distinct case when ${fleetMemberShipEvents.shipTypeId} not in (${FLEET_NON_SHIP_TYPE_IDS_SQL}) then ${fleetMemberShipEvents.shipTypeId} end)::int`,
+				total: sql<number>`count(*) over()::int`,
+			})
+			.from(fleetMemberShipEvents)
+			.innerJoin(
+				fleetTrackingSessions,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetTrackingSessions.id)
+			)
+			.leftJoin(
+				fleetSummaries,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetSummaries.trackingSessionId)
+			)
+			.where(
+				and(
+					inArray(fleetMemberShipEvents.characterId, characterIds),
+					lt(fleetTrackingSessions.startedAt, to),
+					sql`(coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) IS NULL OR coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) > ${from})`,
+					lt(fleetMemberShipEvents.startedAt, to),
+					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`
+				)
+			)
+			.groupBy(
+				fleetMemberShipEvents.characterId,
+				fleetMemberShipEvents.trackingSessionId,
+				fleetTrackingSessions.id,
+				fleetTrackingSessions.name,
+				fleetTrackingSessions.fleetId,
+				fleetTrackingSessions.startedAt,
+				fleetTrackingSessions.endedAt
+			)
+			.orderBy(desc(fleetTrackingSessions.startedAt), desc(fleetTrackingSessions.id))
+			.limit(limit)
+			.offset(offset)
+
+		return {
+			total: rows[0]?.total ?? 0,
+			items: rows.map((row) => ({
+				characterId: row.characterId,
+				sessionId: row.sessionId,
+				sessionName: row.sessionName,
+				fleetId: row.fleetId,
+				wasFC:
+					(bossAttributionBySession.get(row.sessionId)?.get(row.characterId)?.minutes ?? 0) > 0,
+				startedAt: row.startedAt.toISOString(),
+				endedAt: row.endedAt ? row.endedAt.toISOString() : null,
+				totalMinutes: row.totalMinutes ?? 0,
+				shipsFlown: row.shipsFlown,
+			})),
+		}
+	}
+
 	/**
 	 * Stats for a batch of character IDs within the window.
 	 * Used by user-level and corp-level rollups.
@@ -2412,28 +2687,49 @@ export class FleetsDO extends DurableObject implements Fleets {
 			)
 			.groupBy(fleetMemberHistory.characterId)
 
-		// Minutes-in-fleet per character (clamped to window)
-		const minutesRows = await this.db
-			.select({
-				characterId: fleetMemberShipEvents.characterId,
-				minutes: sql<number>`
-					sum(
-						extract(epoch from
-							least(coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp), ${toIso}::timestamp)
-							- greatest(${fleetMemberShipEvents.startedAt}, ${fromIso}::timestamp)
-						) / 60
-					)::int
-				`,
-			})
-			.from(fleetMemberShipEvents)
-			.where(
-				and(
-					inArray(fleetMemberShipEvents.characterId, characterIds),
-					lt(fleetMemberShipEvents.startedAt, to),
-					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`
-				)
+		// Minutes-in-fleet per character (clamped to the report window and the
+		// owning session). If an individual ship interval was not closed, the
+		// enclosing tracking session's end is the authoritative fallback.
+		const minutesRowsResult = await this.db.execute<{
+			character_id: string
+			minutes: number
+		}>(sql`
+			with per_session as (
+				select
+					se.character_id,
+					se.tracking_session_id,
+						least(sum(greatest(0, extract(epoch from
+							least(
+								coalesce(se.ended_at, ${toIso}::timestamp),
+								coalesce(fs.ended_at, s.ended_at, ${toIso}::timestamp),
+								${toIso}::timestamp,
+								s.started_at + interval '24 hours'
+							) - greatest(
+								se.started_at,
+								s.started_at,
+								${fromIso}::timestamp
+							)) / 60)), ${MAX_FLEET_DURATION_MINUTES})::int as minutes
+				from fleet_member_ship_events se
+				inner join fleet_tracking_sessions s on s.id = se.tracking_session_id
+				left join fleet_summaries fs on fs.tracking_session_id = se.tracking_session_id
+				where se.character_id in (${sql.join(
+					characterIds.map((id) => sql`${id}`),
+					sql`, `
+				)})
+					and s.started_at < ${toIso}::timestamp
+					and coalesce(fs.ended_at, s.ended_at, ${toIso}::timestamp) > ${fromIso}::timestamp
+					and se.started_at < ${toIso}::timestamp
+					and (se.ended_at is null or se.ended_at > ${fromIso}::timestamp)
+				group by se.character_id, se.tracking_session_id
 			)
-			.groupBy(fleetMemberShipEvents.characterId)
+			select character_id, coalesce(sum(minutes), 0)::int as minutes
+			from per_session
+			group by character_id
+		`)
+		const minutesRows = minutesRowsResult.rows.map((row) => ({
+			characterId: row.character_id,
+			minutes: row.minutes,
+		}))
 
 		// Ships flown per character — total time in each ship (clamped to window)
 		const shipRows = await this.db
@@ -2443,18 +2739,40 @@ export class FleetsDO extends DurableObject implements Fleets {
 				totalMinutes: sql<number>`
 					sum(
 						extract(epoch from
-							least(coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp), ${toIso}::timestamp)
-							- greatest(${fleetMemberShipEvents.startedAt}, ${fromIso}::timestamp)
+							least(
+								least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${toIso}::timestamp),
+									${toIso}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+								),
+								${toIso}::timestamp
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${fromIso}::timestamp
+							)
 						) / 60
 					)::int
 				`,
 			})
 			.from(fleetMemberShipEvents)
+			.innerJoin(
+				fleetTrackingSessions,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetTrackingSessions.id)
+			)
+			.leftJoin(
+				fleetSummaries,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetSummaries.trackingSessionId)
+			)
 			.where(
 				and(
 					inArray(fleetMemberShipEvents.characterId, characterIds),
+					lt(fleetTrackingSessions.startedAt, to),
+					sql`(coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) IS NULL OR coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) > ${from})`,
 					lt(fleetMemberShipEvents.startedAt, to),
-					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`
+					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`,
+					notInArray(fleetMemberShipEvents.shipTypeId, [...FLEET_NON_SHIP_TYPE_IDS])
 				)
 			)
 			.groupBy(fleetMemberShipEvents.characterId, fleetMemberShipEvents.shipTypeId)
@@ -2462,8 +2780,19 @@ export class FleetsDO extends DurableObject implements Fleets {
 				desc(sql`
 					sum(
 						extract(epoch from
-							least(coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp), ${toIso}::timestamp)
-							- greatest(${fleetMemberShipEvents.startedAt}, ${fromIso}::timestamp)
+							least(
+								least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${toIso}::timestamp),
+									${toIso}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+								),
+								${toIso}::timestamp
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${fromIso}::timestamp
+							)
 						)
 					)
 				`)
@@ -2480,23 +2809,40 @@ export class FleetsDO extends DurableObject implements Fleets {
 				startedAt: fleetTrackingSessions.startedAt,
 				endedAt: fleetTrackingSessions.endedAt,
 				totalMinutes: sql<number>`
-					sum(
+					least(sum(
 						extract(epoch from
-							least(coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp), ${toIso}::timestamp)
-							- greatest(${fleetMemberShipEvents.startedAt}, ${fromIso}::timestamp)
+							least(
+								least(
+									coalesce(${fleetMemberShipEvents.endedAt}, ${toIso}::timestamp),
+									coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}, ${toIso}::timestamp),
+									${toIso}::timestamp,
+									${fleetTrackingSessions.startedAt} + interval '24 hours'
+								),
+								${toIso}::timestamp
+							) - greatest(
+								${fleetMemberShipEvents.startedAt},
+								${fleetTrackingSessions.startedAt},
+								${fromIso}::timestamp
+							)
 						) / 60
-					)::int
+					), ${MAX_FLEET_DURATION_MINUTES})::int
 				`,
-				shipsFlown: sql<number>`count(distinct ${fleetMemberShipEvents.shipTypeId})::int`,
+				shipsFlown: sql<number>`count(distinct case when ${fleetMemberShipEvents.shipTypeId} not in (${FLEET_NON_SHIP_TYPE_IDS_SQL}) then ${fleetMemberShipEvents.shipTypeId} end)::int`,
 			})
 			.from(fleetMemberShipEvents)
 			.innerJoin(
 				fleetTrackingSessions,
 				eq(fleetMemberShipEvents.trackingSessionId, fleetTrackingSessions.id)
 			)
+			.leftJoin(
+				fleetSummaries,
+				eq(fleetMemberShipEvents.trackingSessionId, fleetSummaries.trackingSessionId)
+			)
 			.where(
 				and(
 					inArray(fleetMemberShipEvents.characterId, characterIds),
+					lt(fleetTrackingSessions.startedAt, to),
+					sql`(coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) IS NULL OR coalesce(${fleetSummaries.endedAt}, ${fleetTrackingSessions.endedAt}) > ${from})`,
 					lt(fleetMemberShipEvents.startedAt, to),
 					sql`(${fleetMemberShipEvents.endedAt} IS NULL OR ${fleetMemberShipEvents.endedAt} > ${from})`
 				)
@@ -2644,6 +2990,177 @@ export class FleetsDO extends DurableObject implements Fleets {
 			)
 
 		return rows.map((r) => r.characterId)
+	}
+
+	async getCorporationFleetParticipationMonths(
+		corporationId: string
+	): Promise<FleetParticipationExportMonth[]> {
+		const result = await this.db.execute<{ month: string }>(sql`
+			select distinct to_char(date_trunc('month', event_timestamp), 'YYYY-MM') as month
+			from fleet_member_history
+			where corporation_id = ${corporationId}
+				and event_type = 'join'
+				and event_timestamp is not null
+			order by month desc
+			limit 12
+		`)
+
+		return result.rows.map((row) => {
+			const from = `${row.month}-01T00:00:00.000Z`
+			const [year, month] = row.month.split('-').map(Number)
+			const to = new Date(Date.UTC(year, month, 1)).toISOString()
+			return { month: row.month, from, to }
+		})
+	}
+
+	async getCorporationFleetParticipationPage(
+		args: FleetParticipationExportPageRequest
+	): Promise<FleetParticipationExportPage> {
+		const limit = Math.min(Math.max(args.limit ?? 500, 1), 1000)
+		const from = new Date(args.from)
+		const to = new Date(args.to)
+		if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from >= to) {
+			throw new Error('Invalid fleet participation export range')
+		}
+
+		type ParticipationCursor = { startedAt: string; sessionId: string; characterId: string }
+		const cursor = (() => {
+			if (!args.cursor) return null
+			try {
+				const decoded = JSON.parse(atob(args.cursor)) as Partial<ParticipationCursor> | null
+				if (
+					decoded &&
+					typeof decoded.startedAt === 'string' &&
+					typeof decoded.sessionId === 'string' &&
+					typeof decoded.characterId === 'string'
+				) {
+					return {
+						startedAt: decoded.startedAt,
+						sessionId: decoded.sessionId,
+						characterId: decoded.characterId,
+					}
+				}
+			} catch {
+				throw new Error('Invalid fleet participation export cursor')
+			}
+			return null
+		})()
+
+		const fromIso = from.toISOString()
+		const toIso = to.toISOString()
+		let cursorPredicate = sql``
+		if (cursor) {
+			const cursorValue = cursor
+			cursorPredicate = sql`and (
+					s.started_at > ${cursorValue.startedAt}::timestamp
+					or (s.started_at = ${cursorValue.startedAt}::timestamp and s.id::text > ${cursorValue.sessionId})
+					or (s.started_at = ${cursorValue.startedAt}::timestamp and s.id::text = ${cursorValue.sessionId}
+						and se.character_id > ${cursorValue.characterId})
+				)`
+		}
+
+		const result = await this.db.execute<{
+			date_stamp: string
+			fleet_character_id: string
+			fleet_character_name: string | null
+			fleet_session_id: string
+			fleet_name: string
+			role: string
+			ship_count: number
+			duration_seconds: number
+		}>(sql`
+			select
+				s.started_at as date_stamp,
+				se.character_id as fleet_character_id,
+				max(mh.character_name) as fleet_character_name,
+				s.id::text as fleet_session_id,
+				s.name as fleet_name,
+				case when se.character_id = s.character_id or exists (
+					select 1
+					from fleet_commander_events ce
+					where ce.tracking_session_id = s.id
+						and ce.commander_character_id = se.character_id
+					and ce.observed_at < ${toIso}::timestamp
+					and ce.observed_at >= ${fromIso}::timestamp
+				) then 'FC'
+				else 'Member' end as role,
+				count(distinct case when se.ship_type_id not in (${FLEET_NON_SHIP_TYPE_IDS_SQL}) then se.ship_type_id end)::int as ship_count,
+				least(
+					coalesce(sum(extract(epoch from (
+						least(
+							coalesce(se.ended_at, ${toIso}::timestamp),
+							coalesce(fs.ended_at, s.ended_at, ${toIso}::timestamp),
+							${toIso}::timestamp,
+							s.started_at + interval '24 hours'
+						) - greatest(se.started_at, s.started_at, ${fromIso}::timestamp)
+					))), 0),
+					${MAX_FLEET_DURATION_MINUTES} * 60
+				)::bigint as duration_seconds
+			from fleet_member_ship_events se
+			inner join fleet_tracking_sessions s on s.id = se.tracking_session_id
+			left join fleet_summaries fs on fs.tracking_session_id = se.tracking_session_id
+			left join lateral (
+				select character_name
+				from fleet_member_history
+				where fleet_id = se.fleet_id
+					and character_id = se.character_id
+					and event_type = 'join'
+					and corporation_id = ${args.corporationId}
+					and event_timestamp >= ${fromIso}::timestamp
+					and event_timestamp < ${toIso}::timestamp
+					and event_timestamp >= s.started_at
+					and event_timestamp < coalesce(fs.ended_at, s.ended_at, ${toIso}::timestamp)
+				order by event_timestamp asc
+				limit 1
+			) mh on true
+			where s.started_at < ${toIso}::timestamp
+				and coalesce(fs.ended_at, s.ended_at, ${toIso}::timestamp) > ${fromIso}::timestamp
+				and se.started_at < ${toIso}::timestamp
+				and (se.ended_at is null or se.ended_at > ${fromIso}::timestamp)
+				and exists (
+					select 1
+					from fleet_member_history eligible
+					where eligible.fleet_id = se.fleet_id
+						and eligible.character_id = se.character_id
+						and eligible.event_type = 'join'
+						and eligible.corporation_id = ${args.corporationId}
+						and eligible.event_timestamp >= ${fromIso}::timestamp
+						and eligible.event_timestamp < ${toIso}::timestamp
+						and eligible.event_timestamp >= s.started_at
+					and eligible.event_timestamp < coalesce(fs.ended_at, s.ended_at, ${toIso}::timestamp)
+				)
+				${cursorPredicate}
+			group by s.id, s.started_at, s.name, se.character_id
+			order by s.started_at asc, s.id asc, se.character_id asc
+			limit ${limit + 1}
+		`)
+
+		const rows = result.rows
+		const hasNext = rows.length > limit
+		const pageRows = hasNext ? rows.slice(0, limit) : rows
+		const last = pageRows.at(-1)
+		return {
+			items: pageRows.map((row) => ({
+				dateStamp: new Date(row.date_stamp).toISOString(),
+				fleetCharacterId: row.fleet_character_id,
+				fleetCharacterName: row.fleet_character_name,
+				fleetSessionId: row.fleet_session_id,
+				fleetName: row.fleet_name,
+				role: row.role,
+				shipCount: Number(row.ship_count),
+				durationSeconds: Number(row.duration_seconds),
+			})),
+			nextCursor:
+				hasNext && last
+					? btoa(
+							JSON.stringify({
+								startedAt: new Date(last.date_stamp).toISOString(),
+								sessionId: last.fleet_session_id,
+								characterId: last.fleet_character_id,
+							})
+						)
+					: null,
+		}
 	}
 
 	/**

--- a/apps/fleets/src/test/integration/api.test.ts
+++ b/apps/fleets/src/test/integration/api.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import worker from '../../index'
+
+import type { Env } from '../../context'
 
 const harness = vi.hoisted(() => ({
 	getStub: vi.fn(() => ({})),
@@ -13,23 +17,32 @@ vi.mock('cloudflare:workers', () => ({
 	},
 }))
 
-vi.mock('@repo/db-utils', () => ({
-	and: vi.fn(() => ({})),
-	asc: vi.fn(() => ({})),
-	desc: vi.fn(() => ({})),
-	eq: vi.fn(() => ({})),
-	gt: vi.fn(() => ({})),
-	gte: vi.fn(() => ({})),
-	inArray: vi.fn(() => ({})),
-	isNull: vi.fn(() => ({})),
-	isNotNull: vi.fn(() => ({})),
-	lt: vi.fn(() => ({})),
-	lte: vi.fn(() => ({})),
-	or: vi.fn(() => ({})),
-	sql: vi.fn(() => ({})),
-	createDbClient: vi.fn(() => ({})),
-	createDbClientWs: vi.fn(() => ({})),
-}))
+vi.mock('@repo/db-utils', () => {
+	const sql = Object.assign(
+		vi.fn(() => ({})),
+		{
+			join: vi.fn(() => ({})),
+		}
+	)
+
+	return {
+		and: vi.fn(() => ({})),
+		asc: vi.fn(() => ({})),
+		desc: vi.fn(() => ({})),
+		eq: vi.fn(() => ({})),
+		gt: vi.fn(() => ({})),
+		gte: vi.fn(() => ({})),
+		inArray: vi.fn(() => ({})),
+		isNull: vi.fn(() => ({})),
+		isNotNull: vi.fn(() => ({})),
+		lt: vi.fn(() => ({})),
+		lte: vi.fn(() => ({})),
+		or: vi.fn(() => ({})),
+		sql,
+		createDbClient: vi.fn(() => ({})),
+		createDbClientWs: vi.fn(() => ({})),
+	}
+})
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: harness.getStub,
@@ -43,20 +56,13 @@ vi.mock('@repo/hono-helpers', () => ({
 		log: vi.fn(),
 		warn: vi.fn(),
 	},
-	withOnError: () => async (_err: Error, ctx: { json: (body: unknown, status: number) => Response }) =>
-		ctx.json({ success: false, error: { message: 'internal server error' } }, 500),
-	withNotFound: () =>
-		async (ctx: { json: (body: unknown, status: number) => Response }) =>
-			ctx.json({ success: false, error: { message: 'not found' } }, 404),
-	withWorkersLogger:
-		() =>
-		async (_ctx: unknown, next: () => Promise<Response>) =>
-			await next(),
+	withOnError:
+		() => async (_err: Error, ctx: { json: (body: unknown, status: number) => Response }) =>
+			ctx.json({ success: false, error: { message: 'internal server error' } }, 500),
+	withNotFound: () => async (ctx: { json: (body: unknown, status: number) => Response }) =>
+		ctx.json({ success: false, error: { message: 'not found' } }, 404),
+	withWorkersLogger: () => async (_ctx: unknown, next: () => Promise<Response>) => await next(),
 }))
-
-import worker from '../../index'
-
-import type { Env } from '../../context'
 
 function createEnv(): Env {
 	return {

--- a/apps/fleets/src/test/unit/lifecycle.test.ts
+++ b/apps/fleets/src/test/unit/lifecycle.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	fleetMemberShipEvents,
+	fleetSummaries,
+	fleetTrackingSessionEvents,
+	fleetTrackingSessions,
+} from '../../db/schema'
+import { FleetsDO } from '../../durable-object'
+import { FleetMonitorDO } from '../../fleet-monitor'
+import { sweepStaleFleetMonitors } from '../../index'
 
 const harness = vi.hoisted(() => ({
 	currentDb: null as unknown,
@@ -21,6 +31,13 @@ vi.mock('cloudflare:workers', () => {
 })
 
 vi.mock('@repo/db-utils', async () => {
+	const sql = Object.assign(
+		vi.fn(() => ({})),
+		{
+			join: vi.fn(() => ({})),
+		}
+	)
+
 	return {
 		and: vi.fn(() => ({})),
 		asc: vi.fn(() => ({})),
@@ -34,7 +51,7 @@ vi.mock('@repo/db-utils', async () => {
 		lt: vi.fn(() => ({})),
 		lte: vi.fn(() => ({})),
 		or: vi.fn(() => ({})),
-		sql: vi.fn(() => ({})),
+		sql,
 		createDbClient: vi.fn(() => harness.currentDb),
 		createDbClientWs: vi.fn(() => harness.currentDb),
 	}
@@ -60,16 +77,6 @@ vi.mock('@repo/hono-helpers', () => ({
 	withWorkersLogger: vi.fn(() => vi.fn((_c: unknown, next: () => Promise<void>) => next())),
 }))
 
-import {
-	fleetMemberShipEvents,
-	fleetSummaries,
-	fleetTrackingSessionEvents,
-	fleetTrackingSessions,
-} from '../../db/schema'
-import { sweepStaleFleetMonitors } from '../../index'
-import { FleetMonitorDO } from '../../fleet-monitor'
-import { FleetsDO } from '../../durable-object'
-
 function getNamespaceKey(namespace: object): string {
 	const existing = harness.namespaceIds.get(namespace)
 	if (existing) return existing
@@ -83,12 +90,14 @@ function registerStub(namespace: object, id: string, stub: unknown): void {
 	harness.stubs.set(`${getNamespaceKey(namespace)}:${id}`, stub)
 }
 
-function createDbMock(options: {
-	selectResults?: unknown[]
-	insertResults?: unknown[]
-	updateResults?: unknown[]
-	deleteResults?: unknown[]
-} = {}) {
+function createDbMock(
+	options: {
+		selectResults?: unknown[]
+		insertResults?: unknown[]
+		updateResults?: unknown[]
+		deleteResults?: unknown[]
+	} = {}
+) {
 	const queues = {
 		select: [...(options.selectResults ?? [])],
 		insert: [...(options.insertResults ?? [])],
@@ -149,8 +158,10 @@ function createDbMock(options: {
 				capture.onConflictDoUpdate = args
 				return Promise.resolve(queue.shift())
 			},
-			then: (onFulfilled: ((value: unknown) => unknown) | null, onRejected: ((reason: unknown) => unknown) | null) =>
-				Promise.resolve(queue.shift()).then(onFulfilled, onRejected),
+			then: (
+				onFulfilled: ((value: unknown) => unknown) | null,
+				onRejected: ((reason: unknown) => unknown) | null
+			) => Promise.resolve(queue.shift()).then(onFulfilled, onRejected),
 		}
 
 		return chain
@@ -247,7 +258,6 @@ describe('fleet lifecycle management', () => {
 			initializeMonitoring: vi.fn().mockResolvedValue(undefined),
 		}
 		registerStub(env.FLEET_MONITOR, 'fleet-123', monitorStub)
-
 		;(fleets as any).env = env
 		;(fleets as any).getCharacterFleetInformation = vi.fn().mockResolvedValue({
 			fleet_id: '123',
@@ -483,7 +493,9 @@ describe('fleet lifecycle management', () => {
 				memberCount: 3,
 				members: [],
 			}),
-			getMonitorState: vi.fn().mockResolvedValue({ peakMemberCount: 8, lastChecked: '2026-07-20T00:00:00.000Z' }),
+			getMonitorState: vi
+				.fn()
+				.mockResolvedValue({ peakMemberCount: 8, lastChecked: '2026-07-20T00:00:00.000Z' }),
 		}
 		registerStub(activeSnapshotEnv.FLEET_MONITOR, 'fleet-123', monitorStub)
 		;(activeSnapshotDo as any).env = activeSnapshotEnv
@@ -506,7 +518,9 @@ describe('fleet lifecycle management', () => {
 		expect(monitorStub.getMonitorState).toHaveBeenCalledTimes(1)
 
 		const endedLocationsDb = createDbMock({
-			selectResults: [[{ fleetId: '123', status: 'ended', endedAt: new Date('2026-07-19T23:59:00.000Z') }]],
+			selectResults: [
+				[{ fleetId: '123', status: 'ended', endedAt: new Date('2026-07-19T23:59:00.000Z') }],
+			],
 		})
 		const endedLocationsDo = createFleetsDo(endedLocationsDb)
 		const endedLocationsEnv = createBaseEnv()
@@ -535,11 +549,13 @@ describe('fleet lifecycle management', () => {
 		const liveSnapshotDo = createFleetsDo(liveSnapshotDb)
 		const liveSnapshotEnv = createBaseEnv()
 		const monitorStub = {
-			getFleetStatus: vi.fn().mockRejectedValue(
-				new Error(
-					'ESI request failed: 404 Not Found - {"error":"The fleet does not exist or you don\'t have access to it!"}'
-				)
-			),
+			getFleetStatus: vi
+				.fn()
+				.mockRejectedValue(
+					new Error(
+						'ESI request failed: 404 Not Found - {"error":"The fleet does not exist or you don\'t have access to it!"}'
+					)
+				),
 			getMonitorState: vi.fn().mockResolvedValue({
 				fleetId: '123',
 				characterId: '42',
@@ -603,10 +619,7 @@ describe('fleet lifecycle management', () => {
 
 	it('finalizes a fleet monitor session once and ignores mismatches', async () => {
 		const db = createDbMock({
-			selectResults: [
-				[],
-				[],
-			],
+			selectResults: [[], []],
 			insertResults: [undefined, undefined],
 			updateResults: [undefined, undefined],
 		})
@@ -661,9 +674,15 @@ describe('fleet lifecycle management', () => {
 			}),
 		])
 
-		expect(db.captures.inserts.filter((entry) => entry.table === fleetTrackingSessionEvents)).toHaveLength(1)
-		expect(db.captures.updates.filter((entry) => entry.table === fleetMemberShipEvents)).toHaveLength(1)
-		expect(db.captures.updates.filter((entry) => entry.table === fleetTrackingSessions)).toHaveLength(1)
+		expect(
+			db.captures.inserts.filter((entry) => entry.table === fleetTrackingSessionEvents)
+		).toHaveLength(1)
+		expect(
+			db.captures.updates.filter((entry) => entry.table === fleetMemberShipEvents)
+		).toHaveLength(1)
+		expect(
+			db.captures.updates.filter((entry) => entry.table === fleetTrackingSessions)
+		).toHaveLength(1)
 		expect(db.captures.inserts.filter((entry) => entry.table === fleetSummaries)).toHaveLength(1)
 	})
 

--- a/apps/ui/src/client/features/fleet-tracking/api.ts
+++ b/apps/ui/src/client/features/fleet-tracking/api.ts
@@ -3,24 +3,27 @@ import { apiClient } from '../../lib/api'
 import type {
 	CharacterStatsResponse,
 	CorporationStatsResponse,
-	ListSessionsFilter,
-	SessionCurrentMembersResponse,
+	FleetParticipationExportMonthsResponse,
+	FleetParticipationExportStartResponse,
+	FleetParticipationExportStatusResponse,
 	KickTrackingMembersResponse,
+	ListSessionsFilter,
+	SessionBroadcastLink,
 	SessionCommanderHistoryResponse,
-	SessionRosterResponse,
+	SessionCurrentMembersResponse,
 	SessionLiveMemberLocation,
+	SessionLiveSnapshotResult,
 	SessionMemberShipHistoryResponse,
+	SessionRosterResponse,
 	SessionSummary,
 	SessionTimelineResult,
 	StartSessionRequest,
 	StatsOverviewResponse,
-	StatsRange,
+	StatsRangeInput,
 	StatsSearchResponse,
 	TrackingSession,
 	TrackingSessionListResult,
 	UserStatsResponse,
-	SessionBroadcastLink,
-	SessionLiveSnapshotResult,
 } from './types'
 
 function buildQuery(params: Record<string, string | number | undefined>): string {
@@ -88,7 +91,7 @@ export const fleetTrackingApi = {
 								typeof resp.broadcast.content?.doctrine === 'string'
 									? resp.broadcast.content.doctrine
 									: null,
-					  }
+						}
 					: null,
 			})),
 
@@ -98,9 +101,7 @@ export const fleetTrackingApi = {
 	getCurrentMembers: (sessionId: string): Promise<SessionCurrentMembersResponse> =>
 		apiClient.get(`/fleets/tracking/${encodeURIComponent(sessionId)}/current-members`),
 
-	getLiveMemberLocations: (
-		sessionId: string
-	): Promise<{ members: SessionLiveMemberLocation[] }> =>
+	getLiveMemberLocations: (sessionId: string): Promise<{ members: SessionLiveMemberLocation[] }> =>
 		apiClient.get(`/fleets/tracking/${encodeURIComponent(sessionId)}/current-members/live`),
 
 	kickMembers: (
@@ -116,7 +117,12 @@ export const fleetTrackingApi = {
 
 	getTimeline: (
 		sessionId: string,
-		opts: { eventType?: 'join' | 'leave' | 'ship_change'; characterId?: string; limit?: number; offset?: number } = {}
+		opts: {
+			eventType?: 'join' | 'leave' | 'ship_change'
+			characterId?: string
+			limit?: number
+			offset?: number
+		} = {}
 	): Promise<SessionTimelineResult> =>
 		apiClient.get(
 			`/fleets/tracking/${encodeURIComponent(sessionId)}/timeline${buildQuery({
@@ -143,38 +149,100 @@ export const fleetTrackingApi = {
 
 	// ===== Stats =====
 
-	getStatsOverview: (range?: Partial<StatsRange>): Promise<StatsOverviewResponse> =>
-		apiClient.get(`/fleets/tracking/stats/overview${buildQuery({ from: range?.from, to: range?.to })}`),
+	getStatsOverview: (range?: StatsRangeInput): Promise<StatsOverviewResponse> =>
+		apiClient.get(
+			`/fleets/tracking/stats/overview${buildQuery({
+				from: range?.from,
+				to: range?.to,
+				allTime: range?.allTime ? 'true' : undefined,
+			})}`
+		),
 
 	getCharacterStats: (
 		characterId: string,
-		range?: Partial<StatsRange>
+		range?: StatsRangeInput,
+		pagination?: { limit?: number; offset?: number }
 	): Promise<CharacterStatsResponse> =>
 		apiClient.get(
 			`/fleets/tracking/stats/characters/${encodeURIComponent(characterId)}${buildQuery({
 				from: range?.from,
 				to: range?.to,
+				allTime: range?.allTime ? 'true' : undefined,
+				limit: pagination?.limit,
+				offset: pagination?.offset,
 			})}`
 		),
 
-	getUserStats: (userId: string, range?: Partial<StatsRange>): Promise<UserStatsResponse> =>
+	getUserStats: (
+		userId: string,
+		range?: StatsRangeInput,
+		pagination?: { limit?: number; offset?: number }
+	): Promise<UserStatsResponse> =>
 		apiClient.get(
 			`/fleets/tracking/stats/users/${encodeURIComponent(userId)}${buildQuery({
 				from: range?.from,
 				to: range?.to,
+				allTime: range?.allTime ? 'true' : undefined,
+				limit: pagination?.limit,
+				offset: pagination?.offset,
 			})}`
 		),
 
 	getCorporationStats: (
 		corporationId: string,
-		range?: Partial<StatsRange>
+		range?: StatsRangeInput
 	): Promise<CorporationStatsResponse> =>
 		apiClient.get(
 			`/fleets/tracking/stats/corporations/${encodeURIComponent(corporationId)}${buildQuery({
 				from: range?.from,
 				to: range?.to,
+				allTime: range?.allTime ? 'true' : undefined,
 			})}`
 		),
+
+	getCorporationParticipationExportMonths: (
+		corporationId: string
+	): Promise<FleetParticipationExportMonthsResponse> =>
+		apiClient.get(
+			`/fleets/tracking/stats/corporations/${encodeURIComponent(corporationId)}/export-months`
+		),
+
+	startCorporationParticipationExport: (
+		corporationId: string,
+		dateFrom: string,
+		dateTo: string
+	): Promise<FleetParticipationExportStartResponse> =>
+		apiClient.post(
+			`/fleets/tracking/stats/corporations/${encodeURIComponent(corporationId)}/export`,
+			{ dateFrom, dateTo }
+		),
+
+	getCorporationParticipationExportStatus: (
+		corporationId: string,
+		workflowInstanceId: string
+	): Promise<FleetParticipationExportStatusResponse> =>
+		apiClient.get(
+			`/fleets/tracking/stats/corporations/${encodeURIComponent(corporationId)}/export/${encodeURIComponent(workflowInstanceId)}`
+		),
+
+	downloadCorporationParticipationExport: async (
+		corporationId: string,
+		workflowInstanceId: string,
+		fileName: string
+	): Promise<void> => {
+		const response = await fetch(
+			`/api/fleets/tracking/stats/corporations/${encodeURIComponent(corporationId)}/export/${encodeURIComponent(workflowInstanceId)}/download`,
+			{ credentials: 'include' }
+		)
+		if (!response.ok) throw new Error('Failed to download fleet participation export')
+		const blob = await response.blob()
+		const url = URL.createObjectURL(blob)
+		const link = document.createElement('a')
+		link.href = url
+		link.download = fileName
+		link.click()
+		URL.revokeObjectURL(url)
+	},
 
 	searchStatsEntities: (query: string): Promise<StatsSearchResponse> =>
 		apiClient.get(`/fleets/tracking/stats/search${buildQuery({ q: query })}`),

--- a/apps/ui/src/client/features/fleet-tracking/components/corporation-participation-export-dialog.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/components/corporation-participation-export-dialog.tsx
@@ -1,0 +1,176 @@
+import { useQuery } from '@tanstack/react-query'
+import { Download, Loader2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
+import { Select } from '@/components/ui/select'
+
+import { fleetTrackingApi } from '../api'
+import { fleetStatsKeys, useCorporationParticipationExportMonths } from '../hooks'
+
+interface CorporationParticipationExportDialogProps {
+	corporationId: string
+	open: boolean
+	onOpenChange: (open: boolean) => void
+}
+
+function monthRange(year: number, monthIndex: number): { from: string; to: string } {
+	return {
+		from: new Date(Date.UTC(year, monthIndex, 1)).toISOString(),
+		to: new Date(Date.UTC(year, monthIndex + 1, 1)).toISOString(),
+	}
+}
+
+export function CorporationParticipationExportDialog({
+	corporationId,
+	open,
+	onOpenChange,
+}: CorporationParticipationExportDialogProps) {
+	const { data: monthData, isLoading: monthsLoading } = useCorporationParticipationExportMonths(
+		corporationId,
+		{ enabled: open }
+	)
+	const [period, setPeriod] = useState('month-to-date')
+	const [pending, setPending] = useState<{ workflowInstanceId: string; fileName: string } | null>(
+		null
+	)
+	const [submitting, setSubmitting] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const months = monthData?.months ?? []
+	const periodOptions = useMemo(
+		() => [
+			{ value: 'month-to-date', label: 'Month to date' },
+			{ value: 'last-month', label: 'Last month' },
+			...months.map((month) => ({
+				value: `month:${month.month}`,
+				label: new Date(`${month.month}-01T00:00:00Z`).toLocaleDateString(undefined, {
+					month: 'long',
+					year: 'numeric',
+				}),
+			})),
+		],
+		[months]
+	)
+
+	const selectedRange = useMemo(() => {
+		const now = new Date()
+		if (period === 'month-to-date') {
+			return monthRange(now.getUTCFullYear(), now.getUTCMonth())
+		}
+		if (period === 'last-month') {
+			return monthRange(now.getUTCFullYear(), now.getUTCMonth() - 1)
+		}
+		if (!period.startsWith('month:')) return null
+		return months.find((month) => `month:${month.month}` === period) ?? null
+	}, [months, period])
+
+	const statusQuery = useQuery({
+		queryKey: fleetStatsKeys.corporationExportStatus(
+			corporationId,
+			pending?.workflowInstanceId ?? ''
+		),
+		queryFn: () =>
+			fleetTrackingApi.getCorporationParticipationExportStatus(
+				corporationId,
+				pending!.workflowInstanceId
+			),
+		enabled: open && Boolean(pending),
+		refetchInterval: (query) =>
+			query.state.data?.status === 'queued' || query.state.data?.status === 'running'
+				? 3000
+				: false,
+		refetchOnWindowFocus: false,
+	})
+
+	useEffect(() => {
+		if (!pending || statusQuery.data?.status !== 'completed') return
+		void fleetTrackingApi
+			.downloadCorporationParticipationExport(
+				corporationId,
+				pending.workflowInstanceId,
+				pending.fileName
+			)
+			.then(() => onOpenChange(false))
+			.catch((downloadError: unknown) => {
+				setError(downloadError instanceof Error ? downloadError.message : 'Download failed')
+			})
+			.finally(() => setPending(null))
+	}, [corporationId, onOpenChange, pending, statusQuery.data?.status])
+
+	useEffect(() => {
+		if (statusQuery.data?.status === 'failed' || statusQuery.data?.status === 'unknown') {
+			setError('The fleet participation export failed.')
+			setPending(null)
+		}
+	}, [statusQuery.data?.status])
+
+	const handleSubmit = async () => {
+		if (!selectedRange || submitting || pending) return
+		setSubmitting(true)
+		setError(null)
+		try {
+			const result = await fleetTrackingApi.startCorporationParticipationExport(
+				corporationId,
+				selectedRange.from,
+				selectedRange.to
+			)
+			setPending({ workflowInstanceId: result.workflowInstanceId, fileName: result.fileName })
+		} catch (submitError: unknown) {
+			setError(submitError instanceof Error ? submitError.message : 'Unable to start export')
+		} finally {
+			setSubmitting(false)
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Export fleet participation</DialogTitle>
+					<DialogDescription>
+						Export one row per corporation member and tracked fleet session for the selected period.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-4">
+					<label className="block text-sm font-medium" htmlFor="fleet-export-period">
+						Period
+					</label>
+					<Select
+						inputId="fleet-export-period"
+						options={periodOptions}
+						value={period}
+						onValueChange={setPeriod}
+						searchable
+						placeholder="Select period"
+						loading={monthsLoading}
+						disabled={Boolean(pending)}
+						className="w-full"
+					/>
+					{pending && <p className="text-sm text-muted-foreground">Preparing your CSV...</p>}
+					{error && <p className="text-sm text-destructive">{error}</p>}
+				</div>
+				<DialogFooter>
+					<Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+						Cancel
+					</Button>
+					<Button
+						onClick={() => void handleSubmit()}
+						disabled={!selectedRange || submitting || Boolean(pending)}
+					>
+						{submitting || pending ? <Loader2 className="animate-spin" /> : <Download />}
+						{pending ? 'Exporting...' : 'Export CSV'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/ui/src/client/features/fleet-tracking/components/stats-range-picker.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/components/stats-range-picker.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router'
 
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-import type { StatsRange } from '../types'
+import type { StatsRangeInput } from '../types'
 
 export type RangePreset = '7d' | '30d' | '90d' | '1y' | 'all'
 
@@ -19,7 +19,10 @@ const PRESETS: Array<{ key: RangePreset; label: string; days: number | null }> =
  * Compute the effective from/to from URL search params.
  * If neither is set, defaults to 30 days back.
  */
-export function useRangeFromSearchParams(): { range: Partial<StatsRange>; activePreset: RangePreset | 'custom' } {
+export function useRangeFromSearchParams(): {
+	range: StatsRangeInput
+	activePreset: RangePreset | 'custom'
+} {
 	const [params] = useSearchParams()
 	const from = params.get('from') ?? undefined
 	const to = params.get('to') ?? undefined
@@ -30,7 +33,7 @@ export function useRangeFromSearchParams(): { range: Partial<StatsRange>; active
 		if (preset) {
 			const p = PRESETS.find((x) => x.key === preset)
 			if (p) {
-				if (p.days === null) return { range: { from: undefined, to: undefined }, activePreset: 'all' }
+				if (p.days === null) return { range: { allTime: true }, activePreset: 'all' }
 				const start = new Date(now.getTime() - p.days * 24 * 60 * 60 * 1000)
 				return {
 					range: { from: start.toISOString(), to: now.toISOString() },

--- a/apps/ui/src/client/features/fleet-tracking/hooks.ts
+++ b/apps/ui/src/client/features/fleet-tracking/hooks.ts
@@ -2,7 +2,7 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tansta
 
 import { fleetTrackingApi } from './api'
 
-import type { ListSessionsFilter, StartSessionRequest, StatsRange } from './types'
+import type { ListSessionsFilter, StartSessionRequest, StatsRangeInput } from './types'
 
 export const fleetTrackingKeys = {
 	all: ['fleet-tracking'] as const,
@@ -11,10 +11,16 @@ export const fleetTrackingKeys = {
 	sessions: () => [...fleetTrackingKeys.all, 'session'] as const,
 	session: (id: string) => [...fleetTrackingKeys.sessions(), id] as const,
 	live: (id: string) => [...fleetTrackingKeys.session(id), 'live'] as const,
-	commanderHistory: (id: string) => [...fleetTrackingKeys.session(id), 'commander-history'] as const,
+	commanderHistory: (id: string) =>
+		[...fleetTrackingKeys.session(id), 'commander-history'] as const,
 	timeline: (
 		id: string,
-		opts: { eventType?: 'join' | 'leave' | 'ship_change'; characterId?: string; limit?: number; offset?: number }
+		opts: {
+			eventType?: 'join' | 'leave' | 'ship_change'
+			characterId?: string
+			limit?: number
+			offset?: number
+		}
 	) => [...fleetTrackingKeys.session(id), 'timeline', opts] as const,
 	shipHistory: (id: string, characterId: string) =>
 		[...fleetTrackingKeys.session(id), 'ship-history', characterId] as const,
@@ -23,10 +29,12 @@ export const fleetTrackingKeys = {
 }
 
 export function useTrackingSessions(filter: ListSessionsFilter = {}) {
+	const isHistorical = isHistoricalRange(filter.to)
 	return useQuery({
 		queryKey: fleetTrackingKeys.list(filter),
 		queryFn: () => fleetTrackingApi.listSessions(filter),
-		staleTime: 5_000,
+		staleTime: isHistorical ? HISTORICAL_STATS_STALE_TIME : 5_000,
+		gcTime: isHistorical ? HISTORICAL_STATS_GC_TIME : RECENT_STATS_GC_TIME,
 		placeholderData: keepPreviousData,
 	})
 }
@@ -155,7 +163,7 @@ export function useStartTracking() {
 	return useMutation({
 		mutationFn: (req: StartSessionRequest) => fleetTrackingApi.startSession(req),
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: fleetTrackingKeys.lists() })
+			void qc.invalidateQueries({ queryKey: fleetTrackingKeys.lists() })
 		},
 	})
 }
@@ -165,8 +173,8 @@ export function useStopTracking() {
 	return useMutation({
 		mutationFn: (sessionId: string) => fleetTrackingApi.stopSession(sessionId),
 		onSuccess: (_data, sessionId) => {
-			qc.invalidateQueries({ queryKey: fleetTrackingKeys.lists() })
-			qc.invalidateQueries({ queryKey: fleetTrackingKeys.session(sessionId) })
+			void qc.invalidateQueries({ queryKey: fleetTrackingKeys.lists() })
+			void qc.invalidateQueries({ queryKey: fleetTrackingKeys.session(sessionId) })
 		},
 	})
 }
@@ -182,11 +190,13 @@ export function useKickTrackingMembers() {
 			memberCharacterIds: string[]
 		}) => fleetTrackingApi.kickMembers(sessionId, memberCharacterIds),
 		onSuccess: (_data, variables) => {
-			qc.invalidateQueries({ queryKey: fleetTrackingKeys.live(variables.sessionId) })
-			qc.invalidateQueries({
+			void qc.invalidateQueries({ queryKey: fleetTrackingKeys.live(variables.sessionId) })
+			void qc.invalidateQueries({
 				queryKey: [...fleetTrackingKeys.session(variables.sessionId), 'current-members'] as const,
 			})
-			qc.invalidateQueries({ queryKey: [...fleetTrackingKeys.session(variables.sessionId), 'timeline'] })
+			void qc.invalidateQueries({
+				queryKey: [...fleetTrackingKeys.session(variables.sessionId), 'timeline'],
+			})
 		},
 	})
 }
@@ -195,57 +205,102 @@ export function useKickTrackingMembers() {
 
 export const fleetStatsKeys = {
 	all: ['fleet-tracking', 'stats'] as const,
-	overview: (range?: Partial<StatsRange>) => [...fleetStatsKeys.all, 'overview', range] as const,
-	character: (characterId: string, range?: Partial<StatsRange>) =>
+	overview: (range?: StatsRangeInput) => [...fleetStatsKeys.all, 'overview', range] as const,
+	character: (characterId: string, range?: StatsRangeInput) =>
 		[...fleetStatsKeys.all, 'character', characterId, range] as const,
-	user: (userId: string, range?: Partial<StatsRange>) =>
+	user: (userId: string, range?: StatsRangeInput) =>
 		[...fleetStatsKeys.all, 'user', userId, range] as const,
-	corporation: (corporationId: string, range?: Partial<StatsRange>) =>
+	corporation: (corporationId: string, range?: StatsRangeInput) =>
 		[...fleetStatsKeys.all, 'corporation', corporationId, range] as const,
+	corporationExportMonths: (corporationId: string) =>
+		[...fleetStatsKeys.all, 'corporation-export-months', corporationId] as const,
+	corporationExportStatus: (corporationId: string, workflowInstanceId: string) =>
+		[
+			...fleetStatsKeys.all,
+			'corporation-export-status',
+			corporationId,
+			workflowInstanceId,
+		] as const,
 }
 
 const STATS_STALE_TIME = 60_000
+const HISTORICAL_STATS_STALE_TIME = 30 * 60_000
+const RECENT_STATS_GC_TIME = 30 * 60_000
+const HISTORICAL_STATS_GC_TIME = 24 * 60 * 60_000
 
-export function useStatsOverview(
-	range?: Partial<StatsRange>,
-	options?: { enabled?: boolean }
-) {
+function isHistoricalRange(to: string | undefined): boolean {
+	if (!to) return false
+	const timestamp = Date.parse(to)
+	return Number.isFinite(timestamp) && timestamp < Date.now() - 5 * 60_000
+}
+
+function getStatsCacheOptions(range?: StatsRangeInput) {
+	const isHistorical = isHistoricalRange(range?.to)
+	return {
+		staleTime: isHistorical ? HISTORICAL_STATS_STALE_TIME : STATS_STALE_TIME,
+		gcTime: isHistorical ? HISTORICAL_STATS_GC_TIME : RECENT_STATS_GC_TIME,
+	}
+}
+
+export function useStatsOverview(range?: StatsRangeInput, options?: { enabled?: boolean }) {
 	return useQuery({
 		queryKey: fleetStatsKeys.overview(range),
 		queryFn: () => fleetTrackingApi.getStatsOverview(range),
-		staleTime: STATS_STALE_TIME,
+		...getStatsCacheOptions(range),
 		enabled: options?.enabled ?? true,
 	})
 }
 
-export function useCharacterStats(characterId: string | undefined, range?: Partial<StatsRange>) {
+export function useCharacterStats(
+	characterId: string | undefined,
+	range?: StatsRangeInput,
+	pagination?: { limit?: number; offset?: number }
+) {
 	return useQuery({
-		queryKey: fleetStatsKeys.character(characterId ?? '', range),
-		queryFn: () => fleetTrackingApi.getCharacterStats(characterId!, range),
+		queryKey: fleetStatsKeys.character(characterId ?? '', { ...range, ...pagination }),
+		queryFn: () => fleetTrackingApi.getCharacterStats(characterId!, range, pagination),
 		enabled: !!characterId,
-		staleTime: STATS_STALE_TIME,
+		...getStatsCacheOptions(range),
+		placeholderData: keepPreviousData,
 	})
 }
 
-export function useUserStats(userId: string | undefined, range?: Partial<StatsRange>) {
+export function useUserStats(
+	userId: string | undefined,
+	range?: StatsRangeInput,
+	pagination?: { limit?: number; offset?: number }
+) {
 	return useQuery({
-		queryKey: fleetStatsKeys.user(userId ?? '', range),
-		queryFn: () => fleetTrackingApi.getUserStats(userId!, range),
+		queryKey: fleetStatsKeys.user(userId ?? '', { ...range, ...pagination }),
+		queryFn: () => fleetTrackingApi.getUserStats(userId!, range, pagination),
 		enabled: !!userId,
-		staleTime: STATS_STALE_TIME,
+		...getStatsCacheOptions(range),
+		placeholderData: keepPreviousData,
 	})
 }
 
 export function useCorporationStats(
 	corporationId: string | undefined,
-	range?: Partial<StatsRange>,
+	range?: StatsRangeInput,
 	options?: { enabled?: boolean }
 ) {
 	return useQuery({
 		queryKey: fleetStatsKeys.corporation(corporationId ?? '', range),
 		queryFn: () => fleetTrackingApi.getCorporationStats(corporationId!, range),
 		enabled: options?.enabled ?? !!corporationId,
-		staleTime: STATS_STALE_TIME,
+		...getStatsCacheOptions(range),
+	})
+}
+
+export function useCorporationParticipationExportMonths(
+	corporationId: string | undefined,
+	options?: { enabled?: boolean }
+) {
+	return useQuery({
+		queryKey: fleetStatsKeys.corporationExportMonths(corporationId ?? ''),
+		queryFn: () => fleetTrackingApi.getCorporationParticipationExportMonths(corporationId!),
+		enabled: options?.enabled ?? !!corporationId,
+		staleTime: 10 * 60_000,
 	})
 }
 
@@ -256,5 +311,6 @@ export function useStatsEntitySearch(query: string) {
 		queryFn: () => fleetTrackingApi.searchStatsEntities(trimmed),
 		enabled: trimmed.length >= 2,
 		staleTime: STATS_STALE_TIME,
+		gcTime: RECENT_STATS_GC_TIME,
 	})
 }

--- a/apps/ui/src/client/features/fleet-tracking/routes/character-stats.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/character-stats.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
@@ -15,10 +16,12 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { corporationLogoUrl } from '@/lib/eve-images'
+
 import { SessionStatsGrid } from '../components/session-stats-grid'
 import { ShipDistributionChart } from '../components/ship-distribution-chart'
 import { StatsRangePicker, useRangeFromSearchParams } from '../components/stats-range-picker'
@@ -34,8 +37,17 @@ export default function CharacterStats() {
 	const canViewAll = isAdmin || hasPermission('urn:fleet-tracking:view-all')
 	const ownsCharacter = !!user?.characters.some((ch) => ch.characterId === characterId)
 	const canView = canViewAll || ownsCharacter
+	const [page, setPage] = useState(1)
+	const [pageSize, setPageSize] = useState(25)
+	useEffect(() => {
+		setPage(1)
+	}, [characterId, range.from, range.to])
 
-	const { data, isLoading } = useCharacterStats(canView ? characterId : undefined, range)
+	const { data, isFetching, isLoading } = useCharacterStats(
+		canView ? characterId : undefined,
+		range,
+		{ limit: pageSize, offset: (page - 1) * pageSize }
+	)
 
 	if (!characterId) return <Navigate to="/fleet-tracking/stats" replace />
 
@@ -141,6 +153,23 @@ export default function CharacterStats() {
 
 					<Card>
 						<CardContent className="p-0">
+							{data.recentSessionsTotal > 0 && (
+								<div className="border-b p-4">
+									<UserSearchPaginationControls
+										totalCount={data.recentSessionsTotal}
+										page={page}
+										pageSize={pageSize}
+										onPageChange={setPage}
+										onPageSizeChange={(nextPageSize) => {
+											setPageSize(nextPageSize)
+											setPage(1)
+										}}
+										pageSizeOptions={[10, 25, 50, 100]}
+										itemLabel="fleet sessions"
+										nextButtonLoading={isFetching}
+									/>
+								</div>
+							)}
 							{data.recentSessions.length === 0 ? (
 								<div className="py-8 text-center text-sm text-muted-foreground">
 									No recent fleets for this character in range.
@@ -159,7 +188,9 @@ export default function CharacterStats() {
 									<TableBody>
 										{data.recentSessions.map((s) => (
 											<TableRow key={s.sessionId}>
-												<TableCell><EveTimeDisplay dateStr={s.startedAt} /></TableCell>
+												<TableCell>
+													<EveTimeDisplay dateStr={s.startedAt} />
+												</TableCell>
 												<TableCell>
 													<Link to={`/fleet-tracking/${s.sessionId}`} className="hover:underline">
 														{s.sessionName}

--- a/apps/ui/src/client/features/fleet-tracking/routes/corporation-stats.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/corporation-stats.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Download } from 'lucide-react'
+import { useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
@@ -8,6 +9,8 @@ import { PageHeader } from '@/components/ui/page-header'
 import { useCorporationAccess } from '@/features/corporations'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
+
+import { CorporationParticipationExportDialog } from '../components/corporation-participation-export-dialog'
 import { RankingList } from '../components/ranking-list'
 import { SessionStatsGrid } from '../components/session-stats-grid'
 import { ShipDistributionChart } from '../components/ship-distribution-chart'
@@ -25,11 +28,14 @@ export default function CorporationStats() {
 		(corp) => corp.corporationId === corpId && corp.isMemberCorporation
 	)
 	const canView = canViewAll || !!memberCorporation
+	const [exportOpen, setExportOpen] = useState(false)
 
 	const { data, isLoading } = useCorporationStats(canView ? corpId : undefined, range, {
 		enabled: canView,
 	})
-	usePageTitle(data?.corporationName ? `${data.corporationName} — Corporation Stats` : 'Corporation Stats')
+	usePageTitle(
+		data?.corporationName ? `${data.corporationName} — Corporation Stats` : 'Corporation Stats'
+	)
 
 	if (!corpId) return <Navigate to="/fleet-tracking/stats" replace />
 
@@ -63,13 +69,24 @@ export default function CorporationStats() {
 			<PageHeader
 				title={data?.corporationName ?? 'Corporation Stats'}
 				action={
-					<Button asChild variant="ghost" size="sm">
-						<Link to="/fleet-tracking/stats">
-							<ArrowLeft className="h-4 w-4" />
-							Stats
-						</Link>
-					</Button>
+					<div className="flex items-center gap-2">
+						<Button size="sm" onClick={() => setExportOpen(true)}>
+							<Download className="h-4 w-4" />
+							Export CSV
+						</Button>
+						<Button asChild variant="ghost" size="sm">
+							<Link to="/fleet-tracking/stats">
+								<ArrowLeft className="h-4 w-4" />
+								Stats
+							</Link>
+						</Button>
+					</div>
 				}
+			/>
+			<CorporationParticipationExportDialog
+				corporationId={corpId}
+				open={exportOpen}
+				onOpenChange={setExportOpen}
 			/>
 			<div className="mb-6 flex items-start justify-end gap-4 flex-wrap">
 				<StatsRangePicker />

--- a/apps/ui/src/client/features/fleet-tracking/routes/member-ship-history.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/member-ship-history.tsx
@@ -7,8 +7,16 @@ import { Container } from '@/components/ui/container'
 import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { LoadingPage } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
 import { usePageTitle } from '@/hooks/usePageTitle'
+
 import { useMemberShipHistory, useTrackingSession } from '../hooks'
 import { formatDurationBetween } from '../utils/format'
 
@@ -49,7 +57,7 @@ export default function MemberShipHistory() {
 				<p className="text-sm pt-2">
 					Time in fleet: <span className="font-medium">{formatDuration(totalMs)}</span>
 					{' • '}
-					Ships flown: <span className="font-medium">{rows.length}</span>
+					Ships flown: <span className="font-medium">{data?.shipsFlown ?? 0}</span>
 				</p>
 			</div>
 
@@ -76,11 +84,11 @@ export default function MemberShipHistory() {
 										<TableCell>{r.shipTypeName ?? `type #${r.shipTypeId}`}</TableCell>
 										<TableCell>
 											{r.systemName ?? `system #${r.solarSystemId}`}
-											{r.stationId
-												? ` / ${r.stationName ?? `station #${r.stationId}`}`
-												: ''}
+											{r.stationId ? ` / ${r.stationName ?? `station #${r.stationId}`}` : ''}
 										</TableCell>
-										<TableCell><EveTimeDisplay dateStr={r.startedAt} /></TableCell>
+										<TableCell>
+											<EveTimeDisplay dateStr={r.startedAt} />
+										</TableCell>
 										<TableCell>
 											{r.endedAt ? <EveTimeDisplay dateStr={r.endedAt} /> : 'current'}
 										</TableCell>
@@ -94,8 +102,8 @@ export default function MemberShipHistory() {
 			</Card>
 
 			<p className="text-xs text-muted-foreground mt-3">
-				Note: location shown is where the pilot was when they boarded each ship. Movement within
-				the same ship is not tracked.
+				Note: location shown is where the pilot was when they boarded each ship. Movement within the
+				same ship is not tracked.
 			</p>
 		</Container>
 	)

--- a/apps/ui/src/client/features/fleet-tracking/routes/user-stats.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/routes/user-stats.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
@@ -15,9 +16,11 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
+
 import { SessionStatsGrid } from '../components/session-stats-grid'
 import { ShipDistributionChart } from '../components/ship-distribution-chart'
 import { StatsRangePicker, useRangeFromSearchParams } from '../components/stats-range-picker'
@@ -33,8 +36,16 @@ export default function UserStats() {
 	const canViewAll = isAdmin || hasPermission('urn:fleet-tracking:view-all')
 	const isSelf = !!user && user.id === userId
 	const canView = canViewAll || isSelf
+	const [page, setPage] = useState(1)
+	const [pageSize, setPageSize] = useState(25)
+	useEffect(() => {
+		setPage(1)
+	}, [userId, range.from, range.to])
 
-	const { data, isLoading } = useUserStats(canView ? userId : undefined, range)
+	const { data, isFetching, isLoading } = useUserStats(canView ? userId : undefined, range, {
+		limit: pageSize,
+		offset: (page - 1) * pageSize,
+	})
 
 	if (!userId) return <Navigate to="/fleet-tracking/stats" replace />
 
@@ -80,7 +91,8 @@ export default function UserStats() {
 			<div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
 				<div>
 					<p className="text-sm text-muted-foreground mt-1">
-						{data?.perCharacter.length ?? 0} character{(data?.perCharacter.length ?? 0) === 1 ? '' : 's'}
+						{data?.perCharacter.length ?? 0} character
+						{(data?.perCharacter.length ?? 0) === 1 ? '' : 's'}
 					</p>
 				</div>
 				<StatsRangePicker />
@@ -95,7 +107,10 @@ export default function UserStats() {
 					<SessionStatsGrid
 						stats={[
 							{ label: 'Fleets joined', value: data.totals.fleetsJoined },
-							{ label: 'Time in fleet', value: formatDuration(data.totals.minutesInFleet * 60_000) },
+							{
+								label: 'Time in fleet',
+								value: formatDuration(data.totals.minutesInFleet * 60_000),
+							},
 							{
 								label: 'FC time',
 								value: formatDuration(data.totals.minutesAsFC * 60_000),
@@ -127,10 +142,15 @@ export default function UserStats() {
 									{data.perCharacter.map((c) => (
 										<TableRow key={c.characterId}>
 											<TableCell>
-												{c.characterName} {c.is_primary && <span className="text-xs text-muted-foreground">(main)</span>}
+												{c.characterName}{' '}
+												{c.is_primary && (
+													<span className="text-xs text-muted-foreground">(main)</span>
+												)}
 											</TableCell>
 											<TableCell>{c.stats.totals.fleetsJoined}</TableCell>
-											<TableCell>{formatDuration(c.stats.totals.minutesInFleet * 60_000)}</TableCell>
+											<TableCell>
+												{formatDuration(c.stats.totals.minutesInFleet * 60_000)}
+											</TableCell>
 											<TableCell>{c.stats.totals.timesFC}</TableCell>
 											<TableCell>
 												<Button asChild variant="ghost" size="sm">
@@ -157,6 +177,23 @@ export default function UserStats() {
 
 					<Card>
 						<CardContent className="p-0">
+							{data.recentSessionsTotal > 0 && (
+								<div className="border-b p-4">
+									<UserSearchPaginationControls
+										totalCount={data.recentSessionsTotal}
+										page={page}
+										pageSize={pageSize}
+										onPageChange={setPage}
+										onPageSizeChange={(nextPageSize) => {
+											setPageSize(nextPageSize)
+											setPage(1)
+										}}
+										pageSizeOptions={[10, 25, 50, 100]}
+										itemLabel="fleet sessions"
+										nextButtonLoading={isFetching}
+									/>
+								</div>
+							)}
 							{data.recentSessions.length === 0 ? (
 								<div className="py-8 text-center text-sm text-muted-foreground">
 									No recent fleets in range.
@@ -175,7 +212,9 @@ export default function UserStats() {
 									<TableBody>
 										{data.recentSessions.map((s) => (
 											<TableRow key={`${s.sessionId}-${s.characterId}`}>
-												<TableCell><EveTimeDisplay dateStr={s.startedAt} /></TableCell>
+												<TableCell>
+													<EveTimeDisplay dateStr={s.startedAt} />
+												</TableCell>
 												<TableCell>
 													<Link
 														to={`/fleet-tracking/stats/characters/${s.characterId}`}

--- a/apps/ui/src/client/features/fleet-tracking/types.ts
+++ b/apps/ui/src/client/features/fleet-tracking/types.ts
@@ -120,6 +120,7 @@ export interface SessionMemberShipHistoryRow {
 export interface SessionMemberShipHistoryResponse {
 	characterId: string
 	characterName: string | null
+	shipsFlown: number
 	items: SessionMemberShipHistoryRow[]
 }
 
@@ -233,6 +234,10 @@ export interface StatsRange {
 	to: string
 }
 
+export type StatsRangeInput = Partial<StatsRange> & {
+	allTime?: boolean
+}
+
 export interface TopCharacterWithMeta {
 	characterId: string
 	count: number
@@ -317,6 +322,9 @@ export interface CharacterStatsResponse {
 	}
 	shipsFlown: CharacterShipBreakdownRow[]
 	recentSessions: CharacterRecentSessionRow[]
+	recentSessionsTotal: number
+	recentSessionsLimit: number
+	recentSessionsOffset: number
 }
 
 export interface UserPerCharacterStats {
@@ -339,6 +347,9 @@ export interface UserStatsResponse {
 	perCharacter: UserPerCharacterStats[]
 	shipsFlown: CharacterShipBreakdownRow[]
 	recentSessions: Array<CharacterRecentSessionRow & { characterId: string }>
+	recentSessionsTotal: number
+	recentSessionsLimit: number
+	recentSessionsOffset: number
 }
 
 export interface StatsSearchResponse {
@@ -367,6 +378,35 @@ export interface CorporationStatsResponse {
 		fleetsJoined: number
 		minutesInFleet: number
 	}>
-	topFCs: Array<{ characterId: string; characterName: string; sessions: number; minutesAsFC?: number }>
+	topFCs: Array<{
+		characterId: string
+		characterName: string
+		sessions: number
+		minutesAsFC?: number
+	}>
 	shipsFlown: CharacterShipBreakdownRow[]
+}
+
+export interface FleetParticipationExportMonth {
+	month: string
+	from: string
+	to: string
+}
+
+export interface FleetParticipationExportMonthsResponse {
+	months: FleetParticipationExportMonth[]
+}
+
+export interface FleetParticipationExportStartResponse {
+	workflowInstanceId: string
+	exportId: string
+	fileName: string
+	status: 'queued'
+}
+
+export interface FleetParticipationExportStatusResponse {
+	workflowInstanceId: string
+	status: 'queued' | 'running' | 'completed' | 'failed' | 'unknown'
+	rawStatus: string
+	output: unknown
 }

--- a/packages/fleets/src/index.ts
+++ b/packages/fleets/src/index.ts
@@ -5,10 +5,8 @@
  * This package allows other workers to interact with the Durable Object via RPC.
  */
 import type { DurableObject } from 'cloudflare:workers'
-
-import { EsiGetCharacterFleetInformation, EsiGetFleetInformation, EsiGetFleetMembers } from './esi'
-
 import type { EveCharacterId } from '@repo/eve-types'
+import type { EsiGetCharacterFleetInformation, EsiGetFleetInformation } from './esi'
 import type { FleetDetailsResponse } from './fleet-monitor'
 
 /**
@@ -163,7 +161,9 @@ export interface Fleets extends DurableObject {
 	 * @param fleetId - ESI fleet ID
 	 * @returns Cache snapshot with notFound markers, or null if not in cache
 	 */
-	getFleetCacheStatus(fleetId: string): Promise<{ notFound: boolean; notFoundAt: Date | null; lastChecked: Date } | null>
+	getFleetCacheStatus(
+		fleetId: string
+	): Promise<{ notFound: boolean; notFoundAt: Date | null; lastChecked: Date } | null>
 
 	/**
 	 * Get fleet registration status (is_registered) with cache-first approach
@@ -303,6 +303,22 @@ export interface Fleets extends DurableObject {
 	/** Aggregate metrics for one character within a time window. */
 	getStatsForCharacter(characterId: string, range: StatsRange): Promise<CharacterStatsResult>
 
+	/** Paginated fleet sessions for one character within a time window. */
+	getCharacterFleetSessionsPage(args: {
+		characterId: string
+		range: StatsRange
+		limit?: number
+		offset?: number
+	}): Promise<CharacterFleetSessionsPage>
+
+	/** Paginated fleet sessions for multiple characters within a time window. */
+	getUserFleetSessionsPage(args: {
+		characterIds: string[]
+		range: StatsRange
+		limit?: number
+		offset?: number
+	}): Promise<UserFleetSessionsPage>
+
 	/**
 	 * Aggregate metrics for a set of character IDs (used for user-level and
 	 * corp-level rollups).
@@ -324,6 +340,16 @@ export interface Fleets extends DurableObject {
 	 * of the given corporation within the window. Powers the corp stats page.
 	 */
 	getCharactersByCorpInWindow(corporationId: string, range: StatsRange): Promise<string[]>
+
+	/** Return calendar months with historical participation for a corporation. */
+	getCorporationFleetParticipationMonths(
+		corporationId: string
+	): Promise<FleetParticipationExportMonth[]>
+
+	/** Return one bounded, keyset-paginated participation export page. */
+	getCorporationFleetParticipationPage(
+		args: FleetParticipationExportPageRequest
+	): Promise<FleetParticipationExportPage>
 
 	/**
 	 * Search characters that have appeared in any tracked fleet by (substring) name.
@@ -358,6 +384,17 @@ export interface CorpRollupRow {
 	corporationId: string
 	pilotCount: number
 }
+
+/**
+ * EVE ship type IDs that represent capsules or shuttles rather than fleet
+ * ships. These are the published types in the SDE's Capsule (29) and Shuttle
+ * (31) groups; they remain part of participation time but are excluded from
+ * ships-flown statistics.
+ */
+export const FLEET_NON_SHIP_TYPE_IDS = [
+	670, 672, 11129, 11132, 11134, 21097, 21628, 27299, 27301, 27303, 27305, 29266, 29328, 29330,
+	29332, 29334, 30842, 33328, 33513, 34496, 64034,
+] as const
 
 // ===== Stats types =====
 
@@ -421,6 +458,20 @@ export interface CharacterRecentSessionRow {
 	shipsFlown: number
 }
 
+export interface CharacterFleetSessionsPage {
+	items: CharacterRecentSessionRow[]
+	total: number
+}
+
+export interface UserFleetSessionRow extends CharacterRecentSessionRow {
+	characterId: string
+}
+
+export interface UserFleetSessionsPage {
+	items: UserFleetSessionRow[]
+	total: number
+}
+
 export interface CharacterStatsResult {
 	totals: {
 		fleetsJoined: number
@@ -432,6 +483,37 @@ export interface CharacterStatsResult {
 	}
 	shipsFlown: CharacterShipBreakdownRow[]
 	recentSessions: CharacterRecentSessionRow[]
+}
+
+export interface FleetParticipationExportMonth {
+	month: string
+	from: string
+	to: string
+}
+
+export interface FleetParticipationExportPageRequest {
+	corporationId: string
+	from: string
+	to: string
+	/** Opaque cursor returned by the previous page. */
+	cursor?: string | null
+	limit?: number
+}
+
+export interface FleetParticipationExportRow {
+	dateStamp: string
+	fleetCharacterId: string
+	fleetCharacterName: string | null
+	fleetSessionId: string
+	fleetName: string
+	role: string
+	shipCount: number
+	durationSeconds: number
+}
+
+export interface FleetParticipationExportPage {
+	items: FleetParticipationExportRow[]
+	nextCursor: string | null
 }
 
 // ===== Read-side response types =====


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a CSV export for corporation fleet participation (one row per member per tracked fleet session) and fixes several inaccuracies in the fleet tracking stats queries around session/duration bounds and ship-type counting.

## Changes
- **Fleet participation export**: new `apps/core/src/lib/fleet-participation-export.ts` streams a paginated CSV (date, user/character identity, session, role, ships flown, duration) to a new `FLEET_EXPORTS` R2 bucket; wired into the existing `CsvExportWorkflow` as a new `fleet-corporation-participation` kind.
- **New routes** on `apps/core/src/routes/fleets.ts`: `GET /tracking/stats/corporations/:corpId/export-months` (available months), `POST .../export` (kicks off the export workflow, validates the date range), `GET .../export/:workflowInstanceId` (status), and `.../download` (streams and deletes the CSV artifact). All gated by the existing corp self-service/view-all permission check.
- **Stats query fixes** in `apps/fleets/src/durable-object.ts`: join against `fleetSummaries` for the true session end time, clamp session/pilot durations to a 24h max (`MAX_FLEET_DURATION_MINUTES`), and exclude non-ship type IDs (`FLEET_NON_SHIP_TYPE_IDS`) from "ships flown" counts across overview, per-character, and per-user aggregates.
- **Paginated recent sessions**: character and user stats endpoints now return a paged `recentSessions` list via new `getCharacterFleetSessionsPage`/`getUserFleetSessionsPage` DO methods instead of an unbounded, in-memory-sorted list.
- **All-time range support**: stats endpoints accept `allTime=true`, mapped to an epoch-start `from` date.
- **Cache tuning**: longer-lived response/query caches (30 min) for stats requests over completed historical ranges vs. the existing 5 min cache for recent/live ranges.
- **Export cleanup cron** now also sweeps the new `FLEET_EXPORTS` bucket alongside the existing structure-assets-debug bucket.
- **UI**: new `CorporationParticipationExportDialog` component and supporting API/hooks/types for kicking off, polling, and downloading the export; `stats-range-picker` and stats hooks updated for the `allTime` option and historical-range cache tuning.
- `wrangler.jsonc` adds the `FLEET_EXPORTS` R2 bucket binding.

## Testing
Added/updated unit and integration tests in `apps/core/src/routes/__tests__/fleets.tracking.route.test.ts` (export-months access control for admin/CEO/plain member, export range validation, paginated character/user session endpoints, all-time range) and `apps/core/src/workflows/__tests__/csv-export.workflow.test.ts` / `apps/core/src/test/unit/workflows/csv-export.workflow.test.ts` (fleet participation export workflow dispatch).
<!-- claude:end -->