### PR TITLE
add structures tool default access to CEO/Directors for corp-owned structures

### DIFF
--- a/apps/core/src/lib/__tests__/structure-access.test.ts
+++ b/apps/core/src/lib/__tests__/structure-access.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+	getImplicitStructureAccessCorporationIds,
+	invalidateImplicitStructureAccess,
+} from '../structure-access'
+
+const { getStubMock } = vi.hoisted(() => ({
+	getStubMock: vi.fn(),
+}))
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: getStubMock,
+}))
+
+describe('implicit structure access', () => {
+	it('resolves active managed CEO and director corporations for the user', async () => {
+		const userId = 'user-structure-access'
+		const db = {
+			query: {
+				userCharacters: {
+					findMany: vi.fn().mockResolvedValue([
+						{ characterId: 'ceo-character', corporationId: 'member-corp' },
+						{ characterId: 'director-character', corporationId: 'special-corp' },
+						{ characterId: 'unrelated-character', corporationId: 'other-corp' },
+					]),
+				},
+				managedCorporations: {
+					findMany: vi
+						.fn()
+						.mockResolvedValue([
+							{ corporationId: 'member-corp' },
+							{ corporationId: 'special-corp' },
+						]),
+				},
+			},
+		} as never
+
+		getStubMock.mockImplementation((_binding: unknown, corporationId: string) => ({
+			getCorporationInfo: vi
+				.fn()
+				.mockResolvedValue(
+					corporationId === 'member-corp'
+						? { ceoId: 'ceo-character' }
+						: { ceoId: 'other-character' }
+				),
+			getDirectors: vi
+				.fn()
+				.mockResolvedValue(
+					corporationId === 'special-corp'
+						? [{ characterId: 'director-character', isHealthy: false }]
+						: []
+				),
+		}))
+
+		await expect(
+			getImplicitStructureAccessCorporationIds({ EVE_CORPORATION_DATA: {} } as never, db, userId)
+		).resolves.toEqual(['member-corp', 'special-corp'])
+
+		expect(getStubMock).toHaveBeenCalledTimes(2)
+		invalidateImplicitStructureAccess(userId)
+	})
+
+	it('does not resolve a corporation when the persisted roster lookup fails', async () => {
+		const userId = 'user-structure-access-failure'
+		const db = {
+			query: {
+				userCharacters: {
+					findMany: vi
+						.fn()
+						.mockResolvedValue([
+							{ characterId: 'director-character', corporationId: 'member-corp' },
+						]),
+				},
+				managedCorporations: {
+					findMany: vi.fn().mockResolvedValue([{ corporationId: 'member-corp' }]),
+				},
+			},
+		} as never
+		getStubMock.mockImplementation(() => {
+			throw new Error('director dependency unavailable')
+		})
+
+		await expect(
+			getImplicitStructureAccessCorporationIds({ EVE_CORPORATION_DATA: {} } as never, db, userId)
+		).resolves.toEqual([])
+		invalidateImplicitStructureAccess(userId)
+	})
+})

--- a/apps/core/src/lib/structure-access.ts
+++ b/apps/core/src/lib/structure-access.ts
@@ -1,0 +1,111 @@
+import { and, eq, inArray, or } from '@repo/db-utils'
+import { getStub } from '@repo/do-utils'
+import { logger, TimeCache } from '@repo/hono-helpers'
+
+import { managedCorporations, userCharacters } from '../db/schema'
+
+import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { App } from '../context'
+
+type Db = NonNullable<App['Variables']['db']>
+
+const STRUCTURE_ACCESS_CACHE_TTL_MS = 30 * 1000
+
+const implicitStructureAccessCache = new TimeCache<string[]>(STRUCTURE_ACCESS_CACHE_TTL_MS)
+
+/**
+ * Resolve the corporations for which a user's linked characters are persisted
+ * as CEO/director representatives. This is intentionally user-scoped: callers
+ * cannot supply a character list and use it as an authorization claim.
+ */
+export async function getImplicitStructureAccessCorporationIds(
+	env: App['Bindings'],
+	db: Db | undefined,
+	userId: string
+): Promise<string[]> {
+	if (!db) {
+		return []
+	}
+
+	return implicitStructureAccessCache.getOrSet(`structure-access:${userId}`, async () => {
+		const characters = await db.query.userCharacters.findMany({
+			where: and(
+				eq(userCharacters.userId, userId),
+				eq(userCharacters.isDeleted, false),
+				eq(userCharacters.status, 'active')
+			),
+			columns: {
+				characterId: true,
+				corporationId: true,
+			},
+		})
+
+		const characterIdsByCorporation = new Map<string, Set<string>>()
+		for (const character of characters) {
+			if (!character.corporationId) continue
+			const characterIds = characterIdsByCorporation.get(character.corporationId) ?? new Set()
+			characterIds.add(character.characterId)
+			characterIdsByCorporation.set(character.corporationId, characterIds)
+		}
+
+		const corporationIds = [...characterIdsByCorporation.keys()]
+		if (corporationIds.length === 0) {
+			return []
+		}
+
+		const managed = await db.query.managedCorporations.findMany({
+			where: and(
+				inArray(managedCorporations.corporationId, corporationIds),
+				eq(managedCorporations.isActive, true),
+				eq(managedCorporations.includeInStructureAssetSync, true),
+				eq(managedCorporations.isAltCorp, false),
+				or(
+					eq(managedCorporations.isMemberCorporation, true),
+					eq(managedCorporations.isSpecialPurpose, true)
+				)
+			),
+			columns: {
+				corporationId: true,
+			},
+		})
+
+		const eligibleCorporationIds = new Set(managed.map((row) => row.corporationId))
+		const accessCorporationIds: string[] = []
+
+		for (const corporationId of eligibleCorporationIds) {
+			const characterIds = characterIdsByCorporation.get(corporationId)
+			if (!characterIds) continue
+
+			try {
+				const corporationData = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, corporationId)
+				const [corporationInfo, directors] = await Promise.all([
+					corporationData.getCorporationInfo(corporationId),
+					corporationData.getDirectors(corporationId),
+				])
+
+				const isCeo = corporationInfo?.ceoId
+					? characterIds.has(String(corporationInfo.ceoId))
+					: false
+				const isDirector = directors.some((director) =>
+					characterIds.has(String(director.characterId))
+				)
+
+				if (isCeo || isDirector) {
+					accessCorporationIds.push(corporationId)
+				}
+			} catch (error) {
+				logger.warn('[StructureAccess] Failed to resolve persisted CEO/director roster', {
+					userId,
+					corporationId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+		}
+
+		return accessCorporationIds.sort()
+	})
+}
+
+export function invalidateImplicitStructureAccess(userId: string): void {
+	implicitStructureAccessCache.delete(`structure-access:${userId}`)
+}

--- a/apps/core/src/routes/__tests__/structures.route.test.ts
+++ b/apps/core/src/routes/__tests__/structures.route.test.ts
@@ -40,10 +40,14 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 		sessionId: 'session-1',
 		characters: [],
 		is_admin: false,
-		roles: [],
+		roles: ['urn:structures:all:viewer'],
 		discordUserId: null,
 		...overrides,
 	}
+}
+
+function makeUserWithoutStructureAccess(overrides: Partial<SessionUser> = {}): SessionUser {
+	return makeUser({ roles: [], ...overrides })
 }
 
 function createApp(user?: SessionUser) {
@@ -63,7 +67,9 @@ function createApp(user?: SessionUser) {
 describe('structures routes', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
-		vi.mocked(getCachedUserPermissions).mockResolvedValue([])
+		vi.mocked(getCachedUserPermissions).mockResolvedValue([
+			{ urn: 'urn:structures:all:viewer' },
+		] as never)
 		structuresMocks.getStructureDetail.mockResolvedValue({
 			corporationId: 'corp-1',
 			corporationName: 'Test Corp',
@@ -250,6 +256,31 @@ describe('structures routes', () => {
 				reinforced: 0,
 			},
 		})
+	})
+
+	it('rejects structure data requests without any structure permission scope', async () => {
+		vi.mocked(getCachedUserPermissions).mockResolvedValue([])
+		const app = createApp(makeUserWithoutStructureAccess())
+		const response = await app.request('/api/structures')
+
+		expect(response.status).toBe(403)
+		expect(await response.json()).toEqual({ error: 'Structure permission required' })
+	})
+
+	it('rejects the structure capability endpoint without any structure permission scope', async () => {
+		vi.mocked(getCachedUserPermissions).mockResolvedValue([])
+		const app = createApp(makeUserWithoutStructureAccess())
+		const response = await app.request('/api/structures/access')
+
+		expect(response.status).toBe(403)
+		expect(await response.json()).toEqual({ error: 'Structure permission required' })
+	})
+
+	it('requires authentication for the structure access capability endpoint', async () => {
+		const response = await createApp().request('/api/structures/access')
+
+		expect(response.status).toBe(401)
+		expect(await response.json()).toEqual({ error: 'Unauthorized' })
 	})
 
 	it('strips updatedAt from list responses before sending them to the browser', async () => {

--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 
 import { getStub } from '@repo/do-utils'
-import { hasAllStructureManagerPermission } from '@repo/groups'
+import { hasAllStructureManagerPermission, hasAnyStructurePermission } from '@repo/groups'
 import {
 	STRUCTURE_COMMON_LIST_SORT_FIELDS,
 	STRUCTURE_MOON_STRUCTURE_LIST_SORT_FIELDS,
@@ -12,6 +12,7 @@ import {
 import { createWorkflow } from '@repo/workflow-utils'
 
 import { getCachedUserPermissions } from '../lib/groups-cache'
+import { getImplicitStructureAccessCorporationIds } from '../lib/structure-access'
 import {
 	buildStructureAssetsDebugExportKey,
 	buildStructureAssetsDebugFileName,
@@ -108,13 +109,40 @@ async function getStructureActor(c: Context<App>) {
 	}
 
 	const permissions = await getCachedUserPermissions(c.env, user.id)
+	const implicitSensitiveCorporationIds = await getImplicitStructureAccessCorporationIds(
+		c.env,
+		c.get('db'),
+		user.id
+	)
 
 	return {
 		id: user.id,
 		is_admin: user.is_admin,
 		roles: permissions.map((permission) => permission.urn),
+		implicitSensitiveCorporationIds,
 	}
 }
+
+function hasStructureApiAccess(actor: Awaited<ReturnType<typeof getStructureActor>>): boolean {
+	return (
+		actor.is_admin ||
+		hasAnyStructurePermission(actor.roles.map((urn) => ({ urn }))) ||
+		(actor.implicitSensitiveCorporationIds?.length ?? 0) > 0
+	)
+}
+
+app.use('*', async (c, next) => {
+	if (!c.get('user')) {
+		return next()
+	}
+
+	const actor = await getStructureActor(c)
+	if (!hasStructureApiAccess(actor)) {
+		return c.json({ error: 'Structure permission required' }, 403)
+	}
+
+	return next()
+})
 
 async function canManageStructures(c: Context<App>): Promise<boolean> {
 	const user = c.get('user')
@@ -349,6 +377,18 @@ app.get('/moon-drills', async (c) => {
 
 app.get('/mining-citadels', async (c) => {
 	return handleMiningCitadelsStructuresRequest(c)
+})
+
+app.get('/access', async (c) => {
+	if (!c.get('user')) {
+		return c.json({ error: 'Unauthorized' }, 401)
+	}
+
+	const actor = await getStructureActor(c)
+	return c.json({
+		canView: hasStructureApiAccess(actor),
+		hasImplicitSensitiveAccess: (actor.implicitSensitiveCorporationIds?.length ?? 0) > 0,
+	})
 })
 
 app.post('/:structureId/assets-debug', async (c) => {

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -717,6 +717,72 @@ export function computeStructureAccess(roles: string[], isAdmin: boolean): Struc
 	}
 }
 
+function addImplicitSensitiveAccess(
+	access: StructureAccessScope,
+	corporationIds: Iterable<string>
+): StructureAccessScope {
+	for (const tab of STRUCTURE_ACCESS_TABS) {
+		const target = access.tabs[tab]
+		for (const corporationId of corporationIds) {
+			target.viewCorporationIds.add(corporationId)
+			target.detailsCorporationIds.add(corporationId)
+			target.sensitiveCorporationIds.add(corporationId)
+		}
+	}
+
+	return access
+}
+
+export async function resolveStructureAccess(
+	db: DbClient<DbSchema>,
+	user: SessionUser
+): Promise<StructureAccessScope> {
+	const access = computeStructureAccess(user.roles, user.is_admin)
+	if (user.is_admin || !user.implicitSensitiveCorporationIds?.length) {
+		return access
+	}
+
+	const requestedCorporationIds = [
+		...new Set(
+			user.implicitSensitiveCorporationIds.filter(
+				(corporationId) => corporationId.trim().length > 0
+			)
+		),
+	]
+	if (requestedCorporationIds.length === 0) {
+		return access
+	}
+
+	try {
+		const eligibleCorporations = await db.query.managedCorporations.findMany({
+			where: and(
+				inArray(managedCorporations.corporationId, requestedCorporationIds),
+				eq(managedCorporations.isActive, true),
+				eq(managedCorporations.includeInStructureAssetSync, true),
+				eq(managedCorporations.isAltCorp, false),
+				or(
+					eq(managedCorporations.isMemberCorporation, true),
+					eq(managedCorporations.isSpecialPurpose, true)
+				)
+			),
+			columns: {
+				corporationId: true,
+			},
+		})
+
+		return addImplicitSensitiveAccess(
+			access,
+			eligibleCorporations.map((corporation) => corporation.corporationId)
+		)
+	} catch (error) {
+		logger.warn('[StructureAccess] Failed to revalidate implicit corporation access', {
+			userId: user.id,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return access
+	}
+}
+
 export function canManageStructureModule(user: SessionUser): boolean {
 	const access = computeStructureAccess(user.roles, user.is_admin)
 	return user.is_admin || access.all.managerAll
@@ -1640,7 +1706,7 @@ async function getStructureContext(
 	} = {}
 ): Promise<StructureContext | null> {
 	const requireDetailsPermission = options.requireDetailsPermission ?? false
-	const access = computeStructureAccess(user.roles, user.is_admin)
+	const access = await resolveStructureAccess(db, user)
 	const accessibleCorporations = getAccessibleCorporationIds(access)
 	const structure = await db.query.corporationStructures.findFirst({
 		columns: CORPORATION_STRUCTURE_SELECT_COLUMNS,
@@ -2859,11 +2925,23 @@ function buildSovereigntyStructuresCte(db: DbClient<DbSchema>, corpWhere: any) {
 	)
 }
 
-function buildSovereigntyWhere(
+export function buildSovereigntyWhere(
 	access: StructureAccessScope,
 	query: StructureSovereigntyListQuery
 ): any {
 	const conditions: StructureWhereCondition[] = []
+	const accessibleCorporations = getAccessibleCorporationIds(access, 'sovereignty')
+	if (!accessibleCorporations.hasGlobalAccess) {
+		if (accessibleCorporations.corporationIds.size === 0) {
+			conditions.push(sql`false`)
+		} else {
+			conditions.push(
+				inArray(structureSovereigntySystems.corporationId, [
+					...accessibleCorporations.corporationIds,
+				])
+			)
+		}
+	}
 	addDelimitedFilterCondition(
 		conditions,
 		structureSovereigntySystems.corporationId,
@@ -4284,7 +4362,7 @@ async function listOperationalStructures(
 	query: StructureListQuery = {},
 	activeTab: StructureTab
 ): Promise<StructureListResponse> {
-	const access = computeStructureAccess(user.roles, user.is_admin)
+	const access = await resolveStructureAccess(db, user)
 	const tabAccess = getStructureAccessTarget(access, activeTab)
 	if (!hasAnyStructureAccess(tabAccess)) {
 		return {
@@ -4457,7 +4535,7 @@ export async function listMoonDrillStructures(
 	user: SessionUser,
 	query: StructureMoonDrillListQuery = {}
 ): Promise<RepoStructureMoonDrillListResponse> {
-	const access = computeStructureAccess(user.roles, user.is_admin)
+	const access = await resolveStructureAccess(db, user)
 	const accessForTab = getStructureAccessTarget(access, 'moon-drills')
 	if (!hasAnyStructureAccess(accessForTab)) {
 		return {
@@ -4687,7 +4765,7 @@ export async function listSovereigntyStructures(
 	user: SessionUser,
 	query: StructureSovereigntyListQuery = {}
 ): Promise<RepoStructureSovereigntyListResponse> {
-	const access = computeStructureAccess(user.roles, user.is_admin)
+	const access = await resolveStructureAccess(db, user)
 	const accessibleCorporations = getAccessibleCorporationIds(access)
 	if (!accessibleCorporations.hasGlobalAccess && accessibleCorporations.corporationIds.size === 0) {
 		return {
@@ -4784,7 +4862,7 @@ export async function listMiningCitadelStructures(
 	user: SessionUser,
 	query: StructureMiningCitadelListQuery = {}
 ): Promise<RepoStructureMiningCitadelListResponse> {
-	const access = computeStructureAccess(user.roles, user.is_admin)
+	const access = await resolveStructureAccess(db, user)
 	const accessForTab = getStructureAccessTarget(access, 'mining-citadels')
 	if (!hasAnyStructureAccess(accessForTab)) {
 		return {
@@ -4895,7 +4973,7 @@ export async function updateStructureConfig(
 		return null
 	}
 
-	const access = computeStructureAccess(user.roles, user.is_admin)
+	const access = await resolveStructureAccess(db, user)
 	const structureTab = getStructureTab(context.structure)
 	const canEdit =
 		user.is_admin || canEditStructure(access, context.structure.corporationId, structureTab)

--- a/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
+++ b/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { getStructureDetail, listSovereigntyStructures } from '../../../services/structures.service'
+import {
+	buildSovereigntyWhere,
+	computeStructureAccess,
+	getStructureDetail,
+	listSovereigntyStructures,
+} from '../../../services/structures.service'
 
 const mocks = vi.hoisted(() => {
 	const getStubMock = vi.fn()
@@ -540,6 +545,16 @@ function makeDb() {
 }
 
 describe('sovereignty hub model', () => {
+	it('scopes sovereignty queries to the corporations allowed for the sovereignty tab', () => {
+		const access = computeStructureAccess(['urn:structures:corp-1:sensitive'], false)
+		const condition = buildSovereigntyWhere(access, {}) as { queryChunks?: unknown[] }
+		const chunks = condition.queryChunks ?? []
+
+		expect(
+			chunks.some((chunk) => String((chunk as { value?: unknown }).value ?? '') === ' in ')
+		).toBe(true)
+	})
+
 	it('lists sovereignty hubs without requiring corporation structures rows', async () => {
 		const db = makeDb()
 		mocks.getStubMock.mockReturnValue(db.universeStub)

--- a/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
+++ b/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
@@ -10,6 +10,7 @@ import {
 	getStructureTab,
 	hasAnyStructureAccess,
 	hasStructureAccessForTab,
+	resolveStructureAccess,
 } from '../../../services/structures.service'
 
 vi.mock('@repo/do-utils', () => ({
@@ -38,6 +39,7 @@ type FakeDb = {
 		}
 		managedCorporations: {
 			findFirst: ReturnType<typeof vi.fn>
+			findMany: ReturnType<typeof vi.fn>
 		}
 		structureSkyhooks: {
 			findFirst: ReturnType<typeof vi.fn>
@@ -152,6 +154,7 @@ function makeDb(
 					name: 'Test Corp',
 					includeInStructureAssetSync: false,
 				}),
+				findMany: vi.fn().mockResolvedValue([]),
 			},
 			structureSkyhooks: {
 				findFirst: vi.fn().mockResolvedValue(options.skyhook ?? skyhook),
@@ -242,6 +245,31 @@ describe('structure permission gating', () => {
 		expect(hasStructureAccessForTab(access, 'corp-2', 'structures')).toBe(true)
 		expect(canViewDetailsStructure(access, 'corp-1', 'structures')).toBe(false)
 		expect(canViewSensitiveStructure(access, 'corp-2', 'structures')).toBe(true)
+	})
+
+	it('merges implicit sensitive access across every tab without granting edits', async () => {
+		const db = makeDb()
+		db.query.managedCorporations.findMany.mockResolvedValue([{ corporationId: 'corp-1' }])
+
+		const access = await resolveStructureAccess(db as never, {
+			id: 'user-ceo',
+			is_admin: false,
+			roles: [],
+			implicitSensitiveCorporationIds: ['corp-1'],
+		})
+
+		for (const tab of [
+			'structures',
+			'sovereignty',
+			'skyhooks',
+			'mining-citadels',
+			'moon-drills',
+		] as const) {
+			expect(hasStructureAccessForTab(access, 'corp-1', tab)).toBe(true)
+			expect(canViewDetailsStructure(access, 'corp-1', tab)).toBe(true)
+			expect(canViewSensitiveStructure(access, 'corp-1', tab)).toBe(true)
+			expect(canEditStructure(access, 'corp-1', tab)).toBe(false)
+		}
 	})
 
 	it('returns null for viewer-only detail access and hydrates details for details access', async () => {

--- a/apps/ui/src/client/components/admin-nav.tsx
+++ b/apps/ui/src/client/components/admin-nav.tsx
@@ -28,6 +28,8 @@ import { Link, useLocation } from 'react-router'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
 
+import { Badge } from './ui/badge'
+
 interface AdminNavProps {
 	onNavigate?: () => void
 }
@@ -268,9 +270,13 @@ export function AdminNav({ onNavigate }: AdminNavProps) {
 							<span className="flex items-center gap-2">
 								{item.label}
 								{item.href === '/admin/legacy-migrations' && pendingLegacyMigrationsCount > 0 ? (
-									<span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-[10px] font-semibold leading-none text-destructive-foreground ring-1 ring-destructive/80">
+									<Badge
+										variant="destructive"
+										solid
+										className="h-5 min-w-5 border-0 px-1.5 text-[10px] leading-none ring-1 ring-destructive/80"
+									>
 										{pendingLegacyMigrationsCount > 99 ? '99+' : pendingLegacyMigrationsCount}
-									</span>
+									</Badge>
 								) : null}
 							</span>
 						</Link>

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -39,6 +39,7 @@ import { canAccessMumble } from '@/features/mumble/access'
 import { useMumbleFeatureEnabled } from '@/features/mumble/feature'
 import { useSrpPaymentMismatchAlerts } from '@/features/srp/hooks'
 import { useReviewQueueStatusCount } from '@/features/srp/state/review-queue-snapshot-store'
+import { useStructureAccess } from '@/features/structures/hooks'
 import { useTaxAlerts } from '@/hooks/corporation-tax'
 import { useAuth, useLogout } from '@/hooks/useAuth'
 import { usePendingInvitations } from '@/hooks/useGroups'
@@ -77,13 +78,17 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 	const { data: leadershipCorporationAccess } = useCorporationAccess()
 	const { data: hrCorporations } = useHrAccessibleCorporations()
 	const { permissions, hasAnyPermission } = useUserPermissions()
+	const { data: structureAccess } = useStructureAccess({ enabled: Boolean(user) })
 	const moonScanPermissions = useMoonScanPermissions()
 	const isSiteAdmin = user?.is_admin === true
 	const isAllianceMember = user?.roles?.includes(ROLE_CORE_ALLIANCE_MEMBER) ?? false
 	const canSeeAllianceMemberNav = isSiteAdmin || isAllianceMember
 	const { data: invitations } = usePendingInvitations({ enabled: canSeeAllianceMemberNav })
 	const { isEnabled: isMumbleFeatureEnabled } = useMumbleFeatureEnabled()
-	const canViewStructures = isSiteAdmin || hasAnyStructurePermission(permissions)
+	const canViewStructures =
+		isSiteAdmin ||
+		hasAnyStructurePermission(permissions) ||
+		structureAccess?.hasImplicitSensitiveAccess === true
 	const hasSrpManagerPermission = hasAnyPermission('urn:srp:manager')
 	const hasSrpPayerPermission = hasAnyPermission('urn:srp:payer')
 	const hasSrpReviewerPermission = hasAnyPermission('urn:srp:reviewer')
@@ -669,9 +674,13 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 													<span className="inline-flex items-center gap-2 leading-none">
 														<span>{child.label}</span>
 														{child.badge ? (
-															<span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-[10px] font-semibold leading-none text-destructive-foreground ring-1 ring-destructive/80">
+															<Badge
+																variant="destructive"
+																solid
+																className="h-5 min-w-5 border-0 px-1.5 text-[10px] leading-none ring-1 ring-destructive/80"
+															>
 																{child.badge > 99 ? '99+' : child.badge}
-															</span>
+															</Badge>
 														) : null}
 													</span>
 												</Link>
@@ -726,7 +735,8 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 							{item.badge && (
 								<Badge
 									variant="destructive"
-									className="h-5 min-w-[20px] px-1 text-[10px] flex items-center justify-center"
+									solid
+									className="h-5 min-w-5 border-0 px-1.5 text-[10px] leading-none ring-1 ring-destructive/80"
 								>
 									{item.badge}
 								</Badge>

--- a/apps/ui/src/client/components/ui/badge.tsx
+++ b/apps/ui/src/client/components/ui/badge.tsx
@@ -19,9 +19,48 @@ const badgeVariants = cva(
 				ghost: 'bg-muted/50 text-muted-foreground border-border',
 				special: 'bg-purple-500/20 text-purple-500 border-purple-500/30',
 			},
+			solid: {
+				true: '',
+				false: '',
+			},
 		},
+		compoundVariants: [
+			{
+				variant: 'default',
+				solid: true,
+				class: 'bg-primary text-primary-foreground border-primary',
+			},
+			{
+				variant: 'secondary',
+				solid: true,
+				class: 'bg-secondary text-secondary-foreground border-secondary',
+			},
+			{
+				variant: 'success',
+				solid: true,
+				class: 'bg-success text-success-foreground border-success',
+			},
+			{
+				variant: 'warning',
+				solid: true,
+				class: 'bg-warning text-warning-foreground border-warning',
+			},
+			{
+				variant: 'gold',
+				solid: true,
+				class: 'bg-amber-400 text-amber-950 border-amber-400',
+			},
+			{
+				variant: 'destructive',
+				solid: true,
+				class: 'bg-destructive text-destructive-foreground border-destructive',
+			},
+			{ variant: 'ghost', solid: true, class: 'bg-muted text-foreground border-border' },
+			{ variant: 'special', solid: true, class: 'bg-purple-500 text-white border-purple-500' },
+		],
 		defaultVariants: {
 			variant: 'default',
+			solid: false,
 		},
 	}
 )
@@ -35,9 +74,17 @@ export interface BadgeProps
 	iconPosition?: 'left' | 'right'
 }
 
-function Badge({ className, variant, icon: Icon, iconPosition = 'left', children, ...props }: BadgeProps) {
+function Badge({
+	className,
+	variant,
+	solid,
+	icon: Icon,
+	iconPosition = 'left',
+	children,
+	...props
+}: BadgeProps) {
 	return (
-		<div className={cn(badgeVariants({ variant }), Icon && 'gap-1', className)} {...props}>
+		<div className={cn(badgeVariants({ variant, solid }), Icon && 'gap-1', className)} {...props}>
 			{Icon && iconPosition === 'left' && <Icon className="h-3 w-3 shrink-0" />}
 			{children}
 			{Icon && iconPosition === 'right' && <Icon className="h-3 w-3 shrink-0" />}

--- a/apps/ui/src/client/features/structures/hooks.ts
+++ b/apps/ui/src/client/features/structures/hooks.ts
@@ -7,6 +7,7 @@ import { structureKeys } from './query-keys'
 import type { UseQueryOptions } from '@tanstack/react-query'
 import type { StructureTab } from '@repo/structures'
 import type {
+	StructureAccessSummary,
 	StructureListQuery,
 	StructureMainListResponse,
 	StructureMiningCitadelListQuery,
@@ -32,6 +33,19 @@ type StructureTabQuery =
 const STRUCTURE_LIST_STALE_TIME = 1000 * 60 * 15
 const STRUCTURE_LIST_GC_TIME = 1000 * 60 * 60
 const STRUCTURE_CONFIG_STALE_TIME = 1000 * 60 * 30
+const STRUCTURE_ACCESS_STALE_TIME = 1000 * 30
+
+export function useStructureAccess(
+	options: Pick<UseQueryOptions<StructureAccessSummary>, 'enabled'> = {}
+) {
+	return useQuery<StructureAccessSummary>({
+		queryKey: structureKeys.access(),
+		queryFn: () => api.getStructureAccess(),
+		staleTime: STRUCTURE_ACCESS_STALE_TIME,
+		gcTime: STRUCTURE_ACCESS_STALE_TIME,
+		enabled: options.enabled ?? true,
+	})
+}
 
 function createStructureListQueryOptions<TResponse>(
 	queryKey: readonly unknown[],

--- a/apps/ui/src/client/features/structures/query-keys.ts
+++ b/apps/ui/src/client/features/structures/query-keys.ts
@@ -15,6 +15,7 @@ type StructureTabQuery =
 
 export const structureKeys = {
 	all: ['structures'] as const,
+	access: () => [...structureKeys.all, 'access'] as const,
 	structures: (query: StructureTabQuery) => [...structureKeys.all, 'structures', query] as const,
 	sovereignty: (query: StructureTabQuery) => [...structureKeys.all, 'sovereignty', query] as const,
 	skyhooks: (query: StructureTabQuery) => [...structureKeys.all, 'skyhooks', query] as const,

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -1063,6 +1063,10 @@ export interface StructureListResponse<TItem = StructureListItem> {
 }
 
 export interface StructureMainListResponse extends StructureListResponse<StructureListItem> {}
+export interface StructureAccessSummary {
+	canView: boolean
+	hasImplicitSensitiveAccess: boolean
+}
 export type StructureSovereigntyListResponse = RepoStructureSovereigntyListResponse
 export type StructureSkyhookListResponse = RepoStructureSkyhookListResponse
 export type StructureMoonDrillListResponse = RepoStructureMoonDrillListResponse
@@ -3609,6 +3613,10 @@ export class ApiClient {
 		if (query.typeId) params.set('typeId', query.typeId)
 		const queryString = params.toString()
 		return this.get(`/structures${queryString ? `?${queryString}` : ''}`)
+	}
+
+	async getStructureAccess(): Promise<StructureAccessSummary> {
+		return this.get('/structures/access')
 	}
 
 	async getSovereigntyStructures(

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -65,6 +65,8 @@ import { getSovereigntyVulnerabilityWindowDisplay } from '@/lib/sovereignty-vuln
 import { stripLeadingContextName } from '@/lib/structure-name-utils'
 import toast from '@/lib/toast'
 
+import { useStructureAccess } from '../features/structures/hooks'
+
 import type { FittingDisplayItem, FittingShipSlotType } from '@repo/eve-fitting/flags'
 import type { StructureSovereigntyTransportSection } from '@repo/structures'
 import type { BadgeVariant } from '@/components/ui/badge'
@@ -690,12 +692,19 @@ function structureFittingItemsToDisplayItems(
 export default function StructuresDetailPage() {
 	const { structureId } = useParams<{ structureId: string }>()
 	const queryClient = useQueryClient()
-	const { user, isLoading: authLoading } = useAuth()
+	const { user, isAuthenticated, isLoading: authLoading } = useAuth()
 	const { permissions, isLoading: permissionsLoading } = useUserPermissions()
-	const canViewStructures = user?.is_admin === true || hasAnyStructurePermission(permissions)
+	const { data: structureAccess, isLoading: structureAccessLoading } = useStructureAccess({
+		enabled: isAuthenticated && !authLoading,
+	})
+	const hasImplicitSensitiveAccess = structureAccess?.hasImplicitSensitiveAccess === true
+	const canViewStructures =
+		user?.is_admin === true || hasAnyStructurePermission(permissions) || hasImplicitSensitiveAccess
 	const canViewStructureDetails =
-		user?.is_admin === true || hasStructureDetailsPermission(permissions)
-	const canAccess = canViewStructureDetails && Boolean(structureId)
+		user?.is_admin === true ||
+		hasStructureDetailsPermission(permissions) ||
+		hasImplicitSensitiveAccess
+	const canAccess = !structureAccessLoading && canViewStructureDetails && Boolean(structureId)
 	const {
 		data: structure,
 		isLoading,
@@ -906,11 +915,17 @@ export default function StructuresDetailPage() {
 			])
 		)
 	}, [sovereigntyStructures])
-	if (!authLoading && !permissionsLoading && !canViewStructures) {
+	if (!authLoading && !permissionsLoading && !structureAccessLoading && !canViewStructures) {
 		return <Navigate to="/dashboard" replace />
 	}
 
-	if (!authLoading && !permissionsLoading && canViewStructures && !canViewStructureDetails) {
+	if (
+		!authLoading &&
+		!permissionsLoading &&
+		!structureAccessLoading &&
+		canViewStructures &&
+		!canViewStructureDetails
+	) {
 		return <Navigate to="/structures" replace />
 	}
 

--- a/apps/ui/src/client/routes/structures.tsx
+++ b/apps/ui/src/client/routes/structures.tsx
@@ -101,6 +101,7 @@ import {
 	useMoonDrillStructures,
 	useSkyhookStructures,
 	useSovereigntyStructures,
+	useStructureAccess,
 	useStructureModuleConfig,
 	useStructures,
 } from '../features/structures/hooks'
@@ -524,11 +525,16 @@ type PrimaryStructureFilterSlot = 'type' | 'raidable' | null
 export default function StructuresPage() {
 	usePageTitle('Structures')
 
-	const { user, isLoading: authLoading } = useAuth()
+	const { user, isAuthenticated, isLoading: authLoading } = useAuth()
 	const navigate = useNavigate()
 	const { data: groups = [] } = useGroups({ limit: 100 })
 	const { permissions, isLoading: permissionsLoading } = useUserPermissions()
-	const canViewStructures = user?.is_admin === true || hasAnyStructurePermission(permissions)
+	const { data: structureAccess, isLoading: structureAccessLoading } = useStructureAccess({
+		enabled: isAuthenticated && !authLoading,
+	})
+	const hasImplicitSensitiveAccess = structureAccess?.hasImplicitSensitiveAccess === true
+	const canViewStructures =
+		user?.is_admin === true || hasAnyStructurePermission(permissions) || hasImplicitSensitiveAccess
 	const canManageStructures =
 		user?.is_admin === true || hasAllStructureManagerPermission(permissions)
 	const tableState = useStructureTableUiState((state) => state)
@@ -537,10 +543,10 @@ export default function StructuresPage() {
 	const [areFiltersOpen, setAreFiltersOpen] = useState(true)
 	const visibleTabs = useMemo(
 		() =>
-			user?.is_admin === true
+			user?.is_admin === true || hasImplicitSensitiveAccess
 				? STRUCTURE_TABS
 				: STRUCTURE_TABS.filter((tab) => hasStructureTabPermission(permissions, tab.tab)),
-		[user, permissions]
+		[user, permissions, hasImplicitSensitiveAccess]
 	)
 	const activeTab = visibleTabs.some((tab) => tab.tab === tableState.tab)
 		? tableState.tab
@@ -641,22 +647,44 @@ export default function StructuresPage() {
 	)
 
 	const structuresResponseQuery = useStructures(commonQuery, {
-		enabled: !authLoading && !permissionsLoading && canViewStructures && activeTab === 'structures',
+		enabled:
+			!authLoading &&
+			!permissionsLoading &&
+			!structureAccessLoading &&
+			canViewStructures &&
+			activeTab === 'structures',
 	})
 	const sovereigntyStructures = useSovereigntyStructures(sovereigntyQuery, {
 		enabled:
-			!authLoading && !permissionsLoading && canViewStructures && activeTab === 'sovereignty',
+			!authLoading &&
+			!permissionsLoading &&
+			!structureAccessLoading &&
+			canViewStructures &&
+			activeTab === 'sovereignty',
 	})
 	const skyhookStructures = useSkyhookStructures(skyhookQuery, {
-		enabled: !authLoading && !permissionsLoading && canViewStructures && activeTab === 'skyhooks',
+		enabled:
+			!authLoading &&
+			!permissionsLoading &&
+			!structureAccessLoading &&
+			canViewStructures &&
+			activeTab === 'skyhooks',
 	})
 	const miningCitadelStructures = useMiningCitadelStructures(miningCitadelQuery, {
 		enabled:
-			!authLoading && !permissionsLoading && canViewStructures && activeTab === 'mining-citadels',
+			!authLoading &&
+			!permissionsLoading &&
+			!structureAccessLoading &&
+			canViewStructures &&
+			activeTab === 'mining-citadels',
 	})
 	const moonDrillStructures = useMoonDrillStructures(moonDrillQuery, {
 		enabled:
-			!authLoading && !permissionsLoading && canViewStructures && activeTab === 'moon-drills',
+			!authLoading &&
+			!permissionsLoading &&
+			!structureAccessLoading &&
+			canViewStructures &&
+			activeTab === 'moon-drills',
 	})
 
 	const isSovereigntyTab = activeTab === 'sovereignty'
@@ -1717,7 +1745,7 @@ export default function StructuresPage() {
 		</div>
 	)
 
-	if (!authLoading && !permissionsLoading && !canViewStructures) {
+	if (!authLoading && !permissionsLoading && !structureAccessLoading && !canViewStructures) {
 		return <Navigate to="/dashboard" replace />
 	}
 

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -188,6 +188,8 @@ export interface StructureActor {
 	id: string
 	is_admin: boolean
 	roles: string[]
+	/** Server-derived corporations receiving implicit sensitive read access. */
+	implicitSensitiveCorporationIds?: string[]
 }
 
 export interface StructureListPagingQuery<


### PR DESCRIPTION
<!-- claude:begin -->
**Summary**
Grants corporation CEOs and directors implicit read access to their own corporation structures data, even without an explicit `urn:structures:*` permission grant, as long as the corporation is actively managed and synced for structure assets.

**Changes**
- Added `apps/core/src/lib/structure-access.ts`: resolves the set of corporations where the requesting user linked, active characters are the persisted CEO or a director, restricted to managed corporations flagged `isActive`, `includeInStructureAssetSync`, not an alt corp, and either member or special-purpose. Results are cached per user for 30s via `TimeCache`, with an `invalidateImplicitStructureAccess` escape hatch.
- `apps/core/src/routes/structures.ts`: adds a router-level guard requiring admin, any explicit structure permission, or implicit corp access before serving any `/structures/*` route; adds a new `GET /structures/access` endpoint returning `{ canView, hasImplicitSensitiveAccess }`.
- `apps/structures/src/services/structures.service.ts`: adds `resolveStructureAccess`, which augments `computeStructureAccess` with implicit sensitive (view/details/sensitive, never edit) access for the user implicit corporations, re-validated against `managedCorporations` on each call. Wired into `getStructureContext`, `listOperationalStructures`, `listMoonDrillStructures`, `listSovereigntyStructures`, `listMiningCitadelStructures`, and `updateStructureConfig`. Also exports the previously-private `buildSovereigntyWhere` and scopes sovereignty queries to accessible corporations when the caller lacks global access.
- `packages/structures/src/index.ts`: adds optional `implicitSensitiveCorporationIds` to `StructureActor`.
- UI: adds `useStructureAccess` hook plus `ApiClient.getStructureAccess()`, and uses `hasImplicitSensitiveAccess` in the sidebar nav, structures list page, and structure detail page to show the nav entry, unlock tabs, and allow route access for implicit-access users.
- `apps/ui/src/client/components/ui/badge.tsx`: adds a `solid` variant (with per-color `compoundVariants`) and applies it in `admin-nav.tsx`/`sidebar-nav.tsx` in place of hand-rolled `span` badge markup.

**Testing**
- Added unit tests for `getImplicitStructureAccessCorporationIds`/`invalidateImplicitStructureAccess` covering successful CEO/director resolution and graceful fallback to an empty result when the roster lookup fails.
- Added route tests for the new `/structures` permission guard and `/structures/access` endpoint (403 without permission, 401 unauthenticated).
- Added service tests for `resolveStructureAccess` (implicit access granted across all tabs without edit rights) and `buildSovereigntyWhere` (corporation-scoped IN filtering).
<!-- claude:end -->