### PR TITLE
optimize store query for corporate wallet and transaction journal

### DIFF
--- a/apps/eve-corporation-data/.migrations/0036_natural_reptil.sql
+++ b/apps/eve-corporation-data/.migrations/0036_natural_reptil.sql
@@ -1,0 +1,4 @@
+CREATE INDEX "corporation_wallet_journal_corp_div_date_idx" ON "corporation_wallet_journal" USING btree ("corporation_id","division","date");--> statement-breakpoint
+CREATE INDEX "corporation_wallet_journal_corp_div_num_id_idx" ON "corporation_wallet_journal" USING btree ("corporation_id","division",("journal_id"::numeric));--> statement-breakpoint
+CREATE INDEX "corporation_wallet_tx_corp_div_date_idx" ON "corporation_wallet_transactions" USING btree ("corporation_id","division","date");--> statement-breakpoint
+CREATE INDEX "corporation_wallet_tx_corp_div_num_id_idx" ON "corporation_wallet_transactions" USING btree ("corporation_id","division",("transaction_id"::numeric));

--- a/apps/eve-corporation-data/.migrations/meta/0036_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0036_snapshot.json
@@ -1,0 +1,4037 @@
+{
+  "id": "28d370e3-45a0-4f1b-8d70-5a87e15d3776",
+  "prevId": "c0a763ea-e8ea-448d-a4d9-b57563fb791d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_corporation_roles": {
+      "name": "character_corporation_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_at_hq": {
+          "name": "roles_at_hq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_base": {
+          "name": "roles_at_base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_other": {
+          "name": "roles_at_other",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "character_corporation_roles",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_corporation_roles_corporation_id_character_id_unique": {
+          "name": "character_corporation_roles_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_assets": {
+      "name": "corporation_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_blueprint_copy": {
+          "name": "is_blueprint_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_assets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_assets_corporation_id_item_id_unique": {
+          "name": "corporation_assets_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_config": {
+      "name": "corporation_config",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "corporation_type": {
+          "name": "corporation_type",
+          "type": "corporation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "members_last_sync": {
+          "name": "members_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_tracking_last_sync": {
+          "name": "member_tracking_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets_last_sync": {
+          "name": "wallets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_journal_last_sync": {
+          "name": "wallet_journal_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_transactions_last_sync": {
+          "name": "wallet_transactions_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assets_last_sync": {
+          "name": "assets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structures_last_sync": {
+          "name": "structures_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_last_sync": {
+          "name": "orders_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contracts_last_sync": {
+          "name": "contracts_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_jobs_last_sync": {
+          "name": "industry_jobs_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killmails_last_sync": {
+          "name": "killmails_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_config_include_in_background_refresh_idx": {
+          "name": "corporation_config_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_include_in_structure_asset_sync_idx": {
+          "name": "corporation_config_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_corporation_type_idx": {
+          "name": "corporation_config_corporation_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_member_tracking_last_sync_idx": {
+          "name": "corporation_config_member_tracking_last_sync_idx",
+          "columns": [
+            {
+              "expression": "member_tracking_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallets_last_sync_idx": {
+          "name": "corporation_config_wallets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_assets_last_sync_idx": {
+          "name": "corporation_config_assets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "assets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_structures_last_sync_idx": {
+          "name": "corporation_config_structures_last_sync_idx",
+          "columns": [
+            {
+              "expression": "structures_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_orders_last_sync_idx": {
+          "name": "corporation_config_orders_last_sync_idx",
+          "columns": [
+            {
+              "expression": "orders_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_contracts_last_sync_idx": {
+          "name": "corporation_config_contracts_last_sync_idx",
+          "columns": [
+            {
+              "expression": "contracts_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_industry_jobs_last_sync_idx": {
+          "name": "corporation_config_industry_jobs_last_sync_idx",
+          "columns": [
+            {
+              "expression": "industry_jobs_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_killmails_last_sync_idx": {
+          "name": "corporation_config_killmails_last_sync_idx",
+          "columns": [
+            {
+              "expression": "killmails_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_members_last_sync_idx": {
+          "name": "corporation_config_members_last_sync_idx",
+          "columns": [
+            {
+              "expression": "members_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_transactions_last_sync_idx": {
+          "name": "corporation_config_wallet_transactions_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_transactions_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_journal_last_sync_idx": {
+          "name": "corporation_config_wallet_journal_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_journal_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_contracts": {
+      "name": "corporation_contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptor_id": {
+          "name": "acceptor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyout": {
+          "name": "buyout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collateral": {
+          "name": "collateral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_accepted": {
+          "name": "date_accepted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_expired": {
+          "name": "date_expired",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_to_complete": {
+          "name": "days_to_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_location_id": {
+          "name": "end_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_corporation": {
+          "name": "for_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_corporation_id": {
+          "name": "issuer_corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward": {
+          "name": "reward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_location_id": {
+          "name": "start_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_contracts_leaderboard_all_time_idx": {
+          "name": "corporation_contracts_leaderboard_all_time_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_contracts_leaderboard_period_idx": {
+          "name": "corporation_contracts_leaderboard_period_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_contracts_contract_id_unique": {
+          "name": "corporation_contracts_contract_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contract_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_directors": {
+      "name": "corporation_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_healthy": {
+          "name": "is_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permanent_failure_at": {
+          "name": "permanent_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_directors_corp_healthy_idx": {
+          "name": "corporation_directors_corp_healthy_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_healthy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_next_retry_idx": {
+          "name": "corporation_directors_corp_next_retry_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_permanent_failure_idx": {
+          "name": "corporation_directors_corp_permanent_failure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permanent_failure_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_last_used_idx": {
+          "name": "corporation_directors_last_used_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_directors",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_directors_corporation_id_character_id_unique": {
+          "name": "corporation_directors_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_industry_jobs": {
+      "name": "corporation_industry_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_id": {
+          "name": "installer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_type_id": {
+          "name": "blueprint_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_location_id": {
+          "name": "blueprint_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_location_id": {
+          "name": "output_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs": {
+          "name": "runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_runs": {
+          "name": "licensed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_type_id": {
+          "name": "product_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_date": {
+          "name": "pause_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_character_id": {
+          "name": "completed_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successful_runs": {
+          "name": "successful_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_industry_jobs",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_industry_jobs_corporation_id_job_id_unique": {
+          "name": "corporation_industry_jobs_corporation_id_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_killmails": {
+      "name": "corporation_killmails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_id": {
+          "name": "killmail_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_hash": {
+          "name": "killmail_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_time": {
+          "name": "killmail_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_killmails",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_killmails_corporation_id_killmail_id_unique": {
+          "name": "corporation_killmails_corporation_id_killmail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "killmail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_member_tracking": {
+      "name": "corporation_member_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoff_date": {
+          "name": "logoff_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logon_date": {
+          "name": "logon_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_member_tracking",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_member_tracking_corporation_id_character_id_unique": {
+          "name": "corporation_member_tracking_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_members": {
+      "name": "corporation_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_members_character_id_idx": {
+          "name": "corporation_members_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_members",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_members_corporation_id_character_id_unique": {
+          "name": "corporation_members_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_orders": {
+      "name": "corporation_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escrow": {
+          "name": "escrow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_buy_order": {
+          "name": "is_buy_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issued": {
+          "name": "issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_volume": {
+          "name": "min_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_remain": {
+          "name": "volume_remain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_total": {
+          "name": "volume_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_division": {
+          "name": "wallet_division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_orders",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_orders_corporation_id_order_id_unique": {
+          "name": "corporation_orders_corporation_id_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_public_info": {
+      "name": "corporation_public_info",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ceo_id": {
+          "name": "ceo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_founded": {
+          "name": "date_founded",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_station_id": {
+          "name": "home_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "war_eligible": {
+          "name": "war_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory": {
+      "name": "corporation_structure_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_corp_structure_idx": {
+          "name": "corporation_structure_inventory_corp_structure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_structure_inventory_snapshot_structure_idx": {
+          "name": "corporation_structure_inventory_snapshot_structure_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+          "name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corp_inv_snapshot_fk": {
+          "name": "corp_inv_snapshot_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structure_inventory_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corp_inv_snapshot_item_uniq": {
+          "name": "corp_inv_snapshot_item_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "snapshot_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory_snapshots": {
+      "name": "corporation_structure_inventory_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_snapshots_corp_activated_idx": {
+          "name": "corporation_structure_inventory_snapshots_corp_activated_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corp_inv_snapshots_corp_fk": {
+          "name": "corp_inv_snapshots_corp_fk",
+          "tableFrom": "corporation_structure_inventory_snapshots",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structures": {
+      "name": "corporation_structures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_expires": {
+          "name": "fuel_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_amount": {
+          "name": "fuel_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_burn_rate": {
+          "name": "fuel_burn_rate",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refilled_at": {
+          "name": "last_refilled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_apply": {
+          "name": "next_reinforce_apply",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_hour": {
+          "name": "next_reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforce_hour": {
+          "name": "reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_timer_end": {
+          "name": "state_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_timer_start": {
+          "name": "state_timer_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unanchors_at": {
+          "name": "unanchors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_power": {
+          "name": "low_power",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structures_last_synced_at_idx": {
+          "name": "corporation_structures_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structures",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structures_structure_id_unique": {
+          "name": "corporation_structures_structure_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "structure_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_journal": {
+      "name": "corporation_wallet_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id_type": {
+          "name": "context_id_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_receiver_id": {
+          "name": "tax_receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_wallet_journal_corporation_date_idx": {
+          "name": "corporation_wallet_journal_corporation_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_journal_corporation_reason_date_idx": {
+          "name": "corporation_wallet_journal_corporation_reason_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_journal_corp_div_date_idx": {
+          "name": "corporation_wallet_journal_corp_div_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_journal_corp_div_num_id_idx": {
+          "name": "corporation_wallet_journal_corp_div_num_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"journal_id\"::numeric)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_journal",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+          "name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "journal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_transactions": {
+      "name": "corporation_wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy": {
+          "name": "is_buy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "journal_ref_id": {
+          "name": "journal_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_wallet_tx_corp_div_date_idx": {
+          "name": "corporation_wallet_tx_corp_div_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_tx_corp_div_num_id_idx": {
+          "name": "corporation_wallet_tx_corp_div_num_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"transaction_id\"::numeric)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_transactions",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+          "name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallets": {
+      "name": "corporation_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallets_corporation_id_division_unique": {
+          "name": "corporation_wallets_corporation_id_division_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_fuel_log": {
+      "name": "structure_fuel_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_block_units": {
+          "name": "fuel_block_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_fuel_log_corp_structure_observed_idx": {
+          "name": "structure_fuel_log_corp_structure_observed_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "structure_fuel_log_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_fuel_log_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_fuel_log_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_fuel_log",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_mining_citadel_extractions": {
+      "name": "structure_mining_citadel_extractions",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_start_time": {
+          "name": "extraction_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_arrival_time": {
+          "name": "chunk_arrival_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "natural_decay_time": {
+          "name": "natural_decay_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_mining_citadel_extractions_corporation_id_idx": {
+          "name": "structure_mining_citadel_extractions_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_citadel_extractions_last_synced_at_idx": {
+          "name": "structure_mining_citadel_extractions_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_drills": {
+      "name": "structure_moon_drills",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_drills_corporation_id_idx": {
+          "name": "structure_moon_drills_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_drills_last_synced_at_idx": {
+          "name": "structure_moon_drills_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_geographies": {
+      "name": "structure_moon_geographies",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_name": {
+          "name": "moon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_geographies_corporation_id_idx": {
+          "name": "structure_moon_geographies_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_moon_id_idx": {
+          "name": "structure_moon_geographies_moon_id_idx",
+          "columns": [
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_planet_id_idx": {
+          "name": "structure_moon_geographies_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_system_id_idx": {
+          "name": "structure_moon_geographies_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_last_synced_at_idx": {
+          "name": "structure_moon_geographies_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhook_reagents": {
+      "name": "structure_skyhook_reagents",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "magmatic_gas_secured_stock": {
+          "name": "magmatic_gas_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_unsecured_stock": {
+          "name": "magmatic_gas_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_last_cycle": {
+          "name": "magmatic_gas_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superionic_ice_secured_stock": {
+          "name": "superionic_ice_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_unsecured_stock": {
+          "name": "superionic_ice_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_last_cycle": {
+          "name": "superionic_ice_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhook_reagents_corporation_id_idx": {
+          "name": "structure_skyhook_reagents_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhooks": {
+      "name": "structure_skyhooks",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "effective_workforce": {
+          "name": "effective_workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforcement_timer_end": {
+          "name": "reinforcement_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_start": {
+          "name": "theft_vulnerability_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_end": {
+          "name": "theft_vulnerability_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhooks_corporation_id_idx": {
+          "name": "structure_skyhooks_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_planet_id_idx": {
+          "name": "structure_skyhooks_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_system_id_idx": {
+          "name": "structure_skyhooks_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_type_id_idx": {
+          "name": "structure_skyhooks_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_last_synced_at_idx": {
+          "name": "structure_skyhooks_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_hubs": {
+      "name": "structure_sovereignty_hubs",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_access_list_id": {
+          "name": "fuel_access_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_id": {
+          "name": "controller_alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_name": {
+          "name": "controller_alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay_last_updated": {
+          "name": "reagent_bay_last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay": {
+          "name": "reagent_bay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+        },
+        "upgrades": {
+          "name": "upgrades",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_transport": {
+          "name": "workforce_transport",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_hubs_corporation_id_idx": {
+          "name": "structure_sovereignty_hubs_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_system_id_idx": {
+          "name": "structure_sovereignty_hubs_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_type_id_idx": {
+          "name": "structure_sovereignty_hubs_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_last_synced_at_idx": {
+          "name": "structure_sovereignty_hubs_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_hubs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_systems": {
+      "name": "structure_sovereignty_systems",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_claimant_id": {
+          "name": "corporation_claimant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_since": {
+          "name": "claimed_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sovereignty_hub_structure_id": {
+          "name": "sovereignty_hub_structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capital_system": {
+          "name": "is_capital_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_defense_multiplier": {
+          "name": "activity_defense_multiplier",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "military_level": {
+          "name": "military_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industrial_level": {
+          "name": "industrial_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategic_level": {
+          "name": "strategic_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_systems_corporation_id_idx": {
+          "name": "structure_sovereignty_systems_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_region_id_idx": {
+          "name": "structure_sovereignty_systems_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_alliance_id_idx": {
+          "name": "structure_sovereignty_systems_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+          "name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+          "columns": [
+            {
+              "expression": "sovereignty_hub_structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_last_synced_at_idx": {
+          "name": "structure_sovereignty_systems_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_systems",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.corporation_type": {
+      "name": "corporation_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "alt",
+        "special_purpose",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/eve-corporation-data/.migrations/meta/_journal.json
+++ b/apps/eve-corporation-data/.migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1785598539248,
       "tag": "0035_salty_dragon_man",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1786085723613,
+      "tag": "0036_natural_reptil",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/eve-corporation-data/src/db/schema.ts
+++ b/apps/eve-corporation-data/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm'
 import {
 	boolean,
 	foreignKey,
@@ -312,6 +313,17 @@ export const corporationWalletJournal = pgTable(
 			table.reason,
 			table.date
 		),
+		index('corporation_wallet_journal_corp_div_date_idx').on(
+			table.corporationId,
+			table.division,
+			table.date
+		),
+		index('corporation_wallet_journal_corp_div_num_id_idx').using(
+			'btree',
+			table.corporationId,
+			table.division,
+			sql`(${table.journalId}::numeric)`
+		),
 	]
 )
 
@@ -340,7 +352,20 @@ export const corporationWalletTransactions = pgTable(
 		unitPrice: text('unit_price').notNull(),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
-	(table) => [unique().on(table.corporationId, table.division, table.transactionId)]
+	(table) => [
+		unique().on(table.corporationId, table.division, table.transactionId),
+		index('corporation_wallet_tx_corp_div_date_idx').on(
+			table.corporationId,
+			table.division,
+			table.date
+		),
+		index('corporation_wallet_tx_corp_div_num_id_idx').using(
+			'btree',
+			table.corporationId,
+			table.division,
+			sql`(${table.transactionId}::numeric)`
+		),
+	]
 )
 
 // ============================================================================

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -122,6 +122,7 @@ import type {
 	StructureSyncFailureTarget,
 	StructureSyncPriorityTarget,
 	WalletJournalWindowFilters,
+	WalletTransactionWatermark,
 	WalletTransactionWindowFilters,
 } from '@repo/eve-corporation-data'
 import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
@@ -220,6 +221,21 @@ const STRUCTURE_SNAPSHOT_BATCH_SIZE = 10
 const STRUCTURE_CLEANUP_BATCH_SIZE = 250
 const INVENTORY_SNAPSHOT_CLEANUP_BATCH_SIZE = 250
 const INVENTORY_SNAPSHOT_CLEANUP_MAX_BATCHES = 4
+const WALLET_JOURNAL_INSERT_BATCH_SIZE = 100
+const WALLET_TRANSACTION_INSERT_BATCH_SIZE = 100
+
+function compareNumericStrings(left: string, right: string): number {
+	try {
+		const leftBigInt = BigInt(left)
+		const rightBigInt = BigInt(right)
+		if (leftBigInt === rightBigInt) {
+			return 0
+		}
+		return leftBigInt > rightBigInt ? 1 : -1
+	} catch {
+		return left.localeCompare(right, 'en')
+	}
+}
 
 function chunkArray<T>(items: readonly T[], size: number): T[][] {
 	const chunks: T[][] = []
@@ -1891,26 +1907,84 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		division: number,
 		entries: any[]
 	): Promise<{ persistedNewRows: number }> {
+		if (entries.length === 0) {
+			return { persistedNewRows: 0 }
+		}
+
+		const db = this.getDb()
+		const [watermark] = await db
+			.select({
+				maxJournalId: sql<string | null>`max(${corporationWalletJournal.journalId}::numeric)::text`,
+				maxJournalDate: sql<Date | string | null>`max(${corporationWalletJournal.date})`,
+			})
+			.from(corporationWalletJournal)
+			.where(
+				and(
+					eq(corporationWalletJournal.corporationId, String(corporationId)),
+					eq(corporationWalletJournal.division, division)
+				)
+			)
+		const storedMaxJournalId = watermark?.maxJournalId ?? null
+		const storedMaxJournalDate = parseDateOrNull(watermark?.maxJournalDate)
+		const fetchedMaxJournalId = entries.reduce<string | null>((max, entry) => {
+			const journalId = String(entry.id)
+			if (max === null || compareNumericStrings(journalId, max) > 0) {
+				return journalId
+			}
+			return max
+		}, null)
+		const fetchedMaxJournalDate = entries.reduce<Date | null>((max, entry) => {
+			const entryDate = parseDateOrNull(entry.date)
+			if (entryDate === null || max === null) {
+				return entryDate ?? max
+			}
+			return entryDate > max ? entryDate : max
+		}, null)
+
+		if (
+			storedMaxJournalId !== null &&
+			fetchedMaxJournalId !== null &&
+			compareNumericStrings(fetchedMaxJournalId, storedMaxJournalId) < 0 &&
+			storedMaxJournalDate !== null &&
+			(fetchedMaxJournalDate === null || fetchedMaxJournalDate < storedMaxJournalDate)
+		) {
+			logger.warn('[WalletJournalStore] ESI response is behind the stored journal watermark', {
+				corporationId,
+				division,
+				storedMaxJournalId,
+				fetchedMaxJournalId,
+			})
+		}
+
+		// Sort chronologically before inserting so a partial failure advances the
+		// date watermark as little as possible while still accepting late IDs.
+		const newEntries = entries
+			.filter((entry) => {
+				if (storedMaxJournalId === null) {
+					return true
+				}
+
+				if (compareNumericStrings(String(entry.id), storedMaxJournalId) > 0) {
+					return true
+				}
+
+				const entryDate = parseDateOrNull(entry.date)
+				return (
+					storedMaxJournalDate !== null && entryDate !== null && entryDate >= storedMaxJournalDate
+				)
+			})
+			.slice()
+			.sort((left, right) => {
+				const leftDate = parseDateOrNull(left.date)
+				const rightDate = parseDateOrNull(right.date)
+				if (leftDate !== null && rightDate !== null && leftDate.getTime() !== rightDate.getTime()) {
+					return leftDate < rightDate ? -1 : 1
+				}
+				return compareNumericStrings(String(left.id), String(right.id))
+			})
 		let persistedNewRows = 0
-		const BATCH_SIZE = 25
-		for (let i = 0; i < entries.length; i += BATCH_SIZE) {
-			const batch = entries.slice(i, i + BATCH_SIZE)
-			const batchJournalIds = batch.map((entry) => String(entry.id))
-			const existingRows =
-				batchJournalIds.length > 0
-					? await this.getDb().query.corporationWalletJournal.findMany({
-							where: and(
-								eq(corporationWalletJournal.corporationId, String(corporationId)),
-								eq(corporationWalletJournal.division, division),
-								inArray(corporationWalletJournal.journalId, batchJournalIds)
-							),
-							columns: {
-								journalId: true,
-							},
-						})
-					: []
-			const existingJournalIds = new Set(existingRows.map((row) => row.journalId))
-			persistedNewRows += batchJournalIds.filter((id) => !existingJournalIds.has(id)).length
+		for (let i = 0; i < newEntries.length; i += WALLET_JOURNAL_INSERT_BATCH_SIZE) {
+			const batch = newEntries.slice(i, i + WALLET_JOURNAL_INSERT_BATCH_SIZE)
 			const valuesToInsert = batch.map((entry) => ({
 				corporationId: String(corporationId),
 				division,
@@ -1930,26 +2004,18 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				updatedAt: new Date(),
 			}))
 
-			await this.getDb()
+			const insertedRows = await db
 				.insert(corporationWalletJournal)
 				.values(valuesToInsert)
-				.onConflictDoUpdate({
+				.onConflictDoNothing({
 					target: [
 						corporationWalletJournal.corporationId,
 						corporationWalletJournal.division,
 						corporationWalletJournal.journalId,
 					],
-					set: {
-						amount: sql`excluded.amount`,
-						balance: sql`excluded.balance`,
-						contextId: sql`excluded.context_id`,
-						contextIdType: sql`excluded.context_id_type`,
-						description: sql`excluded.description`,
-						reason: sql`excluded.reason`,
-						tax: sql`excluded.tax`,
-						updatedAt: sql`excluded.updated_at`,
-					},
 				})
+				.returning({ journalId: corporationWalletJournal.journalId })
+			persistedNewRows += insertedRows.length
 		}
 
 		return { persistedNewRows }
@@ -1961,65 +2027,166 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async storeWalletTransactions(
 		corporationId: string,
 		division: number,
-		transactions: any[]
+		transactions: any[],
+		providedWatermark?: WalletTransactionWatermark
 	): Promise<{ persistedNewRows: number }> {
-		let persistedNewRows = 0
-		const BATCH_SIZE = 25
-		for (let i = 0; i < transactions.length; i += BATCH_SIZE) {
-			const batch = transactions.slice(i, i + BATCH_SIZE)
-			const dedupedBatchByTransactionId = new Map<string, any>()
-			for (const tx of batch) {
-				dedupedBatchByTransactionId.set(String(tx.transaction_id), tx)
+		if (transactions.length === 0) {
+			return { persistedNewRows: 0 }
+		}
+
+		const db = this.getDb()
+		let watermark = providedWatermark
+		if (!watermark) {
+			const [storedWatermark] = await db
+				.select({
+					maxTransactionId: sql<
+						string | null
+					>`max(${corporationWalletTransactions.transactionId}::numeric)::text`,
+					maxTransactionDate: sql<Date | string | null>`max(${corporationWalletTransactions.date})`,
+				})
+				.from(corporationWalletTransactions)
+				.where(
+					and(
+						eq(corporationWalletTransactions.corporationId, String(corporationId)),
+						eq(corporationWalletTransactions.division, division)
+					)
+				)
+			watermark = {
+				maxTransactionId: storedWatermark?.maxTransactionId ?? null,
+				maxTransactionDate: parseDateOrNull(storedWatermark?.maxTransactionDate),
 			}
-			const dedupedBatch = [...dedupedBatchByTransactionId.values()]
-			const batchTransactionIds = [...dedupedBatchByTransactionId.keys()]
-			const existingRows =
-				batchTransactionIds.length > 0
-					? await this.getDb().query.corporationWalletTransactions.findMany({
-							where: and(
-								eq(corporationWalletTransactions.corporationId, String(corporationId)),
-								eq(corporationWalletTransactions.division, division),
-								inArray(corporationWalletTransactions.transactionId, batchTransactionIds)
-							),
-							columns: {
-								transactionId: true,
-							},
-						})
-					: []
-			const existingTransactionIds = new Set(existingRows.map((row) => row.transactionId))
-			persistedNewRows += batchTransactionIds.filter((id) => !existingTransactionIds.has(id)).length
-			const valuesToInsert = dedupedBatch.map((tx) => ({
+		}
+		const storedMaxTransactionId = watermark.maxTransactionId
+		const storedMaxTransactionDate = watermark.maxTransactionDate
+
+		const dedupedTransactions = [
+			...new Map(
+				transactions.map((transaction) => [String(transaction.transaction_id), transaction])
+			).values(),
+		]
+		const fetchedMaxTransactionId = dedupedTransactions.reduce<string | null>(
+			(max, transaction) => {
+				const transactionId = String(transaction.transaction_id)
+				if (max === null || compareNumericStrings(transactionId, max) > 0) {
+					return transactionId
+				}
+				return max
+			},
+			null
+		)
+		const fetchedMaxTransactionDate = dedupedTransactions.reduce<Date | null>(
+			(max, transaction) => {
+				const transactionDate = parseDateOrNull(transaction.date)
+				if (transactionDate === null || max === null) {
+					return transactionDate ?? max
+				}
+				return transactionDate > max ? transactionDate : max
+			},
+			null
+		)
+
+		if (
+			storedMaxTransactionId !== null &&
+			fetchedMaxTransactionId !== null &&
+			compareNumericStrings(fetchedMaxTransactionId, storedMaxTransactionId) < 0 &&
+			storedMaxTransactionDate !== null &&
+			(fetchedMaxTransactionDate === null || fetchedMaxTransactionDate < storedMaxTransactionDate)
+		) {
+			logger.warn(
+				'[WalletTransactionStore] ESI response is behind the stored transaction watermark',
+				{
+					corporationId,
+					division,
+					storedMaxTransactionId,
+					fetchedMaxTransactionId,
+				}
+			)
+		}
+
+		const newTransactions = dedupedTransactions
+			.filter((transaction) => {
+				if (storedMaxTransactionId === null) {
+					return true
+				}
+
+				if (compareNumericStrings(String(transaction.transaction_id), storedMaxTransactionId) > 0) {
+					return true
+				}
+
+				const transactionDate = parseDateOrNull(transaction.date)
+				return (
+					storedMaxTransactionDate !== null &&
+					transactionDate !== null &&
+					transactionDate >= storedMaxTransactionDate
+				)
+			})
+			.sort((left, right) => {
+				const leftDate = parseDateOrNull(left.date)
+				const rightDate = parseDateOrNull(right.date)
+				if (leftDate !== null && rightDate !== null && leftDate.getTime() !== rightDate.getTime()) {
+					return leftDate < rightDate ? -1 : 1
+				}
+				return compareNumericStrings(String(left.transaction_id), String(right.transaction_id))
+			})
+
+		let persistedNewRows = 0
+		for (let i = 0; i < newTransactions.length; i += WALLET_TRANSACTION_INSERT_BATCH_SIZE) {
+			const batch = newTransactions.slice(i, i + WALLET_TRANSACTION_INSERT_BATCH_SIZE)
+			const valuesToInsert = batch.map((tx) => ({
 				corporationId: String(corporationId),
 				division,
-				transactionId: tx.transaction_id,
-				clientId: tx.client_id,
+				transactionId: String(tx.transaction_id),
+				clientId: String(tx.client_id),
 				date: new Date(tx.date),
 				isBuy: tx.is_buy,
 				isPersonal: tx.is_personal,
-				journalRefId: tx.journal_ref_id,
-				locationId: tx.location_id,
+				journalRefId: String(tx.journal_ref_id),
+				locationId: String(tx.location_id),
 				quantity: tx.quantity,
-				typeId: tx.type_id,
-				unitPrice: tx.unit_price,
+				typeId: String(tx.type_id),
+				unitPrice: String(tx.unit_price),
 				updatedAt: new Date(),
 			}))
 
-			await this.getDb()
+			const insertedRows = await db
 				.insert(corporationWalletTransactions)
 				.values(valuesToInsert)
-				.onConflictDoUpdate({
+				.onConflictDoNothing({
 					target: [
 						corporationWalletTransactions.corporationId,
 						corporationWalletTransactions.division,
 						corporationWalletTransactions.transactionId,
 					],
-					set: {
-						updatedAt: sql`excluded.updated_at`,
-					},
 				})
+				.returning({ transactionId: corporationWalletTransactions.transactionId })
+			persistedNewRows += insertedRows.length
 		}
 
 		return { persistedNewRows }
+	}
+
+	async getWalletTransactionWatermarks(
+		corporationId: string
+	): Promise<Array<{ division: number; watermark: WalletTransactionWatermark }>> {
+		const rows = await this.getDb()
+			.select({
+				division: corporationWalletTransactions.division,
+				maxTransactionId: sql<
+					string | null
+				>`max(${corporationWalletTransactions.transactionId}::numeric)::text`,
+				maxTransactionDate: sql<Date | string | null>`max(${corporationWalletTransactions.date})`,
+			})
+			.from(corporationWalletTransactions)
+			.where(eq(corporationWalletTransactions.corporationId, String(corporationId)))
+			.groupBy(corporationWalletTransactions.division)
+
+		return rows.map((row) => ({
+			division: row.division,
+			watermark: {
+				maxTransactionId: row.maxTransactionId,
+				maxTransactionDate: parseDateOrNull(row.maxTransactionDate),
+			},
+		}))
 	}
 
 	/**
@@ -5033,56 +5200,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				entriesToInsert: entries.length,
 			})
 
-		// Batch insert to avoid hitting Cloudflare's 50 subrequest limit
-		// Insert 25 entries at a time to be safe
-		const BATCH_SIZE = 25
-		let insertedCount = 0
-
+		let persistedNewRows = 0
 		try {
-			for (let i = 0; i < entries.length; i += BATCH_SIZE) {
-				const batch = entries.slice(i, i + BATCH_SIZE)
-				const valuesToInsert = batch.map((entry) => ({
-					corporationId: String(corporationId),
-					division,
-					journalId: entry.id,
-					amount: entry.amount,
-					balance: entry.balance,
-					contextId: entry.context_id,
-					contextIdType: entry.context_id_type,
-					date: new Date(entry.date),
-					description: entry.description,
-					firstPartyId: entry.first_party_id,
-					reason: entry.reason,
-					refType: entry.ref_type,
-					secondPartyId: entry.second_party_id,
-					tax: entry.tax,
-					taxReceiverId: entry.tax_receiver_id,
-					updatedAt: new Date(),
-				}))
-
-				await this.getDb()
-					.insert(corporationWalletJournal)
-					.values(valuesToInsert)
-					.onConflictDoUpdate({
-						target: [
-							corporationWalletJournal.corporationId,
-							corporationWalletJournal.division,
-							corporationWalletJournal.journalId,
-						],
-						set: {
-							amount: sql`excluded.amount`,
-							balance: sql`excluded.balance`,
-							contextId: sql`excluded.context_id`,
-							contextIdType: sql`excluded.context_id_type`,
-							description: sql`excluded.description`,
-							reason: sql`excluded.reason`,
-							tax: sql`excluded.tax`,
-							updatedAt: sql`excluded.updated_at`,
-						},
-					})
-
-				insertedCount += batch.length
-			}
+			persistedNewRows = (await this.storeWalletJournal(corporationId, division, entries))
+				.persistedNewRows
 		} catch (error) {
 			logger
 				.withTags({
@@ -5091,7 +5212,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					operation: 'fetch_wallet_journal',
 				})
 				.error('Failed to insert journal entries', {
-					insertedSoFar: insertedCount,
+					entriesPersisted: persistedNewRows,
 					totalEntries: entries.length,
 					error: error instanceof Error ? error.message : String(error),
 					errorStack: error instanceof Error ? error.stack : undefined,
@@ -5130,7 +5251,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				operation: 'fetch_wallet_journal',
 			})
 			.debug('Completed wallet journal fetch and store', {
-				totalInserted: insertedCount,
+				totalInserted: persistedNewRows,
 				totalEntries: entries.length,
 			})
 	}
@@ -5155,12 +5276,20 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		await this.requireCorpRole(corporationId, characterId, ['Accountant', 'Junior_Accountant'])
 
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
-		const transactions: EsiCorporationWalletTransaction[] = await esiFetch.fetchWalletTransactions(
+		const watermark = (await this.getWalletTransactionWatermarks(corporationId)).find(
+			(entry) => entry.division === division
+		)?.watermark
+		const fetchResult = await esiFetch.fetchWalletTransactions(
 			tokenStore,
 			corporationId,
 			division,
-			characterId
+			characterId,
+			watermark
 		)
+		if (fetchResult.truncated) {
+			throw new Error('Wallet transaction pagination was truncated before persistence')
+		}
+		const transactions: EsiCorporationWalletTransaction[] = fetchResult.transactions
 
 		logger
 			.withTags({
@@ -5170,52 +5299,16 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			})
 			.debug('Fetched wallet transactions from ESI', {
 				totalTransactions: transactions.length,
+				pagesFetched: fetchResult.pagesFetched,
+				stoppedAtWatermark: fetchResult.stoppedAtWatermark,
+				truncated: fetchResult.truncated,
 			})
 
-		// Batch insert to avoid hitting Cloudflare's 50 subrequest limit
-		const BATCH_SIZE = 25
-		let insertedCount = 0
-
+		let persistedNewRows = 0
 		try {
-			for (let i = 0; i < transactions.length; i += BATCH_SIZE) {
-				const batch = transactions.slice(i, i + BATCH_SIZE)
-				const dedupedBatchByTransactionId = new Map<string, EsiCorporationWalletTransaction>()
-				for (const tx of batch) {
-					dedupedBatchByTransactionId.set(String(tx.transaction_id), tx)
-				}
-				const dedupedBatch = [...dedupedBatchByTransactionId.values()]
-				const valuesToInsert = dedupedBatch.map((tx) => ({
-					corporationId: String(corporationId),
-					division,
-					transactionId: tx.transaction_id,
-					clientId: tx.client_id,
-					date: new Date(tx.date),
-					isBuy: tx.is_buy,
-					isPersonal: tx.is_personal,
-					journalRefId: tx.journal_ref_id,
-					locationId: tx.location_id,
-					quantity: tx.quantity,
-					typeId: tx.type_id,
-					unitPrice: tx.unit_price,
-					updatedAt: new Date(),
-				}))
-
-				await this.getDb()
-					.insert(corporationWalletTransactions)
-					.values(valuesToInsert)
-					.onConflictDoUpdate({
-						target: [
-							corporationWalletTransactions.corporationId,
-							corporationWalletTransactions.division,
-							corporationWalletTransactions.transactionId,
-						],
-						set: {
-							updatedAt: sql`excluded.updated_at`,
-						},
-					})
-
-				insertedCount += dedupedBatch.length
-			}
+			persistedNewRows = (
+				await this.storeWalletTransactions(corporationId, division, transactions, watermark)
+			).persistedNewRows
 		} catch (error) {
 			logger
 				.withTags({
@@ -5224,7 +5317,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					operation: 'fetch_wallet_transactions',
 				})
 				.error('Failed to insert transactions', {
-					insertedSoFar: insertedCount,
+					entriesPersisted: persistedNewRows,
 					totalTransactions: transactions.length,
 					error: error instanceof Error ? error.message : String(error),
 					errorStack: error instanceof Error ? error.stack : undefined,
@@ -5263,7 +5356,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				operation: 'fetch_wallet_transactions',
 			})
 			.debug('Completed wallet transactions fetch and store', {
-				totalInserted: insertedCount,
+				totalInserted: persistedNewRows,
 				totalTransactions: transactions.length,
 			})
 	}

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -12,6 +12,7 @@
  */
 
 import { logger } from '@repo/hono-helpers'
+import { parseDateOrNull } from '@repo/worker-utils'
 import { parseEsiErrorMetadata } from '@repo/workflow-utils'
 
 import {
@@ -45,12 +46,34 @@ import type {
 	EsiCorporationWalletTransaction,
 	EsiSovereigntyHub,
 	EsiSovereigntySystem,
+	WalletTransactionWatermark,
 } from '@repo/eve-corporation-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 
 const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 const SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE = 4
 const SKYHOOK_DETAIL_BATCH_SIZE = 4
+const MAX_WALLET_TRANSACTION_PAGES = 100
+
+function compareNumericStrings(left: string, right: string): number {
+	try {
+		const leftBigInt = BigInt(left)
+		const rightBigInt = BigInt(right)
+		if (leftBigInt === rightBigInt) {
+			return 0
+		}
+		return leftBigInt > rightBigInt ? 1 : -1
+	} catch {
+		return left.localeCompare(right, 'en')
+	}
+}
+
+export interface WalletTransactionsFetchResult {
+	transactions: EsiCorporationWalletTransaction[]
+	pagesFetched: number
+	stoppedAtWatermark: boolean
+	truncated: boolean
+}
 
 export interface StructureEnrichmentFailure {
 	structureId: string
@@ -184,8 +207,9 @@ export async function fetchWalletTransactions(
 	tokenStore: EveTokenStore,
 	corporationId: string,
 	division: number,
-	characterId: string
-): Promise<EsiCorporationWalletTransaction[]> {
+	characterId: string,
+	watermark?: WalletTransactionWatermark
+): Promise<WalletTransactionsFetchResult> {
 	const response = await tokenStore.fetchEsi<
 		Array<{
 			transaction_id: number
@@ -203,7 +227,116 @@ export async function fetchWalletTransactions(
 		cacheMode: 'no-store',
 	})
 
-	return transformWalletTransactions(response.data)
+	const basePath = `/corporations/${corporationId}/wallets/${division}/transactions`
+	const transactions = new Map<string, EsiCorporationWalletTransaction>()
+	let pageData = transformWalletTransactions(response.data)
+	let pagesFetched = 1
+	let fromId: string | undefined
+	let watermarkSeen = false
+	let stoppedAtWatermark = false
+	let completed = pageData.length === 0
+	let truncated = false
+
+	const addPage = (entries: EsiCorporationWalletTransaction[]) => {
+		for (const entry of entries) {
+			transactions.set(entry.transaction_id, entry)
+		}
+	}
+
+	const hasWatermarkRow = (entries: EsiCorporationWalletTransaction[]) =>
+		watermark?.maxTransactionId !== null && watermark?.maxTransactionId !== undefined
+			? entries.some((entry) => entry.transaction_id === watermark.maxTransactionId)
+			: false
+
+	const hasRowsAtOrBeyondWatermark = (
+		entries: EsiCorporationWalletTransaction[],
+		cursorId?: string
+	) => {
+		if (!watermark?.maxTransactionId) {
+			return true
+		}
+
+		return entries.some((entry) => {
+			if (entry.transaction_id === cursorId) {
+				return false
+			}
+			if (compareNumericStrings(entry.transaction_id, watermark.maxTransactionId!) > 0) {
+				return true
+			}
+			const transactionDate = parseDateOrNull(entry.date)
+			return (
+				watermark.maxTransactionDate !== null &&
+				transactionDate !== null &&
+				transactionDate >= watermark.maxTransactionDate
+			)
+		})
+	}
+
+	addPage(pageData)
+	if (hasWatermarkRow(pageData)) {
+		watermarkSeen = true
+		if (!hasRowsAtOrBeyondWatermark(pageData)) {
+			stoppedAtWatermark = true
+		}
+	} else {
+		for (let page = 1; page < MAX_WALLET_TRANSACTION_PAGES; page += 1) {
+			if (pageData.length === 0) {
+				completed = true
+				break
+			}
+
+			const nextFromId = pageData.reduce(
+				(min, entry) => (BigInt(entry.transaction_id) < BigInt(min) ? entry.transaction_id : min),
+				pageData[0].transaction_id
+			)
+			if (nextFromId === fromId) {
+				completed = true
+				break
+			}
+			fromId = nextFromId
+
+			const nextResponse = await tokenStore.fetchEsi<typeof response.data>(
+				`${basePath}?from_id=${encodeURIComponent(fromId)}`,
+				characterId,
+				{ cacheMode: 'no-store' }
+			)
+			pageData = transformWalletTransactions(nextResponse.data)
+			pagesFetched += 1
+			addPage(pageData)
+
+			if (hasWatermarkRow(pageData)) {
+				watermarkSeen = true
+			}
+			if (watermarkSeen && !hasRowsAtOrBeyondWatermark(pageData, fromId)) {
+				stoppedAtWatermark = true
+				completed = true
+				break
+			}
+
+			// ESI includes the cursor row in a from_id response. A singleton cursor
+			// response means there is no older data left to request.
+			if (pageData.length === 1 && pageData[0]?.transaction_id === fromId) {
+				completed = true
+				break
+			}
+		}
+
+		if (!completed && !stoppedAtWatermark) {
+			truncated = true
+			logger.warn('[WalletTransactionsFetch] Page safety limit reached', {
+				corporationId,
+				division,
+				pagesFetched,
+			})
+		}
+	}
+
+	return {
+		transactions: [...transactions.values()],
+		pagesFetched,
+		stoppedAtWatermark,
+		truncated,
+	}
 }
 
 // ========================================================================

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.wallet-transactions.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.wallet-transactions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchWalletTransactions } from '../../../services/esi-fetch'
+
+const rawTransaction = (transactionId: string, date = '2026-08-06T00:00:00Z') => ({
+	transaction_id: Number(transactionId),
+	client_id: 100,
+	date,
+	is_buy: true,
+	is_personal: false,
+	journal_ref_id: 200,
+	location_id: 300,
+	quantity: 1,
+	type_id: 400,
+	unit_price: 500,
+})
+
+describe('wallet transaction ESI pagination', () => {
+	it('stops after the stored watermark row without fetching older pages', async () => {
+		const fetchEsi = vi
+			.fn()
+			.mockResolvedValueOnce({
+				data: [rawTransaction('105'), rawTransaction('104', '2026-08-05T00:00:00Z')],
+			})
+			.mockResolvedValueOnce({
+				data: [
+					rawTransaction('104', '2026-08-05T00:00:00Z'),
+					rawTransaction('103', '2026-08-04T00:00:00Z'),
+					rawTransaction('100', '2026-08-04T00:00:00Z'),
+				],
+			})
+			.mockResolvedValueOnce({
+				data: [
+					rawTransaction('100', '2026-08-04T00:00:00Z'),
+					rawTransaction('99', '2026-08-04T00:00:00Z'),
+				],
+			})
+		const tokenStore = { fetchEsi } as never
+
+		const result = await fetchWalletTransactions(tokenStore, '123', 1, '456', {
+			maxTransactionId: '100',
+			maxTransactionDate: new Date('2026-08-05T00:00:00Z'),
+		})
+
+		expect(result).toMatchObject({
+			pagesFetched: 3,
+			stoppedAtWatermark: true,
+			truncated: false,
+		})
+		expect(result.transactions.map((transaction) => transaction.transaction_id)).toEqual([
+			'105',
+			'104',
+			'103',
+			'100',
+			'99',
+		])
+		expect(fetchEsi).toHaveBeenCalledTimes(3)
+		expect(fetchEsi.mock.calls[1]?.[0]).toBe('/corporations/123/wallets/1/transactions?from_id=104')
+		expect(fetchEsi.mock.calls[2]?.[0]).toBe('/corporations/123/wallets/1/transactions?from_id=100')
+	})
+
+	it('follows cursors until ESI returns only the cursor row when no watermark exists', async () => {
+		const fetchEsi = vi
+			.fn()
+			.mockResolvedValueOnce({ data: [rawTransaction('3'), rawTransaction('2')] })
+			.mockResolvedValueOnce({ data: [rawTransaction('2'), rawTransaction('1')] })
+			.mockResolvedValueOnce({ data: [rawTransaction('1')] })
+		const tokenStore = { fetchEsi } as never
+
+		const result = await fetchWalletTransactions(tokenStore, '123', 1, '456')
+
+		expect(result).toMatchObject({
+			pagesFetched: 3,
+			stoppedAtWatermark: false,
+			truncated: false,
+		})
+		expect(result.transactions.map((transaction) => transaction.transaction_id)).toEqual([
+			'3',
+			'2',
+			'1',
+		])
+		expect(fetchEsi).toHaveBeenCalledTimes(3)
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/services/wallet-journal-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/wallet-journal-storage.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { corporationWalletJournal } from '../../../db/schema'
+import { EveCorporationDataDO } from '../../../durable-object'
+
+function createDoInstance(db: any) {
+	const instance = new EveCorporationDataDO(
+		{} as DurableObjectState,
+		{
+			DATABASE_URL: 'postgres://example',
+			UNIVERSE: {} as never,
+			EVE_TOKEN_STORE: {} as never,
+		} as never
+	)
+
+	;(instance as any).getDb = () => db
+
+	return instance
+}
+
+function createDb(
+	maxJournalId: string | null,
+	maxJournalDate: string | null,
+	insertedJournalIds: string[]
+) {
+	const where = vi.fn().mockResolvedValue([{ maxJournalId, maxJournalDate }])
+	const from = vi.fn(() => ({ where }))
+	const select = vi.fn(() => ({ from }))
+	const returning = vi
+		.fn()
+		.mockResolvedValue(insertedJournalIds.map((journalId) => ({ journalId })))
+	const onConflictDoNothing = vi.fn(() => ({ returning }))
+	const values = vi.fn(() => ({ onConflictDoNothing }))
+	const insert = vi.fn(() => ({ values }))
+
+	return {
+		db: {
+			insert,
+			select,
+		},
+		insert,
+		select,
+		values,
+		onConflictDoNothing,
+	}
+}
+
+const journalEntry = (id: string) => ({
+	id,
+	amount: 100,
+	balance: 200,
+	context_id: 300,
+	context_id_type: 'system_id',
+	date: '2026-08-04T00:00:00Z',
+	description: 'Test journal entry',
+	first_party_id: 400,
+	reason: null,
+	ref_type: 'bounty_prizes',
+	second_party_id: 500,
+	tax: 0,
+	tax_receiver_id: null,
+})
+
+describe('wallet journal storage', () => {
+	it('uses the SQL watermark and inserts only newer journal entries in order', async () => {
+		const { db, insert, select, values, onConflictDoNothing } = createDb(
+			'2',
+			'2026-08-05T00:00:00Z',
+			['3', '4', '5']
+		)
+		const instance = createDoInstance(db)
+
+		const result = await instance.storeWalletJournal('123', 1, [
+			journalEntry('1'),
+			journalEntry('5'),
+			journalEntry('3'),
+			journalEntry('4'),
+		])
+
+		expect(result).toEqual({ persistedNewRows: 3 })
+		expect(select).toHaveBeenCalledTimes(1)
+		expect(insert).toHaveBeenCalledWith(corporationWalletJournal)
+		expect(values).toHaveBeenCalledTimes(1)
+		const valuesCalls = values.mock.calls as unknown as Array<[unknown]>
+		const insertedValues = valuesCalls[0]?.[0] as Array<{ journalId: string }>
+		expect(insertedValues.map((row) => row.journalId)).toEqual(['3', '4', '5'])
+		expect(onConflictDoNothing).toHaveBeenCalledWith(
+			expect.objectContaining({
+				target: [
+					corporationWalletJournal.corporationId,
+					corporationWalletJournal.division,
+					corporationWalletJournal.journalId,
+				],
+			})
+		)
+	})
+
+	it('does not issue an insert when the ESI window is already stored', async () => {
+		const { db, insert, select } = createDb('2', '2026-08-05T00:00:00Z', [])
+		const instance = createDoInstance(db)
+
+		const result = await instance.storeWalletJournal('123', 1, [
+			journalEntry('1'),
+			journalEntry('2'),
+		])
+
+		expect(result).toEqual({ persistedNewRows: 0 })
+		expect(select).toHaveBeenCalledTimes(1)
+		expect(insert).not.toHaveBeenCalled()
+	})
+
+	it('accepts late higher IDs and wrapped lower IDs', async () => {
+		const { db, values } = createDb('500', '2026-08-05T00:00:00Z', ['501', '400', '402'])
+		const instance = createDoInstance(db)
+
+		await instance.storeWalletJournal('123', 1, [
+			{ ...journalEntry('501'), date: '2026-08-04T00:00:00Z' },
+			{ ...journalEntry('400'), date: '2026-08-05T00:00:00Z' },
+			{ ...journalEntry('402'), date: '2026-08-06T00:00:00Z' },
+		])
+
+		const valuesCalls = values.mock.calls as unknown as Array<[unknown]>
+		const insertedValues = valuesCalls[0]?.[0] as Array<{ journalId: string }>
+		expect(insertedValues.map((row) => row.journalId)).toEqual(['501', '400', '402'])
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/services/wallet-transaction-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/wallet-transaction-storage.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { corporationWalletTransactions } from '../../../db/schema'
+import { EveCorporationDataDO } from '../../../durable-object'
+
+function createDoInstance(db: any) {
+	const instance = new EveCorporationDataDO(
+		{} as DurableObjectState,
+		{
+			DATABASE_URL: 'postgres://example',
+			UNIVERSE: {} as never,
+			EVE_TOKEN_STORE: {} as never,
+		} as never
+	)
+
+	;(instance as any).getDb = () => db
+
+	return instance
+}
+
+function createDb(
+	maxTransactionId: string | null,
+	maxTransactionDate: string | null,
+	insertedTransactionIds: string[]
+) {
+	const where = vi.fn().mockResolvedValue([{ maxTransactionId, maxTransactionDate }])
+	const from = vi.fn(() => ({ where }))
+	const select = vi.fn(() => ({ from }))
+	const returning = vi
+		.fn()
+		.mockResolvedValue(insertedTransactionIds.map((transactionId) => ({ transactionId })))
+	const onConflictDoNothing = vi.fn(() => ({ returning }))
+	const values = vi.fn(() => ({ onConflictDoNothing }))
+	const insert = vi.fn(() => ({ values }))
+
+	return {
+		db: {
+			insert,
+			select,
+		},
+		insert,
+		select,
+		values,
+	}
+}
+
+const transaction = (transactionId: string, date = '2026-08-04T00:00:00Z') => ({
+	transaction_id: transactionId,
+	client_id: '100',
+	date,
+	is_buy: true,
+	is_personal: false,
+	journal_ref_id: '200',
+	location_id: '300',
+	quantity: 1,
+	type_id: '400',
+	unit_price: '500',
+})
+
+describe('wallet transaction storage', () => {
+	it('uses the SQL watermark and inserts only qualifying transactions in date order', async () => {
+		const { db, insert, select, values } = createDb('2', '2026-08-05T00:00:00Z', ['3', '4', '5'])
+		const instance = createDoInstance(db)
+
+		const result = await instance.storeWalletTransactions('123', 1, [
+			transaction('1'),
+			transaction('5', '2026-08-06T00:00:00Z'),
+			transaction('3', '2026-08-06T00:00:00Z'),
+			transaction('4', '2026-08-06T00:00:00Z'),
+		])
+
+		expect(result).toEqual({ persistedNewRows: 3 })
+		expect(select).toHaveBeenCalledTimes(1)
+		expect(insert).toHaveBeenCalledWith(corporationWalletTransactions)
+		const valuesCalls = values.mock.calls as unknown as Array<[unknown]>
+		const insertedValues = valuesCalls[0]?.[0] as Array<{ transactionId: string }>
+		expect(insertedValues.map((row) => row.transactionId)).toEqual(['3', '4', '5'])
+	})
+
+	it('accepts late higher IDs and wrapped lower IDs', async () => {
+		const { db, values } = createDb('500', '2026-08-05T00:00:00Z', ['501', '400', '402'])
+		const instance = createDoInstance(db)
+
+		await instance.storeWalletTransactions('123', 1, [
+			transaction('501', '2026-08-04T00:00:00Z'),
+			transaction('400', '2026-08-05T00:00:00Z'),
+			transaction('402', '2026-08-06T00:00:00Z'),
+		])
+
+		const valuesCalls = values.mock.calls as unknown as Array<[unknown]>
+		const insertedValues = valuesCalls[0]?.[0] as Array<{ transactionId: string }>
+		expect(insertedValues.map((row) => row.transactionId)).toEqual(['501', '400', '402'])
+	})
+
+	it('does not issue an insert when the transaction window is already stored', async () => {
+		const { db, insert } = createDb('2', '2026-08-05T00:00:00Z', [])
+		const instance = createDoInstance(db)
+
+		const result = await instance.storeWalletTransactions('123', 1, [
+			transaction('1'),
+			transaction('2'),
+		])
+
+		expect(result).toEqual({ persistedNewRows: 0 })
+		expect(insert).not.toHaveBeenCalled()
+	})
+
+	it('uses the fetch-time watermark without rereading a moving watermark', async () => {
+		const { db, insert, select, values } = createDb('999', '2026-08-07T00:00:00Z', ['3'])
+		const instance = createDoInstance(db)
+
+		const result = await instance.storeWalletTransactions(
+			'123',
+			1,
+			[transaction('3', '2026-08-06T00:00:00Z')],
+			{
+				maxTransactionId: '2',
+				maxTransactionDate: new Date('2026-08-05T00:00:00Z'),
+			}
+		)
+
+		expect(result).toEqual({ persistedNewRows: 1 })
+		expect(select).not.toHaveBeenCalled()
+		const valuesCalls = values.mock.calls as unknown as Array<[unknown]>
+		const insertedValues = valuesCalls[0]?.[0] as Array<{ transactionId: string }>
+		expect(insertedValues.map((row) => row.transactionId)).toEqual(['3'])
+		expect(insert).toHaveBeenCalledTimes(1)
+	})
+})

--- a/apps/eve-corporation-data/src/workflows/steps/wallet-transactions/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/wallet-transactions/index.ts
@@ -36,6 +36,10 @@ export async function syncWalletTransactions(
 ): Promise<WalletTransactionsSyncResult> {
 	const tokenStore = createTokenStore(env)
 	const corpData = getCorporationDataStub(env, corporationId)
+	const watermarks = await corpData.getWalletTransactionWatermarks(corporationId)
+	const watermarkByDivision = new Map(
+		watermarks.map(({ division, watermark }) => [division, watermark])
+	)
 
 	const results = await Promise.allSettled(
 		WALLET_DIVISIONS.map(async (division, index) => {
@@ -44,17 +48,23 @@ export async function syncWalletTransactions(
 				await sleep(delayMs)
 			}
 
-			const transactions = await esiFetch.fetchWalletTransactions(
+			const fetchResult = await esiFetch.fetchWalletTransactions(
 				tokenStore,
 				corporationId,
 				division,
-				directorCharacterId
+				directorCharacterId,
+				watermarkByDivision.get(division)
 			)
+			if (fetchResult.truncated) {
+				throw new Error('Wallet transaction pagination was truncated before persistence')
+			}
 			const storeResult = await corpData.storeWalletTransactions(
 				corporationId,
 				division,
-				transactions
+				fetchResult.transactions,
+				watermarkByDivision.get(division)
 			)
+			const transactions = fetchResult.transactions
 			const maxTransactionId =
 				transactions.length > 0
 					? transactions.reduce(

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -436,6 +436,11 @@ export interface WalletTransactionsStoreResult {
 	persistedNewRows: number
 }
 
+export interface WalletTransactionWatermark {
+	maxTransactionId: string | null
+	maxTransactionDate: Date | null
+}
+
 export interface SkyhookStoreResult {
 	prunedCount: number
 }
@@ -1306,8 +1311,17 @@ export interface EveCorporationData {
 	storeWalletTransactions(
 		corporationId: string,
 		division: number,
-		transactions: any[]
+		transactions: any[],
+		watermark?: WalletTransactionWatermark
 	): Promise<WalletTransactionsStoreResult>
+
+	/**
+	 * Read the compact transaction watermarks for all wallet divisions.
+	 * This is used to bound ESI from_id pagination without loading existing rows.
+	 */
+	getWalletTransactionWatermarks(
+		corporationId: string
+	): Promise<Array<{ division: number; watermark: WalletTransactionWatermark }>>
 
 	/**
 	 * Store assets (workflow-friendly)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Replaces the per-batch "check existing rows then upsert" strategy for corporate wallet journal/transaction storage with a SQL watermark (max stored ID/date) that bounds both what gets fetched from ESI and what gets inserted, cutting redundant reads and writes for corporations with large wallet histories.

## Changes
- Add composite indexes on `corporation_wallet_journal` and `corporation_wallet_transactions` (`corporation_id, division, date` and `corporation_id, division, transaction/journal_id::numeric`) via a new Drizzle migration (`0036_natural_reptil.sql`).
- `storeWalletJournal` / `storeWalletTransactions` now compute the stored max ID/date with a single SQL aggregate query instead of `findMany` existence checks per batch, filter entries to only those newer than the watermark, sort them chronologically, and insert with `onConflictDoNothing` (dropping the previous `onConflictDoUpdate`) while batching inserts (`WALLET_JOURNAL_INSERT_BATCH_SIZE` / `WALLET_TRANSACTION_INSERT_BATCH_SIZE` = 100).
- Add `getWalletTransactionWatermarks` DO method and `WalletTransactionWatermark` type so callers can fetch per-division watermarks without loading rows.
- `fetchWalletTransactions` (esi-fetch service) now paginates via ESI's `from_id` cursor and stops once it has passed the stored watermark, instead of fetching a single page; it reports `pagesFetched`, `stoppedAtWatermark`, and `truncated` (capped at `MAX_WALLET_TRANSACTION_PAGES` = 100), and callers throw if pagination is truncated before persistence.
- Update the `syncWalletTransactions` workflow step and the `EveCorporationData` RPC interface to pass/consume the new watermark and fetch-result shape.
- Wallet transaction numeric fields (`transactionId`, `clientId`, `journalRefId`, `locationId`, `typeId`, `unitPrice`) are now stored as strings for consistent numeric-string comparisons.

## Testing
- Added unit tests for ESI pagination behavior (`esi-fetch.wallet-transactions.test.ts`) covering watermark-based early stop and cursor-following when no watermark exists.
- Added unit tests for the storage watermark/filter/sort logic (`wallet-journal-storage.test.ts`, `wallet-transaction-storage.test.ts`).
<!-- claude:end -->