### PR TITLE
Feat/structure moon composition ux

### DIFF
--- a/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
+++ b/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
@@ -2,6 +2,8 @@ import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStub } from '@repo/do-utils'
+import { summarizeInventoryRows } from '@repo/inventory-display'
+import { calculateStructureProfitability } from '@repo/moon-scan'
 
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 import { clearMoonScanPricingCaches, moonScanRoutes } from '../moon-scan'
@@ -200,6 +202,80 @@ describe('moon-scan profitability and batching behavior', () => {
 		})
 	})
 
+	it('aggregates inventory volume and preserves unknown volume as unavailable', () => {
+		const [bay] = summarizeInventoryRows([
+			{
+				locationFlag: 'MoonMaterialBay',
+				typeId: '16633',
+				quantity: 100,
+				unitVolumeM3: 0.05,
+			},
+			{
+				locationFlag: 'MoonMaterialBay',
+				typeId: '16633',
+				quantity: 20,
+				unitVolumeM3: 0.05,
+			},
+		])
+
+		expect(bay?.items[0]?.volumeM3).toBe(6)
+
+		const [incompleteBay] = summarizeInventoryRows([
+			{
+				locationFlag: 'MoonMaterialBay',
+				typeId: '16633',
+				quantity: 100,
+				unitVolumeM3: 0.05,
+			},
+			{
+				locationFlag: 'MoonMaterialBay',
+				typeId: '16633',
+				quantity: 20,
+				unitVolumeM3: null,
+			},
+		])
+
+		expect(incompleteBay?.items[0]?.volumeM3).toBeNull()
+	})
+
+	it('falls back to canonical ore volume and avoids invalid material volume output', () => {
+		const result = calculateStructureProfitability(
+			{
+				moonId: 'moon-1',
+				sourceScanId: 'scan-1',
+				verifiedAt: '2026-05-01T00:00:00.000Z',
+				verifiedBy: null,
+				ores: [{ oreTypeId: '45490', quantity: '1' }],
+			},
+			{
+				defaultReprocessingYield: '1',
+				defaultCycleDays: 1,
+				fuelBlockPriceOverride: null,
+				magmaticGasPriceOverride: null,
+				profiles: [
+					{
+						id: 'tatara',
+						baseVolumePerHr: '1000',
+						rigBonus: '0',
+						fuelPerHr: '10',
+						magmaticGasPerHr: null,
+						nullsecModifier: '1',
+						isPassive: false,
+					},
+				],
+				typeMaterials: [{ oreTypeId: '45490', materialTypeId: '16633', quantity: 100 }],
+				materialVolumes: {},
+				oreVolumes: { '45490': 0 },
+				prices: [],
+			},
+			'tatara'
+		)
+
+		expect(result?.ores[0]?.oreUnits).toBe(2400)
+		expect(result?.ores[0]?.refinesTo[0]?.volumeM3).toBeNull()
+		expect(result?.ores[0]?.volumeM3).toBeNull()
+	})
+
 	it('uses batched moon lookup for region detail (no per-system moon RPC)', async () => {
 		universeStub.getSystemsByRegionId.mockResolvedValue([
 			{ solarSystemId: 'sys-low', solarSystemName: 'Low', securityStatus: '0.5' },
@@ -352,12 +428,19 @@ describe('moon-scan profitability and batching behavior', () => {
 			'45490': [{ materialTypeId: '16633', quantity: 100 }],
 		})
 		universeStub.resolveTypeNamesByIds.mockResolvedValue({
-			'45490': { typeId: '45490', typeName: 'Bitumens', groupId: '1', groupName: 'Moon Ore' },
+			'45490': {
+				typeId: '45490',
+				typeName: 'Bitumens',
+				groupId: '1',
+				groupName: 'Moon Ore',
+				volume: '10',
+			},
 			'16633': {
 				typeId: '16633',
 				typeName: 'Hydrocarbons',
 				groupId: '2',
 				groupName: 'Moon Materials',
+				volume: '0.05',
 			},
 		})
 		marketsStub.getBatchMarketDataAtTime.mockResolvedValue({
@@ -376,6 +459,11 @@ describe('moon-scan profitability and batching behavior', () => {
 					structureType: 'tatara' | 'metenox'
 					fuelCost: string
 					magmaticGasCost: string | null
+					ores: Array<{
+						refinesTo: Array<{ volumeM3: number; volumePer100M3: number }>
+						oreUnits: number
+						oreVolumeM3: number
+					}>
 				}>
 			} | null
 		}
@@ -388,6 +476,10 @@ describe('moon-scan profitability and batching behavior', () => {
 		expect(tatara?.fuelCost).toBe('239760')
 		expect(metenox?.fuelCost).toBe('119880')
 		expect(metenox?.magmaticGasCost).toBe('26640')
+		expect(tatara?.ores[0]?.oreUnits).toBe(2400)
+		expect(tatara?.ores[0]?.oreVolumeM3).toBe(24000)
+		expect(tatara?.ores[0]?.refinesTo[0]?.volumePer100M3).toBe(5)
+		expect(tatara?.ores[0]?.refinesTo[0]?.volumeM3).toBe(120)
 	})
 
 	it('prices discovered refine materials in verified moon list flow', async () => {

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -12,6 +12,7 @@ import {
 	MOON_ORE_TYPE_IDS,
 	ORE_TYPE_RARITY,
 	parseMoonScanTsv,
+	parseVolumeM3,
 	RARITY_ORDER,
 } from '@repo/moon-scan'
 import { buildCsvLine, createR2MultipartTextWriter } from '@repo/worker-utils'
@@ -38,7 +39,7 @@ import type {
 	VerifiedMoonsSortBy,
 	VerifiedMoonSummaryRecord,
 } from '@repo/moon-scan'
-import type { Universe, UniverseSolarSystem } from '@repo/universe'
+import type { InvType, Universe, UniverseSolarSystem } from '@repo/universe'
 import type { App } from '../context'
 
 // ─── Permission URNs ─────────────────────────────────────────────────────────
@@ -375,7 +376,8 @@ type MoonPricingInputs = {
 	profiles: Awaited<ReturnType<MoonScanDO['getStructureProfiles']>>
 	typeMaterialsMap: Record<string, Array<{ materialTypeId: string; quantity: number }>>
 	priceMap: Record<string, number>
-	typeNamesMap: Record<string, { typeName: string } | null>
+	typeNamesMap: Record<string, InvType | null>
+	materialVolumes: Record<string, number | null>
 	oreVolumes: Record<string, number>
 	pricingSnapshotDate: string | null
 }
@@ -570,7 +572,7 @@ function getMoonProfitabilityInputsFromComposition(
 				.map((ore) => {
 					const liveMaterials = inputs.typeMaterialsMap[ore.oreTypeId] ?? []
 					const fraction = parseFloat(ore.quantity)
-					const oreUnits = (totalVolume * fraction) / getOreVolume(ore.oreTypeId)
+					const oreUnits = (totalVolume * fraction) / (inputs.oreVolumes[ore.oreTypeId] ?? 0)
 
 					const refinesTo = liveMaterials
 						.filter((mat) => !(isPassive && MINERAL_TYPE_IDS.has(mat.materialTypeId)))
@@ -578,6 +580,7 @@ function getMoonProfitabilityInputsFromComposition(
 							const batchQty = mat.quantity
 							const units = Math.floor(Math.floor(oreUnits / 100) * batchQty * reprocessingYield)
 							const unitSellPrice = inputs.priceMap[mat.materialTypeId] ?? 0
+							const unitVolumeM3 = inputs.materialVolumes[mat.materialTypeId] ?? null
 							return {
 								materialTypeId: mat.materialTypeId,
 								materialName:
@@ -587,6 +590,8 @@ function getMoonProfitabilityInputsFromComposition(
 								batchQty,
 								unitSellPrice: String(unitSellPrice),
 								totalValue: String(units * unitSellPrice),
+								volumeM3: unitVolumeM3 === null ? null : units * unitVolumeM3,
+								volumePer100M3: unitVolumeM3 === null ? null : mat.quantity * unitVolumeM3,
 								materialRarity: null,
 							}
 						})
@@ -601,9 +606,14 @@ function getMoonProfitabilityInputsFromComposition(
 						oreTypeId: ore.oreTypeId,
 						oreName: inputs.typeNamesMap[ore.oreTypeId]?.typeName ?? ore.oreTypeId,
 						quantity: ore.quantity,
+						oreUnits: Math.floor(oreUnits),
 						rarity: ORE_TYPE_RARITY[ore.oreTypeId] ?? null,
 						refinesTo,
 						totalOreValue: String(totalOreValue),
+						oreVolumeM3: totalVolume * fraction,
+						volumeM3: refinesTo.some((material) => material.volumeM3 === null)
+							? null
+							: refinesTo.reduce((sum, material) => sum + (material.volumeM3 ?? 0), 0),
 					}
 				})
 				.sort(
@@ -717,6 +727,7 @@ function toMoonProfitabilityQueryInputs(inputs: MoonPricingInputs): MoonProfitab
 		typeMaterials: Object.entries(inputs.typeMaterialsMap).flatMap(([oreTypeId, materials]) =>
 			materials.map((material) => ({ ...material, oreTypeId }))
 		),
+		materialVolumes: inputs.materialVolumes,
 		oreVolumes: inputs.oreVolumes,
 		prices: Object.entries(inputs.priceMap).map(([typeId, price]) => ({ typeId, price })),
 	}
@@ -776,7 +787,7 @@ async function getMoonPricingInputsForOreTypeIds(
 				}),
 				typeIdsForNames.length > 0
 					? universe.resolveTypeNamesByIds(typeIdsForNames)
-					: Promise.resolve({} as Record<string, { typeName: string } | null>),
+					: Promise.resolve({} as Record<string, InvType | null>),
 			])
 
 			const priceMap: Record<string, number> = {}
@@ -790,8 +801,15 @@ async function getMoonPricingInputsForOreTypeIds(
 				typeMaterialsMap,
 				priceMap,
 				typeNamesMap,
+				materialVolumes: Object.fromEntries(
+					materialTypeIds.map((typeId) => [typeId, parseVolumeM3(typeNamesMap[typeId]?.volume)])
+				),
 				oreVolumes: Object.fromEntries(
-					uniqueOreTypeIds.map((typeId) => [typeId, getOreVolume(typeId)])
+					uniqueOreTypeIds.map((typeId) => [
+						typeId,
+						parseVolumeM3(typeNamesMap[typeId]?.volume, getOreVolume(typeId)) ??
+							getOreVolume(typeId),
+					])
 				),
 				pricingSnapshotDate: getPricingSnapshotDate(effectivePricingRevision),
 			}

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -5996,7 +5996,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		let structureRefreshFailed = false
 
 		if (ownedStructureIds.size === 0) {
-			logger.warn(
+			logger.info(
 				'[EveCorporationData] No owned structures available for inventory filtering; attempting a structures refresh',
 				{ corporationId }
 			)

--- a/apps/eve-corporation-data/src/workflows/steps/assets/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/assets/index.ts
@@ -30,7 +30,7 @@ export async function syncAssets(
 		inventoryRowCount: result.inventoryRowCount,
 	})
 	if (result.skipReason === 'no-owned-structures') {
-		logger.warn(
+		logger.info(
 			'[AssetsStep] Structure inventory snapshot was cleared because no owned structures were found',
 			{
 				corporationId,

--- a/apps/structures/package.json
+++ b/apps/structures/package.json
@@ -34,6 +34,7 @@
 		"@repo/groups": "workspace:*",
 		"@repo/hono-helpers": "workspace:*",
 		"@repo/inventory-display": "workspace:*",
+		"@repo/markets": "workspace:*",
 		"@repo/moon-scan": "workspace:*",
 		"@repo/structure-states": "workspace:*",
 		"@repo/structures": "workspace:*",

--- a/apps/structures/src/context.ts
+++ b/apps/structures/src/context.ts
@@ -6,6 +6,7 @@ export type Env = {
 	DATABASE_URL: string
 	EVE_CORPORATION_DATA: DurableObjectNamespace
 	MOON_SCAN: DurableObjectNamespace
+	MARKETS: DurableObjectNamespace
 	UNIVERSE: DurableObjectNamespace
 	NAME: string
 	ENVIRONMENT: string

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -28,6 +28,7 @@ import {
 	getOreVolume,
 	MAGMATIC_GAS_TYPE_ID,
 	ORE_TYPE_RARITY,
+	parseVolumeM3,
 } from '@repo/moon-scan'
 import {
 	FUEL_BLOCK_TYPE_IDS,
@@ -110,7 +111,7 @@ import type {
 	StructureSovereigntyTransportState,
 	StructureTab,
 } from '@repo/structures'
-import type { Universe } from '@repo/universe'
+import type { InvType, Universe } from '@repo/universe'
 import type { Env, SessionUser } from '../context'
 import type { DbSchema } from '../db'
 
@@ -1147,8 +1148,15 @@ async function loadStructureMoonComposition(
 					typeMaterials: Object.entries(typeMaterialsMap).flatMap(([oreTypeId, materials]) =>
 						materials.map((material) => ({ ...material, oreTypeId }))
 					),
+					materialVolumes: Object.fromEntries(
+						materialTypeIds.map((typeId) => [typeId, parseVolumeM3(typeNames[typeId]?.volume)])
+					),
 					oreVolumes: Object.fromEntries(
-						oreTypeIds.map((typeId) => [typeId, getOreVolume(typeId)])
+						oreTypeIds.map((typeId) => [
+							typeId,
+							parseVolumeM3(typeNames[typeId]?.volume, getOreVolume(typeId)) ??
+								getOreVolume(typeId),
+						])
 					),
 					prices: priceResponse.prices
 						.filter((price) => price.bestSellPrice !== null)
@@ -1402,7 +1410,38 @@ async function loadStructureInventoryDetailData(
 			eq(corporationStructureInventory.structureId, structure.structureId)
 		),
 	})
-	const bays = summarizeInventoryRows(rows)
+	const moonMaterialTypeIds = [
+		...new Set(
+			rows.filter((row) => row.locationFlag === 'MoonMaterialBay').map((row) => row.typeId)
+		),
+	]
+	let moonMaterialTypeDetails: Record<string, InvType | null> = {}
+	if (moonMaterialTypeIds.length > 0) {
+		try {
+			const universe = getStub<Universe>(env.UNIVERSE, 'default')
+			moonMaterialTypeDetails = await universe.resolveTypeNamesByIds(moonMaterialTypeIds)
+		} catch (error) {
+			logger.warn('[Structures] Failed to enrich moon material inventory volumes', {
+				corporationId: structure.corporationId,
+				structureId: structure.structureId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+	}
+	const enrichedRows = rows.map((row) => {
+		if (row.locationFlag !== 'MoonMaterialBay') {
+			return row
+		}
+
+		const typeDetails = moonMaterialTypeDetails[row.typeId]
+		const unitVolumeM3 = typeDetails ? Number.parseFloat(typeDetails.volume) : null
+		return {
+			...row,
+			typeName: typeDetails?.typeName ?? null,
+			unitVolumeM3: Number.isFinite(unitVolumeM3) ? unitVolumeM3 : null,
+		}
+	})
+	const bays = summarizeInventoryRows(enrichedRows)
 	const moonMaterialBay = bays.find((bay) => bay.locationFlag === 'MoonMaterialBay')
 	if (!moonMaterialBay || moonMaterialBay.items.length === 0) {
 		return bays

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -23,6 +23,13 @@ import { parseStructurePermissionUrn, STRUCTURE_PERMISSION_SCOPE_ALL } from '@re
 import { logger } from '@repo/hono-helpers'
 import { summarizeInventoryRows } from '@repo/inventory-display'
 import {
+	calculateStructureProfitability,
+	FUEL_BLOCK_TYPE_ID,
+	getOreVolume,
+	MAGMATIC_GAS_TYPE_ID,
+	ORE_TYPE_RARITY,
+} from '@repo/moon-scan'
+import {
 	FUEL_BLOCK_TYPE_IDS,
 	getSkyhookFullness,
 	getSkyhookReagentEntriesFromStorageState,
@@ -71,6 +78,7 @@ import {
 import type { DbClient } from '@repo/db-utils'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { InventoryDisplayBay } from '@repo/inventory-display'
+import type { Markets } from '@repo/markets'
 import type { MoonScanDO } from '@repo/moon-scan'
 import type {
 	StructureListQuery as RepoStructureListQuery,
@@ -90,6 +98,7 @@ import type {
 	StructureSovereigntyListSummary as RepoStructureSovereigntyListSummary,
 	SkyhookReagentStorageState,
 	StructureCommonListSortBy,
+	StructureFittingSlotCapacities,
 	StructureMiningCitadelListQuery,
 	StructureMoonDrillListQuery,
 	StructureMoonStructureListSortBy,
@@ -390,6 +399,8 @@ interface StructureTabData {
 	skyhook?: StructureSkyhookSummary | null
 	moonDrill?: StructureMoonDrillSummary | null
 	miningExtraction?: StructureMiningCitadelSummary | null
+	miningExtractionComposition?: RepoStructureMoonComposition | null
+	moonComposition?: RepoStructureMoonComposition | null
 	miningExtractionHistory?: RepoStructureMiningCitadelExtractionHistory[]
 	inventoryBays?: StructureInventoryBaySummary[]
 }
@@ -415,9 +426,12 @@ export interface StructureDetailResult extends Omit<StructureListItem, 'canViewD
 	skyhook?: StructureSkyhookSummary | null
 	moonDrill?: StructureMoonDrillSummary | null
 	miningExtraction?: StructureMiningCitadelSummary | null
+	miningExtractionComposition?: RepoStructureMoonComposition | null
+	moonComposition?: RepoStructureMoonComposition | null
 	miningExtractionHistory?: RepoStructureMiningCitadelExtractionHistory[]
 	inventoryBays?: StructureInventoryBaySummary[]
 	fittingItems?: StructureFittingItemSummary[]
+	fittingSlotCapacities?: StructureFittingSlotCapacities | null
 }
 
 export interface UpdateStructureConfigInput {
@@ -1011,10 +1025,9 @@ function summarizeStructureSkyhook(
 }
 
 function summarizeStructureMoonDrill(
-	moonDrill: typeof structureMoonDrills.$inferSelect | null,
 	moonGeography: typeof structureMoonGeographies.$inferSelect | null
 ): RepoStructureMoonDrillSummary | null {
-	if (!moonDrill || !moonGeography) {
+	if (!moonGeography) {
 		return null
 	}
 
@@ -1081,10 +1094,11 @@ function summarizeStructureMiningCitadelExtractionHistory(
 	}
 }
 
-async function loadMiningCitadelMoonComposition(
+async function loadStructureMoonComposition(
 	env: Env,
 	moonId: string,
-	structureId: string
+	structureId: string,
+	structureType: 'tatara' | 'metenox'
 ): Promise<RepoStructureMoonComposition | null> {
 	try {
 		const moonScan = getStub<MoonScanDO>(env.MOON_SCAN, 'default')
@@ -1093,19 +1107,91 @@ async function loadMiningCitadelMoonComposition(
 			return null
 		}
 
-		const typeIds = [...new Set(composition.ores.map((ore) => ore.oreTypeId))]
+		const oreTypeIds = [...new Set(composition.ores.map((ore) => ore.oreTypeId))]
 		const universe = getStub<Universe>(env.UNIVERSE, 'default')
-		const typeNames = typeIds.length > 0 ? await universe.resolveTypeNamesByIds(typeIds) : {}
+		let typeNames = await universe.resolveTypeNamesByIds(oreTypeIds)
+		let profitability: ReturnType<typeof calculateStructureProfitability> = null
+		let pricingSnapshotDate: string | null = null
+		try {
+			const markets = getStub<Markets>(env.MARKETS, 'region-10000002')
+			const [settings, profiles, typeMaterialsMap] = await Promise.all([
+				moonScan.getExtractionSettings(),
+				moonScan.getStructureProfiles(),
+				oreTypeIds.length > 0
+					? universe.getTypeMaterials(oreTypeIds)
+					: Promise.resolve(
+							{} as Record<string, Array<{ materialTypeId: string; quantity: number }>>
+						),
+			])
+			const materialTypeIds = [
+				...new Set(
+					Object.values(typeMaterialsMap).flatMap((materials) =>
+						materials.map((material) => material.materialTypeId)
+					)
+				),
+			]
+			typeNames = await universe.resolveTypeNamesByIds([...oreTypeIds, ...materialTypeIds])
+			const priceTypeIds = [
+				...new Set([...materialTypeIds, FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID]),
+			]
+			const priceResponse = await markets.getBatchMarketDataAtTime({
+				regionId: 'universe' as Parameters<Markets['getBatchMarketDataAtTime']>[0]['regionId'],
+				typeIds: priceTypeIds as Parameters<Markets['getBatchMarketDataAtTime']>[0]['typeIds'],
+				atTime: new Date(),
+			})
+			profitability = calculateStructureProfitability(
+				composition,
+				{
+					...settings,
+					profiles,
+					typeMaterials: Object.entries(typeMaterialsMap).flatMap(([oreTypeId, materials]) =>
+						materials.map((material) => ({ ...material, oreTypeId }))
+					),
+					oreVolumes: Object.fromEntries(
+						oreTypeIds.map((typeId) => [typeId, getOreVolume(typeId)])
+					),
+					prices: priceResponse.prices
+						.filter((price) => price.bestSellPrice !== null)
+						.map((price) => ({ typeId: price.typeId, price: Number(price.bestSellPrice) })),
+				},
+				structureType
+			)
+			pricingSnapshotDate = priceResponse.prices[0]?.snapshotTime
+				? new Date(priceResponse.prices[0].snapshotTime).toISOString().slice(0, 10)
+				: null
+		} catch (error) {
+			logger.warn('[Structures] Failed to enrich moon composition pricing', {
+				moonId,
+				structureId,
+				structureType,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
 
 		return {
 			ores: composition.ores.map((ore) => ({
 				typeId: ore.oreTypeId,
 				typeName: typeNames[ore.oreTypeId]?.typeName ?? null,
 				quantity: ore.quantity,
+				rarity: ORE_TYPE_RARITY[ore.oreTypeId] ?? null,
 			})),
+			profitability: profitability
+				? {
+						...profitability,
+						ores: profitability.ores.map((ore) => ({
+							...ore,
+							oreName: typeNames[ore.oreTypeId]?.typeName ?? ore.oreName,
+							refinesTo: ore.refinesTo.map((material) => ({
+								...material,
+								materialName: typeNames[material.materialTypeId]?.typeName ?? material.materialName,
+							})),
+						})),
+					}
+				: null,
+			pricingSnapshotDate,
 		}
 	} catch (error) {
-		logger.warn('[Structures] Failed to enrich mining citadel moon composition', {
+		logger.warn('[Structures] Failed to enrich structure moon composition', {
 			moonId,
 			structureId,
 			error: error instanceof Error ? error.message : String(error),
@@ -1230,19 +1316,20 @@ async function loadStructureTabDetailData(
 	}
 
 	if (tab === 'moon-drills') {
-		const [moonDrillRow, moonGeographyRow] = await Promise.all([
-			db.query.structureMoonDrills.findFirst({
-				where: eq(structureMoonDrills.structureId, structure.structureId),
-			}),
-			db.query.structureMoonGeographies.findFirst({
-				where: eq(structureMoonGeographies.structureId, structure.structureId),
-			}),
-		])
+		const moonGeographyRow = await db.query.structureMoonGeographies.findFirst({
+			where: eq(structureMoonGeographies.structureId, structure.structureId),
+		})
+		const composition = moonGeographyRow
+			? await loadStructureMoonComposition(
+					env,
+					moonGeographyRow.moonId,
+					structure.structureId,
+					'metenox'
+				)
+			: null
 		return {
-			moonDrill:
-				moonDrillRow && moonGeographyRow
-					? summarizeStructureMoonDrill(moonDrillRow, moonGeographyRow)
-					: null,
+			moonDrill: summarizeStructureMoonDrill(moonGeographyRow ?? null),
+			moonComposition: composition,
 		}
 	}
 
@@ -1259,14 +1346,14 @@ async function loadStructureTabDetailData(
 				orderBy: [desc(structureMiningExtractionHistory.extractionStartTime)],
 			}),
 		])
-		const composition =
-			miningExtractionRow && moonGeographyRow
-				? await loadMiningCitadelMoonComposition(
-						env,
-						moonGeographyRow.moonId,
-						structure.structureId
-					)
-				: null
+		const composition = moonGeographyRow
+			? await loadStructureMoonComposition(
+					env,
+					moonGeographyRow.moonId,
+					structure.structureId,
+					'tatara'
+				)
+			: null
 		return {
 			miningExtraction:
 				miningExtractionRow && moonGeographyRow
@@ -1277,6 +1364,8 @@ async function loadStructureTabDetailData(
 							extractionHistoryRows
 						)
 					: null,
+			miningExtractionComposition: composition,
+			moonComposition: composition,
 			miningExtractionHistory: extractionHistoryRows.map(
 				summarizeStructureMiningCitadelExtractionHistory
 			),
@@ -1287,6 +1376,7 @@ async function loadStructureTabDetailData(
 }
 
 async function loadStructureInventoryDetailData(
+	env: Env,
 	db: DbClient<DbSchema>,
 	structure: StructureSourceRecord
 ): Promise<StructureInventoryBaySummary[]> {
@@ -1312,7 +1402,56 @@ async function loadStructureInventoryDetailData(
 			eq(corporationStructureInventory.structureId, structure.structureId)
 		),
 	})
-	return summarizeInventoryRows(rows)
+	const bays = summarizeInventoryRows(rows)
+	const moonMaterialBay = bays.find((bay) => bay.locationFlag === 'MoonMaterialBay')
+	if (!moonMaterialBay || moonMaterialBay.items.length === 0) {
+		return bays
+	}
+
+	try {
+		const markets = getStub<Markets>(env.MARKETS, 'region-10000002')
+		const typeIds = moonMaterialBay.items.map((item) => item.typeId)
+		const priceResponse = await markets.getBatchMarketDataAtTime({
+			regionId: 'universe' as Parameters<Markets['getBatchMarketDataAtTime']>[0]['regionId'],
+			typeIds: typeIds as Parameters<Markets['getBatchMarketDataAtTime']>[0]['typeIds'],
+			atTime: new Date(),
+		})
+		const priceByTypeId = new Map(
+			priceResponse.prices.map((price) => [
+				price.typeId,
+				price.bestSellPrice === null ? null : Number(price.bestSellPrice),
+			])
+		)
+		const pricedItems = moonMaterialBay.items.map((item) => {
+			const unitPrice = priceByTypeId.get(item.typeId)
+			return {
+				...item,
+				estimatedValue:
+					unitPrice === null || unitPrice === undefined ? null : unitPrice * item.quantity,
+			}
+		})
+		const pricedValues = pricedItems
+			.map((item) => item.estimatedValue)
+			.filter((value): value is number => value !== null)
+
+		return bays.map((bay) =>
+			bay.locationFlag === 'MoonMaterialBay'
+				? {
+						...bay,
+						items: pricedItems,
+						totalEstimatedValue:
+							pricedValues.length > 0 ? pricedValues.reduce((sum, value) => sum + value, 0) : null,
+					}
+				: bay
+		)
+	} catch (error) {
+		logger.warn('[Structures] Failed to enrich moon material inventory prices', {
+			corporationId: structure.corporationId,
+			structureId: structure.structureId,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return bays
+	}
 }
 
 const STRUCTURE_FITTING_SLOT_ORDER: Array<StructureFittingItemSummary['flagName']> = [
@@ -1343,47 +1482,71 @@ function compareStructureFittingItems(
 async function loadStructureFittingDetailData(
 	env: Env,
 	structure: StructureSourceRecord
-): Promise<StructureFittingItemSummary[]> {
-	const structureTab = getStructureTab(structure)
-	if (structureTab !== 'structures') {
-		return []
-	}
+): Promise<{
+	items: StructureFittingItemSummary[]
+	slotCapacities: StructureFittingSlotCapacities | null
+}> {
+	const corpData = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, structure.corporationId)
+	const universe = getStub<Universe>(env.UNIVERSE, 'default')
+	const [rawAssets, slotCapacityResult] = await Promise.all([
+		typeof corpData?.searchAssets === 'function'
+			? corpData
+					.searchAssets(structure.corporationId, {
+						locationId: structure.structureId,
+						locationType: 'item',
+					})
+					.catch((error) => {
+						logger.error(
+							'[loadStructureFittingDetailData] Failed to load structure fitting items',
+							{
+								corporationId: structure.corporationId,
+								structureId: structure.structureId,
+								error: error instanceof Error ? error.message : String(error),
+								errorStack: error instanceof Error ? error.stack : undefined,
+							}
+						)
+						return []
+					})
+			: Promise.resolve([]),
+		typeof universe?.resolveTypeSlotCapacitiesByIds === 'function'
+			? universe
+					.resolveTypeSlotCapacitiesByIds([structure.typeId])
+					.then((capacities) => capacities[structure.typeId] ?? null)
+					.catch((error) => {
+						logger.error(
+							'[loadStructureFittingDetailData] Failed to resolve structure slot capacities',
+							{
+								corporationId: structure.corporationId,
+								structureId: structure.structureId,
+								typeId: structure.typeId,
+								error: error instanceof Error ? error.message : String(error),
+								errorStack: error instanceof Error ? error.stack : undefined,
+							}
+						)
+						return null
+					})
+			: Promise.resolve(null),
+	])
 
-	try {
-		const corpData = getStub<EveCorporationData>(env.EVE_CORPORATION_DATA, structure.corporationId)
-		const rawAssets = await corpData.searchAssets(structure.corporationId, {
-			locationId: structure.structureId,
-			locationType: 'item',
+	const items = rawAssets
+		.flatMap((asset) => {
+			const slot = parseFittingSlotFlag(asset.locationFlag)
+			if (!slot) return []
+
+			return [
+				{
+					locationFlag: asset.locationFlag,
+					slotIndex: slot.slotIndex,
+					flagName: slot.flagName,
+					typeId: asset.typeId,
+					typeName: null,
+					quantity: asset.quantity,
+				},
+			]
 		})
+		.sort(compareStructureFittingItems)
 
-		return rawAssets
-			.flatMap((asset) => {
-				const slot = parseFittingSlotFlag(asset.locationFlag)
-				if (!slot) {
-					return []
-				}
-
-				return [
-					{
-						locationFlag: asset.locationFlag,
-						slotIndex: slot.slotIndex,
-						flagName: slot.flagName,
-						typeId: asset.typeId,
-						typeName: null,
-						quantity: asset.quantity,
-					},
-				]
-			})
-			.sort(compareStructureFittingItems)
-	} catch (error) {
-		logger.error('[loadStructureFittingDetailData] Failed to load structure fitting items', {
-			corporationId: structure.corporationId,
-			structureId: structure.structureId,
-			error: error instanceof Error ? error.message : String(error),
-			errorStack: error instanceof Error ? error.stack : undefined,
-		})
-		return []
-	}
+	return { items, slotCapacities: slotCapacityResult }
 }
 
 export async function assertStructureGroupConfigured(
@@ -1752,6 +1915,7 @@ interface StructureContext {
 	canEdit: boolean
 	tabData: StructureTabData | null
 	fittingItems: StructureFittingItemSummary[] | null
+	fittingSlotCapacities: StructureFittingSlotCapacities | null
 	lastRefilledAt: Date | null
 }
 
@@ -1781,7 +1945,9 @@ function buildStructureDetailResult(context: StructureContext): StructureDetailR
 		...(context.tabData ?? {}),
 		moonDrill: context.tabData?.moonDrill ?? null,
 		miningExtraction: context.tabData?.miningExtraction ?? null,
+		miningExtractionComposition: context.tabData?.miningExtractionComposition ?? null,
 		fittingItems: context.fittingItems ?? [],
+		fittingSlotCapacities: context.fittingSlotCapacities,
 	}
 }
 
@@ -1866,9 +2032,9 @@ async function getStructureContext(
 		const canEdit =
 			user.is_admin || canEditStructure(access, sovereigntyHub.corporationId, structureTab)
 
-		const [tabData, inventoryBays, fittingItems] = await Promise.all([
+		const [tabData, inventoryBays, fittingData] = await Promise.all([
 			loadStructureTabDetailData(env, db, syntheticStructure),
-			loadStructureInventoryDetailData(db, syntheticStructure),
+			loadStructureInventoryDetailData(env, db, syntheticStructure),
 			loadStructureFittingDetailData(env, syntheticStructure),
 		])
 		return {
@@ -1884,7 +2050,8 @@ async function getStructureContext(
 				...(tabData ?? {}),
 				inventoryBays,
 			},
-			fittingItems,
+			fittingItems: fittingData.items,
+			fittingSlotCapacities: fittingData.slotCapacities,
 			lastRefilledAt: null,
 		}
 	}
@@ -1917,9 +2084,9 @@ async function getStructureContext(
 		return null
 	}
 
-	const [tabData, inventoryBays, fittingItems] = await Promise.all([
+	const [tabData, inventoryBays, fittingData] = await Promise.all([
 		loadStructureTabDetailData(env, db, structure),
-		loadStructureInventoryDetailData(db, structure),
+		loadStructureInventoryDetailData(env, db, structure),
 		loadStructureFittingDetailData(env, structure),
 	])
 
@@ -1936,7 +2103,8 @@ async function getStructureContext(
 			...(tabData ?? {}),
 			inventoryBays,
 		},
-		fittingItems,
+		fittingItems: fittingData.items,
+		fittingSlotCapacities: fittingData.slotCapacities,
 		lastRefilledAt: structure.lastRefilledAt ?? null,
 	}
 }
@@ -3459,6 +3627,7 @@ async function loadSovereigntyPageItems(
 			canEdit,
 			tabData: null,
 			fittingItems: null,
+			fittingSlotCapacities: null,
 			lastRefilledAt: null,
 		}
 		return buildSovereigntyListItem({

--- a/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
+++ b/apps/structures/src/test/unit/services/structure-permission-gating.test.ts
@@ -211,6 +211,90 @@ describe('structure permission gating', () => {
 		expect(getStructureTab({ typeId: '81826', typeName: 'Metenox Moon Drill' })).toBe('moon-drills')
 	})
 
+	it('shows moon drill geography without requiring a separate moon drill row', async () => {
+		const db = makeDb({
+			structure: {
+				structureId: 'structure-1',
+				corporationId: 'corp-1',
+				name: 'Moon Drill One',
+				typeId: '81826',
+				typeName: 'Metenox Moon Drill',
+				systemId: '30000142',
+				systemName: 'Jita',
+				regionId: '10000002',
+				regionName: 'The Forge',
+				state: 'online',
+				nextReinforceApply: null,
+				stateTimerEnd: null,
+				unanchorsAt: null,
+				fuelExpires: null,
+				fuelAmount: null,
+				fuelBurnRate: null,
+				lowPower: false,
+				syncStatus: 'ok',
+				syncFailureReason: null,
+				lastSyncedAt: new Date('2026-01-01T00:00:00Z'),
+				updatedAt: new Date('2026-01-01T00:00:00Z'),
+			},
+		})
+		db.query.structureMoonGeographies.findFirst.mockResolvedValue({
+			structureId: 'structure-1',
+			corporationId: 'corp-1',
+			moonId: '40129194',
+			moonName: 'Moon 1',
+			planetId: '40129193',
+			planetName: 'Planet 1',
+			systemId: '30000142',
+			systemName: 'Jita',
+		})
+		const env = {
+			MOON_SCAN: {},
+			UNIVERSE: {},
+		}
+		const moonScan = {
+			getVerifiedComposition: vi.fn().mockResolvedValue({
+				moonId: '40129194',
+				sourceScanId: 'scan-1',
+				verifiedAt: '2026-07-31T00:00:00.000Z',
+				verifiedBy: null,
+				ores: [{ oreTypeId: '45490', quantity: '0.25' }],
+			}),
+		}
+		const universe = {
+			resolveTypeNamesByIds: vi.fn().mockResolvedValue({
+				'45490': { typeName: 'Chromite' },
+			}),
+		}
+		vi.mocked(getStub).mockImplementation((namespace) => {
+			if (namespace === env.MOON_SCAN) return moonScan as never
+			return universe as never
+		})
+
+		const result = await getStructureDetail(
+			env as never,
+			db as never,
+			{
+				id: 'user-details',
+				is_admin: false,
+				roles: ['urn:structures:all:details'],
+			},
+			'structure-1'
+		)
+
+		expect(result?.moonDrill).toEqual({
+			moonId: '40129194',
+			moonName: 'Moon 1',
+			planetId: '40129193',
+			planetName: 'Planet 1',
+			systemId: '30000142',
+			systemName: 'Jita',
+		})
+		expect(moonScan.getVerifiedComposition).toHaveBeenCalledWith('40129194')
+		expect(result?.moonComposition?.ores).toEqual([
+			{ typeId: '45490', typeName: 'Chromite', quantity: '0.25', rarity: 'R4' },
+		])
+	})
+
 	beforeEach(() => {
 		vi.clearAllMocks()
 	})
@@ -482,19 +566,43 @@ describe('structure permission gating', () => {
 				verifiedBy: null,
 				ores: [{ oreTypeId: '45490', quantity: '0.25' }],
 			}),
+			getExtractionSettings: vi.fn().mockResolvedValue({
+				defaultReprocessingYield: '0.5',
+				defaultCycleDays: 30,
+				fuelBlockPriceOverride: '2',
+				magmaticGasPriceOverride: null,
+			}),
+			getStructureProfiles: vi.fn().mockResolvedValue([
+				{
+					id: 'tatara',
+					baseVolumePerHr: '1',
+					rigBonus: '0',
+					fuelPerHr: '1',
+					magmaticGasPerHr: '99',
+					isPassive: false,
+					nullsecModifier: '1',
+					lowsecModifier: '1',
+				},
+			]),
 		}
 		const universe = {
+			getTypeMaterials: vi.fn().mockResolvedValue({ '45490': [] }),
 			resolveTypeNamesByIds: vi.fn().mockResolvedValue({
 				'45490': { typeName: 'Chromite' },
 			}),
 		}
+		const markets = {
+			getBatchMarketDataAtTime: vi.fn().mockResolvedValue({ prices: [], missingTypeIds: [] }),
+		}
 		const env = {
 			MOON_SCAN: {},
+			MARKETS: {},
 			UNIVERSE: {},
 			EVE_CORPORATION_DATA: {},
 		}
 		vi.mocked(getStub).mockImplementation((namespace) => {
 			if (namespace === env.MOON_SCAN) return moonScan as never
+			if (namespace === env.MARKETS) return markets as never
 			return universe as never
 		})
 
@@ -511,8 +619,18 @@ describe('structure permission gating', () => {
 
 		expect(moonScan.getVerifiedComposition).toHaveBeenCalledWith('40129194')
 		expect(universe.resolveTypeNamesByIds).toHaveBeenCalledWith(['45490'])
-		expect(result?.miningExtraction?.composition).toEqual({
-			ores: [{ typeId: '45490', typeName: 'Chromite', quantity: '0.25' }],
+		expect(result?.miningExtraction?.composition).toMatchObject({
+			ores: [{ typeId: '45490', typeName: 'Chromite', quantity: '0.25', rarity: 'R4' }],
+			profitability: {
+				structureType: 'tatara',
+				cycleDays: 30,
+				fuelCost: '1440',
+				grossIsk: '0',
+				profit: '-1440',
+			},
 		})
+		expect(result?.miningExtractionComposition?.ores).toEqual([
+			{ typeId: '45490', typeName: 'Chromite', quantity: '0.25', rarity: 'R4' },
+		])
 	})
 })

--- a/apps/structures/wrangler.jsonc
+++ b/apps/structures/wrangler.jsonc
@@ -35,6 +35,11 @@
 				"name": "MOON_SCAN",
 				"class_name": "MoonScanDO",
 				"script_name": "moon-scan"
+			},
+			{
+				"name": "MARKETS",
+				"class_name": "Markets",
+				"script_name": "markets"
 			}
 		]
 	}

--- a/apps/ui/src/client/components/inventory-bays-table.tsx
+++ b/apps/ui/src/client/components/inventory-bays-table.tsx
@@ -30,6 +30,14 @@ function formatCount(value: number): string {
 	return value.toLocaleString()
 }
 
+function formatVolumeM3(value: number | null | undefined): string {
+	if (value === null || value === undefined) {
+		return '-'
+	}
+
+	return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })} m³`
+}
+
 function formatEstimatedValue(value: number | null | undefined): string {
 	return value === null || value === undefined ? '-' : formatISK(value, { showDecimals: false })
 }
@@ -161,7 +169,7 @@ export function InventoryBaysTable({
 			</div>
 
 			<div className="overflow-hidden rounded-lg border border-border/60">
-				<Table>
+				<Table className="text-xs">
 					<TableHeader>
 						<TableRow className="bg-muted/40">
 							<TableHead>Bay</TableHead>
@@ -172,7 +180,7 @@ export function InventoryBaysTable({
 						{visibleBays.length > 0 ? (
 							visibleBays.map((bay) => {
 								const isExpanded = expandedBays.has(bay.locationFlag)
-								const showPrices = bay.locationFlag === 'MoonMaterialBay'
+								const showMoonMaterialDetails = bay.locationFlag === 'MoonMaterialBay'
 								return (
 									<Fragment key={bay.locationFlag}>
 										<TableRow
@@ -201,13 +209,16 @@ export function InventoryBaysTable({
 											<TableRow className="bg-muted/20">
 												<TableCell colSpan={2} className="px-0 py-0">
 													<div className="border-l-2 border-muted px-4 py-3">
-														<Table>
+														<Table className="text-xs">
 															<TableHeader>
 																<TableRow className="bg-transparent">
 																	<TableHead>Item</TableHead>
 																	<TableHead className="text-right">Qty</TableHead>
-																	{showPrices ? (
-																		<TableHead className="text-right">Price</TableHead>
+																	{showMoonMaterialDetails ? (
+																		<>
+																			<TableHead className="text-right">Volume</TableHead>
+																			<TableHead className="text-right">Value</TableHead>
+																		</>
 																	) : null}
 																</TableRow>
 															</TableHeader>
@@ -216,11 +227,9 @@ export function InventoryBaysTable({
 																	bay.items.map((item) => (
 																		<TableRow key={`${bay.locationFlag}-${item.typeId}`}>
 																			<TableCell>
-																				<div className="flex items-start gap-2">
+																				<div className="flex items-center gap-2">
 																					{renderItemIcon ? (
-																						<div className="mt-0.5 shrink-0">
-																							{renderItemIcon(item)}
-																						</div>
+																						<div className="shrink-0">{renderItemIcon(item)}</div>
 																					) : null}
 																					<div className="min-w-0">
 																						<div className="font-medium">
@@ -237,7 +246,12 @@ export function InventoryBaysTable({
 																			<TableCell className="text-right font-mono">
 																				{formatCount(item.quantity)}
 																			</TableCell>
-																			{showPrices ? (
+																			{showMoonMaterialDetails ? (
+																				<TableCell className="text-right font-mono">
+																					{formatVolumeM3(item.volumeM3)}
+																				</TableCell>
+																			) : null}
+																			{showMoonMaterialDetails ? (
 																				<TableCell className="text-right font-mono">
 																					{formatEstimatedValue(item.estimatedValue)}
 																				</TableCell>
@@ -247,7 +261,7 @@ export function InventoryBaysTable({
 																) : (
 																	<TableRow>
 																		<TableCell
-																			colSpan={showPrices ? 3 : 2}
+																			colSpan={showMoonMaterialDetails ? 4 : 2}
 																			className="text-sm italic text-muted-foreground"
 																		>
 																			No items matched the current search.

--- a/apps/ui/src/client/components/inventory-bays-table.tsx
+++ b/apps/ui/src/client/components/inventory-bays-table.tsx
@@ -1,6 +1,5 @@
 import { ChevronDown, ChevronRight, ChevronsUpDown, Search } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
-import type { ReactNode } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -12,8 +11,10 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
+import { formatISK } from '@/lib/format-utils'
 import { cn } from '@/lib/utils'
 
+import type { ReactNode } from 'react'
 import type { InventoryDisplayBay, InventoryDisplayItem } from '@repo/inventory-display'
 
 export interface InventoryBaysTableProps {
@@ -29,6 +30,10 @@ function formatCount(value: number): string {
 	return value.toLocaleString()
 }
 
+function formatEstimatedValue(value: number | null | undefined): string {
+	return value === null || value === undefined ? '-' : formatISK(value, { showDecimals: false })
+}
+
 export function InventoryBaysTable({
 	bays,
 	emptyLabel = 'No inventory recorded for this structure.',
@@ -40,6 +45,20 @@ export function InventoryBaysTable({
 	const [search, setSearch] = useState('')
 	const [expandedBays, setExpandedBays] = useState<Set<string>>(new Set())
 
+	useEffect(() => {
+		if (bays.length === 0) {
+			return
+		}
+
+		setExpandedBays((previous) => {
+			const next = new Set(previous)
+			for (const bay of bays) {
+				next.add(bay.locationFlag)
+			}
+			return next.size === previous.size ? previous : next
+		})
+	}, [bays])
+
 	const visibleBays = useMemo(() => {
 		const query = search.trim().toLowerCase()
 		if (!query) {
@@ -48,7 +67,8 @@ export function InventoryBaysTable({
 
 		return bays
 			.map((bay) => {
-				const bayMatches = bay.label.toLowerCase().includes(query) || bay.locationFlag.toLowerCase().includes(query)
+				const bayMatches =
+					bay.label.toLowerCase().includes(query) || bay.locationFlag.toLowerCase().includes(query)
 				const items = bay.items.filter((item) => {
 					return (
 						item.typeId.toLowerCase().includes(query) ||
@@ -145,7 +165,6 @@ export function InventoryBaysTable({
 					<TableHeader>
 						<TableRow className="bg-muted/40">
 							<TableHead>Bay</TableHead>
-							<TableHead className="text-right">Stacks</TableHead>
 							<TableHead className="text-right">Units</TableHead>
 						</TableRow>
 					</TableHeader>
@@ -153,6 +172,7 @@ export function InventoryBaysTable({
 						{visibleBays.length > 0 ? (
 							visibleBays.map((bay) => {
 								const isExpanded = expandedBays.has(bay.locationFlag)
+								const showPrices = bay.locationFlag === 'MoonMaterialBay'
 								return (
 									<Fragment key={bay.locationFlag}>
 										<TableRow
@@ -162,54 +182,74 @@ export function InventoryBaysTable({
 											<TableCell>
 												<div className="flex items-start gap-2">
 													<div className="mt-0.5 text-muted-foreground">
-														{isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+														{isExpanded ? (
+															<ChevronDown className="h-4 w-4" />
+														) : (
+															<ChevronRight className="h-4 w-4" />
+														)}
 													</div>
-											<div className="min-w-0">
-												<div className="font-medium">{bay.label}</div>
-											</div>
-										</div>
-									</TableCell>
-											<TableCell className="text-right font-mono">{formatCount(bay.totalStacks)}</TableCell>
-											<TableCell className="text-right font-mono">{formatCount(bay.totalQuantity)}</TableCell>
+													<div className="min-w-0">
+														<div className="font-medium">{bay.label}</div>
+													</div>
+												</div>
+											</TableCell>
+											<TableCell className="text-right font-mono">
+												{formatCount(bay.totalQuantity)}
+											</TableCell>
 										</TableRow>
-											{isExpanded ? (
-												<TableRow className="bg-muted/20">
-												<TableCell colSpan={3} className="px-0 py-0">
+										{isExpanded ? (
+											<TableRow className="bg-muted/20">
+												<TableCell colSpan={2} className="px-0 py-0">
 													<div className="border-l-2 border-muted px-4 py-3">
 														<Table>
 															<TableHeader>
 																<TableRow className="bg-transparent">
 																	<TableHead>Item</TableHead>
 																	<TableHead className="text-right">Qty</TableHead>
-																	<TableHead className="text-right">Stacks</TableHead>
+																	{showPrices ? (
+																		<TableHead className="text-right">Price</TableHead>
+																	) : null}
 																</TableRow>
 															</TableHeader>
 															<TableBody>
 																{bay.items.length > 0 ? (
 																	bay.items.map((item) => (
 																		<TableRow key={`${bay.locationFlag}-${item.typeId}`}>
-																				<TableCell>
-																					<div className="flex items-start gap-2">
-																						{renderItemIcon ? (
-																							<div className="mt-0.5 shrink-0">{renderItemIcon(item)}</div>
-																						) : null}
-																						<div className="min-w-0">
-																							<div className="font-medium">{item.typeName ?? item.typeId}</div>
-																							{renderItemDetails ? (
-																								<div className="text-xs text-muted-foreground">
-																									{renderItemDetails(item)}
-																								</div>
-																							) : null}
+																			<TableCell>
+																				<div className="flex items-start gap-2">
+																					{renderItemIcon ? (
+																						<div className="mt-0.5 shrink-0">
+																							{renderItemIcon(item)}
 																						</div>
+																					) : null}
+																					<div className="min-w-0">
+																						<div className="font-medium">
+																							{item.typeName ?? item.typeId}
+																						</div>
+																						{renderItemDetails ? (
+																							<div className="text-xs text-muted-foreground">
+																								{renderItemDetails(item)}
+																							</div>
+																						) : null}
 																					</div>
+																				</div>
+																			</TableCell>
+																			<TableCell className="text-right font-mono">
+																				{formatCount(item.quantity)}
+																			</TableCell>
+																			{showPrices ? (
+																				<TableCell className="text-right font-mono">
+																					{formatEstimatedValue(item.estimatedValue)}
 																				</TableCell>
-																			<TableCell className="text-right font-mono">{formatCount(item.quantity)}</TableCell>
-																			<TableCell className="text-right font-mono">{formatCount(item.stackCount)}</TableCell>
+																			) : null}
 																		</TableRow>
 																	))
 																) : (
 																	<TableRow>
-																		<TableCell colSpan={3} className="text-sm italic text-muted-foreground">
+																		<TableCell
+																			colSpan={showPrices ? 3 : 2}
+																			className="text-sm italic text-muted-foreground"
+																		>
 																			No items matched the current search.
 																		</TableCell>
 																	</TableRow>
@@ -225,7 +265,7 @@ export function InventoryBaysTable({
 							})
 						) : (
 							<TableRow>
-								<TableCell colSpan={3} className="py-8 text-center text-sm text-muted-foreground">
+								<TableCell colSpan={2} className="py-8 text-center text-sm text-muted-foreground">
 									No inventory bays matched the current search.
 								</TableCell>
 							</TableRow>

--- a/apps/ui/src/client/components/moon-composition-card.tsx
+++ b/apps/ui/src/client/components/moon-composition-card.tsx
@@ -1,31 +1,7 @@
+import { MoonCompositionTable, MoonProfitabilityTable } from '@/components/moon-profitability-table'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from '@/components/ui/table'
-import { typeIconUrl } from '@/lib/eve-images'
-import { formatISK } from '@/lib/format-utils'
-
-import { getOreRarity, RARITY_COLORS } from '../features/moon-scan/ore-rarities'
 
 import type { StructureMoonComposition, StructureMoonGeography } from '@repo/structures'
-
-function RarityBadge({ rarity }: { rarity: string | null | undefined }) {
-	if (!rarity) return <span className="text-muted-foreground">-</span>
-
-	return (
-		<span
-			className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold text-white"
-			style={{ backgroundColor: RARITY_COLORS[rarity as keyof typeof RARITY_COLORS] ?? '#555' }}
-		>
-			{rarity}
-		</span>
-	)
-}
 
 export interface MoonCompositionCardProps {
 	composition: StructureMoonComposition | null | undefined
@@ -63,93 +39,19 @@ export function MoonCompositionCard({ composition, moon }: MoonCompositionCardPr
 				) : null}
 
 				{profitability ? (
-					<div className="ml-auto w-full max-w-sm space-y-1 border-b border-border/60 pb-3 text-right font-mono text-xs">
-						<div className="flex justify-between">
-							<span>Gross refinery value</span>
-							<span className="text-foreground">
-								{formatISK(profitability.grossIsk, { showDecimals: false })}
-							</span>
-						</div>
-						<div className="flex justify-between text-muted-foreground">
-							<span>− Fuel blocks</span>
-							<span className="text-red-400">
-								−{formatISK(profitability.fuelCost, { showDecimals: false })}
-							</span>
-						</div>
-						{profitability.magmaticGasCost !== null ? (
-							<div className="flex justify-between text-muted-foreground">
-								<span>− Magmatic gas</span>
-								<span className="text-red-400">
-									−{formatISK(profitability.magmaticGasCost, { showDecimals: false })}
-								</span>
-							</div>
-						) : null}
-						<div className="my-1 border-t border-border/50" />
-						<div className="flex justify-between font-semibold">
-							<span>
-								{profitability.structureType === 'metenox' ? 'Metenox value' : 'Refinery profit'} /{' '}
-								{profitability.cycleDays}d
-							</span>
-							<span
-								className={Number(profitability.profit) >= 0 ? 'text-green-400' : 'text-red-400'}
-							>
-								{formatISK(profitability.profit, { showDecimals: false })}
-							</span>
-						</div>
-						{composition.pricingSnapshotDate ? (
-							<div className="text-muted-foreground">
-								Pricing snapshot: {composition.pricingSnapshotDate}
-							</div>
-						) : null}
+					<MoonProfitabilityTable structure={profitability} />
+				) : composition ? (
+					<div className="space-y-2">
+						<p className="text-sm text-muted-foreground">
+							Verified composition available, but profitability data could not be loaded.
+						</p>
+						<MoonCompositionTable composition={composition} />
 					</div>
 				) : null}
-
-				{composition ? (
-					<Table>
-						<TableHeader>
-							<TableRow>
-								<TableHead>Mineral</TableHead>
-								<TableHead>Rarity</TableHead>
-								<TableHead className="text-right">Composition</TableHead>
-								<TableHead className="text-right">Estimated value</TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{[...composition.ores]
-								.sort((left, right) => Number(right.quantity) - Number(left.quantity))
-								.map((ore) => {
-									const rarity = ore.rarity ?? getOreRarity(ore.typeId) ?? null
-									const estimate = profitability?.ores.find(
-										(candidate) => candidate.oreTypeId === ore.typeId
-									)
-									return (
-										<TableRow key={ore.typeId}>
-											<TableCell>
-												<div className="flex items-center gap-2">
-													<img
-														src={typeIconUrl(ore.typeId, 32)}
-														alt=""
-														className="h-6 w-6 rounded"
-													/>
-													<span>{ore.typeName ?? `Type ${ore.typeId}`}</span>
-												</div>
-											</TableCell>
-											<TableCell>
-												<RarityBadge rarity={rarity} />
-											</TableCell>
-											<TableCell className="text-right tabular-nums">
-												{(Number(ore.quantity) * 100).toFixed(2)}%
-											</TableCell>
-											<TableCell className="text-right tabular-nums">
-												{estimate
-													? formatISK(estimate.totalOreValue, { showDecimals: false })
-													: '-'}
-											</TableCell>
-										</TableRow>
-									)
-								})}
-						</TableBody>
-					</Table>
+				{composition?.pricingSnapshotDate ? (
+					<div className="text-right text-xs text-muted-foreground">
+						Pricing snapshot: {composition.pricingSnapshotDate}
+					</div>
 				) : null}
 			</CardContent>
 		</Card>

--- a/apps/ui/src/client/components/moon-composition-card.tsx
+++ b/apps/ui/src/client/components/moon-composition-card.tsx
@@ -1,0 +1,157 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
+import { typeIconUrl } from '@/lib/eve-images'
+import { formatISK } from '@/lib/format-utils'
+
+import { getOreRarity, RARITY_COLORS } from '../features/moon-scan/ore-rarities'
+
+import type { StructureMoonComposition, StructureMoonGeography } from '@repo/structures'
+
+function RarityBadge({ rarity }: { rarity: string | null | undefined }) {
+	if (!rarity) return <span className="text-muted-foreground">-</span>
+
+	return (
+		<span
+			className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold text-white"
+			style={{ backgroundColor: RARITY_COLORS[rarity as keyof typeof RARITY_COLORS] ?? '#555' }}
+		>
+			{rarity}
+		</span>
+	)
+}
+
+export interface MoonCompositionCardProps {
+	composition: StructureMoonComposition | null | undefined
+	moon: StructureMoonGeography | null | undefined
+}
+
+export function MoonCompositionCard({ composition, moon }: MoonCompositionCardProps) {
+	const profitability = composition?.profitability
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Moon Resources</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4 text-sm">
+				<div className="grid gap-4 border-b border-border/60 pb-4 md:grid-cols-3">
+					<div>
+						<div className="text-muted-foreground">Moon</div>
+						<div className="font-medium">{moon?.moonName ?? moon?.moonId ?? '-'}</div>
+					</div>
+					<div>
+						<div className="text-muted-foreground">Planet</div>
+						<div className="font-medium">{moon?.planetName ?? moon?.planetId ?? '-'}</div>
+					</div>
+					<div>
+						<div className="text-muted-foreground">System</div>
+						<div className="font-medium">{moon?.systemName ?? moon?.systemId ?? '-'}</div>
+					</div>
+				</div>
+
+				{!composition ? (
+					<p className="text-sm text-muted-foreground">
+						No verified moon composition is available for this moon.
+					</p>
+				) : null}
+
+				{profitability ? (
+					<div className="ml-auto w-full max-w-sm space-y-1 border-b border-border/60 pb-3 text-right font-mono text-xs">
+						<div className="flex justify-between">
+							<span>Gross refinery value</span>
+							<span className="text-foreground">
+								{formatISK(profitability.grossIsk, { showDecimals: false })}
+							</span>
+						</div>
+						<div className="flex justify-between text-muted-foreground">
+							<span>− Fuel blocks</span>
+							<span className="text-red-400">
+								−{formatISK(profitability.fuelCost, { showDecimals: false })}
+							</span>
+						</div>
+						{profitability.magmaticGasCost !== null ? (
+							<div className="flex justify-between text-muted-foreground">
+								<span>− Magmatic gas</span>
+								<span className="text-red-400">
+									−{formatISK(profitability.magmaticGasCost, { showDecimals: false })}
+								</span>
+							</div>
+						) : null}
+						<div className="my-1 border-t border-border/50" />
+						<div className="flex justify-between font-semibold">
+							<span>
+								{profitability.structureType === 'metenox' ? 'Metenox value' : 'Refinery profit'} /{' '}
+								{profitability.cycleDays}d
+							</span>
+							<span
+								className={Number(profitability.profit) >= 0 ? 'text-green-400' : 'text-red-400'}
+							>
+								{formatISK(profitability.profit, { showDecimals: false })}
+							</span>
+						</div>
+						{composition.pricingSnapshotDate ? (
+							<div className="text-muted-foreground">
+								Pricing snapshot: {composition.pricingSnapshotDate}
+							</div>
+						) : null}
+					</div>
+				) : null}
+
+				{composition ? (
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Mineral</TableHead>
+								<TableHead>Rarity</TableHead>
+								<TableHead className="text-right">Composition</TableHead>
+								<TableHead className="text-right">Estimated value</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{[...composition.ores]
+								.sort((left, right) => Number(right.quantity) - Number(left.quantity))
+								.map((ore) => {
+									const rarity = ore.rarity ?? getOreRarity(ore.typeId) ?? null
+									const estimate = profitability?.ores.find(
+										(candidate) => candidate.oreTypeId === ore.typeId
+									)
+									return (
+										<TableRow key={ore.typeId}>
+											<TableCell>
+												<div className="flex items-center gap-2">
+													<img
+														src={typeIconUrl(ore.typeId, 32)}
+														alt=""
+														className="h-6 w-6 rounded"
+													/>
+													<span>{ore.typeName ?? `Type ${ore.typeId}`}</span>
+												</div>
+											</TableCell>
+											<TableCell>
+												<RarityBadge rarity={rarity} />
+											</TableCell>
+											<TableCell className="text-right tabular-nums">
+												{(Number(ore.quantity) * 100).toFixed(2)}%
+											</TableCell>
+											<TableCell className="text-right tabular-nums">
+												{estimate
+													? formatISK(estimate.totalOreValue, { showDecimals: false })
+													: '-'}
+											</TableCell>
+										</TableRow>
+									)
+								})}
+						</TableBody>
+					</Table>
+				) : null}
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/ui/src/client/components/moon-profitability-table.tsx
+++ b/apps/ui/src/client/components/moon-profitability-table.tsx
@@ -1,0 +1,262 @@
+import { Fragment } from 'react'
+
+import { FUEL_BLOCK_TYPE_IDS, SKYHOOK_MAGMATIC_GAS_TYPE_ID } from '@repo/structures'
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
+import { typeIconUrl } from '@/lib/eve-images'
+import { formatISK } from '@/lib/format-utils'
+
+import { getOreRarity, RARITY_COLORS } from '../features/moon-scan/ore-rarities'
+
+import type { StructureMoonComposition } from '@repo/structures'
+import type { StructureProfitability } from '../features/moon-scan/types'
+
+const FUEL_BLOCK_ICON_TYPE_ID = Array.from(FUEL_BLOCK_TYPE_IDS)[0] ?? '4247'
+
+function RarityBadge({ rarity }: { rarity: string }) {
+	const color = RARITY_COLORS[rarity as keyof typeof RARITY_COLORS] ?? '#555'
+	return (
+		<span
+			className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold text-white"
+			style={{ backgroundColor: color }}
+		>
+			{rarity}
+		</span>
+	)
+}
+
+function formatVolumeM3(value: number | null | undefined): string {
+	if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+	return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })} m3`
+}
+
+function MaterialCell({
+	materialName,
+	materialTypeId,
+	materialRarity,
+}: {
+	materialName: string
+	materialTypeId: string
+	materialRarity: string | null
+}) {
+	const rarity = materialRarity ?? getOreRarity(materialTypeId)
+	return (
+		<div className="flex items-center gap-2">
+			<span>
+				{rarity && (
+					<>
+						<RarityBadge rarity={rarity} />{' '}
+					</>
+				)}
+				<img
+					src={typeIconUrl(materialTypeId, 32)}
+					alt=""
+					className="inline-block h-5 w-5 rounded align-middle"
+					loading="lazy"
+				/>{' '}
+				<span className="font-semibold text-foreground">{materialName}</span>
+			</span>
+		</div>
+	)
+}
+
+export function MoonProfitabilityTable({ structure }: { structure: StructureProfitability }) {
+	const LABELS: Record<string, string> = { metenox: 'Metenox', tatara: 'Refinery' }
+	const label = LABELS[structure.structureType] ?? structure.structureType
+	const gross = parseFloat(structure.grossIsk)
+	const fuel = parseFloat(structure.fuelCost)
+	const magmatic = parseFloat(structure.magmaticGasCost ?? '0')
+	const profit = parseFloat(structure.profit)
+	const rawOreVolumeM3 = structure.ores.reduce((sum, ore) => sum + ore.oreVolumeM3, 0)
+	const refinedVolumeM3 = structure.ores.some((ore) => ore.volumeM3 === null)
+		? null
+		: structure.ores.reduce((sum, ore) => sum + (ore.volumeM3 ?? 0), 0)
+
+	return (
+		<div className="p-4">
+			<h6 className="mb-3 text-sm font-medium">
+				{label} (per {structure.cycleDays}d cycle)
+			</h6>
+
+			<Table className="mb-3 text-xs">
+				<TableHeader>
+					<TableRow>
+						<TableHead className="text-left">Ore / Material</TableHead>
+						<TableHead className="text-right">Qty</TableHead>
+						<TableHead className="text-right">Volume (m3)</TableHead>
+						<TableHead className="text-right">Refined value</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody className="divide-y divide-border/50">
+					{structure.ores.map((ore) => {
+						const oreRarity = getOreRarity(ore.oreTypeId)
+						const oreColor = oreRarity ? RARITY_COLORS[oreRarity] : '#555'
+						const rows = ore.refinesTo.filter((row) => row.quantity > 0)
+						const oreValue = rows.reduce((sum, row) => sum + parseFloat(row.totalValue), 0)
+						return (
+							<Fragment key={`ore-${ore.oreTypeId}`}>
+								<TableRow className="bg-muted/20">
+									<TableCell className="px-0 pb-1 pt-2">
+										<div className="flex items-center gap-2 whitespace-nowrap">
+											<span
+												className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold text-white"
+												style={{ backgroundColor: oreColor }}
+											>
+												{ore.oreName}
+											</span>
+											<img
+												src={typeIconUrl(ore.oreTypeId, 32)}
+												alt=""
+												className="h-5 w-5 rounded"
+												loading="lazy"
+											/>
+											<span className="whitespace-nowrap text-xs text-muted-foreground">
+												{(parseFloat(ore.quantity) * 100).toFixed(1)}%
+											</span>
+										</div>
+									</TableCell>
+									<TableCell className="pb-1 pt-2 text-right tabular-nums text-muted-foreground">
+										{ore.oreUnits.toLocaleString()}
+									</TableCell>
+									<TableCell className="pb-1 pt-2 text-right tabular-nums text-muted-foreground">
+										{formatVolumeM3(ore.oreVolumeM3)}
+									</TableCell>
+									<TableCell className="pb-1 pt-2 text-right tabular-nums text-muted-foreground">
+										{formatISK(oreValue, { showDecimals: false })}
+									</TableCell>
+								</TableRow>
+								{rows.map((material) => (
+									<TableRow key={`${ore.oreTypeId}-${material.materialTypeId}`}>
+										<TableCell className="py-0.5 pl-3 text-muted-foreground">
+											<MaterialCell
+												materialName={material.materialName}
+												materialTypeId={material.materialTypeId}
+												materialRarity={material.materialRarity}
+											/>
+										</TableCell>
+										<TableCell className="py-0.5 text-right tabular-nums text-muted-foreground">
+											{material.quantity.toLocaleString()}
+										</TableCell>
+										<TableCell className="py-0.5 text-right tabular-nums text-muted-foreground">
+											{formatVolumeM3(material.volumeM3)}
+										</TableCell>
+										<TableCell className="py-0.5 text-right tabular-nums">
+											{formatISK(material.totalValue, { showDecimals: false })}
+										</TableCell>
+									</TableRow>
+								))}
+							</Fragment>
+						)
+					})}
+				</TableBody>
+			</Table>
+
+			<Table className="border-t pt-2 text-sm">
+				<TableBody>
+					<TableRow>
+						<TableCell className="py-1 text-muted-foreground">Total raw ore volume</TableCell>
+						<TableCell className="py-1 text-right font-semibold tabular-nums">
+							{formatVolumeM3(rawOreVolumeM3)}
+						</TableCell>
+					</TableRow>
+					<TableRow>
+						<TableCell className="py-1 text-muted-foreground">Total refined volume</TableCell>
+						<TableCell className="py-1 text-right font-semibold tabular-nums">
+							{formatVolumeM3(refinedVolumeM3)}
+						</TableCell>
+					</TableRow>
+					<TableRow>
+						<TableCell className="py-1 text-muted-foreground">Gross ISK</TableCell>
+						<TableCell className="py-1 text-right font-semibold tabular-nums">
+							{formatISK(String(Math.round(gross)), { showDecimals: false })}
+						</TableCell>
+					</TableRow>
+					<TableRow>
+						<TableCell className="py-1 text-muted-foreground">
+							<span className="inline-flex items-center gap-2">
+								<img
+									src={typeIconUrl(FUEL_BLOCK_ICON_TYPE_ID, 32)}
+									alt=""
+									className="h-5 w-5 rounded"
+									loading="lazy"
+								/>
+								Fuel Blocks
+							</span>
+						</TableCell>
+						<TableCell className="py-1 text-right font-semibold tabular-nums text-red-400">
+							−{formatISK(String(Math.round(fuel)), { showDecimals: false })}
+						</TableCell>
+					</TableRow>
+					{structure.magmaticGasCost && (
+						<TableRow>
+							<TableCell className="py-1 text-muted-foreground">
+								<span className="inline-flex items-center gap-2">
+									<img
+										src={typeIconUrl(SKYHOOK_MAGMATIC_GAS_TYPE_ID, 32)}
+										alt=""
+										className="h-5 w-5 rounded"
+										loading="lazy"
+									/>
+									Magmatic Gas
+								</span>
+							</TableCell>
+							<TableCell className="py-1 text-right font-semibold tabular-nums text-red-400">
+								−{formatISK(String(Math.round(magmatic)), { showDecimals: false })}
+							</TableCell>
+						</TableRow>
+					)}
+					<TableRow className="border-t font-semibold">
+						<TableCell className="py-1.5">Profit</TableCell>
+						<TableCell
+							className={`py-1.5 text-right tabular-nums ${profit >= 0 ? 'text-green-400' : 'text-red-400'}`}
+						>
+							{formatISK(String(Math.round(profit)), { showDecimals: false })}
+						</TableCell>
+					</TableRow>
+				</TableBody>
+			</Table>
+		</div>
+	)
+}
+
+export function MoonCompositionTable({ composition }: { composition: StructureMoonComposition }) {
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Mineral</TableHead>
+					<TableHead>Rarity</TableHead>
+					<TableHead className="text-right">Composition</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{[...composition.ores]
+					.sort((left, right) => Number(right.quantity) - Number(left.quantity))
+					.map((ore) => {
+						const rarity = ore.rarity ?? getOreRarity(ore.typeId)
+						return (
+							<TableRow key={ore.typeId}>
+								<TableCell>
+									<div className="flex items-center gap-2">
+										<img src={typeIconUrl(ore.typeId, 32)} alt="" className="h-6 w-6 rounded" />
+										<span>{ore.typeName ?? `Type ${ore.typeId}`}</span>
+									</div>
+								</TableCell>
+								<TableCell>{rarity ? <RarityBadge rarity={rarity} /> : '—'}</TableCell>
+								<TableCell className="text-right tabular-nums">
+									{(Number(ore.quantity) * 100).toFixed(2)}%
+								</TableCell>
+							</TableRow>
+						)
+					})}
+			</TableBody>
+		</Table>
+	)
+}

--- a/apps/ui/src/client/features/moon-scan/routes/moon.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/moon.tsx
@@ -1,8 +1,7 @@
-import { Fragment } from 'react'
+import { ArrowLeft } from 'lucide-react'
 import { Link, useParams } from 'react-router'
 
-import { ArrowLeft } from 'lucide-react'
-
+import { MoonProfitabilityTable } from '@/components/moon-profitability-table'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Container } from '@/components/ui/container'
@@ -18,12 +17,13 @@ import {
 	TableRow,
 } from '@/components/ui/table'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import { typeIconUrl } from '@/lib/eve-images'
 import { formatISK } from '@/lib/format-utils'
 
 import { ScanStatusBadge } from '../components/ScanStatusBadge'
 import { formatMoonScanDateTime } from '../date'
-import { RARITY_COLORS, getOreRarity } from '../ore-rarities'
 import { useMoonDetail } from '../hooks'
+import { getOreRarity, RARITY_COLORS } from '../ore-rarities'
 import { useMoonScanPermissions } from '../permissions'
 
 import type { OreRefineProduct, OreWithProfitability, StructureProfitability } from '../types'
@@ -40,6 +40,11 @@ function RarityBadge({ rarity }: { rarity: string }) {
 	)
 }
 
+function formatVolumeM3(value: number | null | undefined): string {
+	if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+	return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })} m3`
+}
+
 function OreCompositionTable({ ores }: { ores: OreWithProfitability[] }) {
 	return (
 		<div className="overflow-x-auto">
@@ -49,7 +54,10 @@ function OreCompositionTable({ ores }: { ores: OreWithProfitability[] }) {
 						<TableHead>Ore</TableHead>
 						<TableHead>Rarity</TableHead>
 						<TableHead>Percentage</TableHead>
+						<TableHead className="text-right">Raw ore volume (m3)</TableHead>
 						<TableHead>Refines To (per 100)</TableHead>
+						<TableHead className="text-right">Batch volume (m3)</TableHead>
+						<TableHead className="text-right">Total (refinery m3)</TableHead>
 						<TableHead className="text-right">Jita Sell</TableHead>
 						<TableHead className="text-right">Per 100 ore</TableHead>
 					</TableRow>
@@ -67,23 +75,46 @@ function OreCompositionTable({ ores }: { ores: OreWithProfitability[] }) {
 									{idx === 0 && (
 										<>
 											<TableCell rowSpan={rows.length} className="align-top">
-												<span
-													className="inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold text-white"
-													style={{ backgroundColor: color }}
-												>
-													{ore.oreName}
-												</span>
+												<div className="flex items-center gap-2">
+													<img
+														src={typeIconUrl(ore.oreTypeId, 32)}
+														alt=""
+														className="h-6 w-6 rounded"
+														loading="lazy"
+													/>
+													<span
+														className="inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold text-white"
+														style={{ backgroundColor: color }}
+													>
+														{ore.oreName}
+													</span>
+												</div>
 											</TableCell>
 											<TableCell rowSpan={rows.length} className="align-top whitespace-nowrap">
 												{rarity ? <RarityBadge rarity={rarity} /> : '—'}
 											</TableCell>
-											<TableCell rowSpan={rows.length} className="align-top whitespace-nowrap tabular-nums">
+											<TableCell
+												rowSpan={rows.length}
+												className="align-top whitespace-nowrap tabular-nums"
+											>
 												{(parseFloat(ore.quantity) * 100).toFixed(2)}%
+											</TableCell>
+											<TableCell
+												rowSpan={rows.length}
+												className="align-top whitespace-nowrap text-right tabular-nums text-xs"
+											>
+												{formatVolumeM3(ore.oreVolumeM3)}
 											</TableCell>
 										</>
 									)}
 									<TableCell>
 										<MaterialCell product={product} batchQty={batchQty} />
+									</TableCell>
+									<TableCell className="text-right tabular-nums text-xs">
+										{formatVolumeM3(product.volumePer100M3)}
+									</TableCell>
+									<TableCell className="text-right tabular-nums text-xs">
+										{formatVolumeM3(product.volumeM3)}
 									</TableCell>
 									<TableCell className="text-right tabular-nums text-xs">
 										{formatISK(product.unitSellPrice, { showDecimals: false })}
@@ -104,106 +135,20 @@ function OreCompositionTable({ ores }: { ores: OreWithProfitability[] }) {
 function MaterialCell({ product, batchQty }: { product: OreRefineProduct; batchQty: number }) {
 	const rarity = getOreRarity(product.materialTypeId)
 	return (
-		<span className="text-xs">
-			{rarity && <RarityBadge rarity={rarity} />}
-			{rarity && ' '}
-			{product.materialName}{' '}
-			<span className="text-muted-foreground">×{batchQty.toLocaleString()}</span>
+		<span className="inline-flex items-center gap-2 text-xs">
+			<span>
+				{rarity && <RarityBadge rarity={rarity} />}
+				{rarity && ' '}
+				<img
+					src={typeIconUrl(product.materialTypeId, 32)}
+					alt=""
+					className="inline-block h-5 w-5 rounded align-middle"
+					loading="lazy"
+				/>{' '}
+				<span className="font-semibold text-foreground">{product.materialName}</span>{' '}
+				<span className="text-muted-foreground">×{batchQty.toLocaleString()}</span>
+			</span>
 		</span>
-	)
-}
-
-function StructurePanel({ structure }: { structure: StructureProfitability }) {
-	const LABELS: Record<string, string> = { metenox: 'Metenox', tatara: 'Refinery' }
-	const label = LABELS[structure.structureType] ?? structure.structureType
-	const gross = parseFloat(structure.grossIsk)
-	const fuel = parseFloat(structure.fuelCost)
-	const magmatic = parseFloat(structure.magmaticGasCost ?? '0')
-	const profit = parseFloat(structure.profit)
-
-	return (
-		<div className="p-4">
-			<h6 className="text-sm font-medium mb-3">{label} (per {structure.cycleDays}d cycle)</h6>
-
-			<Table className="mb-3 text-xs">
-				<TableHeader>
-					<TableRow>
-						<TableHead className="text-left">Ore / Material</TableHead>
-						<TableHead className="text-right">Qty</TableHead>
-						<TableHead className="text-right">Value</TableHead>
-					</TableRow>
-				</TableHeader>
-				<TableBody className="divide-y divide-border/50">
-					{structure.ores.map((ore) => {
-						const oreRarity = getOreRarity(ore.oreTypeId)
-						const oreColor = oreRarity ? RARITY_COLORS[oreRarity] : '#555'
-						const rows = ore.refinesTo.filter((r) => r.quantity > 0)
-						if (rows.length === 0) return null
-						const oreValue = rows.reduce((s, r) => s + parseFloat(r.totalValue), 0)
-							return (
-								<Fragment key={`ore-${ore.oreTypeId}`}>
-									{/* Ore header row */}
-									<TableRow className="bg-muted/20">
-										<TableCell colSpan={2} className="px-0 pb-1 pt-2">
-										<span
-											className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold text-white"
-											style={{ backgroundColor: oreColor }}
-										>
-											{ore.oreName}
-										</span>
-										<span className="ml-1.5 text-muted-foreground text-xs">
-											{(parseFloat(ore.quantity) * 100).toFixed(1)}%
-										</span>
-									</TableCell>
-									<TableCell className="pb-1 pt-2 text-right tabular-nums text-muted-foreground">
-										{formatISK(oreValue, { showDecimals: false })}
-									</TableCell>
-								</TableRow>
-								{/* Material rows */}
-								{rows.map((mat) => {
-									const matRarity = getOreRarity(mat.materialTypeId)
-									return (
-										<TableRow key={`${ore.oreTypeId}-${mat.materialTypeId}`}>
-											<TableCell className="py-0.5 pl-3 text-muted-foreground">
-												{matRarity && <><RarityBadge rarity={matRarity} />{' '}</>}
-												{mat.materialName}
-											</TableCell>
-											<TableCell className="py-0.5 text-right tabular-nums text-muted-foreground">{mat.quantity.toLocaleString()}</TableCell>
-											<TableCell className="py-0.5 text-right tabular-nums">{formatISK(mat.totalValue, { showDecimals: false })}</TableCell>
-										</TableRow>
-									)
-								})}
-								</Fragment>
-							)
-						})}
-				</TableBody>
-			</Table>
-
-			<Table className="border-t pt-2 text-sm">
-				<TableBody>
-					<TableRow>
-						<TableCell className="py-1 text-muted-foreground">Gross ISK</TableCell>
-						<TableCell className="py-1 text-right tabular-nums">{formatISK(String(Math.round(gross)), { showDecimals: false })}</TableCell>
-					</TableRow>
-					<TableRow>
-						<TableCell className="py-1 text-muted-foreground">Fuel Blocks</TableCell>
-						<TableCell className="py-1 text-right tabular-nums text-red-400">−{formatISK(String(Math.round(fuel)), { showDecimals: false })}</TableCell>
-					</TableRow>
-					{structure.magmaticGasCost && (
-						<TableRow>
-							<TableCell className="py-1 text-muted-foreground">Magmatic Gas</TableCell>
-							<TableCell className="py-1 text-right tabular-nums text-red-400">−{formatISK(String(Math.round(magmatic)), { showDecimals: false })}</TableCell>
-						</TableRow>
-					)}
-					<TableRow className="border-t font-semibold">
-						<TableCell className="py-1.5">Profit</TableCell>
-						<TableCell className={`py-1.5 text-right tabular-nums ${profit >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-							{formatISK(String(Math.round(profit)), { showDecimals: false })}
-						</TableCell>
-					</TableRow>
-				</TableBody>
-			</Table>
-		</div>
 	)
 }
 
@@ -217,15 +162,17 @@ function ProfitabilityCard({
 	pricingSnapshotDate: string | null
 }) {
 	const ORDER = ['metenox', 'tatara']
-	const visible = ORDER
-		.map((id) => structures.find((s) => s.structureType === id))
-		.filter((s): s is StructureProfitability => s !== undefined)
+	const visible = ORDER.map((id) => structures.find((s) => s.structureType === id)).filter(
+		(s): s is StructureProfitability => s !== undefined
+	)
 
 	return (
 		<div className="rounded-md border bg-card">
 			<div className="border-b px-4 py-3 text-sm font-semibold">Profitability</div>
 			<div className="grid grid-cols-1 gap-0 sm:grid-cols-2 sm:divide-x">
-				{visible.map((s) => <StructurePanel key={s.structureType} structure={s} />)}
+				{visible.map((s) => (
+					<MoonProfitabilityTable key={s.structureType} structure={s} />
+				))}
 			</div>
 			<div className="border-t px-4 py-2 text-xs text-muted-foreground">
 				<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -274,13 +221,13 @@ export default function MoonPage() {
 		<Container>
 			<PageHeader
 				title={moon?.moonName ?? moonId!}
-				description={
-					moon ? `Moon ID: ${moon.moonId}` : undefined
-				}
-				action={(
+				description={moon ? `Moon ID: ${moon.moonId}` : undefined}
+				action={
 					<div className="flex flex-col items-end gap-2">
 						<div className="flex items-center gap-2 text-sm text-muted-foreground">
-							<Link to="/moon-scan" className="hover:underline">Moons</Link>
+							<Link to="/moon-scan" className="hover:underline">
+								Moons
+							</Link>
 							{moon?.solarSystemId && (
 								<>
 									<span>/</span>
@@ -308,7 +255,7 @@ export default function MoonPage() {
 							</Button>
 						)}
 					</div>
-				)}
+				}
 			/>
 
 			<div className="mb-6 -mt-3">
@@ -316,7 +263,9 @@ export default function MoonPage() {
 					{composition ? (
 						<Badge className="bg-green-500/20 text-green-400 border-green-500/30">verified</Badge>
 					) : !isLoading ? (
-						<Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/30">unverified</Badge>
+						<Badge className="bg-yellow-500/20 text-yellow-400 border-yellow-500/30">
+							unverified
+						</Badge>
 					) : null}
 				</div>
 			</div>
@@ -348,8 +297,11 @@ export default function MoonPage() {
 					</div>
 					<OreCompositionTable ores={profitability.ores} />
 					<div className="border-t px-4 py-2 text-xs text-muted-foreground">
-						Verified{composition.verifiedBy ? ` by ${composition.verifiedByName ?? composition.verifiedBy}` : ''} on{' '}
-						{new Date(composition.verifiedAt).toISOString().slice(0, 10)}
+						Verified
+						{composition.verifiedBy
+							? ` by ${composition.verifiedByName ?? composition.verifiedBy}`
+							: ''}{' '}
+						on {new Date(composition.verifiedAt).toISOString().slice(0, 10)}
 					</div>
 				</div>
 			)}
@@ -376,49 +328,52 @@ export default function MoonPage() {
 			<div className="rounded-md border bg-card">
 				<div className="border-b px-4 py-3 text-sm font-semibold">Scan History</div>
 				<div className="overflow-x-auto">
-						<Table>
-							<TableHeader>
-								<TableRow>
-									<TableHead>Date</TableHead>
-									<TableHead>Submitted By</TableHead>
-									<TableHead>Status</TableHead>
-									<TableHead>Ores</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{(detail?.scans ?? []).map((scan) => (
-									<TableRow key={scan.id}>
-										<TableCell className="text-xs whitespace-nowrap">
-											{formatMoonScanDateTime(scan.submittedAt)}
-										</TableCell>
-										<TableCell className="text-xs text-muted-foreground">
-											{scan.submittedByName ?? scan.submittedBy ?? '?'}
-										</TableCell>
-										<TableCell><ScanStatusBadge status={scan.status} /></TableCell>
-										<TableCell className="text-xs text-muted-foreground">
-											{scan.ores.map((ore, i) => {
-												const data = profitability?.ores.find((o) => o.oreTypeId === ore.oreTypeId)
-												const name = data?.oreName ?? ore.oreTypeId
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Date</TableHead>
+								<TableHead>Submitted By</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead>Ores</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{(detail?.scans ?? []).map((scan) => (
+								<TableRow key={scan.id}>
+									<TableCell className="text-xs whitespace-nowrap">
+										{formatMoonScanDateTime(scan.submittedAt)}
+									</TableCell>
+									<TableCell className="text-xs text-muted-foreground">
+										{scan.submittedByName ?? scan.submittedBy ?? '?'}
+									</TableCell>
+									<TableCell>
+										<ScanStatusBadge status={scan.status} />
+									</TableCell>
+									<TableCell className="text-xs text-muted-foreground">
+										{scan.ores.map((ore, i) => {
+											const data = profitability?.ores.find((o) => o.oreTypeId === ore.oreTypeId)
+											const name = data?.oreName ?? ore.oreTypeId
 											return (
 												<span key={ore.oreTypeId}>
-													{name} ({(parseFloat(ore.quantity) * 100).toFixed(1)}%){i < scan.ores.length - 1 ? ', ' : ''}
-													</span>
-												)
-											})}
-										</TableCell>
-									</TableRow>
-								))}
-								{detail?.scans.length === 0 && (
-									<TableRow>
-										<TableCell colSpan={4} className="py-6 text-center text-sm text-muted-foreground">
-											No scan records for this moon.
-										</TableCell>
-									</TableRow>
-								)}
-							</TableBody>
-						</Table>
-					</div>
+													{name} ({(parseFloat(ore.quantity) * 100).toFixed(1)}%)
+													{i < scan.ores.length - 1 ? ', ' : ''}
+												</span>
+											)
+										})}
+									</TableCell>
+								</TableRow>
+							))}
+							{detail?.scans.length === 0 && (
+								<TableRow>
+									<TableCell colSpan={4} className="py-6 text-center text-sm text-muted-foreground">
+										No scan records for this moon.
+									</TableCell>
+								</TableRow>
+							)}
+						</TableBody>
+					</Table>
 				</div>
-			</Container>
+			</div>
+		</Container>
 	)
 }

--- a/apps/ui/src/client/features/moon-scan/types.ts
+++ b/apps/ui/src/client/features/moon-scan/types.ts
@@ -166,6 +166,8 @@ export interface OreRefineProduct {
 	batchQty: number
 	unitSellPrice: string
 	totalValue: string
+	volumeM3: number | null
+	volumePer100M3: number | null
 	materialRarity: string | null
 }
 
@@ -173,9 +175,12 @@ export interface OreWithProfitability {
 	oreTypeId: string
 	oreName: string
 	quantity: string
+	oreUnits: number
 	rarity: string | null
 	refinesTo: OreRefineProduct[]
 	totalOreValue: string
+	oreVolumeM3: number
+	volumeM3: number | null
 }
 
 export interface StructureProfitability {

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -24,6 +24,7 @@ import type {
 	StructureMiningCitadelListQuery as RepoStructureMiningCitadelListQuery,
 	StructureMiningCitadelListResponse as RepoStructureMiningCitadelListResponse,
 	StructureMiningCitadelSummary as RepoStructureMiningCitadelSummary,
+	StructureMoonComposition as RepoStructureMoonComposition,
 	StructureMoonDrillListItem as RepoStructureMoonDrillListItem,
 	StructureMoonDrillListQuery as RepoStructureMoonDrillListQuery,
 	StructureMoonDrillListResponse as RepoStructureMoonDrillListResponse,
@@ -979,6 +980,7 @@ export interface StructureSkyhookSummary {
 
 export type StructureMoonDrillSummary = RepoStructureMoonDrillSummary
 export type StructureMiningCitadelSummary = RepoStructureMiningCitadelSummary
+export type StructureMoonComposition = RepoStructureMoonComposition
 export type StructureMiningCitadelExtractionHistory = RepoStructureMiningCitadelExtractionHistory
 
 export type StructureSovereigntyListItem = RepoStructureSovereigntyListItem
@@ -1014,6 +1016,13 @@ export interface StructureFittingItem {
 	isConsumable?: boolean
 }
 
+export interface StructureFittingSlotCapacities {
+	high: number
+	mid: number
+	low: number
+	rig: number
+}
+
 export interface StructureDetailResult extends Omit<StructureListItem, 'canViewDetails'> {
 	includeInStructureAssetSync: boolean
 	assetsLastSync: string | null
@@ -1035,9 +1044,12 @@ export interface StructureDetailResult extends Omit<StructureListItem, 'canViewD
 	skyhook?: StructureSkyhookSummary | null
 	moonDrill?: StructureMoonDrillSummary | null
 	miningExtraction?: StructureMiningCitadelSummary | null
+	miningExtractionComposition?: StructureMoonComposition | null
+	moonComposition?: StructureMoonComposition | null
 	miningExtractionHistory?: StructureMiningCitadelExtractionHistory[]
 	inventoryBays?: StructureInventoryBay[]
 	fittingItems?: StructureFittingItem[]
+	fittingSlotCapacities?: StructureFittingSlotCapacities | null
 }
 
 export interface StructureAssetsDebugResult {

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -26,6 +26,7 @@ import {
 
 import { CorporationLogo } from '@/components/corporation-logo'
 import { InventoryBaysTable } from '@/components/inventory-bays-table'
+import { MoonCompositionCard } from '@/components/moon-composition-card'
 import { SkyhookStateBadge } from '@/components/skyhook-state-badge'
 import { StructureStateBadge } from '@/components/structure-state-badge'
 import { StructureSyncStatusBadge } from '@/components/structure-sync-status-badge'
@@ -58,7 +59,7 @@ import { useNowMs } from '@/hooks/useNowMs'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { api } from '@/lib/api'
-import { formatDateTimeLong } from '@/lib/date-utils'
+import { formatDateTimeLong, formatUtcDateTime } from '@/lib/date-utils'
 import { formatDurationMs } from '@/lib/duration-utils'
 import { allianceLogoUrl, typeIconUrl, typeImageUrl, typeRenderUrl } from '@/lib/eve-images'
 import { getSovereigntyVulnerabilityWindowDisplay } from '@/lib/sovereignty-vulnerability-window'
@@ -209,6 +210,10 @@ function formatReinforcementHourUtc(hour: number | null): string {
 
 function formatNullableDateTime(value: string | null | undefined): string {
 	return value ? formatDateTimeLong(value) : '-'
+}
+
+function formatEveTimeLabel(value: string | null | undefined): string {
+	return value ? `${formatUtcDateTime(value, true)} EVE` : '-'
 }
 
 function formatNullableNumber(value: number | null | undefined): string {
@@ -867,7 +872,12 @@ export default function StructuresDetailPage() {
 
 		return structureFittingItemsToDisplayItems(structure)
 	}, [structure])
-	const hasStructureFitting = fittingItems.length > 0
+	const fittingSlotCapacities: NonNullable<StructureDetailResult['fittingSlotCapacities']> =
+		structure?.fittingSlotCapacities ?? { high: 0, mid: 0, low: 0, rig: 0 }
+	const hasStructureFitting =
+		fittingItems.length > 0 ||
+		structure?.fittingSlotCapacities == null ||
+		Object.values(fittingSlotCapacities).some((capacity) => capacity > 0)
 	const isReinforced = structure ? isReinforcedStructureState(structure.state) : false
 	const structureFamily = structure
 		? getStructureTabForTypeId(structure.typeId, structure.typeName)
@@ -876,12 +886,17 @@ export default function StructuresDetailPage() {
 	const hasSovereigntySummary = structureFamily === 'sovereignty' && Boolean(structure?.sovereignty)
 	const hasSkyhookSummary = structureFamily === 'skyhooks' && Boolean(structure?.skyhook)
 	const isSkyhookStructure = structureFamily === 'skyhooks'
-	const hasMoonDrillSummary = structureFamily === 'moon-drills' && Boolean(structure?.moonDrill)
+	const isMoonDrillStructure = structureFamily === 'moon-drills'
 	const hasMiningExtractionSummary =
 		structureFamily === 'mining-citadels' &&
-		(Boolean(structure?.miningExtraction) || (structure?.miningExtractionHistory?.length ?? 0) > 0)
+		(Boolean(structure?.miningExtraction) ||
+			(structure?.miningExtractionHistory?.length ?? 0) > 0 ||
+			Boolean(structure?.miningExtractionComposition))
 	const moonDrill = structure?.moonDrill ?? null
 	const miningExtraction = structure?.miningExtraction ?? null
+	const miningExtractionComposition =
+		structure?.miningExtractionComposition ?? miningExtraction?.composition ?? null
+	const moonComposition = structure?.moonComposition ?? miningExtractionComposition
 	const miningExtractionHistory = structure?.miningExtractionHistory ?? []
 	const hasStructure = Boolean(structure)
 	const [selectedExtractionId, setSelectedExtractionId] = useState<string | null>(null)
@@ -900,9 +915,8 @@ export default function StructuresDetailPage() {
 			value: extraction.id,
 			label:
 				extraction.id === currentExtractionId
-					? `Current extraction (${formatNullableDateTime(extraction.extractionStartTime)})`
-					: `${formatNullableDateTime(extraction.extractionStartTime)} - ${formatNullableDateTime(extraction.naturalDecayTime)}`,
-			description: `Chunk arrival: ${formatNullableDateTime(extraction.chunkArrivalTime)}`,
+					? `Current extraction (${formatEveTimeLabel(extraction.extractionStartTime)})`
+					: `${formatEveTimeLabel(extraction.extractionStartTime)} - ${formatEveTimeLabel(extraction.naturalDecayTime)}`,
 		}))
 	}, [currentExtractionId, miningExtractionHistory])
 	const sovereigntyHub = structure?.sovereignty?.hub ?? null
@@ -1017,7 +1031,7 @@ export default function StructuresDetailPage() {
 				title={
 					hasSkyhookSummary
 						? 'Skyhook Details'
-						: hasMoonDrillSummary || hasMiningExtractionSummary
+						: isMoonDrillStructure || hasMiningExtractionSummary
 							? stripLeadingContextName(structure.name, structure.systemName)
 							: structure.name
 				}
@@ -1045,497 +1059,133 @@ export default function StructuresDetailPage() {
 				}
 			/>
 
-			<div className="grid gap-4 md:grid-cols-2">
-				<Card>
-					<CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
-						<div className="space-y-1.5">
-							<CardTitle>Summary</CardTitle>
-							<CardDescription>Current synced state and operational metadata.</CardDescription>
-						</div>
-						{isAdmin && (
-							<div className="flex items-center gap-3">
-								{isAssetsDebugPolling ? (
-									<span className="text-xs text-muted-foreground">
-										Generating asset debug snapshot...
-									</span>
-								) : null}
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => {
-										if (isAssetsDebugBusy) return
-										void debugAssetsMutation.mutateAsync()
-									}}
-									loading={isAssetsDebugBusy}
-									loadingText={isAssetsDebugPolling ? 'Generating...' : 'Queueing...'}
-								>
-									<Search className="h-4 w-4" />
-									Debug Assets
-								</Button>
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => {
-										if (isInventoryRebuildBusy) return
-										void rebuildInventoryMutation.mutateAsync()
-									}}
-									loading={isInventoryRebuildBusy}
-									loadingText="Rebuilding..."
-								>
-									<Recycle className="h-4 w-4" />
-									Rebuild Inventory Snapshot
-								</Button>
-							</div>
-						)}
-					</CardHeader>
-					<CardContent className="space-y-4 text-sm">
-						<div className="grid grid-cols-2 gap-4">
-							<div>
-								<div className="text-muted-foreground">Region</div>
-								<div className="font-medium">
-									{structure.regionName ?? structure.regionId ?? '-'}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">System</div>
-								<div className="font-medium">{structure.systemName ?? structure.systemId}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">
-									{hasSovereigntySummary ? 'Controlling Alliance' : 'Type'}
-								</div>
-								<div className="font-medium">
-									{hasSovereigntySummary ? (
-										sovereigntyAllianceId ? (
-											<div className="flex items-center gap-2">
-												<AllianceLogo
-													allianceId={sovereigntyAllianceId}
-													allianceName={sovereigntyAllianceName}
-												/>
-												<span>{sovereigntyAllianceName ?? sovereigntyAllianceId}</span>
-											</div>
-										) : (
-											'-'
-										)
-									) : (
-										(structure.typeName ?? structure.typeId)
-									)}
-								</div>
-							</div>
-							{!hasSovereigntySummary && !isSkyhookStructure && (
-								<div>
-									<div className="text-muted-foreground">Low Power</div>
-									<div className="font-medium">{structure.lowPower ? 'Yes' : 'No'}</div>
-								</div>
-							)}
-							{!hasSovereigntySummary && !isSkyhookStructure && (
-								<>
-									<div>
-										<div className="text-muted-foreground">Fuel</div>
-										<div className="font-medium">
-											{structure.fuelAmount !== null ? (
-												`${structure.fuelAmount.toLocaleString()} units`
-											) : structure.fuelExpires ? (
-												<DurationDisplay endDate={structure.fuelExpires} format="compact" />
-											) : (
-												'-'
-											)}
-										</div>
-									</div>
-									<div>
-										<div className="text-muted-foreground">Last Refilled</div>
-										<div className="font-medium">
-											{structure.lastRefilledAt ? (
-												<EveTimeDisplay dateStr={structure.lastRefilledAt} format="compact" />
-											) : (
-												'-'
-											)}
-										</div>
-									</div>
-									<div>
-										<div className="text-muted-foreground">Burn / Hr</div>
-										<div className="font-medium">
-											{formatBurnRate(
-												structure.fuelBurnRate === null
-													? null
-													: Number.parseFloat(structure.fuelBurnRate)
-											)}
-										</div>
-									</div>
-								</>
-							)}
-							{hasSovereigntySummary && (
-								<div>
-									<div className="text-muted-foreground">Claimed Since</div>
-									<div className="font-medium">
-										{structure.sovereignty?.claimedSince ? (
-											<EveTimeDisplay
-												dateStr={structure.sovereignty.claimedSince}
-												format="compact"
-											/>
-										) : (
-											'-'
-										)}
-									</div>
-								</div>
-							)}
-							{hasSovereigntySummary && (
-								<div>
-									<div className="text-muted-foreground">Capital System</div>
-									<div className="font-medium">
-										{structure.sovereignty?.isCapitalSystem ? 'Yes' : 'No'}
-									</div>
-								</div>
-							)}
-							{hasSovereigntySummary && (
-								<div>
-									<div className="text-muted-foreground">Activity Defense Multiplier</div>
-									<div className="font-medium">
-										{structure.sovereignty?.activityDefenseMultiplier ?? '-'}
-									</div>
-								</div>
-							)}
-							<div>
-								<div className="text-muted-foreground">
-									{hasSovereigntySummary ? 'Vulnerability State' : 'State'}
-								</div>
-								<div className="font-medium">
-									{hasSovereigntySummary ? (
-										<Badge variant={sovereigntyVulnerabilityState.variant}>
-											{sovereigntyVulnerabilityState.label}
-										</Badge>
-									) : structure.skyhook ? (
-										<SkyhookStateBadge state={structure.skyhook.state} />
-									) : (
-										<StructureStateBadge state={structure.state} />
-									)}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">
-									{hasSovereigntySummary ? (
-										'Vulnerability Window'
-									) : isReinforced ? (
-										<Badge variant="destructive">Reinforced until</Badge>
-									) : (
-										'Next State'
-									)}
-								</div>
-								<div className="font-medium">
-									{hasSovereigntySummary ? (
-										structure.sovereignty?.vulnerabilityWindowStart &&
-										structure.sovereignty?.vulnerabilityWindowEnd ? (
-											<span className="inline-flex flex-wrap items-center gap-1">
-												<EveTimeDisplay
-													dateStr={structure.sovereignty.vulnerabilityWindowStart}
-													format="window"
-													className="whitespace-nowrap"
-												/>
-												<span>-</span>
-												<EveTimeDisplay
-													dateStr={structure.sovereignty.vulnerabilityWindowEnd}
-													format="window"
-													className="whitespace-nowrap"
-												/>
-											</span>
-										) : structure.sovereignty?.vulnerabilityWindowEnd ? (
-											<EveTimeDisplay
-												dateStr={structure.sovereignty.vulnerabilityWindowEnd}
-												format="window"
-												className="whitespace-nowrap"
-											/>
-										) : (
-											'-'
-										)
-									) : structure.nextStateAt ? (
-										<EveTimeDisplay dateStr={structure.nextStateAt} format="compact" />
-									) : (
-										'-'
-									)}
-								</div>
-								{hasSovereigntySummary &&
-								(structure.sovereignty?.vulnerabilityWindowStart ||
-									structure.sovereignty?.vulnerabilityWindowEnd) ? (
-									<div className="mt-1 text-xs text-muted-foreground">
-										<LiveSovereigntyVulnerabilityWindow
-											vulnerabilityWindowStart={structure.sovereignty?.vulnerabilityWindowStart}
-											vulnerabilityWindowEnd={structure.sovereignty?.vulnerabilityWindowEnd}
-										/>
-									</div>
-								) : null}
-							</div>
-						</div>
-						<div className="flex flex-wrap gap-2 pt-2">
-							{structure.hidden && <Badge variant="ghost">Hidden</Badge>}
-							{!hasSovereigntySummary && !isSkyhookStructure && structure.lowPowerAllowed && (
-								<Badge variant="success">Low Power Alerts Suppressed</Badge>
-							)}
-							{structure.assignedGroupId && <Badge variant="special">Group Assigned</Badge>}
-						</div>
-						<div className="space-y-3">
-							{!hasSovereigntySummary && !isSkyhookStructure && (
-								<div className="space-y-2">
-									<div className="text-xs uppercase tracking-wider text-muted-foreground">
-										Reinforcement
-									</div>
-									<div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-sm">
-										<div className="grid gap-3">
-											<div>
-												<div className="text-xs text-muted-foreground">Reinforcement Hour</div>
-												<div className="font-medium">
-													{formatReinforcementHourUtc(structure.reinforceHour)}
-												</div>
-											</div>
-											<div>
-												<div className="text-xs text-muted-foreground">Next Reinforcement Hour</div>
-												<div className="font-medium">
-													{structure.nextReinforceHour !== null
-														? formatReinforcementHourUtc(structure.nextReinforceHour)
-														: '-'}
-												</div>
-											</div>
-											<div>
-												<div className="text-xs text-muted-foreground">
-													Next Reinforcement Applies
-												</div>
-												<div className="font-medium">
-													{structure.nextReinforceApply ? (
-														<EveTimeDisplay
-															dateStr={structure.nextReinforceApply}
-															format="compact"
-														/>
-													) : (
-														'-'
-													)}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-							)}
-							{!hasSovereigntySummary && !isSkyhookStructure && (
-								<div className="space-y-2">
-									<div className="text-xs uppercase tracking-wider text-muted-foreground">
-										Structure Services
-									</div>
-									{structure.services.length > 0 ? (
-										<div className="space-y-1.5">
-											{structure.services.map((service) => (
-												<div
-													key={`${service.name}-${service.state}`}
-													className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
-												>
-													<div className="flex min-w-0 items-center gap-2">
-														<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground">
-															{renderServiceIcon(service.name)}
-														</div>
-														<div className="min-w-0">
-															<div className="truncate text-sm font-medium">{service.name}</div>
-														</div>
-													</div>
-													<Badge variant={serviceBadgeVariant(service.state)} className="shrink-0">
-														{formatServiceStateLabel(service.state)}
-													</Badge>
-												</div>
-											))}
-										</div>
-									) : (
-										<div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
-											No structure services were reported for this structure.
-										</div>
-									)}
-								</div>
-							)}
-							<div className="space-y-2">
-								<div className="text-xs uppercase tracking-wider text-muted-foreground">
-									Sync Status
-								</div>
-								<div className="rounded-lg border border-border/60 p-4">
-									<div className="mb-3 flex flex-wrap items-center gap-2">
-										<StructureSyncStatusBadge
-											label="Structure"
-											status={structure.syncStatus}
-											description={syncDescription}
-										/>
-										{!hasSovereigntySummary && (
-											<>
-												<span aria-hidden className="text-sm text-muted-foreground">
-													-
-												</span>
-												<StructureSyncStatusBadge
-													label="Assets"
-													status={assetsSyncStatus}
-													description={assetsSyncDescription}
-												/>
-											</>
-										)}
-									</div>
-									<div className="mt-2 text-sm text-muted-foreground">{syncDescription}</div>
-								</div>
-							</div>
-						</div>
-					</CardContent>
-				</Card>
-
-				<Card>
-					<CardHeader>
-						<CardTitle>Configuration</CardTitle>
-						<CardDescription>
-							Manager-level settings for visibility, alert suppression, and group assignment.
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-5">
-						<div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-							<div>
-								<div className="font-medium">Hidden</div>
-								<div className="text-sm text-muted-foreground">
-									Completely omit this structure from non-sensitive users.
-								</div>
-							</div>
-							<Switch checked={hidden} onCheckedChange={setHidden} />
-						</div>
-						{!hasSovereigntySummary && !isSkyhookStructure && (
-							<div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
-								<div>
-									<div className="font-medium">Low Power Allowed</div>
-									<div className="text-sm text-muted-foreground">
-										Suppress low-power alerts for structures where that is intentional.
-									</div>
-								</div>
-								<Switch checked={lowPowerAllowed} onCheckedChange={setLowPowerAllowed} />
-							</div>
-						)}
-						<FilterField label="Assigned Group">
-							<Select
-								options={groupOptions}
-								value={assignedGroupId}
-								onValueChange={(value) => setAssignedGroupId(value)}
-								placeholder="No Group"
-							/>
-						</FilterField>
-						<div className="flex items-center justify-end gap-3 pt-2">
-							<Button
-								variant="ghost"
-								onClick={() => {
-									setHidden(structure.hidden)
-									if (!hasSovereigntySummary) {
-										setLowPowerAllowed(structure.lowPowerAllowed)
-									}
-									setAssignedGroupId(structure.assignedGroupId ?? '')
-								}}
-							>
-								Reset
-							</Button>
-							<Button
-								variant="confirm"
-								onClick={() => void handleSave()}
-								loading={updateMutation.isPending}
-							>
-								<Save className="h-4 w-4" />
-								Save Changes
-							</Button>
-						</div>
-					</CardContent>
-				</Card>
-			</div>
-
-			{hasSovereigntySummary && (
-				<div className="space-y-4">
+			<div className="grid grid-flow-row grid-cols-1 gap-4 md:grid-cols-2">
+				<div className="contents">
 					<Card>
-						<CardHeader>
-							<CardTitle>Hub Configuration</CardTitle>
-							<CardDescription>
-								Workforce transport routing and the hub's current resource allocation.
-							</CardDescription>
+						<CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+							<div className="space-y-1.5">
+								<CardTitle>Summary</CardTitle>
+								<CardDescription>Current synced state and operational metadata.</CardDescription>
+							</div>
+							{isAdmin && (
+								<div className="flex items-center gap-3">
+									{isAssetsDebugPolling ? (
+										<span className="text-xs text-muted-foreground">
+											Generating asset debug snapshot...
+										</span>
+									) : null}
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => {
+											if (isAssetsDebugBusy) return
+											void debugAssetsMutation.mutateAsync()
+										}}
+										loading={isAssetsDebugBusy}
+										loadingText={isAssetsDebugPolling ? 'Generating...' : 'Queueing...'}
+									>
+										<Search className="h-4 w-4" />
+										Debug Assets
+									</Button>
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => {
+											if (isInventoryRebuildBusy) return
+											void rebuildInventoryMutation.mutateAsync()
+										}}
+										loading={isInventoryRebuildBusy}
+										loadingText="Rebuilding..."
+									>
+										<Recycle className="h-4 w-4" />
+										Rebuild Inventory Snapshot
+									</Button>
+								</div>
+							)}
 						</CardHeader>
-						<CardContent className="space-y-6 text-sm">
-							<div className="grid gap-4 md:grid-cols-2">
-								<ResourceAllocationCard
-									label="Power Allocation"
-									allocated={sovereigntyHub?.resourcePowerAllocated}
-									available={sovereigntyHub?.resourcePowerAvailable}
-								/>
-								<ResourceAllocationCard
-									label="Workforce Allocation"
-									allocated={sovereigntyHub?.resourceWorkforceAllocated}
-									available={sovereigntyHub?.resourceWorkforceAvailable}
-								/>
-							</div>
-
-							<div className="grid gap-4 lg:grid-cols-2">
-								<WorkforceTransportSection
-									label="Workforce Transport Configuration"
-									section={sovereigntyHub?.workforceTransport?.configuration}
-									systemLinkById={sovereigntyHubStructureIdBySystemId}
-								/>
-								<WorkforceTransportSection
-									label="Workforce Transport State"
-									section={sovereigntyHub?.workforceTransport?.state}
-									systemLinkById={sovereigntyHubStructureIdBySystemId}
-								/>
-							</div>
-						</CardContent>
-					</Card>
-
-					<div className="grid gap-4 lg:grid-cols-2">
-						<Card>
-							<CardHeader>
-								<CardTitle>Upgrades</CardTitle>
-								<CardDescription>
-									Installed sovereignty hub upgrades and their current power state.
-								</CardDescription>
-							</CardHeader>
-							<CardContent className="space-y-2">
-								{sovereigntyHub?.upgrades?.length ? (
-									<div className="space-y-1.5">
-										{sovereigntyHub.upgrades.map((upgrade) => (
-											<div
-												key={`${upgrade.typeId}-${upgrade.powerState}`}
-												className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
-											>
-												<div className="flex min-w-0 items-center gap-2">
-													<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground">
-														<InventoryItemIcon typeId={upgrade.typeId} />
-													</div>
-													<div className="min-w-0">
-														<div className="truncate text-sm font-medium">
-															{upgrade.typeName ?? upgrade.typeId}
-														</div>
-													</div>
-												</div>
-												<Badge
-													variant={
-														upgrade.powerState.toLowerCase() === 'online' ? 'success' : 'ghost'
-													}
-													className="shrink-0"
-												>
-													{upgrade.powerState}
-												</Badge>
-											</div>
-										))}
+						<CardContent className="space-y-4 text-sm">
+							<div className="grid grid-cols-2 gap-4">
+								<div>
+									<div className="text-muted-foreground">Region</div>
+									<div className="font-medium">
+										{structure.regionName ?? structure.regionId ?? '-'}
 									</div>
-								) : (
-									<div className="rounded-lg border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
-										No upgrades reported.
+								</div>
+								<div>
+									<div className="text-muted-foreground">System</div>
+									<div className="font-medium">{structure.systemName ?? structure.systemId}</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">
+										{hasSovereigntySummary ? 'Controlling Alliance' : 'Type'}
+									</div>
+									<div className="font-medium">
+										{hasSovereigntySummary ? (
+											sovereigntyAllianceId ? (
+												<div className="flex items-center gap-2">
+													<AllianceLogo
+														allianceId={sovereigntyAllianceId}
+														allianceName={sovereigntyAllianceName}
+													/>
+													<span>{sovereigntyAllianceName ?? sovereigntyAllianceId}</span>
+												</div>
+											) : (
+												'-'
+											)
+										) : (
+											(structure.typeName ?? structure.typeId)
+										)}
+									</div>
+								</div>
+								{!hasSovereigntySummary && !isSkyhookStructure && (
+									<div>
+										<div className="text-muted-foreground">Low Power</div>
+										<div className="font-medium">{structure.lowPower ? 'Yes' : 'No'}</div>
 									</div>
 								)}
-							</CardContent>
-						</Card>
-						<Card>
-							<CardHeader>
-								<CardTitle>Reagent Bay</CardTitle>
-								<CardDescription>
-									Current sovereignty hub reagents, burn rates, and estimated remaining time.
-								</CardDescription>
-							</CardHeader>
-							<CardContent className="space-y-4">
-								<div className="grid gap-4 md:grid-cols-2 text-sm">
+								{!hasSovereigntySummary && !isSkyhookStructure && (
+									<>
+										<div>
+											<div className="text-muted-foreground">Fuel</div>
+											<div className="font-medium">
+												{structure.fuelAmount !== null ? (
+													`${structure.fuelAmount.toLocaleString()} units`
+												) : structure.fuelExpires ? (
+													<DurationDisplay endDate={structure.fuelExpires} format="compact" />
+												) : (
+													'-'
+												)}
+											</div>
+										</div>
+										<div>
+											<div className="text-muted-foreground">Last Refilled</div>
+											<div className="font-medium">
+												{structure.lastRefilledAt ? (
+													<EveTimeDisplay dateStr={structure.lastRefilledAt} format="compact" />
+												) : (
+													'-'
+												)}
+											</div>
+										</div>
+										<div>
+											<div className="text-muted-foreground">Burn / Hr</div>
+											<div className="font-medium">
+												{formatBurnRate(
+													structure.fuelBurnRate === null
+														? null
+														: Number.parseFloat(structure.fuelBurnRate)
+												)}
+											</div>
+										</div>
+									</>
+								)}
+								{hasSovereigntySummary && (
 									<div>
-										<div className="text-muted-foreground">Last Updated</div>
+										<div className="text-muted-foreground">Claimed Since</div>
 										<div className="font-medium">
-											{sovereigntyHub?.reagentBayLastUpdated ? (
+											{structure.sovereignty?.claimedSince ? (
 												<EveTimeDisplay
-													dateStr={sovereigntyHub.reagentBayLastUpdated}
+													dateStr={structure.sovereignty.claimedSince}
 													format="compact"
 												/>
 											) : (
@@ -1543,502 +1193,818 @@ export default function StructuresDetailPage() {
 											)}
 										</div>
 									</div>
+								)}
+								{hasSovereigntySummary && (
 									<div>
-										<div className="text-muted-foreground">Reagent Types</div>
+										<div className="text-muted-foreground">Capital System</div>
 										<div className="font-medium">
-											{sovereigntyHub?.reagentBay?.reagents.length ?? 0}
+											{structure.sovereignty?.isCapitalSystem ? 'Yes' : 'No'}
 										</div>
 									</div>
-								</div>
-								{sovereigntyHub?.reagentBay?.reagents.length ? (
-									<div className="overflow-hidden rounded-lg border border-border/60 bg-background">
-										<Table>
-											<TableHeader>
-												<TableRow>
-													<TableHead>Reagent</TableHead>
-													<TableHead>Amount</TableHead>
-													<TableHead>Burn / Hr</TableHead>
-													<TableHead>Est. Remaining</TableHead>
-													<TableHead>Last Cycle</TableHead>
-												</TableRow>
-											</TableHeader>
-											<TableBody>
-												{sovereigntyHub.reagentBay.reagents.map((reagent) => (
-													<TableRow key={reagent.typeId}>
-														<TableCell>
-															<div className="flex min-w-0 items-center gap-2">
-																<InventoryItemIcon typeId={reagent.typeId} />
-																<span className="truncate font-medium">
-																	{reagent.typeName ?? reagent.typeId}
-																</span>
-															</div>
-														</TableCell>
-														<TableCell>{formatNullableNumber(reagent.amount)}</TableCell>
-														<TableCell>{formatNullableNumber(reagent.burningPerHour)}</TableCell>
-														<TableCell>
-															{formatEstimatedRemaining(reagent.amount, reagent.burningPerHour)}
-														</TableCell>
-														<TableCell>{formatNullableDateTime(reagent.lastCycle)}</TableCell>
-													</TableRow>
-												))}
-											</TableBody>
-										</Table>
-									</div>
-								) : (
-									<div className="rounded-lg border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
-										No reagent data reported.
+								)}
+								{hasSovereigntySummary && (
+									<div>
+										<div className="text-muted-foreground">Activity Defense Multiplier</div>
+										<div className="font-medium">
+											{structure.sovereignty?.activityDefenseMultiplier ?? '-'}
+										</div>
 									</div>
 								)}
+								<div>
+									<div className="text-muted-foreground">
+										{hasSovereigntySummary ? 'Vulnerability State' : 'State'}
+									</div>
+									<div className="font-medium">
+										{hasSovereigntySummary ? (
+											<Badge variant={sovereigntyVulnerabilityState.variant}>
+												{sovereigntyVulnerabilityState.label}
+											</Badge>
+										) : structure.skyhook ? (
+											<SkyhookStateBadge state={structure.skyhook.state} />
+										) : (
+											<StructureStateBadge state={structure.state} />
+										)}
+									</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">
+										{hasSovereigntySummary ? (
+											'Vulnerability Window'
+										) : isReinforced ? (
+											<Badge variant="destructive">Reinforced until</Badge>
+										) : (
+											'Next State'
+										)}
+									</div>
+									<div className="font-medium">
+										{hasSovereigntySummary ? (
+											structure.sovereignty?.vulnerabilityWindowStart &&
+											structure.sovereignty?.vulnerabilityWindowEnd ? (
+												<span className="inline-flex flex-wrap items-center gap-1">
+													<EveTimeDisplay
+														dateStr={structure.sovereignty.vulnerabilityWindowStart}
+														format="window"
+														className="whitespace-nowrap"
+													/>
+													<span>-</span>
+													<EveTimeDisplay
+														dateStr={structure.sovereignty.vulnerabilityWindowEnd}
+														format="window"
+														className="whitespace-nowrap"
+													/>
+												</span>
+											) : structure.sovereignty?.vulnerabilityWindowEnd ? (
+												<EveTimeDisplay
+													dateStr={structure.sovereignty.vulnerabilityWindowEnd}
+													format="window"
+													className="whitespace-nowrap"
+												/>
+											) : (
+												'-'
+											)
+										) : structure.nextStateAt ? (
+											<EveTimeDisplay dateStr={structure.nextStateAt} format="compact" />
+										) : (
+											'-'
+										)}
+									</div>
+									{hasSovereigntySummary &&
+									(structure.sovereignty?.vulnerabilityWindowStart ||
+										structure.sovereignty?.vulnerabilityWindowEnd) ? (
+										<div className="mt-1 text-xs text-muted-foreground">
+											<LiveSovereigntyVulnerabilityWindow
+												vulnerabilityWindowStart={structure.sovereignty?.vulnerabilityWindowStart}
+												vulnerabilityWindowEnd={structure.sovereignty?.vulnerabilityWindowEnd}
+											/>
+										</div>
+									) : null}
+								</div>
+							</div>
+							<div className="flex flex-wrap gap-2 pt-2">
+								{structure.hidden && <Badge variant="ghost">Hidden</Badge>}
+								{!hasSovereigntySummary && !isSkyhookStructure && structure.lowPowerAllowed && (
+									<Badge variant="success">Low Power Alerts Suppressed</Badge>
+								)}
+								{structure.assignedGroupId && <Badge variant="special">Group Assigned</Badge>}
+							</div>
+							<div className="space-y-3">
+								{!hasSovereigntySummary && !isSkyhookStructure && (
+									<div className="space-y-2">
+										<div className="text-xs uppercase tracking-wider text-muted-foreground">
+											Reinforcement
+										</div>
+										<div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-sm">
+											<div className="grid gap-3">
+												<div>
+													<div className="text-xs text-muted-foreground">Reinforcement Hour</div>
+													<div className="font-medium">
+														{formatReinforcementHourUtc(structure.reinforceHour)}
+													</div>
+												</div>
+												<div>
+													<div className="text-xs text-muted-foreground">
+														Next Reinforcement Hour
+													</div>
+													<div className="font-medium">
+														{structure.nextReinforceHour !== null
+															? formatReinforcementHourUtc(structure.nextReinforceHour)
+															: '-'}
+													</div>
+												</div>
+												<div>
+													<div className="text-xs text-muted-foreground">
+														Next Reinforcement Applies
+													</div>
+													<div className="font-medium">
+														{structure.nextReinforceApply ? (
+															<EveTimeDisplay
+																dateStr={structure.nextReinforceApply}
+																format="compact"
+															/>
+														) : (
+															'-'
+														)}
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								)}
+								{!hasSovereigntySummary && !isSkyhookStructure && (
+									<div className="space-y-2">
+										<div className="text-xs uppercase tracking-wider text-muted-foreground">
+											Structure Services
+										</div>
+										{structure.services.length > 0 ? (
+											<div className="space-y-1.5">
+												{structure.services.map((service) => (
+													<div
+														key={`${service.name}-${service.state}`}
+														className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
+													>
+														<div className="flex min-w-0 items-center gap-2">
+															<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground">
+																{renderServiceIcon(service.name)}
+															</div>
+															<div className="min-w-0">
+																<div className="truncate text-sm font-medium">{service.name}</div>
+															</div>
+														</div>
+														<Badge
+															variant={serviceBadgeVariant(service.state)}
+															className="shrink-0"
+														>
+															{formatServiceStateLabel(service.state)}
+														</Badge>
+													</div>
+												))}
+											</div>
+										) : (
+											<div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+												No structure services were reported for this structure.
+											</div>
+										)}
+									</div>
+								)}
+								<div className="space-y-2">
+									<div className="text-xs uppercase tracking-wider text-muted-foreground">
+										Sync Status
+									</div>
+									<div className="rounded-lg border border-border/60 p-4">
+										<div className="mb-3 flex flex-wrap items-center gap-2">
+											<StructureSyncStatusBadge
+												label="Structure"
+												status={structure.syncStatus}
+												description={syncDescription}
+											/>
+											{!hasSovereigntySummary && (
+												<>
+													<span aria-hidden className="text-sm text-muted-foreground">
+														-
+													</span>
+													<StructureSyncStatusBadge
+														label="Assets"
+														status={assetsSyncStatus}
+														description={assetsSyncDescription}
+													/>
+												</>
+											)}
+										</div>
+										<div className="mt-2 text-sm text-muted-foreground">{syncDescription}</div>
+									</div>
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Configuration</CardTitle>
+							<CardDescription>
+								Manager-level settings for visibility, alert suppression, and group assignment.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="space-y-5">
+							<div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
+								<div>
+									<div className="font-medium">Hidden</div>
+									<div className="text-sm text-muted-foreground">
+										Completely omit this structure from non-sensitive users.
+									</div>
+								</div>
+								<Switch checked={hidden} onCheckedChange={setHidden} />
+							</div>
+							{!hasSovereigntySummary && !isSkyhookStructure && (
+								<div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 p-4">
+									<div>
+										<div className="font-medium">Low Power Allowed</div>
+										<div className="text-sm text-muted-foreground">
+											Suppress low-power alerts for structures where that is intentional.
+										</div>
+									</div>
+									<Switch checked={lowPowerAllowed} onCheckedChange={setLowPowerAllowed} />
+								</div>
+							)}
+							<FilterField label="Assigned Group">
+								<Select
+									options={groupOptions}
+									value={assignedGroupId}
+									onValueChange={(value) => setAssignedGroupId(value)}
+									placeholder="No Group"
+								/>
+							</FilterField>
+							<div className="flex items-center justify-end gap-3 pt-2">
+								<Button
+									variant="ghost"
+									onClick={() => {
+										setHidden(structure.hidden)
+										if (!hasSovereigntySummary) {
+											setLowPowerAllowed(structure.lowPowerAllowed)
+										}
+										setAssignedGroupId(structure.assignedGroupId ?? '')
+									}}
+								>
+									Reset
+								</Button>
+								<Button
+									variant="confirm"
+									onClick={() => void handleSave()}
+									loading={updateMutation.isPending}
+								>
+									<Save className="h-4 w-4" />
+									Save Changes
+								</Button>
+							</div>
+						</CardContent>
+					</Card>
+				</div>
+
+				{hasSovereigntySummary && (
+					<div className="contents">
+						<Card>
+							<CardHeader>
+								<CardTitle>Hub Configuration</CardTitle>
+								<CardDescription>
+									Workforce transport routing and the hub's current resource allocation.
+								</CardDescription>
+							</CardHeader>
+							<CardContent className="space-y-6 text-sm">
+								<div className="grid gap-4 md:grid-cols-2">
+									<ResourceAllocationCard
+										label="Power Allocation"
+										allocated={sovereigntyHub?.resourcePowerAllocated}
+										available={sovereigntyHub?.resourcePowerAvailable}
+									/>
+									<ResourceAllocationCard
+										label="Workforce Allocation"
+										allocated={sovereigntyHub?.resourceWorkforceAllocated}
+										available={sovereigntyHub?.resourceWorkforceAvailable}
+									/>
+								</div>
+
+								<div className="grid gap-4 lg:grid-cols-2">
+									<WorkforceTransportSection
+										label="Workforce Transport Configuration"
+										section={sovereigntyHub?.workforceTransport?.configuration}
+										systemLinkById={sovereigntyHubStructureIdBySystemId}
+									/>
+									<WorkforceTransportSection
+										label="Workforce Transport State"
+										section={sovereigntyHub?.workforceTransport?.state}
+										systemLinkById={sovereigntyHubStructureIdBySystemId}
+									/>
+								</div>
 							</CardContent>
 						</Card>
-					</div>
-				</div>
-			)}
 
-			{hasSkyhookSummary && (
-				<Card>
-					<CardHeader>
-						<CardTitle>Skyhook State</CardTitle>
-						<CardDescription>
-							Vulnerability state and ownership context for this skyhook.
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="grid gap-4 md:grid-cols-2 text-sm">
-						<div>
-							<div className="text-muted-foreground">Planet</div>
-							<div className="font-medium">
-								{structure.skyhook?.planetName ?? structure.skyhook?.planetId ?? '-'}
-							</div>
+						<div className="contents">
+							<Card>
+								<CardHeader>
+									<CardTitle>Upgrades</CardTitle>
+									<CardDescription>
+										Installed sovereignty hub upgrades and their current power state.
+									</CardDescription>
+								</CardHeader>
+								<CardContent className="space-y-2">
+									{sovereigntyHub?.upgrades?.length ? (
+										<div className="space-y-1.5">
+											{sovereigntyHub.upgrades.map((upgrade) => (
+												<div
+													key={`${upgrade.typeId}-${upgrade.powerState}`}
+													className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
+												>
+													<div className="flex min-w-0 items-center gap-2">
+														<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground">
+															<InventoryItemIcon typeId={upgrade.typeId} />
+														</div>
+														<div className="min-w-0">
+															<div className="truncate text-sm font-medium">
+																{upgrade.typeName ?? upgrade.typeId}
+															</div>
+														</div>
+													</div>
+													<Badge
+														variant={
+															upgrade.powerState.toLowerCase() === 'online' ? 'success' : 'ghost'
+														}
+														className="shrink-0"
+													>
+														{upgrade.powerState}
+													</Badge>
+												</div>
+											))}
+										</div>
+									) : (
+										<div className="rounded-lg border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
+											No upgrades reported.
+										</div>
+									)}
+								</CardContent>
+							</Card>
+							<Card>
+								<CardHeader>
+									<CardTitle>Reagent Bay</CardTitle>
+									<CardDescription>
+										Current sovereignty hub reagents, burn rates, and estimated remaining time.
+									</CardDescription>
+								</CardHeader>
+								<CardContent className="space-y-4">
+									<div className="grid gap-4 md:grid-cols-2 text-sm">
+										<div>
+											<div className="text-muted-foreground">Last Updated</div>
+											<div className="font-medium">
+												{sovereigntyHub?.reagentBayLastUpdated ? (
+													<EveTimeDisplay
+														dateStr={sovereigntyHub.reagentBayLastUpdated}
+														format="compact"
+													/>
+												) : (
+													'-'
+												)}
+											</div>
+										</div>
+										<div>
+											<div className="text-muted-foreground">Reagent Types</div>
+											<div className="font-medium">
+												{sovereigntyHub?.reagentBay?.reagents.length ?? 0}
+											</div>
+										</div>
+									</div>
+									{sovereigntyHub?.reagentBay?.reagents.length ? (
+										<div className="overflow-hidden rounded-lg border border-border/60 bg-background">
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Reagent</TableHead>
+														<TableHead>Amount</TableHead>
+														<TableHead>Burn / Hr</TableHead>
+														<TableHead>Est. Remaining</TableHead>
+														<TableHead>Last Cycle</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{sovereigntyHub.reagentBay.reagents.map((reagent) => (
+														<TableRow key={reagent.typeId}>
+															<TableCell>
+																<div className="flex min-w-0 items-center gap-2">
+																	<InventoryItemIcon typeId={reagent.typeId} />
+																	<span className="truncate font-medium">
+																		{reagent.typeName ?? reagent.typeId}
+																	</span>
+																</div>
+															</TableCell>
+															<TableCell>{formatNullableNumber(reagent.amount)}</TableCell>
+															<TableCell>{formatNullableNumber(reagent.burningPerHour)}</TableCell>
+															<TableCell>
+																{formatEstimatedRemaining(reagent.amount, reagent.burningPerHour)}
+															</TableCell>
+															<TableCell>{formatNullableDateTime(reagent.lastCycle)}</TableCell>
+														</TableRow>
+													))}
+												</TableBody>
+											</Table>
+										</div>
+									) : (
+										<div className="rounded-lg border border-dashed border-border/60 px-3 py-4 text-sm text-muted-foreground">
+											No reagent data reported.
+										</div>
+									)}
+								</CardContent>
+							</Card>
 						</div>
-						<div>
-							<div className="text-muted-foreground">System</div>
-							<div className="font-medium">
-								{structure.skyhook?.systemName ?? structure.systemName ?? '-'}
+					</div>
+				)}
+
+				{hasSkyhookSummary && (
+					<Card>
+						<CardHeader>
+							<CardTitle>Skyhook State</CardTitle>
+							<CardDescription>
+								Vulnerability state and ownership context for this skyhook.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="grid gap-4 md:grid-cols-2 text-sm">
+							<div>
+								<div className="text-muted-foreground">Planet</div>
+								<div className="font-medium">
+									{structure.skyhook?.planetName ?? structure.skyhook?.planetId ?? '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Effective Workforce</div>
-							<div className="font-medium">
-								{formatNullableNumber(structure.skyhook?.effectiveWorkforce)}
+							<div>
+								<div className="text-muted-foreground">System</div>
+								<div className="font-medium">
+									{structure.skyhook?.systemName ?? structure.systemName ?? '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">State</div>
-							<div className="font-medium">
-								{structure.skyhook ? <SkyhookStateBadge state={structure.skyhook.state} /> : '-'}
+							<div>
+								<div className="text-muted-foreground">Effective Workforce</div>
+								<div className="font-medium">
+									{formatNullableNumber(structure.skyhook?.effectiveWorkforce)}
+								</div>
 							</div>
-						</div>
-						<div className="md:col-span-2">
-							<div className="text-muted-foreground">Fullness</div>
-							<div className="mt-1">
-								{structure.skyhook ? (
-									<SkyhookFullnessBar
-										volumeM3={
-											(structure.skyhook.totalSecuredVolumeM3 ?? 0) +
-											(structure.skyhook.totalUnsecuredVolumeM3 ?? 0)
-										}
-										capacityM3={
-											(structure.skyhook.securedCapacityM3 ?? 0) +
-											(structure.skyhook.unsecuredCapacityM3 ?? 0)
-										}
-										fillPercent={getSkyhookFullnessPercent(structure.skyhook)}
-									/>
-								) : (
-									'-'
-								)}
+							<div>
+								<div className="text-muted-foreground">State</div>
+								<div className="font-medium">
+									{structure.skyhook ? <SkyhookStateBadge state={structure.skyhook.state} /> : '-'}
+								</div>
 							</div>
-						</div>
-						<div>
-							<div className="text-muted-foreground">Theft Vulnerability</div>
-							<div className="font-medium">
-								{structure.skyhook ? (
-									structure.skyhook.theftVulnerabilityStart &&
-									structure.skyhook.theftVulnerabilityEnd ? (
-										<span className="inline-flex flex-wrap items-center gap-1">
+							<div className="md:col-span-2">
+								<div className="text-muted-foreground">Fullness</div>
+								<div className="mt-1">
+									{structure.skyhook ? (
+										<SkyhookFullnessBar
+											volumeM3={
+												(structure.skyhook.totalSecuredVolumeM3 ?? 0) +
+												(structure.skyhook.totalUnsecuredVolumeM3 ?? 0)
+											}
+											capacityM3={
+												(structure.skyhook.securedCapacityM3 ?? 0) +
+												(structure.skyhook.unsecuredCapacityM3 ?? 0)
+											}
+											fillPercent={getSkyhookFullnessPercent(structure.skyhook)}
+										/>
+									) : (
+										'-'
+									)}
+								</div>
+							</div>
+							<div>
+								<div className="text-muted-foreground">Theft Vulnerability</div>
+								<div className="font-medium">
+									{structure.skyhook ? (
+										structure.skyhook.theftVulnerabilityStart &&
+										structure.skyhook.theftVulnerabilityEnd ? (
+											<span className="inline-flex flex-wrap items-center gap-1">
+												<EveTimeDisplay
+													dateStr={structure.skyhook.theftVulnerabilityStart}
+													format="window"
+													className="whitespace-nowrap"
+												/>
+												<span>-</span>
+												<EveTimeDisplay
+													dateStr={structure.skyhook.theftVulnerabilityEnd}
+													format="window"
+													className="whitespace-nowrap"
+												/>
+											</span>
+										) : structure.skyhook.theftVulnerabilityStart ? (
 											<EveTimeDisplay
 												dateStr={structure.skyhook.theftVulnerabilityStart}
 												format="window"
 												className="whitespace-nowrap"
 											/>
-											<span>-</span>
-											<EveTimeDisplay
-												dateStr={structure.skyhook.theftVulnerabilityEnd}
-												format="window"
-												className="whitespace-nowrap"
-											/>
-										</span>
-									) : structure.skyhook.theftVulnerabilityStart ? (
-										<EveTimeDisplay
-											dateStr={structure.skyhook.theftVulnerabilityStart}
-											format="window"
-											className="whitespace-nowrap"
-										/>
+										) : (
+											'-'
+										)
 									) : (
 										'-'
-									)
-								) : (
-									'-'
-								)}
-							</div>
-						</div>
-					</CardContent>
-				</Card>
-			)}
-
-			{hasSkyhookSummary && (
-				<Card>
-					<CardHeader>
-						<CardTitle>Reagents</CardTitle>
-						<CardDescription>
-							Skyhook reagent stock, bay fullness, and last cycle timestamps.
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-4">
-						<div className="grid gap-4 md:grid-cols-2 text-sm">
-							<div className="rounded-lg border border-border/60 bg-muted/20 p-3">
-								<div className="text-muted-foreground">Secure Bay</div>
-								<div className="mt-1">
-									<SkyhookBayFillCell
-										stock={structure.skyhook?.totalSecuredStock ?? 0}
-										volumeM3={structure.skyhook?.totalSecuredVolumeM3 ?? 0}
-										capacityM3={structure.skyhook?.securedCapacityM3 ?? 0}
-										fillPercent={structure.skyhook?.securedFillPercent ?? 0}
-									/>
-								</div>
-							</div>
-							<div className="rounded-lg border border-border/60 bg-muted/20 p-3">
-								<div className="text-muted-foreground">Surplus Bay</div>
-								<div className="mt-1">
-									<SkyhookBayFillCell
-										stock={structure.skyhook?.totalUnsecuredStock ?? 0}
-										volumeM3={structure.skyhook?.totalUnsecuredVolumeM3 ?? 0}
-										capacityM3={structure.skyhook?.unsecuredCapacityM3 ?? 0}
-										fillPercent={structure.skyhook?.unsecuredFillPercent ?? 0}
-									/>
-								</div>
-							</div>
-						</div>
-						{!structure.skyhook || structure.skyhook.reagents.length === 0 ? (
-							<div className="rounded-md border border-dashed border-border/70 px-3 py-4 text-sm text-muted-foreground">
-								No reagent snapshot is currently available for this skyhook.
-							</div>
-						) : (
-							<Table>
-								<TableHeader>
-									<TableRow>
-										<TableHead>Type</TableHead>
-										<TableHead>Secure Bay</TableHead>
-										<TableHead>Surplus Bay</TableHead>
-										<TableHead>Last Cycle</TableHead>
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{structure.skyhook.reagents.map((reagent) => (
-										<TableRow key={`${reagent.typeId}-${reagent.lastCycle}`}>
-											<TableCell className="font-medium">
-												{reagent.typeName ?? reagent.typeId}
-											</TableCell>
-											<TableCell>
-												<SkyhookBayFillCell
-													stock={reagent.securedStock}
-													volumeM3={reagent.securedVolumeM3}
-													capacityM3={reagent.securedCapacityM3}
-													fillPercent={reagent.securedFillPercent}
-												/>
-											</TableCell>
-											<TableCell>
-												<SkyhookBayFillCell
-													stock={reagent.unsecuredStock}
-													volumeM3={reagent.unsecuredVolumeM3}
-													capacityM3={reagent.unsecuredCapacityM3}
-													fillPercent={reagent.unsecuredFillPercent}
-												/>
-											</TableCell>
-											<TableCell>
-												<EveTimeDisplay dateStr={reagent.lastCycle} format="compact" />
-											</TableCell>
-										</TableRow>
-									))}
-								</TableBody>
-							</Table>
-						)}
-					</CardContent>
-				</Card>
-			)}
-
-			{hasMoonDrillSummary && (
-				<Card>
-					<CardHeader>
-						<CardTitle>Moon Drill</CardTitle>
-						<CardDescription>Moon association resolved from the latest snapshot.</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-4 text-sm">
-						{!moonDrill ? (
-							<div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-yellow-50">
-								Moon drill snapshot has not been ingested yet for this structure.
-							</div>
-						) : null}
-						<div className="grid gap-4 md:grid-cols-2">
-							<div>
-								<div className="text-muted-foreground">Moon</div>
-								<div className="font-medium">
-									{stripLeadingContextName(
-										moonDrill?.moonName ?? moonDrill?.moonId,
-										moonDrill?.planetName
 									)}
 								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Planet</div>
-								<div className="font-medium">
-									{moonDrill?.planetName ?? moonDrill?.planetId ?? '-'}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">System</div>
-								<div className="font-medium">
-									{moonDrill?.systemName ?? moonDrill?.systemId ?? '-'}
-								</div>
-							</div>
-						</div>
-					</CardContent>
-				</Card>
-			)}
-
-			{hasMiningExtractionSummary && (
-				<Card>
-					<CardHeader>
-						<CardTitle>Mining Citadel</CardTitle>
-						<CardDescription>Recorded extraction periods for this structure.</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-4 text-sm">
-						{extractionOptions.length > 0 ? (
-							<div>
-								<div className="mb-1 text-muted-foreground">Extraction period</div>
-								<Select
-									options={extractionOptions}
-									value={selectedExtractionId ?? ''}
-									onValueChange={(value) => setSelectedExtractionId(value)}
-									placeholder="Select an extraction period"
-									showValueHint
-								/>
-							</div>
-						) : null}
-						{!selectedExtraction ? (
-							<div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-yellow-50">
-								No mining extraction period is currently selected for this structure.
-							</div>
-						) : null}
-						<div className="grid gap-4 md:grid-cols-2">
-							<div>
-								<div className="text-muted-foreground">Moon</div>
-								<div className="font-medium">
-									{stripLeadingContextName(
-										miningExtraction?.moonName ??
-											selectedHistoricalExtraction?.moonId ??
-											miningExtraction?.moonId,
-										miningExtraction?.planetName ?? null
-									)}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Planet</div>
-								<div className="font-medium">
-									{miningExtraction?.planetName ?? miningExtraction?.planetId ?? '-'}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">System</div>
-								<div className="font-medium">
-									{miningExtraction?.systemName ?? miningExtraction?.systemId ?? '-'}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Extraction Start</div>
-								<div className="font-medium">
-									{formatNullableDateTime(selectedExtraction?.extractionStartTime ?? null)}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Chunk Arrival</div>
-								<div className="font-medium">
-									{formatNullableDateTime(selectedExtraction?.chunkArrivalTime ?? null)}
-								</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Natural Decay</div>
-								<div className="font-medium">
-									{formatNullableDateTime(selectedExtraction?.naturalDecayTime ?? null)}
-								</div>
-							</div>
-						</div>
-						{selectedExtraction === miningExtraction && miningExtraction?.composition ? (
-							<div className="rounded-md border border-border/60 bg-muted/20">
-								<div className="border-b border-border/60 px-3 py-2">
-									<div className="font-medium">Current Moon Composition</div>
-								</div>
-								<Table>
-									<TableHeader>
-										<TableRow>
-											<TableHead>Mineral</TableHead>
-											<TableHead className="text-right">Composition</TableHead>
-										</TableRow>
-									</TableHeader>
-									<TableBody>
-										{[...miningExtraction.composition.ores]
-											.sort((left, right) => Number(right.quantity) - Number(left.quantity))
-											.map((ore) => (
-												<TableRow key={ore.typeId}>
-													<TableCell>{ore.typeName ?? `Type ${ore.typeId}`}</TableCell>
-													<TableCell className="text-right tabular-nums">
-														{(Number(ore.quantity) * 100).toFixed(2)}%
-													</TableCell>
-												</TableRow>
-											))}
-									</TableBody>
-								</Table>
-							</div>
-						) : null}
-					</CardContent>
-				</Card>
-			)}
-
-			<div className="grid gap-4 md:grid-cols-2">
-				{hasStructureFitting ? (
-					<Card>
-						<CardHeader>
-							<CardTitle>Fitting</CardTitle>
-							<CardDescription>Structure fitting from the latest known snapshot.</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-6">
-							<div className="overflow-x-auto">
-								<FittingPanel
-									shipTypeId={structure.typeId}
-									shipTypeName={structure.typeName ?? structure.name}
-									items={fittingItems}
-									getIconUrl={typeIconUrl}
-									getRenderUrl={typeRenderUrl}
-								/>
-							</div>
-							<div className="space-y-3 border-t border-border/60 pt-6">
-								<div>
-									<div className="text-sm font-medium">Slot Layout</div>
-									<div className="text-sm text-muted-foreground">
-										High, mid, low, and rig slot fittings from the latest structure asset snapshot,
-										with loaded charges and scripts shown beneath their parent modules.
-									</div>
-								</div>
-								<FittingSlotTable
-									items={fittingItems}
-									getIconUrl={typeIconUrl}
-									slotTypes={STRUCTURE_SLOT_TABLE_TYPES}
-									emptyState="No high, mid, low, or rig slot items detected."
-								/>
 							</div>
 						</CardContent>
 					</Card>
-				) : null}
+				)}
 
-				{structure.inventoryBays && structure.inventoryBays.length > 0 ? (
+				{hasSkyhookSummary && (
 					<Card>
 						<CardHeader>
-							<CardTitle>Inventory</CardTitle>
+							<CardTitle>Reagents</CardTitle>
 							<CardDescription>
-								Aggregated bay contents from the latest corp asset projection for this structure.
+								Skyhook reagent stock, bay fullness, and last cycle timestamps.
 							</CardDescription>
 						</CardHeader>
 						<CardContent className="space-y-4">
-							<InventoryBaysTable
-								bays={structure.inventoryBays}
-								renderItemIcon={(item) => <InventoryItemIcon typeId={item.typeId} />}
-							/>
-						</CardContent>
-					</Card>
-				) : null}
-			</div>
-
-			{isAdmin && assetsDebug ? (
-				<Card>
-					<CardHeader>
-						<CardTitle>Asset Debug</CardTitle>
-						<CardDescription>
-							Raw corporation assets fetched for this structure&apos;s owning corporation and
-							filtered to this structure ID. This is a direct asset snapshot, not the grouped
-							inventory view.
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="space-y-4">
-						<div className="grid gap-4 sm:grid-cols-3 text-sm">
-							<div>
-								<div className="text-muted-foreground">Fetched At</div>
-								<div className="font-medium">{formatDateTimeLong(assetsDebug.fetchedAt)}</div>
+							<div className="grid gap-4 md:grid-cols-2 text-sm">
+								<div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+									<div className="text-muted-foreground">Secure Bay</div>
+									<div className="mt-1">
+										<SkyhookBayFillCell
+											stock={structure.skyhook?.totalSecuredStock ?? 0}
+											volumeM3={structure.skyhook?.totalSecuredVolumeM3 ?? 0}
+											capacityM3={structure.skyhook?.securedCapacityM3 ?? 0}
+											fillPercent={structure.skyhook?.securedFillPercent ?? 0}
+										/>
+									</div>
+								</div>
+								<div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+									<div className="text-muted-foreground">Surplus Bay</div>
+									<div className="mt-1">
+										<SkyhookBayFillCell
+											stock={structure.skyhook?.totalUnsecuredStock ?? 0}
+											volumeM3={structure.skyhook?.totalUnsecuredVolumeM3 ?? 0}
+											capacityM3={structure.skyhook?.unsecuredCapacityM3 ?? 0}
+											fillPercent={structure.skyhook?.unsecuredFillPercent ?? 0}
+										/>
+									</div>
+								</div>
 							</div>
-							<div>
-								<div className="text-muted-foreground">Raw Assets Fetched</div>
-								<div className="font-medium">{assetsDebug.fetchedAssetCount.toLocaleString()}</div>
-							</div>
-							<div>
-								<div className="text-muted-foreground">Matching Rows</div>
-								<div className="font-medium">{assetsDebug.itemCount.toLocaleString()}</div>
-							</div>
-						</div>
-
-						{assetsDebug.items.length > 0 ? (
-							<div className="overflow-x-auto rounded-lg border border-border/60">
+							{!structure.skyhook || structure.skyhook.reagents.length === 0 ? (
+								<div className="rounded-md border border-dashed border-border/70 px-3 py-4 text-sm text-muted-foreground">
+									No reagent snapshot is currently available for this skyhook.
+								</div>
+							) : (
 								<Table>
 									<TableHeader>
-										<TableRow className="bg-muted/40">
-											<TableHead>Item</TableHead>
-											<TableHead className="text-right">Qty</TableHead>
-											<TableHead>Flag</TableHead>
-											<TableHead>Location</TableHead>
-											<TableHead className="text-right">Singleton</TableHead>
-											<TableHead>Item ID</TableHead>
-											<TableHead>Updated</TableHead>
+										<TableRow>
+											<TableHead>Type</TableHead>
+											<TableHead>Secure Bay</TableHead>
+											<TableHead>Surplus Bay</TableHead>
+											<TableHead>Last Cycle</TableHead>
 										</TableRow>
 									</TableHeader>
 									<TableBody>
-										{assetsDebug.items.map((item) => (
-											<TableRow key={item.itemId}>
-												<TableCell>
-													<div className="flex items-start gap-2">
-														<div className="mt-0.5 shrink-0">
-															<InventoryItemIcon typeId={item.typeId} />
-														</div>
-														<div className="min-w-0">
-															<div className="font-medium">{item.typeName ?? item.typeId}</div>
-															<div className="text-xs text-muted-foreground">{item.typeId}</div>
-														</div>
-													</div>
-												</TableCell>
-												<TableCell className="text-right font-mono">
-													{item.quantity.toLocaleString()}
+										{structure.skyhook.reagents.map((reagent) => (
+											<TableRow key={`${reagent.typeId}-${reagent.lastCycle}`}>
+												<TableCell className="font-medium">
+													{reagent.typeName ?? reagent.typeId}
 												</TableCell>
 												<TableCell>
-													<div className="font-medium">{item.locationFlagLabel}</div>
-													<div className="text-xs text-muted-foreground">{item.locationFlag}</div>
+													<SkyhookBayFillCell
+														stock={reagent.securedStock}
+														volumeM3={reagent.securedVolumeM3}
+														capacityM3={reagent.securedCapacityM3}
+														fillPercent={reagent.securedFillPercent}
+													/>
 												</TableCell>
-												<TableCell>{item.locationType}</TableCell>
-												<TableCell className="text-right">
-													{item.isSingleton ? 'Yes' : 'No'}
+												<TableCell>
+													<SkyhookBayFillCell
+														stock={reagent.unsecuredStock}
+														volumeM3={reagent.unsecuredVolumeM3}
+														capacityM3={reagent.unsecuredCapacityM3}
+														fillPercent={reagent.unsecuredFillPercent}
+													/>
 												</TableCell>
-												<TableCell className="font-mono text-xs">{item.itemId}</TableCell>
-												<TableCell className="text-xs text-muted-foreground">
-													{formatDateTimeLong(item.updatedAt)}
+												<TableCell>
+													<EveTimeDisplay dateStr={reagent.lastCycle} format="compact" />
 												</TableCell>
 											</TableRow>
 										))}
 									</TableBody>
 								</Table>
-							</div>
-						) : (
-							<p className="text-sm text-muted-foreground">
-								No raw assets matched this structure ID.
-							</p>
+							)}
+						</CardContent>
+					</Card>
+				)}
+
+				{(isMoonDrillStructure || hasMiningExtractionSummary) && (
+					<div className="contents">
+						{isMoonDrillStructure ? (
+							<MoonCompositionCard composition={moonComposition} moon={moonDrill} />
+						) : null}
+
+						{hasMiningExtractionSummary && (
+							<Card>
+								<CardHeader>
+									<CardTitle>Mining Extractions</CardTitle>
+									<CardDescription>Recorded extraction periods for this structure.</CardDescription>
+								</CardHeader>
+								<CardContent className="space-y-4 text-sm">
+									{extractionOptions.length > 0 ? (
+										<div>
+											<div className="mb-1 text-muted-foreground">Extraction period</div>
+											<Select
+												options={extractionOptions}
+												value={selectedExtractionId ?? ''}
+												onValueChange={(value) => setSelectedExtractionId(value)}
+												placeholder="Select an extraction period"
+											/>
+										</div>
+									) : null}
+									{!selectedExtraction ? (
+										<div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-yellow-50">
+											No mining extraction period is currently selected for this structure.
+										</div>
+									) : null}
+									<div className="grid gap-4 md:grid-cols-2">
+										<div>
+											<div className="text-muted-foreground">Extraction Start</div>
+											<div className="font-medium">
+												{selectedExtraction?.extractionStartTime ? (
+													<DurationDisplay
+														endDate={selectedExtraction.extractionStartTime}
+														maxUnits={3}
+														durationStyle="compact"
+													/>
+												) : (
+													'-'
+												)}
+											</div>
+										</div>
+										<div>
+											<div className="text-muted-foreground">Chunk Arrival</div>
+											<div className="font-medium">
+												{selectedExtraction?.chunkArrivalTime ? (
+													<DurationDisplay
+														endDate={selectedExtraction.chunkArrivalTime}
+														maxUnits={3}
+														durationStyle="compact"
+													/>
+												) : (
+													'-'
+												)}
+											</div>
+										</div>
+										<div>
+											<div className="text-muted-foreground">Natural Decay</div>
+											<div className="font-medium">
+												{selectedExtraction?.naturalDecayTime ? (
+													<DurationDisplay
+														endDate={selectedExtraction.naturalDecayTime}
+														maxUnits={3}
+														durationStyle="compact"
+													/>
+												) : (
+													'-'
+												)}
+											</div>
+										</div>
+									</div>
+								</CardContent>
+							</Card>
 						)}
-					</CardContent>
-				</Card>
-			) : null}
+
+						{hasMiningExtractionSummary ? (
+							<MoonCompositionCard composition={moonComposition} moon={miningExtraction} />
+						) : null}
+					</div>
+				)}
+
+				<div className="contents">
+					{hasStructureFitting ? (
+						<Card>
+							<CardHeader>
+								<CardTitle>Fitting</CardTitle>
+								<CardDescription>
+									Structure fitting and static slot layout from the latest known snapshot.
+								</CardDescription>
+							</CardHeader>
+							<CardContent className="space-y-6">
+								<div className="overflow-x-auto">
+									<FittingPanel
+										shipTypeId={structure.typeId}
+										shipTypeName={structure.typeName ?? structure.name}
+										items={fittingItems}
+										slotCapacities={fittingSlotCapacities}
+										getIconUrl={typeIconUrl}
+										getRenderUrl={typeRenderUrl}
+									/>
+								</div>
+								<div className="space-y-3 border-t border-border/60 pt-6">
+									<FittingSlotTable
+										items={fittingItems}
+										getIconUrl={typeIconUrl}
+										slotTypes={STRUCTURE_SLOT_TABLE_TYPES}
+										slotCapacities={fittingSlotCapacities}
+										emptyState="No high, mid, low, or rig slot items detected."
+									/>
+								</div>
+							</CardContent>
+						</Card>
+					) : null}
+
+					{structure.inventoryBays && structure.inventoryBays.length > 0 ? (
+						<Card>
+							<CardHeader>
+								<CardTitle>Inventory</CardTitle>
+								<CardDescription>
+									Aggregated bay contents from the latest corp asset projection for this structure.
+								</CardDescription>
+							</CardHeader>
+							<CardContent className="space-y-4">
+								<InventoryBaysTable
+									bays={structure.inventoryBays}
+									renderItemIcon={(item) => <InventoryItemIcon typeId={item.typeId} />}
+								/>
+							</CardContent>
+						</Card>
+					) : null}
+				</div>
+
+				{isAdmin && assetsDebug ? (
+					<Card>
+						<CardHeader>
+							<CardTitle>Asset Debug</CardTitle>
+							<CardDescription>
+								Raw corporation assets fetched for this structure&apos;s owning corporation and
+								filtered to this structure ID. This is a direct asset snapshot, not the grouped
+								inventory view.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="space-y-4">
+							<div className="grid gap-4 sm:grid-cols-3 text-sm">
+								<div>
+									<div className="text-muted-foreground">Fetched At</div>
+									<div className="font-medium">{formatDateTimeLong(assetsDebug.fetchedAt)}</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">Raw Assets Fetched</div>
+									<div className="font-medium">
+										{assetsDebug.fetchedAssetCount.toLocaleString()}
+									</div>
+								</div>
+								<div>
+									<div className="text-muted-foreground">Matching Rows</div>
+									<div className="font-medium">{assetsDebug.itemCount.toLocaleString()}</div>
+								</div>
+							</div>
+
+							{assetsDebug.items.length > 0 ? (
+								<div className="overflow-x-auto rounded-lg border border-border/60">
+									<Table>
+										<TableHeader>
+											<TableRow className="bg-muted/40">
+												<TableHead>Item</TableHead>
+												<TableHead className="text-right">Qty</TableHead>
+												<TableHead>Flag</TableHead>
+												<TableHead>Location</TableHead>
+												<TableHead className="text-right">Singleton</TableHead>
+												<TableHead>Item ID</TableHead>
+												<TableHead>Updated</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{assetsDebug.items.map((item) => (
+												<TableRow key={item.itemId}>
+													<TableCell>
+														<div className="flex items-start gap-2">
+															<div className="mt-0.5 shrink-0">
+																<InventoryItemIcon typeId={item.typeId} />
+															</div>
+															<div className="min-w-0">
+																<div className="font-medium">{item.typeName ?? item.typeId}</div>
+																<div className="text-xs text-muted-foreground">{item.typeId}</div>
+															</div>
+														</div>
+													</TableCell>
+													<TableCell className="text-right font-mono">
+														{item.quantity.toLocaleString()}
+													</TableCell>
+													<TableCell>
+														<div className="font-medium">{item.locationFlagLabel}</div>
+														<div className="text-xs text-muted-foreground">{item.locationFlag}</div>
+													</TableCell>
+													<TableCell>{item.locationType}</TableCell>
+													<TableCell className="text-right">
+														{item.isSingleton ? 'Yes' : 'No'}
+													</TableCell>
+													<TableCell className="font-mono text-xs">{item.itemId}</TableCell>
+													<TableCell className="text-xs text-muted-foreground">
+														{formatDateTimeLong(item.updatedAt)}
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								</div>
+							) : (
+								<p className="text-sm text-muted-foreground">
+									No raw assets matched this structure ID.
+								</p>
+							)}
+						</CardContent>
+					</Card>
+				) : null}
+			</div>
 		</Container>
 	)
 }

--- a/apps/universe/src/durable-object.ts
+++ b/apps/universe/src/durable-object.ts
@@ -15,6 +15,7 @@ import {
 	normalizeUniverseServiceName,
 	resolveUniverseFuelModuleRule,
 	selectNearestMoonByPosition,
+	TYPE_SLOT_DOGMA_ATTRIBUTE_IDS,
 	UniverseMoonResourceSchema,
 	UniverseMoonSchema,
 	UniverseMoonWithResourcesSchema,
@@ -58,6 +59,7 @@ import type {
 	InvType,
 	TypeMaterial,
 	TypeMetadata,
+	TypeSlotCapacities,
 	Universe,
 	UniverseConstellation,
 	UniverseFuelModuleRule,
@@ -139,6 +141,7 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 	private regionsBySystemCache: LRUCache<{ regionId: string; regionName: string }>
 	private regionConnectionsCache: LRUCache<Array<{ fromRegionId: string; toRegionId: string }>>
 	private typeMaterialsCache: LRUCache<TypeMaterial[]>
+	private typeSlotCapacitiesCache: LRUCache<TypeSlotCapacities>
 	private structureFuelRuleCache: StructureFuelRuleCache | null = null
 	private structureFuelRuleCachePromise: Promise<StructureFuelRuleCache> | null = null
 	private readonly esiRateLimits: EsiRateLimitGuard
@@ -178,6 +181,7 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 			200
 		)
 		this.typeMaterialsCache = new LRUCache<TypeMaterial[]>(8000)
+		this.typeSlotCapacitiesCache = new LRUCache<TypeSlotCapacities>(2000)
 		this.esiRateLimits = new EsiRateLimitGuard(new EsiRateLimitStore(env.ESI_RATE_LIMITS))
 	}
 
@@ -1154,6 +1158,64 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 			logger.error('Failed to resolve type metadata', error)
 			throw error
 		}
+	}
+
+	/** Resolve fitting slot capacities from the SDE type dogma attributes. */
+	async resolveTypeSlotCapacitiesByIds(
+		typeIds: string[]
+	): Promise<Record<string, TypeSlotCapacities>> {
+		if (typeIds.length === 0) return {}
+		if (typeIds.length > 1000) throw new Error('Maximum 1000 typeIds allowed per request')
+
+		const result: Record<string, TypeSlotCapacities> = {}
+		const missingTypeIds: string[] = []
+		for (const typeId of new Set(typeIds)) {
+			const cached = this.typeSlotCapacitiesCache.get(typeId)
+			if (cached) {
+				result[typeId] = cached
+			} else {
+				missingTypeIds.push(typeId)
+			}
+		}
+
+		if (missingTypeIds.length === 0) return result
+
+		const rows = await this.db
+			.select({
+				typeId: universeTypeDogmaAttributes.typeId,
+				attributeId: universeTypeDogmaAttributes.attributeId,
+				value: universeTypeDogmaAttributes.value,
+			})
+			.from(universeTypeDogmaAttributes)
+			.where(
+				and(
+					inArray(universeTypeDogmaAttributes.typeId, missingTypeIds),
+					inArray(
+						universeTypeDogmaAttributes.attributeId,
+						Object.values(TYPE_SLOT_DOGMA_ATTRIBUTE_IDS)
+					)
+				)
+			)
+
+		const capacitiesByTypeId = new Map<string, TypeSlotCapacities>()
+		for (const typeId of missingTypeIds) {
+			capacitiesByTypeId.set(typeId, { high: 0, mid: 0, low: 0, rig: 0 })
+		}
+		for (const row of rows) {
+			const capacities = capacitiesByTypeId.get(row.typeId)
+			if (!capacities) continue
+			const value = Math.max(0, Math.trunc(Number(row.value)))
+			if (row.attributeId === '14') capacities.high = value
+			if (row.attributeId === '13') capacities.mid = value
+			if (row.attributeId === '12') capacities.low = value
+			if (row.attributeId === '1137') capacities.rig = value
+		}
+
+		for (const [typeId, capacities] of capacitiesByTypeId) {
+			this.typeSlotCapacitiesCache.set(typeId, capacities)
+			result[typeId] = capacities
+		}
+		return result
 	}
 
 	/**

--- a/apps/universe/src/scripts/import-sde-inventory.ts
+++ b/apps/universe/src/scripts/import-sde-inventory.ts
@@ -20,11 +20,11 @@ import {
 	universeTypeDogmaEffects,
 } from '../db/schema'
 import {
-	FUEL_DOGMA_ATTRIBUTE_IDS,
 	isFuelDogmaAttribute,
 	isFuelModifier,
 	selectStructureDogmaTypeIds,
 	STRUCTURE_CATEGORY_ID,
+	STRUCTURE_DOGMA_ATTRIBUTE_IDS,
 	STRUCTURE_MODULE_CATEGORY_ID,
 } from './sde-fuel-selection'
 import {
@@ -549,7 +549,7 @@ async function importDogmaAttributes(
 	if (!allDogma) {
 		await db
 			.delete(universeDogmaAttributes)
-			.where(notInArray(universeDogmaAttributes.attributeId, [...FUEL_DOGMA_ATTRIBUTE_IDS]))
+			.where(notInArray(universeDogmaAttributes.attributeId, [...STRUCTURE_DOGMA_ATTRIBUTE_IDS]))
 	}
 
 	const reportProgress = createProgressReporter('dogma attributes', rows.length)
@@ -715,7 +715,7 @@ async function importTypeDogma(
 				.where(
 					or(
 						notInArray(universeTypeDogmaAttributes.typeId, [...structureDogmaTypeIds]),
-						notInArray(universeTypeDogmaAttributes.attributeId, [...FUEL_DOGMA_ATTRIBUTE_IDS])
+						notInArray(universeTypeDogmaAttributes.attributeId, [...STRUCTURE_DOGMA_ATTRIBUTE_IDS])
 					)
 				)
 		}

--- a/apps/universe/src/scripts/sde-fuel-selection.ts
+++ b/apps/universe/src/scripts/sde-fuel-selection.ts
@@ -8,6 +8,11 @@ export const FUEL_DOGMA_ATTRIBUTE_IDS: readonly string[] = [
 	'2339',
 	STRUCTURE_SERVICE_MODULE_ATTRIBUTE_ID,
 ]
+export const STRUCTURE_SLOT_DOGMA_ATTRIBUTE_IDS: readonly string[] = ['12', '13', '14', '1137']
+export const STRUCTURE_DOGMA_ATTRIBUTE_IDS: readonly string[] = [
+	...FUEL_DOGMA_ATTRIBUTE_IDS,
+	...STRUCTURE_SLOT_DOGMA_ATTRIBUTE_IDS,
+]
 
 export type SdeFuelType = {
 	typeId: string
@@ -48,7 +53,7 @@ export function selectStructureDogmaTypeIds(
 }
 
 export function isFuelDogmaAttribute(attributeId: string, allDogma: boolean): boolean {
-	return allDogma || FUEL_DOGMA_ATTRIBUTE_IDS.includes(attributeId)
+	return allDogma || STRUCTURE_DOGMA_ATTRIBUTE_IDS.includes(attributeId)
 }
 
 export function isFuelModifier(modifier: SdeFuelModifier): boolean {

--- a/apps/universe/src/test/unit/sde-fuel-selection.test.ts
+++ b/apps/universe/src/test/unit/sde-fuel-selection.test.ts
@@ -6,8 +6,10 @@ import {
 	isFuelModifier,
 	selectStructureDogmaTypeIds,
 	STRUCTURE_CATEGORY_ID,
+	STRUCTURE_DOGMA_ATTRIBUTE_IDS,
 	STRUCTURE_MODULE_CATEGORY_ID,
 	STRUCTURE_SERVICE_MODULE_ATTRIBUTE_ID,
+	STRUCTURE_SLOT_DOGMA_ATTRIBUTE_IDS,
 } from '../../scripts/sde-fuel-selection'
 
 describe('SDE fuel selection', () => {
@@ -78,12 +80,17 @@ describe('SDE fuel selection', () => {
 		)
 	})
 
-	it('retains only fuel attributes in the default import mode', () => {
+	it('retains structure fuel and fitting attributes in the default import mode', () => {
 		expect(STRUCTURE_SERVICE_MODULE_ATTRIBUTE_ID).toBe('2792')
 		expect(FUEL_DOGMA_ATTRIBUTE_IDS).toEqual(['2108', '2109', '2110', '2339', '2792'])
 		for (const attributeId of FUEL_DOGMA_ATTRIBUTE_IDS) {
 			expect(isFuelDogmaAttribute(attributeId, false)).toBe(true)
 		}
+		expect(STRUCTURE_SLOT_DOGMA_ATTRIBUTE_IDS).toEqual(['12', '13', '14', '1137'])
+		expect(STRUCTURE_DOGMA_ATTRIBUTE_IDS).toEqual([
+			...FUEL_DOGMA_ATTRIBUTE_IDS,
+			...STRUCTURE_SLOT_DOGMA_ATTRIBUTE_IDS,
+		])
 		expect(isFuelDogmaAttribute('9999', false)).toBe(false)
 		expect(isFuelDogmaAttribute('9999', true)).toBe(true)
 	})

--- a/packages/eve-fitting/src/fitting-slot-table.tsx
+++ b/packages/eve-fitting/src/fitting-slot-table.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react'
-
-import type { FittingDisplayItem, FittingShipSlotType } from './flags'
+import type { FittingDisplayItem, FittingShipSlotType, FittingSlotCapacities } from './flags'
 
 interface FittingSlotTableProps {
 	items: FittingDisplayItem[]
 	getIconUrl?: (typeId: string | number, size?: 32 | 64) => string
 	slotTypes?: FittingShipSlotType[]
+	slotCapacities?: FittingSlotCapacities
 	emptyState?: ReactNode
 }
 
@@ -27,7 +27,8 @@ interface GroupedSlotItems {
 
 function groupItemsBySlot(
 	items: FittingDisplayItem[],
-	slotTypes: FittingShipSlotType[]
+	slotTypes: FittingShipSlotType[],
+	slotCapacities: FittingSlotCapacities
 ): Array<{ slotType: FittingShipSlotType; groupedSlots: GroupedSlotItems[] }> {
 	return slotTypes
 		.map((slotType) => {
@@ -37,6 +38,10 @@ function groupItemsBySlot(
 				const group = slotGroups.get(item.slotIndex) ?? []
 				group.push(item)
 				slotGroups.set(item.slotIndex, group)
+			}
+			const capacity = Math.max(0, Math.trunc(slotCapacities[slotType] ?? 0))
+			for (let slotIndex = 0; slotIndex < capacity; slotIndex += 1) {
+				if (!slotGroups.has(slotIndex)) slotGroups.set(slotIndex, [])
 			}
 
 			const groupedSlots = [...slotGroups.entries()]
@@ -64,9 +69,10 @@ export function FittingSlotTable({
 	items,
 	getIconUrl,
 	slotTypes = DEFAULT_SLOT_TYPES,
+	slotCapacities = {},
 	emptyState = 'No fitting items detected.',
 }: FittingSlotTableProps) {
-	const sections = groupItemsBySlot(items, slotTypes)
+	const sections = groupItemsBySlot(items, slotTypes, slotCapacities)
 
 	if (sections.length === 0) {
 		return <p className="text-sm text-muted-foreground">{emptyState}</p>
@@ -79,9 +85,15 @@ export function FittingSlotTable({
 					<div className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 						{SLOT_TYPE_LABELS[section.slotType] ?? section.slotType}
 					</div>
-					<div className="space-y-1 rounded-md border border-border/40 bg-muted/10 p-1">
+					<div className="space-y-0.5 rounded-md border border-border/40 bg-muted/10 p-1">
 						{section.groupedSlots.map((slotGroup) => (
-							<div key={`${slotGroup.slotType}:${slotGroup.slotIndex}`} className="space-y-1">
+							<div key={`${slotGroup.slotType}:${slotGroup.slotIndex}`} className="space-y-0.5">
+								{slotGroup.items.length === 0 ? (
+									<div className="flex items-center gap-2 rounded px-1 py-1 text-sm text-muted-foreground">
+										<span className="h-5 w-5 shrink-0 rounded border border-dashed border-border/60" />
+										<span>Empty</span>
+									</div>
+								) : null}
 								{slotGroup.items.map((item, itemIndex) => (
 									<div
 										key={`${item.slotType}:${item.slotIndex}:${item.typeId}:${itemIndex}`}
@@ -100,7 +112,9 @@ export function FittingSlotTable({
 										<div className="min-w-0 flex-1">
 											<p className="truncate text-sm font-medium leading-tight">{item.typeName}</p>
 											{item.quantity > 1 ? (
-												<p className="text-xs text-muted-foreground">x{item.quantity.toLocaleString()}</p>
+												<p className="text-xs text-muted-foreground">
+													x{item.quantity.toLocaleString()}
+												</p>
 											) : null}
 											{item.isConsumable && (
 												<p className="text-xs text-muted-foreground/60">loaded item</p>

--- a/packages/inventory-display/src/grouping.ts
+++ b/packages/inventory-display/src/grouping.ts
@@ -114,6 +114,13 @@ export function summarizeInventoryRows(rows: InventoryRowLike[]): InventoryDispl
 				if (existing) {
 					existing.quantity += row.quantity
 					existing.stackCount += 1
+					if (existing.volumeM3 !== null && existing.volumeM3 !== undefined) {
+						if (row.unitVolumeM3 === null || row.unitVolumeM3 === undefined) {
+							existing.volumeM3 = null
+						} else {
+							existing.volumeM3 += row.quantity * row.unitVolumeM3
+						}
+					}
 					if (existing.typeName === undefined && row.typeName !== undefined) {
 						existing.typeName = row.typeName
 					}
@@ -123,6 +130,10 @@ export function summarizeInventoryRows(rows: InventoryRowLike[]): InventoryDispl
 						typeName: row.typeName ?? undefined,
 						quantity: row.quantity,
 						stackCount: 1,
+						volumeM3:
+							row.unitVolumeM3 === null || row.unitVolumeM3 === undefined
+								? null
+								: row.quantity * row.unitVolumeM3,
 					})
 				}
 			}
@@ -139,7 +150,8 @@ export function summarizeInventoryRows(rows: InventoryRowLike[]): InventoryDispl
 			}
 		})
 		.sort((left, right) => {
-			const orderDiff = getInventoryBayOrder(left.locationFlag) - getInventoryBayOrder(right.locationFlag)
+			const orderDiff =
+				getInventoryBayOrder(left.locationFlag) - getInventoryBayOrder(right.locationFlag)
 			if (orderDiff !== 0) {
 				return orderDiff
 			}

--- a/packages/inventory-display/src/types.ts
+++ b/packages/inventory-display/src/types.ts
@@ -3,6 +3,8 @@ export interface InventoryDisplayItem {
 	typeName?: string | null
 	quantity: number
 	stackCount: number
+	/** Total volume for the aggregated quantity, in cubic metres. */
+	volumeM3?: number | null
 	estimatedValue?: number | null
 }
 
@@ -20,4 +22,6 @@ export interface InventoryRowLike {
 	typeId: string
 	quantity: number
 	typeName?: string | null
+	/** Unit volume for one item, in cubic metres. */
+	unitVolumeM3?: number | null
 }

--- a/packages/inventory-display/src/types.ts
+++ b/packages/inventory-display/src/types.ts
@@ -3,6 +3,7 @@ export interface InventoryDisplayItem {
 	typeName?: string | null
 	quantity: number
 	stackCount: number
+	estimatedValue?: number | null
 }
 
 export interface InventoryDisplayBay {
@@ -10,6 +11,7 @@ export interface InventoryDisplayBay {
 	label: string
 	totalQuantity: number
 	totalStacks: number
+	totalEstimatedValue?: number | null
 	items: InventoryDisplayItem[]
 }
 

--- a/packages/moon-scan/src/index.ts
+++ b/packages/moon-scan/src/index.ts
@@ -1,9 +1,21 @@
-import { MOON_GOO_TYPE_IDS, MOON_ORE_TYPE_IDS } from './reprocessing'
+import {
+	FUEL_BLOCK_TYPE_ID,
+	MAGMATIC_GAS_TYPE_ID,
+	MOON_GOO_TYPE_IDS,
+	MOON_ORE_TYPE_IDS,
+} from './reprocessing'
 
 export type { ParsedOre, ParsedScan, ParseResult } from './parser'
 export { parseMoonScanTsv } from './parser'
 
-export { FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID, MOON_GOO_TYPE_IDS, MOON_ORE_TYPE_IDS, MOON_ORE_VOLUME_M3, getOreVolume } from './reprocessing'
+export {
+	FUEL_BLOCK_TYPE_ID,
+	MAGMATIC_GAS_TYPE_ID,
+	MOON_GOO_TYPE_IDS,
+	MOON_ORE_TYPE_IDS,
+	MOON_ORE_VOLUME_M3,
+	getOreVolume,
+} from './reprocessing'
 
 export type MoonScanStatus = 'pending' | 'verified' | 'rejected'
 export type MoonScanSource = 'user' | 'system'
@@ -39,10 +51,12 @@ export interface VerifiedMoonSummaryRecord extends VerifiedMoonSummary {
 }
 
 export interface VerifiedMoonPage {
-	items: Array<VerifiedMoonSummary & {
-		metenoxProfit?: string | null
-		tataraProfit?: string | null
-	}>
+	items: Array<
+		VerifiedMoonSummary & {
+			metenoxProfit?: string | null
+			tataraProfit?: string | null
+		}
+	>
 	total: number
 	page: number
 	pageSize: number
@@ -252,9 +266,115 @@ export interface MoonProfitability {
 	pricingSnapshotDate: string | null
 }
 
+/**
+ * Calculate the profitability estimate for one structure profile from a
+ * verified moon composition. Names are intentionally left as type IDs here;
+ * callers that have universe data can resolve display names without making
+ * the calculation depend on a second data source.
+ */
+export function calculateStructureProfitability(
+	composition: VerifiedComposition,
+	inputs: MoonProfitabilityQueryInputs,
+	structureType: StructureType
+): StructureProfitability | null {
+	const profile = inputs.profiles.find((candidate) => candidate.id === structureType)
+	if (!profile) return null
+
+	const typeMaterials = new Map<
+		string,
+		Array<MoonProfitabilityQueryInputs['typeMaterials'][number]>
+	>()
+	for (const material of inputs.typeMaterials) {
+		const materials = typeMaterials.get(material.oreTypeId) ?? []
+		materials.push(material)
+		typeMaterials.set(material.oreTypeId, materials)
+	}
+
+	const prices = new Map(inputs.prices.map((price) => [price.typeId, price.price]))
+	const reprocessingYield = Number.parseFloat(inputs.defaultReprocessingYield)
+	const cycleHours = (profile.isPassive ? 1 : inputs.defaultCycleDays) * 24
+	const baseVolumePerHour = Number.parseFloat(profile.baseVolumePerHr)
+	const rigBonus = Number.parseFloat(profile.rigBonus)
+	const securityModifier = profile.isPassive ? Number.parseFloat(profile.nullsecModifier) : 1
+	const totalVolume = baseVolumePerHour * (1 + rigBonus) * securityModifier * cycleHours
+
+	const ores = composition.ores
+		.map((ore) => {
+			const oreUnits =
+				(totalVolume * Number.parseFloat(ore.quantity)) / (inputs.oreVolumes[ore.oreTypeId] ?? 0)
+			const refinesTo = (typeMaterials.get(ore.oreTypeId) ?? [])
+				.filter(
+					(material) => !(profile.isPassive && ['35', '36'].includes(material.materialTypeId))
+				)
+				.map((material) => {
+					const units = Math.floor(
+						Math.floor(oreUnits / 100) * material.quantity * reprocessingYield
+					)
+					const unitSellPrice = prices.get(material.materialTypeId) ?? 0
+					return {
+						materialTypeId: material.materialTypeId,
+						materialName: material.materialTypeId,
+						quantity: units,
+						batchSize: 100,
+						batchQty: material.quantity,
+						unitSellPrice: String(unitSellPrice),
+						totalValue: String(units * unitSellPrice),
+						materialRarity: null,
+					}
+				})
+			const totalOreValue = refinesTo.reduce(
+				(sum, material) => sum + Number(material.totalValue),
+				0
+			)
+			return {
+				oreTypeId: ore.oreTypeId,
+				oreName: ore.oreTypeId,
+				quantity: ore.quantity,
+				rarity: ORE_TYPE_RARITY[ore.oreTypeId] ?? null,
+				refinesTo,
+				totalOreValue: String(totalOreValue),
+			}
+		})
+		.sort(
+			(left, right) =>
+				(RARITY_ORDER[right.rarity as OreRarity] ?? 0) -
+				(RARITY_ORDER[left.rarity as OreRarity] ?? 0)
+		)
+
+	const grossIsk = ores.reduce((sum, ore) => sum + Number(ore.totalOreValue), 0)
+	const fuelUnits = Number.parseFloat(profile.fuelPerHr) * cycleHours
+	const magmaticGasUnits = profile.isPassive
+		? Number.parseFloat(profile.magmaticGasPerHr ?? '0') * cycleHours
+		: 0
+	const fuelPriceOverride = Number.parseFloat(inputs.fuelBlockPriceOverride ?? '')
+	const magmaticGasPriceOverride = Number.parseFloat(inputs.magmaticGasPriceOverride ?? '')
+	const fuelPrice =
+		fuelPriceOverride > 0 ? fuelPriceOverride : (prices.get(FUEL_BLOCK_TYPE_ID) ?? 0)
+	const magmaticGasPrice =
+		magmaticGasPriceOverride > 0
+			? magmaticGasPriceOverride
+			: (prices.get(MAGMATIC_GAS_TYPE_ID) ?? 0)
+	const fuelCost = fuelUnits * fuelPrice
+	const magmaticGasCost = magmaticGasUnits * magmaticGasPrice
+
+	return {
+		structureType,
+		cycleDays: profile.isPassive ? 1 : inputs.defaultCycleDays,
+		grossIsk: String(Math.round(grossIsk)),
+		fuelCost: String(Math.round(fuelCost)),
+		magmaticGasCost: profile.isPassive ? String(Math.round(magmaticGasCost)) : null,
+		profit: String(Math.round(grossIsk - fuelCost - magmaticGasCost)),
+		ores,
+	}
+}
+
 export interface MoonScanDO {
 	// Scans
-	submitScans(scans: SubmitScanInput[], submittedBy: string | null, autoVerify: boolean): Promise<MoonScan[]>
+	submitScans(
+		scans: SubmitScanInput[],
+		submittedBy: string | null,
+		autoVerify: boolean
+	): Promise<MoonScan[]>
 	getScans(filters: ScanFilters): Promise<PaginatedScans>
 	getScan(scanId: string): Promise<MoonScan | null>
 	verifyScan(scanId: string, verifiedBy: string, notes: string | null): Promise<MoonScan>
@@ -294,6 +414,9 @@ export interface MoonScanDO {
 	getExtractionSettings(): Promise<ExtractionSettings>
 	updateExtractionSettings(settings: Partial<ExtractionSettings>): Promise<ExtractionSettings>
 	getStructureProfiles(): Promise<StructureProfile[]>
-	updateStructureProfile(id: StructureType, profile: Partial<StructureProfile>): Promise<StructureProfile>
+	updateStructureProfile(
+		id: StructureType,
+		profile: Partial<StructureProfile>
+	): Promise<StructureProfile>
 	cacheCharacterName(characterId: string, name: string): Promise<void>
 }

--- a/packages/moon-scan/src/index.ts
+++ b/packages/moon-scan/src/index.ts
@@ -1,5 +1,6 @@
 import {
 	FUEL_BLOCK_TYPE_ID,
+	getOreVolume,
 	MAGMATIC_GAS_TYPE_ID,
 	MOON_GOO_TYPE_IDS,
 	MOON_ORE_TYPE_IDS,
@@ -15,6 +16,7 @@ export {
 	MOON_ORE_TYPE_IDS,
 	MOON_ORE_VOLUME_M3,
 	getOreVolume,
+	parseVolumeM3,
 } from './reprocessing'
 
 export type MoonScanStatus = 'pending' | 'verified' | 'rejected'
@@ -82,6 +84,7 @@ export interface MoonProfitabilityQueryInputs {
 		materialTypeId: string
 		quantity: number
 	}>
+	materialVolumes: Record<string, number | null>
 	oreVolumes: Record<string, number>
 	prices: Array<{
 		typeId: string
@@ -236,6 +239,10 @@ export interface OreRefineProduct {
 	batchQty: number
 	unitSellPrice: string
 	totalValue: string
+	/** Total output volume for this material during the calculated structure cycle. */
+	volumeM3: number | null
+	/** Output volume for the material's per-100-ore batch. */
+	volumePer100M3: number | null
 	/** Rarity of this material's source ore, for coloring the badge */
 	materialRarity: string | null
 }
@@ -244,9 +251,15 @@ export interface OreWithProfitability {
 	oreTypeId: string
 	oreName: string
 	quantity: string
+	/** Calculated raw ore units processed during the structure cycle. */
+	oreUnits: number
 	rarity: string | null
 	refinesTo: OreRefineProduct[]
 	totalOreValue: string
+	/** Total raw ore volume for this ore during the calculated structure cycle. */
+	oreVolumeM3: number
+	/** Total refined-material volume for this ore during the calculated structure cycle. */
+	volumeM3: number | null
 }
 
 export interface StructureProfitability {
@@ -300,8 +313,12 @@ export function calculateStructureProfitability(
 
 	const ores = composition.ores
 		.map((ore) => {
-			const oreUnits =
-				(totalVolume * Number.parseFloat(ore.quantity)) / (inputs.oreVolumes[ore.oreTypeId] ?? 0)
+			const configuredOreVolume = inputs.oreVolumes[ore.oreTypeId]
+			const oreVolumeM3 =
+				Number.isFinite(configuredOreVolume) && configuredOreVolume > 0
+					? configuredOreVolume
+					: getOreVolume(ore.oreTypeId)
+			const oreUnits = (totalVolume * Number.parseFloat(ore.quantity)) / oreVolumeM3
 			const refinesTo = (typeMaterials.get(ore.oreTypeId) ?? [])
 				.filter(
 					(material) => !(profile.isPassive && ['35', '36'].includes(material.materialTypeId))
@@ -311,6 +328,7 @@ export function calculateStructureProfitability(
 						Math.floor(oreUnits / 100) * material.quantity * reprocessingYield
 					)
 					const unitSellPrice = prices.get(material.materialTypeId) ?? 0
+					const unitVolumeM3 = inputs.materialVolumes[material.materialTypeId] ?? null
 					return {
 						materialTypeId: material.materialTypeId,
 						materialName: material.materialTypeId,
@@ -319,6 +337,8 @@ export function calculateStructureProfitability(
 						batchQty: material.quantity,
 						unitSellPrice: String(unitSellPrice),
 						totalValue: String(units * unitSellPrice),
+						volumeM3: unitVolumeM3 === null ? null : units * unitVolumeM3,
+						volumePer100M3: unitVolumeM3 === null ? null : material.quantity * unitVolumeM3,
 						materialRarity: null,
 					}
 				})
@@ -330,9 +350,14 @@ export function calculateStructureProfitability(
 				oreTypeId: ore.oreTypeId,
 				oreName: ore.oreTypeId,
 				quantity: ore.quantity,
+				oreUnits: Math.floor(oreUnits),
 				rarity: ORE_TYPE_RARITY[ore.oreTypeId] ?? null,
 				refinesTo,
 				totalOreValue: String(totalOreValue),
+				oreVolumeM3: totalVolume * Number.parseFloat(ore.quantity),
+				volumeM3: refinesTo.some((material) => material.volumeM3 === null)
+					? null
+					: refinesTo.reduce((sum, material) => sum + (material.volumeM3 ?? 0), 0),
 			}
 		})
 		.sort(

--- a/packages/moon-scan/src/reprocessing.ts
+++ b/packages/moon-scan/src/reprocessing.ts
@@ -6,16 +6,21 @@ import {
 } from '@repo/universe'
 
 // Re-export canonical moon extraction IDs from @repo/universe.
-export {
-	FUEL_BLOCK_TYPE_ID,
-	MAGMATIC_GAS_TYPE_ID,
-	MOON_GOO_TYPE_IDS,
-	MOON_ORE_TYPE_IDS,
-}
+export { FUEL_BLOCK_TYPE_ID, MAGMATIC_GAS_TYPE_ID, MOON_GOO_TYPE_IDS, MOON_ORE_TYPE_IDS }
 
-// All moon ores have the same volume — not stored in the SDE
+// Defensive fallback for older or incomplete universe data. Current SDE rows
+// define all moon ores as 10 m3 per unit, and callers prefer those values.
 export const MOON_ORE_VOLUME_M3 = 10
 
 export function getOreVolume(_oreTypeId: string): number {
 	return MOON_ORE_VOLUME_M3
+}
+
+/** Parse an SDE volume while rejecting missing, invalid, and non-positive values. */
+export function parseVolumeM3(
+	value: string | number | null | undefined,
+	fallback: number | null = null
+): number | null {
+	const parsed = typeof value === 'number' ? value : Number.parseFloat(value ?? '')
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -449,6 +449,7 @@ export interface StructureInventoryItem {
 	typeName?: string | null
 	quantity: number
 	stackCount: number
+	volumeM3?: number | null
 	estimatedValue?: number | null
 }
 
@@ -752,8 +753,10 @@ export interface StructureMoonComposition {
 			oreTypeId: string
 			oreName: string
 			quantity: string
+			oreUnits: number
 			rarity: string | null
 			totalOreValue: string
+			oreVolumeM3: number
 			refinesTo: Array<{
 				materialTypeId: string
 				materialName: string
@@ -762,8 +765,11 @@ export interface StructureMoonComposition {
 				batchQty: number
 				unitSellPrice: string
 				totalValue: string
+				volumeM3: number | null
+				volumePer100M3: number | null
 				materialRarity: string | null
 			}>
+			volumeM3: number | null
 		}>
 	} | null
 	pricingSnapshotDate?: string | null

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -449,6 +449,7 @@ export interface StructureInventoryItem {
 	typeName?: string | null
 	quantity: number
 	stackCount: number
+	estimatedValue?: number | null
 }
 
 export interface StructureInventoryBay {
@@ -456,6 +457,7 @@ export interface StructureInventoryBay {
 	label: string
 	totalQuantity: number
 	totalStacks: number
+	totalEstimatedValue?: number | null
 	items: StructureInventoryItem[]
 }
 
@@ -737,7 +739,34 @@ export interface StructureMoonComposition {
 		typeId: string
 		typeName: string | null
 		quantity: string
+		rarity: string | null
 	}>
+	profitability?: {
+		structureType: 'tatara' | 'metenox'
+		cycleDays: number
+		grossIsk: string
+		fuelCost: string
+		magmaticGasCost: string | null
+		profit: string
+		ores: Array<{
+			oreTypeId: string
+			oreName: string
+			quantity: string
+			rarity: string | null
+			totalOreValue: string
+			refinesTo: Array<{
+				materialTypeId: string
+				materialName: string
+				quantity: number
+				batchSize: number
+				batchQty: number
+				unitSellPrice: string
+				totalValue: string
+				materialRarity: string | null
+			}>
+		}>
+	} | null
+	pricingSnapshotDate?: string | null
 }
 
 export interface StructureMiningCitadelSummary extends StructureMoonGeography {
@@ -767,6 +796,13 @@ export interface StructureFittingItem {
 	isConsumable?: boolean
 }
 
+export interface StructureFittingSlotCapacities {
+	high: number
+	mid: number
+	low: number
+	rig: number
+}
+
 export interface StructureDetailResult extends Omit<StructureListItem, 'canViewDetails'> {
 	includeInStructureAssetSync: boolean
 	assetsLastSync: string | null
@@ -788,9 +824,12 @@ export interface StructureDetailResult extends Omit<StructureListItem, 'canViewD
 	skyhook?: StructureSkyhookSummary | null
 	moonDrill?: StructureMoonDrillSummary | null
 	miningExtraction?: StructureMiningCitadelSummary | null
+	miningExtractionComposition?: StructureMoonComposition | null
+	moonComposition?: StructureMoonComposition | null
 	miningExtractionHistory?: StructureMiningCitadelExtractionHistory[]
 	inventoryBays?: StructureInventoryBay[]
 	fittingItems?: StructureFittingItem[]
+	fittingSlotCapacities?: StructureFittingSlotCapacities | null
 }
 
 export interface StructureListResponse<TItem = StructureListItem> {

--- a/packages/universe/src/index.ts
+++ b/packages/universe/src/index.ts
@@ -22,7 +22,7 @@ import type {
 	EveCharacterId,
 	EveStructureId,
 } from './structure'
-import type { TypeMetadata } from './type-metadata'
+import type { TypeMetadata, TypeSlotCapacities } from './type-metadata'
 
 /**
  * @repo/universe
@@ -245,6 +245,11 @@ export interface Universe {
 	 * @returns Record mapping type IDs to metadata
 	 */
 	resolveTypeMetadataByIds(typeIds: string[]): Promise<Record<string, TypeMetadata>>
+
+	/**
+	 * Resolve static fitting slot capacities from SDE dogma attributes by type ID.
+	 */
+	resolveTypeSlotCapacitiesByIds(typeIds: string[]): Promise<Record<string, TypeSlotCapacities>>
 
 	/**
 	 * Parse inventory text and return structured item metadata.

--- a/packages/universe/src/type-metadata.ts
+++ b/packages/universe/src/type-metadata.ts
@@ -6,3 +6,18 @@ export interface TypeMetadata {
 	marketGroupName: string | null
 	categoryName: string
 }
+
+/** Static dogma attributes that define the fitting slots available on a type. */
+export const TYPE_SLOT_DOGMA_ATTRIBUTE_IDS = {
+	low: '12',
+	mid: '13',
+	high: '14',
+	rig: '1137',
+} as const
+
+export interface TypeSlotCapacities {
+	high: number
+	mid: number
+	low: number
+	rig: number
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2398,6 +2398,9 @@ importers:
       '@repo/inventory-display':
         specifier: workspace:*
         version: link:../../packages/inventory-display
+      '@repo/markets':
+        specifier: workspace:*
+        version: link:../../packages/markets
       '@repo/moon-scan':
         specifier: workspace:*
         version: link:../../packages/moon-scan


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Extends the Structures app's moon mining detail view with moon composition data, ore/material volume, and live-market profitability estimates for Tatara/Metenox structures, and adds fitting slot capacity/empty-slot display. Also fixes a moon-drill detail bug where composition and drill info were incorrectly gated behind an unrelated DB row.

## Changes
- Unify moon composition loading (`loadStructureMoonComposition`) for both mining citadels (tatara) and moon drills (metenox), decoupling `moonDrill` summary display from the presence of a `structureMoonDrills` row.
- Enrich moon composition with ore rarity and (best-effort) profitability: pulls extraction settings/structure profiles from `moon-scan`, type materials/prices from `universe`/`markets`, and computes gross ISK, fuel/magmatic gas cost, and profit via new `calculateStructureProfitability` in `@repo/moon-scan`.
- Add per-ore and per-material volume (`oreVolumeM3`, `volumeM3`, `volumePer100M3`) to the profitability calculation, sourcing SDE type volumes via a new `parseVolumeM3` helper with a defensive fallback to the canonical moon-ore volume, and surface totals in a new `MoonProfitabilityTable` component.
- Add volume aggregation (`volumeM3`) to `summarizeInventoryRows` in `@repo/inventory-display`, propagating unit volume through `InventoryRowLike`/`InventoryDisplayItem` and marking volume unavailable if any contributing row is missing it.
- Add a `MARKETS` durable object binding to the `structures` app and a new `@repo/markets` dependency.
- Price and show volume for the `MoonMaterialBay` inventory bay using live market/SDE data, adding `volumeM3`/`estimatedValue`/`totalEstimatedValue` to inventory bay/item types and columns in `InventoryBaysTable`.
- Resolve structure fitting slot capacities (high/mid/low/rig) from SDE dogma attributes via a new `Universe.resolveTypeSlotCapacitiesByIds` RPC, and render empty fitting slots in `FittingSlotTable`.
- Split `MoonCompositionCard` into `MoonCompositionTable` and `MoonProfitabilityTable` (new file), showing moon/planet/system info, ore composition with rarity, and a detailed ore/material profitability and volume breakdown with fuel-block/magmatic-gas icons.
- Restructure the structures detail page layout (grid `contents` wrappers), drop the "Stacks" column from the inventory bays table in favor of optional price/volume columns, and tighten item icon alignment.
- Reduce two asset-sync log lines from `warn` to `info`.
- Rename `FUEL_DOGMA_ATTRIBUTE_IDS` usage in the SDE import script to a broader `STRUCTURE_DOGMA_ATTRIBUTE_IDS` set that also covers slot attributes.

## Testing
- Updated/added unit tests in `apps/structures/src/test/unit/services/structure-permission-gating.test.ts` covering moon-drill composition without a separate moon-drill row, and mining-extraction composition with pricing/profitability.
- Added/updated tests in `apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts` covering inventory volume aggregation with unknown-volume handling, and ore/material volume in structure profitability (including the canonical-volume fallback).
- Updated `apps/universe/src/test/unit/sde-fuel-selection.test.ts` for the new `STRUCTURE_SLOT_DOGMA_ATTRIBUTE_IDS`/`STRUCTURE_DOGMA_ATTRIBUTE_IDS` constants.
<!-- claude:end -->