### PR TITLE
Fix/fleet export labels

### DIFF
--- a/apps/ui/src/client/features/fleet-tracking/components/corporation-participation-export-dialog.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/components/corporation-participation-export-dialog.tsx
@@ -16,6 +16,8 @@ import { Select } from '@/components/ui/select'
 import { fleetTrackingApi } from '../api'
 import { fleetStatsKeys, useCorporationParticipationExportMonths } from '../hooks'
 
+import type { FleetParticipationExportMonth } from '../types'
+
 interface CorporationParticipationExportDialogProps {
 	corporationId: string
 	open: boolean
@@ -27,6 +29,33 @@ function monthRange(year: number, monthIndex: number): { from: string; to: strin
 		from: new Date(Date.UTC(year, monthIndex, 1)).toISOString(),
 		to: new Date(Date.UTC(year, monthIndex + 1, 1)).toISOString(),
 	}
+}
+
+export function buildParticipationPeriodOptions(
+	months: readonly FleetParticipationExportMonth[],
+	now = new Date()
+): Array<{ value: string; label: string }> {
+	const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`
+	const previousMonthDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+	const previousMonth = `${previousMonthDate.getUTCFullYear()}-${String(
+		previousMonthDate.getUTCMonth() + 1
+	).padStart(2, '0')}`
+	const representedMonths = new Set([currentMonth, previousMonth])
+
+	return [
+		{ value: 'month-to-date', label: 'Month to date' },
+		{ value: 'last-month', label: 'Last month' },
+		...months
+			.filter((month) => !representedMonths.has(month.month))
+			.map((month) => ({
+				value: `month:${month.month}`,
+				label: new Date(`${month.month}-01T00:00:00Z`).toLocaleDateString(undefined, {
+					month: 'long',
+					year: 'numeric',
+					timeZone: 'UTC',
+				}),
+			})),
+	]
 }
 
 export function CorporationParticipationExportDialog({
@@ -46,30 +75,7 @@ export function CorporationParticipationExportDialog({
 	const [error, setError] = useState<string | null>(null)
 
 	const months = monthData?.months ?? []
-	const periodOptions = useMemo(() => {
-		const now = new Date()
-		const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`
-		const previousMonthDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
-		const previousMonth = `${previousMonthDate.getUTCFullYear()}-${String(
-			previousMonthDate.getUTCMonth() + 1
-		).padStart(2, '0')}`
-		const representedMonths = new Set([currentMonth, previousMonth])
-
-		return [
-			{ value: 'month-to-date', label: 'Month to date' },
-			{ value: 'last-month', label: 'Last month' },
-			...months
-				.filter((month) => !representedMonths.has(month.month))
-				.map((month) => ({
-					value: `month:${month.month}`,
-					label: new Date(`${month.month}-01T00:00:00Z`).toLocaleDateString(undefined, {
-						month: 'long',
-						year: 'numeric',
-						timeZone: 'UTC',
-					}),
-				})),
-		]
-	}, [months])
+	const periodOptions = useMemo(() => buildParticipationPeriodOptions(months), [months])
 
 	const selectedRange = useMemo(() => {
 		const now = new Date()

--- a/apps/ui/src/client/features/fleet-tracking/components/corporation-participation-export-dialog.tsx
+++ b/apps/ui/src/client/features/fleet-tracking/components/corporation-participation-export-dialog.tsx
@@ -46,20 +46,30 @@ export function CorporationParticipationExportDialog({
 	const [error, setError] = useState<string | null>(null)
 
 	const months = monthData?.months ?? []
-	const periodOptions = useMemo(
-		() => [
+	const periodOptions = useMemo(() => {
+		const now = new Date()
+		const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`
+		const previousMonthDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+		const previousMonth = `${previousMonthDate.getUTCFullYear()}-${String(
+			previousMonthDate.getUTCMonth() + 1
+		).padStart(2, '0')}`
+		const representedMonths = new Set([currentMonth, previousMonth])
+
+		return [
 			{ value: 'month-to-date', label: 'Month to date' },
 			{ value: 'last-month', label: 'Last month' },
-			...months.map((month) => ({
-				value: `month:${month.month}`,
-				label: new Date(`${month.month}-01T00:00:00Z`).toLocaleDateString(undefined, {
-					month: 'long',
-					year: 'numeric',
-				}),
-			})),
-		],
-		[months]
-	)
+			...months
+				.filter((month) => !representedMonths.has(month.month))
+				.map((month) => ({
+					value: `month:${month.month}`,
+					label: new Date(`${month.month}-01T00:00:00Z`).toLocaleDateString(undefined, {
+						month: 'long',
+						year: 'numeric',
+						timeZone: 'UTC',
+					}),
+				})),
+		]
+	}, [months])
 
 	const selectedRange = useMemo(() => {
 		const now = new Date()

--- a/apps/ui/src/test/unit/features/fleet-tracking/corporation-participation-export-dialog.unit.test.ts
+++ b/apps/ui/src/test/unit/features/fleet-tracking/corporation-participation-export-dialog.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildParticipationPeriodOptions } from '@/features/fleet-tracking/components/corporation-participation-export-dialog'
+
+describe('buildParticipationPeriodOptions', () => {
+	it('keeps current and previous months represented by the preset options', () => {
+		const options = buildParticipationPeriodOptions(
+			[
+				{ month: '2026-08', from: '2026-08-01T00:00:00.000Z', to: '2026-09-01T00:00:00.000Z' },
+				{ month: '2026-07', from: '2026-07-01T00:00:00.000Z', to: '2026-08-01T00:00:00.000Z' },
+				{ month: '2026-06', from: '2026-06-01T00:00:00.000Z', to: '2026-07-01T00:00:00.000Z' },
+				{ month: '2026-05', from: '2026-05-01T00:00:00.000Z', to: '2026-06-01T00:00:00.000Z' },
+			],
+			new Date('2026-08-05T12:00:00.000Z')
+		)
+
+		expect(options.map((option) => option.value)).toEqual([
+			'month-to-date',
+			'last-month',
+			'month:2026-06',
+			'month:2026-05',
+		])
+		expect(options.slice(2).map((option) => option.label)).toEqual(['June 2026', 'May 2026'])
+	})
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the fleet tracking participation export dialog so the month dropdown no longer shows duplicate entries for the current and previous month, and corrects month labels that could be off by one day due to a missing UTC timezone.

## Changes
- Extracted period-option building into a standalone `buildParticipationPeriodOptions` function and filter out any months from `useCorporationParticipationExportMonths` that duplicate the "Month to date" / "Last month" preset options.
- Added `timeZone: 'UTC'` to the `toLocaleDateString` call used to format month labels, preventing the label from shifting to an adjacent month in non-UTC locales.
- Accept an injectable `now` parameter for deterministic testing.

## Testing
- Added a unit test (`corporation-participation-export-dialog.unit.test.ts`) verifying that current/previous months are excluded from the generated list and that remaining month labels render correctly.
<!-- claude:end -->