### PR TITLE
fix erroneous permissions error for showing structures nav item

### DIFF
--- a/apps/core/src/routes/__tests__/structures.route.test.ts
+++ b/apps/core/src/routes/__tests__/structures.route.test.ts
@@ -267,13 +267,16 @@ describe('structures routes', () => {
 		expect(await response.json()).toEqual({ error: 'Structure permission required' })
 	})
 
-	it('rejects the structure capability endpoint without any structure permission scope', async () => {
+	it('returns no structure access for users without a structure permission scope', async () => {
 		vi.mocked(getCachedUserPermissions).mockResolvedValue([])
 		const app = createApp(makeUserWithoutStructureAccess())
 		const response = await app.request('/api/structures/access')
 
-		expect(response.status).toBe(403)
-		expect(await response.json()).toEqual({ error: 'Structure permission required' })
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			canView: false,
+			hasImplicitSensitiveAccess: false,
+		})
 	})
 
 	it('requires authentication for the structure access capability endpoint', async () => {

--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -136,6 +136,13 @@ app.use('*', async (c, next) => {
 		return next()
 	}
 
+	// The capability endpoint is used by the authenticated application shell to
+	// decide whether to render the Structures navigation. It must be able to
+	// return `canView: false`; it does not expose structure data.
+	if (c.req.path === '/access' || c.req.path === '/api/structures/access') {
+		return next()
+	}
+
 	const actor = await getStructureActor(c)
 	if (!hasStructureApiAccess(actor)) {
 		return c.json({ error: 'Structure permission required' }, 403)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the `/api/structures/access` capability endpoint so it no longer returns a 403 for users without any structure permissions, which was incorrectly hiding/erroring the Structures nav item instead of just reporting no access.

## Changes
- Added an early bypass in the `structures` route's blanket permission-check middleware so requests to `/access` (and `/api/structures/access`) skip the `hasStructureApiAccess` gate and reach the handler, since that endpoint is meant to report capability rather than require it.
- Updated the corresponding test: a user with no structure permission scope now expects a `200` response with `{ canView: false, hasImplicitSensitiveAccess: false }` instead of a `403` error.

## Testing
- Updated unit test in `apps/core/src/routes/__tests__/structures.route.test.ts` covers the no-permission case, asserting a `200` with `canView: false`.
<!-- claude:end -->