### PR TITLE
maybe this time it will go away

### DIFF
--- a/apps/bills/src/durable-object.ts
+++ b/apps/bills/src/durable-object.ts
@@ -687,12 +687,15 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 			return
 		}
 
-		await createWorkflowBatch(
-			this.env.BILL_DISCORD_NOTIFY,
-			pendingRows.map((row) => ({
-				id: `bill-notify-immediate-${row.id}-${Date.now()}`,
-				params: { notificationEventId: row.id },
-			}))
+		await withRpcResult(
+			createWorkflowBatch(
+				this.env.BILL_DISCORD_NOTIFY,
+				pendingRows.map((row) => ({
+					id: `bill-notify-immediate-${row.id}-${Date.now()}`,
+					params: { notificationEventId: row.id },
+				}))
+			),
+			() => undefined
 		)
 	}
 

--- a/apps/bills/src/scheduled.ts
+++ b/apps/bills/src/scheduled.ts
@@ -83,17 +83,20 @@ async function refreshBillPayments(env: Env, options: { scheduledTimeMs: number 
 		const batchResults = await Promise.allSettled(
 			batches.map(async (batch, batchIndex) => {
 				try {
-					const instances = await createWorkflowBatch(env.BILL_PAYMENT_STATUS_CHECK, batch)
+					const instancesCreated = await withRpcResult(
+						createWorkflowBatch(env.BILL_PAYMENT_STATUS_CHECK, batch),
+						(instances) => instances.length
+					)
 
 					refreshLogger.info('[Bills] Created workflow batch', {
 						batchIndex: batchIndex + 1,
 						totalBatches: batches.length,
-						instancesCreated: instances.length,
+						instancesCreated,
 					})
 
 					return {
 						success: true,
-						instancesCreated: instances.length,
+						instancesCreated,
 						batchIndex,
 						batchSize: batch.length,
 					}
@@ -208,15 +211,18 @@ async function enqueueDueSchedules(env: Env, options: { scheduledTimeMs: number 
 		const batchResults = await Promise.allSettled(
 			batches.map(async (batch, batchIndex) => {
 				try {
-					const instances = await createWorkflowBatch(env.BILLS_SCHEDULE_EXECUTOR, batch)
+					const instancesCreated = await withRpcResult(
+						createWorkflowBatch(env.BILLS_SCHEDULE_EXECUTOR, batch),
+						(instances) => instances.length
+					)
 					scheduleLogger.info('[Bills] Created schedule workflow batch', {
 						batchIndex: batchIndex + 1,
 						totalBatches: batches.length,
-						instancesCreated: instances.length,
+						instancesCreated,
 					})
 					return {
 						success: true,
-						instancesCreated: instances.length,
+						instancesCreated,
 						batchSize: batch.length,
 					}
 				} catch (error) {
@@ -369,8 +375,10 @@ async function dispatchPendingNotificationWorkflows(
 		let created = 0
 		for (let i = 0; i < workflowOptions.length; i += BATCH_SIZE) {
 			const batch = workflowOptions.slice(i, i + BATCH_SIZE)
-			const instances = await createWorkflowBatch(env.BILL_DISCORD_NOTIFY, batch)
-			created += instances.length
+			created += await withRpcResult(
+				createWorkflowBatch(env.BILL_DISCORD_NOTIFY, batch),
+				(instances) => instances.length
+			)
 		}
 
 		notifyLogger.info('[Bills] Dispatched bill notification workflows', {

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -3549,6 +3549,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		if (activeSnapshotId !== null) {
 			const existingRows = db
 				.select({
+					id: sql<string>`gen_random_uuid()`.as('id'),
 					corporationId: corporationStructureInventory.corporationId,
 					snapshotId: sql<string>`${snapshotId}`.as('snapshotId'),
 					structureId: corporationStructureInventory.structureId,

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -3,7 +3,7 @@ import { createRemoteJWKSet, jwtVerify } from 'jose'
 import * as z4 from 'zod/v4/core'
 
 import { and, asc, eq, gt, inArray, isNull, lt, lte, or } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { EsiRequestClient } from '@repo/esi'
 import { buildEsiUserKey, buildPublicEsiUserKey, EsiRateLimitStore } from '@repo/esi-rate-limit'
 import {
@@ -1966,11 +1966,11 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		}
 
 		const esiStub = getStub<EsiHelperStub>(this.env.ESI, 'default')
-		return await esiStub
-			.fetchCharacterAffiliation(String(normalizedIds[0]), normalizedIds.map(String), {
+		return await withRpcResult(
+			esiStub.fetchCharacterAffiliation(String(normalizedIds[0]), normalizedIds.map(String), {
 				cacheMode: 'no-store',
-			})
-			.then((affiliations) =>
+			}),
+			(affiliations) =>
 				affiliations.map((affiliation) => ({
 					character_id: Number.parseInt(String(affiliation.character_id), 10),
 					corporation_id: Number.parseInt(String(affiliation.corporation_id), 10),
@@ -1981,7 +1981,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 						? Number.parseInt(String(affiliation.faction_id), 10)
 						: undefined,
 				}))
-			)
+		)
 	}
 
 	/**
@@ -2027,7 +2027,6 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	): Promise<{
 		data: T[]
 		pages: number
-		responses: Array<EsiResponse<T[]>>
 	}> {
 		const maxConcurrent = options?.maxConcurrent ?? 5
 		const cacheMode = options?.cacheMode ?? 'default'
@@ -2043,14 +2042,11 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		})
 
 		const totalPages = firstResponse.pages ?? 1
-		const responses: Array<EsiResponse<T[]>> = [firstResponse]
-
 		// If there's only one page, return early
 		if (totalPages === 1) {
 			return {
 				data: firstResponse.data,
 				pages: totalPages,
-				responses,
 			}
 		}
 
@@ -2071,18 +2067,15 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			remainingResponses.push(...batchResponses)
 		}
 
-		responses.push(...remainingResponses)
-
 		// Combine all data from all pages
-		const allData: T[] = []
-		for (const response of responses) {
-			allData.push(...response.data)
-		}
+		const allData = [
+			...firstResponse.data,
+			...remainingResponses.flatMap((response) => response.data),
+		]
 
 		return {
 			data: allData,
 			pages: totalPages,
-			responses,
 		}
 	}
 
@@ -2096,7 +2089,6 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	): Promise<{
 		data: T[]
 		pages: number
-		responses: Array<EsiResponse<T[]>>
 	}> {
 		const maxConcurrent = options?.maxConcurrent ?? 5
 
@@ -2109,14 +2101,11 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		const firstResponse = await this.fetchPublicEsi<T[]>(firstPagePath)
 
 		const totalPages = firstResponse.pages ?? 1
-		const responses: Array<EsiResponse<T[]>> = [firstResponse]
-
 		// If there's only one page, return early
 		if (totalPages === 1) {
 			return {
 				data: firstResponse.data,
 				pages: totalPages,
-				responses,
 			}
 		}
 
@@ -2135,18 +2124,15 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			remainingResponses.push(...batchResponses)
 		}
 
-		responses.push(...remainingResponses)
-
 		// Combine all data from all pages
-		const allData: T[] = []
-		for (const response of responses) {
-			allData.push(...response.data)
-		}
+		const allData = [
+			...firstResponse.data,
+			...remainingResponses.flatMap((response) => response.data),
+		]
 
 		return {
 			data: allData,
 			pages: totalPages,
-			responses,
 		}
 	}
 
@@ -2516,7 +2502,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	 */
 	async resolveNames(names: string[]): Promise<Record<string, string>> {
 		const resolver = getStub<EsiTypeResolverHelperStub>(this.env.ESI_TYPE_RESOLVER, 'default')
-		return await resolver.resolveNames(names)
+		return await withRpcResult(resolver.resolveNames(names), (nameMap) => ({ ...nameMap }))
 	}
 
 	/**
@@ -2524,7 +2510,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	 */
 	async resolveIds(ids: string[]): Promise<Record<string, string>> {
 		const resolver = getStub<EsiTypeResolverHelperStub>(this.env.ESI_TYPE_RESOLVER, 'default')
-		return await resolver.resolveIds(ids)
+		return await withRpcResult(resolver.resolveIds(ids), (nameMap) => ({ ...nameMap }))
 	}
 
 	/**
@@ -2544,7 +2530,10 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		}
 
 		const esiStub = getStub<EsiHelperStub>(this.env.ESI, 'default')
-		return await esiStub.searchCharacter(tokens[0].characterId, characterName, strict)
+		return await withRpcResult(
+			esiStub.searchCharacter(tokens[0].characterId, characterName, strict),
+			(characterIds) => [...characterIds]
+		)
 	}
 
 	/**

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -925,7 +925,7 @@ export default function StructuresPage() {
 			return (
 				<TableRow key={structure.structureId} {...getStructureRowProps(structure)}>
 					<TableCell>
-						<SkyhookStateBadge state={structure.state} />
+						<StructureStateBadge state={structure.state} />
 					</TableCell>
 					<TableCell className="font-medium">
 						{structure.regionName ?? structure.regionId ?? '-'}

--- a/apps/universe/src/durable-object.ts
+++ b/apps/universe/src/durable-object.ts
@@ -2,7 +2,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { alias } from 'drizzle-orm/pg-core'
 
 import { and, eq, gt, ilike, inArray, ne, sql } from '@repo/db-utils'
-import { getStub, LRUCache } from '@repo/do-utils'
+import { getStub, LRUCache, withRpcResult } from '@repo/do-utils'
 import { buildPublicEsiUserKey, EsiRateLimitGuard, EsiRateLimitStore } from '@repo/esi-rate-limit'
 import { logger } from '@repo/hono-helpers'
 import {
@@ -44,7 +44,7 @@ import { parseInventory } from './utils/inventory-parser'
 import { resolveMoonRegionIds } from './utils/moon-region-lookup'
 
 import type { EsiTypeResolver } from '@repo/esi'
-import type { EsiResponse, EveTokenStore } from '@repo/eve-token-store'
+import type { EveTokenStore } from '@repo/eve-token-store'
 import type { InventoryParseResult } from '@repo/eve-types'
 import type {
 	EsiGetStructureMarketDataResponse,
@@ -430,12 +430,14 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 		// then hydrate full system rows through resolveSolarSystemsByIds (which backfills DB/cache).
 		const tokenStoreStub = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
 		if (!allSolarSystemNamesCache || allSolarSystemNamesCacheExpiry <= Date.now()) {
-			const idsResult = await tokenStoreStub.fetchPublicEsi<number[]>(
-				'/latest/universe/systems/?datasource=tranquility'
+			const ids = await withRpcResult(
+				tokenStoreStub.fetchPublicEsi<number[]>('/latest/universe/systems/?datasource=tranquility'),
+				(idsResult) => idsResult.data.map((id) => String(id))
 			)
-			const ids = idsResult.data.map((id) => String(id))
 			const resolverStub = getStub<EsiTypeResolver>(this.env.ESI_TYPE_RESOLVER, 'global')
-			const namesById = await resolverStub.resolveIds(ids)
+			const namesById = await withRpcResult(resolverStub.resolveIds(ids), (result) => ({
+				...result,
+			}))
 			allSolarSystemNamesCache = ids
 				.map((id) => ({ id, name: namesById[id] }))
 				.filter((row) => Boolean(row.name))
@@ -524,16 +526,14 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 				authorizedCharacterId,
 			})
 
-			const response: EsiResponse<EsiGetStructureResponse> = await tokenStoreStub.fetchEsi(
-				`/universe/structures/${String(structureId)}`,
-				String(authorizedCharacterId),
-				{ cacheMode: 'no-store' }
+			return await withRpcResult(
+				tokenStoreStub.fetchEsi(
+					`/universe/structures/${String(structureId)}`,
+					String(authorizedCharacterId),
+					{ cacheMode: 'no-store' }
+				),
+				(response) => EsiGetStructureResponseSchema.parse(response.data)
 			)
-
-			// Validate the response using the schema
-			const validatedData = EsiGetStructureResponseSchema.parse(response.data)
-
-			return validatedData
 		} catch (error) {
 			// If the structure doesn't exist, the character doesn't have access, or token is invalid, return null
 			logger.error(
@@ -572,16 +572,14 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 				structureId ? String(structureId) : 'default'
 			)
 			// fetchEsiAllPages expects the element type, not the array type
-			const result = await tokenStoreStub.fetchEsiAllPages<EsiGetStructureMarketDataResponseObject>(
-				`/markets/structures/${String(structureId)}`,
-				String(authorizedCharacterId),
-				{ cacheMode: 'no-store' }
+			return await withRpcResult(
+				tokenStoreStub.fetchEsiAllPages<EsiGetStructureMarketDataResponseObject>(
+					`/markets/structures/${String(structureId)}`,
+					String(authorizedCharacterId),
+					{ cacheMode: 'no-store' }
+				),
+				(result) => EsiGetStructureMarketDataResponseSchema.parse(result.data)
 			)
-
-			// Validate the combined data using the schema (array of orders)
-			const validatedData = EsiGetStructureMarketDataResponseSchema.parse(result.data)
-
-			return validatedData
 		} catch (error) {
 			// If the structure doesn't exist, the character doesn't have access, or token is invalid, return null
 			logger.error(
@@ -1067,9 +1065,10 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 
 			if (sdeUnresolved.length > 0) {
 				const resolverStub = getStub<EsiTypeResolver>(this.env.ESI_TYPE_RESOLVER, 'global')
-				const fallbackNames = await resolverStub
-					.resolveIds(sdeUnresolved)
-					.catch(() => ({}) as Record<string, string>)
+				const fallbackNames = await withRpcResult(
+					resolverStub.resolveIds(sdeUnresolved),
+					(result) => ({ ...result })
+				).catch(() => ({}) as Record<string, string>)
 				const newRows: Array<typeof invTypes.$inferInsert> = []
 				for (const [id, name] of Object.entries(fallbackNames)) {
 					if (name) {
@@ -1277,9 +1276,10 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 
 			if (unresolved.length > 0) {
 				const resolverStub = getStub<EsiTypeResolver>(this.env.ESI_TYPE_RESOLVER, 'global')
-				const fallbackNames = await resolverStub
-					.resolveIds(unresolved)
-					.catch(() => ({}) as Record<string, string>)
+				const fallbackNames = await withRpcResult(
+					resolverStub.resolveIds(unresolved),
+					(result) => ({ ...result })
+				).catch(() => ({}) as Record<string, string>)
 				const newRows: Array<typeof universeRegions.$inferInsert> = []
 				for (const [id, name] of Object.entries(fallbackNames)) {
 					if (name) {

--- a/packages/eve-token-store/src/index.ts
+++ b/packages/eve-token-store/src/index.ts
@@ -666,7 +666,7 @@ export interface EveTokenStore {
 	 * @param characterId - Character ID for authentication
 	 * @param options - Optional configuration
 	 * @param options.maxConcurrent - Maximum concurrent requests (default: 5)
-	 * @returns Combined data array, total pages, and individual page responses
+	 * @returns Combined data array and total pages
 	 *
 	 * @example
 	 * ```ts
@@ -686,7 +686,6 @@ export interface EveTokenStore {
 	): Promise<{
 		data: T[]
 		pages: number
-		responses: Array<EsiResponse<T[]>>
 	}>
 
 	/**
@@ -696,7 +695,7 @@ export interface EveTokenStore {
 	 * @param basePath - ESI path without page parameter (e.g., '/markets/prices')
 	 * @param options - Optional configuration
 	 * @param options.maxConcurrent - Maximum concurrent requests (default: 5)
-	 * @returns Combined data array, total pages, and individual page responses
+	 * @returns Combined data array and total pages
 	 *
 	 * @example
 	 * ```ts
@@ -714,7 +713,6 @@ export interface EveTokenStore {
 	): Promise<{
 		data: T[]
 		pages: number
-		responses: Array<EsiResponse<T[]>>
 	}>
 
 	/**


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes an RPC memory-leak gap by routing several previously-missed Durable Object RPC calls through `withRpcResult`, fixes a duplicate-key bug when rebuilding a structure's inventory snapshot, and corrects a UI badge mismatch on the structures page.

## Changes
- Wrap remaining unprotected DO RPC calls (`createWorkflowBatch`, `fetchCharacterAffiliation`, `resolveNames`/`resolveIds`, `searchCharacter`, `fetchPublicEsi`, `fetchEsi`, `fetchEsiAllPages`) in `withRpcResult` across `apps/bills`, `apps/eve-token-store`, and `apps/universe` so RPC results are properly disposed after use.
- Simplify `fetchEsiAllPages`/`fetchPublicEsiAllPages` in `eve-token-store` to no longer collect and return the intermediate per-page `responses` array (only the combined `data` and `pages` are needed); update the `EveTokenStore` interface/docs accordingly.
- In `eve-corporation-data`'s `rebuildStructureInventorySnapshot`, generate a fresh `id` (`gen_random_uuid()`) for rows copied into the new snapshot instead of reusing the source row's id, avoiding a primary-key collision.
- Fix the structures list page to render `StructureStateBadge` instead of the incorrect `SkyhookStateBadge` for a general structure row.

## Testing
Not evident from the diff — no test changes included.
<!-- claude:end -->