### PR TITLE
add HR application reply notifications and wider eslint fixes

### DIFF
--- a/apps/core/src/durable-object.ts
+++ b/apps/core/src/durable-object.ts
@@ -3,19 +3,21 @@ import { DurableObject } from 'cloudflare:workers'
 import { CORE_ROLES, SERVICE_CORE } from '@repo/core'
 import { and, asc, eq, inArray, isNull, lt, ne, or, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import {
-	getEsiInstance,
-	getEsiInstanceForCharacter,
-	getEsiInstanceForCorporation,
-} from '@repo/esi'
+import { getEsiInstance, getEsiInstanceForCharacter, getEsiInstanceForCorporation } from '@repo/esi'
 import { logger } from '@repo/hono-helpers'
 
 import { createDb } from './db'
-import { discordServers, managedCorporations, userCharacters, userIpAddresses, users } from './db/schema'
+import {
+	discordServers,
+	managedCorporations,
+	userCharacters,
+	userIpAddresses,
+	users,
+} from './db/schema'
 import {
 	buildImmunitasAccessAlertMessage,
-	IMMUNITAS_ALERT_INITIAL_DELAY_MS,
 	IMMUNITAS_ALERT_COOLDOWN_MS,
+	IMMUNITAS_ALERT_INITIAL_DELAY_MS,
 	IMMUNITAS_ALERT_RETRY_MS,
 	IMMUNITAS_ALERT_TTL_MS,
 	shouldRetryImmunitasAccessAlertDelivery,
@@ -23,14 +25,12 @@ import {
 import { recordUserIpAddress } from './lib/ip-tracking'
 import {
 	buildTokenInvalidationMessage,
+	shouldRetryTokenInvalidationAlertDelivery,
 	TOKEN_INVALID_ALERT_COOLDOWN_MS,
 	TOKEN_INVALID_ALERT_RETRY_MS,
 	TOKEN_INVALID_ALERT_TTL_MS,
-	shouldRetryTokenInvalidationAlertDelivery,
 } from './lib/token-invalid-alerts'
-import {
-	validateAndSyncCharacterTokenValidityBatchTransitions,
-} from './lib/token-validity'
+import { validateAndSyncCharacterTokenValidityBatchTransitions } from './lib/token-validity'
 import { triggerDiscordRefreshWorkflow, triggerUserRefreshWorkflow } from './lib/workflow-triggers'
 import { processExpiredTempops } from './services/mumble-tempop.service'
 import { updateCharacterPublicInfo } from './workflows/steps/update-character'
@@ -209,7 +209,7 @@ export class CoreDO extends DurableObject<Env> implements Core {
 								requestorLabels: value.pendingRequestorLabels ?? [],
 								attemptCount: value.attemptCount ?? 0,
 							},
-					  ]
+						]
 					: [])
 			const queueKey = key.slice(CoreDO.IMMUNITAS_ALERT_STORAGE_PREFIX.length)
 			this.pendingImmunitasAccessAlerts.set(queueKey, {
@@ -374,10 +374,7 @@ export class CoreDO extends DurableObject<Env> implements Core {
 		return characters.map((character) => character.characterId)
 	}
 
-	async listUsersWithActiveCharactersPage(input: {
-		limit: number
-		offset: number
-	}): Promise<{
+	async listUsersWithActiveCharactersPage(input: { limit: number; offset: number }): Promise<{
 		users: Array<{ userId: string; characterIds: string[] }>
 		totalCount: number
 	}> {
@@ -416,7 +413,10 @@ export class CoreDO extends DurableObject<Env> implements Core {
 				userId: true,
 				characterId: true,
 			},
-			orderBy: (table, operators) => [operators.asc(table.userId), operators.asc(table.characterId)],
+			orderBy: (table, operators) => [
+				operators.asc(table.userId),
+				operators.asc(table.characterId),
+			],
 		})
 
 		const characterIdsByUserId = new Map<string, string[]>()
@@ -454,7 +454,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 			},
 		})
 
-		const dueCharacterIndex = new Map(dueCharacterIds.map((characterId, index) => [characterId, index]))
+		const dueCharacterIndex = new Map(
+			dueCharacterIds.map((characterId, index) => [characterId, index])
+		)
 		const userOrder = new Map<string, number>()
 		const dueUserIds = new Set<string>()
 
@@ -468,7 +470,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 		}
 
 		const ownedCharacterIdSet = new Set(dueCharacterOwners.map((row) => row.characterId))
-		const unownedCharacterIds = dueCharacterIds.filter((characterId) => !ownedCharacterIdSet.has(characterId))
+		const unownedCharacterIds = dueCharacterIds.filter(
+			(characterId) => !ownedCharacterIdSet.has(characterId)
+		)
 
 		if (dueUserIds.size === 0) {
 			return { userBatches: [], unownedCharacterIds }
@@ -548,7 +552,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 			refreshSucceeded: boolean
 		}>
 	> {
-		const normalizedCharacterIds = [...new Set(input.characterIds.map((id) => String(id).trim()))].filter(Boolean)
+		const normalizedCharacterIds = [
+			...new Set(input.characterIds.map((id) => String(id).trim())),
+		].filter(Boolean)
 		if (normalizedCharacterIds.length === 0) {
 			return []
 		}
@@ -723,7 +729,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 			})
 		)
 
-		const corporationIds = [...new Set(Array.from(characterInfoMap.values()).map((info) => info.corporation_id))]
+		const corporationIds = [
+			...new Set(Array.from(characterInfoMap.values()).map((info) => info.corporation_id)),
+		]
 		const corporationNames = new Map<string, string>()
 		await Promise.all(
 			corporationIds.map(async (corporationId) => {
@@ -1114,9 +1122,7 @@ export class CoreDO extends DurableObject<Env> implements Core {
 				? legacyActorCharacterNames[note.legacyCreatedByUserId]
 				: undefined
 			const authorCharacterName =
-				attributedPrimary?.characterName ??
-				legacyAuthorCharacterName ??
-				importerCharacterName
+				attributedPrimary?.characterName ?? legacyAuthorCharacterName ?? importerCharacterName
 
 			try {
 				await hrStub.createNote(
@@ -1344,7 +1350,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 
 		return baseRows.map((row) => ({
 			...row,
-			corporationName: row.corporationId ? (resolvedNames[row.corporationId] ?? row.corporationName) : null,
+			corporationName: row.corporationId
+				? (resolvedNames[row.corporationId] ?? row.corporationName)
+				: null,
 			allianceName: row.allianceId ? (resolvedNames[row.allianceId] ?? row.allianceName) : null,
 			isDeleted:
 				row.isDeleted ||
@@ -1463,15 +1471,6 @@ export class CoreDO extends DurableObject<Env> implements Core {
 				: 'legacy'
 			return { sources, preferredSource }
 		}
-		const buildMatchSet = (rows: Array<{ targetType: string; targetValue: string }>): Set<string> =>
-			new Set(
-				rows.map((row) => {
-					const normalizedValue =
-						row.targetType === 'character_name' ? row.targetValue.toLowerCase() : row.targetValue
-					return `${row.targetType}:${normalizedValue}`
-				})
-			)
-
 		const uniqueCharacterPairs = [
 			...new Map(
 				input.characterPairs
@@ -1985,7 +1984,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 			return []
 		}
 
-		const normalized = [...new Set(characterIds.map((characterId) => String(characterId).trim()))].filter(Boolean)
+		const normalized = [
+			...new Set(characterIds.map((characterId) => String(characterId).trim())),
+		].filter(Boolean)
 		if (normalized.length === 0) {
 			return []
 		}
@@ -2074,9 +2075,7 @@ export class CoreDO extends DurableObject<Env> implements Core {
 		const skipped = normalizedCharacterIds.length - added
 
 		const nextEligibleAt =
-			existing?.nextEligibleAt && existing.nextEligibleAt > now
-				? existing.nextEligibleAt
-				: now
+			existing?.nextEligibleAt && existing.nextEligibleAt > now ? existing.nextEligibleAt : now
 
 		this.pendingTokenInvalidationAlerts.set(input.userId, {
 			expiresAt,
@@ -2130,7 +2129,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 				group.requestorUserId,
 				{
 					requestorUserId: group.requestorUserId,
-					requestorLabels: new Set(group.requestorLabels.map((label) => String(label).trim()).filter(Boolean)),
+					requestorLabels: new Set(
+						group.requestorLabels.map((label) => String(label).trim()).filter(Boolean)
+					),
 					attemptCount: group.attemptCount ?? 0,
 				},
 			])
@@ -2150,8 +2151,10 @@ export class CoreDO extends DurableObject<Env> implements Core {
 		existingRequestorGroup.attemptCount += 1
 		pendingRequestorGroupsByUserId.set(input.requestorUserId, existingRequestorGroup)
 		const added =
-			pendingTargetCharacterLabels.size - beforeTargetSize +
-			existingRequestorGroup.requestorLabels.size - beforeRequestorSize
+			pendingTargetCharacterLabels.size -
+			beforeTargetSize +
+			existingRequestorGroup.requestorLabels.size -
+			beforeRequestorSize
 		const skipped = Math.max(0, 2 - added)
 		const nextEligibleAt = hasPendingEntry
 			? existing!.nextEligibleAt
@@ -2198,9 +2201,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 		}
 	}
 
-	private buildPendingTokenInvalidationMessage(characterNames: string[]): ReturnType<
-		typeof buildTokenInvalidationMessage
-	> {
+	private buildPendingTokenInvalidationMessage(
+		characterNames: string[]
+	): ReturnType<typeof buildTokenInvalidationMessage> {
 		return buildTokenInvalidationMessage({
 			characterNames,
 			invalidCharacterCount: characterNames.length,
@@ -2523,7 +2526,9 @@ export class CoreDO extends DurableObject<Env> implements Core {
 		}
 
 		const dueEntries = [...this.pendingImmunitasAccessAlerts.entries()]
-			.filter(([, entry]) => entry.pendingTargetCharacterLabels.length > 0 && entry.nextEligibleAt <= now)
+			.filter(
+				([, entry]) => entry.pendingTargetCharacterLabels.length > 0 && entry.nextEligibleAt <= now
+			)
 			.sort((a, b) => a[1].nextEligibleAt - b[1].nextEligibleAt)
 			.slice(0, 20)
 
@@ -2603,12 +2608,15 @@ export class CoreDO extends DurableObject<Env> implements Core {
 						result.error ?? 'fatal Discord delivery failure'
 					)
 					failed++
-					this.logger.warn('[CoreDO] Dropped immunitas access alert due to fatal Discord delivery failure', {
-						queueKey,
-						targetUserId: entry.targetUserId,
-						accessType: entry.accessType,
-						error: result.error ?? 'Unknown Discord delivery error',
-					})
+					this.logger.warn(
+						'[CoreDO] Dropped immunitas access alert due to fatal Discord delivery failure',
+						{
+							queueKey,
+							targetUserId: entry.targetUserId,
+							accessType: entry.accessType,
+							error: result.error ?? 'Unknown Discord delivery error',
+						}
+					)
 					continue
 				}
 
@@ -2797,10 +2805,13 @@ export class CoreDO extends DurableObject<Env> implements Core {
 						result.error ?? 'fatal Discord delivery failure'
 					)
 					failed++
-					this.logger.warn('[CoreDO] Dropped token invalidation alert due to fatal Discord delivery failure', {
-						userId,
-						error: result.error ?? 'Unknown Discord delivery error',
-					})
+					this.logger.warn(
+						'[CoreDO] Dropped token invalidation alert due to fatal Discord delivery failure',
+						{
+							userId,
+							error: result.error ?? 'Unknown Discord delivery error',
+						}
+					)
 					continue
 				}
 

--- a/apps/core/src/lib/__tests__/corporation-alerts.test.ts
+++ b/apps/core/src/lib/__tests__/corporation-alerts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	buildCorporationApplicationApplicantUpdateMessage,
 	buildCorporationApplicationFirstTimeAcceptedMessage,
 	buildCorporationApplicationSubmittedMessage,
 } from '../corporation-alerts'
@@ -24,7 +25,8 @@ describe('corporation alerts embed builder', () => {
 		const embed = message.embeds?.[0]
 		expect(embed).toMatchObject({
 			title: 'New application to Rift Coalition submitted',
-			description: '[View Application](https://pleaseignore.app/corporations/corp-456/applications/app-123)',
+			description:
+				'[View Application](https://pleaseignore.app/corporations/corp-456/applications/app-123)',
 			thumbnail: {
 				url: 'https://images.evetech.net/characters/char-789/portrait?size=256',
 			},
@@ -89,7 +91,8 @@ describe('corporation alerts embed builder', () => {
 		const embed = message.embeds?.[0]
 		expect(embed).toMatchObject({
 			title: 'First application to Rift Coalition accepted',
-			description: '[View Application](https://pleaseignore.app/corporations/corp-456/applications/app-123)',
+			description:
+				'[View Application](https://pleaseignore.app/corporations/corp-456/applications/app-123)',
 			thumbnail: {
 				url: 'https://images.evetech.net/characters/char-789/portrait?size=256',
 			},
@@ -108,5 +111,26 @@ describe('corporation alerts embed builder', () => {
 				inline: true,
 			},
 		])
+	})
+
+	it('renders an applicant-facing update with the user-accessible application link', () => {
+		const message = buildCorporationApplicationApplicantUpdateMessage({
+			applicationId: 'app-123',
+			corporationName: 'Rift Coalition',
+			updateType: 'message',
+			updatedAt: '2026-06-11T12:30:00.000Z',
+		})
+
+		expect(message).toMatchObject({
+			content: '',
+			allowEveryone: false,
+			embeds: [
+				{
+					title: 'Your corporation application to Rift Coalition received an update',
+					description: '[View your application](https://pleaseignore.app/my-applications/app-123)',
+					timestamp: '2026-06-11T12:30:00.000Z',
+				},
+			],
+		})
 	})
 })

--- a/apps/core/src/lib/corporation-alerts.ts
+++ b/apps/core/src/lib/corporation-alerts.ts
@@ -1,11 +1,11 @@
-import type { DiscordEmbed, MessageContent } from '@repo/discord'
+import { ALERT_DESTINATION_TYPES } from './alert-routing'
 
-import {
-	ALERT_DESTINATION_TYPES,
-	type AlertDestinationRecord,
-	type AlertDestinationType,
-	type AlertRegistryEntry,
-	type AlertTypeDefinition,
+import type { DiscordEmbed, MessageContent } from '@repo/discord'
+import type {
+	AlertDestinationRecord,
+	AlertDestinationType,
+	AlertRegistryEntry,
+	AlertTypeDefinition,
 } from './alert-routing'
 
 export const CORPORATION_ALERT_TYPES = [
@@ -74,10 +74,16 @@ const ALERT_TYPE_DEFINITIONS: CorporationAlertTypeDefinition[] = [
 const DISCORD_ALERT_COLORS = {
 	applicationSubmitted: 0x3b82f6,
 	applicationAccepted: 0x22c55e,
+	applicationUpdate: 0x3b82f6,
 }
 
-function formatDiscordTimestamp(date: Date): string {
-	return `<t:${Math.floor(date.getTime() / 1000)}:F>`
+export type CorporationApplicationApplicantUpdateType = 'message' | 'review_note'
+
+export interface CorporationApplicationApplicantUpdatePayload {
+	applicationId: string
+	corporationName: string
+	updateType: CorporationApplicationApplicantUpdateType
+	updatedAt: string
 }
 
 function buildApplicationFields(
@@ -166,6 +172,25 @@ export function buildCorporationApplicationFirstTimeAcceptedMessage(
 				},
 				fields: buildApplicationFields(applicantLabel, 'First application'),
 				timestamp: acceptedAt.toISOString(),
+			},
+		],
+	}
+}
+
+export function buildCorporationApplicationApplicantUpdateMessage(
+	payload: CorporationApplicationApplicantUpdatePayload
+): MessageContent {
+	const applicationUrl = `https://pleaseignore.app/my-applications/${payload.applicationId}`
+
+	return {
+		content: '',
+		allowEveryone: false,
+		embeds: [
+			{
+				title: `Your corporation application to ${payload.corporationName} received an update`,
+				description: `[View your application](${applicationUrl})`,
+				color: DISCORD_ALERT_COLORS.applicationUpdate,
+				timestamp: payload.updatedAt,
 			},
 		],
 	}

--- a/apps/core/src/lib/groups-cache.ts
+++ b/apps/core/src/lib/groups-cache.ts
@@ -159,7 +159,7 @@ export function clearUserRolesCache(userId: string): void {
  * Clear group-related caches
  * Call this when group data changes
  */
-export function clearGroupCache(groupId: string): void {
+export function clearGroupCache(_groupId: string): void {
 	// Clear all group entries for this groupId
 	// Since we can't iterate efficiently, we rely on TTL expiration
 	// For immediate invalidation, we'd need to track keys per group

--- a/apps/core/src/lib/immunitas-alerts.ts
+++ b/apps/core/src/lib/immunitas-alerts.ts
@@ -102,10 +102,6 @@ export function buildImmunitasAccessAlertMessage(input: {
 	updatedAt?: Date
 }): MessageContent {
 	const accessTypeLabel = getAccessTypeLabel(input.accessType)
-	const attemptLabel =
-		input.attemptCount === 1
-			? 'One unauthorized attempt'
-			: `${input.attemptCount} unauthorized attempts`
 	const description =
 		input.attemptCount === 1
 			? 'One unauthorized attempt to access an immunitas account was blocked.'

--- a/apps/core/src/lib/industry-order-auth.ts
+++ b/apps/core/src/lib/industry-order-auth.ts
@@ -3,9 +3,10 @@
  */
 
 import { getStub } from '@repo/do-utils'
-import { EntityType, type Industry, type IndustryOrder, type ServiceProviderId } from '@repo/industry'
+import { EntityType } from '@repo/industry'
 
-import type { Env, SessionUser } from '../context'
+import type { Industry, IndustryOrder, ServiceProviderId } from '@repo/industry'
+import type { Env } from '../context'
 
 /**
  * Check if the user is the issuer of an order
@@ -111,9 +112,7 @@ export async function getClaimableProvider(
 		// Find a provider that offers this service type
 		for (const provider of providers) {
 			const services = await industryDO.listProviderServices(provider.id)
-			const hasService = services.some(
-				(s) => s.serviceType === orderType && s.status === 'active'
-			)
+			const hasService = services.some((s) => s.serviceType === orderType && s.status === 'active')
 			if (hasService) {
 				return provider.id
 			}

--- a/apps/core/src/lib/skill-plan-auth.ts
+++ b/apps/core/src/lib/skill-plan-auth.ts
@@ -1,7 +1,6 @@
 import { eq } from '@repo/db-utils'
 
-import { getCachedUserMemberships } from './groups-cache'
-import { getCachedUserPermissions } from './groups-cache'
+import { getCachedUserMemberships, getCachedUserPermissions } from './groups-cache'
 
 import type { SkillPlan, SkillPlanSummary } from '@repo/skills'
 import type { DbClient, schema } from '../db'

--- a/apps/core/src/pages/fleet-join.ts
+++ b/apps/core/src/pages/fleet-join.ts
@@ -1,11 +1,9 @@
 import { getStub } from '@repo/do-utils'
-import { createEveCharacterId } from '@repo/eve-types'
 
 import type { Context } from 'hono'
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { CharacterForFleetJoin, Fleets } from '@repo/fleets'
-import { logger } from '@repo/hono-helpers'
 
 /**
  * Render the fleet quick join page

--- a/apps/core/src/routes/__tests__/broadcasts.actions.route.test.ts
+++ b/apps/core/src/routes/__tests__/broadcasts.actions.route.test.ts
@@ -7,10 +7,9 @@ import { getStub } from '@repo/do-utils'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 import broadcastsRoutes from '../broadcasts'
 
-import type { BroadcastWithDetails } from '@repo/broadcasts'
+import type { BroadcastTemplate, BroadcastWithDetails } from '@repo/broadcasts'
 import type { UserPermission } from '@repo/groups'
 import type { SessionUser } from '../../context'
-import type { BroadcastTemplate } from '@repo/broadcasts'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),

--- a/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
+++ b/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
@@ -46,7 +46,7 @@ vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
 }))
 
-const backgroundTasks: Promise<unknown>[] = []
+const backgroundTasks: Array<Promise<unknown>> = []
 
 vi.mock('../../lib/background-task', () => ({
 	waitUntilWithTelemetry: (
@@ -224,11 +224,7 @@ describe('character detail access for HR page viewers', () => {
 
 	it('returns public overview data without private fields', async () => {
 		const app = createApp(makeUser(), db)
-		const res = await app.request(
-			'/api/characters/2001',
-			{},
-			env
-		)
+		const res = await app.request('/api/characters/2001', {}, env)
 
 		await Promise.all(backgroundTasks.splice(0, backgroundTasks.length))
 
@@ -259,11 +255,7 @@ describe('character detail access for HR page viewers', () => {
 		} as any)
 
 		const app = createApp(makeUser(), db)
-		const res = await app.request(
-			'/api/characters/2001/private',
-			{},
-			env
-		)
+		const res = await app.request('/api/characters/2001/private', {}, env)
 
 		await Promise.all(backgroundTasks.splice(0, backgroundTasks.length))
 
@@ -307,10 +299,12 @@ describe('character detail access for HR page viewers', () => {
 		} as any)
 		vi.mocked(db.query.users.findFirst).mockResolvedValue({ immunitas: false } as any)
 		hoisted.core.getUserCorporations.mockResolvedValue([])
-		hoisted.hr.listApplications.mockImplementation(async (_filters: any, _userId: string, access: any) => {
-			if (access.isAdmin || access.isAuditor) return []
-			return [{ corporationId: '2001', status: 'accepted' }]
-		})
+		hoisted.hr.listApplications.mockImplementation(
+			async (_filters: any, _userId: string, access: any) => {
+				if (access.isAdmin || access.isAuditor) return []
+				return [{ corporationId: '2001', status: 'accepted' }]
+			}
+		)
 		hoisted.hr.checkPermission.mockResolvedValue(true)
 
 		const app = createApp(makeUser(), db)
@@ -344,11 +338,7 @@ describe('character detail access for HR page viewers', () => {
 		vi.mocked(db.query.users.findFirst).mockResolvedValue({ immunitas: true } as any)
 
 		const app = createApp(makeUser({ is_admin: true }), db)
-		const res = await app.request(
-			'/api/characters/2001/private',
-			{},
-			env
-		)
+		const res = await app.request('/api/characters/2001/private', {}, env)
 
 		await Promise.all(backgroundTasks.splice(0, backgroundTasks.length))
 
@@ -387,5 +377,4 @@ describe('character detail access for HR page viewers', () => {
 		expect(body.totalSp).toBe(123456)
 		expect(hoisted.core.queueImmunitasAccessAlert).not.toHaveBeenCalled()
 	})
-
 })

--- a/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
@@ -19,7 +19,7 @@ vi.mock('../../lib/groups-cache', () => ({
 const getStubMock = vi.mocked(getStub)
 const getCachedUserPermissionsMock = vi.mocked(getCachedUserPermissions)
 
-const backgroundTasks: Promise<unknown>[] = []
+const backgroundTasks: Array<Promise<unknown>> = []
 
 vi.mock('../../lib/background-task', () => ({
 	waitUntilWithTelemetry: (
@@ -119,10 +119,7 @@ function makeDbStub() {
 	}
 }
 
-function createApp(
-	user?: SessionUser,
-	db: ReturnType<typeof makeDbStub> = makeDbStub()
-) {
+function createApp(user?: SessionUser, db: ReturnType<typeof makeDbStub> = makeDbStub()) {
 	const app = new Hono<{
 		Bindings: any
 		Variables: { user?: SessionUser; db?: ReturnType<typeof makeDbStub> }
@@ -215,14 +212,10 @@ describe('fulcrum route access matrix', () => {
 		expect(await res.json()).toEqual({
 			error: 'HR staff access requires a shared corporation or an open application',
 		})
-		expect(hrStub.listApplications).toHaveBeenCalledWith(
-			{ userId: 'target-1' },
-			'user-1',
-			{
-				isAdmin: false,
-				isAuditor: false,
-			}
-		)
+		expect(hrStub.listApplications).toHaveBeenCalledWith({ userId: 'target-1' }, 'user-1', {
+			isAdmin: false,
+			isAuditor: false,
+		})
 		expect(coreStub.getUserCorporations).toHaveBeenCalledWith('target-1')
 	})
 
@@ -273,7 +266,10 @@ describe('fulcrum route access matrix', () => {
 		expect(hrStub.checkPermission).not.toHaveBeenCalled()
 		expect(coreStub.getUserCharacters).toHaveBeenCalledWith('target-1', false)
 		expect(fulcrumStub.listReports).toHaveBeenCalledWith({ characterId: '3001' }, 50)
-		const body = (await res.json()) as Array<{ characterId: string; hasValidToken?: boolean | null }>
+		const body = (await res.json()) as Array<{
+			characterId: string
+			hasValidToken?: boolean | null
+		}>
 		expect(body[0]).toMatchObject({ characterId: '3001', hasValidToken: true })
 	})
 
@@ -383,14 +379,10 @@ describe('fulcrum route access matrix', () => {
 		expect(await res.json()).toEqual({
 			error: 'HR staff access requires a shared corporation or an open application',
 		})
-		expect(hrStub.listApplications).toHaveBeenCalledWith(
-			{ userId: 'target-1' },
-			'user-1',
-			{
-				isAdmin: false,
-				isAuditor: false,
-			}
-		)
+		expect(hrStub.listApplications).toHaveBeenCalledWith({ userId: 'target-1' }, 'user-1', {
+			isAdmin: false,
+			isAuditor: false,
+		})
 		expect(coreStub.getUserCorporations).toHaveBeenCalledWith('target-1')
 	})
 
@@ -623,8 +615,8 @@ describe('fulcrum route access matrix', () => {
 				corporationName: 'Corp 2002',
 			},
 		])
-		hrStub.checkPermission.mockImplementation(async (_userId: string, corporationId: string) =>
-			corporationId === '1001'
+		hrStub.checkPermission.mockImplementation(
+			async (_userId: string, corporationId: string) => corporationId === '1001'
 		)
 		hrStub.getUserRoles.mockResolvedValue([
 			{
@@ -941,8 +933,8 @@ describe('fulcrum route access matrix', () => {
 						},
 					]
 		)
-		hrStub.checkPermission.mockImplementation(async (_userId: string, corporationId: string) =>
-			corporationId === '2002'
+		hrStub.checkPermission.mockImplementation(
+			async (_userId: string, corporationId: string) => corporationId === '2002'
 		)
 		hrStub.getUserRoles.mockResolvedValue([
 			{
@@ -1016,8 +1008,8 @@ describe('fulcrum route access matrix', () => {
 				userId: 'target-user',
 				characterName: 'Target Pilot Two',
 			} as any)
-		hrStub.checkPermission.mockImplementation(async (_userId: string, corporationId: string) =>
-			corporationId === '2002'
+		hrStub.checkPermission.mockImplementation(
+			async (_userId: string, corporationId: string) => corporationId === '2002'
 		)
 		hrStub.getUserRoles.mockResolvedValue([
 			{
@@ -1153,12 +1145,15 @@ describe('fulcrum route access matrix', () => {
 				userId: 'target-user',
 				characterName: 'Target Pilot Two',
 			} as any)
-		eveCharacterDataStub.getInstance.mockImplementation(async (characterId: string) => ({
-			getCharacterInfo: vi.fn().mockResolvedValue({
-				characterId,
-				corporationId: characterId === '3001' ? '2002' : '3003',
-			}),
-		}) as any)
+		eveCharacterDataStub.getInstance.mockImplementation(
+			async (characterId: string) =>
+				({
+					getCharacterInfo: vi.fn().mockResolvedValue({
+						characterId,
+						corporationId: characterId === '3001' ? '2002' : '3003',
+					}),
+				}) as any
+		)
 		coreStub.getUserCorporations.mockResolvedValue([
 			{
 				corporationId: '1001',
@@ -1169,8 +1164,8 @@ describe('fulcrum route access matrix', () => {
 				corporationName: 'Corp 2002',
 			},
 		])
-		hrStub.checkPermission.mockImplementation(async (_userId: string, corporationId: string) =>
-			corporationId === '1001'
+		hrStub.checkPermission.mockImplementation(
+			async (_userId: string, corporationId: string) => corporationId === '1001'
 		)
 		hrStub.getUserRoles.mockResolvedValue([
 			{
@@ -1438,28 +1433,29 @@ describe('fulcrum route access matrix', () => {
 				updatedAt: new Date(),
 			},
 		] as any)
-		hrStub.listApplications.mockImplementation(async (_filters: any, _userId: string, _access: any) =>
-			_filters.status === 'pending'
-				? []
-				: [
-						{
-							id: 'app-1',
-							corporationId: '1001',
-							userId: 'target-1',
-							characterId: '3001',
-							characterName: 'Alt Pilot',
-							applicationText: 'app',
-							status: 'accepted',
-							reviewedBy: null,
-							reviewedByCharacterName: null,
-							reviewedAt: null,
-							reviewNotes: null,
-							createdAt: new Date(),
-							updatedAt: new Date(),
-							lastStaffInteractionAt: null,
-							altCharacterIds: [],
-						},
-					]
+		hrStub.listApplications.mockImplementation(
+			async (_filters: any, _userId: string, _access: any) =>
+				_filters.status === 'pending'
+					? []
+					: [
+							{
+								id: 'app-1',
+								corporationId: '1001',
+								userId: 'target-1',
+								characterId: '3001',
+								characterName: 'Alt Pilot',
+								applicationText: 'app',
+								status: 'accepted',
+								reviewedBy: null,
+								reviewedByCharacterName: null,
+								reviewedAt: null,
+								reviewNotes: null,
+								createdAt: new Date(),
+								updatedAt: new Date(),
+								lastStaffInteractionAt: null,
+								altCharacterIds: [],
+							},
+						]
 		)
 
 		const app = createApp(makeUser())
@@ -1555,25 +1551,28 @@ describe('fulcrum route access matrix', () => {
 			},
 		] as any)
 		hrStub.listApplications.mockResolvedValue([])
-		hrStub.listApplications.mockImplementation(async (_filters: any, _userId: string, _access: any) => [
-			{
-				id: 'app-1',
-				corporationId: '1001',
-				userId: 'target-1',
-				characterId: '3001',
-				characterName: 'Alt Pilot',
-				applicationText: 'app',
-				status: 'under_review',
-				reviewedBy: null,
-				reviewedByCharacterName: null,
-				reviewedAt: null,
-				reviewNotes: null,
-				createdAt: new Date(),
-				updatedAt: new Date(),
-				lastStaffInteractionAt: null,
-				altCharacterIds: [],
-			},
-		] as any)
+		hrStub.listApplications.mockImplementation(
+			async (_filters: any, _userId: string, _access: any) =>
+				[
+					{
+						id: 'app-1',
+						corporationId: '1001',
+						userId: 'target-1',
+						characterId: '3001',
+						characterName: 'Alt Pilot',
+						applicationText: 'app',
+						status: 'under_review',
+						reviewedBy: null,
+						reviewedByCharacterName: null,
+						reviewedAt: null,
+						reviewNotes: null,
+						createdAt: new Date(),
+						updatedAt: new Date(),
+						lastStaffInteractionAt: null,
+						altCharacterIds: [],
+					},
+				] as any
+		)
 
 		const app = createApp(makeUser())
 		const res = await app.request(
@@ -1746,7 +1745,7 @@ describe('fulcrum route access matrix', () => {
 					sendDm: false,
 				}),
 			},
-			env,
+			env
 		)
 
 		expect(res.status).toBe(201)
@@ -1788,7 +1787,7 @@ describe('fulcrum route access matrix', () => {
 					characterIds: ['3001', '3002'],
 				}),
 			},
-			env,
+			env
 		)
 
 		expect(res.status).toBe(201)

--- a/apps/core/src/routes/__tests__/groups.admins.route.test.ts
+++ b/apps/core/src/routes/__tests__/groups.admins.route.test.ts
@@ -1,13 +1,14 @@
-import { Hono } from 'hono'
 import { createExecutionContext } from 'cloudflare:test'
+import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStub } from '@repo/do-utils'
 
-import groupsRoutes from '../groups'
 import { createDb } from '../../db'
+import groupsRoutes from '../groups'
 
 import type { SessionUser } from '../../context'
+import type * as sessionMiddleware from '../../middleware/session'
 
 const serviceMocks = vi.hoisted(() => ({
 	waitUntilWithTelemetry: vi.fn((_: unknown, __: string, task: () => Promise<unknown>) => {
@@ -35,13 +36,13 @@ vi.mock('../../lib/workflow-triggers', () => ({
 }))
 
 vi.mock('../../middleware/session', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('../../middleware/session')>()
+	const actual = await importOriginal<typeof sessionMiddleware>()
 
 	const passThrough =
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			}
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		}
 
 	return {
 		...actual,
@@ -49,13 +50,13 @@ vi.mock('../../middleware/session', async (importOriginal) => {
 		requireAllianceMember: passThrough,
 		requireAdmin:
 			() =>
-				async (c: any, next: () => Promise<void>): Promise<Response | void> => {
-					const user = c.get('user')
-					if (!user?.is_admin) {
-						return c.json({ error: 'Forbidden' }, 403)
-					}
-					await next()
-				},
+			async (c: any, next: () => Promise<void>): Promise<Response | void> => {
+				const user = c.get('user')
+				if (!user?.is_admin) {
+					return c.json({ error: 'Forbidden' }, 403)
+				}
+				await next()
+			},
 	}
 })
 
@@ -118,15 +119,15 @@ describe('groups admin membership routes', () => {
 			throw new Error('Unexpected binding')
 		})
 
-			createDbMock.mockReturnValue({
-				query: {
-					userCharacters: {
-						findFirst: vi.fn(),
-					},
+		createDbMock.mockReturnValue({
+			query: {
+				userCharacters: {
+					findFirst: vi.fn(),
 				},
-			} as any)
-			serviceMocks.triggerDiscordRefreshWorkflow.mockResolvedValue(undefined)
-			serviceMocks.triggerMumbleRefreshWorkflow.mockResolvedValue(undefined)
+			},
+		} as any)
+		serviceMocks.triggerDiscordRefreshWorkflow.mockResolvedValue(undefined)
+		serviceMocks.triggerMumbleRefreshWorkflow.mockResolvedValue(undefined)
 	})
 
 	it('allows non-site-admin group owner flow to add an admin (DO enforces ownership)', async () => {
@@ -151,10 +152,19 @@ describe('groups admin membership routes', () => {
 		const user = makeUser({ id: 'owner-user', is_admin: false })
 		const app = createApp(user)
 
-		const res = await app.request('/api/groups/group-1/admins/target-user', { method: 'DELETE' }, env)
+		const res = await app.request(
+			'/api/groups/group-1/admins/target-user',
+			{ method: 'DELETE' },
+			env
+		)
 
 		expect(res.status).toBe(200)
-		expect(groupsStub.removeAdmin).toHaveBeenCalledWith('group-1', 'owner-user', 'target-user', false)
+		expect(groupsStub.removeAdmin).toHaveBeenCalledWith(
+			'group-1',
+			'owner-user',
+			'target-user',
+			false
+		)
 	})
 
 	it('forces site-admin direct member adds through the admin-managed endpoint', async () => {

--- a/apps/core/src/routes/__tests__/hr.alts.route.test.ts
+++ b/apps/core/src/routes/__tests__/hr.alts.route.test.ts
@@ -74,21 +74,10 @@ function makeHrStub() {
 	}
 }
 
-function makeDbStub() {
-	return {
-		query: {
-			managedCorporations: { findMany: vi.fn().mockResolvedValue([]) },
-			users: { findMany: vi.fn().mockResolvedValue([]) },
-			userCharacters: { findMany: vi.fn().mockResolvedValue([]) },
-		},
-	}
-}
-
-function createApp(opts: { user?: SessionUser; db?: ReturnType<typeof makeDbStub> }) {
+function createApp(opts: { user?: SessionUser }) {
 	const app = new Hono<{ Bindings: any; Variables: any }>()
 	app.use('*', async (c, next) => {
 		if (opts.user) c.set('user', opts.user)
-		if (opts.db) c.set('db', opts.db)
 		await next()
 	})
 	app.route('/api/hr', hrRoutes)
@@ -121,51 +110,71 @@ describe('POST /api/hr/applications/:id/alts', () => {
 
 	it('returns 401 when not authenticated', async () => {
 		const app = createApp({})
-		const res = await app.request('/api/hr/applications/app-1/alts', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ altCharacterIds: ['2001'] }),
-		}, env)
+		const res = await app.request(
+			'/api/hr/applications/app-1/alts',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ altCharacterIds: ['2001'] }),
+			},
+			env
+		)
 		expect(res.status).toBe(401)
 	})
 
 	it('returns 400 when body is missing', async () => {
 		const app = createApp({ user: makeUser() })
-		const res = await app.request('/api/hr/applications/app-1/alts', {
-			method: 'POST',
-		}, env)
+		const res = await app.request(
+			'/api/hr/applications/app-1/alts',
+			{
+				method: 'POST',
+			},
+			env
+		)
 		expect(res.status).toBe(400)
 	})
 
 	it('returns 400 when altCharacterIds is not an array', async () => {
 		const app = createApp({ user: makeUser() })
-		const res = await app.request('/api/hr/applications/app-1/alts', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ altCharacterIds: '2001' }),
-		}, env)
+		const res = await app.request(
+			'/api/hr/applications/app-1/alts',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ altCharacterIds: '2001' }),
+			},
+			env
+		)
 		expect(res.status).toBe(400)
 		expect(await res.json()).toMatchObject({ error: expect.stringContaining('altCharacterIds') })
 	})
 
 	it('returns 400 when altCharacterIds is an empty array', async () => {
 		const app = createApp({ user: makeUser() })
-		const res = await app.request('/api/hr/applications/app-1/alts', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ altCharacterIds: [] }),
-		}, env)
+		const res = await app.request(
+			'/api/hr/applications/app-1/alts',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ altCharacterIds: [] }),
+			},
+			env
+		)
 		expect(res.status).toBe(400)
 		expect(await res.json()).toMatchObject({ error: expect.stringContaining('altCharacterIds') })
 	})
 
 	it('calls addApplicationAlts with resolved character names and returns 200', async () => {
 		const app = createApp({ user: makeUser() })
-		const res = await app.request('/api/hr/applications/app-1/alts', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ altCharacterIds: ['2001', '2002'] }),
-		}, env)
+		const res = await app.request(
+			'/api/hr/applications/app-1/alts',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ altCharacterIds: ['2001', '2002'] }),
+			},
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(await res.json()).toEqual({ success: true })
@@ -182,16 +191,24 @@ describe('POST /api/hr/applications/:id/alts', () => {
 	})
 
 	it('returns 400 when service throws (e.g. terminal application state)', async () => {
-		hrStub.addApplicationAlts.mockRejectedValue(new Error('You can only modify alts on active applications'))
+		hrStub.addApplicationAlts.mockRejectedValue(
+			new Error('You can only modify alts on active applications')
+		)
 		const app = createApp({ user: makeUser() })
-		const res = await app.request('/api/hr/applications/app-1/alts', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ altCharacterIds: ['2001'] }),
-		}, env)
+		const res = await app.request(
+			'/api/hr/applications/app-1/alts',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ altCharacterIds: ['2001'] }),
+			},
+			env
+		)
 
 		expect(res.status).toBe(400)
-		expect(await res.json()).toMatchObject({ error: 'You can only modify alts on active applications' })
+		expect(await res.json()).toMatchObject({
+			error: 'You can only modify alts on active applications',
+		})
 	})
 })
 
@@ -239,16 +256,25 @@ describe('DELETE /api/hr/applications/:id/alts/:altCharacterId', () => {
 
 		expect(res.status).toBe(200)
 		expect(hrStub.removeApplicationAlt).toHaveBeenCalledWith(
-			'app-1', 'user-1', '1001', 'Main Pilot', '9999', 'Unknown'
+			'app-1',
+			'user-1',
+			'1001',
+			'Main Pilot',
+			'9999',
+			'Unknown'
 		)
 	})
 
 	it('returns 400 when service throws (e.g. terminal application state)', async () => {
-		hrStub.removeApplicationAlt.mockRejectedValue(new Error('You can only modify alts on active applications'))
+		hrStub.removeApplicationAlt.mockRejectedValue(
+			new Error('You can only modify alts on active applications')
+		)
 		const app = createApp({ user: makeUser() })
 		const res = await app.request('/api/hr/applications/app-1/alts/2001', { method: 'DELETE' }, env)
 
 		expect(res.status).toBe(400)
-		expect(await res.json()).toMatchObject({ error: 'You can only modify alts on active applications' })
+		expect(await res.json()).toMatchObject({
+			error: 'You can only modify alts on active applications',
+		})
 	})
 })

--- a/apps/core/src/routes/__tests__/hr.application-alerts.test.ts
+++ b/apps/core/src/routes/__tests__/hr.application-alerts.test.ts
@@ -1,5 +1,5 @@
-import { Hono } from 'hono'
 import { createExecutionContext } from 'cloudflare:test'
+import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStub } from '@repo/do-utils'
@@ -19,6 +19,17 @@ const serviceMocks = vi.hoisted(() => ({
 		isFirstApplication: true,
 	}),
 	getApplication: vi.fn(),
+	sendMessage: vi.fn().mockResolvedValue({
+		id: 'message-1',
+		applicationId: 'app-1',
+		senderId: 'hr-1',
+		senderCharacterId: 'main-1',
+		senderCharacterName: null,
+		recipientId: 'user-1',
+		message: 'Please provide one more detail.',
+		createdAt: new Date('2026-06-11T12:30:00.000Z'),
+	}),
+	sendDirectMessage: vi.fn().mockResolvedValue({ success: true }),
 	updateApplicationStatus: vi.fn().mockResolvedValue(undefined),
 }))
 
@@ -111,6 +122,8 @@ describe('HR application submission alerts', () => {
 			return {
 				submitApplication: serviceMocks.submitApplication,
 				getApplication: serviceMocks.getApplication,
+				sendMessage: serviceMocks.sendMessage,
+				sendDirectMessage: serviceMocks.sendDirectMessage,
 				updateApplicationStatus: serviceMocks.updateApplicationStatus,
 			}
 		})
@@ -273,6 +286,7 @@ describe('HR application submission alerts', () => {
 				'Not accepted.'
 			)
 			expect(serviceMocks.dispatchCorporationAlert).not.toHaveBeenCalled()
+			expect(serviceMocks.sendDirectMessage).not.toHaveBeenCalled()
 			expect(serviceMocks.waitUntilWithTelemetry).not.toHaveBeenCalled()
 		}
 	)
@@ -281,7 +295,7 @@ describe('HR application submission alerts', () => {
 		serviceMocks.getApplication.mockResolvedValueOnce({
 			id: 'app-1',
 			corporationId: 'corp-1',
-			userId: 'user-1',
+			userId: 'applicant-1',
 			characterId: 'main-1',
 			characterName: 'Main Pilot',
 			applicationText: 'Let me in.',
@@ -300,7 +314,7 @@ describe('HR application submission alerts', () => {
 			activityLog: [],
 		})
 
-		const app = createApp(makeUser({ is_admin: true }), createDb())
+		const app = createApp(makeUser({ id: 'hr-1', is_admin: true }), createDb())
 		const executionCtx = createExecutionContext()
 		const response = await app.request(
 			'/api/hr/applications/app-1',
@@ -326,5 +340,85 @@ describe('HR application submission alerts', () => {
 				alertType: 'corp_application_first_time_accepted',
 			})
 		)
+		expect(serviceMocks.sendDirectMessage).toHaveBeenCalledWith(
+			'applicant-1',
+			expect.objectContaining({
+				embeds: [
+					expect.objectContaining({
+						title: 'Your corporation application to Test Corporation received an update',
+					}),
+				],
+			})
+		)
+	})
+
+	it('DMs the application owner after an HR-authored public message', async () => {
+		serviceMocks.getApplication.mockResolvedValueOnce({
+			id: 'app-1',
+			corporationId: 'corp-1',
+			userId: 'applicant-1',
+			characterId: 'main-1',
+			characterName: 'Main Pilot',
+			applicationText: 'Let me in.',
+			status: 'pending',
+			reviewedBy: null,
+			reviewedByCharacterName: null,
+			reviewedAt: null,
+			reviewNotes: null,
+			createdAt: new Date('2026-06-11T12:00:00.000Z'),
+			updatedAt: new Date('2026-06-11T12:00:00.000Z'),
+			lastStaffInteractionAt: null,
+			altCharacterIds: [],
+			isFirstApplication: true,
+			recommendations: [],
+			recommendationCount: 0,
+			activityLog: [],
+		})
+		const app = createApp(makeUser({ id: 'hr-1', is_admin: true }), createDb())
+		const executionCtx = createExecutionContext()
+		const response = await app.request(
+			'/api/hr/applications/app-1/messages',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					recipientId: 'applicant-1',
+					message: 'Please provide one more detail.',
+				}),
+			},
+			{ HR: { name: 'HR' }, DISCORD: { name: 'DISCORD' } } as any,
+			executionCtx
+		)
+
+		expect(response.status).toBe(201)
+		expect(serviceMocks.sendDirectMessage).toHaveBeenCalledWith(
+			'applicant-1',
+			expect.objectContaining({
+				embeds: [
+					expect.objectContaining({
+						title: 'Your corporation application to Test Corporation received an update',
+						description: '[View your application](https://pleaseignore.app/my-applications/app-1)',
+					}),
+				],
+			})
+		)
+	})
+
+	it('does not DM an applicant for their own application message', async () => {
+		const app = createApp(makeUser(), createDb())
+		const executionCtx = createExecutionContext()
+		const response = await app.request(
+			'/api/hr/applications/app-1/messages',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ message: 'Here is more information.' }),
+			},
+			{ HR: { name: 'HR' }, DISCORD: { name: 'DISCORD' } } as any,
+			executionCtx
+		)
+
+		expect(response.status).toBe(201)
+		expect(serviceMocks.sendDirectMessage).not.toHaveBeenCalled()
 	})
 })

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -4,10 +4,17 @@ import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import { eq } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { assertEveCharacterId } from '@repo/eve-types'
-import { captureException, toErrorMessage } from '@repo/hono-helpers'
+import { captureException, logger, toErrorMessage } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from '../db'
-import { managedCorporations, mumbleTempops, oauthStates, userCharacters, users } from '../db/schema'
+import {
+	managedCorporations,
+	mumbleTempops,
+	oauthStates,
+	userCharacters,
+	users,
+} from '../db/schema'
 import { waitUntilWithTelemetry } from '../lib/background-task'
 import { getDiscordStatus } from '../lib/discord-helpers'
 import { getCachedUserPermissions } from '../lib/groups-cache'
@@ -17,15 +24,11 @@ import { requireAuth } from '../middleware/session'
 import { ActivityService } from '../services/activity.service'
 import { AuthService } from '../services/auth.service'
 import { hydrateCharacterAffiliation } from '../services/character-affiliation-hydration.service'
-import {
-	recheckDirectorHealthAfterTokenReauth,
-	type DirectorHealthRecheckStub,
-	type ManagedCorporationSummary,
-} from '../services/director-health-recheck.service'
 import { reconcileUserCoreMembershipRoles } from '../services/core-role-reconciliation.service'
-import { provisionTempopGuest } from '../services/mumble.service'
-import { storeCredentialHandoff } from '../services/mumble-tempop.service'
 import { autoRegisterDirectorCorporation } from '../services/corporation-auto-register.service'
+import { recheckDirectorHealthAfterTokenReauth } from '../services/director-health-recheck.service'
+import { storeCredentialHandoff } from '../services/mumble-tempop.service'
+import { provisionTempopGuest } from '../services/mumble.service'
 import { SessionService } from '../services/session.service'
 import { CharacterAlreadyClaimedError, UserService } from '../services/user.service'
 
@@ -35,14 +38,12 @@ import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { BlacklistEntry, Hr } from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
-import type {
-	ClaimMainOAuthMetadata,
-	OAuthStateMetadata,
-	TempopOAuthMetadata,
-} from '../db/schema'
 import type { App } from '../context'
-import { logger } from '@repo/hono-helpers'
-import { createWorkflow } from '@repo/workflow-utils'
+import type { ClaimMainOAuthMetadata, OAuthStateMetadata, TempopOAuthMetadata } from '../db/schema'
+import type {
+	DirectorHealthRecheckStub,
+	ManagedCorporationSummary,
+} from '../services/director-health-recheck.service'
 
 /**
  * Authentication routes
@@ -756,7 +757,9 @@ auth.get('/callback', async (c) => {
 				return c.json({
 					characterLinked: true,
 					tokenUpdated: true,
-					character: existingCharacter ? { ...existingCharacter, hasValidToken: true } : existingCharacter,
+					character: existingCharacter
+						? { ...existingCharacter, hasValidToken: true }
+						: existingCharacter,
 				})
 			} else {
 				return c.json({ error: 'Character is already linked to another account' }, 400)
@@ -810,12 +813,7 @@ auth.get('/callback', async (c) => {
 			.update(userCharacters)
 			.set({ hasValidToken: true })
 			.where(eq(userCharacters.characterId, characterId))
-		triggerDirectorHealthRecheckAfterTokenReauth(
-			c,
-			db,
-			characterId,
-			characterInfo.characterName
-		)
+		triggerDirectorHealthRecheckAfterTokenReauth(c, db, characterId, characterInfo.characterName)
 
 		await activityService.logCharacterLinked(stateUserId, characterId, getRequestMetadata(c))
 		triggerLegacyMigrationRecheck(c, stateUserId)
@@ -982,12 +980,7 @@ auth.get('/callback', async (c) => {
 			.update(userCharacters)
 			.set({ hasValidToken: true })
 			.where(eq(userCharacters.characterId, characterId))
-		triggerDirectorHealthRecheckAfterTokenReauth(
-			c,
-			db,
-			characterId,
-			characterInfo.characterName
-		)
+		triggerDirectorHealthRecheckAfterTokenReauth(c, db, characterId, characterInfo.characterName)
 
 		await activityService.logLogin(user.id, characterId, getRequestMetadata(c))
 
@@ -1187,10 +1180,7 @@ auth.post('/claim-main', async (c) => {
 		logger.warn('[Auth] claim-main ticket owner hash no longer matches, refusing', {
 			characterId,
 		})
-		return c.json(
-			{ error: 'This character has changed ownership. Please login again.' },
-			400
-		)
+		return c.json({ error: 'This character has changed ownership. Please login again.' }, 400)
 	}
 
 	// SECURITY: Check if character ID/name is blacklisted before creating user
@@ -1225,10 +1215,7 @@ auth.post('/claim-main', async (c) => {
 				characterId,
 				reason: toErrorMessage(error),
 			})
-			return c.json(
-				{ error: 'This character has already been claimed. Please login again.' },
-				409
-			)
+			return c.json({ error: 'This character has already been claimed. Please login again.' }, 409)
 		}
 
 		captureException(error as Error, {

--- a/apps/core/src/routes/bills-admin.ts
+++ b/apps/core/src/routes/bills-admin.ts
@@ -176,7 +176,7 @@ app.get('/', requireAuth(), requireAdmin(), async (c) => {
 					statuses: Set<string>
 				}
 			>()
-			const coalescedRows: (typeof fullRows)[number][] = []
+			const coalescedRows: Array<(typeof fullRows)[number]> = []
 			for (const row of fullRows) {
 				if (!row.groupBillId) {
 					coalescedRows.push(row)
@@ -204,7 +204,8 @@ app.get('/', requireAuth(), requireAdmin(), async (c) => {
 					coalescedRows.push(representative)
 				}
 
-				entry.representative.groupBillTotalCount = (entry.representative.groupBillTotalCount ?? 0) + 1
+				entry.representative.groupBillTotalCount =
+					(entry.representative.groupBillTotalCount ?? 0) + 1
 				if (row.status === 'paid') {
 					entry.representative.groupBillPaidCount =
 						(entry.representative.groupBillPaidCount ?? 0) + 1

--- a/apps/core/src/routes/bills-user.ts
+++ b/apps/core/src/routes/bills-user.ts
@@ -192,7 +192,7 @@ app.get('/my-bills', requireAuth(), requireBillingViewer(), async (c) => {
 		// If exactly 1 appears the user is the pure payer — render as individual.
 		const groupBillMap = new Map<string, (typeof enrichedRows)[0]>()
 		const groupBillStatuses = new Map<string, Set<string>>()
-		const nonGroupRows: (typeof enrichedRows)[0][] = []
+		const nonGroupRows: Array<(typeof enrichedRows)[0]> = []
 		for (const row of enrichedRows) {
 			if (row.groupBillId) {
 				if (!groupBillMap.has(row.groupBillId)) {

--- a/apps/core/src/routes/broadcasts.ts
+++ b/apps/core/src/routes/broadcasts.ts
@@ -1,20 +1,18 @@
 import { Hono } from 'hono'
 
-import { and, eq } from '@repo/db-utils'
-import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
-import { getStub } from '@repo/do-utils'
 import { getBroadcastSystemTemplateToken } from '@repo/broadcasts'
-import { createDb, schema } from '../db'
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+import { and, eq } from '@repo/db-utils'
+import { getStub } from '@repo/do-utils'
 
-import {
-	getCachedUserPermissions,
-} from '../lib/groups-cache'
+import { createDb, schema } from '../db'
+import { getCachedUserPermissions } from '../lib/groups-cache'
 import { validatePagination } from '../lib/validation'
 import { requireAuth } from '../middleware/session'
 import {
-	canAccessBroadcastTargetByAction,
 	buildBroadcastPermissionContext,
 	canAccessBroadcastPermissionId,
+	canAccessBroadcastTargetByAction,
 	filterBroadcastTargetsByAction,
 } from './broadcasts-permissions'
 
@@ -67,10 +65,6 @@ interface ParsedTemplateResult {
 	normalizedMessageTemplate: string
 }
 
-function extractTemplateTagBlocks(messageTemplate: string): string[] {
-	return [...messageTemplate.matchAll(/\{\{([^}]*)\}\}/g)].map((match) => (match[1] ?? '').trim())
-}
-
 function parseTemplateMessage(messageTemplate: string): ParsedTemplateResult {
 	const tokens: ParsedTemplateToken[] = []
 	const invalidTokens = new Set<string>()
@@ -86,9 +80,7 @@ function parseTemplateMessage(messageTemplate: string): ParsedTemplateResult {
 			}
 
 			const wrappedToken =
-				rawToken.startsWith('<') && rawToken.endsWith('>')
-					? rawToken.slice(1, -1).trim()
-					: rawToken
+				rawToken.startsWith('<') && rawToken.endsWith('>') ? rawToken.slice(1, -1).trim() : rawToken
 
 			const systemToken = getBroadcastSystemTemplateToken(wrappedToken)
 			if (systemToken) {
@@ -139,10 +131,7 @@ function parseTemplateMessage(messageTemplate: string): ParsedTemplateResult {
 					.map((option) => toTemplateFieldLabel(option.trim()))
 					.filter(Boolean)
 
-				if (
-					!BROADCAST_TEMPLATE_SELECT_LABEL_PATTERN.test(labelName) ||
-					options.length === 0
-				) {
+				if (!BROADCAST_TEMPLATE_SELECT_LABEL_PATTERN.test(labelName) || options.length === 0) {
 					invalidTokens.add(rawToken)
 					return `{{${rawToken}}}`
 				}
@@ -189,17 +178,6 @@ function parseTemplateMessage(messageTemplate: string): ParsedTemplateResult {
 		invalidTokens: [...invalidTokens],
 		normalizedMessageTemplate,
 	}
-}
-
-function getInvalidTemplateTagNames(messageTemplate: string): string[] {
-	return parseTemplateMessage(messageTemplate).invalidTokens
-}
-
-function getTemplateFieldSchemaNames(fieldSchema: unknown): string[] {
-	if (!Array.isArray(fieldSchema)) return []
-	return fieldSchema
-		.map((field) => (typeof field === 'object' && field !== null ? (field as { name?: unknown }).name : null))
-		.filter((name): name is string => typeof name === 'string')
 }
 
 function hasFleetTrackingRequiredTokens(messageTemplate: string): boolean {
@@ -393,7 +371,11 @@ function normalizeTemplateTargetIds(payload: Record<string, unknown>): string[] 
 			? [payload.targetId]
 			: []
 
-	return [...new Set([...targetIdsFromArray, ...singleTargetId].map((value) => value.trim()).filter(Boolean))]
+	return [
+		...new Set(
+			[...targetIdsFromArray, ...singleTargetId].map((value) => value.trim()).filter(Boolean)
+		),
+	]
 }
 
 /**
@@ -929,7 +911,9 @@ broadcasts.get('/templates/:id', async (c) => {
 	if (!user.is_admin) {
 		const permissionContext = await getUserBroadcastPermissionContext(c.env, user.id)
 		const templateTargets = await Promise.all(
-			template.targetIds.map((templateTargetId) => broadcastsStub.getTarget(templateTargetId, user.id))
+			template.targetIds.map((templateTargetId) =>
+				broadcastsStub.getTarget(templateTargetId, user.id)
+			)
 		)
 		const resolvedTemplateTargets = templateTargets.filter(
 			(target): target is NonNullable<typeof target> => Boolean(target)
@@ -988,18 +972,23 @@ broadcasts.post('/templates', async (c) => {
 	if (fleetTrackingEnabled && !hasFleetTrackingRequiredTokens(data.messageTemplate)) {
 		return c.json(
 			{
-				error: 'Fleet tracking templates must include both {{<fleetName>}} and {{<fleetCommander>}} tokens.',
+				error:
+					'Fleet tracking templates must include both {{<fleetName>}} and {{<fleetCommander>}} tokens.',
 			},
 			400
 		)
 	}
 
 	const broadcastsStub = getStub<Broadcasts>(c.env.BROADCASTS, 'default')
-	const targets = await Promise.all(targetIds.map((targetId) => broadcastsStub.getTarget(targetId, user.id)))
+	const targets = await Promise.all(
+		targetIds.map((targetId) => broadcastsStub.getTarget(targetId, user.id))
+	)
 	if (targets.some((target) => !target)) {
 		return c.json({ error: 'One or more targets not found' }, 404)
 	}
-	const resolvedTargets = targets.filter((target): target is NonNullable<typeof target> => Boolean(target))
+	const resolvedTargets = targets.filter((target): target is NonNullable<typeof target> =>
+		Boolean(target)
+	)
 	const targetType = resolvedTargets[0]?.type
 	if (!targetType || resolvedTargets.some((target) => target.type !== targetType)) {
 		return c.json({ error: 'All selected targets must share the same target type' }, 400)
@@ -1061,15 +1050,18 @@ broadcasts.patch('/templates/:id', async (c) => {
 	if (!template) {
 		return c.json({ error: 'Template not found' }, 404)
 	}
-	const nextTargetIds = data.targetIds !== undefined || data.targetId !== undefined
-		? normalizeTemplateTargetIds(data)
-		: template.targetIds
+	const nextTargetIds =
+		data.targetIds !== undefined || data.targetId !== undefined
+			? normalizeTemplateTargetIds(data)
+			: template.targetIds
 	if (nextTargetIds.length === 0) {
 		return c.json({ error: 'At least one target is required' }, 400)
 	}
 
 	const currentTargets = await Promise.all(
-		template.targetIds.map((templateTargetId) => broadcastsStub.getTarget(templateTargetId, user.id))
+		template.targetIds.map((templateTargetId) =>
+			broadcastsStub.getTarget(templateTargetId, user.id)
+		)
 	)
 	const resolvedCurrentTargets = currentTargets.filter(
 		(target): target is NonNullable<typeof target> => Boolean(target)
@@ -1125,7 +1117,8 @@ broadcasts.patch('/templates/:id', async (c) => {
 	) {
 		return c.json(
 			{
-				error: 'Fleet tracking templates must include both {{<fleetName>}} and {{<fleetCommander>}} tokens.',
+				error:
+					'Fleet tracking templates must include both {{<fleetName>}} and {{<fleetCommander>}} tokens.',
 			},
 			400
 		)
@@ -1150,11 +1143,7 @@ broadcasts.patch('/templates/:id', async (c) => {
 		updatePayload.fieldSchema = normalizedFieldSchema
 	}
 
-	const updated = await broadcastsStub.updateTemplate(
-		templateId,
-		updatePayload,
-		user.id
-	)
+	const updated = await broadcastsStub.updateTemplate(templateId, updatePayload, user.id)
 	return c.json(updated)
 })
 
@@ -1174,9 +1163,13 @@ broadcasts.delete('/templates/:id', async (c) => {
 		return c.json({ error: 'Template not found' }, 404)
 	}
 	const targets = await Promise.all(
-		template.targetIds.map((templateTargetId) => broadcastsStub.getTarget(templateTargetId, user.id))
+		template.targetIds.map((templateTargetId) =>
+			broadcastsStub.getTarget(templateTargetId, user.id)
+		)
 	)
-	const resolvedTargets = targets.filter((target): target is NonNullable<typeof target> => Boolean(target))
+	const resolvedTargets = targets.filter((target): target is NonNullable<typeof target> =>
+		Boolean(target)
+	)
 
 	// Check permissions against target's manage permission
 	const permissionContext = user.is_admin
@@ -1479,8 +1472,7 @@ broadcasts.post('/:id/send', async (c) => {
 	}
 	const userPermissions = await getCachedUserPermissions(c.env, user.id)
 	const canStartTracking =
-		user.is_admin ||
-		userPermissions.some((p) => p.urn === 'urn:fleet-tracking:create')
+		user.is_admin || userPermissions.some((p) => p.urn === 'urn:fleet-tracking:create')
 	if (parseEnabledFlag(broadcast.content.__fleetTrackingEnabled) && !canStartTracking) {
 		return c.json(
 			{

--- a/apps/core/src/routes/characters.ts
+++ b/apps/core/src/routes/characters.ts
@@ -554,12 +554,14 @@ app.get('/:characterId', requireAuth(), async (c) => {
 	const eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
 
 	try {
-		let [info, corporationHistory, attributes, lastUpdated] = await Promise.all([
+		const [initialInfo, initialCorporationHistory, attributes, lastUpdated] = await Promise.all([
 			eveCharacterData.getCharacterInfo(),
 			eveCharacterData.getCorporationHistory(),
 			eveCharacterData.getAttributes(),
 			eveCharacterData.getLastUpdated(),
 		])
+		let info = initialInfo
+		let corporationHistory = initialCorporationHistory
 
 		if (!info) {
 			logger.info('[Character Detail] Character not in database, attempting auto-fetch', {

--- a/apps/core/src/routes/corporation-tax/alerts-routes.ts
+++ b/apps/core/src/routes/corporation-tax/alerts-routes.ts
@@ -1,6 +1,5 @@
 import { and, asc, eq, ilike, inArray, or } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import { logger } from '@repo/hono-helpers'
 
 import { userCharacters, users } from '../../db/schema'
 import { requireAuth } from '../../middleware/session'

--- a/apps/core/src/routes/corporation-tax/index.ts
+++ b/apps/core/src/routes/corporation-tax/index.ts
@@ -30,7 +30,6 @@ import {
 	TAX_RULE_PRIORITY_MAX,
 	TAX_RULE_PRIORITY_MIN,
 } from './shared'
-import { buildCsvLine } from '@repo/worker-utils'
 
 import type { CorporationTax } from '@repo/corporation-tax'
 import type { EveCharacterData } from '@repo/eve-character-data'
@@ -716,7 +715,7 @@ app.post('/rule-groups', requireAuth(), async (c) => {
 	let body: Record<string, unknown>
 	try {
 		body = await c.req.json()
-	} catch (_error) {
+	} catch {
 		return c.json({ error: 'Invalid JSON payload' }, 400)
 	}
 
@@ -1050,7 +1049,7 @@ app.post('/corporations/:corporationId/assessments/run', requireAuth(), async (c
 	let body: Record<string, unknown>
 	try {
 		body = await c.req.json()
-	} catch (_error) {
+	} catch {
 		return c.json({ error: 'Invalid JSON payload' }, 400)
 	}
 
@@ -1101,7 +1100,7 @@ app.post('/corporations/:corporationId/assessments/rebuild-finalized', requireAu
 	let body: Record<string, unknown>
 	try {
 		body = await c.req.json()
-	} catch (_error) {
+	} catch {
 		return c.json({ error: 'Invalid JSON payload' }, 400)
 	}
 
@@ -1239,7 +1238,7 @@ app.post('/corporations/:corporationId/ledger/ingest', requireAuth(), async (c) 
 	let body: Record<string, unknown> = {}
 	try {
 		body = await c.req.json()
-	} catch (_error) {
+	} catch {
 		// Optional JSON body; defaults are applied if empty/invalid.
 	}
 
@@ -1566,7 +1565,7 @@ app.post('/corporations/:corporationId/ledger/trim', requireAuth(), async (c) =>
 	let body: Record<string, unknown> = {}
 	try {
 		body = await c.req.json()
-	} catch (_error) {
+	} catch {
 		// Optional payload.
 	}
 
@@ -2014,7 +2013,7 @@ app.post('/corporations/:corporationId/periods/issue-bills', requireAuth(), asyn
 	let body: Record<string, unknown>
 	try {
 		body = await c.req.json()
-	} catch (_error) {
+	} catch {
 		return c.json({ error: 'Invalid JSON payload' }, 400)
 	}
 
@@ -2164,7 +2163,7 @@ app.post('/corporations/:corporationId/bills/sync', requireAuth(), async (c) => 
 	let body: Record<string, unknown> = {}
 	try {
 		body = await c.req.json()
-	} catch (_error) {
+	} catch {
 		// Optional JSON body; ignore parse errors for empty body.
 	}
 
@@ -2195,10 +2194,7 @@ async function resolveMemberSummaryTargets(input: {
 	user: SessionUser
 	corporationId: string
 	characterQuery?: string
-}): Promise<
-	| { targetCharacterIds: string[] | undefined }
-	| { response: Response }
-> {
+}): Promise<{ targetCharacterIds: string[] | undefined } | { response: Response }> {
 	const { c, user, corporationId, characterQuery } = input
 	const canReadWithTaxScopes = await canReadTaxFeature(c.env, user, corporationId)
 	const memberCharacterIds = await getMemberCharacterIdsInCorporation(c, user, corporationId)
@@ -2215,7 +2211,9 @@ async function resolveMemberSummaryTargets(input: {
 	if (characterQuery) {
 		const numericOnly = /^\d+$/.test(characterQuery)
 		if (numericOnly) {
-			const targetCharacterIds = allowedCharacterIds.includes(characterQuery) ? [characterQuery] : []
+			const targetCharacterIds = allowedCharacterIds.includes(characterQuery)
+				? [characterQuery]
+				: []
 			if (!canReadWithTaxScopes && targetCharacterIds.length === 0) {
 				return { response: c.json({ error: 'Forbidden' }, 403) }
 			}

--- a/apps/core/src/routes/corporation-tax/reports-routes.ts
+++ b/apps/core/src/routes/corporation-tax/reports-routes.ts
@@ -2,7 +2,7 @@ import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { requireAuth } from '../../middleware/session'
-import { canAuditTaxFeature, canReadTaxFeature } from '../../middleware/tax-permissions'
+import { canAuditTaxFeature } from '../../middleware/tax-permissions'
 import {
 	parseBooleanQueryParam,
 	parseDateQueryParam,

--- a/apps/core/src/routes/corporations/alerts-routes.ts
+++ b/apps/core/src/routes/corporations/alerts-routes.ts
@@ -1,16 +1,16 @@
 import { Hono } from 'hono'
-import type { Context } from 'hono'
 import { z } from 'zod'
 
+import { validateAlertDestinationRequirements } from '@repo/alert-destinations'
 import { eq } from '@repo/db-utils'
 import { logger } from '@repo/hono-helpers'
-import { validateAlertDestinationRequirements } from '@repo/alert-destinations'
 
-import { alertDestinations, managedCorporations } from '../../db/schema'
+import { managedCorporations } from '../../db/schema'
 import {
 	CORPORATION_ALERT_DESTINATION_TYPES,
 	CORPORATION_ALERT_TYPES,
 } from '../../lib/corporation-alerts'
+import { requireAdmin, requireAuth } from '../../middleware/session'
 import {
 	createCorporationAlertDestination,
 	deleteCorporationAlertDestination,
@@ -18,8 +18,8 @@ import {
 	listCorporationAlertTypes,
 	updateCorporationAlertDestination,
 } from '../../services/corporation-alerts.service'
-import { requireAdmin, requireAuth } from '../../middleware/session'
 
+import type { Context } from 'hono'
 import type { App } from '../../context'
 
 const app = new Hono<App>()
@@ -222,14 +222,24 @@ app.put('/:corporationId/alerts/:destinationId', requireAuth(), requireAdmin(), 
 
 		if (body.destinationType === 'discord_channel') {
 			if (body.discordServerId !== undefined && body.discordServerId === null) {
-				return c.json({ error: 'discordServerId cannot be cleared for discord_channel destinations' }, 400)
+				return c.json(
+					{ error: 'discordServerId cannot be cleared for discord_channel destinations' },
+					400
+				)
 			}
 			if (body.channelId !== undefined && body.channelId === null) {
-				return c.json({ error: 'channelId cannot be cleared for discord_channel destinations' }, 400)
+				return c.json(
+					{ error: 'channelId cannot be cleared for discord_channel destinations' },
+					400
+				)
 			}
 		}
 
-		if (body.destinationType === 'discord_user' && body.coreUserId !== undefined && body.coreUserId === null) {
+		if (
+			body.destinationType === 'discord_user' &&
+			body.coreUserId !== undefined &&
+			body.coreUserId === null
+		) {
 			return c.json({ error: 'coreUserId cannot be cleared for discord_user destinations' }, 400)
 		}
 

--- a/apps/core/src/routes/freight.ts
+++ b/apps/core/src/routes/freight.ts
@@ -8,20 +8,17 @@
 import { Hono } from 'hono'
 
 import { getStub } from '@repo/do-utils'
-import { TimeCache, logger } from '@repo/hono-helpers'
+import { logger, TimeCache } from '@repo/hono-helpers'
 
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import { requireAllianceMember, requireAuth } from '../middleware/session'
+import { resolveFreightLeaderboardWindow } from './freight-leaderboard-period'
 
 import type { EsiTypeResolver } from '@repo/esi'
-import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { CorporationContractSortBy, EveCorporationData } from '@repo/eve-corporation-data'
 import type { Freight } from '@repo/freight'
 import type { App } from '../context'
-import type { CorporationContractSortBy } from '@repo/eve-corporation-data'
-import {
-	resolveFreightLeaderboardWindow,
-	type FreightLeaderboardPeriod,
-} from './freight-leaderboard-period'
+import type { FreightLeaderboardPeriod } from './freight-leaderboard-period'
 
 const FREIGHT_MANAGER_URN = 'urn:freight:manager'
 
@@ -70,7 +67,10 @@ app.get('/routes/active', requireAuth(), async (c) => {
 
 		return c.json(routes)
 	} catch (error) {
-		logger.error('Error listing active freight routes:', { error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined })
+		logger.error('Error listing active freight routes:', {
+			error: error instanceof Error ? error.message : String(error),
+			stack: error instanceof Error ? error.stack : undefined,
+		})
 		return c.json({ error: 'Failed to list freight routes' }, 500)
 	}
 })
@@ -95,7 +95,10 @@ app.get('/routes', requireAuth(), async (c) => {
 
 		return c.json(routes)
 	} catch (error) {
-		logger.error('Error listing freight routes:', { error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined })
+		logger.error('Error listing freight routes:', {
+			error: error instanceof Error ? error.message : String(error),
+			stack: error instanceof Error ? error.stack : undefined,
+		})
 		return c.json({ error: 'Failed to list freight routes' }, 500)
 	}
 })
@@ -106,13 +109,17 @@ app.get('/routes', requireAuth(), async (c) => {
  */
 function validateFreightRouteOptionalFields(data: Record<string, unknown>): string | null {
 	if (data.maxVolume !== undefined && data.maxVolume !== null) {
-		const maxVol = typeof data.maxVolume === 'string' ? parseFloat(data.maxVolume) : Number(data.maxVolume)
+		const maxVol =
+			typeof data.maxVolume === 'string' ? parseFloat(data.maxVolume) : Number(data.maxVolume)
 		if (isNaN(maxVol) || maxVol <= 0) {
 			return 'maxVolume must be a positive number'
 		}
 	}
 	if (data.collateralFeeRate !== undefined && data.collateralFeeRate !== null) {
-		const rate = typeof data.collateralFeeRate === 'string' ? parseFloat(data.collateralFeeRate) : Number(data.collateralFeeRate)
+		const rate =
+			typeof data.collateralFeeRate === 'string'
+				? parseFloat(data.collateralFeeRate)
+				: Number(data.collateralFeeRate)
 		if (isNaN(rate) || rate < 0 || rate > 1) {
 			return 'collateralFeeRate must be a decimal between 0 and 1'
 		}
@@ -136,10 +143,16 @@ function validateFreightRouteOptionalFields(data: Record<string, unknown>): stri
  * Validate fields for update (all required fields are optional, only validate if present)
  */
 function validateFreightRouteUpdateFields(data: Record<string, unknown>): string | null {
-	if (data.pickupName !== undefined && (typeof data.pickupName !== 'string' || !data.pickupName.trim())) {
+	if (
+		data.pickupName !== undefined &&
+		(typeof data.pickupName !== 'string' || !data.pickupName.trim())
+	) {
 		return 'pickupName must be a non-empty string'
 	}
-	if (data.destinationName !== undefined && (typeof data.destinationName !== 'string' || !data.destinationName.trim())) {
+	if (
+		data.destinationName !== undefined &&
+		(typeof data.destinationName !== 'string' || !data.destinationName.trim())
+	) {
 		return 'destinationName must be a non-empty string'
 	}
 	if (data.iskPerVolumeUnit !== undefined) {
@@ -380,10 +393,7 @@ app.get('/contracts', requireAuth(), requireAllianceMember(), async (c) => {
 				: DEFAULT_CONTRACT_SORT_BY
 		const sortDirection: 'asc' | 'desc' =
 			rawSortDirection === 'desc' ? 'desc' : DEFAULT_CONTRACT_SORT_DIRECTION
-		const corpDataStub = getStub<EveCorporationData>(
-			c.env.EVE_CORPORATION_DATA,
-			'alliance-queries'
-		)
+		const corpDataStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, 'alliance-queries')
 
 		const contractPage = await corpDataStub.getAllianceCourierContracts(
 			ALLIANCE_ID,
@@ -422,9 +432,7 @@ app.get('/contracts', requireAuth(), requireAllianceMember(), async (c) => {
 			startLocationName: contract.startLocationId
 				? (names[contract.startLocationId] ?? null)
 				: null,
-			endLocationName: contract.endLocationId
-				? (names[contract.endLocationId] ?? null)
-				: null,
+			endLocationName: contract.endLocationId ? (names[contract.endLocationId] ?? null) : null,
 		}))
 
 		return c.json({
@@ -445,89 +453,94 @@ app.get('/contracts', requireAuth(), requireAllianceMember(), async (c) => {
  * Delegates contract window opening to the Freight worker, which owns the
  * authenticated ESI request and limiter keying for this action.
  */
-app.post('/contracts/:contractId/open-in-game', requireAuth(), requireAllianceMember(), async (c) => {
-	const user = c.get('user')!
-	const contractIdParam = c.req.param('contractId')
+app.post(
+	'/contracts/:contractId/open-in-game',
+	requireAuth(),
+	requireAllianceMember(),
+	async (c) => {
+		const user = c.get('user')!
+		const contractIdParam = c.req.param('contractId')
 
-	const contractId = Number(contractIdParam)
-	if (!Number.isInteger(contractId) || contractId <= 0) {
-		return c.json({ error: 'Invalid contract ID' }, 400)
-	}
-
-	// Resolve the user's main character: explicit mainCharacterId, then the
-	// primary character, then fall back to the first linked character.
-	const mainCharacter =
-		user.characters.find((char) => char.characterId === user.mainCharacterId) ??
-		user.characters.find((char) => char.is_primary) ??
-		user.characters[0]
-
-	if (!mainCharacter) {
-		return c.json({ error: 'No EVE character linked to this account' }, 400)
-	}
-
-	try {
-		const freightStub = getStub<Freight>(c.env.FREIGHT, 'default')
-		const result = await freightStub.openContractInGame(
-			mainCharacter.characterId,
-			mainCharacter.characterName,
-			contractId
-		)
-
-		if (result.success) {
-			return c.json({ success: true, characterName: mainCharacter.characterName })
+		const contractId = Number(contractIdParam)
+		if (!Number.isInteger(contractId) || contractId <= 0) {
+			return c.json({ error: 'Invalid contract ID' }, 400)
 		}
 
-		if (result.error === 'token_unavailable') {
+		// Resolve the user's main character: explicit mainCharacterId, then the
+		// primary character, then fall back to the first linked character.
+		const mainCharacter =
+			user.characters.find((char) => char.characterId === user.mainCharacterId) ??
+			user.characters.find((char) => char.is_primary) ??
+			user.characters[0]
+
+		if (!mainCharacter) {
+			return c.json({ error: 'No EVE character linked to this account' }, 400)
+		}
+
+		try {
+			const freightStub = getStub<Freight>(c.env.FREIGHT, 'default')
+			const result = await freightStub.openContractInGame(
+				mainCharacter.characterId,
+				mainCharacter.characterName,
+				contractId
+			)
+
+			if (result.success) {
+				return c.json({ success: true, characterName: mainCharacter.characterName })
+			}
+
+			if (result.error === 'token_unavailable') {
+				return c.json(
+					{
+						error: result.error,
+						message: result.message,
+					},
+					409
+				)
+			}
+
+			if (result.error === 'scope_missing') {
+				return c.json(
+					{
+						error: result.error,
+						message: result.message,
+					},
+					409
+				)
+			}
+
+			if (result.error === 'esi_rate_limited') {
+				return c.json(
+					{
+						error: result.error,
+						message: result.message,
+					},
+					429
+				)
+			}
+
+			// 520 / other: ESI reaches no client, or the client is offline.
+			logger.warn('Freight worker openwindow/contract returned non-success', {
+				contractId,
+				characterId: mainCharacter.characterId,
+				error: result.error,
+			})
 			return c.json(
 				{
-					error: result.error,
+					error: 'client_unreachable',
 					message: result.message,
 				},
-				409
+				502
 			)
+		} catch (error) {
+			logger.error('Error opening contract in-game:', {
+				error: error instanceof Error ? error.message : String(error),
+				contractId,
+			})
+			return c.json({ error: 'Failed to open contract in-game' }, 500)
 		}
-
-		if (result.error === 'scope_missing') {
-			return c.json(
-				{
-					error: result.error,
-					message: result.message,
-				},
-				409
-			)
-		}
-
-		if (result.error === 'esi_rate_limited') {
-			return c.json(
-				{
-					error: result.error,
-					message: result.message,
-				},
-				429
-			)
-		}
-
-		// 520 / other: ESI reaches no client, or the client is offline.
-		logger.warn('Freight worker openwindow/contract returned non-success', {
-			contractId,
-			characterId: mainCharacter.characterId,
-			error: result.error,
-		})
-		return c.json(
-			{
-				error: 'client_unreachable',
-				message: result.message,
-			},
-			502
-		)
-	} catch (error) {
-		logger.error('Error opening contract in-game:', {
-			error: error instanceof Error ? error.message : String(error),
-			contractId,
-		})
-		return c.json({ error: 'Failed to open contract in-game' }, 500)
 	}
-})
+)
 
 /**
  * GET /freight/leaderboard
@@ -535,10 +548,7 @@ app.post('/contracts/:contractId/open-in-game', requireAuth(), requireAllianceMe
  */
 app.get('/leaderboard', requireAuth(), requireAllianceMember(), async (c) => {
 	try {
-		const corpDataStub = getStub<EveCorporationData>(
-			c.env.EVE_CORPORATION_DATA,
-			'alliance-queries'
-		)
+		const corpDataStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, 'alliance-queries')
 
 		const period = c.req.query('period') as FreightLeaderboardPeriod | '30d' | undefined
 		const window = resolveFreightLeaderboardWindow(period)

--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -596,7 +596,6 @@ app.post('/characters/:characterId/reports', requireAuth(), async (c) => {
 			return c.json({ error: 'Database not available' }, 500)
 		}
 
-		const core = getCoreStub(c)
 		const auditor = await isHrAuditorUser(c, user)
 		const immunitasTarget = await getImmunitasReportTarget(c, db, characterId)
 		const resolvedTargetUserId = immunitasTarget?.userId
@@ -773,7 +772,6 @@ app.post('/reports/batch', requireAuth(), async (c) => {
 			return c.json({ error: 'Database not available' }, 500)
 		}
 
-		const core = getCoreStub(c)
 		const auditor = await isHrAuditorUser(c, user)
 		const requestorCharacterLabel =
 			user.characters.find((char) => char.is_primary)?.characterName ??
@@ -1096,16 +1094,14 @@ app.get('/reports/:reportId/sections/:section', requireAuth(), async (c) => {
 		if (page === undefined) {
 			const manifest = await fulcrum.getReportSections(reportId)
 			if ((manifest?.sections[section]?.chunks ?? 0) > 0) {
-				return c.json(
-					{ error: 'A page parameter is required for chunked report sections' },
-					400,
-				)
+				return c.json({ error: 'A page parameter is required for chunked report sections' }, 400)
 			}
 		}
 
-		const data = page === undefined && pageSize === undefined
-			? await fulcrum.getReportSectionData(reportId, section)
-			: await fulcrum.getReportSectionData(reportId, section, page, pageSize)
+		const data =
+			page === undefined && pageSize === undefined
+				? await fulcrum.getReportSectionData(reportId, section)
+				: await fulcrum.getReportSectionData(reportId, section, page, pageSize)
 		if (!data) {
 			return c.json({ error: 'Section data not found' }, 404)
 		}

--- a/apps/core/src/routes/groups.ts
+++ b/apps/core/src/routes/groups.ts
@@ -4,22 +4,25 @@ import { z } from 'zod'
 import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { and, eq } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
 import { userCharacters } from '../db/schema.js'
 import { waitUntilWithTelemetry } from '../lib/background-task'
+import { clearUserCache, getCachedUserMemberships } from '../lib/groups-cache'
+import {
+	triggerDiscordRefreshWorkflow,
+	triggerMumbleRefreshWorkflow,
+} from '../lib/workflow-triggers'
+import { requireAdmin, requireAuth } from '../middleware/session'
 import {
 	dispatchGroupApplicationSubmittedAlert,
 	dispatchGroupInvitationAlert,
 } from '../services/group-alerts.service'
-import { clearUserCache, getCachedUserMemberships } from '../lib/groups-cache'
-import { triggerDiscordRefreshWorkflow, triggerMumbleRefreshWorkflow } from '../lib/workflow-triggers'
-import { requireAdmin, requireAuth } from '../middleware/session'
 
 import type { Discord } from '@repo/discord'
 import type { Groups } from '@repo/groups'
 import type { App } from '../context'
-import { logger } from '@repo/hono-helpers'
 
 /**
  * Groups management routes
@@ -285,7 +288,6 @@ groups.post('/', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), requireAdmin
  */
 groups.get('/my-groups', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), async (c) => {
 	const user = c.get('user')!
-	const groupsDO = getStub<Groups>(c.env.GROUPS, 'default')
 
 	const memberships = await getCachedUserMemberships(c.env, user.id)
 	return c.json(memberships)
@@ -486,25 +488,21 @@ groups.post(
  * Cancel an invitation (same permissions as creating invitations)
  * Works on both active and expired pending invitations
  */
-groups.delete(
-	'/invitations/:id',
-	requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }),
-	async (c) => {
-		const user = c.get('user')!
-		const invitationId = c.req.param('id')
-		const groupsDO = getStub<Groups>(c.env.GROUPS, 'default')
+groups.delete('/invitations/:id', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), async (c) => {
+	const user = c.get('user')!
+	const invitationId = c.req.param('id')
+	const groupsDO = getStub<Groups>(c.env.GROUPS, 'default')
 
-		try {
-			await groupsDO.cancelInvitation(invitationId, user.id)
-			return c.json({ success: true }, 200)
-		} catch (error) {
-			if (error instanceof Error) {
-				return c.json({ error: error.message }, 400)
-			}
-			throw error
+	try {
+		await groupsDO.cancelInvitation(invitationId, user.id)
+		return c.json({ success: true }, 200)
+	} catch (error) {
+		if (error instanceof Error) {
+			return c.json({ error: error.message }, 400)
 		}
+		throw error
 	}
-)
+})
 
 /**
  * POST /:groupId/invite-codes
@@ -1547,33 +1545,29 @@ groups.delete(
  *
  * Add a group admin (admin only)
  */
-groups.post(
-	'/:groupId/admins',
-	requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }),
-	async (c) => {
-		const user = c.get('user')!
-		const groupId = c.req.param('groupId')
-		const body = await c.req.json()
-		const groupsDO = getStub<Groups>(c.env.GROUPS, 'default')
+groups.post('/:groupId/admins', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), async (c) => {
+	const user = c.get('user')!
+	const groupId = c.req.param('groupId')
+	const body = await c.req.json()
+	const groupsDO = getStub<Groups>(c.env.GROUPS, 'default')
 
-		if (!body.userId) {
-			return c.json({ error: 'userId is required' }, 400)
-		}
-
-		try {
-			await groupsDO.addAdmin(groupId, user.id, body.userId, user.is_admin)
-			return c.json({ success: true }, 200)
-		} catch (error) {
-			if (error instanceof Error) {
-				if (error.message.includes('not found')) {
-					return c.json({ error: 'Group or user not found' }, 404)
-				}
-				return c.json({ error: error.message }, 400)
-			}
-			throw error
-		}
+	if (!body.userId) {
+		return c.json({ error: 'userId is required' }, 400)
 	}
-)
+
+	try {
+		await groupsDO.addAdmin(groupId, user.id, body.userId, user.is_admin)
+		return c.json({ success: true }, 200)
+	} catch (error) {
+		if (error instanceof Error) {
+			if (error.message.includes('not found')) {
+				return c.json({ error: 'Group or user not found' }, 404)
+			}
+			return c.json({ error: error.message }, 400)
+		}
+		throw error
+	}
+})
 
 /**
  * DELETE /:groupId/admins/:userId
@@ -1635,7 +1629,10 @@ groups.post(
 
 			const db = createDb(c.env.DATABASE_URL)
 			const targetUser = await db.query.userCharacters.findFirst({
-				where: and(eq(userCharacters.is_primary, true), eq(userCharacters.characterName, body.characterName)),
+				where: and(
+					eq(userCharacters.is_primary, true),
+					eq(userCharacters.characterName, body.characterName)
+				),
 				columns: {
 					userId: true,
 				},
@@ -1709,8 +1706,7 @@ groups.post('/:id/join', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), asyn
 		waitUntilWithTelemetry(
 			c.executionCtx,
 			'groups.discord-refresh.join-group',
-			() =>
-				triggerDiscordRefreshWorkflow({ env: c.env, userId: user.id, source: 'group-joined' }),
+			() => triggerDiscordRefreshWorkflow({ env: c.env, userId: user.id, source: 'group-joined' }),
 			{
 				userId: user.id,
 				groupId,
@@ -1778,8 +1774,7 @@ groups.post('/:id/leave', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), asy
 		waitUntilWithTelemetry(
 			c.executionCtx,
 			'groups.mumble-refresh.leave-group',
-			() =>
-				triggerMumbleRefreshWorkflow({ env: c.env, userIds: [user.id], source: 'group-left' }),
+			() => triggerMumbleRefreshWorkflow({ env: c.env, userIds: [user.id], source: 'group-left' }),
 			{
 				userId: user.id,
 				groupId,
@@ -2051,10 +2046,7 @@ groups.post(
 		try {
 			const membershipType = parseDiscordRoleMembershipType(body.membershipType)
 			if (!membershipType) {
-				return c.json(
-					{ error: "membershipType must be 'member' or 'owner_admin'" },
-					400
-				)
+				return c.json({ error: "membershipType must be 'member' or 'owner_admin'" }, 400)
 			}
 
 			const result = await groupsDO.assignRoleToDiscordServer(
@@ -2173,12 +2165,16 @@ groups.post(
 					}
 
 					// Then update roles — admin-initiated refresh allows removal of roles no longer granted
-					const results = await discordDO.updateUserRoles(user.id, [
-						{
-							guildId: config.guildId,
-							roleIds: config.roleIds,
-						},
-					], true)
+					const results = await discordDO.updateUserRoles(
+						user.id,
+						[
+							{
+								guildId: config.guildId,
+								roleIds: config.roleIds,
+							},
+						],
+						true
+					)
 
 					if (results[0]?.success) {
 						successCount++

--- a/apps/core/src/routes/hr.ts
+++ b/apps/core/src/routes/hr.ts
@@ -3,26 +3,27 @@ import { z } from 'zod'
 
 import { and, eq, ilike, inArray, or } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
-import type { Discord } from '@repo/discord'
 import { captureException, logger } from '@repo/hono-helpers'
 import { APPLICATION_STATUSES } from '@repo/hr'
 
 import { managedCorporations, userCharacters, users } from '../db/schema'
+import { waitUntilWithTelemetry } from '../lib/background-task'
+import { buildCorporationApplicationApplicantUpdateMessage } from '../lib/corporation-alerts'
 import {
 	hasHrAuditorPermission as hasHrAuditorPermissionForUser,
 	resolveHrAccessState,
 } from '../lib/hr-access'
-import { waitUntilWithTelemetry } from '../lib/background-task'
 import { getIpHashMatches, getUserIpHistory } from '../lib/ip-history'
-import { dispatchCorporationAlert } from '../services/corporation-alerts.service'
-import { validatePagination } from '../lib/validation'
 import { getUserCorporationAffiliationIds } from '../lib/user-corporation-affiliations'
+import { validatePagination } from '../lib/validation'
 import { requireAdmin, requireAuth } from '../middleware/session'
+import { dispatchCorporationAlert } from '../services/corporation-alerts.service'
 
 import type { Context } from 'hono'
 import type { Core } from '@repo/core'
+import type { Discord } from '@repo/discord'
 import type { Esi, EsiTypeResolver } from '@repo/esi'
-import type { ApplicationFilters, Hr, HrNote, NoteFilters } from '@repo/hr'
+import type { Application, ApplicationFilters, Hr, HrNote, NoteFilters } from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
 import type { App } from '../context'
 
@@ -42,6 +43,50 @@ const upsertApplicationStaffNoteSchema = z.object({
  */
 function getHrStub(c: Context<App>): Hr {
 	return getStub<Hr>(c.env.HR, 'default')
+}
+
+function queueApplicationApplicantUpdateNotification(
+	c: Context<App>,
+	application: Pick<Application, 'id' | 'userId' | 'corporationId'>,
+	updateType: 'message' | 'review_note',
+	updatedAt: Date
+): void {
+	waitUntilWithTelemetry(
+		c.executionCtx,
+		'hr-application-applicant-update-notification',
+		async () => {
+			const db = c.get('db')
+			const corporation = db
+				? await db.query.managedCorporations.findFirst({
+						where: eq(managedCorporations.corporationId, application.corporationId),
+						columns: { name: true },
+					})
+				: null
+			const discord = getStub<Discord>(c.env.DISCORD, 'default')
+			const result = await discord.sendDirectMessage(
+				application.userId,
+				buildCorporationApplicationApplicantUpdateMessage({
+					applicationId: application.id,
+					corporationName: corporation?.name ?? application.corporationId,
+					updateType,
+					updatedAt: updatedAt.toISOString(),
+				})
+			)
+
+			if (!result.success) {
+				logger.warn('[HR] Failed to send application update Discord notification', {
+					applicationId: application.id,
+					userId: application.userId,
+					error: result.error,
+				})
+			}
+		},
+		{
+			applicationId: application.id,
+			userId: application.userId,
+			updateType,
+		}
+	)
 }
 
 /**
@@ -98,7 +143,10 @@ async function getActiveMemberCorporationIds(c: Context<App>): Promise<string[]>
 	}
 
 	const memberCorporations = await db.query.managedCorporations.findMany({
-		where: and(eq(managedCorporations.isActive, true), eq(managedCorporations.isMemberCorporation, true)),
+		where: and(
+			eq(managedCorporations.isActive, true),
+			eq(managedCorporations.isMemberCorporation, true)
+		),
 		columns: { corporationId: true },
 	})
 
@@ -337,7 +385,10 @@ async function hasHrAuditorPermission(c: Context<App>): Promise<boolean> {
 	})
 }
 
-async function canManageHrRolesForCorporation(c: Context<App>, corporationId: string): Promise<boolean> {
+async function canManageHrRolesForCorporation(
+	c: Context<App>,
+	corporationId: string
+): Promise<boolean> {
 	const db = c.get('db')
 	if (!db) {
 		throw new Error('Database not available')
@@ -359,7 +410,10 @@ async function canManageHrRolesForCorporation(c: Context<App>, corporationId: st
 	)
 }
 
-async function canUseHrToolsForCorporation(c: Context<App>, corporationId: string): Promise<boolean> {
+async function canUseHrToolsForCorporation(
+	c: Context<App>,
+	corporationId: string
+): Promise<boolean> {
 	const user = c.get('user')!
 
 	if (user.is_admin) {
@@ -547,13 +601,13 @@ app.get('/applications', requireAuth(), async (c) => {
 	const searchCharacterIds =
 		searchQuery && searchQuery.length > 0
 			? (
-				await db.query.userCharacters.findMany({
-					where: ilike(userCharacters.characterName, `%${searchQuery}%`),
-					columns: { characterId: true },
-					limit: 200,
-				})
-			).map((character) => character.characterId)
-		: []
+					await db.query.userCharacters.findMany({
+						where: ilike(userCharacters.characterName, `%${searchQuery}%`),
+						columns: { characterId: true },
+						limit: 200,
+					})
+				).map((character) => character.characterId)
+			: []
 
 	// Parse query params
 	const corporationId = c.req.query('corporationId')
@@ -628,12 +682,12 @@ app.get('/applications/paged', requireAuth(), async (c) => {
 	const searchCharacterIds =
 		searchQuery && searchQuery.length > 0
 			? (
-				await db.query.userCharacters.findMany({
-					where: ilike(userCharacters.characterName, `%${searchQuery}%`),
-					columns: { characterId: true },
-					limit: 200,
-				})
-			).map((character) => character.characterId)
+					await db.query.userCharacters.findMany({
+						where: ilike(userCharacters.characterName, `%${searchQuery}%`),
+						columns: { characterId: true },
+						limit: 200,
+					})
+				).map((character) => character.characterId)
 			: []
 
 	const filters: ApplicationFilters = {
@@ -698,7 +752,9 @@ app.get('/applications/:id', requireAuth(), async (c) => {
 			}
 		}
 		const discordUsername =
-			application.userId === user.id ? null : await resolveApplicationDiscordUsername(c, application.userId)
+			application.userId === user.id
+				? null
+				: await resolveApplicationDiscordUsername(c, application.userId)
 
 		const resolver = getStub<EsiTypeResolver>(c.env.ESI_TYPE_RESOLVER, 'global')
 		const db = c.get('db')!
@@ -747,7 +803,31 @@ app.patch('/applications/:id', requireAuth(), async (c) => {
 				403
 			)
 		}
-		await hr.updateApplicationStatus(applicationId, status, user.id, characterId, characterName, reviewNotes)
+		await hr.updateApplicationStatus(
+			applicationId,
+			status,
+			user.id,
+			characterId,
+			characterName,
+			reviewNotes
+		)
+
+		const normalizedReviewNotes = reviewNotes?.trim()
+		const previousReviewNotes = applicationBeforeUpdate.reviewNotes?.trim()
+		if (
+			applicationBeforeUpdate.userId !== user.id &&
+			normalizedReviewNotes &&
+			normalizedReviewNotes !== previousReviewNotes &&
+			(status === 'accepted' || status === 'rejected')
+		) {
+			// Only final-status review notes are shown on the applicant-facing page.
+			queueApplicationApplicantUpdateNotification(
+				c,
+				applicationBeforeUpdate,
+				'review_note',
+				new Date()
+			)
+		}
 
 		if (
 			status === 'accepted' &&
@@ -891,7 +971,14 @@ app.delete('/applications/:id/alts/:altCharacterId', requireAuth(), async (c) =>
 
 	try {
 		const hr = getHrStub(c)
-		await hr.removeApplicationAlt(applicationId, user.id, characterId, characterName, altCharacterId, altCharacterName)
+		await hr.removeApplicationAlt(
+			applicationId,
+			user.id,
+			characterId,
+			characterName,
+			altCharacterId,
+			altCharacterName
+		)
 		return c.json({ success: true })
 	} catch (error) {
 		return c.json(
@@ -938,7 +1025,10 @@ app.get('/recommendations/pending', requireAuth(), async (c) => {
 
 	try {
 		const hr = getHrStub(c)
-		const applications = await hr.listCorpApplicationsForRecommendation(accessibleCorporationIds, user.id)
+		const applications = await hr.listCorpApplicationsForRecommendation(
+			accessibleCorporationIds,
+			user.id
+		)
 		return c.json(applications)
 	} catch (error) {
 		return c.json(
@@ -975,7 +1065,8 @@ app.get('/recommendations/applications/:id', requireAuth(), async (c) => {
 		if (!accessibleCorporationIds.includes(application.corporationId)) {
 			return c.json(
 				{
-					error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+					error:
+						'Access denied. Recommendations are only available for member corporations you are attached to.',
 				},
 				403
 			)
@@ -1024,7 +1115,8 @@ app.post('/applications/:applicationId/recommendations', requireAuth(), async (c
 		if (!accessibleCorporationIds.includes(application.corporationId)) {
 			return c.json(
 				{
-					error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+					error:
+						'Access denied. Recommendations are only available for member corporations you are attached to.',
 				},
 				403
 			)
@@ -1187,6 +1279,10 @@ app.post('/applications/:applicationId/messages', requireAuth(), async (c) => {
 			{ isApplicant, isAdmin: user.is_admin, corporationId: application.corporationId }
 		)
 
+		if (!isApplicant) {
+			queueApplicationApplicantUpdateNotification(c, application, 'message', result.createdAt)
+		}
+
 		// Enrich the returned message with sender character name
 		const senderName = primaryCharacter?.characterName || 'Unknown'
 
@@ -1249,7 +1345,10 @@ app.get('/applications/:applicationId/messages/count', requireAuth(), async (c) 
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
-		if (application.userId !== user.id && !(await canUseHrToolsForCorporation(c, application.corporationId))) {
+		if (
+			application.userId !== user.id &&
+			!(await canUseHrToolsForCorporation(c, application.corporationId))
+		) {
 			return c.json(
 				{ error: 'Access denied. HR tools are only available for member corporations.' },
 				403
@@ -1305,7 +1404,8 @@ app.get('/applications/:applicationId/staff-notes', requireAuth(), async (c) => 
 		const notes = await hr.listApplicationStaffNotes(applicationId)
 		return c.json(notes)
 	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Failed to list application staff notes'
+		const message =
+			error instanceof Error ? error.message : 'Failed to list application staff notes'
 		const status = message.includes('permission') ? 403 : 400
 		return c.json({ error: message }, status)
 	}
@@ -1341,11 +1441,12 @@ app.post('/applications/:applicationId/staff-notes', requireAuth(), async (c) =>
 		}
 
 		const managementAccess = await getHrRoleManagementAccess(c, application.corporationId)
-		const hasHrStaffPermission = await hr.checkPermission(user.id, application.corporationId, 'hr_viewer')
-		const hasWritePermission =
-			user.is_admin ||
-			managementAccess === 'ceo' ||
-			hasHrStaffPermission
+		const hasHrStaffPermission = await hr.checkPermission(
+			user.id,
+			application.corporationId,
+			'hr_viewer'
+		)
+		const hasWritePermission = user.is_admin || managementAccess === 'ceo' || hasHrStaffPermission
 		if (!hasWritePermission) {
 			return c.json({ error: 'HR staff, CEO, or admin access required' }, 403)
 		}
@@ -1400,11 +1501,12 @@ app.patch('/applications/:applicationId/staff-notes/:noteId', requireAuth(), asy
 		}
 
 		const managementAccess = await getHrRoleManagementAccess(c, application.corporationId)
-		const hasHrStaffPermission = await hr.checkPermission(user.id, application.corporationId, 'hr_viewer')
-		const hasWritePermission =
-			user.is_admin ||
-			managementAccess === 'ceo' ||
-			hasHrStaffPermission
+		const hasHrStaffPermission = await hr.checkPermission(
+			user.id,
+			application.corporationId,
+			'hr_viewer'
+		)
+		const hasWritePermission = user.is_admin || managementAccess === 'ceo' || hasHrStaffPermission
 		if (!hasWritePermission) {
 			return c.json({ error: 'HR staff, CEO, or admin access required' }, 403)
 		}
@@ -1434,7 +1536,8 @@ app.patch('/applications/:applicationId/staff-notes/:noteId', requireAuth(), asy
 		}
 		return c.json(updated)
 	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Failed to update application staff note'
+		const message =
+			error instanceof Error ? error.message : 'Failed to update application staff note'
 		const status = message.includes('permission') ? 403 : 400
 		return c.json({ error: message }, status)
 	}
@@ -1465,11 +1568,12 @@ app.delete('/applications/:applicationId/staff-notes/:noteId', requireAuth(), as
 		}
 
 		const managementAccess = await getHrRoleManagementAccess(c, application.corporationId)
-		const hasHrStaffPermission = await hr.checkPermission(user.id, application.corporationId, 'hr_viewer')
-		const hasWritePermission =
-			user.is_admin ||
-			managementAccess === 'ceo' ||
-			hasHrStaffPermission
+		const hasHrStaffPermission = await hr.checkPermission(
+			user.id,
+			application.corporationId,
+			'hr_viewer'
+		)
+		const hasWritePermission = user.is_admin || managementAccess === 'ceo' || hasHrStaffPermission
 		if (!hasWritePermission) {
 			return c.json({ error: 'HR staff, CEO, or admin access required' }, 403)
 		}
@@ -1490,7 +1594,8 @@ app.delete('/applications/:applicationId/staff-notes/:noteId', requireAuth(), as
 		await hr.deleteApplicationStaffNote(noteId, user.id, actorCharacterId, actorCharacterName)
 		return c.json({ success: true })
 	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Failed to delete application staff note'
+		const message =
+			error instanceof Error ? error.message : 'Failed to delete application staff note'
 		const status = message.includes('permission') ? 403 : 400
 		return c.json({ error: message }, status)
 	}
@@ -1601,10 +1706,7 @@ app.get('/corporations', requireAuth(), async (c) => {
 			hr_viewer: 1,
 		}
 		const explicitUserRoles = await hr.getUserRoles(user.id)
-		const highestExplicitRoleByCorp = new Map<
-			string,
-			typeof explicitUserRoles[number]['role']
-		>()
+		const highestExplicitRoleByCorp = new Map<string, (typeof explicitUserRoles)[number]['role']>()
 		for (const role of explicitUserRoles.filter((r) => r.isActive)) {
 			const corpId = role.corporationId
 			if (!corpId) continue
@@ -1631,10 +1733,7 @@ app.get('/corporations', requireAuth(), async (c) => {
 			}
 		})
 
-		return c.json(
-			results
-				.sort((a, b) => a.name.localeCompare(b.name))
-		)
+		return c.json(results.sort((a, b) => a.name.localeCompare(b.name)))
 	} catch (error) {
 		logger.error('[HR Roles] Failed to list accessible HR corporations', {
 			userId: user.id,
@@ -2028,7 +2127,10 @@ app.post('/:corporationId/roles', requireAuth(), async (c) => {
 	const { userId, characterId, role, expiresAt } = await c.req.json()
 
 	if (!(await canManageHrRolesForCorporation(c, corporationId))) {
-		return c.json({ error: 'Access denied. HR roles can only be managed for member corporations.' }, 403)
+		return c.json(
+			{ error: 'Access denied. HR roles can only be managed for member corporations.' },
+			403
+		)
 	}
 
 	// Authorization check
@@ -2039,7 +2141,10 @@ app.post('/:corporationId/roles', requireAuth(), async (c) => {
 
 	// Only CEOs and site admins can grant HR admin
 	if (role === 'hr_admin' && managementAccess !== 'ceo' && managementAccess !== 'site_admin') {
-		return c.json({ error: 'Access denied. Only corporation CEOs or site admins can grant HR admin.' }, 403)
+		return c.json(
+			{ error: 'Access denied. Only corporation CEOs or site admins can grant HR admin.' },
+			403
+		)
 	}
 
 	// HR admins can only grant lower roles
@@ -2097,7 +2202,10 @@ app.get('/:corporationId/roles', requireAuth(), async (c) => {
 	const db = c.get('db')
 
 	if (!(await canManageHrRolesForCorporation(c, corporationId))) {
-		return c.json({ error: 'Access denied. HR roles can only be managed for member corporations.' }, 403)
+		return c.json(
+			{ error: 'Access denied. HR roles can only be managed for member corporations.' },
+			403
+		)
 	}
 
 	const managementAccess = await getHrRoleManagementAccess(c, corporationId)
@@ -2281,7 +2389,10 @@ app.delete('/:corporationId/roles/:roleId', requireAuth(), async (c) => {
 	const roleId = c.req.param('roleId')
 
 	if (!(await canManageHrRolesForCorporation(c, corporationId))) {
-		return c.json({ error: 'Access denied. HR roles can only be managed for member corporations.' }, 403)
+		return c.json(
+			{ error: 'Access denied. HR roles can only be managed for member corporations.' },
+			403
+		)
 	}
 
 	// Authorization check
@@ -2480,7 +2591,11 @@ app.get('/audit/ip-history/:ipAddressHash/matches', requireAuth(), async (c) => 
  */
 app.get('/legacy/history', requireAuth(), async (c) => {
 	const user = c.get('user')!
-	if (!user.is_admin && !(await hasHrAuditorPermission(c)) && !(await hasExplicitMemberCorpHrAccess(c))) {
+	if (
+		!user.is_admin &&
+		!(await hasHrAuditorPermission(c)) &&
+		!(await hasExplicitMemberCorpHrAccess(c))
+	) {
 		return c.json({ error: 'Forbidden' }, 403)
 	}
 
@@ -2502,7 +2617,11 @@ app.get('/legacy/history', requireAuth(), async (c) => {
  */
 app.get('/legacy/history/:legacyApplicationId', requireAuth(), async (c) => {
 	const user = c.get('user')!
-	if (!user.is_admin && !(await hasHrAuditorPermission(c)) && !(await hasExplicitMemberCorpHrAccess(c))) {
+	if (
+		!user.is_admin &&
+		!(await hasHrAuditorPermission(c)) &&
+		!(await hasExplicitMemberCorpHrAccess(c))
+	) {
 		return c.json({ error: 'Forbidden' }, 403)
 	}
 

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -702,62 +702,6 @@ function getPricingSnapshotDate(pricingRevision: string | null): string | null {
 	return pricingRevision?.split(':', 1)[0] ?? null
 }
 
-function getMoonProfitValuesFromComposition(
-	composition: VerifiedComposition,
-	inputs: MoonPricingInputs
-): Pick<VerifiedMoonsListItem, 'metenoxProfit' | 'tataraProfit'> {
-	const reprocessingYield = parseFloat(inputs.settings.defaultReprocessingYield)
-	const cycleDays = inputs.settings.defaultCycleDays
-	let metenoxProfit: number | null = null
-	let tataraProfit: number | null = null
-
-	for (const profile of inputs.profiles) {
-		const baseRate = parseFloat(profile.baseVolumePerHr) * (1 + parseFloat(profile.rigBonus))
-		const fuelPerHr = parseFloat(profile.fuelPerHr)
-		const magmaticGasPerHr = profile.magmaticGasPerHr ? parseFloat(profile.magmaticGasPerHr) : 0
-		const cycleHours = cycleDays * 24
-		const totalVolume = profile.isPassive
-			? baseRate * parseFloat(profile.nullsecModifier) * cycleHours
-			: baseRate * cycleHours
-		const fuelUnits = fuelPerHr * cycleHours
-		const magmaticGasUnits = profile.isPassive ? magmaticGasPerHr * cycleHours : 0
-
-		let grossIsk = 0
-		for (const ore of composition.ores) {
-			const liveMaterials = inputs.typeMaterialsMap[ore.oreTypeId] ?? []
-			const fraction = parseFloat(ore.quantity)
-			const oreUnits = (totalVolume * fraction) / getOreVolume(ore.oreTypeId)
-			for (const material of liveMaterials) {
-				if (profile.isPassive && MINERAL_TYPE_IDS.has(material.materialTypeId)) continue
-				const rawUnits = Math.floor(oreUnits / 100) * material.quantity * reprocessingYield
-				grossIsk += Math.floor(rawUnits) * (inputs.priceMap[material.materialTypeId] ?? 0)
-			}
-		}
-
-		const fuelCost =
-			fuelUnits *
-			resolveEffectivePrice(
-				inputs.settings.fuelBlockPriceOverride,
-				inputs.priceMap[FUEL_BLOCK_TYPE_ID] ?? 0
-			)
-		const magmaticGasCost =
-			magmaticGasUnits *
-			resolveEffectivePrice(
-				inputs.settings.magmaticGasPriceOverride,
-				inputs.priceMap[MAGMATIC_GAS_TYPE_ID] ?? 0
-			)
-		const profit = Math.round(grossIsk - fuelCost - magmaticGasCost)
-
-		if (profile.id === 'metenox') metenoxProfit = profit
-		else if (profile.id === 'tatara') tataraProfit = profit
-	}
-
-	return {
-		metenoxProfit: metenoxProfit !== null ? String(metenoxProfit) : null,
-		tataraProfit: tataraProfit !== null ? String(tataraProfit) : null,
-	}
-}
-
 function toMoonProfitabilityQueryInputs(inputs: MoonPricingInputs): MoonProfitabilityQueryInputs {
 	return {
 		...inputs.settings,

--- a/apps/core/src/routes/skill-plans.ts
+++ b/apps/core/src/routes/skill-plans.ts
@@ -1,28 +1,26 @@
 import { Hono } from 'hono'
 
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
+import {
+	getCachedGroup,
+	getCachedUserMemberships,
+	getCachedUserPermissions,
+} from '../lib/groups-cache'
 import {
 	canCheckCharacterProgress,
 	canDeletePlan,
 	canModifyPlan,
 	canViewPlan,
 } from '../lib/skill-plan-auth'
-import { getCachedGroup, getCachedUserMemberships, getCachedUserPermissions } from '../lib/groups-cache'
 import { requireAllianceMember } from '../middleware/session'
 
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { Hr } from '@repo/hr'
-import type {
-	AddSkillToPlanInput,
-	CreateSkillPlanInput,
-	SkillPlan,
-	SkillPlanCategory,
-	Skills,
-} from '@repo/skills'
+import type { AddSkillToPlanInput, CreateSkillPlanInput, Skills } from '@repo/skills'
 import type { App } from '../context'
-import { logger } from '@repo/hono-helpers'
 
 /**
  * Helper function to resolve maintainer name from maintainerId
@@ -257,12 +255,7 @@ const skillPlansRoutes = new Hono<App>()
 							? ('group' as const)
 							: ('user' as const)
 						const maintainerName = plan.maintainerId
-							? await resolveMaintainerName(
-								plan.maintainerId,
-								user.id,
-								c.env,
-								db
-							)
+							? await resolveMaintainerName(plan.maintainerId, user.id, c.env, db)
 							: 'System'
 						return {
 							...plan,

--- a/apps/core/src/services/__tests__/director-health-recheck.service.test.ts
+++ b/apps/core/src/services/__tests__/director-health-recheck.service.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-	recheckDirectorHealthAfterTokenReauth,
-	type DirectorHealthRecheckStub,
-} from '../director-health-recheck.service'
+import { recheckDirectorHealthAfterTokenReauth } from '../director-health-recheck.service'
+
+import type { DirectorHealthRecheckStub } from '../director-health-recheck.service'
 
 describe('director health reauth recheck', () => {
 	it('re-verifies a matching director and updates managed corporation health', async () => {
@@ -18,7 +17,8 @@ describe('director health reauth recheck', () => {
 					lastHealthCheck: null,
 					lastUsed: null,
 					failureCount: 3,
-					lastFailureReason: 'Director token is missing required ESI scopes: esi-fleets.read_fleet.v1',
+					lastFailureReason:
+						'Director token is missing required ESI scopes: esi-fleets.read_fleet.v1',
 					priority: 100,
 				},
 				{
@@ -58,17 +58,17 @@ describe('director health reauth recheck', () => {
 				},
 			])
 
-		const verifyDirectorHealth = vi.fn<DirectorHealthRecheckStub['verifyDirectorHealth']>().mockResolvedValue(true)
+		const verifyDirectorHealth = vi
+			.fn<DirectorHealthRecheckStub['verifyDirectorHealth']>()
+			.mockResolvedValue(true)
 
 		const updateManagedCorporationHealth = vi.fn().mockResolvedValue(undefined)
 
 		const result = await recheckDirectorHealthAfterTokenReauth({
 			characterId: '111',
 			characterName: 'Test Auth',
-			corporations: [
-				{ corporationId: '1001', name: 'Corp One' },
-			],
-			getCorporationStub: (corporationId) =>
+			corporations: [{ corporationId: '1001', name: 'Corp One' }],
+			getCorporationStub: (_corporationId) =>
 				({
 					getDirectors,
 					verifyDirectorHealth,

--- a/apps/core/src/services/auth.service.ts
+++ b/apps/core/src/services/auth.service.ts
@@ -2,9 +2,9 @@ import { and, eq } from '@repo/db-utils'
 
 import { userSessions } from '../db/schema'
 
+import type { CreateSessionOptions, UserSessionDTO } from '@repo/core'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { createDb } from '../db'
-import type { CreateSessionOptions, RequestMetadata, UserSessionDTO } from '@repo/core'
 
 /**
  * Authentication Service

--- a/apps/core/src/services/corporation-alerts.service.ts
+++ b/apps/core/src/services/corporation-alerts.service.ts
@@ -1,44 +1,38 @@
+import { and, desc, eq } from '@repo/db-utils'
+import { buildDiscordWebhookMessagePayload } from '@repo/discord'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
-import {
-	and,
-	desc,
-	eq,
-} from '@repo/db-utils'
-
+import { alertDestinations, discordServers, managedCorporations } from '../db/schema'
 import {
 	corporationAlertRegistry,
 	getCorporationAlertTypeDefinitions,
 	isCorporationAlertDestinationType,
 	isCorporationAlertType,
-	type CorporationAlertDestinationRecord,
-	type CorporationAlertPayloadByType,
-	type CorporationAlertType,
 } from '../lib/corporation-alerts'
-import type { AlertRegistryEntry } from '../lib/alert-routing'
-import { alertDestinations, managedCorporations, discordServers } from '../db/schema'
-import type * as schema from '../db/schema'
 import {
 	createAlertDestination,
 	deleteAlertDestination,
 	listAlertDestinations,
 	updateAlertDestination,
-	type AlertDestinationInsert,
-	type AlertDestinationListItem,
-	type AlertDestinationRow,
 } from './alert-destinations.service'
 
-import type {
-	Discord,
-	MessageContent,
-	SendMessageResult,
-} from '@repo/discord'
-import { buildDiscordWebhookMessagePayload } from '@repo/discord'
+import type { Discord, MessageContent, SendMessageResult } from '@repo/discord'
 import type { Groups } from '@repo/groups'
-import type { DbClient } from '../db'
 import type { Env } from '../context'
-import type { AlertDestinationType } from '../lib/alert-routing'
+import type { DbClient } from '../db'
+import type * as schema from '../db/schema'
+import type { AlertDestinationType, AlertRegistryEntry } from '../lib/alert-routing'
+import type {
+	CorporationAlertDestinationRecord,
+	CorporationAlertPayloadByType,
+	CorporationAlertType,
+} from '../lib/corporation-alerts'
+import type {
+	AlertDestinationInsert,
+	AlertDestinationListItem,
+	AlertDestinationRow,
+} from './alert-destinations.service'
 
 export type CorporationAlertDestinationRow = AlertDestinationRow & { corporationId: string }
 export type CorporationAlertDestinationInsert = AlertDestinationInsert
@@ -77,7 +71,9 @@ export interface UpdateCorporationAlertDestinationInput {
 	updatedBy?: string | null
 }
 
-export interface DispatchCorporationAlertInput<T extends CorporationAlertType = CorporationAlertType> {
+export interface DispatchCorporationAlertInput<
+	T extends CorporationAlertType = CorporationAlertType,
+> {
 	corporationId: string
 	alertType: T
 	payload: CorporationAlertPayloadByType[T]
@@ -176,7 +172,10 @@ export async function updateCorporationAlertDestination(
 		throw new Error(`Unsupported alert type: ${input.alertType}`)
 	}
 
-	if (input.destinationType !== undefined && !isCorporationAlertDestinationType(input.destinationType)) {
+	if (
+		input.destinationType !== undefined &&
+		!isCorporationAlertDestinationType(input.destinationType)
+	) {
 		throw new Error(`Unsupported alert destination type: ${input.destinationType}`)
 	}
 

--- a/apps/core/src/services/dkp.service.ts
+++ b/apps/core/src/services/dkp.service.ts
@@ -1,12 +1,12 @@
 import { and, desc, eq, gte, inArray, lte, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
 
-import { dkpDecayConfig, dkpTransactions, userCharacters, users } from '../db/schema'
+import { dkpTransactions, userCharacters, users } from '../db/schema'
 
 import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { DbClient, schema } from '../db'
-import { logger } from '@repo/hono-helpers'
 
 const MS_PER_DAY = 86_400_000
 
@@ -141,7 +141,7 @@ export class DkpService {
 		try {
 			const currentBalance = await this.getCharacterBalance(params.characterId)
 			currentBalanceAmount = currentBalance.balance.current
-		} catch (error) {
+		} catch {
 			// Character has no prior transactions, balance is 0
 			currentBalanceAmount = 0
 		}
@@ -349,7 +349,7 @@ export class DkpService {
 	 */
 	async getCharacterBalance(
 		characterId: string,
-		period?: '7d' | '30d' | '90d' | 'all'
+		_period?: '7d' | '30d' | '90d' | 'all'
 	): Promise<{
 		characterId: string
 		characterName: string
@@ -422,7 +422,7 @@ export class DkpService {
 	 */
 	async getUserBalance(
 		userId: string,
-		period?: '7d' | '30d' | '90d' | 'all'
+		_period?: '7d' | '30d' | '90d' | 'all'
 	): Promise<{
 		userId: string
 		balance: {
@@ -537,7 +537,7 @@ export class DkpService {
 	 */
 	async getCorporationBalance(
 		corporationId: string,
-		period?: '7d' | '30d' | '90d' | 'all'
+		_period?: '7d' | '30d' | '90d' | 'all'
 	): Promise<{
 		corporationId: string
 		corporationName: string

--- a/apps/core/src/services/esi.service.ts
+++ b/apps/core/src/services/esi.service.ts
@@ -10,7 +10,7 @@ const AUTH_CHARACTER_ID = '2114114257' // Test Auth character
  * Module-level cache for all solar system names.
  * Loaded lazily on first search, persists for the Worker instance lifetime.
  */
-let systemNamesCache: { id: number; name: string }[] | null = null
+let systemNamesCache: Array<{ id: number; name: string }> | null = null
 let systemNamesCacheExpiry = 0
 
 /**
@@ -160,7 +160,7 @@ export class EsiService {
 	 * Load all solar system names from ESI public endpoints.
 	 * Caches in module-level variable for the Worker instance lifetime (1 hour refresh).
 	 */
-	private async getAllSystemNames(): Promise<{ id: number; name: string }[]> {
+	private async getAllSystemNames(): Promise<Array<{ id: number; name: string }>> {
 		if (systemNamesCache && systemNamesCacheExpiry > Date.now()) {
 			return systemNamesCache
 		}
@@ -168,15 +168,13 @@ export class EsiService {
 		logger.info('Loading all system names from ESI...')
 
 		// Step 1: Get all system IDs (public endpoint, no auth)
-		const idsResult = await this.tokenStore.fetchPublicEsi<number[]>(
-			'/latest/universe/systems/'
-		)
+		const idsResult = await this.tokenStore.fetchPublicEsi<number[]>('/latest/universe/systems/')
 		const allIds = idsResult.data
 		logger.info('Loaded system IDs', { count: allIds.length })
 
 		// Step 2: Resolve names in batches of 1000 via resolveIds
 		const BATCH_SIZE = 1000
-		const systems: { id: number; name: string }[] = []
+		const systems: Array<{ id: number; name: string }> = []
 
 		for (let i = 0; i < allIds.length; i += BATCH_SIZE) {
 			const batch = allIds.slice(i, i + BATCH_SIZE)

--- a/apps/core/src/services/group-alerts.service.ts
+++ b/apps/core/src/services/group-alerts.service.ts
@@ -1,18 +1,17 @@
 import { and, inArray, isNotNull } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 
+import * as schema from '../db/schema'
 import {
 	buildGroupApplicationSubmittedMessage,
 	buildGroupInvitationMessage,
 } from '../lib/group-alerts'
 import { getPrimaryCharacterSummaryByUserId } from '../lib/user-character-lookup'
 
-import type { Discord } from '@repo/discord'
+import type { Discord, MessageContent } from '@repo/discord'
 import type { Groups } from '@repo/groups'
-import type { MessageContent } from '@repo/discord'
-import type { DbClient } from '../db'
-import * as schema from '../db/schema'
 import type { Env } from '../context'
+import type { DbClient } from '../db'
 
 type DispatchResult = {
 	recipientCount: number
@@ -76,7 +75,8 @@ export async function dispatchGroupApplicationSubmittedAlert(
 		applicantUserId: string
 		applicationNote: string | null
 		submittedAt: Date
-	}): Promise<DispatchResult> {
+	}
+): Promise<DispatchResult> {
 	const groupsStub = getStub<Groups>(env.GROUPS, 'default')
 	const discordStub = getStub<Discord>(env.DISCORD, 'default')
 
@@ -128,7 +128,8 @@ export async function dispatchGroupInvitationAlert(
 		inviterUserId: string
 		inviteeUserId: string
 		createdAt: Date
-	}): Promise<DispatchResult> {
+	}
+): Promise<DispatchResult> {
 	const discordStub = getStub<Discord>(env.DISCORD, 'default')
 	const [inviteeRecipients, inviter] = await Promise.all([
 		getDiscordLinkedUserIds(db, [input.inviteeUserId]),
@@ -152,11 +153,7 @@ export async function dispatchGroupInvitationAlert(
 		createdAt: input.createdAt,
 	})
 
-	const { sentCount, failedCount } = await sendToRecipients(
-		discordStub,
-		inviteeRecipients,
-		message
-	)
+	const { sentCount, failedCount } = await sendToRecipients(discordStub, inviteeRecipients, message)
 
 	return {
 		recipientCount: inviteeRecipients.length,

--- a/apps/core/src/services/session.service.ts
+++ b/apps/core/src/services/session.service.ts
@@ -21,7 +21,7 @@ export class SessionService {
 	 * @returns Number of sessions invalidated
 	 */
 	async invalidateAllUserSessions(userId: string): Promise<number> {
-		const result = await this.db.delete(userSessions).where(eq(userSessions.userId, userId))
+		await this.db.delete(userSessions).where(eq(userSessions.userId, userId))
 
 		// Drizzle doesn't provide a standard way to get affected rows count
 		// We return 0 as a placeholder (the operation still succeeds)

--- a/apps/core/src/test/mocks/cloudflare-workers.ts
+++ b/apps/core/src/test/mocks/cloudflare-workers.ts
@@ -27,7 +27,6 @@ export class WorkflowEntrypoint<Env = unknown, Params = unknown> {
 		this.env = env
 	}
 
-	// eslint-disable-next-line @typescript-eslint/require-await
 	async run(_event: unknown, _step: unknown): Promise<Params> {
 		throw new Error('WorkflowEntrypoint.run is not implemented in unit-test shim')
 	}

--- a/apps/core/src/test/unit/workflows/csv-export.workflow.test.ts
+++ b/apps/core/src/test/unit/workflows/csv-export.workflow.test.ts
@@ -20,7 +20,6 @@ vi.mock('cloudflare:workers', () => {
 			this.env = env
 		}
 
-		// eslint-disable-next-line @typescript-eslint/require-await
 		async run(_event: unknown, _step: unknown): Promise<Params> {
 			throw new Error('WorkflowEntrypoint.run is not implemented in unit-test shim')
 		}

--- a/apps/core/src/workflows/steps/update-character/try-character-authenticated-fetch.ts
+++ b/apps/core/src/workflows/steps/update-character/try-character-authenticated-fetch.ts
@@ -5,12 +5,12 @@
 import { eq } from 'drizzle-orm'
 
 import { getStub } from '@repo/do-utils'
+
+import { userCharacters } from '../../../db/schema'
 import {
 	didTokenTransitionFromValidToInvalid,
 	queueTokenInvalidationAlertsForUser,
 } from '../../../lib/token-invalid-alerts'
-
-import { userCharacters } from '../../../db/schema'
 import {
 	markCharacterTokenInvalidFromAuthFailure,
 	validateAndSyncCharacterTokenValidity,
@@ -77,9 +77,9 @@ export async function tryCharacterAuthenticatedFetch(
 			previousHasValidToken: existingCharacter?.hasValidToken ?? null,
 			touchLastCharacterRefresh: true,
 			forceValidate: ctx.forceTokenValidation === true,
-	})
+		})
 
-	let tokenInvalidated = didTokenTransitionFromValidToInvalid(
+	const tokenInvalidated = didTokenTransitionFromValidToInvalid(
 		previousHasValidToken,
 		nextHasValidToken
 	)
@@ -116,10 +116,7 @@ export async function tryCharacterAuthenticatedFetch(
 				error: errorMessage,
 				errorDetails: extractErrorDetails(error),
 			})
-			if (
-				downgradedToken &&
-				didTokenTransitionFromValidToInvalid(previousHasValidToken, false)
-			) {
+			if (downgradedToken && didTokenTransitionFromValidToInvalid(previousHasValidToken, false)) {
 				try {
 					const coreStub = getStub<CoreRpc>(ctx.env.CORE, 'default')
 					const queueResult = await queueTokenInvalidationAlertsForUser(coreStub, {
@@ -145,7 +142,7 @@ export async function tryCharacterAuthenticatedFetch(
 				error: errorMessage,
 				status: downgradedToken ? 'invalid_token' : validation.status,
 				success: false,
-			tokenInvalidated: downgradedToken && previousHasValidToken === true,
+				tokenInvalidated: downgradedToken && previousHasValidToken === true,
 			}
 		}
 	}

--- a/apps/core/src/workflows/steps/user-roles/get-user-role-attachments.ts
+++ b/apps/core/src/workflows/steps/user-roles/get-user-role-attachments.ts
@@ -1,4 +1,3 @@
-import { ROLE_CORE_ALLIANCE_MEMBER, ROLE_CORE_CORP_MEMBER } from '@repo/core'
 import { getStub } from '@repo/do-utils'
 import { RoleAttachmentType } from '@repo/groups'
 


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds Discord DM notifications to HR applicants when their application receives a staff reply or a final-status review note, and applies a broad ESLint/formatting cleanup (import ordering, line wrapping, unused-variable prefixes) across `apps/core`.

## Changes
- Added `buildCorporationApplicationApplicantUpdateMessage` in `apps/core/src/lib/corporation-alerts.ts` to build the Discord DM embed for applicant-facing application updates.
- Added `queueApplicationApplicantUpdateNotification` in `apps/core/src/routes/hr.ts`, which sends the applicant a Discord DM (via `waitUntilWithTelemetry`) when:
  - an HR-authored public message is posted on their application (`POST /applications/:applicationId/messages`), or
  - their application is moved to `accepted`/`rejected` with new review notes (`PATCH /applications/:id`).
- No DM is sent when the applicant is the one posting the message or updating their own application.
- Removed the now-unused `formatDiscordTimestamp` helper and unused `attemptLabel` variable in the alerts code.
- Wide-reaching lint/formatting fixes across many `apps/core` files (import ordering/grouping, line-wrap/line-break style, prefixing an unused `groupId` param with `_`), with no behavioral changes.

## Testing
- Extended `apps/core/src/routes/__tests__/hr.application-alerts.test.ts` with cases verifying:
  - a DM is sent to the applicant after an HR-authored public message,
  - a DM is sent after acceptance with review notes,
  - no DM is sent for an applicant's own message on their own application.
<!-- claude:end -->