### PR TITLE
address common workflow errors

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -15,8 +15,8 @@ import {
 	or,
 	sql,
 } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
-import { logger, TimeCache } from '@repo/hono-helpers'
+import { getStub, withRpcResult } from '@repo/do-utils'
+import { logger, TimeCache, toErrorLogDetails } from '@repo/hono-helpers'
 import {
 	getStructureTabForTypeId,
 	SKYHOOK_MAGMATIC_GAS_TYPE_ID,
@@ -237,6 +237,113 @@ function compareNumericStrings(left: string, right: string): number {
 	}
 }
 
+interface NormalizedDecimal {
+	sign: -1 | 0 | 1
+	digits: string
+	scale: number
+}
+
+function normalizeDecimal(value: unknown): NormalizedDecimal | null {
+	const text = String(value ?? '').trim()
+	const match = /^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))$/.exec(text)
+	if (!match) {
+		return null
+	}
+
+	const sign = match[1] === '-' ? -1 : 1
+	const whole = match[2] ?? '0'
+	let fraction = match[3] ?? match[4] ?? ''
+	while (fraction.endsWith('0')) {
+		fraction = fraction.slice(0, -1)
+	}
+
+	const digits = `${whole}${fraction}`.replace(/^0+(?=\d)/, '')
+	if (/^0+$/.test(digits)) {
+		return { sign: 0, digits: '0', scale: 0 }
+	}
+
+	return {
+		sign,
+		digits,
+		scale: fraction.length,
+	}
+}
+
+function areOppositeAmounts(left: unknown, right: unknown): boolean {
+	const leftAmount = normalizeDecimal(left)
+	const rightAmount = normalizeDecimal(right)
+	if (leftAmount === null || rightAmount === null) {
+		return false
+	}
+
+	return (
+		leftAmount.sign !== 0 &&
+		rightAmount.sign !== 0 &&
+		leftAmount.sign === -rightAmount.sign &&
+		leftAmount.digits === rightAmount.digits &&
+		leftAmount.scale === rightAmount.scale
+	)
+}
+
+function walletJournalMetadata(entry: any): string {
+	return JSON.stringify([
+		entry.context_id ?? null,
+		entry.context_id_type ?? null,
+		entry.date ?? null,
+		entry.description ?? null,
+		entry.first_party_id ?? null,
+		entry.reason ?? null,
+		entry.ref_type ?? null,
+		entry.second_party_id ?? null,
+		entry.tax ?? null,
+		entry.tax_receiver_id ?? null,
+	])
+}
+
+function filterZeroSumJournalPairs(entries: any[]): any[] {
+	const entriesByJournalId = new Map<string, number[]>()
+	for (const [index, entry] of entries.entries()) {
+		const journalId = String(entry.id)
+		const indexes = entriesByJournalId.get(journalId) ?? []
+		indexes.push(index)
+		entriesByJournalId.set(journalId, indexes)
+	}
+
+	const filteredIndexes = new Set<number>()
+	for (const indexes of entriesByJournalId.values()) {
+		for (let leftPosition = 0; leftPosition < indexes.length; leftPosition += 1) {
+			const leftIndex = indexes[leftPosition]
+			if (leftIndex === undefined || filteredIndexes.has(leftIndex)) {
+				continue
+			}
+
+			const left = entries[leftIndex]
+			for (
+				let rightPosition = leftPosition + 1;
+				rightPosition < indexes.length;
+				rightPosition += 1
+			) {
+				const rightIndex = indexes[rightPosition]
+				if (rightIndex === undefined || filteredIndexes.has(rightIndex)) {
+					continue
+				}
+
+				const right = entries[rightIndex]
+				if (
+					walletJournalMetadata(left) === walletJournalMetadata(right) &&
+					areOppositeAmounts(left.amount, right.amount)
+				) {
+					filteredIndexes.add(leftIndex)
+					filteredIndexes.add(rightIndex)
+					break
+				}
+			}
+		}
+	}
+
+	return entries.filter((_, index) => !filteredIndexes.has(index))
+}
+
 function chunkArray<T>(items: readonly T[], size: number): T[][] {
 	const chunks: T[][] = []
 	for (let index = 0; index < items.length; index += size) {
@@ -278,11 +385,13 @@ async function resolveAllianceNames(
 	const resolved = await Promise.all(
 		uniqueAllianceIds.map(async (allianceId) => {
 			try {
-				const response = await tokenStore.fetchPublicEsi<{ name?: string }>(
-					`/alliances/${allianceId}`,
-					{ cacheMode: 'no-store' }
+				const name = await withRpcResult(
+					tokenStore.fetchPublicEsi<{ name?: string }>(`/alliances/${allianceId}`, {
+						cacheMode: 'no-store',
+					}),
+					(response) => response.data.name?.trim() ?? null
 				)
-				return [allianceId, response.data.name?.trim() ?? null] as const
+				return [allianceId, name] as const
 			} catch (error) {
 				logger.warn('[EveCorporationData] Failed to resolve alliance name', {
 					allianceId,
@@ -324,6 +433,15 @@ type SkyhookStorageRow = {
 	lastObservedAt: Date
 	sourceSyncAt: Date
 	lastSyncedAt: Date
+}
+
+function cloneRpcRecord<T>(record: Record<string, T>): Record<string, T> {
+	return Object.fromEntries(
+		Object.entries(record).map(([key, value]) => [
+			key,
+			value !== null && typeof value === 'object' ? { ...value } : value,
+		])
+	) as Record<string, T>
 }
 type SkyhookReagentStorageRow = {
 	structureId: string
@@ -928,26 +1046,30 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		try {
-			const response: EsiResponse<EsiCharacterRoles> = await retryWithBackoff(
-				() =>
-					this.getEveTokenStoreStub().fetchEsi(`/characters/${characterId}/roles`, characterId, {
-						cacheMode: 'no-store',
-					}),
-				{
-					onRetry: (attempt, error, delayMs) => {
-						logger.warn('[EveCorporationData] Retrying role refresh after ESI throttling', {
-							corporationId,
-							characterId,
-							requiredRole,
-							attempt,
-							delayMs,
-							error: error.message,
-						})
-					},
+			return await withRpcResult(
+				retryWithBackoff<EsiResponse<EsiCharacterRoles>>(
+					() =>
+						this.getEveTokenStoreStub().fetchEsi(`/characters/${characterId}/roles`, characterId, {
+							cacheMode: 'no-store',
+						}),
+					{
+						onRetry: (attempt, error, delayMs) => {
+							logger.warn('[EveCorporationData] Retrying role refresh after ESI throttling', {
+								corporationId,
+								characterId,
+								requiredRole,
+								attempt,
+								delayMs,
+								error: error.message,
+							})
+						},
+					}
+				),
+				async (response) => {
+					await this.storeCharacterRolesSnapshot(corporationId, characterId, response.data)
+					return hasRole(response.data)
 				}
 			)
-			await this.storeCharacterRolesSnapshot(corporationId, characterId, response.data)
-			return hasRole(response.data)
 		} catch (error) {
 			logger.warn('[EveCorporationData] Failed to refresh roles while checking corp role', {
 				corporationId,
@@ -1958,33 +2080,41 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		// Sort chronologically before inserting so a partial failure advances the
 		// date watermark as little as possible while still accepting late IDs.
-		const newEntries = entries
-			.filter((entry) => {
-				if (storedMaxJournalId === null) {
-					return true
-				}
+		const candidateEntries = entries.filter((entry) => {
+			if (storedMaxJournalId === null) {
+				return true
+			}
 
-				if (compareNumericStrings(String(entry.id), storedMaxJournalId) > 0) {
-					return true
-				}
+			if (compareNumericStrings(String(entry.id), storedMaxJournalId) > 0) {
+				return true
+			}
 
-				const entryDate = parseDateOrNull(entry.date)
-				return (
-					storedMaxJournalDate !== null && entryDate !== null && entryDate >= storedMaxJournalDate
-				)
+			const entryDate = parseDateOrNull(entry.date)
+			return (
+				storedMaxJournalDate !== null && entryDate !== null && entryDate >= storedMaxJournalDate
+			)
+		})
+		const newEntries = filterZeroSumJournalPairs(candidateEntries)
+
+		if (newEntries.length !== candidateEntries.length) {
+			logger.info('[WalletJournalStore] Filtered zero-sum journal pairs', {
+				corporationId,
+				division,
+				filteredEntries: candidateEntries.length - newEntries.length,
 			})
-			.slice()
-			.sort((left, right) => {
-				const leftDate = parseDateOrNull(left.date)
-				const rightDate = parseDateOrNull(right.date)
-				if (leftDate !== null && rightDate !== null && leftDate.getTime() !== rightDate.getTime()) {
-					return leftDate < rightDate ? -1 : 1
-				}
-				return compareNumericStrings(String(left.id), String(right.id))
-			})
+		}
+
+		const sortedEntries = newEntries.slice().sort((left, right) => {
+			const leftDate = parseDateOrNull(left.date)
+			const rightDate = parseDateOrNull(right.date)
+			if (leftDate !== null && rightDate !== null && leftDate.getTime() !== rightDate.getTime()) {
+				return leftDate < rightDate ? -1 : 1
+			}
+			return compareNumericStrings(String(left.id), String(right.id))
+		})
 		let persistedNewRows = 0
-		for (let i = 0; i < newEntries.length; i += WALLET_JOURNAL_INSERT_BATCH_SIZE) {
-			const batch = newEntries.slice(i, i + WALLET_JOURNAL_INSERT_BATCH_SIZE)
+		for (let i = 0; i < sortedEntries.length; i += WALLET_JOURNAL_INSERT_BATCH_SIZE) {
+			const batch = sortedEntries.slice(i, i + WALLET_JOURNAL_INSERT_BATCH_SIZE)
 			const valuesToInsert = batch.map((entry) => ({
 				corporationId: String(corporationId),
 				division,
@@ -2737,13 +2867,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		const [systemsById, regionsBySystemId, typeNamesById, structureInfos] = await Promise.all([
 			systemIds.length > 0
-				? universe.resolveSolarSystemsByIds(systemIds)
+				? withRpcResult(universe.resolveSolarSystemsByIds(systemIds), cloneRpcRecord)
 				: Promise.resolve({} as Record<string, UniverseSolarSystem | null>),
 			systemIds.length > 0
-				? universe.getRegionsBySystemIds(systemIds)
+				? withRpcResult(universe.getRegionsBySystemIds(systemIds), cloneRpcRecord)
 				: Promise.resolve({} as Record<string, { regionId: string; regionName: string }>),
 			typeIds.length > 0
-				? tokenStore.resolveIds(typeIds)
+				? withRpcResult(tokenStore.resolveIds(typeIds), (names) => ({ ...names }))
 				: Promise.resolve({} as Record<string, string>),
 			characterId
 				? Promise.all(
@@ -2755,9 +2885,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 							try {
 								// Moon-drills need universe hydration so we can later infer the
 								// attached moon from the returned coordinates.
-								return await universe.getStructureInfo(
-									structure.structure_id as EveStructureId,
-									characterId as EveCharacterId
+								return await withRpcResult(
+									universe.getStructureInfo(
+										structure.structure_id as EveStructureId,
+										characterId as EveCharacterId
+									),
+									(structureInfo) => (structureInfo ? { ...structureInfo } : null)
 								)
 							} catch (error) {
 								logger.warn('[EveCorporationData] Failed to hydrate structure name', {
@@ -3070,9 +3203,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					}
 
 					try {
-						const moonGeography = await universe.resolveNearestMoonGeographyBySystemPosition(
-							structure.systemId,
-							structure.structureInfo.position
+						const moonGeography = await withRpcResult(
+							universe.resolveNearestMoonGeographyBySystemPosition(
+								structure.systemId,
+								structure.structureInfo.position
+							),
+							(geography) => (geography ? { ...geography } : null)
 						)
 
 						return buildMoonGeographyStorageRow({
@@ -3480,9 +3616,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		})
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
 			systems.length > 0
-				? await universe.resolveSolarSystemsByIds([
-						...new Set(systems.map((system) => system.system_id)),
-					])
+				? await withRpcResult(
+						universe.resolveSolarSystemsByIds([
+							...new Set(systems.map((system) => system.system_id)),
+						]),
+						cloneRpcRecord
+					)
 				: {}
 		const regionIds = [
 			...new Set(
@@ -3495,7 +3634,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			),
 		]
 		const regionGeography: Awaited<ReturnType<Universe['resolveRegionsByIds']>> =
-			regionIds.length > 0 ? await universe.resolveRegionsByIds(regionIds) : {}
+			regionIds.length > 0
+				? await withRpcResult(universe.resolveRegionsByIds(regionIds), cloneRpcRecord)
+				: {}
 		const allianceNames = await resolveAllianceNames(
 			tokenStore,
 			systems.flatMap((system) => (system.alliance_id ? [system.alliance_id] : []))
@@ -3838,9 +3979,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
 			newHubs.length > 0
-				? ((await universe.resolveSolarSystemsByIds([
-						...new Set(newHubs.map((hub) => hub.system_id)),
-					])) ?? {})
+				? await withRpcResult(
+						universe.resolveSolarSystemsByIds([...new Set(newHubs.map((hub) => hub.system_id))]),
+						(result) => cloneRpcRecord(result ?? {})
+					)
 				: {}
 		const values: SovereigntyHubInsertRow[] = hubs.map((hub) => {
 			const existing = existingByStructureId.get(hub.structure_id)
@@ -4590,16 +4732,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const newSkyhooks = skyhooks.filter((skyhook) => !baseStructureById.has(skyhook.structure_id))
 		const planetGeography: Awaited<ReturnType<Universe['resolvePlanetGeographyByIds']>> =
 			newSkyhooks.length > 0
-				? await universe.resolvePlanetGeographyByIds([
-						...new Set(newSkyhooks.map((skyhook) => skyhook.planet_id)),
-					])
+				? await withRpcResult(
+						universe.resolvePlanetGeographyByIds([
+							...new Set(newSkyhooks.map((skyhook) => skyhook.planet_id)),
+						]),
+						cloneRpcRecord
+					)
 				: {}
 		const resolvedPlanetGeographies = Object.values(planetGeography).filter(
 			(planet): planet is UniversePlanetGeography => planet !== null
 		)
 		const systemIds = [...new Set(resolvedPlanetGeographies.map((planet) => planet.solarSystemId))]
 		const systemGeography: Awaited<ReturnType<Universe['resolveSolarSystemsByIds']>> =
-			systemIds.length > 0 ? await universe.resolveSolarSystemsByIds(systemIds) : {}
+			systemIds.length > 0
+				? await withRpcResult(universe.resolveSolarSystemsByIds(systemIds), cloneRpcRecord)
+				: {}
 		const regionIds = [
 			...new Set(
 				Object.values(systemGeography)
@@ -4609,7 +4756,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			),
 		]
 		const regionGeography: Awaited<ReturnType<Universe['resolveRegionsByIds']>> =
-			regionIds.length > 0 ? await universe.resolveRegionsByIds(regionIds) : {}
+			regionIds.length > 0
+				? await withRpcResult(universe.resolveRegionsByIds(regionIds), cloneRpcRecord)
+				: {}
 
 		const synthesizedRows = skyhooks
 			.map((skyhook) => {
@@ -5214,8 +5363,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				.error('Failed to insert journal entries', {
 					entriesPersisted: persistedNewRows,
 					totalEntries: entries.length,
-					error: error instanceof Error ? error.message : String(error),
-					errorStack: error instanceof Error ? error.stack : undefined,
+					...toErrorLogDetails(error),
 				})
 
 			// Clear cache for this division so next attempt fetches fresh data
@@ -5237,7 +5385,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 						operation: 'fetch_wallet_journal',
 					})
 					.error('Failed to clear cache', {
-						error: clearError instanceof Error ? clearError.message : String(clearError),
+						...toErrorLogDetails(clearError),
 					})
 			}
 
@@ -5420,9 +5568,17 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const syncStartedAt = new Date()
 		const result = await syncAssetsPaged({
 			fetchPage: (page) =>
-				tokenStore.fetchEsi(`${basePath}?page=${page}`, characterId, {
-					cacheMode: 'no-store',
-				}) as Promise<EsiResponse<RawEsiAsset[]>>,
+				withRpcResult(
+					tokenStore.fetchEsi<RawEsiAsset[]>(`${basePath}?page=${page}`, characterId, {
+						cacheMode: 'no-store',
+					}),
+					(response) =>
+						({
+							data: response.data.map((asset) => ({ ...asset })),
+							pages: response.pages,
+							page: response.page,
+						}) as EsiResponse<RawEsiAsset[]>
+				),
 			storeAssets: (assets) => this.storeAssetsPage(corporationId, assets, syncStartedAt),
 			onProgress: ({ page, totalPages, totalAssets }) => {
 				if (page % 10 === 0 || page === totalPages) {
@@ -6409,13 +6565,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const { characterId } = await this.getConfiguredCharacter(corporationId)
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 
-		const response = await tokenStore.fetchEsi<number[]>(
-			`/corporations/${corporationId}/members`,
-			characterId,
-			{ cacheMode: 'no-store' }
+		const currentMemberIds = await withRpcResult(
+			tokenStore.fetchEsi<number[]>(`/corporations/${corporationId}/members`, characterId, {
+				cacheMode: 'no-store',
+			}),
+			(response) => new Set(response.data.map(String))
 		)
-
-		const currentMemberIds = new Set(response.data.map(String))
 
 		// Fetch all members from database
 		const dbMembers = await this.getDb()

--- a/apps/eve-corporation-data/src/services/director-manager.ts
+++ b/apps/eve-corporation-data/src/services/director-manager.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, sql } from '@repo/db-utils'
-import { logger } from '@repo/hono-helpers'
+import { withRpcResult } from '@repo/do-utils'
+import { logger, toErrorLogDetails } from '@repo/hono-helpers'
 import {
 	classifyEsiCredentialFailure,
 	parseEsiErrorMetadata,
@@ -57,6 +58,9 @@ const PERMANENT_FAILURE_PREFIX = '[PERMANENT]'
 const DIRECTOR_DEPENDENCY_FAILURE_PREFIX = 'Director dependency failure'
 const INVALID_STALE_PERMANENT_MS = 7 * 24 * 60 * 60 * 1000
 const TRANSIENT_DIRECTOR_COOLDOWN_MS = 10 * 60 * 1000
+// A director check fans out through token-store, ESI, and the database. Keep
+// those paths sequential within one corporation to avoid connection bursts.
+const DIRECTOR_HEALTH_CHECK_CONCURRENCY = 1
 
 const FULL_SYNC_REQUIRED_ROLE_SETS: CorporationRole[][] = [
 	['Director'],
@@ -76,6 +80,52 @@ function describeTokenValidationFailure(validation: TokenValidationResult): stri
 	}
 
 	return `Director token validation failed: ${validation.status}`
+}
+
+function getErrorContext(error: unknown): Record<string, unknown> {
+	const details = toErrorLogDetails(error)
+	const root = error && typeof error === 'object' ? (error as Record<string, unknown>) : {}
+	const cause = root.cause && typeof root.cause === 'object' ? root.cause : null
+	const causeRecord = cause as Record<string, unknown> | null
+	const query =
+		typeof root.query === 'string' ? root.query.replace(/\s+/g, ' ').slice(0, 2_000) : undefined
+	const values = {
+		error: details.message,
+		errorName: details.name,
+		errorStack: details.stack,
+		errorCause: details.cause,
+		errorCode: root.code ?? causeRecord?.code,
+		errorDetail: root.detail ?? causeRecord?.detail,
+		errorHint: root.hint ?? causeRecord?.hint,
+		errorSeverity: root.severity ?? causeRecord?.severity,
+		errorPosition: root.position ?? causeRecord?.position,
+		errorQuery: query,
+		errorParamsCount: Array.isArray(root.params) ? root.params.length : undefined,
+		causeName: causeRecord?.name,
+		causeMessage: causeRecord?.message,
+		causeStack: causeRecord?.stack,
+		causeCode: causeRecord?.code,
+		causeDetail: causeRecord?.detail,
+		causeHint: causeRecord?.hint,
+		causeSeverity: causeRecord?.severity,
+	}
+
+	return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined))
+}
+
+async function settleInBatches<T, R>(
+	items: T[],
+	operation: (item: T) => Promise<R>,
+	concurrency: number
+): Promise<Array<PromiseSettledResult<R>>> {
+	const results: Array<PromiseSettledResult<R>> = []
+
+	for (let index = 0; index < items.length; index += concurrency) {
+		const batch = items.slice(index, index + concurrency)
+		results.push(...(await Promise.allSettled(batch.map(operation))))
+	}
+
+	return results
 }
 
 /**
@@ -102,6 +152,8 @@ export class DirectorManager {
 			isVerified: boolean
 		}) => Promise<void>
 	) {}
+
+	private deferHealthSnapshot = false
 
 	/**
 	 * Add a new director for this corporation
@@ -262,7 +314,10 @@ export class DirectorManager {
 			// steps do not run with a director that cannot produce credentials.
 			for (const candidate of healthyDirectors) {
 				try {
-					const tokenInfo = await this.tokenStore.getTokenInfo(candidate.characterId)
+					const tokenInfo = await withRpcResult(
+						this.tokenStore.getTokenInfo(candidate.characterId),
+						(info) => (info ? { ...info } : null)
+					)
 					if (!tokenInfo) {
 						await this.safeRecordFailure(candidate.directorId, 'No token available for director')
 						continue
@@ -277,8 +332,9 @@ export class DirectorManager {
 							)
 							continue
 						}
-						const refreshResult = await this.tokenStore.refreshTokenWithResult(
-							candidate.characterId
+						const refreshResult = await withRpcResult(
+							this.tokenStore.refreshTokenWithResult(candidate.characterId),
+							(result) => ({ ...result })
 						)
 						if (!refreshResult.success) {
 							const reason =
@@ -306,32 +362,36 @@ export class DirectorManager {
 					}
 
 					if (options?.requiredRoleSets && options.requiredRoleSets.length > 0) {
-						const rolesResponse: EsiResponse<EsiCharacterRoles> = await retryWithBackoff(
-							() =>
-								this.tokenStore.fetchEsi(
-									`/characters/${candidate.characterId}/roles`,
-									candidate.characterId,
-									{ cacheMode: 'no-store' }
-								),
-							{
-								onRetry: (attempt, error, delayMs) => {
-									logger.warn(
-										'[DirectorManager] Retrying director role lookup after ESI throttling',
-										{
-											corporationId: this.corporationId,
-											directorId: candidate.directorId,
-											characterId: candidate.characterId,
-											attempt,
-											delayMs,
-											error: error.message,
-										}
-									)
-								},
+						const requiredRoleSets = options.requiredRoleSets
+						const missingRoleSets = await withRpcResult(
+							retryWithBackoff<EsiResponse<EsiCharacterRoles>>(
+								() =>
+									this.tokenStore.fetchEsi(
+										`/characters/${candidate.characterId}/roles`,
+										candidate.characterId,
+										{ cacheMode: 'no-store' }
+									),
+								{
+									onRetry: (attempt, error, delayMs) => {
+										logger.warn(
+											'[DirectorManager] Retrying director role lookup after ESI throttling',
+											{
+												corporationId: this.corporationId,
+												directorId: candidate.directorId,
+												characterId: candidate.characterId,
+												attempt,
+												delayMs,
+												error: error.message,
+											}
+										)
+									},
+								}
+							),
+							(rolesResponse) => {
+								const roleSet = this.buildEffectiveRoleSet(rolesResponse.data)
+								return this.getMissingRoleSets(roleSet, requiredRoleSets)
 							}
 						)
-						const rawRoles = rolesResponse.data
-						const roleSet = this.buildEffectiveRoleSet(rawRoles)
-						const missingRoleSets = this.getMissingRoleSets(roleSet, options.requiredRoleSets)
 						if (missingRoleSets.length > 0) {
 							await this.safeRecordFailure(
 								candidate.directorId,
@@ -407,22 +467,25 @@ export class DirectorManager {
 
 		let affiliations: EsiCharacterAffiliation[]
 		try {
-			affiliations = await retryWithBackoff(
-				() => this.tokenStore.fetchCharacterAffiliations([characterId]),
-				{
-					onRetry: (attempt, error, delayMs) => {
-						logger.warn(
-							'[DirectorManager] Retrying character affiliation lookup after ESI throttling',
-							{
-								corporationId: this.corporationId,
-								characterId,
-								attempt,
-								delayMs,
-								error: error.message,
-							}
-						)
-					},
-				}
+			affiliations = await withRpcResult(
+				retryWithBackoff<EsiCharacterAffiliation[]>(
+					() => this.tokenStore.fetchCharacterAffiliations([characterId]),
+					{
+						onRetry: (attempt, error, delayMs) => {
+							logger.warn(
+								'[DirectorManager] Retrying character affiliation lookup after ESI throttling',
+								{
+									corporationId: this.corporationId,
+									characterId,
+									attempt,
+									delayMs,
+									error: error.message,
+								}
+							)
+						},
+					}
+				),
+				(result) => result.map((affiliation) => ({ ...affiliation }))
 			)
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
@@ -538,24 +601,38 @@ export class DirectorManager {
 		options?: { forceUnhealthy?: boolean }
 	): Promise<void> {
 		try {
-			await this.recordFailure(directorId, reason, options)
+			if (options) {
+				await this.recordFailure(directorId, reason, options)
+			} else {
+				await this.recordFailure(directorId, reason)
+			}
 		} catch (error) {
 			logger.error('[DirectorManager] Failed to record director failure', {
 				corporationId: this.corporationId,
 				directorId,
 				reason,
-				error: error instanceof Error ? error.message : String(error),
+				...getErrorContext(error),
 			})
 		}
 	}
 
 	private async syncHealthSnapshot(): Promise<void> {
-		if (!this.onHealthSnapshotChanged) {
+		if (!this.onHealthSnapshotChanged || this.deferHealthSnapshot) {
+			return
+		}
+
+		let healthyDirectorCount: number
+		try {
+			healthyDirectorCount = await this.getHealthyDirectorsCount()
+		} catch (error) {
+			logger.error('[DirectorManager] Failed to count healthy directors for auth snapshot', {
+				corporationId: this.corporationId,
+				...getErrorContext(error),
+			})
 			return
 		}
 
 		try {
-			const healthyDirectorCount = await this.getHealthyDirectorsCount()
 			await this.onHealthSnapshotChanged({
 				corporationId: this.corporationId,
 				healthyDirectorCount,
@@ -564,7 +641,8 @@ export class DirectorManager {
 		} catch (error) {
 			logger.error('[DirectorManager] Failed to propagate corp auth health snapshot', {
 				corporationId: this.corporationId,
-				error: error instanceof Error ? error.message : String(error),
+				healthyDirectorCount,
+				...getErrorContext(error),
 			})
 		}
 	}
@@ -942,8 +1020,15 @@ export class DirectorManager {
 			return false
 		}
 
+		let verificationPhase = 'token-validation'
 		try {
-			const tokenValidation = await this.tokenStore.validateToken(String(director.characterId))
+			const tokenValidation = await withRpcResult(
+				this.tokenStore.validateToken(String(director.characterId)),
+				(result) => ({
+					...result,
+					missingScopes: result.missingScopes ? [...result.missingScopes] : result.missingScopes,
+				})
+			)
 			if (!tokenValidation.isValid) {
 				if (tokenValidation.status === 'transient_error') {
 					await this.recordFailure(
@@ -971,6 +1056,7 @@ export class DirectorManager {
 				return false
 			}
 
+			verificationPhase = 'affiliation-check'
 			const affiliationCheck = await this.checkAffiliation(String(director.characterId))
 			if (!affiliationCheck.matches) {
 				await this.handleAffiliationMismatch({
@@ -983,73 +1069,82 @@ export class DirectorManager {
 			}
 
 			// Fetch character roles from ESI
-			const response: EsiResponse<EsiCharacterRoles> = await retryWithBackoff(
-				() =>
-					this.tokenStore.fetchEsi(
-						`/characters/${director.characterId}/roles`,
-						director.characterId,
-						{ cacheMode: 'no-store' }
-					),
-				{
-					onRetry: (attempt, error, delayMs) => {
-						logger.warn(
-							'[DirectorManager] Retrying director health role check after ESI throttling',
-							{
-								corporationId: this.corporationId,
-								directorId,
-								characterId: director.characterId,
-								attempt,
-								delayMs,
-								error: error.message,
-							}
-						)
-					},
+			verificationPhase = 'roles-fetch'
+			const missingRoleSets = await withRpcResult(
+				retryWithBackoff<EsiResponse<EsiCharacterRoles>>(
+					() =>
+						this.tokenStore.fetchEsi(
+							`/characters/${director.characterId}/roles`,
+							director.characterId,
+							{ cacheMode: 'no-store' }
+						),
+					{
+						onRetry: (attempt, error, delayMs) => {
+							logger.warn(
+								'[DirectorManager] Retrying director health role check after ESI throttling',
+								{
+									corporationId: this.corporationId,
+									directorId,
+									characterId: director.characterId,
+									attempt,
+									delayMs,
+									error: error.message,
+								}
+							)
+						},
+					}
+				),
+				async (response) => {
+					const roles = response.data
+					const roleSet = this.buildEffectiveRoleSet(roles)
+					const requiredRoleSets = options?.requiredRoleSets ?? FULL_SYNC_REQUIRED_ROLE_SETS
+
+					verificationPhase = 'roles-persistence'
+					await this.db
+						.insert(characterCorporationRoles)
+						.values({
+							corporationId: this.corporationId,
+							characterId: String(director.characterId),
+							roles: roles.roles || [],
+							rolesAtHq: roles.roles_at_hq,
+							rolesAtBase: roles.roles_at_base,
+							rolesAtOther: roles.roles_at_other,
+							updatedAt: new Date(),
+						})
+						.onConflictDoUpdate({
+							target: [
+								characterCorporationRoles.corporationId,
+								characterCorporationRoles.characterId,
+							],
+							set: {
+								roles: roles.roles || [],
+								rolesAtHq: roles.roles_at_hq,
+								rolesAtBase: roles.roles_at_base,
+								rolesAtOther: roles.roles_at_other,
+								updatedAt: new Date(),
+							},
+						})
+
+					verificationPhase = 'health-state-persistence'
+					await this.db
+						.update(corporationDirectors)
+						.set({
+							lastHealthCheck: new Date(),
+							isHealthy: true,
+							failureCount: 0,
+							lastFailureReason: null,
+							nextRetryAt: null,
+							permanentFailureAt: null,
+							updatedAt: new Date(),
+						})
+						.where(eq(corporationDirectors.id, directorId))
+
+					verificationPhase = 'health-snapshot'
+					await this.syncHealthSnapshot()
+
+					return this.getMissingRoleSets(roleSet, requiredRoleSets)
 				}
 			)
-
-			const roles = response.data
-			const roleSet = this.buildEffectiveRoleSet(roles)
-			const requiredRoleSets = options?.requiredRoleSets ?? FULL_SYNC_REQUIRED_ROLE_SETS
-			const missingRoleSets = this.getMissingRoleSets(roleSet, requiredRoleSets)
-
-			// Store roles in database
-			await this.db
-				.insert(characterCorporationRoles)
-				.values({
-					corporationId: this.corporationId,
-					characterId: String(director.characterId),
-					roles: roles.roles || [],
-					rolesAtHq: roles.roles_at_hq,
-					rolesAtBase: roles.roles_at_base,
-					rolesAtOther: roles.roles_at_other,
-					updatedAt: new Date(),
-				})
-				.onConflictDoUpdate({
-					target: [characterCorporationRoles.corporationId, characterCorporationRoles.characterId],
-					set: {
-						roles: roles.roles || [],
-						rolesAtHq: roles.roles_at_hq,
-						rolesAtBase: roles.roles_at_base,
-						rolesAtOther: roles.roles_at_other,
-						updatedAt: new Date(),
-					},
-				})
-
-			// Update director health check timestamp
-			await this.db
-				.update(corporationDirectors)
-				.set({
-					lastHealthCheck: new Date(),
-					isHealthy: true,
-					failureCount: 0,
-					lastFailureReason: null,
-					nextRetryAt: null,
-					permanentFailureAt: null,
-					updatedAt: new Date(),
-				})
-				.where(eq(corporationDirectors.id, directorId))
-
-			await this.syncHealthSnapshot()
 
 			if (missingRoleSets.length > 0) {
 				const reason = `Director permission failure: Director missing required roles: ${missingRoleSets
@@ -1066,12 +1161,12 @@ export class DirectorManager {
 
 			return true
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error)
-
 			logger.error('[DirectorManager] Director health verification failed', {
+				corporationId: this.corporationId,
 				directorId,
 				characterId: director.characterId,
-				error: errorMessage,
+				phase: verificationPhase,
+				...getErrorContext(error),
 			})
 
 			const failureReason = classifyEsiCredentialFailure(error)
@@ -1079,7 +1174,7 @@ export class DirectorManager {
 				: this.isDirectorLookupNotFoundFailure(error)
 					? this.buildDirectorLookupFailureReason('verify-director-health', error)
 					: this.buildDirectorDependencyFailureReason('verify-director-health', error)
-			await this.recordFailure(directorId, failureReason)
+			await this.safeRecordFailure(directorId, failureReason)
 			return false
 		}
 	}
@@ -1128,20 +1223,29 @@ export class DirectorManager {
 					)
 				: []
 
-		const results = await Promise.allSettled(
-			nonPermanentDirectors.map(async (director) => {
-				return await this.verifyDirectorHealth(director.directorId)
-			})
-		)
-
-		if (permanentDirectorsToAffiliationCheck.length > 0) {
-			await Promise.allSettled(
-				permanentDirectorsToAffiliationCheck.map(async (director) => {
-					await this.verifyPermanentDirectorAffiliation(director.directorId)
-					return true
-				})
+		let results: Array<PromiseSettledResult<boolean>>
+		this.deferHealthSnapshot = true
+		try {
+			results = await settleInBatches(
+				nonPermanentDirectors,
+				async (director) => await this.verifyDirectorHealth(director.directorId),
+				DIRECTOR_HEALTH_CHECK_CONCURRENCY
 			)
+
+			if (permanentDirectorsToAffiliationCheck.length > 0) {
+				await settleInBatches(
+					permanentDirectorsToAffiliationCheck,
+					async (director) => {
+						await this.verifyPermanentDirectorAffiliation(director.directorId)
+						return true
+					},
+					DIRECTOR_HEALTH_CHECK_CONCURRENCY
+				)
+			}
+		} finally {
+			this.deferHealthSnapshot = false
 		}
+		await this.syncHealthSnapshot()
 
 		// Count verified vs failed
 		let verified = 0

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -11,6 +11,7 @@
  * - Reusability across different contexts
  */
 
+import { disposeRpcResult, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { parseDateOrNull } from '@repo/worker-utils'
 import { parseEsiErrorMetadata } from '@repo/workflow-utils'
@@ -91,14 +92,15 @@ export async function fetchPublicInfo(
 	tokenStore: EveTokenStore,
 	corporationId: string
 ): Promise<any> {
-	const response = await tokenStore.fetchPublicEsi<any>(`/corporations/${corporationId}`, {
-		cacheMode: 'no-store',
-	})
-
-	return {
-		corporationId: String(corporationId),
-		...transformPublicInfo(response.data),
-	}
+	return withRpcResult(
+		tokenStore.fetchPublicEsi<any>(`/corporations/${corporationId}`, {
+			cacheMode: 'no-store',
+		}),
+		(response) => ({
+			corporationId: String(corporationId),
+			...transformPublicInfo(response.data),
+		})
+	)
 }
 
 // ========================================================================
@@ -113,13 +115,12 @@ export async function fetchMembers(
 	corporationId: string,
 	characterId: string
 ): Promise<EsiCorporationMembers> {
-	const response = await tokenStore.fetchEsi<number[]>(
-		`/corporations/${corporationId}/members`,
-		characterId,
-		{ cacheMode: 'no-store' }
+	return withRpcResult(
+		tokenStore.fetchEsi<number[]>(`/corporations/${corporationId}/members`, characterId, {
+			cacheMode: 'no-store',
+		}),
+		(response) => transformMembers(response.data)
 	)
-
-	return transformMembers(response.data)
 }
 
 /**
@@ -130,19 +131,20 @@ export async function fetchMemberTracking(
 	corporationId: string,
 	characterId: string
 ): Promise<EsiCorporationMemberTracking[]> {
-	const response = await tokenStore.fetchEsi<
-		Array<{
-			character_id: number
-			base_id?: number
-			location_id?: number
-			logoff_date?: string
-			logon_date?: string
-			ship_type_id?: number
-			start_date?: string
-		}>
-	>(`/corporations/${corporationId}/membertracking`, characterId, { cacheMode: 'no-store' })
-
-	return transformMemberTracking(response.data)
+	return withRpcResult(
+		tokenStore.fetchEsi<
+			Array<{
+				character_id: number
+				base_id?: number
+				location_id?: number
+				logoff_date?: string
+				logon_date?: string
+				ship_type_id?: number
+				start_date?: string
+			}>
+		>(`/corporations/${corporationId}/membertracking`, characterId, { cacheMode: 'no-store' }),
+		(response) => transformMemberTracking(response.data)
+	)
 }
 
 // ========================================================================
@@ -157,13 +159,14 @@ export async function fetchWallets(
 	corporationId: string,
 	characterId: string
 ): Promise<EsiCorporationWallet[]> {
-	const response = await tokenStore.fetchEsi<Array<{ division: number; balance: number }>>(
-		`/corporations/${corporationId}/wallets`,
-		characterId,
-		{ cacheMode: 'no-store' }
+	return withRpcResult(
+		tokenStore.fetchEsi<Array<{ division: number; balance: number }>>(
+			`/corporations/${corporationId}/wallets`,
+			characterId,
+			{ cacheMode: 'no-store' }
+		),
+		(response) => transformWallets(response.data)
 	)
-
-	return transformWallets(response.data)
 }
 
 /**
@@ -191,13 +194,14 @@ export async function fetchWalletJournal(
 		tax_receiver_id?: number
 	}
 
-	const result = await tokenStore.fetchEsiAllPages<RawJournalEntry>(
-		`/corporations/${corporationId}/wallets/${division}/journal`,
-		characterId,
-		{ cacheMode: 'no-store' }
+	return withRpcResult(
+		tokenStore.fetchEsiAllPages<RawJournalEntry>(
+			`/corporations/${corporationId}/wallets/${division}/journal`,
+			characterId,
+			{ cacheMode: 'no-store' }
+		),
+		(result) => transformWalletJournal(result.data)
 	)
-
-	return transformWalletJournal(result.data)
 }
 
 /**
@@ -227,6 +231,41 @@ export async function fetchWalletTransactions(
 		cacheMode: 'no-store',
 	})
 
+	try {
+		return await fetchWalletTransactionsPages(
+			tokenStore,
+			corporationId,
+			division,
+			characterId,
+			response,
+			watermark
+		)
+	} finally {
+		disposeRpcResult(response)
+	}
+}
+
+async function fetchWalletTransactionsPages(
+	tokenStore: EveTokenStore,
+	corporationId: string,
+	division: number,
+	characterId: string,
+	response: {
+		data: Array<{
+			transaction_id: number
+			client_id: number
+			date: string
+			is_buy: boolean
+			is_personal: boolean
+			journal_ref_id: number
+			location_id: number
+			quantity: number
+			type_id: number
+			unit_price: number
+		}>
+	},
+	watermark?: WalletTransactionWatermark
+): Promise<WalletTransactionsFetchResult> {
 	const basePath = `/corporations/${corporationId}/wallets/${division}/transactions`
 	const transactions = new Map<string, EsiCorporationWalletTransaction>()
 	let pageData = transformWalletTransactions(response.data)
@@ -300,7 +339,11 @@ export async function fetchWalletTransactions(
 				characterId,
 				{ cacheMode: 'no-store' }
 			)
-			pageData = transformWalletTransactions(nextResponse.data)
+			try {
+				pageData = transformWalletTransactions(nextResponse.data)
+			} finally {
+				disposeRpcResult(nextResponse)
+			}
 			pagesFetched += 1
 			addPage(pageData)
 
@@ -368,7 +411,11 @@ export async function fetchAssets(
 		{ cacheMode: 'no-store' }
 	)
 
-	return transformAssets(result.data)
+	try {
+		return transformAssets(result.data)
+	} finally {
+		disposeRpcResult(result)
+	}
 }
 
 /**
@@ -397,7 +444,11 @@ export async function fetchStructures(
 		}>
 	>(`/corporations/${corporationId}/structures`, characterId)
 
-	return transformStructures(response.data, corporationId)
+	try {
+		return transformStructures(response.data, corporationId)
+	} finally {
+		disposeRpcResult(response)
+	}
 }
 
 export async function fetchSovereigntySystems(
@@ -451,41 +502,45 @@ export async function fetchSovereigntySystems(
 		{ cacheMode: 'no-store' }
 	)
 
-	return response.data.solar_systems.map((system) => {
-		if ('alliance' in system.claim) {
-			const claim = system.claim.alliance
+	try {
+		return response.data.solar_systems.map((system) => {
+			if ('alliance' in system.claim) {
+				const claim = system.claim.alliance
+				return {
+					system_id: String(system.solar_system_id),
+					claim_type: 'alliance' as const,
+					alliance_id: String(claim.alliance_id),
+					corporation_id: String(claim.corporation_id),
+					claimed_since: claim.claimed_since,
+					is_capital_system: claim.is_capital_system,
+					sovereignty_hub_structure_id: String(claim.sovereignty_hub.id),
+					vulnerability_window: claim.sovereignty_hub.vulnerability_window ?? null,
+					activity_defense_multiplier: String(claim.development.activity_defense_multiplier),
+					military_level: claim.development.military_level,
+					industrial_level: claim.development.industrial_level,
+					strategic_level: claim.development.strategic_level,
+					raw: system as Record<string, unknown>,
+				}
+			}
+
+			if ('faction' in system.claim) {
+				return {
+					system_id: String(system.solar_system_id),
+					claim_type: 'faction' as const,
+					faction_id: String(system.claim.faction.faction_id),
+					raw: system as Record<string, unknown>,
+				}
+			}
+
 			return {
 				system_id: String(system.solar_system_id),
-				claim_type: 'alliance' as const,
-				alliance_id: String(claim.alliance_id),
-				corporation_id: String(claim.corporation_id),
-				claimed_since: claim.claimed_since,
-				is_capital_system: claim.is_capital_system,
-				sovereignty_hub_structure_id: String(claim.sovereignty_hub.id),
-				vulnerability_window: claim.sovereignty_hub.vulnerability_window ?? null,
-				activity_defense_multiplier: String(claim.development.activity_defense_multiplier),
-				military_level: claim.development.military_level,
-				industrial_level: claim.development.industrial_level,
-				strategic_level: claim.development.strategic_level,
+				claim_type: 'unclaimed' as const,
 				raw: system as Record<string, unknown>,
 			}
-		}
-
-		if ('faction' in system.claim) {
-			return {
-				system_id: String(system.solar_system_id),
-				claim_type: 'faction' as const,
-				faction_id: String(system.claim.faction.faction_id),
-				raw: system as Record<string, unknown>,
-			}
-		}
-
-		return {
-			system_id: String(system.solar_system_id),
-			claim_type: 'unclaimed' as const,
-			raw: system as Record<string, unknown>,
-		}
-	})
+		})
+	} finally {
+		disposeRpcResult(response)
+	}
 }
 
 function isRateLimitEsiError(error: unknown): boolean {
@@ -610,41 +665,45 @@ export async function fetchSovereigntyHubs(
 					characterId,
 					{ cacheMode: 'no-store' }
 				)
-				const detail = detailResult.data
+				try {
+					const detail = detailResult.data
 
-				return {
-					structure_id: String(detail.id),
-					corporation_id: corporationId,
-					system_id: String(detail.solar_system_id),
-					name: null,
-					type_id: SOVEREIGNTY_HUB_TYPE_ID,
-					fuel_access_list_id:
-						detail.fuel_access_list_id !== undefined && detail.fuel_access_list_id !== null
-							? String(detail.fuel_access_list_id)
-							: null,
-					reagent_bay: {
-						last_updated: detail.reagent_bay.last_updated,
-						reagents: detail.reagent_bay.reagents.map((reagent) => ({
-							type_id: String(reagent.type_id),
-							amount: reagent.amount,
-							burning_per_hour: reagent.burning_per_hour,
-							last_cycle: reagent.last_cycle,
+					return {
+						structure_id: String(detail.id),
+						corporation_id: corporationId,
+						system_id: String(detail.solar_system_id),
+						name: null,
+						type_id: SOVEREIGNTY_HUB_TYPE_ID,
+						fuel_access_list_id:
+							detail.fuel_access_list_id !== undefined && detail.fuel_access_list_id !== null
+								? String(detail.fuel_access_list_id)
+								: null,
+						reagent_bay: {
+							last_updated: detail.reagent_bay.last_updated,
+							reagents: detail.reagent_bay.reagents.map((reagent) => ({
+								type_id: String(reagent.type_id),
+								amount: reagent.amount,
+								burning_per_hour: reagent.burning_per_hour,
+								last_cycle: reagent.last_cycle,
+							})),
+						},
+						resources: detail.resources,
+						upgrades: detail.upgrades.map((upgrade) => ({
+							type_id: String(upgrade.type_id),
+							power_state: upgrade.power_state,
 						})),
-					},
-					resources: detail.resources,
-					upgrades: detail.upgrades.map((upgrade) => ({
-						type_id: String(upgrade.type_id),
-						power_state: upgrade.power_state,
-					})),
-					vulnerability_window: detail.vulnerability_window ?? null,
-					workforce_transport: {
-						configuration: detail.workforce_transport.configuration,
-						state: detail.workforce_transport.state,
-					},
-					raw: {
-						detail,
-					},
-				} as EsiSovereigntyHub
+						vulnerability_window: detail.vulnerability_window ?? null,
+						workforce_transport: {
+							configuration: detail.workforce_transport.configuration,
+							state: detail.workforce_transport.state,
+						},
+						raw: {
+							detail,
+						},
+					} as EsiSovereigntyHub
+				} finally {
+					disposeRpcResult(detailResult)
+				}
 			})
 		)
 
@@ -767,30 +826,34 @@ export async function fetchCorporationSkyhooks(
 					{ cacheMode: 'no-store' }
 				)
 
-				const detail = detailResult.data
-				const theftVulnerability = detail.theft_vulnerability ?? null
+				try {
+					const detail = detailResult.data
+					const theftVulnerability = detail.theft_vulnerability ?? null
 
-				return {
-					structure_id: String(detail.id),
-					planet_id: String(detail.planet_id),
-					corporation_id: String(corporationId),
-					state: detail.state,
-					is_active: detail.is_active,
-					effective_workforce: detail.effective_workforce ?? null,
-					reagents:
-						detail.reagents?.map((reagent) => ({
-							type_id: String(reagent.type_id),
-							secured_stock: reagent.secured_stock,
-							unsecured_stock: reagent.unsecured_stock,
-							last_cycle: reagent.last_cycle,
-						})) ?? [],
-					reinforcement_timer: detail.reinforcement_timer ?? null,
-					theft_vulnerability: theftVulnerability,
-					raw: {
-						listing: entry,
-						detail,
-					},
-				} as EsiCorporationSkyhook
+					return {
+						structure_id: String(detail.id),
+						planet_id: String(detail.planet_id),
+						corporation_id: String(corporationId),
+						state: detail.state,
+						is_active: detail.is_active,
+						effective_workforce: detail.effective_workforce ?? null,
+						reagents:
+							detail.reagents?.map((reagent) => ({
+								type_id: String(reagent.type_id),
+								secured_stock: reagent.secured_stock,
+								unsecured_stock: reagent.unsecured_stock,
+								last_cycle: reagent.last_cycle,
+							})) ?? [],
+						reinforcement_timer: detail.reinforcement_timer ?? null,
+						theft_vulnerability: theftVulnerability,
+						raw: {
+							listing: entry,
+							detail,
+						},
+					} as EsiCorporationSkyhook
+				} finally {
+					disposeRpcResult(detailResult)
+				}
 			})
 		)
 
@@ -866,14 +929,18 @@ export async function fetchCorporationMiningExtractions(
 		{ cacheMode: 'no-store' }
 	)
 
-	return result.data.map((extraction) => ({
-		structure_id: String(extraction.structure_id),
-		moon_id: String(extraction.moon_id),
-		extraction_start_time: extraction.extraction_start_time,
-		chunk_arrival_time: extraction.chunk_arrival_time,
-		natural_decay_time: extraction.natural_decay_time,
-		raw: extraction as Record<string, unknown>,
-	}))
+	try {
+		return result.data.map((extraction) => ({
+			structure_id: String(extraction.structure_id),
+			moon_id: String(extraction.moon_id),
+			extraction_start_time: extraction.extraction_start_time,
+			chunk_arrival_time: extraction.chunk_arrival_time,
+			natural_decay_time: extraction.natural_decay_time,
+			raw: extraction as Record<string, unknown>,
+		}))
+	} finally {
+		disposeRpcResult(result)
+	}
 }
 
 // ========================================================================
@@ -908,7 +975,11 @@ export async function fetchOrders(
 		}>
 	>(`/corporations/${corporationId}/orders`, characterId, { cacheMode: 'no-store' })
 
-	return transformOrders(response.data)
+	try {
+		return transformOrders(response.data)
+	} finally {
+		disposeRpcResult(response)
+	}
 }
 
 /**
@@ -946,7 +1017,11 @@ export async function fetchContracts(
 		}>
 	>(`/corporations/${corporationId}/contracts`, characterId, { cacheMode: 'no-store' })
 
-	return transformContracts(response.data)
+	try {
+		return transformContracts(response.data)
+	} finally {
+		disposeRpcResult(response)
+	}
 }
 
 /**
@@ -984,7 +1059,11 @@ export async function fetchIndustryJobs(
 		}>
 	>(`/corporations/${corporationId}/industry/jobs`, characterId, { cacheMode: 'no-store' })
 
-	return transformIndustryJobs(response.data)
+	try {
+		return transformIndustryJobs(response.data)
+	} finally {
+		disposeRpcResult(response)
+	}
 }
 
 // ========================================================================
@@ -1006,5 +1085,9 @@ export async function fetchKillmails(
 		}>
 	>(`/corporations/${corporationId}/killmails/recent`, characterId)
 
-	return transformKillmails(response.data)
+	try {
+		return transformKillmails(response.data)
+	} finally {
+		disposeRpcResult(response)
+	}
 }

--- a/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { logger } from '@repo/hono-helpers'
+
 import { DirectorManager } from '../../../services/director-manager'
 
 describe('DirectorManager.selectDirector', () => {
@@ -549,6 +551,69 @@ describe('DirectorManager.verifyDirectorHealth', () => {
 		)
 	})
 
+	it('logs database write context when health persistence fails', async () => {
+		const cause = Object.assign(new Error('connection reset by peer'), {
+			code: 'ECONNRESET',
+			detail: 'upstream connection closed',
+		})
+		const databaseError = Object.assign(new Error('Failed query: update corporation_directors'), {
+			query: 'update corporation_directors set is_healthy = $1 where id = $2',
+			params: [true, 'dir-1'],
+			cause,
+		})
+		const rolesUpsert = vi.fn().mockResolvedValue(undefined)
+		const rolesValues = vi.fn().mockReturnValue({ onConflictDoUpdate: rolesUpsert })
+		const insert = vi.fn().mockReturnValue({ values: rolesValues })
+		const where = vi.fn().mockRejectedValue(databaseError)
+		const set = vi.fn().mockReturnValue({ where })
+		const update = vi.fn().mockReturnValue({ set })
+		const db = {
+			query: {
+				corporationDirectors: {
+					findFirst: vi.fn().mockResolvedValue({
+						id: 'dir-1',
+						characterId: '111',
+					}),
+				},
+			},
+			insert,
+			update,
+		}
+		const tokenStore = {
+			validateToken: vi.fn().mockResolvedValue({
+				characterId: '111',
+				isValid: true,
+				missingScopes: [],
+				scopes: ['publicData'],
+				refreshAttempted: false,
+				refreshSucceeded: false,
+				status: 'valid',
+			}),
+			fetchCharacterAffiliations: vi
+				.fn()
+				.mockResolvedValue([{ character_id: 111, corporation_id: 98000001 }]),
+			fetchEsi: vi.fn().mockResolvedValue({ data: { roles: ['Trader'] } }),
+		}
+		const loggerError = vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+		const manager = new DirectorManager(db as never, '98000001', tokenStore as never)
+		vi.spyOn(manager, 'recordFailure').mockResolvedValue(undefined)
+
+		await expect(manager.verifyDirectorHealth('dir-1')).resolves.toBe(false)
+
+		expect(loggerError).toHaveBeenCalledWith(
+			'[DirectorManager] Director health verification failed',
+			expect.objectContaining({
+				phase: 'health-state-persistence',
+				error: 'Failed query: update corporation_directors',
+				errorQuery: 'update corporation_directors set is_healthy = $1 where id = $2',
+				errorParamsCount: 2,
+				causeMessage: 'connection reset by peer',
+				causeCode: 'ECONNRESET',
+				causeDetail: 'upstream connection closed',
+			})
+		)
+	})
+
 	it('marks unhealthy when required role sets are missing', async () => {
 		const rolesUpsert = vi.fn().mockResolvedValue(undefined)
 		const rolesValues = vi.fn().mockReturnValue({ onConflictDoUpdate: rolesUpsert })
@@ -843,6 +908,49 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 				isVerified: true,
 			})
 		)
+	})
+
+	it('limits concurrent director health checks within a corporation', async () => {
+		const where = vi.fn().mockResolvedValue(undefined)
+		const set = vi.fn().mockReturnValue({ where })
+		const update = vi.fn().mockReturnValue({ set })
+		const manager = new DirectorManager({ update } as never, '98000001', {} as never)
+		const directors = ['dir-1', 'dir-2', 'dir-3'].map((directorId, index) => ({
+			directorId,
+			characterId: String(111 + index),
+			characterName: `Director ${index + 1}`,
+			isHealthy: true,
+			lastHealthCheck: null,
+			lastUsed: null,
+			failureCount: 0,
+			lastFailureReason: null,
+			priority: index + 1,
+		}))
+		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue(directors)
+
+		let activeChecks = 0
+		let maxActiveChecks = 0
+		const releaseChecks: Array<() => void> = []
+		const verifyDirectorHealth = vi
+			.spyOn(manager, 'verifyDirectorHealth')
+			.mockImplementation(async () => {
+				activeChecks++
+				maxActiveChecks = Math.max(maxActiveChecks, activeChecks)
+				await new Promise<void>((resolve) => releaseChecks.push(resolve))
+				activeChecks--
+				return true
+			})
+
+		const verification = manager.verifyAllDirectorsHealth()
+		await vi.waitFor(() => expect(verifyDirectorHealth).toHaveBeenCalledTimes(1))
+		releaseChecks.shift()?.()
+		await vi.waitFor(() => expect(verifyDirectorHealth).toHaveBeenCalledTimes(2))
+		releaseChecks.shift()?.()
+		await vi.waitFor(() => expect(verifyDirectorHealth).toHaveBeenCalledTimes(3))
+		releaseChecks.shift()?.()
+
+		await expect(verification).resolves.toEqual({ verified: 3, failed: 0 })
+		expect(maxActiveChecks).toBe(1)
 	})
 
 	it('marks corporation unverified when all director checks fail', async () => {

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -42,6 +42,8 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: mocks.getStub,
+	withRpcResult: async <T, R>(request: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await request),
 }))
 
 function makeDb() {

--- a/apps/eve-corporation-data/src/test/unit/services/wallet-journal-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/wallet-journal-storage.test.ts
@@ -123,4 +123,55 @@ describe('wallet journal storage', () => {
 		const insertedValues = valuesCalls[0]?.[0] as Array<{ journalId: string }>
 		expect(insertedValues.map((row) => row.journalId)).toEqual(['501', '400', '402'])
 	})
+
+	it('filters same-party zero-sum journal pairs regardless of ref type', async () => {
+		const { db, insert } = createDb(null, null, [])
+		const instance = createDoInstance(db)
+		const sharedFields = {
+			balance: 1000,
+			context_id: '666579046',
+			context_id_type: 'industry_job_id',
+			date: '2026-08-07T00:00:00Z',
+			description: 'Industry facility tax',
+			first_party_id: '123',
+			reason: null,
+			ref_type: 'brokers_fee',
+			second_party_id: '123',
+			tax: null,
+			tax_receiver_id: null,
+		}
+
+		const result = await instance.storeWalletJournal('123', 1, [
+			{ id: '100', amount: '-447', ...sharedFields },
+			{ id: '100', amount: '447', ...sharedFields },
+		])
+
+		expect(result).toEqual({ persistedNewRows: 0 })
+		expect(insert).not.toHaveBeenCalled()
+	})
+
+	it('does not filter opposite amounts for different parties', async () => {
+		const { db, insert, values } = createDb(null, null, ['100', '100'])
+		const instance = createDoInstance(db)
+		const sharedFields = {
+			balance: 1000,
+			context_id: '666579046',
+			context_id_type: 'industry_job_id',
+			date: '2026-08-07T00:00:00Z',
+			description: 'Industry facility tax',
+			first_party_id: '123',
+			reason: null,
+			ref_type: 'industry_job_tax',
+			tax: null,
+			tax_receiver_id: null,
+		}
+
+		await instance.storeWalletJournal('123', 1, [
+			{ id: '100', amount: '-447', second_party_id: '456', ...sharedFields },
+			{ id: '100', amount: '447', second_party_id: '789', ...sharedFields },
+		])
+
+		expect(insert).toHaveBeenCalledTimes(1)
+		expect(values).toHaveBeenCalledTimes(1)
+	})
 })

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -36,6 +36,9 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: mocks.getStubMock,
+	withRpcResult: async <T, R>(request: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await request),
+	disposeRpcResult: () => undefined,
 }))
 
 vi.mock('../../../services/esi-fetch', () => ({

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -55,6 +55,8 @@ vi.mock('cloudflare:workers', () => {
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: (...args: unknown[]) => getStubMock(...args),
+	withRpcResult: async <T, R>(request: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await request),
 }))
 
 vi.mock('@repo/workflow-utils', () => ({

--- a/apps/eve-corporation-data/src/workflows/steps/assets/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/assets/index.ts
@@ -1,3 +1,4 @@
+import { withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { getCorporationDataStub } from '../../utils/services'
@@ -16,8 +17,14 @@ export async function syncAssets(
 	const corpData = getCorporationDataStub(env, corporationId)
 
 	logger.info('[AssetsStep] Starting structure inventory sync', { corporationId })
-	const result = await corpData.syncAssetsWithDirector(corporationId, directorCharacterId)
-	logger.info('[AssetsStep] Synced structure inventory', { corporationId, count: result.assetsCount })
+	const result = await withRpcResult(
+		corpData.syncAssetsWithDirector(corporationId, directorCharacterId),
+		(result) => ({ assetsCount: result.assetsCount })
+	)
+	logger.info('[AssetsStep] Synced structure inventory', {
+		corporationId,
+		count: result.assetsCount,
+	})
 
 	return {
 		assetsCount: result.assetsCount,

--- a/apps/eve-corporation-data/src/workflows/steps/common/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/common/index.ts
@@ -1,3 +1,4 @@
+import { withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { parseDateOrNull } from '@repo/worker-utils'
 
@@ -181,7 +182,10 @@ export async function triggerTaxProjectionRefresh(
 ): Promise<TriggerTaxProjectionRefreshResult> {
 	const taxStub = getCorporationTaxStub(env)
 	try {
-		const result = await taxStub.triggerProjectionRefreshFromWalletSync(actorUserId, input)
+		const result = await withRpcResult(
+			taxStub.triggerProjectionRefreshFromWalletSync(actorUserId, input),
+			(result) => ({ ...result })
+		)
 
 		logger.info('[CommonStep] Triggered tax projection refresh from wallet sync', {
 			corporationId: input.corporationId,

--- a/apps/eve-corporation-data/src/workflows/steps/directors/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/directors/index.ts
@@ -1,10 +1,15 @@
+import { withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
-import { createDirectorManager, createTokenStore, getCorporationDataStub } from '../../utils/services'
+import {
+	createDirectorManager,
+	createTokenStore,
+	getCorporationDataStub,
+} from '../../utils/services'
 
+import type { CorporationRole } from '@repo/eve-corporation-data'
 import type { Env } from '../../../context'
 import type { DirectorInfo } from '../../types'
-import type { CorporationRole } from '@repo/eve-corporation-data'
 
 /**
  * Select a healthy director for the corporation
@@ -96,8 +101,10 @@ function hasDirectorAuthority(role: EsiCorporationMemberRole): boolean {
 async function resolveCharacterName(env: Env, characterId: string): Promise<string> {
 	const tokenStore = createTokenStore(env)
 	try {
-		const result = await tokenStore.fetchPublicEsi<{ name?: string }>(`/characters/${characterId}`)
-		return result.data?.name?.trim() || characterId
+		return await withRpcResult(
+			tokenStore.fetchPublicEsi<{ name?: string }>(`/characters/${characterId}`),
+			(result) => result.data?.name?.trim() || characterId
+		)
 	} catch (error) {
 		logger.warn('[DirectorStep] Failed to resolve character name while auto-adding director', {
 			characterId,
@@ -109,16 +116,12 @@ async function resolveCharacterName(env: Env, characterId: string): Promise<stri
 
 async function isCharacterLinkedToUser(env: Env, characterId: string): Promise<boolean> {
 	try {
-		const owner = await env.CORE.getCharacterOwner(characterId)
-		return owner !== null
+		return await withRpcResult(env.CORE.getCharacterOwner(characterId), (owner) => owner !== null)
 	} catch (error) {
-		logger.warn(
-			'[DirectorStep] Failed to verify character ownership while reconciling directors',
-			{
-				characterId,
-				error: error instanceof Error ? error.message : String(error),
-			}
-		)
+		logger.warn('[DirectorStep] Failed to verify character ownership while reconciling directors', {
+			characterId,
+			error: error instanceof Error ? error.message : String(error),
+		})
 		return false
 	}
 }
@@ -135,19 +138,25 @@ export async function reconcileDirectorsFromCorporationRoles(
 ): Promise<{ added: number; removed: number; discovered: number; skippedUnlinked: number }> {
 	const tokenStore = createTokenStore(env)
 	const corpData = getCorporationDataStub(env, corporationId)
-	const rolesResponse = await tokenStore.fetchEsi<EsiCorporationMemberRole[]>(
-		`/corporations/${corporationId}/roles`,
-		directorCharacterId,
-		{ cacheMode: 'no-store' }
+	const authoritativeDirectorIds = await withRpcResult(
+		tokenStore.fetchEsi<EsiCorporationMemberRole[]>(
+			`/corporations/${corporationId}/roles`,
+			directorCharacterId,
+			{ cacheMode: 'no-store' }
+		),
+		(rolesResponse) =>
+			new Set(
+				rolesResponse.data.filter(hasDirectorAuthority).map((row) => String(row.character_id))
+			)
 	)
-
-	const authoritativeDirectorIds = new Set(
-		rolesResponse.data.filter(hasDirectorAuthority).map((row) => String(row.character_id))
+	const existingDirectors = await withRpcResult(corpData.getDirectors(corporationId), (directors) =>
+		directors.map((director) => ({ ...director }))
 	)
-	const existingDirectors = await corpData.getDirectors(corporationId)
 	const existingDirectorIds = new Set(existingDirectors.map((d) => d.characterId))
 
-	const toAdd = [...authoritativeDirectorIds].filter((characterId) => !existingDirectorIds.has(characterId))
+	const toAdd = [...authoritativeDirectorIds].filter(
+		(characterId) => !existingDirectorIds.has(characterId)
+	)
 	const toRemove = existingDirectors
 		.filter((d) => !authoritativeDirectorIds.has(d.characterId))
 		.map((d) => d.characterId)
@@ -157,13 +166,10 @@ export async function reconcileDirectorsFromCorporationRoles(
 		const isLinked = await isCharacterLinkedToUser(env, characterId)
 		if (!isLinked) {
 			skippedUnlinked++
-			logger.info(
-				'[DirectorStep] Skipping auto-add for director candidate without linked user',
-				{
-					corporationId,
-					characterId,
-				}
-			)
+			logger.info('[DirectorStep] Skipping auto-add for director candidate without linked user', {
+				corporationId,
+				characterId,
+			})
 			continue
 		}
 

--- a/apps/eve-corporation-data/src/workflows/steps/members/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/members/index.ts
@@ -1,3 +1,4 @@
+import { withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import * as esiFetch from '../../../services/esi-fetch'
@@ -32,7 +33,10 @@ export async function storeMembers(
 	memberIds: MemberIds
 ): Promise<StoreMembersResult> {
 	const corpData = getCorporationDataStub(env, corporationId)
-	const result = await corpData.storeMembers(corporationId, memberIds)
+	const result = await withRpcResult(corpData.storeMembers(corporationId, memberIds), (result) => ({
+		departedMemberIds: [...result.departedMemberIds],
+		addedMemberIds: [...result.addedMemberIds],
+	}))
 
 	logger.info('[MembersStep] Stored members', {
 		corporationId,
@@ -60,10 +64,13 @@ export async function sendMembershipChangedMessages(
 		return
 	}
 
-	await env.CORE.handleCharacterAffiliationChanges(memberIds, {
-		source: 'corp-membership-changed',
-		bypassThrottle: true,
-	})
+	await withRpcResult(
+		env.CORE.handleCharacterAffiliationChanges(memberIds, {
+			source: 'corp-membership-changed',
+			bypassThrottle: true,
+		}),
+		() => undefined
+	)
 
 	logger.info('[MembersStep] Membership changes sent to Core for unified affiliation handling', {
 		count: memberIds.length,

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -1,4 +1,4 @@
-import { getStub } from '@repo/do-utils'
+import { disposeRpcResult, getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import * as esiFetch from '../../../services/esi-fetch'
@@ -50,6 +50,28 @@ type PaginatedEsiResponse<T> = {
 	data: T
 	pages?: number
 	page?: number
+}
+
+function detachRpcValue<T>(value: T): T {
+	if (Array.isArray(value)) {
+		return value.map((entry) => detachRpcValue(entry)) as T
+	}
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, entry]) => [key, detachRpcValue(entry)])
+		) as T
+	}
+	return value
+}
+
+function fetchListingPage<T>(
+	request: Promise<PaginatedEsiResponse<T>>
+): Promise<PaginatedEsiResponse<T>> {
+	return withRpcResult(request, (response) => ({
+		data: detachRpcValue(response.data),
+		pages: response.pages,
+		page: response.page,
+	}))
 }
 
 async function fetchStructureListing<T, E>(
@@ -129,7 +151,7 @@ export async function fetchSovereigntyEnrichment(
 		const tokenStore = createTokenStore(env)
 		let sovereigntySystems = await readSharedSovereigntySystemsForCorporation(env, corporationId)
 		if (!sovereigntySystems) {
-			logger.warn(
+			logger.info(
 				'[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache',
 				{
 					corporationId,
@@ -143,19 +165,27 @@ export async function fetchSovereigntyEnrichment(
 		}
 		const sovereigntyHubListing = await fetchStructureListing(
 			(page) =>
-				tokenStore.fetchEsi<{ sovereignty_hubs: Array<{ id: number; solar_system_id: number }> }>(
-					`/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
-					directorCharacterId,
-					{ cacheMode: 'no-store' }
+				fetchListingPage(
+					tokenStore.fetchEsi<{
+						sovereignty_hubs: Array<{ id: number; solar_system_id: number }>
+					}>(
+						`/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
+						directorCharacterId,
+						{ cacheMode: 'no-store' }
+					)
 				),
 			(data) => data.sovereignty_hubs,
 			'sovereignty-hubs'
 		)
 		const liveStructureIds = sovereigntyHubListing.map((hub) => String(hub.id))
-		const priorityQueue = await corpData.getStructurePriorityQueue(
-			corporationId,
-			'sovereignty',
-			liveStructureIds
+		const priorityQueue = await withRpcResult(
+			corpData.getStructurePriorityQueue(corporationId, 'sovereignty', liveStructureIds),
+			(queue) => ({
+				...queue,
+				newStructureIds: [...queue.newStructureIds],
+				pruneCandidateIds: [...queue.pruneCandidateIds],
+				syncPriorities: queue.syncPriorities.map((priority) => ({ ...priority })),
+			})
 		)
 		const prioritizedQueue = buildPriorityQueuedEntries(
 			sovereigntyHubListing,
@@ -193,28 +223,32 @@ export async function fetchSovereigntyEnrichment(
 		const systemGeography = await universe.resolveSolarSystemsByIds([
 			...new Set(collectedHubs.map((hub) => hub.system_id)),
 		])
-		const allianceBySystemId = buildSovereigntyAllianceBySystemId(sovereigntySystems)
-		const enrichedSovereigntyHubs = collectedHubs.map((hub) => ({
-			...hub,
-			system_name: systemGeography[hub.system_id]?.solarSystemName ?? hub.system_name ?? null,
-			controller_alliance_id: allianceBySystemId.get(hub.system_id) ?? null,
-		}))
+		try {
+			const allianceBySystemId = buildSovereigntyAllianceBySystemId(sovereigntySystems)
+			const enrichedSovereigntyHubs = collectedHubs.map((hub) => ({
+				...hub,
+				system_name: systemGeography[hub.system_id]?.solarSystemName ?? hub.system_name ?? null,
+				controller_alliance_id: allianceBySystemId.get(hub.system_id) ?? null,
+			}))
 
-		logger.debug('[StructuresStep] Fetched sovereignty structure enrichment', {
-			corporationId,
-			sovereigntySystems: sovereigntySystems.length,
-			sovereigntyHubs: collectedHubs.length,
-			failureCount,
-		})
+			logger.debug('[StructuresStep] Fetched sovereignty structure enrichment', {
+				corporationId,
+				sovereigntySystems: sovereigntySystems.length,
+				sovereigntyHubs: collectedHubs.length,
+				failureCount,
+			})
 
-		return {
-			sovereigntySystems,
-			sovereigntyHubs: enrichedSovereigntyHubs,
-			pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
-			failures: sovereigntyHubResult.failures,
-			failureCount,
-			rateLimitFailureCount,
-			nonRateLimitFailureCount,
+			return {
+				sovereigntySystems,
+				sovereigntyHubs: enrichedSovereigntyHubs,
+				pruneCandidateIds: prioritizedQueue.pruneCandidateIds,
+				failures: sovereigntyHubResult.failures,
+				failureCount,
+				rateLimitFailureCount,
+				nonRateLimitFailureCount,
+			}
+		} finally {
+			disposeRpcResult(systemGeography)
 		}
 	} catch (error) {
 		if (shouldSuppressDirectorUnhealthyOnStructureEnrichmentAuthFailure(error)) {
@@ -234,19 +268,25 @@ export async function fetchSkyhookEnrichment(
 		const tokenStore = createTokenStore(env)
 		const skyhookListing = await fetchStructureListing(
 			(page) =>
-				tokenStore.fetchEsi<{ skyhooks: Array<{ id: number; planet_id: number }> }>(
-					`/corporations/${corporationId}/structures/skyhooks${page === 1 ? '' : `?page=${page}`}`,
-					directorCharacterId,
-					{ cacheMode: 'no-store' }
+				fetchListingPage(
+					tokenStore.fetchEsi<{ skyhooks: Array<{ id: number; planet_id: number }> }>(
+						`/corporations/${corporationId}/structures/skyhooks${page === 1 ? '' : `?page=${page}`}`,
+						directorCharacterId,
+						{ cacheMode: 'no-store' }
+					)
 				),
 			(data) => data.skyhooks,
 			'skyhooks'
 		)
 		const liveStructureIds = skyhookListing.map((skyhook) => String(skyhook.id))
-		const priorityQueue = await corpData.getStructurePriorityQueue(
-			corporationId,
-			'skyhooks',
-			liveStructureIds
+		const priorityQueue = await withRpcResult(
+			corpData.getStructurePriorityQueue(corporationId, 'skyhooks', liveStructureIds),
+			(queue) => ({
+				...queue,
+				newStructureIds: [...queue.newStructureIds],
+				pruneCandidateIds: [...queue.pruneCandidateIds],
+				syncPriorities: queue.syncPriorities.map((priority) => ({ ...priority })),
+			})
 		)
 		const prioritizedQueue = buildPriorityQueuedEntries(
 			skyhookListing,
@@ -352,9 +392,12 @@ export async function storeSkyhookEnrichment(
 	enrichment: SkyhookEnrichmentData
 ): Promise<SkyhookStoreResult> {
 	const corpData = getCorporationDataStub(env, corporationId)
-	const result = await corpData.storeSkyhooks(corporationId, enrichment.skyhooks, {
-		pruneCandidateIds: enrichment.pruneCandidateIds,
-	})
+	const result = await withRpcResult(
+		corpData.storeSkyhooks(corporationId, enrichment.skyhooks, {
+			pruneCandidateIds: enrichment.pruneCandidateIds,
+		}),
+		({ prunedCount }) => ({ prunedCount })
+	)
 	if (enrichment.failures.length > 0) {
 		await corpData.markStructureEnrichmentFailures(corporationId, 'skyhooks', enrichment.failures)
 	}

--- a/apps/eve-corporation-data/src/workflows/steps/wallet-journal/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/wallet-journal/index.ts
@@ -1,4 +1,5 @@
-import { logger } from '@repo/hono-helpers'
+import { withRpcResult } from '@repo/do-utils'
+import { logger, toErrorLogDetails } from '@repo/hono-helpers'
 
 import * as esiFetch from '../../../services/esi-fetch'
 import { createTokenStore, getCorporationDataStub } from '../../utils/services'
@@ -50,7 +51,10 @@ export async function syncWalletJournal(
 				division,
 				directorCharacterId
 			)
-			const storeResult = await corpData.storeWalletJournal(corporationId, division, entries)
+			const storeResult = await withRpcResult(
+				corpData.storeWalletJournal(corporationId, division, entries),
+				(result) => ({ persistedNewRows: result.persistedNewRows })
+			)
 			const maxJournalId =
 				entries.length > 0
 					? entries.reduce(
@@ -114,10 +118,12 @@ export async function syncWalletJournal(
 	// Log failures (if any) but do not throw to retain previous behavior
 	results.forEach((result, index) => {
 		if (result.status === 'rejected') {
+			const errorDetails = toErrorLogDetails(result.reason)
 			logger.error('[WalletJournalStep] Division failed', {
 				corporationId,
 				division: WALLET_DIVISIONS[index],
-				error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+				...errorDetails,
+				error: errorDetails.message,
 			})
 		}
 	})

--- a/apps/eve-corporation-data/src/workflows/steps/wallet-transactions/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/wallet-transactions/index.ts
@@ -1,3 +1,4 @@
+import { withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import * as esiFetch from '../../../services/esi-fetch'
@@ -36,7 +37,14 @@ export async function syncWalletTransactions(
 ): Promise<WalletTransactionsSyncResult> {
 	const tokenStore = createTokenStore(env)
 	const corpData = getCorporationDataStub(env, corporationId)
-	const watermarks = await corpData.getWalletTransactionWatermarks(corporationId)
+	const watermarks = await withRpcResult(
+		corpData.getWalletTransactionWatermarks(corporationId),
+		(watermarks) =>
+			watermarks.map(({ division, watermark }) => ({
+				division,
+				watermark: watermark ? { ...watermark } : undefined,
+			}))
+	)
 	const watermarkByDivision = new Map(
 		watermarks.map(({ division, watermark }) => [division, watermark])
 	)
@@ -58,11 +66,14 @@ export async function syncWalletTransactions(
 			if (fetchResult.truncated) {
 				throw new Error('Wallet transaction pagination was truncated before persistence')
 			}
-			const storeResult = await corpData.storeWalletTransactions(
-				corporationId,
-				division,
-				fetchResult.transactions,
-				watermarkByDivision.get(division)
+			const storeResult = await withRpcResult(
+				corpData.storeWalletTransactions(
+					corporationId,
+					division,
+					fetchResult.transactions,
+					watermarkByDivision.get(division)
+				),
+				(result) => ({ persistedNewRows: result.persistedNewRows })
 			)
 			const transactions = fetchResult.transactions
 			const maxTransactionId =

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -1,6 +1,6 @@
 import { WorkflowEntrypoint } from 'cloudflare:workers'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
 import {
 	classifyEsiCredentialFailure,
@@ -134,8 +134,14 @@ async function syncCoreAuthHealthSnapshot(
 	workflowInstanceId: string
 ): Promise<{ healthyDirectorCount: number; isVerified: boolean }> {
 	const corpStub = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, corporationId)
-	const directors = await corpStub.getDirectors(corporationId)
-	const healthyDirectorCount = directors.filter((director) => director.isHealthy).length
+	const directorSnapshot = await withRpcResult(
+		corpStub.getDirectors(corporationId),
+		(directors) => ({
+			directorCount: directors.length,
+			healthyDirectorCount: directors.filter((director) => director.isHealthy).length,
+		})
+	)
+	const { directorCount, healthyDirectorCount } = directorSnapshot
 	const isVerified = healthyDirectorCount > 0
 	await env.CORE.updateCorporationAuthHealth(corporationId, {
 		healthyDirectorCount,
@@ -147,7 +153,7 @@ async function syncCoreAuthHealthSnapshot(
 		workflowInstanceId,
 		healthyDirectorCount,
 		isVerified,
-		directorCount: directors.length,
+		directorCount,
 	})
 	return { healthyDirectorCount, isVerified }
 }
@@ -173,7 +179,10 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 				{ timeout: '30 seconds' },
 				async () => {
 					try {
-						return await corpData.getCorporationSyncConfig(corporationId)
+						return await withRpcResult(
+							corpData.getCorporationSyncConfig(corporationId),
+							(config) => (config ? { ...config } : null)
+						)
 					} catch (error) {
 						logger.warn(
 							'[EveCorporationSyncWorkflow] Failed to load corporation config for asset gating',
@@ -726,10 +735,18 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 									const liveMiningExtractions = fetchedMiningExtractions.filter((extraction) =>
 										miningCitadelStructureIds.has(String(extraction.structure_id))
 									)
-									const priorityQueue = await corpData.getStructurePriorityQueue(
-										corporationId,
-										'mining-extractions' as StructureSyncPriorityTarget,
-										liveMiningExtractions.map((extraction) => String(extraction.structure_id))
+									const priorityQueue = await withRpcResult(
+										corpData.getStructurePriorityQueue(
+											corporationId,
+											'mining-extractions' as StructureSyncPriorityTarget,
+											liveMiningExtractions.map((extraction) => String(extraction.structure_id))
+										),
+										(queue) => ({
+											...queue,
+											newStructureIds: [...queue.newStructureIds],
+											pruneCandidateIds: [...queue.pruneCandidateIds],
+											syncPriorities: queue.syncPriorities.map((priority) => ({ ...priority })),
+										})
 									)
 									const prioritizedMiningExtractions = buildPriorityQueuedEntries(
 										liveMiningExtractions.map((extraction) => ({
@@ -838,6 +855,8 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 											failureCount: sovereigntyEnrichment.failureCount,
 											rateLimitFailureCount: sovereigntyEnrichment.rateLimitFailureCount,
 											nonRateLimitFailureCount: sovereigntyEnrichment.nonRateLimitFailureCount,
+											failureDetails: sovereigntyEnrichment.failures.slice(0, 10),
+											failureDetailsOmitted: Math.max(0, sovereigntyEnrichment.failureCount - 10),
 										}
 									)
 								} else if (sovereigntyEnrichment.rateLimitFailureCount > 0) {
@@ -972,6 +991,8 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 											failureCount: skyhookEnrichment.failureCount,
 											rateLimitFailureCount: skyhookEnrichment.rateLimitFailureCount,
 											nonRateLimitFailureCount: skyhookEnrichment.nonRateLimitFailureCount,
+											failureDetails: skyhookEnrichment.failures.slice(0, 10),
+											failureDetailsOmitted: Math.max(0, skyhookEnrichment.failureCount - 10),
 										}
 									)
 								} else if (skyhookEnrichment.rateLimitFailureCount > 0) {

--- a/apps/eve-corporation-data/src/workflows/utils/services.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/services.ts
@@ -1,4 +1,4 @@
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { createDb } from '../../db'
@@ -28,10 +28,13 @@ export function createDirectorManager(env: Env, corporationId: string): Director
 		tokenStore,
 		async (characterId, expectedCorporationId, actualCorporationId) => {
 			try {
-				await env.CORE.handleCharacterAffiliationChanges([characterId], {
-					source: `director-affiliation-mismatch:${expectedCorporationId}:${actualCorporationId ?? 'unknown'}`,
-					bypassThrottle: true,
-				})
+				await withRpcResult(
+					env.CORE.handleCharacterAffiliationChanges([characterId], {
+						source: `director-affiliation-mismatch:${expectedCorporationId}:${actualCorporationId ?? 'unknown'}`,
+						bypassThrottle: true,
+					}),
+					() => undefined
+				)
 			} catch (error) {
 				logger.warn('[DirectorManager] Failed to propagate affiliation mismatch to Core', {
 					corporationId: expectedCorporationId,

--- a/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
@@ -1,3 +1,5 @@
+import { withRpcResult } from '@repo/do-utils'
+
 import * as esiFetch from '../../services/esi-fetch'
 import { createTokenStore, getGlobalCorporationDataStub } from './services'
 
@@ -21,9 +23,12 @@ export async function readSharedSovereigntySystemsForCorporation(
 	corporationId: string
 ): Promise<EsiSovereigntySystem[] | null> {
 	const globalCorpData = getGlobalCorporationDataStub(env)
-	return await globalCorpData.getSharedSovereigntySystemsForCorporation(
-		corporationId,
-		SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+	return await withRpcResult(
+		globalCorpData.getSharedSovereigntySystemsForCorporation(
+			corporationId,
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_TTL_SECONDS
+		),
+		(systems) => systems?.map((system) => ({ ...system })) ?? null
 	)
 }
 

--- a/packages/do-utils/src/for-do.ts
+++ b/packages/do-utils/src/for-do.ts
@@ -17,12 +17,11 @@
 //     whose only member is a guidance string, so every method call fails to
 //     compile with a readable "pass the interface" message.
 //
-// DISPOSAL is deliberately nothing-to-do for plain DO stubs. A DO stub is never
-// itself an RpcTarget in this repo; the one place an RpcTarget appears is a
-// second-hop method return (EveCharacterDataInstance from getInstance()), which
-// the Cloudflare runtime already types Disposable — so `using x = await
-// forDO(ns).byName(id).getInstance(id)` just works and this accessor attaches no
-// Symbol.dispose to anything, and never disposes a stub on the caller's behalf.
+// DISPOSAL belongs to the caller of an RPC method, not to this namespace
+// accessor. The stub itself is not disposed, but every non-primitive value
+// returned by a cross-worker method must be consumed and disposed. Use
+// `withRpcResult` from this package when the shared interface is Promise-typed,
+// or native `using` when the return type is declared as Disposable.
 //
 // CLAUDE.md rule: idFromName / getByName / jurisdiction are called ONLY inside
 // this module (in `route`), never at a call site — including the sharded paths.
@@ -116,9 +115,9 @@ export interface ShardedClient<Stub> {
 	 * Fan `fn` out across all shards concurrently and collect results in shard
 	 * order. Cost is O(N) billed RPC sessions — keep N modest and fan-out
 	 * infrequent. NOTE: `fn` should return serializable data. If a shard method
-	 * returns an RpcTarget, the CALLER owns each returned value and must dispose
-	 * it (`using`) — map() does not, and must not, dispose the shard sessions
-	 * out from under those results.
+	 * returns a non-primitive RPC value, the CALLER owns each returned value and
+	 * must dispose it (`using` or `withRpcResult`) — map() does not, and must not,
+	 * dispose the shard sessions out from under those results.
 	 */
 	map<R>(fn: (stub: Stub, shardIndex: number) => Promise<R> | R): Promise<R[]>
 }
@@ -158,7 +157,9 @@ const LCG_MULT = 2862933555777941757n
 
 function assertShardCount(shards: number): void {
 	if (!Number.isInteger(shards) || shards < 1) {
-		throw new RangeError(`@repo/do-utils: shards must be a positive integer, received ${String(shards)}`)
+		throw new RangeError(
+			`@repo/do-utils: shards must be a positive integer, received ${String(shards)}`
+		)
 	}
 }
 
@@ -197,7 +198,11 @@ export function shardIndex(key: string, shards: number): number {
 }
 
 /** Deterministic shard instance name: `${prefix}:${shardIndex(key, shards)}`. */
-export function shardName(key: string, shards: number, prefix: string = DEFAULT_SHARD_PREFIX): string {
+export function shardName(
+	key: string,
+	shards: number,
+	prefix: string = DEFAULT_SHARD_PREFIX
+): string {
 	return `${prefix}:${shardIndex(key, shards)}`
 }
 
@@ -211,7 +216,10 @@ class ShardedClientImpl<Stub> implements ShardedClient<Stub> {
 	}
 
 	forKey(key: string, options?: StubOptions): Stub {
-		return this.ns.getByName(`${this.prefix}:${shardIndex(key, this.shards)}`, options) as unknown as Stub
+		return this.ns.getByName(
+			`${this.prefix}:${shardIndex(key, this.shards)}`,
+			options
+		) as unknown as Stub
 	}
 
 	shard(index: number, options?: StubOptions): Stub {
@@ -256,7 +264,11 @@ class DoClientImpl<Stub> implements DoClient<Stub> {
 	}
 
 	sharded(options: ShardOptions): ShardedClient<Stub> {
-		return new ShardedClientImpl<Stub>(this.ns, options.shards, options.prefix ?? DEFAULT_SHARD_PREFIX)
+		return new ShardedClientImpl<Stub>(
+			this.ns,
+			options.shards,
+			options.prefix ?? DEFAULT_SHARD_PREFIX
+		)
 	}
 
 	jurisdiction(jurisdiction: DurableObjectJurisdiction): DoClient<Stub> {

--- a/packages/do-utils/src/index.ts
+++ b/packages/do-utils/src/index.ts
@@ -6,6 +6,7 @@ export type { DrizzleSqliteDODatabase, SqliteMigrationConfig } from './sqlite-cl
 
 // Fluent, type-safe DO namespace accessor: singleton / per-name / sharded (+ fan-out)
 export { forDO, shardIndex, shardName } from './for-do'
+export { disposeRpcResult, withRpcResult } from './rpc-result'
 export type {
 	AnyDoNamespace,
 	DoClient,
@@ -22,9 +23,10 @@ export type {
  * This helper provides type-safe access to Durable Object stubs when calling
  * across workers using shared interface packages.
  *
- * Only stubs that return RpcTargets (which have a `dispose()` method) will have
- * automatic resource management via the 'using' keyword. Regular DurableObject
- * stubs don't need disposal.
+ * The stub itself does not need disposal. However, every non-primitive value
+ * returned by a cross-worker RPC method must be disposed after its contents are
+ * consumed. Use `withRpcResult` for ordinary Promise-typed interfaces, or the
+ * native `using` syntax when the return type is declared as Disposable.
  *
  * Note: DurableObjectNamespace, DurableObjectId, and DurableObjectStub are expected
  * to be available as global types in the worker environment (from worker-configuration.d.ts)
@@ -32,14 +34,13 @@ export type {
  * @example
  * ```ts
  * import type { EveTokenStore } from '@repo/eve-token-store'
- * import { getStub } from '@repo/do-utils'
+ * import { getStub, withRpcResult } from '@repo/do-utils'
  *
- * // Regular DurableObject stub (no disposal needed)
+ * // Regular DurableObject stub (the stub itself needs no disposal)
  * const stub = getStub<Groups>(c.env.GROUPS, 'default')
- * const groups = await stub.listGroups()
+ * const groups = await withRpcResult(stub.listGroups(), (result) => [...result])
  *
- * // RpcTarget stub (disposal needed - only if stub has dispose method)
- * // Note: Most stubs don't need 'using' - only those that return RpcTargets
+ * // RpcTarget result (native `using` is also valid when the interface exposes it)
  * ```
  */
 export function getStub<T>(

--- a/packages/do-utils/src/rpc-result.test.ts
+++ b/packages/do-utils/src/rpc-result.test.ts
@@ -23,13 +23,13 @@ describe('RPC result lifecycle helpers', () => {
 		expect(dispose).toHaveBeenCalledOnce()
 	})
 
-	it('supports callable dispose methods and ignores primitives', () => {
+	it('ignores ordinary dispose properties and primitives', () => {
 		const dispose = vi.fn()
 
 		disposeRpcResult({ dispose })
 		disposeRpcResult(null)
 		disposeRpcResult('value')
 
-		expect(dispose).toHaveBeenCalledOnce()
+		expect(dispose).not.toHaveBeenCalled()
 	})
 })

--- a/packages/do-utils/src/rpc-result.test.ts
+++ b/packages/do-utils/src/rpc-result.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { disposeRpcResult, withRpcResult } from './rpc-result'
+
+describe('RPC result lifecycle helpers', () => {
+	it('disposes a result after consuming it', async () => {
+		const dispose = vi.fn()
+		const result = { value: 42, [Symbol.dispose]: dispose }
+
+		await expect(withRpcResult(Promise.resolve(result), (value) => value.value)).resolves.toBe(42)
+		expect(dispose).toHaveBeenCalledOnce()
+	})
+
+	it('disposes results when the consumer throws', async () => {
+		const dispose = vi.fn()
+		const result = { [Symbol.dispose]: dispose }
+
+		await expect(
+			withRpcResult(Promise.resolve(result), () => {
+				throw new Error('consumer failed')
+			})
+		).rejects.toThrow('consumer failed')
+		expect(dispose).toHaveBeenCalledOnce()
+	})
+
+	it('supports callable dispose methods and ignores primitives', () => {
+		const dispose = vi.fn()
+
+		disposeRpcResult({ dispose })
+		disposeRpcResult(null)
+		disposeRpcResult('value')
+
+		expect(dispose).toHaveBeenCalledOnce()
+	})
+})

--- a/packages/do-utils/src/rpc-result.ts
+++ b/packages/do-utils/src/rpc-result.ts
@@ -9,15 +9,15 @@ export function disposeRpcResult(result: unknown): void {
 	}
 
 	const disposableResult = result as Record<PropertyKey, unknown>
-	const symbolDisposer = disposableResult[Symbol.dispose]
-	if (typeof symbolDisposer === 'function') {
-		;(symbolDisposer as () => void).call(result)
-		return
-	}
-
-	const disposer = disposableResult.dispose
-	if (typeof disposer === 'function') {
-		;(disposer as () => void).call(result)
+	// `Symbol.dispose` is an optional runtime capability and is not included in
+	// the lib target of every package that consumes this shared source file.
+	const symbolDispose = Reflect.get(Symbol, 'dispose')
+	if (typeof symbolDispose === 'symbol') {
+		const symbolDisposer = disposableResult[symbolDispose]
+		if (typeof symbolDisposer === 'function') {
+			;(symbolDisposer as () => void).call(result)
+			return
+		}
 	}
 }
 

--- a/packages/do-utils/src/rpc-result.ts
+++ b/packages/do-utils/src/rpc-result.ts
@@ -1,0 +1,39 @@
+/**
+ * Release a non-primitive value returned by Workers RPC after its contents have
+ * been consumed. Plain test doubles do not have a disposer, so this is a safe
+ * no-op outside the Workers RPC runtime.
+ */
+export function disposeRpcResult(result: unknown): void {
+	if (result === null || (typeof result !== 'object' && typeof result !== 'function')) {
+		return
+	}
+
+	const disposableResult = result as Record<PropertyKey, unknown>
+	const symbolDisposer = disposableResult[Symbol.dispose]
+	if (typeof symbolDisposer === 'function') {
+		;(symbolDisposer as () => void).call(result)
+		return
+	}
+
+	const disposer = disposableResult.dispose
+	if (typeof disposer === 'function') {
+		;(disposer as () => void).call(result)
+	}
+}
+
+/**
+ * Consume an RPC result and dispose it after the consumer has finished reading
+ * it. This is the callback equivalent of `using result = await rpcCall()` and
+ * remains compatible with plain unit-test mocks.
+ */
+export async function withRpcResult<T, R>(
+	rpcCall: Promise<T>,
+	consume: (result: T) => R | Promise<R>
+): Promise<R> {
+	const result = await rpcCall
+	try {
+		return await consume(result)
+	} finally {
+		disposeRpcResult(result)
+	}
+}

--- a/packages/hono-helpers/src/helpers/errors.test.ts
+++ b/packages/hono-helpers/src/helpers/errors.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { toErrorLogDetails } from './errors'
+
+describe('toErrorLogDetails', () => {
+	it('extracts database diagnostics and redacts sensitive query parameters', () => {
+		const cause = Object.assign(new Error('connection reset by peer'), {
+			code: 'ECONNRESET',
+			detail: 'upstream connection closed',
+		})
+		const error = Object.assign(
+			new Error(
+				'Failed query: update users set access_token = $1 where id = $2\nparams: secret, user-1'
+			),
+			{
+				query: 'update users set access_token = $1 where id = $2',
+				params: ['secret', 'user-1'],
+				cause,
+			}
+		)
+
+		expect(toErrorLogDetails(error)).toMatchObject({
+			message: 'Failed query: update users set access_token = $1 where id = $2',
+			query: 'update users set access_token = $1 where id = $2',
+			paramsCount: 2,
+			parameterColumns: ['access_token', 'id'],
+			parameterValues: ['<redacted>', 'user-1'],
+			cause: 'connection reset by peer',
+			causeCode: 'ECONNRESET',
+			causeDetail: 'upstream connection closed',
+		})
+		expect(toErrorLogDetails(error).message).not.toContain('secret')
+	})
+
+	it('keeps payment, SRP, and fleet tokens visible while bounding long text', () => {
+		const longReason = 'reason '.repeat(200)
+		const error = Object.assign(
+			new Error(
+				'Failed query: insert into bill_payments (payment_token, srp_token, token, reason) values ($1, $2, $3, $4)'
+			),
+			{
+				query:
+					'insert into bill_payments (payment_token, srp_token, token, reason) values ($1, $2, $3, $4)',
+				params: ['payment-token', 'srp-token', 'fleet-token', longReason],
+			}
+		)
+
+		expect(toErrorLogDetails(error)).toMatchObject({
+			parameterColumns: ['payment_token', 'srp_token', 'token', 'reason'],
+			parameterValues: [
+				'payment-token',
+				'srp-token',
+				'fleet-token',
+				`${longReason.slice(0, 1_000)}...[truncated]`,
+			],
+		})
+	})
+
+	it('extracts driver fields when the database error is not an Error instance', () => {
+		expect(
+			toErrorLogDetails({
+				message: 'database unavailable',
+				code: '57P01',
+				detail: 'admin shutdown',
+			})
+		).toMatchObject({
+			message: 'database unavailable',
+			code: '57P01',
+			detail: 'admin shutdown',
+		})
+	})
+})

--- a/packages/hono-helpers/src/helpers/errors.ts
+++ b/packages/hono-helpers/src/helpers/errors.ts
@@ -22,6 +22,180 @@ export interface ErrorLogDetails {
 	name?: string
 	stack?: string
 	cause?: string
+	code?: string | number
+	detail?: string
+	hint?: string
+	severity?: string
+	position?: string | number
+	query?: string
+	paramsCount?: number
+	parameterColumns?: Array<string | null>
+	parameterValues?: unknown[]
+	causeName?: string
+	causeStack?: string
+	causeCode?: string | number
+	causeDetail?: string
+	causeHint?: string
+	causeSeverity?: string
+}
+
+type ErrorRecord = Record<string, unknown>
+
+function asErrorRecord(value: unknown): ErrorRecord | null {
+	return value && typeof value === 'object' ? (value as ErrorRecord) : null
+}
+
+function asLogValue(value: unknown): string | number | undefined {
+	return typeof value === 'string' || typeof value === 'number' ? value : undefined
+}
+
+function asLogString(value: unknown): string | undefined {
+	const logValue = asLogValue(value)
+	return logValue === undefined ? undefined : String(logValue)
+}
+
+function normalizeQuery(query: string): string {
+	return query.replace(/\s+/g, ' ').slice(0, 2_000)
+}
+
+const SENSITIVE_DATABASE_COLUMNS = new Set([
+	'access_token',
+	'api_key',
+	'authorization',
+	'client_secret',
+	'credential',
+	'credentials',
+	'key',
+	'password',
+	'private_key',
+	'refresh_token',
+	'session_token',
+])
+
+const LONG_TEXT_DATABASE_COLUMNS = new Set([
+	'content',
+	'context_text',
+	'description',
+	'error_message',
+	'external_metadata',
+	'full_description',
+	'message',
+	'message_template',
+	'metadata',
+	'note',
+	'note_text',
+	'notes',
+	'original_content',
+	'reason',
+	'review_notes',
+	'source_metadata',
+])
+
+const MAX_DATABASE_STRING_LENGTH = 500
+const MAX_DATABASE_LONG_TEXT_LENGTH = 1_000
+
+function normalizeColumnName(column: string): string {
+	return column.replaceAll('"', '').trim().toLowerCase()
+}
+
+function getColumnFromValueList(
+	query: string,
+	index: number,
+	pattern: RegExp
+): string | null | undefined {
+	const match = pattern.exec(query)
+	if (!match) return undefined
+
+	const columns: string[] = match[1]?.split(',').map(normalizeColumnName) ?? []
+	const placeholders: string[] = match[2]?.match(/\$\d+/g) ?? []
+	return columns[placeholders.indexOf(`$${index + 1}`)] ?? null
+}
+
+function getDatabaseParameterColumn(query: string | undefined, index: number): string | null {
+	if (!query) return null
+
+	const valueListPatterns = [
+		/\binsert\s+into\s+[^()]+\(([^)]+)\)\s*values\s*\(([^)]+)\)/i,
+		/\bwith\s+\w+\s*\(([^)]+)\)\s+as\s*\(\s*values\s*\(([^)]+)\)/i,
+	]
+	for (const pattern of valueListPatterns) {
+		const column = getColumnFromValueList(query, index, pattern)
+		if (column !== undefined) return column
+	}
+
+	const placeholder = new RegExp(`\\$${index + 1}(?!\\d)`)
+	const match = placeholder.exec(query)
+	if (!match) return null
+
+	const precedingQuery = query.slice(0, match.index)
+	const boundaryMatches = [...precedingQuery.matchAll(/\b(?:set|where|values|and|or)\b|,/gi)]
+	const lastBoundary = boundaryMatches.at(-1)?.index ?? Math.max(0, precedingQuery.length - 500)
+	const parameterContext = precedingQuery.slice(lastBoundary, match.index)
+	const columnMatch = parameterContext.match(
+		/(?:^|\b(?:set|where|and|or)\b|,)\s*"?([a-z_][a-z0-9_]*)"?\s*(?:=|in\s*\(|is(?:\s+not)?\s*)[^,]*$/i
+	)
+	return columnMatch?.[1] ? normalizeColumnName(columnMatch[1]) : null
+}
+
+function formatParameterValue(value: unknown, column: string | null): unknown {
+	if (column && SENSITIVE_DATABASE_COLUMNS.has(column)) return '<redacted>'
+	if (
+		value === null ||
+		value === undefined ||
+		typeof value === 'number' ||
+		typeof value === 'boolean'
+	) {
+		return value
+	}
+	if (typeof value === 'bigint') return String(value)
+	if (value instanceof Date) return value.toISOString()
+
+	try {
+		const serialized = typeof value === 'string' ? value : JSON.stringify(value)
+		const maxLength =
+			column && LONG_TEXT_DATABASE_COLUMNS.has(column)
+				? MAX_DATABASE_LONG_TEXT_LENGTH
+				: MAX_DATABASE_STRING_LENGTH
+		if (serialized.length <= maxLength) return serialized
+		return `${serialized.slice(0, maxLength)}...[truncated]`
+	} catch {
+		return `[${typeof value}]`
+	}
+}
+
+function getDatabaseParameterColumns(
+	params: unknown[] | undefined,
+	query: string | undefined
+): Array<string | null> | undefined {
+	return params?.map((_, index) => getDatabaseParameterColumn(query, index))
+}
+
+function getDatabaseParameterValues(
+	params: unknown[] | undefined,
+	parameterColumns: Array<string | null> | undefined
+): unknown[] | undefined {
+	return params?.map((value, index) =>
+		formatParameterValue(value, parameterColumns?.[index] ?? null)
+	)
+}
+
+function getDatabaseQuery(message: string, error: ErrorRecord): string | undefined {
+	if (typeof error.query === 'string') {
+		return normalizeQuery(error.query)
+	}
+
+	if (!message.startsWith('Failed query:')) {
+		return undefined
+	}
+
+	const paramsIndex = message.indexOf('\nparams:')
+	return normalizeQuery(paramsIndex >= 0 ? message.slice(0, paramsIndex) : message)
+}
+
+function getCauseMessage(cause: unknown): string | undefined {
+	if (cause instanceof Error) return cause.message || cause.name
+	if (cause === undefined || cause === null) return undefined
+	return String(cause)
 }
 
 /**
@@ -37,21 +211,39 @@ export function toErrorMessage(error: unknown): string {
  * Ensures Cloudflare logs always include a stable message field.
  */
 export function toErrorLogDetails(error: unknown): ErrorLogDetails {
-	if (error instanceof Error) {
-		return {
-			message: error.message || error.name || 'unknown_error',
-			name: error.name,
-			stack: error.stack,
-			cause:
-				error.cause instanceof Error
-					? error.cause.message
-					: error.cause !== undefined
-						? String(error.cause)
-						: undefined,
-		}
-	}
+	const record = asErrorRecord(error) ?? {}
+	const message =
+		error instanceof Error
+			? error.message || error.name || 'unknown_error'
+			: typeof record.message === 'string'
+				? record.message
+				: toErrorMessage(error)
+	const causeRecord = asErrorRecord(record.cause)
+	const causeMessage = getCauseMessage(record.cause)
+	const paramsCount = Array.isArray(record.params) ? record.params.length : undefined
+	const query = getDatabaseQuery(message, record)
+	const params = Array.isArray(record.params) ? record.params : undefined
+	const parameterColumns = getDatabaseParameterColumns(params, query)
 
 	return {
-		message: toErrorMessage(error),
+		message: message.startsWith('Failed query:') ? message.split('\nparams:')[0] : message,
+		name: error instanceof Error ? error.name : undefined,
+		stack: error instanceof Error ? error.stack : undefined,
+		cause: causeMessage,
+		code: asLogValue(record.code) ?? asLogValue(causeRecord?.code),
+		detail: asLogString(record.detail) ?? asLogString(causeRecord?.detail),
+		hint: asLogString(record.hint) ?? asLogString(causeRecord?.hint),
+		severity: asLogString(record.severity) ?? asLogString(causeRecord?.severity),
+		position: asLogValue(record.position) ?? asLogValue(causeRecord?.position),
+		query,
+		paramsCount,
+		parameterColumns,
+		parameterValues: getDatabaseParameterValues(params, parameterColumns),
+		causeName: causeRecord?.name as string | undefined,
+		causeStack: causeRecord?.stack as string | undefined,
+		causeCode: asLogValue(causeRecord?.code),
+		causeDetail: asLogString(causeRecord?.detail),
+		causeHint: asLogString(causeRecord?.hint),
+		causeSeverity: asLogString(causeRecord?.severity),
 	}
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Hardens the `eve-corporation-data` worker against recurring workflow failure modes: RPC results that leak/aren't disposed across worker boundaries, duplicate zero-sum wallet journal entries, thin database error logs, and director health checks that could burst too many concurrent ESI/DB calls per corporation.

## Changes

- **RPC result lifecycle**: adds `withRpcResult`/`disposeRpcResult` to `@repo/do-utils` (`packages/do-utils/src/rpc-result.ts`) to consume and dispose non-primitive values returned from cross-worker RPC calls, with `getStub` docs updated to point at the new pattern. Applied throughout `eve-corporation-data`'s durable object, services, and workflow steps everywhere a stub call's result is used.
- **Wallet journal dedup**: adds `normalizeDecimal`, `areOppositeAmounts`, `walletJournalMetadata`, and `filterZeroSumJournalPairs` to drop same-journal-id, opposite-amount entry pairs with matching metadata before persisting wallet journal rows, logging how many were filtered.
- **Richer database error logging**: expands `toErrorLogDetails` in `@repo/hono-helpers` to extract query text, parameter counts/columns/values (redacting sensitive columns like tokens/passwords and truncating long text), and nested `cause` diagnostics (code/detail/hint/severity/position). Used in `director-manager.ts` and the wallet journal workflow step, including a `verificationPhase`/`phase` tag on director health check failures.
- **Director health check concurrency**: serializes per-corporation director health checks (`DIRECTOR_HEALTH_CHECK_CONCURRENCY = 1`) via a new `settleInBatches` helper instead of firing all checks with `Promise.allSettled` at once, and defers the health snapshot callback until after all checks complete (`deferHealthSnapshot`) instead of firing once per director.
- Minor fixes: `verifyDirectorHealth`'s catch path now uses `safeRecordFailure` instead of `recordFailure` directly; sovereignty cache-miss log downgraded from `warn` to `info`; sync workflow logs now include bounded `failureDetails`/`failureDetailsOmitted` for sovereignty/skyhook enrichment failures.

## Testing

- Added unit tests for `filterZeroSumJournalPairs` behavior in `wallet-journal-storage.test.ts` (filters same-party zero-sum pairs, does not filter opposite amounts for different parties).
- Added unit tests for the director health check concurrency limit and the richer error-context logging on health persistence failures in `director-manager.test.ts`.
- Added unit tests for `withRpcResult`/`disposeRpcResult` in `rpc-result.test.ts` and for `toErrorLogDetails` in `errors.test.ts` (query/param redaction, truncation, non-Error database errors).
- Updated existing `@repo/do-utils` mocks in unit tests to stub `withRpcResult`/`disposeRpcResult`.
<!-- claude:end -->