### PR TITLE
fix fresh session oauth consent redirect

### DIFF
--- a/apps/ui/src/client/lib/auth-redirect.ts
+++ b/apps/ui/src/client/lib/auth-redirect.ts
@@ -1,0 +1,12 @@
+export function shouldUseFullPageAuthRedirect(destination: string): boolean {
+	if (destination.startsWith('/invite/') || destination.startsWith('/login')) {
+		return true
+	}
+
+	try {
+		const url = new URL(destination)
+		return url.protocol === 'http:' || url.protocol === 'https:'
+	} catch {
+		return false
+	}
+}

--- a/apps/ui/src/client/routes/auth-callback.tsx
+++ b/apps/ui/src/client/routes/auth-callback.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router'
 
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { apiClient } from '@/lib/api'
+import { shouldUseFullPageAuthRedirect } from '@/lib/auth-redirect'
 
 interface CallbackResponse {
 	success?: boolean
@@ -88,10 +89,11 @@ export default function AuthCallbackPage() {
 					// Use redirect URL if present, otherwise go to dashboard
 					const destination = response.redirectUrl || '/dashboard'
 
-					// If redirect URL starts with /invite/, /login, or other server routes,
-					// do a full page reload instead of SPA navigation
-					if (destination.startsWith('/invite/') || destination.startsWith('/login')) {
-						window.location.href = destination
+					// Absolute destinations, including the third-party OAuth /authorize URL, must
+					// use a browser navigation. React Router treats an absolute URL passed to
+					// navigate() as a route-relative path (for example, /auth/callback/https:/...).
+					if (shouldUseFullPageAuthRedirect(destination)) {
+						window.location.assign(destination)
 					} else {
 						void navigate(destination)
 					}

--- a/apps/ui/src/test/unit/auth-callback-redirect.test.ts
+++ b/apps/ui/src/test/unit/auth-callback-redirect.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldUseFullPageAuthRedirect } from '@/lib/auth-redirect'
+
+describe('auth callback redirect handling', () => {
+	it('uses a browser navigation for absolute OAuth authorize URLs', () => {
+		expect(
+			shouldUseFullPageAuthRedirect(
+				'https://pleaseignore.app/authorize?response_type=code&client_id=client&state=state'
+			)
+		).toBe(true)
+	})
+
+	it('uses SPA navigation for ordinary internal destinations', () => {
+		expect(shouldUseFullPageAuthRedirect('/dashboard')).toBe(false)
+	})
+
+	it('keeps server-rendered destinations on a full browser navigation', () => {
+		expect(shouldUseFullPageAuthRedirect('/login?redirect=%2Fauthorize')).toBe(true)
+		expect(shouldUseFullPageAuthRedirect('/invite/invite-code')).toBe(true)
+	})
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes OAuth consent redirects for fresh sessions where the server-provided `redirectUrl` (e.g. a third-party `/authorize` URL) was being mishandled by SPA navigation, resulting in a broken route like `/auth/callback/https:/...` instead of an actual browser navigation to the destination.

## Changes
- Add `shouldUseFullPageAuthRedirect` (`apps/ui/src/client/lib/auth-redirect.ts`) to determine whether a redirect destination needs a full browser navigation — true for `/invite/*`, `/login*`, and any absolute `http:`/`https:` URL.
- Update `auth-callback.tsx` to use this helper and call `window.location.assign(destination)` (instead of `window.location.href = destination`) for full-page redirects, since React Router's `navigate()` misinterprets absolute URLs as route-relative paths.
- Add unit tests covering absolute OAuth authorize URLs, internal SPA destinations, and server-rendered destinations (`/login`, `/invite/...`).

## Testing
Added `apps/ui/src/test/unit/auth-callback-redirect.test.ts` covering the new `shouldUseFullPageAuthRedirect` helper for OAuth authorize URLs, internal destinations, and server-rendered routes.
<!-- claude:end -->