### PR TITLE
fix structure asset sync cooldown and failure mode

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -124,6 +124,7 @@ import type {
 	SkyhookStoreResult,
 	SkyhookSyncPriority,
 	SovereigntyHubSyncPriority,
+	StructureInventorySyncResult,
 	StructureSyncFailureTarget,
 	StructureSyncPriorityTarget,
 	WalletJournalWindowFilters,
@@ -2733,7 +2734,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async syncAssetsWithDirector(
 		corporationId: string,
 		directorCharacterId: string
-	): Promise<{ assetsCount: number }> {
+	): Promise<StructureInventorySyncResult> {
 		this.assertNonNpcCorporation(corporationId)
 		logger.info('[EveCorporationData] syncAssetsWithDirector invoked', {
 			corporationId,
@@ -2745,14 +2746,17 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				corporationId,
 				nextAllowedAt: nextAllowedAt.toISOString(),
 			})
-			return { assetsCount: 0 }
+			return {
+				assetsCount: 0,
+				snapshotUpdated: false,
+				skipReason: 'cooldown',
+				ownedStructureCount: null,
+				fetchedAssetCount: 0,
+				inventoryRowCount: 0,
+			}
 		}
 		await this.requireCorpRole(corporationId, directorCharacterId, ['Director'])
-		const assetsCount = await this.fetchAndStoreStructureInventoryByCharacter(
-			corporationId,
-			directorCharacterId
-		)
-		return { assetsCount }
+		return await this.fetchAndStoreStructureInventoryByCharacter(corporationId, directorCharacterId)
 	}
 
 	private async hydrateStructureRows(
@@ -5885,7 +5889,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	private async fetchAndStoreStructureInventory(
 		corporationId: string,
 		forceRefresh = false
-	): Promise<number> {
+	): Promise<StructureInventorySyncResult> {
 		if (!forceRefresh) {
 			const nextAllowedAt = await this.getStructureInventoryNextAllowedAt(corporationId)
 			if (nextAllowedAt) {
@@ -5893,7 +5897,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					corporationId,
 					nextAllowedAt: nextAllowedAt.toISOString(),
 				})
-				return 0
+				return {
+					assetsCount: 0,
+					snapshotUpdated: false,
+					skipReason: 'cooldown',
+					ownedStructureCount: null,
+					fetchedAssetCount: 0,
+					inventoryRowCount: 0,
+				}
 			}
 		}
 
@@ -5919,7 +5930,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		corporationId: string,
 		characterId: string,
 		options?: { forceRefresh?: boolean }
-	): Promise<number> {
+	): Promise<StructureInventorySyncResult> {
 		const config = await this.getDb().query.corporationConfig.findFirst({
 			where: eq(corporationConfig.corporationId, corporationId),
 		})
@@ -5931,11 +5942,19 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					lastSyncAt: config.assetsLastSync.toISOString(),
 					nextAllowedAt: nextAllowedAt.toISOString(),
 				})
-				return 0
+				return {
+					assetsCount: 0,
+					snapshotUpdated: false,
+					skipReason: 'cooldown',
+					ownedStructureCount: null,
+					fetchedAssetCount: 0,
+					inventoryRowCount: 0,
+				}
 			}
 		}
 
 		let ownedStructureIds = await this.getOwnedStructureIds(corporationId)
+		let structureRefreshFailed = false
 
 		if (ownedStructureIds.size === 0) {
 			logger.warn(
@@ -5947,6 +5966,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				await this.fetchAndStoreStructures(corporationId, true)
 				ownedStructureIds = await this.getOwnedStructureIds(corporationId)
 			} catch (error) {
+				structureRefreshFailed = true
 				logger.warn(
 					'[EveCorporationData] Structures refresh fallback failed before inventory filtering',
 					{
@@ -5958,6 +5978,12 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		if (ownedStructureIds.size === 0) {
+			if (structureRefreshFailed) {
+				throw new Error(
+					`Unable to determine owned structures for ${corporationId}; refusing to clear or timestamp the inventory snapshot`
+				)
+			}
+
 			logger.info(
 				'[EveCorporationData] No owned structures found; clearing structure inventory snapshot',
 				{
@@ -5966,7 +5992,14 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			)
 			await this.storeStructureInventory(corporationId, [])
 			await this.updateCorporationSyncTimestamp(corporationId, 'assetsLastSync')
-			return 0
+			return {
+				assetsCount: 0,
+				snapshotUpdated: true,
+				skipReason: 'no-owned-structures',
+				ownedStructureCount: 0,
+				fetchedAssetCount: 0,
+				inventoryRowCount: 0,
+			}
 		}
 
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
@@ -5978,7 +6011,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					ownedStructureCount: ownedStructureIds.size,
 				}
 			)
-			const result = await this.fetchAndStoreAssetsByCharacter(corporationId, characterId)
+			const fetchedAssetCount = await this.fetchAndStoreAssetsByCharacter(
+				corporationId,
+				characterId
+			)
 			const inventoryCount = await this.storeStructureInventoryBatches(
 				corporationId,
 				ownedStructureIds,
@@ -5987,11 +6023,18 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			await this.updateCorporationSyncTimestamp(corporationId, 'assetsLastSync')
 			logger.info('[EveCorporationData] Stored structure inventory snapshot', {
 				corporationId,
-				fetchedAssetCount: result,
+				fetchedAssetCount,
 				storedInventoryCount: inventoryCount,
 			})
 
-			return inventoryCount
+			return {
+				assetsCount: inventoryCount,
+				snapshotUpdated: true,
+				skipReason: null,
+				ownedStructureCount: ownedStructureIds.size,
+				fetchedAssetCount,
+				inventoryRowCount: inventoryCount,
+			}
 		} catch (error) {
 			logger.error(
 				'[fetchAndStoreStructureInventory] Failed to store structure inventory snapshot',

--- a/apps/eve-corporation-data/src/test/unit/workflows/assets-step.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/assets-step.test.ts
@@ -10,7 +10,14 @@ vi.mock('../../../workflows/utils/services', () => ({
 
 describe('assets workflow step', () => {
 	it('delegates asset sync to corporation DO method and returns count', async () => {
-		const syncAssetsWithDirector = vi.fn().mockResolvedValue({ assetsCount: 4321 })
+		const syncAssetsWithDirector = vi.fn().mockResolvedValue({
+			assetsCount: 4321,
+			snapshotUpdated: true,
+			skipReason: null,
+			ownedStructureCount: 82,
+			fetchedAssetCount: 4321,
+			inventoryRowCount: 4321,
+		})
 		getCorporationDataStubMock.mockReturnValue({
 			syncAssetsWithDirector,
 		})
@@ -19,6 +26,32 @@ describe('assets workflow step', () => {
 		const result = await syncAssets(env, '98000001', '90000001')
 
 		expect(syncAssetsWithDirector).toHaveBeenCalledWith('98000001', '90000001')
-		expect(result).toEqual({ assetsCount: 4321 })
+		expect(result).toEqual({
+			assetsCount: 4321,
+			snapshotUpdated: true,
+			skipReason: null,
+			ownedStructureCount: 82,
+			fetchedAssetCount: 4321,
+			inventoryRowCount: 4321,
+		})
+	})
+
+	it('preserves an explicit cooldown skip without treating it as a successful sync', async () => {
+		const syncAssetsWithDirector = vi.fn().mockResolvedValue({
+			assetsCount: 0,
+			snapshotUpdated: false,
+			skipReason: 'cooldown',
+			ownedStructureCount: null,
+			fetchedAssetCount: 0,
+			inventoryRowCount: 0,
+		})
+		getCorporationDataStubMock.mockReturnValue({
+			syncAssetsWithDirector,
+		})
+
+		const result = await syncAssets({} as any, '98000001', '90000001')
+
+		expect(result.snapshotUpdated).toBe(false)
+		expect(result.skipReason).toBe('cooldown')
 	})
 })

--- a/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/sync-workflow.test.ts
@@ -249,7 +249,7 @@ describe('EveCorporationSyncWorkflow', () => {
 			'structures',
 			'Station Manager access required'
 		)
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets', 'skyhooks'])
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['skyhooks'])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
 	})
@@ -328,7 +328,7 @@ describe('EveCorporationSyncWorkflow', () => {
 			'structures',
 			'Station Manager access required'
 		)
-		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['assets', 'skyhooks'])
+		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', ['skyhooks'])
 		expect(updateCorporationAuthHealth).toHaveBeenCalled()
 		expect(corpDataStub.getCorporationSyncConfig).toHaveBeenCalledWith('693378155')
 	})
@@ -400,7 +400,6 @@ describe('EveCorporationSyncWorkflow', () => {
 		})
 
 		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [
-			'assets',
 			'structures',
 			'skyhooks',
 		])
@@ -550,7 +549,6 @@ describe('EveCorporationSyncWorkflow', () => {
 		])
 		expect(syncAssetsMock).toHaveBeenCalledWith(env, '693378155', '900000001')
 		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [
-			'assets',
 			'structures',
 			'skyhooks',
 		])
@@ -998,7 +996,6 @@ describe('EveCorporationSyncWorkflow', () => {
 		expect(storeSkyhookEnrichmentMock).toHaveBeenCalled()
 		expect(fetchMiningExtractionEnrichmentMock).toHaveBeenCalled()
 		expect(updateSyncTimestampsMock).toHaveBeenCalledWith(env, '693378155', [
-			'assets',
 			'structures',
 			'skyhooks',
 		])

--- a/apps/eve-corporation-data/src/workflows/steps/assets/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/assets/index.ts
@@ -3,11 +3,10 @@ import { logger } from '@repo/hono-helpers'
 
 import { getCorporationDataStub } from '../../utils/services'
 
+import type { StructureInventorySyncResult } from '@repo/eve-corporation-data'
 import type { Env } from '../../../context'
 
-export interface AssetsSyncResult {
-	assetsCount: number
-}
+export type AssetsSyncResult = StructureInventorySyncResult
 
 export async function syncAssets(
 	env: Env,
@@ -19,14 +18,25 @@ export async function syncAssets(
 	logger.info('[AssetsStep] Starting structure inventory sync', { corporationId })
 	const result = await withRpcResult(
 		corpData.syncAssetsWithDirector(corporationId, directorCharacterId),
-		(result) => ({ assetsCount: result.assetsCount })
+		(result) => ({ ...result })
 	)
-	logger.info('[AssetsStep] Synced structure inventory', {
+	logger.info('[AssetsStep] Structure inventory sync completed', {
 		corporationId,
-		count: result.assetsCount,
-	})
-
-	return {
 		assetsCount: result.assetsCount,
+		snapshotUpdated: result.snapshotUpdated,
+		skipReason: result.skipReason,
+		ownedStructureCount: result.ownedStructureCount,
+		fetchedAssetCount: result.fetchedAssetCount,
+		inventoryRowCount: result.inventoryRowCount,
+	})
+	if (result.skipReason === 'no-owned-structures') {
+		logger.warn(
+			'[AssetsStep] Structure inventory snapshot was cleared because no owned structures were found',
+			{
+				corporationId,
+			}
+		)
 	}
+
+	return result
 }

--- a/apps/eve-corporation-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-corporation-data/src/workflows/sync-workflow.ts
@@ -1096,7 +1096,14 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 				})
 				assetsSync = {
 					dataType: 'assets',
-					stats: { assetsCount: result.assetsCount },
+					stats: {
+						assetsCount: result.assetsCount,
+						assetsSnapshotUpdated: result.snapshotUpdated,
+						assetsSyncSkipReason: result.skipReason,
+						assetsOwnedStructureCount: result.ownedStructureCount,
+						assetsFetchedCount: result.fetchedAssetCount,
+						assetsInventoryRowCount: result.inventoryRowCount,
+					},
 				}
 			}
 
@@ -1195,7 +1202,7 @@ export class EveCorporationSyncWorkflow extends WorkflowEntrypoint<Env, EveCorpo
 				.filter((result): result is NonNullable<typeof result> => result !== null)
 				.reduce((acc, result) => ({ ...acc, ...result.stats }), {} as SyncStats)
 			const syncedDataTypesForTimestamps = syncedDataTypes.filter(
-				(dataType) => dataType !== 'structures' || structureSyncCompleted
+				(dataType) => dataType !== 'assets' && (dataType !== 'structures' || structureSyncCompleted)
 			)
 
 			const walletJournalFetched = walletJournalSync?.stats.walletJournalFetchedCount ?? 0

--- a/apps/eve-corporation-data/src/workflows/types.ts
+++ b/apps/eve-corporation-data/src/workflows/types.ts
@@ -49,6 +49,11 @@ export interface SyncStats {
 	contractsCount?: number
 	industryJobsCount?: number
 	killmailsCount?: number
+	assetsSnapshotUpdated?: boolean
+	assetsSyncSkipReason?: 'cooldown' | 'no-owned-structures' | null
+	assetsOwnedStructureCount?: number | null
+	assetsFetchedCount?: number
+	assetsInventoryRowCount?: number
 }
 
 /**

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -1092,6 +1092,15 @@ export interface CorporationAuthStatus {
  * }
  * ```
  */
+export interface StructureInventorySyncResult {
+	assetsCount: number
+	snapshotUpdated: boolean
+	skipReason: 'cooldown' | 'no-owned-structures' | null
+	ownedStructureCount: number | null
+	fetchedAssetCount: number
+	inventoryRowCount: number
+}
+
 export interface EveCorporationData {
 	// ========================================================================
 	// CONFIGURATION METHODS
@@ -1364,12 +1373,12 @@ export interface EveCorporationData {
 	 *
 	 * @param corporationId - The corporation ID
 	 * @param directorCharacterId - Character ID to authenticate ESI requests
-	 * @returns Count of assets fetched/stored
+	 * @returns Snapshot outcome and asset/inventory counts
 	 */
 	syncAssetsWithDirector(
 		corporationId: string,
 		directorCharacterId: string
-	): Promise<{ assetsCount: number }>
+	): Promise<StructureInventorySyncResult>
 
 	/**
 	 * Store structures (workflow-friendly)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the structure asset sync so a cooldown skip is no longer mistaken for a successful sync, and prevents the inventory snapshot from being wiped when structure ownership can't be determined due to an upstream failure.

## Changes
- Replaced the plain `{ assetsCount: number }` / `number` return values from `syncAssetsWithDirector`, `fetchAndStoreStructureInventory`, and `fetchAndStoreStructureInventoryByCharacter` with a new `StructureInventorySyncResult` type carrying `assetsCount`, `snapshotUpdated`, `skipReason` (`'cooldown' | 'no-owned-structures' | null`), `ownedStructureCount`, `fetchedAssetCount`, and `inventoryRowCount`.
- When the sync is skipped due to cooldown, the result now explicitly reports `snapshotUpdated: false` and `skipReason: 'cooldown'` instead of a bare `assetsCount: 0` that looked identical to a real (empty) sync.
- If refreshing owned structures fails and no owned structures can be determined, the sync now throws instead of silently falling through to clear/timestamp the inventory snapshot as if the corp legitimately owns no structures.
- Removed `'assets'` from the generic `syncedDataTypesForTimestamps` list in the sync workflow, since the assets sync path now manages its own `assetsLastSync` timestamp internally based on the actual outcome.
- Propagated the richer result through the `assets` workflow step (`AssetsSyncResult`) and `SyncStats` (new `assetsSnapshotUpdated`, `assetsSyncSkipReason`, `assetsOwnedStructureCount`, `assetsFetchedCount`, `assetsInventoryRowCount` fields), with corresponding log statements.

## Testing
- Updated unit tests in `assets-step.test.ts` and `sync-workflow.test.ts` to reflect the new result shape and timestamp behavior, including a new test asserting a cooldown skip is not treated as a successful sync.
<!-- claude:end -->