### PR TITLE
fix structure workflow error and fuel burn rate calc

### DIFF
--- a/apps/bills/src/durable-object.ts
+++ b/apps/bills/src/durable-object.ts
@@ -1,11 +1,12 @@
 import { DurableObject } from 'cloudflare:workers'
 import { and, eq, isNull, lte } from 'drizzle-orm'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger, toErrorLogDetails } from '@repo/hono-helpers'
 import { createWorkflowBatch } from '@repo/workflow-utils'
 
 import { createDb } from './db'
+import { billNotificationEvents, bills } from './db/schema'
 import { BillService } from './services/bill.service'
 import { ScheduleService } from './services/schedule.service'
 import { TemplateService } from './services/template.service'
@@ -13,13 +14,13 @@ import { generateUuidV7 } from './utils/uuid'
 
 import type {
 	Bill,
-	BillMetadata,
-	BillNotificationEventType,
 	BillExternalRef,
 	BillFilters,
 	BillIntegrationView,
 	BillListPage,
 	BillListQuery,
+	BillMetadata,
+	BillNotificationEventType,
 	BillPartySearchQuery,
 	BillPartySearchRow,
 	Bills,
@@ -54,7 +55,6 @@ import type {
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { Groups } from '@repo/groups'
 import type { Env } from './context'
-import { billNotificationEvents, bills } from './db/schema'
 import type { billPayments } from './db/schema'
 
 /**
@@ -356,11 +356,17 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 		return this.billService.deleteBill(actorUserId, billId)
 	}
 
-	async issueGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult> {
+	async issueGroupBill(
+		actorUserId: string,
+		groupBillId: string
+	): Promise<GroupBillOperationResult> {
 		return this.billService.issueGroupBill(actorUserId, groupBillId)
 	}
 
-	async cancelGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult> {
+	async cancelGroupBill(
+		actorUserId: string,
+		groupBillId: string
+	): Promise<GroupBillOperationResult> {
 		return this.billService.cancelGroupBill(actorUserId, groupBillId)
 	}
 
@@ -371,7 +377,10 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 		return this.billService.revertGroupBillToDraft(actorUserId, groupBillId)
 	}
 
-	async deleteGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult> {
+	async deleteGroupBill(
+		actorUserId: string,
+		groupBillId: string
+	): Promise<GroupBillOperationResult> {
 		return this.billService.deleteGroupBill(actorUserId, groupBillId)
 	}
 
@@ -540,8 +549,22 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 				const groupBillId = crypto.randomUUID()
 				const groupsStub = getStub<Groups>(this.env.GROUPS, 'default')
 				const [group, members] = await Promise.all([
-					groupsStub.getGroup(scheduleResult.payerId, scheduleResult.ownerId),
-					groupsStub.getGroupMembers(scheduleResult.payerId, scheduleResult.ownerId),
+					withRpcResult(
+						groupsStub.getGroup(scheduleResult.payerId, scheduleResult.ownerId),
+						(result) =>
+							result
+								? {
+										...result,
+										adminUserIds: result.adminUserIds
+											? [...result.adminUserIds]
+											: result.adminUserIds,
+									}
+								: null
+					),
+					withRpcResult(
+						groupsStub.getGroupMembers(scheduleResult.payerId, scheduleResult.ownerId),
+						(result) => result.map((member) => ({ ...member }))
+					),
 				])
 
 				if (!group) {
@@ -664,7 +687,8 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 			return
 		}
 
-		await createWorkflowBatch(this.env.BILL_DISCORD_NOTIFY, 
+		await createWorkflowBatch(
+			this.env.BILL_DISCORD_NOTIFY,
 			pendingRows.map((row) => ({
 				id: `bill-notify-immediate-${row.id}-${Date.now()}`,
 				params: { notificationEventId: row.id },
@@ -672,11 +696,14 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 		)
 	}
 
-	private async resolveIssuedNotificationRecipients(
-		bill: { payerId: string; payerType: EntityType }
-	): Promise<string[]> {
+	private async resolveIssuedNotificationRecipients(bill: {
+		payerId: string
+		payerType: EntityType
+	}): Promise<string[]> {
 		if (bill.payerType === 'character') {
-			const owner = await this.env.CORE.getCharacterOwner(bill.payerId)
+			const owner = await withRpcResult(this.env.CORE.getCharacterOwner(bill.payerId), (owner) =>
+				owner ? { ...owner } : null
+			)
 			return owner?.userId ? [owner.userId] : []
 		}
 
@@ -687,8 +714,8 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 		const corpId = bill.payerId
 		const corpStub = getStub<EveCorporationData>(this.env.EVE_CORPORATION_DATA, corpId)
 		const [corpInfo, directors] = await Promise.all([
-			corpStub.getCorporationInfo(corpId),
-			corpStub.getDirectors(corpId),
+			withRpcResult(corpStub.getCorporationInfo(corpId), (info) => (info ? { ...info } : null)),
+			withRpcResult(corpStub.getDirectors(corpId), (rows) => rows.map((row) => ({ ...row }))),
 		])
 
 		const characterIds = new Set<string>()
@@ -705,7 +732,11 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 		}
 
 		const owners = await Promise.all(
-			[...characterIds].map(async (characterId) => this.env.CORE.getCharacterOwner(characterId))
+			[...characterIds].map((characterId) =>
+				withRpcResult(this.env.CORE.getCharacterOwner(characterId), (owner) =>
+					owner ? { ...owner } : null
+				)
+			)
 		)
 		const userIds = new Set<string>()
 		for (const owner of owners) {

--- a/apps/bills/src/scheduled.ts
+++ b/apps/bills/src/scheduled.ts
@@ -1,14 +1,14 @@
 import { and, eq, inArray, isNull, lte, or } from 'drizzle-orm'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger, withWorkerLogContext } from '@repo/hono-helpers'
 import { createWorkflowBatch } from '@repo/workflow-utils'
 
 import { createDb } from './db'
 import { billNotificationEvents, bills, billSchedules } from './db/schema'
 
-import type { Env } from './context'
 import type { Bills } from '@repo/bills'
+import type { Env } from './context'
 
 /**
  * Refreshes bill payment status by scheduling workflows for all open bills
@@ -308,9 +308,12 @@ async function enqueueDueSoonNotifications(
 		const billsStub = getStub<Bills>(env.BILLS, 'default')
 		const results = await Promise.allSettled(
 			dueSoonBillIds.map((billId) =>
-				billsStub.enqueueBillNotificationEvent(billId, 'due_24h', {
-					source: 'scheduled_due_soon_sweep',
-				})
+				withRpcResult(
+					billsStub.enqueueBillNotificationEvent(billId, 'due_24h', {
+						source: 'scheduled_due_soon_sweep',
+					}),
+					() => undefined
+				)
 			)
 		)
 		const succeeded = results.filter((r) => r.status === 'fulfilled').length

--- a/apps/bills/src/test/unit/workflows/bill-payment-status-check.test.ts
+++ b/apps/bills/src/test/unit/workflows/bill-payment-status-check.test.ts
@@ -9,6 +9,10 @@ const findPaymentsForBillMock = vi.fn()
 const checkPaymentStatusMock = vi.fn()
 const updateCheckTimestampMock = vi.fn()
 const getStubMock = vi.fn()
+const withRpcResultMock = vi.fn(
+	async (request: Promise<unknown>, consume: (result: unknown) => unknown | Promise<unknown>) =>
+		consume(await request)
+)
 
 vi.mock('cloudflare:workers', () => {
 	class WorkflowEntrypoint<Env = unknown> {
@@ -46,6 +50,8 @@ vi.mock('../../../workflows/steps/update-check-timestamp', () => ({
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: (...args: unknown[]) => getStubMock(...args),
+	withRpcResult: (request: Promise<unknown>, consume: (result: unknown) => unknown) =>
+		withRpcResultMock(request, consume),
 }))
 
 type MockContext = {

--- a/apps/bills/src/workflows/bill-discord-notify.ts
+++ b/apps/bills/src/workflows/bill-discord-notify.ts
@@ -1,7 +1,7 @@
 import { WorkflowEntrypoint } from 'cloudflare:workers'
 import { eq, sql } from 'drizzle-orm'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { formatISK } from '@repo/worker-utils'
 
 import { createDb } from '../db'
@@ -184,9 +184,12 @@ export class BillDiscordNotifyWorkflow extends WorkflowEntrypoint<
 				const payeeName =
 					bill.payeeId && bill.payeeId.trim().length > 0
 						? ((
-								await getStub<EsiTypeResolver>(this.env.ESI_TYPE_RESOLVER, 'global').resolveIds([
-									bill.payeeId,
-								])
+								await withRpcResult(
+									getStub<EsiTypeResolver>(this.env.ESI_TYPE_RESOLVER, 'global').resolveIds([
+										bill.payeeId,
+									]),
+									(names) => ({ ...names })
+								)
 							)[bill.payeeId] ?? bill.payeeId)
 						: 'Unknown'
 
@@ -200,7 +203,10 @@ export class BillDiscordNotifyWorkflow extends WorkflowEntrypoint<
 				})
 
 				const discord = getStub<Discord>(this.env.DISCORD, 'default')
-				const result = await discord.sendDirectMessage(eventRow.recipientUserId, message)
+				const result = await withRpcResult(
+					discord.sendDirectMessage(eventRow.recipientUserId, message),
+					(result) => ({ ...result })
+				)
 				if (!result.success) {
 					return {
 						success: false as const,

--- a/apps/bills/src/workflows/bill-payment-status-check.ts
+++ b/apps/bills/src/workflows/bill-payment-status-check.ts
@@ -1,6 +1,6 @@
 import { WorkflowEntrypoint } from 'cloudflare:workers'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
@@ -174,21 +174,30 @@ export class BillPaymentStatusCheckWorkflow extends WorkflowEntrypoint<Env, Work
 					async () => {
 						const billsStub = getStub<BillsNotificationStub>(this.env.BILLS, 'default')
 						if (paymentStatusResult.overdueMarked) {
-							await billsStub.enqueueBillNotificationEvent(billId, 'overdue', {
-								source: 'bill_payment_status_workflow',
-							})
+							await withRpcResult(
+								billsStub.enqueueBillNotificationEvent(billId, 'overdue', {
+									source: 'bill_payment_status_workflow',
+								}),
+								() => undefined
+							)
 						}
 						if (paymentStatusResult.markedPaid) {
-							await billsStub.enqueueBillNotificationEvent(billId, 'paid', {
-								source: 'bill_payment_status_workflow',
-							})
+							await withRpcResult(
+								billsStub.enqueueBillNotificationEvent(billId, 'paid', {
+									source: 'bill_payment_status_workflow',
+								}),
+								() => undefined
+							)
 						}
 						if (shouldSyncTaxAssessment) {
 							const taxStub = getStub<CorporationTaxSyncStub>(this.env.CORPORATION_TAX, 'default')
-							await taxStub.syncBillStatus(TAX_SYNC_ACTOR, {
-								id: billId,
-								status: paymentStatusResult.statusAfter as BillStatus,
-							})
+							await withRpcResult(
+								taxStub.syncBillStatus(TAX_SYNC_ACTOR, {
+									id: billId,
+									status: paymentStatusResult.statusAfter as BillStatus,
+								}),
+								() => undefined
+							)
 						}
 					}
 				)

--- a/apps/bills/src/workflows/bill-schedule-executor.ts
+++ b/apps/bills/src/workflows/bill-schedule-executor.ts
@@ -1,6 +1,6 @@
 import { WorkflowEntrypoint } from 'cloudflare:workers'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
 import type { Bills } from '@repo/bills'
@@ -40,7 +40,9 @@ export class BillScheduleExecutorWorkflow extends WorkflowEntrypoint<Env, { sche
 			},
 			async () => {
 				const billsStub = getStub<Bills>(this.env.BILLS, 'default')
-				return await billsStub.executeSchedule(scheduleId)
+				return await withRpcResult(billsStub.executeSchedule(scheduleId), (result) => ({
+					...result,
+				}))
 			}
 		)
 

--- a/apps/core/src/lib/__tests__/time-cache.test.ts
+++ b/apps/core/src/lib/__tests__/time-cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { TimeCache } from '@repo/hono-helpers'
+
+describe('TimeCache', () => {
+	it('shares an in-flight computation for concurrent misses', async () => {
+		const cache = new TimeCache<string>(60_000)
+		const compute = vi.fn(async () => 'value')
+
+		const values = await Promise.all([
+			cache.getOrSet('key', compute),
+			cache.getOrSet('key', compute),
+			cache.getOrSet('key', compute),
+		])
+
+		expect(values).toEqual(['value', 'value', 'value'])
+		expect(compute).toHaveBeenCalledOnce()
+	})
+
+	it('does not cache rejected computations', async () => {
+		const cache = new TimeCache<string>(60_000)
+		const compute = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(new Error('failed'))
+			.mockResolvedValueOnce('recovered')
+
+		await expect(cache.getOrSet('key', compute)).rejects.toThrow('failed')
+		await expect(cache.getOrSet('key', compute)).resolves.toBe('recovered')
+		expect(compute).toHaveBeenCalledTimes(2)
+	})
+})

--- a/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
+++ b/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
@@ -376,5 +376,6 @@ describe('character detail access for HR page viewers', () => {
 		expect(body.characterName).toBe('Target Pilot')
 		expect(body.totalSp).toBe(123456)
 		expect(hoisted.core.queueImmunitasAccessAlert).not.toHaveBeenCalled()
+		expect(hoisted.groups.getUserPermissions).not.toHaveBeenCalled()
 	})
 })

--- a/apps/core/src/routes/characters.ts
+++ b/apps/core/src/routes/characters.ts
@@ -502,14 +502,15 @@ app.get('/:characterId/private', requireAuth(), async (c) => {
 app.get('/:characterId/skills', requireAuth(), async (c) => {
 	const characterIdStr = c.req.param('characterId')
 	const characterId = createEveCharacterId(characterIdStr)
-	const accessOrResponse = await resolveCharacterAccessContext(c, characterIdStr)
+	const user = c.get('user')!
+	const isActualOwner = user.characters.some(
+		(character) => character.characterId.toString() === characterIdStr
+	)
 
-	if (accessOrResponse instanceof Response) {
-		return accessOrResponse
-	}
-
-	const access = accessOrResponse
-	if (!access.isActualOwner && !access.isAdmin) {
+	// This endpoint only permits the character owner or a site admin. Avoid the
+	// shared-character resolver here because it performs unrelated HR/corporate
+	// access checks for every concurrent skills request.
+	if (!isActualOwner && !user.is_admin) {
 		return c.json({ error: 'You do not have permission to view this character' }, 403)
 	}
 

--- a/apps/eve-corporation-data/.migrations/0038_third_chat.sql
+++ b/apps/eve-corporation-data/.migrations/0038_third_chat.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "corporation_assets_corp_location_idx" ON "corporation_assets" USING btree ("corporation_id","location_id","location_type","location_flag");

--- a/apps/eve-corporation-data/.migrations/meta/0038_snapshot.json
+++ b/apps/eve-corporation-data/.migrations/meta/0038_snapshot.json
@@ -1,0 +1,3971 @@
+{
+  "id": "31d26e7e-cb54-410c-b6fc-c948a7a64e58",
+  "prevId": "b5390611-01a4-4fdc-bb3b-92f5b2107d43",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_corporation_roles": {
+      "name": "character_corporation_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_at_hq": {
+          "name": "roles_at_hq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_base": {
+          "name": "roles_at_base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles_at_other": {
+          "name": "roles_at_other",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "character_corporation_roles_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "character_corporation_roles",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_corporation_roles_corporation_id_character_id_unique": {
+          "name": "character_corporation_roles_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_assets": {
+      "name": "corporation_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_blueprint_copy": {
+          "name": "is_blueprint_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_assets_corp_location_idx": {
+          "name": "corporation_assets_corp_location_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_assets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_assets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_assets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_assets_corporation_id_item_id_unique": {
+          "name": "corporation_assets_corporation_id_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_config": {
+      "name": "corporation_config",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "include_in_background_refresh": {
+          "name": "include_in_background_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_in_structure_asset_sync": {
+          "name": "include_in_structure_asset_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "corporation_type": {
+          "name": "corporation_type",
+          "type": "corporation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "members_last_sync": {
+          "name": "members_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_tracking_last_sync": {
+          "name": "member_tracking_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets_last_sync": {
+          "name": "wallets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_journal_last_sync": {
+          "name": "wallet_journal_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_transactions_last_sync": {
+          "name": "wallet_transactions_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assets_last_sync": {
+          "name": "assets_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structures_last_sync": {
+          "name": "structures_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_last_sync": {
+          "name": "orders_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contracts_last_sync": {
+          "name": "contracts_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_jobs_last_sync": {
+          "name": "industry_jobs_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killmails_last_sync": {
+          "name": "killmails_last_sync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_config_include_in_background_refresh_idx": {
+          "name": "corporation_config_include_in_background_refresh_idx",
+          "columns": [
+            {
+              "expression": "include_in_background_refresh",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_include_in_structure_asset_sync_idx": {
+          "name": "corporation_config_include_in_structure_asset_sync_idx",
+          "columns": [
+            {
+              "expression": "include_in_structure_asset_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_corporation_type_idx": {
+          "name": "corporation_config_corporation_type_idx",
+          "columns": [
+            {
+              "expression": "corporation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_member_tracking_last_sync_idx": {
+          "name": "corporation_config_member_tracking_last_sync_idx",
+          "columns": [
+            {
+              "expression": "member_tracking_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallets_last_sync_idx": {
+          "name": "corporation_config_wallets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_assets_last_sync_idx": {
+          "name": "corporation_config_assets_last_sync_idx",
+          "columns": [
+            {
+              "expression": "assets_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_structures_last_sync_idx": {
+          "name": "corporation_config_structures_last_sync_idx",
+          "columns": [
+            {
+              "expression": "structures_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_orders_last_sync_idx": {
+          "name": "corporation_config_orders_last_sync_idx",
+          "columns": [
+            {
+              "expression": "orders_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_contracts_last_sync_idx": {
+          "name": "corporation_config_contracts_last_sync_idx",
+          "columns": [
+            {
+              "expression": "contracts_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_industry_jobs_last_sync_idx": {
+          "name": "corporation_config_industry_jobs_last_sync_idx",
+          "columns": [
+            {
+              "expression": "industry_jobs_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_killmails_last_sync_idx": {
+          "name": "corporation_config_killmails_last_sync_idx",
+          "columns": [
+            {
+              "expression": "killmails_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_members_last_sync_idx": {
+          "name": "corporation_config_members_last_sync_idx",
+          "columns": [
+            {
+              "expression": "members_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_transactions_last_sync_idx": {
+          "name": "corporation_config_wallet_transactions_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_transactions_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_config_wallet_journal_last_sync_idx": {
+          "name": "corporation_config_wallet_journal_last_sync_idx",
+          "columns": [
+            {
+              "expression": "wallet_journal_last_sync",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_contracts": {
+      "name": "corporation_contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptor_id": {
+          "name": "acceptor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyout": {
+          "name": "buyout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collateral": {
+          "name": "collateral",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_accepted": {
+          "name": "date_accepted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_completed": {
+          "name": "date_completed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_expired": {
+          "name": "date_expired",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_to_complete": {
+          "name": "days_to_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_location_id": {
+          "name": "end_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_corporation": {
+          "name": "for_corporation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_corporation_id": {
+          "name": "issuer_corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward": {
+          "name": "reward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_location_id": {
+          "name": "start_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_contracts_leaderboard_all_time_idx": {
+          "name": "corporation_contracts_leaderboard_all_time_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_contracts_leaderboard_period_idx": {
+          "name": "corporation_contracts_leaderboard_period_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acceptor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_contracts_contract_id_unique": {
+          "name": "corporation_contracts_contract_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contract_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_directors": {
+      "name": "corporation_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_healthy": {
+          "name": "is_healthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permanent_failure_at": {
+          "name": "permanent_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_directors_corp_healthy_idx": {
+          "name": "corporation_directors_corp_healthy_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_healthy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_next_retry_idx": {
+          "name": "corporation_directors_corp_next_retry_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_corp_permanent_failure_idx": {
+          "name": "corporation_directors_corp_permanent_failure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permanent_failure_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_directors_last_used_idx": {
+          "name": "corporation_directors_last_used_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_directors_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_directors_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_directors",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_directors_corporation_id_character_id_unique": {
+          "name": "corporation_directors_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_industry_jobs": {
+      "name": "corporation_industry_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_id": {
+          "name": "installer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_type_id": {
+          "name": "blueprint_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_location_id": {
+          "name": "blueprint_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_location_id": {
+          "name": "output_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runs": {
+          "name": "runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_runs": {
+          "name": "licensed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_type_id": {
+          "name": "product_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_date": {
+          "name": "pause_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_character_id": {
+          "name": "completed_character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successful_runs": {
+          "name": "successful_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_industry_jobs_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_industry_jobs",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_industry_jobs_corporation_id_job_id_unique": {
+          "name": "corporation_industry_jobs_corporation_id_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_killmails": {
+      "name": "corporation_killmails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_id": {
+          "name": "killmail_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_hash": {
+          "name": "killmail_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killmail_time": {
+          "name": "killmail_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_killmails_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_killmails_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_killmails",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_killmails_corporation_id_killmail_id_unique": {
+          "name": "corporation_killmails_corporation_id_killmail_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "killmail_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_member_tracking": {
+      "name": "corporation_member_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoff_date": {
+          "name": "logoff_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logon_date": {
+          "name": "logon_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_type_id": {
+          "name": "ship_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_member_tracking_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_member_tracking",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_member_tracking_corporation_id_character_id_unique": {
+          "name": "corporation_member_tracking_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_members": {
+      "name": "corporation_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_members_character_id_idx": {
+          "name": "corporation_members_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_members_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_members_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_members",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_members_corporation_id_character_id_unique": {
+          "name": "corporation_members_corporation_id_character_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "character_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_orders": {
+      "name": "corporation_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escrow": {
+          "name": "escrow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_buy_order": {
+          "name": "is_buy_order",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issued": {
+          "name": "issued",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_volume": {
+          "name": "min_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range": {
+          "name": "range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_remain": {
+          "name": "volume_remain",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_total": {
+          "name": "volume_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_division": {
+          "name": "wallet_division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_orders_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_orders_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_orders",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_orders_corporation_id_order_id_unique": {
+          "name": "corporation_orders_corporation_id_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_public_info": {
+      "name": "corporation_public_info",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ceo_id": {
+          "name": "ceo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_founded": {
+          "name": "date_founded",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_station_id": {
+          "name": "home_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "war_eligible": {
+          "name": "war_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory": {
+      "name": "corporation_structure_inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_singleton": {
+          "name": "is_singleton",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location_flag": {
+          "name": "location_flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_corp_structure_idx": {
+          "name": "corporation_structure_inventory_corp_structure_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_structure_inventory_snapshot_structure_idx": {
+          "name": "corporation_structure_inventory_snapshot_structure_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structure_inventory_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk": {
+          "name": "corporation_structure_inventory_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "corp_inv_snapshot_fk": {
+          "name": "corp_inv_snapshot_fk",
+          "tableFrom": "corporation_structure_inventory",
+          "tableTo": "corporation_structure_inventory_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corp_inv_snapshot_item_uniq": {
+          "name": "corp_inv_snapshot_item_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "snapshot_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structure_inventory_snapshots": {
+      "name": "corporation_structure_inventory_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "corporation_structure_inventory_snapshots_corp_activated_idx": {
+          "name": "corporation_structure_inventory_snapshots_corp_activated_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corp_inv_snapshots_corp_fk": {
+          "name": "corp_inv_snapshots_corp_fk",
+          "tableFrom": "corporation_structure_inventory_snapshots",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_structures": {
+      "name": "corporation_structures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_expires": {
+          "name": "fuel_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_amount": {
+          "name": "fuel_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_burn_rate": {
+          "name": "fuel_burn_rate",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fuel_blocks": {
+          "name": "last_fuel_blocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refilled_at": {
+          "name": "last_refilled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_apply": {
+          "name": "next_reinforce_apply",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reinforce_hour": {
+          "name": "next_reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforce_hour": {
+          "name": "reinforce_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_timer_end": {
+          "name": "state_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_timer_start": {
+          "name": "state_timer_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unanchors_at": {
+          "name": "unanchors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_power": {
+          "name": "low_power",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_structures_last_synced_at_idx": {
+          "name": "corporation_structures_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_structures_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_structures_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_structures",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_structures_structure_id_unique": {
+          "name": "corporation_structures_structure_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "structure_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_journal": {
+      "name": "corporation_wallet_journal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id_type": {
+          "name": "context_id_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax": {
+          "name": "tax",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_receiver_id": {
+          "name": "tax_receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_wallet_journal_corporation_date_idx": {
+          "name": "corporation_wallet_journal_corporation_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_journal_corporation_reason_date_idx": {
+          "name": "corporation_wallet_journal_corporation_reason_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_journal_corp_div_date_idx": {
+          "name": "corporation_wallet_journal_corp_div_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_journal_corp_div_num_id_idx": {
+          "name": "corporation_wallet_journal_corp_div_num_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"journal_id\"::numeric)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_journal_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_journal",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_journal_corporation_id_division_journal_id_unique": {
+          "name": "corporation_wallet_journal_corporation_id_division_journal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "journal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallet_transactions": {
+      "name": "corporation_wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_buy": {
+          "name": "is_buy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "journal_ref_id": {
+          "name": "journal_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "corporation_wallet_tx_corp_div_date_idx": {
+          "name": "corporation_wallet_tx_corp_div_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "corporation_wallet_tx_corp_div_num_id_idx": {
+          "name": "corporation_wallet_tx_corp_div_num_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "division",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"transaction_id\"::numeric)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallet_transactions_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallet_transactions",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallet_transactions_corporation_id_division_transaction_id_unique": {
+          "name": "corporation_wallet_transactions_corporation_id_division_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division",
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.corporation_wallets": {
+      "name": "corporation_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "corporation_wallets_corporation_id_corporation_config_corporation_id_fk": {
+          "name": "corporation_wallets_corporation_id_corporation_config_corporation_id_fk",
+          "tableFrom": "corporation_wallets",
+          "tableTo": "corporation_config",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "corporation_wallets_corporation_id_division_unique": {
+          "name": "corporation_wallets_corporation_id_division_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "division"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_mining_citadel_extractions": {
+      "name": "structure_mining_citadel_extractions",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_start_time": {
+          "name": "extraction_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_arrival_time": {
+          "name": "chunk_arrival_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "natural_decay_time": {
+          "name": "natural_decay_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_mining_citadel_extractions_corporation_id_idx": {
+          "name": "structure_mining_citadel_extractions_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_mining_citadel_extractions_last_synced_at_idx": {
+          "name": "structure_mining_citadel_extractions_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_mining_citadel_extractions_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_mining_citadel_extractions_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_mining_citadel_extractions",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_drills": {
+      "name": "structure_moon_drills",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_drills_corporation_id_idx": {
+          "name": "structure_moon_drills_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_drills_last_synced_at_idx": {
+          "name": "structure_moon_drills_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_drills_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_drills_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_drills_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_drills",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_moon_geographies": {
+      "name": "structure_moon_geographies",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_id": {
+          "name": "moon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moon_name": {
+          "name": "moon_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_moon_geographies_corporation_id_idx": {
+          "name": "structure_moon_geographies_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_moon_id_idx": {
+          "name": "structure_moon_geographies_moon_id_idx",
+          "columns": [
+            {
+              "expression": "moon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_planet_id_idx": {
+          "name": "structure_moon_geographies_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_system_id_idx": {
+          "name": "structure_moon_geographies_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_moon_geographies_last_synced_at_idx": {
+          "name": "structure_moon_geographies_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_moon_geographies_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_moon_geographies_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_moon_geographies",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhook_reagents": {
+      "name": "structure_skyhook_reagents",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "magmatic_gas_secured_stock": {
+          "name": "magmatic_gas_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_unsecured_stock": {
+          "name": "magmatic_gas_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "magmatic_gas_last_cycle": {
+          "name": "magmatic_gas_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superionic_ice_secured_stock": {
+          "name": "superionic_ice_secured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_unsecured_stock": {
+          "name": "superionic_ice_unsecured_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "superionic_ice_last_cycle": {
+          "name": "superionic_ice_last_cycle",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhook_reagents_corporation_id_idx": {
+          "name": "structure_skyhook_reagents_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhook_reagents_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhook_reagents_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhook_reagents",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_skyhooks": {
+      "name": "structure_skyhooks",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planet_id": {
+          "name": "planet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planet_name": {
+          "name": "planet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "effective_workforce": {
+          "name": "effective_workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinforcement_timer_end": {
+          "name": "reinforcement_timer_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_start": {
+          "name": "theft_vulnerability_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theft_vulnerability_end": {
+          "name": "theft_vulnerability_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_skyhooks_corporation_id_idx": {
+          "name": "structure_skyhooks_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_planet_id_idx": {
+          "name": "structure_skyhooks_planet_id_idx",
+          "columns": [
+            {
+              "expression": "planet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_system_id_idx": {
+          "name": "structure_skyhooks_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_type_id_idx": {
+          "name": "structure_skyhooks_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_skyhooks_last_synced_at_idx": {
+          "name": "structure_skyhooks_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_skyhooks_structure_id_corporation_structures_structure_id_fk": {
+          "name": "structure_skyhooks_structure_id_corporation_structures_structure_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "corporation_structures",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "structure_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_skyhooks_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_skyhooks",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_hubs": {
+      "name": "structure_sovereignty_hubs",
+      "schema": "",
+      "columns": {
+        "structure_id": {
+          "name": "structure_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel_access_list_id": {
+          "name": "fuel_access_list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_id": {
+          "name": "controller_alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_alliance_name": {
+          "name": "controller_alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay_last_updated": {
+          "name": "reagent_bay_last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reagent_bay": {
+          "name": "reagent_bay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"lastUpdated\":\"\",\"reagents\":[]}'::jsonb"
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"power\":{\"allocated\":0,\"available\":0},\"workforce\":{\"allocated\":0,\"available\":0}}'::jsonb"
+        },
+        "upgrades": {
+          "name": "upgrades",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_transport": {
+          "name": "workforce_transport",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"configuration\":{\"mode\":\"unknown\",\"systems\":[]},\"state\":{\"mode\":\"unknown\",\"systems\":[]}}'::jsonb"
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "sync_failure_reason": {
+          "name": "sync_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempted_sync_at": {
+          "name": "last_attempted_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_hubs_corporation_id_idx": {
+          "name": "structure_sovereignty_hubs_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_system_id_idx": {
+          "name": "structure_sovereignty_hubs_system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_type_id_idx": {
+          "name": "structure_sovereignty_hubs_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_hubs_last_synced_at_idx": {
+          "name": "structure_sovereignty_hubs_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_hubs_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_hubs",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.structure_sovereignty_systems": {
+      "name": "structure_sovereignty_systems",
+      "schema": "",
+      "columns": {
+        "system_id": {
+          "name": "system_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_name": {
+          "name": "region_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_type": {
+          "name": "claim_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alliance_id": {
+          "name": "alliance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alliance_name": {
+          "name": "alliance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corporation_claimant_id": {
+          "name": "corporation_claimant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction_id": {
+          "name": "faction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_since": {
+          "name": "claimed_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sovereignty_hub_structure_id": {
+          "name": "sovereignty_hub_structure_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_capital_system": {
+          "name": "is_capital_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_start": {
+          "name": "vulnerability_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_window_end": {
+          "name": "vulnerability_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_defense_multiplier": {
+          "name": "activity_defense_multiplier",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "military_level": {
+          "name": "military_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industrial_level": {
+          "name": "industrial_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strategic_level": {
+          "name": "strategic_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sync_at": {
+          "name": "source_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "structure_sovereignty_systems_corporation_id_idx": {
+          "name": "structure_sovereignty_systems_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_region_id_idx": {
+          "name": "structure_sovereignty_systems_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_alliance_id_idx": {
+          "name": "structure_sovereignty_systems_alliance_id_idx",
+          "columns": [
+            {
+              "expression": "alliance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_sovereignty_hub_structure_id_idx": {
+          "name": "structure_sovereignty_systems_sovereignty_hub_structure_id_idx",
+          "columns": [
+            {
+              "expression": "sovereignty_hub_structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "structure_sovereignty_systems_last_synced_at_idx": {
+          "name": "structure_sovereignty_systems_last_synced_at_idx",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk": {
+          "name": "structure_sovereignty_systems_corporation_id_managed_corporations_corporation_id_fk",
+          "tableFrom": "structure_sovereignty_systems",
+          "tableTo": "managed_corporations",
+          "columnsFrom": [
+            "corporation_id"
+          ],
+          "columnsTo": [
+            "corporation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.corporation_type": {
+      "name": "corporation_type",
+      "schema": "public",
+      "values": [
+        "member",
+        "alt",
+        "special_purpose",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/eve-corporation-data/.migrations/meta/_journal.json
+++ b/apps/eve-corporation-data/.migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1786136141644,
       "tag": "0037_overconfident_vision",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1786157175675,
+      "tag": "0038_third_chat",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/eve-corporation-data/package.json
+++ b/apps/eve-corporation-data/package.json
@@ -15,6 +15,7 @@
 		"deploy": "run-wrangler-deploy",
 		"dev": "run-vite-dev",
 		"diagnose-sovereignty": "tsx ./src/scripts/diagnose-sovereignty.ts",
+		"diagnose-structure-services": "tsx ./src/scripts/diagnose-structure-services.ts",
 		"fix:workers-types": "run-wrangler-types",
 		"preview": "run-vite-preview",
 		"query-killmails": "tsx ./src/scripts/query-killmails.ts",

--- a/apps/eve-corporation-data/src/db/schema.ts
+++ b/apps/eve-corporation-data/src/db/schema.ts
@@ -394,7 +394,15 @@ export const corporationAssets = pgTable(
 		isBlueprintCopy: boolean('is_blueprint_copy').default(false),
 		updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 	},
-	(table) => [unique().on(table.corporationId, table.itemId)]
+	(table) => [
+		unique().on(table.corporationId, table.itemId),
+		index('corporation_assets_corp_location_idx').on(
+			table.corporationId,
+			table.locationId,
+			table.locationType,
+			table.locationFlag
+		),
+	]
 )
 
 /**

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -9,6 +9,7 @@ import {
 	gte,
 	inArray,
 	isNotNull,
+	like,
 	lt,
 	lte,
 	ne,
@@ -59,7 +60,7 @@ import {
 import { dedupeByItemId, syncAssetsPaged } from './services/assets-paging-sync'
 import { DirectorManager } from './services/director-manager'
 import * as esiFetch from './services/esi-fetch'
-import { calculateStructureFuelBurnRate } from './services/structure-fuel-calculation'
+import { calculateStructureFuelBurnRateDetails } from './services/structure-fuel-calculation'
 import { preserveStructureHydrationFields } from './services/structure-hydration'
 import {
 	findRefilledStructureIds,
@@ -224,6 +225,8 @@ const INVENTORY_SNAPSHOT_CLEANUP_BATCH_SIZE = 250
 const INVENTORY_SNAPSHOT_CLEANUP_MAX_BATCHES = 4
 const WALLET_JOURNAL_INSERT_BATCH_SIZE = 100
 const WALLET_TRANSACTION_INSERT_BATCH_SIZE = 100
+const STRUCTURE_FUEL_SYNC_FAILURE_REASON =
+	'Some online service modules could not be identified for fuel consumption purposes'
 
 function compareNumericStrings(left: string, right: string): number {
 	try {
@@ -884,10 +887,13 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		try {
-			await this.env.CORE.handleCharacterAffiliationChanges([characterId], {
-				source: `director-affiliation-mismatch:${expectedCorporationId}:${actualCorporationId ?? 'unknown'}`,
-				bypassThrottle: true,
-			})
+			await withRpcResult(
+				this.env.CORE.handleCharacterAffiliationChanges([characterId], {
+					source: `director-affiliation-mismatch:${expectedCorporationId}:${actualCorporationId ?? 'unknown'}`,
+					bypassThrottle: true,
+				}),
+				() => undefined
+			)
 		} catch (error) {
 			logger.warn('[EveCorporationData] Failed to propagate director affiliation mismatch', {
 				characterId,
@@ -1158,6 +1164,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async getCorporationSyncConfig(corporationId: string): Promise<{
 		includeInBackgroundRefresh: boolean
 		includeInStructureAssetSync: boolean
+		assetsLastSync: Date | null
 		structuresLastSync: Date | null
 	} | null> {
 		const config = await this.getDb().query.corporationConfig.findFirst({
@@ -1165,6 +1172,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			columns: {
 				includeInBackgroundRefresh: true,
 				includeInStructureAssetSync: true,
+				assetsLastSync: true,
 				structuresLastSync: true,
 			},
 		})
@@ -1176,6 +1184,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		return {
 			includeInBackgroundRefresh: config.includeInBackgroundRefresh,
 			includeInStructureAssetSync: config.includeInStructureAssetSync,
+			assetsLastSync: config.assetsLastSync,
 			structuresLastSync: config.structuresLastSync,
 		}
 	}
@@ -2902,31 +2911,86 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			services: Array<{ name: string; state: string }> | null
 			fuelBurnRate: string | null
 		}>
-	): Promise<Map<string, string | null>> {
-		const fuelBurnRateByStructure = new Map(
-			structures.map((structure) => [structure.structureId, structure.fuelBurnRate] as const)
+	): Promise<
+		Map<
+			string,
+			{
+				fuelBurnRate: string | null
+				unresolvedServiceNames: string[]
+				unresolvedModuleTypeIds: string[]
+			}
+		>
+	> {
+		const fuelBurnRateByStructure = new Map<
+			string,
+			{
+				fuelBurnRate: string | null
+				unresolvedServiceNames: string[]
+				unresolvedModuleTypeIds: string[]
+			}
+		>(
+			structures.map(
+				(structure) =>
+					[
+						structure.structureId,
+						{
+							fuelBurnRate: structure.fuelBurnRate,
+							unresolvedServiceNames: [],
+							unresolvedModuleTypeIds: [],
+						},
+					] as const
+			)
 		)
 		if (structures.length === 0) {
 			return fuelBurnRateByStructure
 		}
 
 		const structureTypeIds = [...new Set(structures.map((structure) => structure.typeId))]
+		let serviceModuleTypeIdsByStructureId = new Map<string, string[]>()
+		try {
+			serviceModuleTypeIdsByStructureId = await this.getStructureServiceModuleTypeIds(
+				corporationId,
+				structures.map((structure) => structure.structureId)
+			)
+		} catch (error) {
+			logger.warn('[EveCorporationData] Failed to read stored structure service modules', {
+				corporationId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+		const serviceModuleTypeIds = [
+			...new Set([...serviceModuleTypeIdsByStructureId.values()].flatMap((typeIds) => typeIds)),
+		]
 		const serviceNames = [
 			...new Set(
-				structures.flatMap((structure) => (structure.services ?? []).map((service) => service.name))
+				structures.flatMap((structure) => {
+					if ((serviceModuleTypeIdsByStructureId.get(structure.structureId)?.length ?? 0) > 0) {
+						return []
+					}
+
+					return (structure.services ?? [])
+						.filter((service) => service.state.trim().toLowerCase() === 'online')
+						.map((service) => service.name)
+				})
 			),
 		]
 
 		try {
 			const universe = getStub<Universe>(this.env.UNIVERSE, 'default')
 			const fuelRules = await withRpcResult(
-				universe.resolveStructureFuelRules(structureTypeIds, serviceNames),
+				universe.resolveStructureFuelRules(structureTypeIds, serviceNames, serviceModuleTypeIds),
 				(result) => ({ ...result })
 			)
 			const modulesByServiceName = new Map<string, UniverseFuelModuleRule>()
+			const modulesByTypeId = new Map<string, UniverseFuelModuleRule>()
 			for (const [serviceName, module] of Object.entries(fuelRules.modulesByServiceName)) {
 				if (module !== null) {
 					modulesByServiceName.set(normalizeUniverseServiceName(serviceName), module)
+				}
+			}
+			for (const [typeId, module] of Object.entries(fuelRules.modulesByTypeId)) {
+				if (module !== null) {
+					modulesByTypeId.set(typeId, module)
 				}
 			}
 
@@ -2946,15 +3010,39 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			}
 
 			for (const structure of structures) {
-				const burnRate = calculateStructureFuelBurnRate(
+				const installedModuleTypeIds =
+					serviceModuleTypeIdsByStructureId.get(structure.structureId) ?? []
+				const fuelResult = calculateStructureFuelBurnRateDetails(
 					structure.services,
 					modulesByServiceName,
-					fuelRules.structureModifiersByTypeId[structure.typeId] ?? []
+					fuelRules.structureModifiersByTypeId[structure.typeId] ?? [],
+					fuelRules.builtInModulesByStructureTypeId[structure.typeId] ?? null,
+					installedModuleTypeIds,
+					modulesByTypeId
 				)
-				fuelBurnRateByStructure.set(
-					structure.structureId,
-					burnRate === null ? null : burnRate.toFixed(4)
-				)
+				if (
+					fuelResult.unresolvedServiceNames.length > 0 ||
+					fuelResult.unresolvedModuleTypeIds.length > 0
+				) {
+					logger.warn(
+						'[EveCorporationData] Some online service modules could not be identified for fuel consumption',
+						{
+							corporationId,
+							structureId: structure.structureId,
+							structureTypeId: structure.typeId,
+							unresolvedServiceNames: fuelResult.unresolvedServiceNames,
+							unresolvedModuleTypeIds: fuelResult.unresolvedModuleTypeIds,
+							installedModuleTypeIds,
+							sdeVersion: fuelRules.sdeVersion,
+						}
+					)
+				}
+				fuelBurnRateByStructure.set(structure.structureId, {
+					fuelBurnRate:
+						fuelResult.fuelBurnRate === null ? null : fuelResult.fuelBurnRate.toFixed(4),
+					unresolvedServiceNames: fuelResult.unresolvedServiceNames,
+					unresolvedModuleTypeIds: fuelResult.unresolvedModuleTypeIds,
+				})
 			}
 		} catch (error) {
 			logger.warn('[EveCorporationData] Failed to resolve deterministic structure fuel rules', {
@@ -2964,6 +3052,110 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		return fuelBurnRateByStructure
+	}
+
+	private async getStructureServiceModuleTypeIds(
+		corporationId: string,
+		structureIds: readonly string[]
+	): Promise<Map<string, string[]>> {
+		if (structureIds.length === 0) {
+			return new Map()
+		}
+
+		const rows = await this.getDb()
+			.select({
+				structureId: corporationAssets.locationId,
+				typeId: corporationAssets.typeId,
+			})
+			.from(corporationAssets)
+			.where(
+				and(
+					eq(corporationAssets.corporationId, corporationId),
+					eq(corporationAssets.locationType, 'item'),
+					inArray(corporationAssets.locationId, [...structureIds]),
+					like(corporationAssets.locationFlag, 'ServiceSlot%')
+				)
+			)
+
+		const typeIdsByStructureId = new Map<string, string[]>()
+		for (const row of rows) {
+			const typeIds = typeIdsByStructureId.get(row.structureId) ?? []
+			if (!typeIds.includes(row.typeId)) {
+				typeIds.push(row.typeId)
+			}
+			typeIdsByStructureId.set(row.structureId, typeIds)
+		}
+
+		return typeIdsByStructureId
+	}
+
+	private async refreshStoredStructureFuelBurnRates(
+		corporationId: string,
+		structureIds?: readonly string[]
+	): Promise<void> {
+		const conditions = [eq(corporationStructures.corporationId, corporationId)]
+		if (structureIds && structureIds.length > 0) {
+			conditions.push(inArray(corporationStructures.structureId, [...structureIds]))
+		}
+		const structures = await this.getDb().query.corporationStructures.findMany({
+			where: and(...conditions),
+			columns: {
+				structureId: true,
+				typeId: true,
+				services: true,
+				fuelBurnRate: true,
+				syncStatus: true,
+				syncFailureReason: true,
+			},
+		})
+		if (structures.length === 0) {
+			return
+		}
+
+		const fuelBurnRateByStructure = await this.resolveStructureFuelBurnRates(
+			corporationId,
+			structures
+		)
+		const rows = [...fuelBurnRateByStructure.entries()]
+		if (rows.length === 0) {
+			return
+		}
+
+		await this.getDb()
+			.update(corporationStructures)
+			.set({
+				fuelBurnRate: sql`case ${corporationStructures.structureId} ${sql.join(
+					rows.map(([structureId, result]) => sql`when ${structureId} then ${result.fuelBurnRate}`),
+					sql` `
+				)} else ${corporationStructures.fuelBurnRate} end`,
+				syncStatus: sql`case ${corporationStructures.structureId} ${sql.join(
+					rows.map(([structureId, result]) => {
+						return result.unresolvedServiceNames.length > 0 ||
+							result.unresolvedModuleTypeIds.length > 0
+							? sql`when ${structureId} then ${'error'}`
+							: sql`when ${structureId} then case when ${corporationStructures.syncFailureReason} = ${STRUCTURE_FUEL_SYNC_FAILURE_REASON} then ${'ok'} else ${corporationStructures.syncStatus} end`
+					}),
+					sql` `
+				)} else ${corporationStructures.syncStatus} end`,
+				syncFailureReason: sql`case ${corporationStructures.structureId} ${sql.join(
+					rows.map(([structureId, result]) => {
+						return result.unresolvedServiceNames.length > 0 ||
+							result.unresolvedModuleTypeIds.length > 0
+							? sql`when ${structureId} then ${STRUCTURE_FUEL_SYNC_FAILURE_REASON}`
+							: sql`when ${structureId} then case when ${corporationStructures.syncFailureReason} = ${STRUCTURE_FUEL_SYNC_FAILURE_REASON} then null else ${corporationStructures.syncFailureReason} end`
+					}),
+					sql` `
+				)} else ${corporationStructures.syncFailureReason} end`,
+			})
+			.where(
+				and(
+					eq(corporationStructures.corporationId, corporationId),
+					inArray(
+						corporationStructures.structureId,
+						rows.map(([structureId]) => structureId)
+					)
+				)
+			)
 	}
 
 	/**
@@ -2997,10 +3189,21 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		for (let i = 0; i < hydratedStructures.length; i += BATCH_SIZE) {
 			const batch = hydratedStructures.slice(i, i + BATCH_SIZE)
-			const batchValues = batch.map((structure) => ({
-				...structure,
-				fuelBurnRate: fuelBurnRateByStructure.get(structure.structureId) ?? null,
-			}))
+			const batchValues = batch.map((structure) => {
+				const fuelResult = fuelBurnRateByStructure.get(structure.structureId)
+				const hasUnresolvedFuelModules =
+					(fuelResult?.unresolvedServiceNames.length ?? 0) > 0 ||
+					(fuelResult?.unresolvedModuleTypeIds.length ?? 0) > 0
+
+				return {
+					...structure,
+					syncStatus: hasUnresolvedFuelModules ? 'error' : structure.syncStatus,
+					syncFailureReason: hasUnresolvedFuelModules
+						? STRUCTURE_FUEL_SYNC_FAILURE_REASON
+						: structure.syncFailureReason,
+					fuelBurnRate: fuelResult?.fuelBurnRate ?? null,
+				}
+			})
 
 			await this.getDb()
 				.insert(corporationStructures)
@@ -3395,6 +3598,19 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		await this.finalizeStructureInventorySnapshot(corporationId, snapshotId, observedAt)
 
+		try {
+			await this.refreshStoredStructureFuelBurnRates(corporationId, [String(structureId)])
+		} catch (error) {
+			logger.warn(
+				'[EveCorporationData] Failed to refresh structure fuel rate after inventory rebuild',
+				{
+					corporationId,
+					structureId: String(structureId),
+					error: error instanceof Error ? error.message : String(error),
+				}
+			)
+		}
+
 		logger.info('[EveCorporationData] Rebuilt structure inventory snapshot from stored assets', {
 			corporationId,
 			structureId: String(structureId),
@@ -3522,7 +3738,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 			if (characterIds.length > 0) {
 				try {
-					const result = await this.env.CORE.addPendingDiscordRefreshesForCharacters(characterIds)
+					const result = await withRpcResult(
+						this.env.CORE.addPendingDiscordRefreshesForCharacters(characterIds),
+						(result) => ({ ...result })
+					)
 					logger.info(
 						'[EveCorporationData] Queued Discord refresh after alliance affiliation change',
 						{
@@ -5610,6 +5829,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		logger.debug('[fetchAndStoreAssets] Pruned stale asset rows after successful sync', {
 			corporationId,
 		})
+		try {
+			await this.refreshStoredStructureFuelBurnRates(corporationId)
+		} catch (error) {
+			logger.warn('[EveCorporationData] Failed to refresh structure fuel rates after asset sync', {
+				corporationId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
 
 		return result.assetsCount
 	}
@@ -6962,7 +7189,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		await Promise.all(
 			directors.map(async (director) => {
 				try {
-					const tokenInfo = await tokenStoreStub.getTokenInfo(director.characterId)
+					const tokenInfo = await withRpcResult(
+						tokenStoreStub.getTokenInfo(director.characterId),
+						(info) => (info ? { isExpired: info.isExpired, scopes: [...info.scopes] } : null)
+					)
 					if (!tokenInfo || tokenInfo.isExpired) {
 						return
 					}

--- a/apps/eve-corporation-data/src/lib/esi-transforms.ts
+++ b/apps/eve-corporation-data/src/lib/esi-transforms.ts
@@ -99,7 +99,10 @@ export function transformAssets(assets: any[]): EsiCorporationAsset[] {
 	}))
 }
 
-export function transformStructures(structures: any[], corporationId: string): EsiCorporationStructure[] {
+export function transformStructures(
+	structures: any[],
+	corporationId: string
+): EsiCorporationStructure[] {
 	return structures.map((structure) => ({
 		structure_id: String(structure.structure_id),
 		corporation_id: String(corporationId),
@@ -114,7 +117,9 @@ export function transformStructures(structures: any[], corporationId: string): E
 		state_timer_end: structure.state_timer_end,
 		state_timer_start: structure.state_timer_start,
 		unanchors_at: structure.unanchors_at,
-		services: structure.services,
+		services: structure.services?.map((service: { name: string; state: string }) => ({
+			...service,
+		})),
 	}))
 }
 
@@ -157,9 +162,7 @@ export function transformContracts(contracts: any[]): EsiCorporationContract[] {
 		issuer_id: String(contract.issuer_id),
 		price: contract.price,
 		reward: contract.reward,
-		start_location_id: contract.start_location_id
-			? String(contract.start_location_id)
-			: undefined,
+		start_location_id: contract.start_location_id ? String(contract.start_location_id) : undefined,
 		status: contract.status,
 		title: contract.title,
 		type: contract.type,

--- a/apps/eve-corporation-data/src/scripts/diagnose-structure-services.ts
+++ b/apps/eve-corporation-data/src/scripts/diagnose-structure-services.ts
@@ -1,0 +1,316 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_COMPATIBILITY_DATE = '2026-05-19'
+const EVE_OAUTH_METADATA_URL = 'https://login.eveonline.com/.well-known/oauth-authorization-server'
+const ESI_BASE_URL = 'https://esi.evetech.net'
+const USER_AGENT = 'eve-corporation-data-structure-service-diagnostics/1.0'
+
+type OAuthMetadata = {
+	token_endpoint: string
+}
+
+type RawStructureService = {
+	name?: unknown
+	state?: unknown
+	[key: string]: unknown
+}
+
+type RawCorporationStructure = {
+	structure_id?: unknown
+	type_id?: unknown
+	services?: unknown
+	[key: string]: unknown
+}
+
+type RawCorporationAsset = {
+	item_id?: unknown
+	location_flag?: unknown
+	location_id?: unknown
+	location_type?: unknown
+	type_id?: unknown
+	[key: string]: unknown
+}
+
+function loadEnvFile(): void {
+	const envPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../.env')
+
+	try {
+		for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+			const trimmed = line.trim()
+			if (!trimmed || trimmed.startsWith('#')) continue
+
+			const match = trimmed.match(/^([^=]+)=(.*)$/)
+			if (!match) continue
+
+			const key = match[1].trim()
+			let value = match[2].trim()
+			if (
+				(value.startsWith('"') && value.endsWith('"')) ||
+				(value.startsWith("'") && value.endsWith("'"))
+			) {
+				value = value.slice(1, -1)
+			} else {
+				const commentIndex = value.indexOf(' #')
+				if (commentIndex !== -1) value = value.slice(0, commentIndex).trimEnd()
+			}
+			process.env[key] = value
+		}
+	} catch {
+		// The environment may already be populated by the shell.
+	}
+}
+
+function parseArgs(): {
+	corporationId: string
+	compatibilityDate: string
+	includeAssets: boolean
+} {
+	const args = process.argv.slice(2)
+	let corporationId: string | undefined
+	let compatibilityDate = DEFAULT_COMPATIBILITY_DATE
+	let includeAssets = false
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index]
+		if (arg === '--corp' || arg === '--corporation-id') {
+			corporationId = args[++index]
+		} else if (arg === '--compatibility-date') {
+			compatibilityDate = args[++index] ?? compatibilityDate
+		} else if (arg === '--assets') {
+			includeAssets = true
+		} else if (arg === '--help' || arg === '-h') {
+			console.log(
+				'Usage: pnpm -F eve-corporation-data diagnose-structure-services --corp <id> [options]'
+			)
+			console.log('')
+			console.log('Options:')
+			console.log('  --corp, --corporation-id <id>  Corporation ID to inspect')
+			console.log('  --compatibility-date <date>    ESI compatibility date override')
+			console.log('  --assets                       Inspect ServiceSlot asset rows as well')
+			console.log('')
+			console.log('Environment:')
+			console.log('  DIAGNOSTIC_EVE_SSO_REFRESH_TOKEN')
+			console.log('  DIAGNOSTIC_EVE_SSO_CLIENT_ID')
+			console.log('  DIAGNOSTIC_EVE_SSO_CLIENT_SECRET')
+			process.exit(0)
+		} else {
+			throw new Error(`Unknown argument: ${arg}`)
+		}
+	}
+
+	if (!corporationId) throw new Error('Missing required --corp/--corporation-id value')
+	return { corporationId, compatibilityDate, includeAssets }
+}
+
+function getRequiredEnv(name: string): string {
+	const value = process.env[name]?.trim()
+	if (!value) throw new Error(`Missing ${name}`)
+	return value
+}
+
+async function fetchJson<T>(
+	url: string,
+	init: RequestInit,
+	label: string
+): Promise<{
+	data: T
+	headers: Headers
+}> {
+	const response = await fetch(url, init)
+	if (!response.ok) {
+		throw new Error(
+			`${label} failed: ${response.status} ${response.statusText} - ${await response.text()}`
+		)
+	}
+
+	return { data: (await response.json()) as T, headers: response.headers }
+}
+
+async function refreshAccessToken(): Promise<string> {
+	const metadata = await fetchJson<OAuthMetadata>(
+		EVE_OAUTH_METADATA_URL,
+		{ headers: { accept: 'application/json', 'User-Agent': USER_AGENT } },
+		'GET /.well-known/oauth-authorization-server'
+	)
+	const clientId = getRequiredEnv('DIAGNOSTIC_EVE_SSO_CLIENT_ID')
+	const clientSecret = getRequiredEnv('DIAGNOSTIC_EVE_SSO_CLIENT_SECRET')
+	const refreshToken = getRequiredEnv('DIAGNOSTIC_EVE_SSO_REFRESH_TOKEN')
+	const credentials = btoa(`${clientId}:${clientSecret}`)
+	const response = await fetch(metadata.data.token_endpoint, {
+		method: 'POST',
+		headers: {
+			Authorization: `Basic ${credentials}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'User-Agent': USER_AGENT,
+		},
+		body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: refreshToken }),
+	})
+	if (!response.ok) {
+		throw new Error(`Refresh token exchange failed: ${response.status} ${response.statusText}`)
+	}
+
+	const body = (await response.json()) as { access_token?: string }
+	if (!body.access_token) throw new Error('Refresh token exchange did not return an access token')
+	return body.access_token
+}
+
+async function fetchCorporationStructures(
+	corporationId: string,
+	accessToken: string,
+	compatibilityDate: string
+): Promise<RawCorporationStructure[]> {
+	const headers = {
+		Authorization: `Bearer ${accessToken}`,
+		'User-Agent': USER_AGENT,
+		'X-Compatibility-Date': compatibilityDate,
+	}
+	const structures: RawCorporationStructure[] = []
+	const firstPage = await fetchJson<RawCorporationStructure[]>(
+		`${ESI_BASE_URL}/corporations/${corporationId}/structures/?page=1`,
+		{ headers },
+		'GET /corporations/{corporation_id}/structures/?page=1'
+	)
+	structures.push(...firstPage.data)
+
+	const totalPages = Number(firstPage.headers.get('X-Pages') ?? '1')
+	for (let page = 2; page <= totalPages; page += 1) {
+		const result = await fetchJson<RawCorporationStructure[]>(
+			`${ESI_BASE_URL}/corporations/${corporationId}/structures/?page=${page}`,
+			{ headers },
+			`GET /corporations/{corporation_id}/structures/?page=${page}`
+		)
+		structures.push(...result.data)
+	}
+
+	return structures
+}
+
+async function fetchCorporationAssets(
+	corporationId: string,
+	accessToken: string,
+	compatibilityDate: string
+): Promise<RawCorporationAsset[]> {
+	const headers = {
+		Authorization: `Bearer ${accessToken}`,
+		'User-Agent': USER_AGENT,
+		'X-Compatibility-Date': compatibilityDate,
+	}
+	const assets: RawCorporationAsset[] = []
+	const firstPage = await fetchJson<RawCorporationAsset[]>(
+		`${ESI_BASE_URL}/corporations/${corporationId}/assets/?page=1`,
+		{ headers },
+		'GET /corporations/{corporation_id}/assets/?page=1'
+	)
+	assets.push(...firstPage.data)
+
+	const totalPages = Number(firstPage.headers.get('X-Pages') ?? '1')
+	for (let page = 2; page <= totalPages; page += 1) {
+		const result = await fetchJson<RawCorporationAsset[]>(
+			`${ESI_BASE_URL}/corporations/${corporationId}/assets/?page=${page}`,
+			{ headers },
+			`GET /corporations/{corporation_id}/assets/?page=${page}`
+		)
+		assets.push(...result.data)
+	}
+
+	return assets
+}
+
+function printPayloadShape(structures: readonly RawCorporationStructure[]): void {
+	const serviceEntries = structures.flatMap((structure) =>
+		Array.isArray(structure.services) ? structure.services : []
+	)
+	const services = serviceEntries.filter(
+		(service): service is RawStructureService => typeof service === 'object' && service !== null
+	)
+	const serviceNames = new Map<string, number>()
+	for (const service of services) {
+		const name = typeof service.name === 'string' ? service.name : '<missing name>'
+		serviceNames.set(name, (serviceNames.get(name) ?? 0) + 1)
+	}
+	const serviceKeys = [...new Set(services.flatMap((service) => Object.keys(service)))].sort()
+	const structuresWithTypeIds = structures.filter(
+		(structure) => structure.type_id !== undefined
+	).length
+	const servicesWithTypeIds = services.filter((service) => service.type_id !== undefined).length
+
+	console.log(`Structures: ${structures.length}`)
+	console.log(`Structures with top-level type_id: ${structuresWithTypeIds}`)
+	console.log(`Service entries: ${services.length}`)
+	console.log(`Service object keys: ${serviceKeys.join(', ') || '<none>'}`)
+	console.log(`Service entries with type_id: ${servicesWithTypeIds}`)
+	console.log('Service names:')
+	for (const [name, count] of [...serviceNames.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+		console.log(`  ${count}x ${name}`)
+	}
+
+	console.log('Sample structure service payloads:')
+	for (const structure of structures.slice(0, 10)) {
+		console.log(
+			JSON.stringify({
+				structure_id: structure.structure_id,
+				type_id: structure.type_id,
+				services: structure.services,
+			})
+		)
+	}
+}
+
+function printServiceSlotAssets(
+	structures: readonly RawCorporationStructure[],
+	assets: readonly RawCorporationAsset[]
+): void {
+	const structureIds = new Set(
+		structures
+			.map((structure) => structure.structure_id)
+			.filter(
+				(structureId): structureId is string | number =>
+					typeof structureId === 'string' || typeof structureId === 'number'
+			)
+			.map(String)
+	)
+	const serviceSlotAssets = assets.filter(
+		(asset) =>
+			typeof asset.location_flag === 'string' &&
+			asset.location_flag.startsWith('ServiceSlot') &&
+			asset.location_type === 'item' &&
+			structureIds.has(String(asset.location_id))
+	)
+
+	console.log(`Assets: ${assets.length}`)
+	console.log(`ServiceSlot assets on listed structures: ${serviceSlotAssets.length}`)
+	console.log('ServiceSlot asset payloads:')
+	for (const asset of serviceSlotAssets) {
+		console.log(
+			JSON.stringify({
+				item_id: asset.item_id,
+				location_flag: asset.location_flag,
+				location_id: asset.location_id,
+				location_type: asset.location_type,
+				type_id: asset.type_id,
+			})
+		)
+	}
+}
+
+async function main(): Promise<void> {
+	loadEnvFile()
+	const { corporationId, compatibilityDate, includeAssets } = parseArgs()
+	const accessToken = await refreshAccessToken()
+	const structures = await fetchCorporationStructures(corporationId, accessToken, compatibilityDate)
+	printPayloadShape(structures)
+	if (includeAssets) {
+		const assets = await fetchCorporationAssets(corporationId, accessToken, compatibilityDate)
+		printServiceSlotAssets(structures, assets)
+	}
+}
+
+main().catch((error) => {
+	console.error(
+		'Structure service diagnostic failed:',
+		error instanceof Error ? error.message : String(error)
+	)
+	process.exitCode = 1
+})

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -56,6 +56,18 @@ const SOVEREIGNTY_HUB_DETAIL_BATCH_SIZE = 4
 const SKYHOOK_DETAIL_BATCH_SIZE = 4
 const MAX_WALLET_TRANSACTION_PAGES = 100
 
+function detachRpcValue<T>(value: T): T {
+	if (Array.isArray(value)) {
+		return value.map((entry) => detachRpcValue(entry)) as T
+	}
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, entry]) => [key, detachRpcValue(entry)])
+		) as T
+	}
+	return value
+}
+
 function compareNumericStrings(left: string, right: string): number {
 	try {
 		const leftBigInt = BigInt(left)
@@ -504,10 +516,11 @@ export async function fetchSovereigntySystems(
 
 	try {
 		return response.data.solar_systems.map((system) => {
-			if ('alliance' in system.claim) {
-				const claim = system.claim.alliance
+			const detachedSystem = detachRpcValue(system)
+			if ('alliance' in detachedSystem.claim) {
+				const claim = detachedSystem.claim.alliance
 				return {
-					system_id: String(system.solar_system_id),
+					system_id: String(detachedSystem.solar_system_id),
 					claim_type: 'alliance' as const,
 					alliance_id: String(claim.alliance_id),
 					corporation_id: String(claim.corporation_id),
@@ -519,23 +532,23 @@ export async function fetchSovereigntySystems(
 					military_level: claim.development.military_level,
 					industrial_level: claim.development.industrial_level,
 					strategic_level: claim.development.strategic_level,
-					raw: system as Record<string, unknown>,
+					raw: detachedSystem as Record<string, unknown>,
 				}
 			}
 
-			if ('faction' in system.claim) {
+			if ('faction' in detachedSystem.claim) {
 				return {
-					system_id: String(system.solar_system_id),
+					system_id: String(detachedSystem.solar_system_id),
 					claim_type: 'faction' as const,
-					faction_id: String(system.claim.faction.faction_id),
-					raw: system as Record<string, unknown>,
+					faction_id: String(detachedSystem.claim.faction.faction_id),
+					raw: detachedSystem as Record<string, unknown>,
 				}
 			}
 
 			return {
-				system_id: String(system.solar_system_id),
+				system_id: String(detachedSystem.solar_system_id),
 				claim_type: 'unclaimed' as const,
-				raw: system as Record<string, unknown>,
+				raw: detachedSystem as Record<string, unknown>,
 			}
 		})
 	} finally {
@@ -666,7 +679,7 @@ export async function fetchSovereigntyHubs(
 					{ cacheMode: 'no-store' }
 				)
 				try {
-					const detail = detailResult.data
+					const detail = detachRpcValue(detailResult.data)
 
 					return {
 						structure_id: String(detail.id),
@@ -827,7 +840,7 @@ export async function fetchCorporationSkyhooks(
 				)
 
 				try {
-					const detail = detailResult.data
+					const detail = detachRpcValue(detailResult.data)
 					const theftVulnerability = detail.theft_vulnerability ?? null
 
 					return {
@@ -930,14 +943,17 @@ export async function fetchCorporationMiningExtractions(
 	)
 
 	try {
-		return result.data.map((extraction) => ({
-			structure_id: String(extraction.structure_id),
-			moon_id: String(extraction.moon_id),
-			extraction_start_time: extraction.extraction_start_time,
-			chunk_arrival_time: extraction.chunk_arrival_time,
-			natural_decay_time: extraction.natural_decay_time,
-			raw: extraction as Record<string, unknown>,
-		}))
+		return result.data.map((extraction) => {
+			const detachedExtraction = detachRpcValue(extraction)
+			return {
+				structure_id: String(detachedExtraction.structure_id),
+				moon_id: String(detachedExtraction.moon_id),
+				extraction_start_time: detachedExtraction.extraction_start_time,
+				chunk_arrival_time: detachedExtraction.chunk_arrival_time,
+				natural_decay_time: detachedExtraction.natural_decay_time,
+				raw: detachedExtraction as Record<string, unknown>,
+			}
+		})
 	} finally {
 		disposeRpcResult(result)
 	}

--- a/apps/eve-corporation-data/src/services/structure-fuel-calculation.ts
+++ b/apps/eve-corporation-data/src/services/structure-fuel-calculation.ts
@@ -1,4 +1,4 @@
-import { normalizeUniverseServiceName } from '@repo/universe'
+import { resolveUniverseFuelModuleRule } from '@repo/universe'
 
 import type { UniverseFuelModuleRule, UniverseStructureFuelModifier } from '@repo/universe'
 
@@ -7,29 +7,33 @@ export interface StructureFuelService {
 	state: string
 }
 
-export function calculateStructureFuelBurnRate(
+export interface StructureFuelBurnRateResult {
+	fuelBurnRate: number | null
+	unresolvedServiceNames: string[]
+	unresolvedModuleTypeIds: string[]
+}
+
+export function calculateStructureFuelBurnRateDetails(
 	services: readonly StructureFuelService[] | null,
 	modulesByServiceName: ReadonlyMap<string, UniverseFuelModuleRule>,
-	modifiers: readonly UniverseStructureFuelModifier[]
-): number | null {
-	if (services === null) {
-		return null
-	}
-
-	if (services.length === 0) {
-		return 0
-	}
-
+	modifiers: readonly UniverseStructureFuelModifier[],
+	builtInModule: UniverseFuelModuleRule | null = null,
+	installedModuleTypeIds: readonly string[] = [],
+	modulesByTypeId: ReadonlyMap<string, UniverseFuelModuleRule> = new Map()
+): StructureFuelBurnRateResult {
 	let totalFuelUnitsPerHour = 0
-	for (const service of services) {
-		if (service.state.trim().toLowerCase() !== 'online') {
-			continue
+	let onlineServiceCount = 0
+	let resolvedServiceCount = 0
+	const countedModuleTypeIds = new Set<string>()
+	const unresolvedServiceNames = new Set<string>()
+	const unresolvedModuleTypeIds = new Set<string>()
+	const hasInstalledModuleSnapshot = installedModuleTypeIds.length > 0
+	const addModule = (module: UniverseFuelModuleRule): void => {
+		if (countedModuleTypeIds.has(module.typeId)) {
+			return
 		}
-
-		const module = modulesByServiceName.get(normalizeUniverseServiceName(service.name))
-		if (!module) {
-			return null
-		}
+		countedModuleTypeIds.add(module.typeId)
+		resolvedServiceCount += 1
 
 		const modifier = modifiers.find(
 			(candidate) => candidate.serviceGroupId === module.serviceGroupId
@@ -38,5 +42,72 @@ export function calculateStructureFuelBurnRate(
 		totalFuelUnitsPerHour += module.fuelUnitsPerHour * multiplier
 	}
 
-	return totalFuelUnitsPerHour
+	if (hasInstalledModuleSnapshot) {
+		for (const typeId of installedModuleTypeIds) {
+			const module = modulesByTypeId.get(typeId)
+			if (module) {
+				addModule(module)
+			} else {
+				unresolvedModuleTypeIds.add(typeId)
+			}
+		}
+		if (builtInModule) {
+			addModule(builtInModule)
+		}
+
+		return {
+			fuelBurnRate: resolvedServiceCount > 0 ? totalFuelUnitsPerHour : null,
+			unresolvedServiceNames: [],
+			unresolvedModuleTypeIds: [...unresolvedModuleTypeIds],
+		}
+	}
+
+	if (services === null) {
+		return { fuelBurnRate: null, unresolvedServiceNames: [], unresolvedModuleTypeIds: [] }
+	}
+
+	if (services.length === 0) {
+		return { fuelBurnRate: 0, unresolvedServiceNames: [], unresolvedModuleTypeIds: [] }
+	}
+
+	for (const service of services) {
+		if (service.state.trim().toLowerCase() !== 'online') {
+			continue
+		}
+		onlineServiceCount += 1
+
+		const resolvedModule = resolveUniverseFuelModuleRule(service.name, modulesByServiceName)
+		const fallbackModule = resolvedModule ?? builtInModule
+		const module = fallbackModule
+		if (!module) {
+			unresolvedServiceNames.add(service.name)
+			continue
+		}
+		addModule(module)
+	}
+
+	return {
+		fuelBurnRate:
+			onlineServiceCount === 0 ? 0 : resolvedServiceCount > 0 ? totalFuelUnitsPerHour : null,
+		unresolvedServiceNames: [...unresolvedServiceNames],
+		unresolvedModuleTypeIds: [],
+	}
+}
+
+export function calculateStructureFuelBurnRate(
+	services: readonly StructureFuelService[] | null,
+	modulesByServiceName: ReadonlyMap<string, UniverseFuelModuleRule>,
+	modifiers: readonly UniverseStructureFuelModifier[],
+	builtInModule: UniverseFuelModuleRule | null = null,
+	installedModuleTypeIds: readonly string[] = [],
+	modulesByTypeId: ReadonlyMap<string, UniverseFuelModuleRule> = new Map()
+): number | null {
+	return calculateStructureFuelBurnRateDetails(
+		services,
+		modulesByServiceName,
+		modifiers,
+		builtInModule,
+		installedModuleTypeIds,
+		modulesByTypeId
+	).fuelBurnRate
 }

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.structure-enrichment.test.ts
@@ -58,6 +58,43 @@ describe('esi structure enrichment ownership handling', () => {
 		expect(systems).toEqual([])
 	})
 
+	it('detaches nested sovereignty data before disposing the RPC response', async () => {
+		const system = {
+			solar_system_id: 30000142,
+			claim: {
+				alliance: {
+					alliance_id: 99000001,
+					corporation_id: 98000001,
+					claimed_since: '2026-07-01T00:00:00.000Z',
+					is_capital_system: false,
+					sovereignty_hub: { id: 81001 },
+					development: {
+						activity_defense_multiplier: 1,
+						military_level: 3,
+						industrial_level: 2,
+						strategic_level: 1,
+					},
+				},
+			},
+		}
+		const response = {
+			data: { solar_systems: [system] },
+			[Symbol.dispose]: vi.fn(() => {
+				Object.assign(system, { claim: { unclaimed: true } })
+			}),
+		}
+		const tokenStore = {
+			fetchPublicEsi: vi.fn().mockResolvedValue(response),
+		}
+
+		const systems = await fetchSovereigntySystems(tokenStore as never)
+
+		expect(response[Symbol.dispose]).toHaveBeenCalledOnce()
+		expect((systems[0] as unknown as { raw: Record<string, unknown> }).raw).toMatchObject({
+			claim: { alliance: { alliance_id: 99000001 } },
+		})
+	})
+
 	it('fetches skyhook detail from the corp skyhook endpoints and maps the requesting corporation id', async () => {
 		const tokenStore = {
 			fetchEsi: vi

--- a/apps/eve-corporation-data/src/test/unit/services/structure-fuel-calculation.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-fuel-calculation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { calculateStructureFuelBurnRate } from '../../../services/structure-fuel-calculation'
+import { resolveUniverseFuelModuleRule } from '@repo/universe'
+
+import {
+	calculateStructureFuelBurnRate,
+	calculateStructureFuelBurnRateDetails,
+} from '../../../services/structure-fuel-calculation'
 
 const modules = new Map([
 	[
@@ -43,6 +48,33 @@ const modulesWithEsiCasing = new Map([
 		},
 	],
 ])
+
+const aliasedModules = new Map(
+	[
+		['standup biochemical reactor i', '45539'],
+		['standup capital shipyard i', '35881'],
+		['standup cloning center i', '35894'],
+		['standup composite reactor i', '45537'],
+		['standup conduit generator i', '35913'],
+		['standup cynosural field generator i', '35912'],
+		['standup cynosural system jammer i', '35914'],
+		['standup hybrid reactor i', '45538'],
+		['standup invention lab i', '35886'],
+		['standup metenox moon drill', '82941'],
+		['standup manufacturing plant i', '35878'],
+		['standup moon drill i', '45009'],
+		['standup reprocessing facility i', '35899'],
+		['standup research lab i', '35891'],
+	].map(([typeName, typeId]) => [
+		typeName,
+		{
+			typeId,
+			typeName,
+			serviceGroupId: '1321',
+			fuelUnitsPerHour: 10,
+		},
+	])
+)
 
 describe('calculateStructureFuelBurnRate', () => {
 	it('applies the matching structure service-group discount', () => {
@@ -90,14 +122,174 @@ describe('calculateStructureFuelBurnRate', () => {
 		).toBe(52)
 	})
 
+	it('counts one research module once when ESI reports multiple capabilities', () => {
+		expect(
+			calculateStructureFuelBurnRate(
+				[
+					{ name: 'Material Efficiency Research', state: 'online' },
+					{ name: 'Blueprint Copying', state: 'online' },
+					{ name: 'Time Efficiency Research', state: 'online' },
+				],
+				aliasedModules,
+				[]
+			)
+		).toBe(10)
+	})
+
 	it('fails closed when an online service is unknown', () => {
 		expect(
 			calculateStructureFuelBurnRate([{ name: 'Unknown Service', state: 'online' }], modules, [])
 		).toBeNull()
 	})
 
+	it('reports the identifiable rate while retaining unresolved online services', () => {
+		expect(
+			calculateStructureFuelBurnRateDetails(
+				[
+					{ name: 'Standup Market Hub I', state: 'online' },
+					{ name: 'Unknown Service', state: 'online' },
+				],
+				modules,
+				[]
+			)
+		).toEqual({
+			fuelBurnRate: 40,
+			unresolvedServiceNames: ['Unknown Service'],
+			unresolvedModuleTypeIds: [],
+		})
+	})
+
 	it('distinguishes an unknown service list from an empty online service list', () => {
 		expect(calculateStructureFuelBurnRate(null, modules, [])).toBeNull()
 		expect(calculateStructureFuelBurnRate([], modules, [])).toBe(0)
+	})
+
+	it('resolves ESI service labels to their SDE service modules', () => {
+		const expected = [
+			['Composite Reactions', '45537'],
+			['Reprocessing', '35899'],
+			['Material Efficiency Research', '35891'],
+			['Blueprint Copying', '35891'],
+			['Time Efficiency Research', '35891'],
+			['Automatic Moon Drilling', '82941'],
+			['Manufacturing (Standard)', '35878'],
+			['Biochemical Reactions', '45539'],
+			['Invention', '35886'],
+			['Clone Bay', '35894'],
+			['Manufacturing (Capitals)', '35881'],
+			['Moon Drilling', '45009'],
+			['Hybrid Reactions', '45538'],
+			['Jump Access', '35913'],
+			['Cynosural Field Generation', '35912'],
+			['Cynosural System Jammer', '35914'],
+		] as const
+
+		for (const [serviceName, typeId] of expected) {
+			expect(resolveUniverseFuelModuleRule(serviceName, aliasedModules)?.typeId).toBe(typeId)
+		}
+	})
+
+	it('uses the SDE-resolved built-in module when ESI only provides a service label', () => {
+		const builtInModule = {
+			typeId: '35913',
+			typeName: 'Standup Conduit Generator I',
+			serviceGroupId: '1321',
+			fuelUnitsPerHour: 30,
+		}
+
+		expect(
+			calculateStructureFuelBurnRate(
+				[{ name: 'Jump Access', state: 'online' }],
+				new Map(),
+				[],
+				builtInModule
+			)
+		).toBe(30)
+	})
+
+	it('retains a built-in module when fitted asset rows contain other modules', () => {
+		const builtInModule = {
+			typeId: '35913',
+			typeName: 'Standup Conduit Generator I',
+			serviceGroupId: '1321',
+			fuelUnitsPerHour: 30,
+		}
+
+		expect(
+			calculateStructureFuelBurnRate(
+				[{ name: 'Jump Access', state: 'online' }],
+				new Map(),
+				[],
+				builtInModule,
+				['35892'],
+				new Map([
+					[
+						'35892',
+						{
+							typeId: '35892',
+							typeName: 'Standup Market Hub I',
+							serviceGroupId: '1321',
+							fuelUnitsPerHour: 40,
+						},
+					],
+				])
+			)
+		).toBe(70)
+	})
+
+	it('uses concrete installed asset modules even when an ESI label is not aliased', () => {
+		const installedModule = {
+			typeId: '35892',
+			typeName: 'Standup Market Hub I',
+			serviceGroupId: '1321',
+			fuelUnitsPerHour: 55,
+		}
+
+		expect(
+			calculateStructureFuelBurnRate(
+				[{ name: 'Unmapped ESI Service', state: 'online' }],
+				modules,
+				[],
+				null,
+				[installedModule.typeId],
+				new Map([[installedModule.typeId, installedModule]])
+			)
+		).toBe(55)
+	})
+
+	it('uses all resolved concrete asset modules without requiring an alias match', () => {
+		expect(
+			calculateStructureFuelBurnRate(
+				[{ name: 'Market', state: 'online' }],
+				modules,
+				[],
+				null,
+				['45999'],
+				new Map([
+					[
+						'45999',
+						{
+							typeId: '45999',
+							typeName: 'Unrelated Service Module',
+							serviceGroupId: '1321',
+							fuelUnitsPerHour: 55,
+						},
+					],
+				])
+			)
+		).toBe(55)
+	})
+
+	it('fails closed when an installed asset type is missing from the SDE cache', () => {
+		expect(
+			calculateStructureFuelBurnRate(
+				[{ name: 'Market', state: 'online' }],
+				modules,
+				[],
+				null,
+				['unknown-service-module'],
+				new Map()
+			)
+		).toBeNull()
 	})
 })

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -388,6 +388,7 @@ interface StructureTabData {
 
 export interface StructureDetailResult extends Omit<StructureListItem, 'canViewDetails'> {
 	includeInStructureAssetSync: boolean
+	assetsLastSync: string | null
 	canViewSensitive: boolean
 	canEdit: boolean
 	services: Array<{
@@ -1229,6 +1230,22 @@ async function loadStructureFittingDetailData(
 	}
 }
 
+async function loadCorporationAssetsLastSync(
+	env: Env,
+	corporationId: string
+): Promise<Date | null> {
+	try {
+		const corpData = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, corporationId)
+		return (await corpData.getCorporationSyncConfig(corporationId))?.assetsLastSync ?? null
+	} catch (error) {
+		logger.warn('[Structures] Failed to load corporation asset sync timestamp', {
+			corporationId,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return null
+	}
+}
+
 export async function assertStructureGroupConfigured(
 	db: DbClient<DbSchema>,
 	groupId: string
@@ -1586,6 +1603,7 @@ interface StructureContext {
 	structure: StructureSourceRecord
 	corporationName: string
 	includeInStructureAssetSync: boolean
+	assetsLastSync: Date | null
 	config: typeof structureConfigs.$inferSelect | null
 	canViewDetails: boolean
 	canViewSensitive: boolean
@@ -1606,6 +1624,7 @@ function buildStructureDetailResult(context: StructureContext): StructureDetailR
 	return {
 		...structure,
 		includeInStructureAssetSync: context.includeInStructureAssetSync,
+		assetsLastSync: toIso(context.assetsLastSync),
 		canViewSensitive: context.canViewSensitive,
 		canEdit: context.canEdit,
 		fuelBurnRate: context.structure.fuelBurnRate ?? null,
@@ -1710,11 +1729,13 @@ async function getStructureContext(
 			loadStructureInventoryDetailData(db, syntheticStructure),
 			loadStructureFittingDetailData(env, syntheticStructure),
 		])
+		const assetsLastSync = await loadCorporationAssetsLastSync(env, sovereigntyHub.corporationId)
 
 		return {
 			structure: syntheticStructure,
 			corporationName: corporation?.name ?? sovereigntyHub.corporationId,
 			includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
+			assetsLastSync,
 			config: null,
 			canViewDetails,
 			canViewSensitive,
@@ -1756,16 +1777,18 @@ async function getStructureContext(
 		return null
 	}
 
-	const [tabData, inventoryBays, fittingItems] = await Promise.all([
+	const [tabData, inventoryBays, fittingItems, assetsLastSync] = await Promise.all([
 		loadStructureTabDetailData(db, structure),
 		loadStructureInventoryDetailData(db, structure),
 		loadStructureFittingDetailData(env, structure),
+		loadCorporationAssetsLastSync(env, structure.corporationId),
 	])
 
 	return {
 		structure,
 		corporationName: corporation?.name ?? structure.corporationId,
 		includeInStructureAssetSync: corporation?.includeInStructureAssetSync ?? false,
+		assetsLastSync,
 		config: config ?? null,
 		canViewDetails,
 		canViewSensitive,
@@ -3278,6 +3301,7 @@ async function loadSovereigntyPageItems(
 			structure,
 			corporationName: row.corporationName ?? row.corporationId,
 			includeInStructureAssetSync: row.includeInStructureAssetSync ?? false,
+			assetsLastSync: null,
 			config: null,
 			canViewDetails,
 			canViewSensitive,

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -1013,6 +1013,7 @@ export interface StructureFittingItem {
 
 export interface StructureDetailResult extends Omit<StructureListItem, 'canViewDetails'> {
 	includeInStructureAssetSync: boolean
+	assetsLastSync: string | null
 	canViewSensitive: boolean
 	canEdit: boolean
 	services: Array<{

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -36,6 +36,7 @@ import { Container } from '@/components/ui/container'
 import { DurationDisplay } from '@/components/ui/duration-display'
 import { EveTimeDisplay } from '@/components/ui/eve-time-display'
 import { FilterField } from '@/components/ui/filter-field'
+import { HoverPopover } from '@/components/ui/hover-popover'
 import { LoadingPage } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
 import { Progress } from '@/components/ui/progress'
@@ -1261,7 +1262,25 @@ export default function StructuresDetailPage() {
 								<div className="rounded-lg border border-border/60 p-4">
 									<div className="mb-3 flex flex-wrap items-center gap-2">
 										{!hasSovereigntySummary && structure.includeInStructureAssetSync && (
-											<Badge variant="success">Asset Sync Enabled</Badge>
+											<HoverPopover
+												align="start"
+												side="top"
+												className="w-80 space-y-2"
+												trigger={
+													<span className="inline-flex cursor-help">
+														<Badge variant="success">Asset Sync Enabled</Badge>
+													</span>
+												}
+											>
+												<div className="space-y-1">
+													<div className="text-sm font-medium">Asset Sync</div>
+													<div className="text-sm text-muted-foreground">
+														{structure.assetsLastSync
+															? `Last successful asset sync at ${formatDateTimeLong(structure.assetsLastSync)}.`
+															: 'No successful asset sync has been recorded.'}
+													</div>
+												</div>
+											</HoverPopover>
 										)}
 										<div className="mt-0.5">
 											<StructureSyncStatusBadge

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -1913,7 +1913,7 @@ export default function StructuresPage() {
 									<Button
 										variant="ghost"
 										size="sm"
-										className="ml-auto h-7 shrink-0 px-2 text-xs"
+										className="ml-3 h-7 shrink-0 px-2 text-xs"
 										onPointerDown={(event) => {
 											event.preventDefault()
 											event.stopPropagation()
@@ -1927,7 +1927,7 @@ export default function StructuresPage() {
 										Clear Filters
 									</Button>
 								)}
-								<span className="ml-2 hidden text-xs font-normal text-muted-foreground sm:inline">
+								<span className="ml-auto mr-3 hidden text-xs font-normal text-muted-foreground sm:inline">
 									Click to {areFiltersOpen ? 'hide' : 'show'}
 								</span>
 							</AccordionTrigger>

--- a/apps/universe/src/durable-object.ts
+++ b/apps/universe/src/durable-object.ts
@@ -13,6 +13,7 @@ import {
 	MOON_BASE_MINERAL_TYPE_IDS,
 	MOON_GOO_TYPE_IDS,
 	normalizeUniverseServiceName,
+	resolveUniverseFuelModuleRule,
 	selectNearestMoonByPosition,
 	UniverseMoonResourceSchema,
 	UniverseMoonSchema,
@@ -90,6 +91,8 @@ type StructureFuelRuleCache = {
 	expiresAt: number
 	sdeVersion: string | null
 	modulesByServiceName: Map<string, UniverseFuelModuleRule>
+	modulesByTypeId: Map<string, UniverseFuelModuleRule>
+	builtInModulesByStructureTypeId: Map<string, UniverseFuelModuleRule | null>
 	structureModifiersByTypeId: Map<string, UniverseStructureFuelModifier[]>
 }
 
@@ -212,8 +215,16 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 			.where(gt(sql`cast(${fuelAmountAttributes.value} as double precision)`, 0))
 
 		const modulesByServiceName = new Map<string, UniverseFuelModuleRule>()
+		const modulesByTypeId = new Map<string, UniverseFuelModuleRule>()
 		const ambiguousServiceNames = new Set<string>()
 		for (const row of moduleRows) {
+			const module = {
+				typeId: row.typeId,
+				typeName: row.typeName,
+				serviceGroupId: row.serviceGroupId,
+				fuelUnitsPerHour: Number(row.fuelUnitsPerHour),
+			}
+			modulesByTypeId.set(row.typeId, module)
 			const name = normalizeUniverseServiceName(row.typeName)
 			if (ambiguousServiceNames.has(name)) {
 				continue
@@ -227,12 +238,22 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 				})
 				continue
 			}
-			modulesByServiceName.set(name, {
-				typeId: row.typeId,
-				typeName: row.typeName,
-				serviceGroupId: row.serviceGroupId,
-				fuelUnitsPerHour: Number(row.fuelUnitsPerHour),
+			modulesByServiceName.set(name, module)
+		}
+
+		const builtInModuleRows = await this.db
+			.select({
+				structureTypeId: universeTypeDogmaAttributes.typeId,
+				moduleTypeId: universeTypeDogmaAttributes.value,
 			})
+			.from(universeTypeDogmaAttributes)
+			.where(eq(universeTypeDogmaAttributes.attributeId, '2792'))
+		const builtInModulesByStructureTypeId = new Map<string, UniverseFuelModuleRule | null>()
+		for (const row of builtInModuleRows) {
+			const module = modulesByTypeId.get(row.moduleTypeId)
+			if (module) {
+				builtInModulesByStructureTypeId.set(row.structureTypeId, module)
+			}
 		}
 
 		const structureFuelAttributes = alias(universeTypeDogmaAttributes, 'structure_fuel_attributes')
@@ -285,6 +306,8 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 			expiresAt: Date.now() + STRUCTURE_FUEL_RULE_CACHE_TTL_MS,
 			sdeVersion,
 			modulesByServiceName,
+			modulesByTypeId,
+			builtInModulesByStructureTypeId,
 			structureModifiersByTypeId,
 		}
 	}
@@ -313,11 +336,13 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 
 	async resolveStructureFuelRules(
 		structureTypeIds: string[],
-		serviceNames: string[]
+		serviceNames: string[],
+		serviceModuleTypeIds: string[] = []
 	): Promise<UniverseFuelRuleResolution> {
 		const cache = await this.getStructureFuelRuleCache()
 		const uniqueStructureTypeIds = [...new Set(structureTypeIds)]
 		const uniqueServiceNames = [...new Set(serviceNames)]
+		const uniqueServiceModuleTypeIds = [...new Set(serviceModuleTypeIds)]
 		const knownStructureRows =
 			uniqueStructureTypeIds.length > 0
 				? await this.db
@@ -328,13 +353,22 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 		const knownStructureTypeIds = new Set(knownStructureRows.map((row) => row.typeId))
 
 		const modulesByServiceName: Record<string, UniverseFuelModuleRule | null> = {}
+		const modulesByTypeId: Record<string, UniverseFuelModuleRule | null> = {}
+		const builtInModulesByStructureTypeId: Record<string, UniverseFuelModuleRule | null> = {}
 		const unresolvedServiceNames: string[] = []
 		for (const serviceName of uniqueServiceNames) {
-			const rule = cache.modulesByServiceName.get(normalizeUniverseServiceName(serviceName)) ?? null
+			const rule = resolveUniverseFuelModuleRule(serviceName, cache.modulesByServiceName)
 			modulesByServiceName[serviceName] = rule
 			if (rule === null) {
 				unresolvedServiceNames.push(serviceName)
 			}
+		}
+		for (const moduleTypeId of uniqueServiceModuleTypeIds) {
+			modulesByTypeId[moduleTypeId] = cache.modulesByTypeId.get(moduleTypeId) ?? null
+		}
+		for (const structureTypeId of uniqueStructureTypeIds) {
+			builtInModulesByStructureTypeId[structureTypeId] =
+				cache.builtInModulesByStructureTypeId.get(structureTypeId) ?? null
 		}
 
 		const structureModifiersByTypeId: Record<string, UniverseStructureFuelModifier[]> = {}
@@ -349,6 +383,8 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 		return {
 			sdeVersion: cache.sdeVersion,
 			modulesByServiceName,
+			modulesByTypeId,
+			builtInModulesByStructureTypeId,
 			structureModifiersByTypeId,
 			unresolvedServiceNames,
 			missingStructureTypeIds: uniqueStructureTypeIds.filter(

--- a/apps/universe/src/scripts/import-sde-inventory.ts
+++ b/apps/universe/src/scripts/import-sde-inventory.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { config } from 'dotenv'
-import { sql } from 'drizzle-orm'
+import { notInArray, or, sql } from 'drizzle-orm'
 import { z } from 'zod'
 
 import { createDb } from '../db'
@@ -20,6 +20,15 @@ import {
 	universeTypeDogmaEffects,
 } from '../db/schema'
 import {
+	FUEL_DOGMA_ATTRIBUTE_IDS,
+	isFuelDogmaAttribute,
+	isFuelModifier,
+	selectStructureDogmaTypeIds,
+	STRUCTURE_CATEGORY_ID,
+	STRUCTURE_MODULE_CATEGORY_ID,
+} from './sde-fuel-selection'
+import {
+	forEachSdeJsonlRow,
 	getEnglishName,
 	prepareSdeDataDir,
 	readSdeJsonlTable,
@@ -164,8 +173,6 @@ type InvType = z.output<typeof invTypeSchema>
 type DogmaEffect = z.output<typeof dogmaEffectSchema>
 type DogmaUnit = z.output<typeof dogmaUnitSchema>
 type DogmaAttribute = z.output<typeof dogmaAttributeSchema>
-type TypeDogma = z.output<typeof typeDogmaSchema>
-
 type SeedFlag = {
 	flagId: string
 	flagName: string
@@ -174,6 +181,7 @@ type SeedFlag = {
 }
 
 const PROGRESS_INTERVAL = 5000
+const ALL_DOGMA_FLAG = '--all-dogma'
 
 type SeedFlagDefinition = {
 	flagId: string
@@ -241,11 +249,13 @@ function getOptionalEnglishText(
 	return getEnglishName(value, '')
 }
 
-function createProgressReporter(typeLabel: string, total: number): (processed: number) => void {
+function createProgressReporter(typeLabel: string, total?: number): (processed: number) => void {
 	let nextProgressAt = PROGRESS_INTERVAL
 	return (processed: number) => {
-		while (processed >= nextProgressAt && total > 0) {
-			console.log(`  ... ${typeLabel}: ${Math.min(processed, total)}/${total}`)
+		while (processed >= nextProgressAt && (total === undefined || total > 0)) {
+			const progress =
+				total === undefined ? `${processed}` : `${Math.min(processed, total)}/${total}`
+			console.log(`  ... ${typeLabel}: ${progress}`)
 			nextProgressAt += PROGRESS_INTERVAL
 		}
 	}
@@ -291,10 +301,22 @@ async function importCategories(db: ReturnType<typeof createDb>, sdeDataDir: str
 	console.log(`  ✓ ${rows.length} categories`)
 }
 
-async function importGroups(db: ReturnType<typeof createDb>, sdeDataDir: string) {
+async function importGroups(
+	db: ReturnType<typeof createDb>,
+	sdeDataDir: string
+): Promise<Map<string, number>> {
 	console.log('Importing inventory groups...')
 	const raw = await readSdeJsonlTable<z.input<typeof invGroupSchema>>(sdeDataDir, 'groups.jsonl')
 	const data = z.array(invGroupSchema).parse(raw)
+	const structureGroupCategories = new Map(
+		data
+			.filter(
+				(group) =>
+					group.categoryID === STRUCTURE_CATEGORY_ID ||
+					group.categoryID === STRUCTURE_MODULE_CATEGORY_ID
+			)
+			.map((group) => [group._key.toString(), group.categoryID] as const)
+	)
 	const rows = data.map((group: InvGroup) => {
 		const groupId = group._key.toString()
 		return {
@@ -336,6 +358,7 @@ async function importGroups(db: ReturnType<typeof createDb>, sdeDataDir: string)
 	}
 
 	console.log(`  ✓ ${rows.length} groups`)
+	return structureGroupCategories
 }
 
 async function importMarketGroups(db: ReturnType<typeof createDb>, sdeDataDir: string) {
@@ -382,16 +405,19 @@ async function importMarketGroups(db: ReturnType<typeof createDb>, sdeDataDir: s
 	console.log(`  ✓ ${rows.length} market groups`)
 }
 
-async function importTypes(db: ReturnType<typeof createDb>, sdeDataDir: string) {
+async function importTypes(
+	db: ReturnType<typeof createDb>,
+	sdeDataDir: string,
+	structureGroupCategories: Map<string, number>
+) {
 	console.log('Importing inventory types...')
 	const raw = await readSdeJsonlTable<z.input<typeof invTypeSchema>>(sdeDataDir, 'types.jsonl')
 	const data = z.array(invTypeSchema).parse(raw)
 	const rows = data.map((type: InvType) => {
-		const typeId = type._key.toString()
 		return {
-			typeId,
+			typeId: type._key.toString(),
 			groupId: type.groupID.toString(),
-			typeName: getEnglishName(type.name, `Unknown Type (${typeId})`),
+			typeName: getEnglishName(type.name, `Unknown Type (${type._key})`),
 			description: getOptionalEnglishText(type.description) ?? '',
 			mass: (type.mass ?? 0).toString(),
 			volume: (type.volume ?? 0).toString(),
@@ -406,6 +432,10 @@ async function importTypes(db: ReturnType<typeof createDb>, sdeDataDir: string) 
 			graphicId: type.graphicID?.toString() ?? '0',
 		}
 	})
+	const structureDogmaTypeIds = selectStructureDogmaTypeIds(
+		structureGroupCategories,
+		data.map((type) => ({ typeId: type._key.toString(), groupId: type.groupID.toString() }))
+	)
 
 	const reportProgress = createProgressReporter('types', rows.length)
 	const BATCH_SIZE = 500
@@ -438,7 +468,11 @@ async function importTypes(db: ReturnType<typeof createDb>, sdeDataDir: string) 
 		reportProgress(processed)
 	}
 
+	console.log(
+		`  ... fuel dogma candidates: ${structureDogmaTypeIds.structureTypeIds.size} structures, ${structureDogmaTypeIds.dogmaTypeIds.size - structureDogmaTypeIds.structureTypeIds.size} structure modules`
+	)
 	console.log(`  ✓ ${rows.length} types`)
+	return structureDogmaTypeIds
 }
 
 async function importDogmaUnits(db: ReturnType<typeof createDb>, sdeDataDir: string) {
@@ -481,30 +515,42 @@ async function importDogmaUnits(db: ReturnType<typeof createDb>, sdeDataDir: str
 	console.log(`  ✓ ${rows.length} dogma units`)
 }
 
-async function importDogmaAttributes(db: ReturnType<typeof createDb>, sdeDataDir: string) {
+async function importDogmaAttributes(
+	db: ReturnType<typeof createDb>,
+	sdeDataDir: string,
+	allDogma: boolean
+) {
 	console.log('Importing dogma attributes...')
 	const raw = await readSdeJsonlTable<z.input<typeof dogmaAttributeSchema>>(
 		sdeDataDir,
 		'dogmaAttributes.jsonl'
 	)
 	const data = z.array(dogmaAttributeSchema).parse(raw)
-	const rows = data.map((attribute: DogmaAttribute) => {
-		const attributeId = attribute._key.toString()
-		return {
-			attributeId,
-			attributeCategoryId: attribute.attributeCategoryID?.toString() ?? null,
-			dataType: attribute.dataType ?? null,
-			defaultValue: attribute.defaultValue?.toString() ?? null,
-			attributeName: attribute.name,
-			displayName: getEnglishName(attribute.displayName, '') || null,
-			description: getOptionalEnglishText(attribute.description),
-			displayWhenZero: attribute.displayWhenZero ?? null,
-			highIsGood: attribute.highIsGood ?? null,
-			published: attribute.published ?? null,
-			stackable: attribute.stackable ?? null,
-			unitId: attribute.unitID?.toString() ?? null,
-		}
-	})
+	const rows = data
+		.filter((attribute) => isFuelDogmaAttribute(attribute._key.toString(), allDogma))
+		.map((attribute: DogmaAttribute) => {
+			const attributeId = attribute._key.toString()
+			return {
+				attributeId,
+				attributeCategoryId: attribute.attributeCategoryID?.toString() ?? null,
+				dataType: attribute.dataType ?? null,
+				defaultValue: attribute.defaultValue?.toString() ?? null,
+				attributeName: attribute.name,
+				displayName: getEnglishName(attribute.displayName, '') || null,
+				description: getOptionalEnglishText(attribute.description),
+				displayWhenZero: attribute.displayWhenZero ?? null,
+				highIsGood: attribute.highIsGood ?? null,
+				published: attribute.published ?? null,
+				stackable: attribute.stackable ?? null,
+				unitId: attribute.unitID?.toString() ?? null,
+			}
+		})
+
+	if (!allDogma) {
+		await db
+			.delete(universeDogmaAttributes)
+			.where(notInArray(universeDogmaAttributes.attributeId, [...FUEL_DOGMA_ATTRIBUTE_IDS]))
+	}
 
 	const reportProgress = createProgressReporter('dogma attributes', rows.length)
 	const BATCH_SIZE = 500
@@ -537,36 +583,71 @@ async function importDogmaAttributes(db: ReturnType<typeof createDb>, sdeDataDir
 	console.log(`  ✓ ${rows.length} dogma attributes`)
 }
 
-async function importDogmaEffects(db: ReturnType<typeof createDb>, sdeDataDir: string) {
+async function importDogmaEffects(
+	db: ReturnType<typeof createDb>,
+	sdeDataDir: string,
+	allDogma: boolean
+): Promise<Set<string>> {
 	console.log('Importing dogma effects and modifiers...')
 	const raw = await readSdeJsonlTable<z.input<typeof dogmaEffectSchema>>(
 		sdeDataDir,
 		'dogmaEffects.jsonl'
 	)
 	const data = z.array(dogmaEffectSchema).parse(raw)
-	const effectRows = data.map((effect: DogmaEffect) => ({
-		effectId: effect._key.toString(),
-		effectName: effect.name ?? `Unknown Effect (${effect._key})`,
-		description: getOptionalEnglishText(effect.description),
-		displayName: getEnglishName(effect.displayName, '') || null,
-		effectCategoryId: effect.effectCategoryID ?? null,
-		published: effect.published === undefined ? null : toBoolean(effect.published),
-	}))
-	const modifierRows = data.flatMap((effect: DogmaEffect) =>
-		(effect.modifierInfo ?? []).map((modifier, modifierIndex) => ({
+	const fuelEffectIds = new Set(
+		data
+			.filter((effect) => allDogma || effect.modifierInfo?.some(isFuelModifier))
+			.map((effect) => effect._key.toString())
+	)
+	if (!allDogma) {
+		console.log(`  ... fuel dogma effects selected: ${fuelEffectIds.size}`)
+	}
+	const effectRows = data
+		.filter((effect) => fuelEffectIds.has(effect._key.toString()))
+		.map((effect: DogmaEffect) => ({
 			effectId: effect._key.toString(),
-			modifierIndex,
-			domain: modifier.domain ?? null,
-			func: modifier.func ?? null,
-			groupId: modifier.groupID?.toString() ?? null,
-			modifiedAttributeId: modifier.modifiedAttributeID?.toString() ?? null,
-			modifyingAttributeId: modifier.modifyingAttributeID?.toString() ?? null,
-			operation: modifier.operation ?? null,
-			skillTypeId: modifier.skillTypeID?.toString() ?? null,
+			effectName: effect.name ?? `Unknown Effect (${effect._key})`,
+			description: getOptionalEnglishText(effect.description),
+			displayName: getEnglishName(effect.displayName, '') || null,
+			effectCategoryId: effect.effectCategoryID ?? null,
+			published: effect.published === undefined ? null : toBoolean(effect.published),
 		}))
+	const modifierRows = data.flatMap((effect: DogmaEffect) =>
+		(effect.modifierInfo ?? []).flatMap((modifier, modifierIndex) =>
+			allDogma || isFuelModifier(modifier)
+				? [
+						{
+							effectId: effect._key.toString(),
+							modifierIndex,
+							domain: modifier.domain ?? null,
+							func: modifier.func ?? null,
+							groupId: modifier.groupID?.toString() ?? null,
+							modifiedAttributeId: modifier.modifiedAttributeID?.toString() ?? null,
+							modifyingAttributeId: modifier.modifyingAttributeID?.toString() ?? null,
+							operation: modifier.operation ?? null,
+							skillTypeId: modifier.skillTypeID?.toString() ?? null,
+						},
+					]
+				: []
+		)
 	)
 
+	if (!allDogma) {
+		if (fuelEffectIds.size === 0) {
+			await db.delete(universeDogmaEffects)
+			await db.delete(universeDogmaEffectModifiers)
+		} else {
+			const effectIds = [...fuelEffectIds]
+			await db
+				.delete(universeDogmaEffects)
+				.where(notInArray(universeDogmaEffects.effectId, effectIds))
+			await db.delete(universeDogmaEffectModifiers)
+		}
+	}
+
 	const BATCH_SIZE = 500
+	const effectProgress = createProgressReporter('dogma effects', effectRows.length)
+	let effectsProcessed = 0
 	for (let i = 0; i < effectRows.length; i += BATCH_SIZE) {
 		const batch = effectRows.slice(i, i + BATCH_SIZE)
 		await db
@@ -582,8 +663,12 @@ async function importDogmaEffects(db: ReturnType<typeof createDb>, sdeDataDir: s
 					published: sql`excluded.published`,
 				},
 			})
+		effectsProcessed += batch.length
+		effectProgress(effectsProcessed)
 	}
 
+	const modifierProgress = createProgressReporter('dogma modifiers', modifierRows.length)
+	let modifiersProcessed = 0
 	for (let i = 0; i < modifierRows.length; i += BATCH_SIZE) {
 		const batch = modifierRows.slice(i, i + BATCH_SIZE)
 		await db
@@ -601,36 +686,75 @@ async function importDogmaEffects(db: ReturnType<typeof createDb>, sdeDataDir: s
 					skillTypeId: sql`excluded.skill_type_id`,
 				},
 			})
+		modifiersProcessed += batch.length
+		modifierProgress(modifiersProcessed)
 	}
 
 	console.log(`  ✓ ${effectRows.length} dogma effects and ${modifierRows.length} modifiers`)
+	return fuelEffectIds
 }
 
-async function importTypeDogma(db: ReturnType<typeof createDb>, sdeDataDir: string) {
-	console.log('Importing type dogma attributes and effects...')
-	const raw = await readSdeJsonlTable<z.input<typeof typeDogmaSchema>>(
-		sdeDataDir,
-		'typeDogma.jsonl'
-	)
-	const data = z.array(typeDogmaSchema).parse(raw)
-	const attributeRows = data.flatMap((type: TypeDogma) =>
-		(type.dogmaAttributes ?? []).map((attribute) => ({
-			typeId: type._key.toString(),
-			attributeId: attribute.attributeID.toString(),
-			value: attribute.value.toString(),
-		}))
-	)
-	const effectRows = data.flatMap((type: TypeDogma) =>
-		(type.dogmaEffects ?? []).map((effect) => ({
-			typeId: type._key.toString(),
-			effectId: effect.effectID.toString(),
-			isDefault: effect.isDefault,
-		}))
+async function importTypeDogma(
+	db: ReturnType<typeof createDb>,
+	sdeDataDir: string,
+	allDogma: boolean,
+	structureDogmaTypeIds: Set<string>,
+	structureTypeIds: Set<string>,
+	fuelEffectIds: Set<string>
+) {
+	console.log(
+		`Importing type dogma attributes and effects (${allDogma ? 'all types' : 'structure fuel subset'})...`
 	)
 
+	if (!allDogma) {
+		if (structureDogmaTypeIds.size === 0) {
+			await db.delete(universeTypeDogmaAttributes)
+		} else {
+			await db
+				.delete(universeTypeDogmaAttributes)
+				.where(
+					or(
+						notInArray(universeTypeDogmaAttributes.typeId, [...structureDogmaTypeIds]),
+						notInArray(universeTypeDogmaAttributes.attributeId, [...FUEL_DOGMA_ATTRIBUTE_IDS])
+					)
+				)
+		}
+
+		if (structureTypeIds.size === 0 || fuelEffectIds.size === 0) {
+			await db.delete(universeTypeDogmaEffects)
+		} else {
+			await db
+				.delete(universeTypeDogmaEffects)
+				.where(
+					or(
+						notInArray(universeTypeDogmaEffects.typeId, [...structureTypeIds]),
+						notInArray(universeTypeDogmaEffects.effectId, [...fuelEffectIds])
+					)
+				)
+		}
+	}
+
 	const BATCH_SIZE = 500
-	for (let i = 0; i < attributeRows.length; i += BATCH_SIZE) {
-		const batch = attributeRows.slice(i, i + BATCH_SIZE)
+	const attributeRows: Array<{
+		typeId: string
+		attributeId: string
+		value: string
+	}> = []
+	const effectRows: Array<{
+		typeId: string
+		effectId: string
+		isDefault: boolean
+	}> = []
+	let attributeCount = 0
+	let effectCount = 0
+	let sourceRowCount = 0
+
+	const attributeProgress = createProgressReporter('type dogma attributes')
+	const effectProgress = createProgressReporter('type dogma effects')
+
+	const flushAttributes = async () => {
+		if (attributeRows.length === 0) return
+		const batch = attributeRows.splice(0, attributeRows.length)
 		await db
 			.insert(universeTypeDogmaAttributes)
 			.values(batch)
@@ -638,10 +762,13 @@ async function importTypeDogma(db: ReturnType<typeof createDb>, sdeDataDir: stri
 				target: [universeTypeDogmaAttributes.typeId, universeTypeDogmaAttributes.attributeId],
 				set: { value: sql`excluded.value` },
 			})
+		attributeCount += batch.length
+		attributeProgress(attributeCount)
 	}
 
-	for (let i = 0; i < effectRows.length; i += BATCH_SIZE) {
-		const batch = effectRows.slice(i, i + BATCH_SIZE)
+	const flushEffects = async () => {
+		if (effectRows.length === 0) return
+		const batch = effectRows.splice(0, effectRows.length)
 		await db
 			.insert(universeTypeDogmaEffects)
 			.values(batch)
@@ -649,9 +776,60 @@ async function importTypeDogma(db: ReturnType<typeof createDb>, sdeDataDir: stri
 				target: [universeTypeDogmaEffects.typeId, universeTypeDogmaEffects.effectId],
 				set: { isDefault: sql`excluded.is_default` },
 			})
+		effectCount += batch.length
+		effectProgress(effectCount)
 	}
 
-	console.log(`  ✓ ${attributeRows.length} type dogma attributes and ${effectRows.length} effects`)
+	await forEachSdeJsonlRow<z.input<typeof typeDogmaSchema>>(
+		sdeDataDir,
+		'typeDogma.jsonl',
+		async (raw, index) => {
+			sourceRowCount = index + 1
+			if (sourceRowCount % PROGRESS_INTERVAL === 0) {
+				console.log(`  ... type dogma source rows: ${sourceRowCount}`)
+			}
+
+			const type = typeDogmaSchema.parse(raw)
+			const typeId = type._key.toString()
+			if (!allDogma && !structureDogmaTypeIds.has(typeId)) {
+				return
+			}
+
+			for (const attribute of type.dogmaAttributes ?? []) {
+				if (!isFuelDogmaAttribute(attribute.attributeID.toString(), allDogma)) {
+					continue
+				}
+				attributeRows.push({
+					typeId,
+					attributeId: attribute.attributeID.toString(),
+					value: attribute.value.toString(),
+				})
+				if (attributeRows.length >= BATCH_SIZE) {
+					await flushAttributes()
+				}
+			}
+
+			if (!allDogma && !structureTypeIds.has(typeId)) {
+				return
+			}
+			for (const effect of type.dogmaEffects ?? []) {
+				const effectId = effect.effectID.toString()
+				if (!allDogma && !fuelEffectIds.has(effectId)) {
+					continue
+				}
+				effectRows.push({ typeId, effectId, isDefault: effect.isDefault })
+				if (effectRows.length >= BATCH_SIZE) {
+					await flushEffects()
+				}
+			}
+		}
+	)
+
+	await flushAttributes()
+	await flushEffects()
+	console.log(
+		`  ✓ ${attributeCount} type dogma attributes and ${effectCount} effects from ${sourceRowCount} source rows`
+	)
 }
 
 function resolveSeedFlag(
@@ -774,12 +952,25 @@ async function storeSdeVersion(
 }
 
 async function main() {
+	const args = new Set(process.argv.slice(2))
+	if (args.has('--help')) {
+		console.log(`Usage: pnpm run import:sde-inventory [${ALL_DOGMA_FLAG}]`)
+		console.log('By default, only structure fuel dogma data is imported.')
+		console.log(`${ALL_DOGMA_FLAG} imports all type dogma attributes and effects.`)
+		return
+	}
+	const unknownArgs = [...args].filter((arg) => arg !== ALL_DOGMA_FLAG)
+	if (unknownArgs.length > 0) {
+		throw new Error(`Unknown arguments: ${unknownArgs.join(', ')}`)
+	}
+	const allDogma = args.has(ALL_DOGMA_FLAG)
 	const databaseUrl = process.env.DATABASE_URL_MIGRATIONS
 	if (!databaseUrl) {
 		throw new Error('DATABASE_URL_MIGRATIONS environment variable is required')
 	}
 
 	console.log('Starting SDE inventory data import...')
+	console.log(`Dogma import mode: ${allDogma ? 'all data' : 'structure fuel subset'}`)
 	const sdeDataDir = await prepareSdeDataDir()
 	const sdeMetadata = await readSdeMetadata(sdeDataDir)
 	console.log(`Reading from: ${sdeDataDir}`)
@@ -787,14 +978,21 @@ async function main() {
 	const db = createDb(databaseUrl)
 
 	await importCategories(db, sdeDataDir)
-	await importGroups(db, sdeDataDir)
+	const structureGroupCategories = await importGroups(db, sdeDataDir)
 	await importMarketGroups(db, sdeDataDir)
-	await importTypes(db, sdeDataDir)
+	const structureDogmaTypeIds = await importTypes(db, sdeDataDir, structureGroupCategories)
 	await importTypeMaterials(db, sdeDataDir)
 	await importDogmaUnits(db, sdeDataDir)
-	await importDogmaAttributes(db, sdeDataDir)
-	await importDogmaEffects(db, sdeDataDir)
-	await importTypeDogma(db, sdeDataDir)
+	await importDogmaAttributes(db, sdeDataDir, allDogma)
+	const fuelEffectIds = await importDogmaEffects(db, sdeDataDir, allDogma)
+	await importTypeDogma(
+		db,
+		sdeDataDir,
+		allDogma,
+		structureDogmaTypeIds.dogmaTypeIds,
+		structureDogmaTypeIds.structureTypeIds,
+		fuelEffectIds
+	)
 	await importFlags(db, sdeDataDir)
 	await storeSdeVersion(db, sdeMetadata)
 

--- a/apps/universe/src/scripts/sde-fuel-selection.ts
+++ b/apps/universe/src/scripts/sde-fuel-selection.ts
@@ -1,0 +1,62 @@
+export const STRUCTURE_CATEGORY_ID = 65
+export const STRUCTURE_MODULE_CATEGORY_ID = 66
+export const STRUCTURE_SERVICE_MODULE_ATTRIBUTE_ID = '2792'
+export const FUEL_DOGMA_ATTRIBUTE_IDS: readonly string[] = [
+	'2108',
+	'2109',
+	'2110',
+	'2339',
+	STRUCTURE_SERVICE_MODULE_ATTRIBUTE_ID,
+]
+
+export type SdeFuelType = {
+	typeId: string
+	groupId: string
+}
+
+export type SdeFuelModifier = {
+	modifiedAttributeID?: number | null
+	modifyingAttributeID?: number | null
+	operation?: number | null
+	func?: string
+	domain?: string
+}
+
+export type StructureDogmaTypeIds = {
+	structureTypeIds: Set<string>
+	dogmaTypeIds: Set<string>
+}
+
+export function selectStructureDogmaTypeIds(
+	groupCategories: ReadonlyMap<string, number>,
+	types: readonly SdeFuelType[]
+): StructureDogmaTypeIds {
+	const structureTypeIds = new Set<string>()
+	const dogmaTypeIds = new Set<string>()
+
+	for (const type of types) {
+		const categoryId = groupCategories.get(type.groupId)
+		if (categoryId === STRUCTURE_CATEGORY_ID) {
+			structureTypeIds.add(type.typeId)
+		}
+		if (categoryId === STRUCTURE_CATEGORY_ID || categoryId === STRUCTURE_MODULE_CATEGORY_ID) {
+			dogmaTypeIds.add(type.typeId)
+		}
+	}
+
+	return { structureTypeIds, dogmaTypeIds }
+}
+
+export function isFuelDogmaAttribute(attributeId: string, allDogma: boolean): boolean {
+	return allDogma || FUEL_DOGMA_ATTRIBUTE_IDS.includes(attributeId)
+}
+
+export function isFuelModifier(modifier: SdeFuelModifier): boolean {
+	return (
+		(modifier.modifiedAttributeID === 2109 || modifier.modifiedAttributeID === 2110) &&
+		modifier.modifyingAttributeID === 2339 &&
+		modifier.operation === 6 &&
+		modifier.func === 'LocationGroupModifier' &&
+		modifier.domain === 'structureID'
+	)
+}

--- a/apps/universe/src/scripts/sde-jsonl.ts
+++ b/apps/universe/src/scripts/sde-jsonl.ts
@@ -1,7 +1,8 @@
 import { execFile } from 'node:child_process'
-import { promises as fs } from 'node:fs'
+import { createReadStream, promises as fs } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { createInterface } from 'node:readline'
 import { promisify } from 'node:util'
 
 const CCP_SDE_JSONL_URL =
@@ -57,6 +58,31 @@ export async function readSdeJsonlTable<T>(sdeDataDir: string, jsonlName: string
 		.map((line) => line.trim())
 		.filter((line) => line.length > 0)
 		.map((line) => JSON.parse(line) as T)
+}
+
+export async function forEachSdeJsonlRow<T>(
+	sdeDataDir: string,
+	jsonlName: string,
+	onRow: (row: T, index: number) => Promise<void> | void
+): Promise<void> {
+	const jsonlPath = join(sdeDataDir, jsonlName)
+	if (!(await fileExists(jsonlPath))) {
+		throw new Error(`Could not find required JSONL file ${jsonlName} in ${sdeDataDir}`)
+	}
+
+	const input = createReadStream(jsonlPath, { encoding: 'utf-8' })
+	const lines = createInterface({ input, crlfDelay: Infinity })
+	let index = 0
+
+	for await (const line of lines) {
+		const trimmed = line.trim()
+		if (!trimmed) {
+			continue
+		}
+
+		await onRow(JSON.parse(trimmed) as T, index)
+		index += 1
+	}
 }
 
 export async function readSdeMetadata(sdeDataDir: string): Promise<SdeMetadata | null> {

--- a/apps/universe/src/test/unit/sde-fuel-selection.test.ts
+++ b/apps/universe/src/test/unit/sde-fuel-selection.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	FUEL_DOGMA_ATTRIBUTE_IDS,
+	isFuelDogmaAttribute,
+	isFuelModifier,
+	selectStructureDogmaTypeIds,
+	STRUCTURE_CATEGORY_ID,
+	STRUCTURE_MODULE_CATEGORY_ID,
+	STRUCTURE_SERVICE_MODULE_ATTRIBUTE_ID,
+} from '../../scripts/sde-fuel-selection'
+
+describe('SDE fuel selection', () => {
+	it('includes every tracked Upwell structure family and fuel service module', () => {
+		const groupCategories = new Map([
+			['citadel', STRUCTURE_CATEGORY_ID],
+			['engineering', STRUCTURE_CATEGORY_ID],
+			['refinery', STRUCTURE_CATEGORY_ID],
+			['moon-drill', STRUCTURE_CATEGORY_ID],
+			['navigation', STRUCTURE_CATEGORY_ID],
+			['service', STRUCTURE_MODULE_CATEGORY_ID],
+			['sovereignty-hub', 40],
+			['skyhook', 46],
+		])
+		const structures = [
+			['35825', 'engineering'],
+			['35826', 'engineering'],
+			['35827', 'engineering'],
+			['35832', 'citadel'],
+			['35833', 'citadel'],
+			['35834', 'citadel'],
+			['35835', 'refinery'],
+			['35836', 'refinery'],
+			['35840', 'navigation'],
+			['35841', 'navigation'],
+			['37534', 'navigation'],
+			['40340', 'citadel'],
+			['47512', 'citadel'],
+			['47513', 'citadel'],
+			['47514', 'citadel'],
+			['47515', 'citadel'],
+			['47516', 'citadel'],
+			['81826', 'moon-drill'],
+		] as const
+		const serviceModules = [
+			['35878', 'service'],
+			['35881', 'service'],
+			['35886', 'service'],
+			['35891', 'service'],
+			['35892', 'service'],
+			['35894', 'service'],
+			['35899', 'service'],
+			['35912', 'service'],
+			['35913', 'service'],
+			['35914', 'service'],
+			['45009', 'service'],
+			['45537', 'service'],
+			['45538', 'service'],
+			['45539', 'service'],
+			['82941', 'service'],
+		] as const
+		const excludedStructures = [
+			['32458', 'sovereignty-hub'],
+			['81080', 'skyhook'],
+		] as const
+
+		const result = selectStructureDogmaTypeIds(
+			groupCategories,
+			[...structures, ...serviceModules, ...excludedStructures].map(([typeId, groupId]) => ({
+				typeId,
+				groupId,
+			}))
+		)
+
+		expect(result.structureTypeIds).toEqual(new Set(structures.map(([typeId]) => typeId)))
+		expect(result.dogmaTypeIds).toEqual(
+			new Set([...structures, ...serviceModules].map(([typeId]) => typeId))
+		)
+	})
+
+	it('retains only fuel attributes in the default import mode', () => {
+		expect(STRUCTURE_SERVICE_MODULE_ATTRIBUTE_ID).toBe('2792')
+		expect(FUEL_DOGMA_ATTRIBUTE_IDS).toEqual(['2108', '2109', '2110', '2339', '2792'])
+		for (const attributeId of FUEL_DOGMA_ATTRIBUTE_IDS) {
+			expect(isFuelDogmaAttribute(attributeId, false)).toBe(true)
+		}
+		expect(isFuelDogmaAttribute('9999', false)).toBe(false)
+		expect(isFuelDogmaAttribute('9999', true)).toBe(true)
+	})
+
+	it('recognizes only structure fuel modifier relationships', () => {
+		const validModifier = {
+			modifiedAttributeID: 2109,
+			modifyingAttributeID: 2339,
+			operation: 6,
+			func: 'LocationGroupModifier',
+			domain: 'structureID',
+		}
+
+		expect(isFuelModifier(validModifier)).toBe(true)
+		expect(isFuelModifier({ ...validModifier, modifiedAttributeID: 2108 })).toBe(false)
+		expect(isFuelModifier({ ...validModifier, domain: 'itemID' })).toBe(false)
+	})
+})

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -519,6 +519,7 @@ export interface CorporationConfigData extends CorporationLastSyncData {
 export interface CorporationSyncConfigData {
 	includeInBackgroundRefresh: boolean
 	includeInStructureAssetSync: boolean
+	assetsLastSync: Date | null
 	structuresLastSync: Date | null
 }
 

--- a/packages/hono-helpers/src/cache.ts
+++ b/packages/hono-helpers/src/cache.ts
@@ -18,6 +18,7 @@ export class TimeCache<T> {
 			timestamp: number
 		}
 	>()
+	private pending = new Map<string, Promise<T>>()
 
 	/**
 	 * @param ttlMs - Time to live in milliseconds
@@ -37,9 +38,23 @@ export class TimeCache<T> {
 			return cached
 		}
 
-		const value = await compute()
-		this.set(key, value)
-		return value
+		const pending = this.pending.get(key)
+		if (pending) {
+			return pending
+		}
+
+		const computation = Promise.resolve()
+			.then(compute)
+			.then((value) => {
+				this.set(key, value)
+				return value
+			})
+			.finally(() => {
+				this.pending.delete(key)
+			})
+
+		this.pending.set(key, computation)
+		return computation
 	}
 
 	/**

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -748,6 +748,7 @@ export interface StructureFittingItem {
 
 export interface StructureDetailResult extends Omit<StructureListItem, 'canViewDetails'> {
 	includeInStructureAssetSync: boolean
+	assetsLastSync: string | null
 	canViewSensitive: boolean
 	canEdit: boolean
 	services: Array<{

--- a/packages/universe/src/fuel-rules.ts
+++ b/packages/universe/src/fuel-rules.ts
@@ -16,6 +16,8 @@ export interface UniverseStructureFuelModifier {
 export interface UniverseFuelRuleResolution {
 	sdeVersion: string | null
 	modulesByServiceName: Record<string, UniverseFuelModuleRule | null>
+	modulesByTypeId: Record<string, UniverseFuelModuleRule | null>
+	builtInModulesByStructureTypeId: Record<string, UniverseFuelModuleRule | null>
 	structureModifiersByTypeId: Record<string, UniverseStructureFuelModifier[]>
 	unresolvedServiceNames: string[]
 	missingStructureTypeIds: string[]
@@ -23,4 +25,49 @@ export interface UniverseFuelRuleResolution {
 
 export function normalizeUniverseServiceName(name: string): string {
 	return name.normalize('NFKC').trim().toLowerCase()
+}
+
+/**
+ * ESI exposes human-readable service labels rather than the SDE service-module
+ * type names. The labels have no stable SDE relationship. These fallbacks are
+ * therefore only used for fitted services; built-in services are resolved from
+ * the structure's SDE dogma data instead.
+ */
+export const UNIVERSE_ESI_SERVICE_MODULE_ALIASES: Readonly<Record<string, string>> = {
+	'automatic moon drilling': 'standup metenox moon drill',
+	'biochemical reactions': 'standup biochemical reactor i',
+	'blueprint copying': 'standup research lab i',
+	'clone bay': 'standup cloning center i',
+	'composite reactions': 'standup composite reactor i',
+	'conduit generation': 'standup conduit generator i',
+	'cynosural field generation': 'standup cynosural field generator i',
+	'cynosural system jammer': 'standup cynosural system jammer i',
+	'hybrid reactions': 'standup hybrid reactor i',
+	invention: 'standup invention lab i',
+	'jump access': 'standup conduit generator i',
+	'manufacturing (capitals)': 'standup capital shipyard i',
+	'manufacturing (standard)': 'standup manufacturing plant i',
+	market: 'standup market hub i',
+	'moon drilling': 'standup moon drill i',
+	'material efficiency research': 'standup research lab i',
+	reprocessing: 'standup reprocessing facility i',
+	'time efficiency research': 'standup research lab i',
+}
+
+export function resolveUniverseFuelModuleRule(
+	serviceName: string,
+	modulesByServiceName: ReadonlyMap<string, UniverseFuelModuleRule>
+): UniverseFuelModuleRule | null {
+	const normalizedServiceName = normalizeUniverseServiceName(serviceName)
+	const moduleName = UNIVERSE_ESI_SERVICE_MODULE_ALIASES[normalizedServiceName]
+	const lookupNames = moduleName ? [normalizedServiceName, moduleName] : [normalizedServiceName]
+
+	for (const lookupName of lookupNames) {
+		const module = modulesByServiceName.get(lookupName)
+		if (module) {
+			return module
+		}
+	}
+
+	return null
 }

--- a/packages/universe/src/index.ts
+++ b/packages/universe/src/index.ts
@@ -407,6 +407,7 @@ export interface Universe {
 	 */
 	resolveStructureFuelRules(
 		structureTypeIds: string[],
-		serviceNames: string[]
+		serviceNames: string[],
+		serviceModuleTypeIds?: string[]
 	): Promise<UniverseFuelRuleResolution>
 }


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes RPC use-after-dispose errors that surfaced during structure sync workflows, and reworks structure fuel burn rate calculation to resolve fitted service modules (including ESI-label aliasing and built-in structure modules) more accurately, with visibility into unresolved modules via sync status.

## Changes
- **Structure workflow RPC errors**: Added `detachRpcValue` in `apps/eve-corporation-data/src/services/esi-fetch.ts` to deep-copy sovereignty/skyhook/mining-extraction RPC responses before the underlying request is disposed, preventing "I/O on behalf of a different request" failures. Wrapped numerous cross-DO RPC calls (`bills`, `eve-corporation-data`) in the new `withRpcResult` helper from `@repo/do-utils` to copy results before disposal.
- **Fuel burn rate calculation**:
  - Added `calculateStructureFuelBurnRateDetails` (`apps/eve-corporation-data/src/services/structure-fuel-calculation.ts`), returning unresolved service names/module type IDs alongside the burn rate; `calculateStructureFuelBurnRate` now delegates to it.
  - Resolve fitted service modules from stored `corporation_assets` `ServiceSlot*` items (new `getStructureServiceModuleTypeIds`), added a `corporation_assets_corp_location_idx` index/migration to support that lookup.
  - Added built-in structure service module resolution via SDE dogma attribute `2792`, plus an ESI service-label-to-SDE-module alias table (`UNIVERSE_ESI_SERVICE_MODULE_ALIASES` / `resolveUniverseFuelModuleRule` in `packages/universe/src/fuel-rules.ts`).
  - `Universe.resolveStructureFuelRules` now also accepts `serviceModuleTypeIds` and returns `modulesByTypeId` / `builtInModulesByStructureTypeId`.
  - Structures with unresolved fuel modules are now flagged with `syncStatus: 'error'` and a descriptive `syncFailureReason`, and fuel burn rates are refreshed after asset syncs and inventory rebuilds (`refreshStoredStructureFuelBurnRates`).
  - Added `diagnose-structure-services` script and SDE fuel-selection helpers (`apps/universe/src/scripts/sde-fuel-selection.ts`) plus a streaming `forEachSdeJsonlRow` JSONL reader for diagnosing/importing structure service data.
- **Other fixes bundled in**:
  - `TimeCache.getOrSet` now dedupes concurrent in-flight computations for the same key and doesn't cache rejected computations (`packages/hono-helpers/src/cache.ts`).
  - `GET /:characterId/skills` in `apps/core/src/routes/characters.ts` now checks ownership/admin directly instead of the shared `resolveCharacterAccessContext`, avoiding unrelated HR/corporate access checks on every request.
  - Structures UI: added an asset-sync-last-run tooltip on the structure detail page (`assetsLastSync`), and minor filter-bar spacing tweaks.

## Testing
- Added/updated unit tests: `TimeCache` dedupe/rejection behavior, `esi-fetch` RPC detachment before disposal, `structure-fuel-calculation` (including alias/built-in module resolution), and `sde-fuel-selection` helpers.
- Updated `bill-payment-status-check` workflow test to mock the new `withRpcResult` helper.
- Updated HR-auditor route test to assert `getUserPermissions` is no longer called for the skills endpoint.
<!-- claude:end -->