### PR TITLE
Fix/tax ux overhaul

### DIFF
--- a/apps/bills/src/durable-object.ts
+++ b/apps/bills/src/durable-object.ts
@@ -28,6 +28,8 @@ import type {
 	BillScheduleWithDetails,
 	BillStatistics,
 	BillStatusEvent,
+	BillStatusEventByPayerPage,
+	BillStatusEventByPayerPageQuery,
 	BillStatusEventPage,
 	BillStatusEventPageQuery,
 	BillTemplate,
@@ -181,6 +183,12 @@ export class BillsDO extends DurableObject<Env> implements Bills {
 
 	async listBillStatusEventsPage(query: BillStatusEventPageQuery): Promise<BillStatusEventPage> {
 		return this.billService.listBillStatusEventsPage(query)
+	}
+
+	async listBillStatusEventsByPayerPage(
+		query: BillStatusEventByPayerPageQuery
+	): Promise<BillStatusEventByPayerPage> {
+		return this.billService.listBillStatusEventsByPayerPage(query)
 	}
 
 	async updateBill(actorUserId: string, billId: string, data: UpdateBillInput): Promise<Bill> {

--- a/apps/bills/src/services/bill.service.ts
+++ b/apps/bills/src/services/bill.service.ts
@@ -20,6 +20,8 @@ import type {
 	BillStatistics,
 	BillStatus,
 	BillStatusEvent,
+	BillStatusEventByPayerPage,
+	BillStatusEventByPayerPageQuery,
 	BillStatusEventPage,
 	BillStatusEventPageQuery,
 	BillStatusEventType,
@@ -293,7 +295,18 @@ export class BillService {
 
 		const rows = await this.db.query.billStatusEvents.findMany({
 			where: inArray(billStatusEvents.billId, normalizedBillIds),
-			orderBy: (events, operators) => [operators.desc(events.createdAt), operators.desc(events.id)],
+			orderBy: (events, operators) => [
+				(query.sortDir === 'asc' ? operators.asc : operators.desc)(
+					query.sortBy === 'eventType'
+						? events.eventType
+						: query.sortBy === 'billId'
+							? events.billId
+							: query.sortBy === 'actorUserId'
+								? events.actorUserId
+								: events.createdAt
+				),
+				operators.desc(events.id),
+			],
 			limit: normalizedLimit,
 			offset: normalizedOffset,
 		})
@@ -308,6 +321,65 @@ export class BillService {
 				actorUserId: event.actorUserId,
 				metadata: event.metadata ?? null,
 				createdAt: event.createdAt,
+			})),
+			rowCount,
+		}
+	}
+
+	async listBillStatusEventsByPayerPage(
+		query: BillStatusEventByPayerPageQuery
+	): Promise<BillStatusEventByPayerPage> {
+		const normalizedLimit = Number.isFinite(query.limit)
+			? Math.max(1, Math.min(200, Math.floor(query.limit)))
+			: 25
+		const normalizedOffset = Number.isFinite(query.offset)
+			? Math.max(0, Math.floor(query.offset))
+			: 0
+		const conditions = [eq(bills.payerId, query.payerId), eq(bills.payerType, query.payerType)]
+		if (query.externalSourceType) {
+			conditions.push(eq(bills.externalSourceType, query.externalSourceType))
+		}
+		const where = and(...conditions)
+		const countRows = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(billStatusEvents)
+			.innerJoin(bills, eq(billStatusEvents.billId, bills.id))
+			.where(where)
+		const rowCount = countRows[0]?.count ?? 0
+		if (rowCount === 0) return { rows: [], rowCount }
+
+		const rows = await this.db
+			.select({ event: billStatusEvents, bill: bills })
+			.from(billStatusEvents)
+			.innerJoin(bills, eq(billStatusEvents.billId, bills.id))
+			.where(where)
+			.orderBy(
+				(query.sortDir === 'asc' ? asc : desc)(
+					query.sortBy === 'eventType'
+						? billStatusEvents.eventType
+						: query.sortBy === 'billId'
+							? billStatusEvents.billId
+							: query.sortBy === 'actorUserId'
+								? billStatusEvents.actorUserId
+								: billStatusEvents.createdAt
+				),
+				desc(billStatusEvents.id)
+			)
+			.limit(normalizedLimit)
+			.offset(normalizedOffset)
+
+		return {
+			rows: rows.map(({ event, bill }) => ({
+				id: event.id,
+				billId: event.billId,
+				eventType: event.eventType,
+				fromStatus: event.fromStatus,
+				toStatus: event.toStatus,
+				actorUserId: event.actorUserId,
+				metadata: event.metadata ?? null,
+				createdAt: event.createdAt,
+				externalSourceType: bill.externalSourceType,
+				externalSourceId: bill.externalSourceId,
 			})),
 			rowCount,
 		}

--- a/apps/core/src/middleware/tax-permissions.ts
+++ b/apps/core/src/middleware/tax-permissions.ts
@@ -245,6 +245,18 @@ export async function canAuditTaxFeature(
 	})
 }
 
+/** Read-only corporation-scoped reports may use the same scoped access model as the dashboard. */
+export async function canReadTaxReports(
+	env: App['Bindings'],
+	user: SessionUser,
+	corporationId?: string
+): Promise<boolean> {
+	if (!corporationId?.trim()) {
+		return canAuditTaxFeature(env, user)
+	}
+	return canReadTaxFeature(env, user, corporationId)
+}
+
 export async function canManageTaxFeature(
 	env: App['Bindings'],
 	user: SessionUser,

--- a/apps/core/src/routes/__tests__/corporation-tax.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporation-tax.route.test.ts
@@ -1800,7 +1800,7 @@ describe('corporation-tax routes', () => {
 		routeStubs({ corporationTaxStub, characterDataStub })
 
 		const response = await app.request(
-			'/api/corporation-tax/corporations/1234/member-summary?fromDate=2026-03-01T00:00:00.000Z&toDate=2026-03-31T23:59:59.999Z&topRefTypesLimit=3',
+			'/api/corporation-tax/corporations/1234/member-summary?fromDate=2026-03-01T00:00:00.000Z&toDate=2026-03-31T23:59:59.999Z&topRefTypesLimit=3&refTypes=bounty_prizes,ess_escrow_transfer',
 			{},
 			env
 		)
@@ -1812,6 +1812,7 @@ describe('corporation-tax routes', () => {
 		expect(corporationTaxStub.getMemberSummaryReport).toHaveBeenCalledWith({
 			corporationId: '1234',
 			characterIds: ['7001'],
+			refTypes: ['bounty_prizes', 'ess_escrow_transfer'],
 			fromDate: new Date('2026-03-01T00:00:00.000Z'),
 			toDate: new Date('2026-03-31T23:59:59.999Z'),
 			topRefTypesLimit: 3,
@@ -1842,6 +1843,7 @@ describe('corporation-tax routes', () => {
 		expect(corporationTaxStub.getMemberSummaryReport).toHaveBeenCalledWith({
 			corporationId: '1234',
 			characterIds: ['7001'],
+			refTypes: undefined,
 			fromDate: undefined,
 			toDate: undefined,
 			topRefTypesLimit: undefined,
@@ -1901,6 +1903,7 @@ describe('corporation-tax routes', () => {
 		expect(corporationTaxStub.getMemberSummaryReport).toHaveBeenCalledWith({
 			corporationId: '1234',
 			characterIds: ['81234567'],
+			refTypes: undefined,
 			fromDate: undefined,
 			toDate: undefined,
 			topRefTypesLimit: undefined,

--- a/apps/core/src/routes/__tests__/corporation-tax.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporation-tax.route.test.ts
@@ -90,6 +90,8 @@ function makeCorporationTaxStub() {
 		listLedgerEntries: vi.fn(),
 		listLedgerParties: vi.fn(),
 		runAssessmentForPeriod: vi.fn(),
+		startAssessmentWorkflow: vi.fn(),
+		getAssessmentWorkflowStatus: vi.fn(),
 		rebuildFinalizedRollupsForPeriod: vi.fn(),
 		createBillsForAssessment: vi.fn(),
 		syncAssessmentBillStatus: vi.fn(),
@@ -729,14 +731,18 @@ describe('corporation-tax routes', () => {
 		expect(corporationTaxStub.runAssessmentForPeriod).not.toHaveBeenCalled()
 	})
 
-	it('forwards run-assessment payload as parsed dates', async () => {
+	it('queues run-assessment payload as parsed dates', async () => {
 		const user = makeUser()
 		const app = createApp(user)
 		const corporationTaxStub = makeCorporationTaxStub()
 		const featuresStub = { checkFlag: vi.fn().mockResolvedValue(true) }
 		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:tax:admin' }] as any)
-		corporationTaxStub.runAssessmentForPeriod.mockResolvedValue({
-			assessment: { id: 'assessment-1' },
+		corporationTaxStub.startAssessmentWorkflow.mockResolvedValue({
+			workflowInstanceId: 'tax-assessment-4002-run-1',
+			corporationId: '4002',
+			periodStart: '2026-03-01T00:00:00.000Z',
+			periodEnd: '2026-03-31T00:00:00.000Z',
+			status: 'queued',
 		})
 		routeStubs({ corporationTaxStub, featuresStub })
 
@@ -753,11 +759,17 @@ describe('corporation-tax routes', () => {
 			env
 		)
 
-		expect(response.status).toBe(200)
-		expect(await response.json()).toEqual({ assessment: { id: 'assessment-1' } })
-		expect(corporationTaxStub.runAssessmentForPeriod).toHaveBeenCalledTimes(1)
+		expect(response.status).toBe(202)
+		expect(await response.json()).toEqual({
+			workflowInstanceId: 'tax-assessment-4002-run-1',
+			corporationId: '4002',
+			periodStart: '2026-03-01T00:00:00.000Z',
+			periodEnd: '2026-03-31T00:00:00.000Z',
+			status: 'queued',
+		})
+		expect(corporationTaxStub.startAssessmentWorkflow).toHaveBeenCalledTimes(1)
 
-		const [actorUserId, payload] = corporationTaxStub.runAssessmentForPeriod.mock.calls[0]
+		const [actorUserId, payload] = corporationTaxStub.startAssessmentWorkflow.mock.calls[0]
 		expect(actorUserId).toBe(user.id)
 		expect(payload.corporationId).toBe('4002')
 		expect(payload.periodStart).toBeInstanceOf(Date)
@@ -856,7 +868,10 @@ describe('corporation-tax routes', () => {
 		const app = createApp(makeUser())
 		const corporationTaxStub = makeCorporationTaxStub()
 		getCachedUserPermissionsMock.mockResolvedValue([{ urn: 'urn:tax:admin' }] as any)
-		corporationTaxStub.listLedgerEntries.mockResolvedValue([{ id: 'ledger-1' }])
+		corporationTaxStub.listLedgerEntries.mockResolvedValue({
+			rows: [{ id: 'ledger-1' }],
+			totalRows: 1,
+		})
 		routeStubs({ corporationTaxStub })
 
 		const response = await app.request(
@@ -866,7 +881,7 @@ describe('corporation-tax routes', () => {
 		)
 
 		expect(response.status).toBe(200)
-		expect(await response.json()).toEqual([{ id: 'ledger-1' }])
+		expect(await response.json()).toEqual({ rows: [{ id: 'ledger-1' }], totalRows: 1 })
 		expect(corporationTaxStub.listLedgerEntries).toHaveBeenCalledWith('4002', {
 			division: undefined,
 			sourceTypes: ['character_wallet_journal', 'character_wallet_transaction'],
@@ -880,6 +895,8 @@ describe('corporation-tax routes', () => {
 			maxAmount: undefined,
 			limit: 20,
 			offset: 3,
+			sortBy: undefined,
+			sortDir: 'desc',
 		})
 	})
 

--- a/apps/core/src/routes/corporation-tax/alerts-routes.ts
+++ b/apps/core/src/routes/corporation-tax/alerts-routes.ts
@@ -3,7 +3,7 @@ import { getStub } from '@repo/do-utils'
 
 import { userCharacters, users } from '../../db/schema'
 import { requireAuth } from '../../middleware/session'
-import { canManageTaxFeature, canReadTaxFeature } from '../../middleware/tax-permissions'
+import { canManageTaxFeature } from '../../middleware/tax-permissions'
 import {
 	disposeRpcStub,
 	filterAlertsForUser,
@@ -395,8 +395,7 @@ export function registerCorporationTaxAlertsRoutes(
 			return c.json({ error: 'Unauthorized' }, 401)
 		}
 
-		const corporationId = c.req.query('corporationId') || undefined
-		const canRead = await canReadTaxFeature(c.env, user, corporationId)
+		const canRead = await canManageTaxFeature(c.env, user)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -421,6 +420,9 @@ export function registerCorporationTaxAlertsRoutes(
 					.filter(Boolean)
 			)
 		)
+		if (ids.length > 100) {
+			return c.json({ error: 'ids must contain no more than 100 user IDs' }, 400)
+		}
 
 		if (!q && ids.length === 0) {
 			return c.json([])
@@ -471,7 +473,8 @@ export function registerCorporationTaxAlertsRoutes(
 		} catch (error) {
 			logTaxRouteError(c, 'Error searching tax audit actors', error, {
 				userId: user.id,
-				corporationId: corporationId ?? null,
+				query: q ?? null,
+				requestedIdCount: ids.length,
 			})
 			return c.json({ error: 'Failed to search tax audit actors' }, 500)
 		}

--- a/apps/core/src/routes/corporation-tax/index.ts
+++ b/apps/core/src/routes/corporation-tax/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 
 import { isTaxIncomeRefType } from '@repo/corporation-tax'
-import { and, desc, eq, ilike, inArray, or } from '@repo/db-utils'
+import { and, desc, eq, ilike, or } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger, TimeCache } from '@repo/hono-helpers'
 
@@ -48,7 +48,7 @@ const ledgerPartiesCache = new TimeCache<
 		recipientCount: number
 		lastSeenAt: Date
 	}>
->(60_000)
+>(5 * 60_000)
 
 function normalizeLedgerPartySearchText(value: string): string {
 	return value
@@ -560,7 +560,7 @@ app.get('/corporations/:corporationId/payee-corporations/search', requireAuth(),
 /**
  * GET /corporation-tax/corporations/:corporationId/divisions
  * List known wallet divisions for a corporation.
- * Requires tax viewer+ permission, or CEO/director self-service access for that corporation.
+ * Requires a global tax auditor or tax administrator permission.
  */
 app.get('/corporations/:corporationId/divisions', requireAuth(), async (c) => {
 	const user = c.get('user')
@@ -987,16 +987,25 @@ app.get('/corporations/:corporationId/assessments', requireAuth(), async (c) => 
 	}
 
 	const corporationId = c.req.param('corporationId')
-	const canManage = await canManageTaxFeature(c.env, user, corporationId)
-	if (!canManage) {
+	const canRead = await canReadTaxFeature(c.env, user, corporationId)
+	if (!canRead) {
 		return c.json({ error: 'Forbidden' }, 403)
 	}
 
 	const status = c.req.query('status')
 	const assessmentScope = c.req.query('assessmentScope')
 	const withBillOnly = parseBooleanQueryParam(c.req.query('withBillOnly'))
+	const unbilledOnly = parseBooleanQueryParam(c.req.query('unbilledOnly'))
 	const limit = parseIntegerQueryParam(c.req.query('limit'))
 	const offset = parseIntegerQueryParam(c.req.query('offset'))
+	const sortBy = c.req.query('sortBy')
+	const sortDir = c.req.query('sortDir') === 'asc' ? 'asc' : 'desc'
+	if (limit !== undefined && (limit < 1 || limit > 200)) {
+		return c.json({ error: 'limit must be an integer between 1 and 200' }, 400)
+	}
+	if (offset !== undefined && offset < 0) {
+		return c.json({ error: 'offset must be an integer >= 0' }, 400)
+	}
 
 	try {
 		const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
@@ -1017,8 +1026,19 @@ app.get('/corporations/:corporationId/assessments', requireAuth(), async (c) => 
 					? assessmentScope
 					: undefined,
 			withBillOnly,
+			unbilledOnly,
 			limit,
 			offset,
+			sortBy:
+				sortBy === 'taxPeriodEnd' ||
+				sortBy === 'assessmentScope' ||
+				sortBy === 'scopeId' ||
+				sortBy === 'status' ||
+				sortBy === 'taxDue' ||
+				sortBy === 'taxDelta'
+					? sortBy
+					: undefined,
+			sortDir,
 		})
 		return c.json(assessments)
 	} catch (error) {
@@ -1032,7 +1052,7 @@ app.get('/corporations/:corporationId/assessments', requireAuth(), async (c) => 
 
 /**
  * POST /corporation-tax/corporations/:corporationId/assessments/run
- * Compute or recompute a corporation-level assessment for a period.
+ * Queue a corporation-level assessment for a period.
  */
 app.post('/corporations/:corporationId/assessments/run', requireAuth(), async (c) => {
 	const user = c.get('user')
@@ -1067,19 +1087,53 @@ app.post('/corporations/:corporationId/assessments/run', requireAuth(), async (c
 
 	try {
 		const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
-		const result = await stub.runAssessmentForPeriod(user.id, {
+		const result = await stub.startAssessmentWorkflow(user.id, {
 			corporationId,
 			periodStart,
 			periodEnd,
 			// Static override: keep assessments corporation-wallet only for now.
 			includeCharacterWallets: false,
 		})
-		return c.json(result)
+		return c.json(result, 202)
 	} catch (error) {
-		logTaxRouteError(c, 'Error running tax assessment for period', error, { userId: user.id })
-		return c.json({ error: 'Failed to run tax assessment for period' }, 500)
+		logTaxRouteError(c, 'Error queueing tax assessment for period', error, { userId: user.id })
+		return c.json({ error: 'Failed to queue tax assessment for period' }, 500)
 	}
 })
+
+/**
+ * GET /corporation-tax/corporations/:corporationId/assessments/runs/:workflowInstanceId
+ * Read the status of a queued assessment workflow.
+ */
+app.get(
+	'/corporations/:corporationId/assessments/runs/:workflowInstanceId',
+	requireAuth(),
+	async (c) => {
+		const user = c.get('user')
+		if (!user) {
+			return c.json({ error: 'Unauthorized' }, 401)
+		}
+
+		const corporationId = c.req.param('corporationId')
+		const workflowInstanceId = c.req.param('workflowInstanceId')
+		const canRun = await canManageTaxFeature(c.env, user, corporationId)
+		if (!canRun) {
+			return c.json({ error: 'Forbidden' }, 403)
+		}
+
+		try {
+			const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
+			return c.json(await stub.getAssessmentWorkflowStatus(corporationId, workflowInstanceId))
+		} catch (error) {
+			logTaxRouteError(c, 'Error reading tax assessment workflow status', error, {
+				userId: user.id,
+				corporationId,
+				workflowInstanceId,
+			})
+			return c.json({ error: 'Failed to read tax assessment workflow status' }, 500)
+		}
+	}
+)
 
 /**
  * POST /corporation-tax/corporations/:corporationId/assessments/rebuild-finalized
@@ -1162,7 +1216,6 @@ app.get(
 
 		const limit = parseIntegerQueryParam(c.req.query('limit'))
 		const offset = parseIntegerQueryParam(c.req.query('offset'))
-
 		try {
 			const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
 			const lines = await stub.listAssessmentLines({
@@ -1443,6 +1496,26 @@ app.get('/corporations/:corporationId/ledger/entries', requireAuth(), async (c) 
 	const division = parseIntegerQueryParam(c.req.query('division'))
 	const limit = parseIntegerQueryParam(c.req.query('limit'))
 	const offset = parseIntegerQueryParam(c.req.query('offset'))
+	const sortByQuery = c.req.query('sortBy')
+	const ledgerSortFields = new Set(['entryDate', 'amount', 'division', 'refType', 'sourceType'])
+	if (sortByQuery && !ledgerSortFields.has(sortByQuery)) {
+		return c.json(
+			{ error: 'sortBy must be one of: entryDate, amount, division, refType, sourceType' },
+			400
+		)
+	}
+	const sortBy = sortByQuery as
+		| 'entryDate'
+		| 'amount'
+		| 'division'
+		| 'refType'
+		| 'sourceType'
+		| undefined
+	const sortDirQuery = parseSortDirectionQueryParam(c.req.query('sortDir'))
+	if (sortDirQuery === null) {
+		return c.json({ error: "sortDir must be 'asc' or 'desc'" }, 400)
+	}
+	const sortDir = sortDirQuery ?? 'desc'
 	const refTypes = c.req
 		.query('refTypes')
 		?.split(',')
@@ -1503,6 +1576,8 @@ app.get('/corporations/:corporationId/ledger/entries', requireAuth(), async (c) 
 				maxAmount: c.req.query('maxAmount') || undefined,
 				limit: limit ?? undefined,
 				offset: offset ?? undefined,
+				sortBy,
+				sortDir,
 			})
 			return c.json(entries)
 		} finally {
@@ -2054,7 +2129,7 @@ app.get('/corporations/:corporationId/bills/history', requireAuth(), async (c) =
 	}
 
 	const corporationId = c.req.param('corporationId')
-	const canRead = await canAuditTaxFeature(c.env, user, corporationId)
+	const canRead = await canReadTaxFeature(c.env, user, corporationId)
 	if (!canRead) {
 		return c.json({ error: 'Forbidden' }, 403)
 	}
@@ -2086,17 +2161,30 @@ app.get('/corporations/:corporationId/bills/history/events', requireAuth(), asyn
 	}
 
 	const corporationId = c.req.param('corporationId')
-	const canRead = await canAuditTaxFeature(c.env, user, corporationId)
+	const canRead = await canReadTaxFeature(c.env, user, corporationId)
 	if (!canRead) {
 		return c.json({ error: 'Forbidden' }, 403)
 	}
 
 	const limit = parseIntegerQueryParam(c.req.query('limit'))
 	const offset = parseIntegerQueryParam(c.req.query('offset'))
+	const sortBy = c.req.query('sortBy')
+	const sortDir = c.req.query('sortDir') === 'asc' ? 'asc' : 'desc'
 
 	try {
 		const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
-		const history = await stub.getCorporationBillEventHistory(corporationId, limit, offset)
+		const history = await stub.getCorporationBillEventHistory(
+			corporationId,
+			limit,
+			offset,
+			sortBy === 'createdAt' ||
+				sortBy === 'eventType' ||
+				sortBy === 'billId' ||
+				sortBy === 'actorUserId'
+				? sortBy
+				: undefined,
+			sortDir
+		)
 		return c.json(history)
 	} catch (error) {
 		logTaxRouteError(c, 'Error fetching corporation tax bill event history', error, {
@@ -2122,7 +2210,7 @@ app.get(
 
 		const corporationId = c.req.param('corporationId')
 		const assessmentId = c.req.param('assessmentId')
-		const canRead = await canAuditTaxFeature(c.env, user, corporationId)
+		const canRead = await canReadTaxFeature(c.env, user, corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -2220,11 +2308,12 @@ async function resolveMemberSummaryTargets(input: {
 			return { targetCharacterIds }
 		}
 
-		const scopedCharacterIds = [...allowedCharacterIds]
-		if (scopedCharacterIds.length === 0) {
+		const allowedCharacterIdSet = new Set(allowedCharacterIds)
+		if (allowedCharacterIdSet.size === 0) {
 			return { targetCharacterIds: [] }
 		}
 
+		const maxCharacterSearchResults = 100
 		const matchedCharacterIds = new Set<string>()
 
 		try {
@@ -2232,7 +2321,10 @@ async function resolveMemberSummaryTargets(input: {
 			try {
 				const searchResultIds = await tokenStoreStub.searchCharacter(characterQuery, false)
 				for (const characterId of searchResultIds) {
-					if (scopedCharacterIds.includes(characterId)) {
+					if (
+						matchedCharacterIds.size < maxCharacterSearchResults &&
+						allowedCharacterIdSet.has(characterId)
+					) {
 						matchedCharacterIds.add(characterId)
 					}
 				}
@@ -2249,24 +2341,32 @@ async function resolveMemberSummaryTargets(input: {
 
 		const db = c.get('db')
 		if (db) {
+			const characterSearchConditions = [
+				ilike(userCharacters.characterName, `${characterQuery}%`),
+				eq(userCharacters.status, 'active'),
+				eq(userCharacters.isDeleted, false),
+			]
+			if (canReadWithTaxScopes) {
+				characterSearchConditions.push(eq(userCharacters.corporationId, corporationId))
+			} else {
+				characterSearchConditions.push(eq(userCharacters.userId, user.id))
+			}
+
 			const rows = await db
 				.select({
 					characterId: userCharacters.characterId,
 				})
 				.from(userCharacters)
-				.where(
-					and(
-						inArray(userCharacters.characterId, scopedCharacterIds),
-						ilike(userCharacters.characterName, `${characterQuery}%`)
-					)
-				)
+				.where(and(...characterSearchConditions))
 				.limit(100)
 			for (const row of rows) {
-				matchedCharacterIds.add(row.characterId)
+				if (allowedCharacterIdSet.has(row.characterId)) {
+					matchedCharacterIds.add(row.characterId)
+				}
 			}
 		}
 
-		const targetCharacterIds = Array.from(matchedCharacterIds)
+		const targetCharacterIds = Array.from(matchedCharacterIds).slice(0, maxCharacterSearchResults)
 		if (!canReadWithTaxScopes && targetCharacterIds.length === 0) {
 			return { response: c.json({ error: 'Forbidden' }, 403) }
 		}
@@ -2376,32 +2476,36 @@ app.get('/corporations/:corporationId/member-summary', requireAuth(), async (c) 
 	}
 })
 
-app.get('/corporations/:corporationId/member-summary/taxable-ref-types', requireAuth(), async (c) => {
-	const user = c.get('user')
-	if (!user) {
-		return c.json({ error: 'Unauthorized' }, 401)
-	}
-
-	const corporationId = c.req.param('corporationId')
-	if (!(await canReadTaxFeature(c.env, user, corporationId))) {
-		return c.json({ error: 'Forbidden' }, 403)
-	}
-
-	try {
-		const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
-		try {
-			return c.json({ refTypes: await stub.getTaxableIncomeRefTypes(corporationId) })
-		} finally {
-			disposeRpcStub(stub)
+app.get(
+	'/corporations/:corporationId/member-summary/taxable-ref-types',
+	requireAuth(),
+	async (c) => {
+		const user = c.get('user')
+		if (!user) {
+			return c.json({ error: 'Unauthorized' }, 401)
 		}
-	} catch (error) {
-		logTaxRouteError(c, 'Error fetching taxable corporation tax income types', error, {
-			userId: user.id,
-			corporationId,
-		})
-		return c.json({ error: 'Failed to fetch taxable income types' }, 500)
+
+		const corporationId = c.req.param('corporationId')
+		if (!(await canReadTaxFeature(c.env, user, corporationId))) {
+			return c.json({ error: 'Forbidden' }, 403)
+		}
+
+		try {
+			const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
+			try {
+				return c.json({ refTypes: await stub.getTaxableIncomeRefTypes(corporationId) })
+			} finally {
+				disposeRpcStub(stub)
+			}
+		} catch (error) {
+			logTaxRouteError(c, 'Error fetching taxable corporation tax income types', error, {
+				userId: user.id,
+				corporationId,
+			})
+			return c.json({ error: 'Failed to fetch taxable income types' }, 500)
+		}
 	}
-})
+)
 
 registerCorporationTaxReportsRoutes(app)
 registerCorporationTaxAlertsRoutes(app, { validateDiscordDestinationInput })

--- a/apps/core/src/routes/corporation-tax/index.ts
+++ b/apps/core/src/routes/corporation-tax/index.ts
@@ -2293,6 +2293,14 @@ app.get('/corporations/:corporationId/member-summary', requireAuth(), async (c) 
 	const corporationId = c.req.param('corporationId')
 	const characterQueryRaw = (c.req.query('character') ?? c.req.query('characterId') ?? '').trim()
 	const characterQuery = characterQueryRaw.length > 0 ? characterQueryRaw : undefined
+	const refTypes = (c.req.query('refTypes') ?? '')
+		.split(',')
+		.map((value) => value.trim())
+		.filter(Boolean)
+	if (refTypes.some((value) => !isTaxIncomeRefType(value))) {
+		return c.json({ error: 'refTypes must only include valid tax income ref types' }, 400)
+	}
+	const selectedRefTypes = refTypes.length > 0 ? refTypes : undefined
 	const fromDate = parseDateQueryParam(c.req.query('fromDate'))
 	const toDate = parseDateQueryParam(c.req.query('toDate'))
 	const topRefTypesLimit = parseIntegerQueryParam(c.req.query('topRefTypesLimit'))
@@ -2339,6 +2347,7 @@ app.get('/corporations/:corporationId/member-summary', requireAuth(), async (c) 
 			const result = await stub.getMemberSummaryReport({
 				corporationId,
 				characterIds: resolvedTargets.targetCharacterIds,
+				refTypes: selectedRefTypes,
 				fromDate: fromDate ?? undefined,
 				toDate: toDate ?? undefined,
 				topRefTypesLimit: topRefTypesLimit ?? undefined,
@@ -2364,6 +2373,33 @@ app.get('/corporations/:corporationId/member-summary', requireAuth(), async (c) 
 			corporationId,
 		})
 		return c.json({ error: 'Failed to fetch member summary' }, 500)
+	}
+})
+
+app.get('/corporations/:corporationId/member-summary/taxable-ref-types', requireAuth(), async (c) => {
+	const user = c.get('user')
+	if (!user) {
+		return c.json({ error: 'Unauthorized' }, 401)
+	}
+
+	const corporationId = c.req.param('corporationId')
+	if (!(await canReadTaxFeature(c.env, user, corporationId))) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	try {
+		const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
+		try {
+			return c.json({ refTypes: await stub.getTaxableIncomeRefTypes(corporationId) })
+		} finally {
+			disposeRpcStub(stub)
+		}
+	} catch (error) {
+		logTaxRouteError(c, 'Error fetching taxable corporation tax income types', error, {
+			userId: user.id,
+			corporationId,
+		})
+		return c.json({ error: 'Failed to fetch taxable income types' }, 500)
 	}
 })
 

--- a/apps/core/src/routes/corporation-tax/reports-routes.ts
+++ b/apps/core/src/routes/corporation-tax/reports-routes.ts
@@ -2,7 +2,7 @@ import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { requireAuth } from '../../middleware/session'
-import { canAuditTaxFeature } from '../../middleware/tax-permissions'
+import { canAuditTaxFeature, canReadTaxReports } from '../../middleware/tax-permissions'
 import {
 	parseBooleanQueryParam,
 	parseDateQueryParam,
@@ -94,7 +94,7 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			return c.json({ error: parsed.error }, 400)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, parsed.filters?.corporationId)
+		const canRead = await canReadTaxReports(c.env, user, parsed.filters?.corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -129,7 +129,7 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			return c.json({ error: parsed.error }, 400)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, parsed.filters?.corporationId)
+		const canRead = await canReadTaxReports(c.env, user, parsed.filters?.corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -162,7 +162,7 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			return c.json({ error: parsed.error }, 400)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, parsed.filters?.corporationId)
+		const canRead = await canReadTaxReports(c.env, user, parsed.filters?.corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -177,6 +177,30 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 				corporationId: parsed.filters?.corporationId,
 			})
 			return c.json({ error: 'Failed to fetch top income sources report' }, 500)
+		}
+	})
+
+	app.get('/reports/taxable-ref-types', requireAuth(), async (c) => {
+		const user = c.get('user')
+		if (!user) {
+			return c.json({ error: 'Unauthorized' }, 401)
+		}
+
+		const corporationId = c.req.query('corporationId')?.trim() || undefined
+		if (!(await canReadTaxReports(c.env, user, corporationId))) {
+			return c.json({ error: 'Forbidden' }, 403)
+		}
+
+		try {
+			const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
+			const refTypes = await stub.getTaxableIncomeRefTypes(corporationId)
+			return c.json({ refTypes })
+		} catch (error) {
+			logTaxReportsRouteError(c, 'Error fetching taxable report income types', error, {
+				userId: user.id,
+				corporationId,
+			})
+			return c.json({ error: 'Failed to fetch taxable income types' }, 500)
 		}
 	})
 
@@ -195,7 +219,7 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			return c.json({ error: parsed.error }, 400)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, parsed.filters?.corporationId)
+		const canRead = await canReadTaxReports(c.env, user, parsed.filters?.corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -230,7 +254,7 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			return c.json({ error: parsed.error }, 400)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, parsed.filters?.corporationId)
+		const canRead = await canReadTaxReports(c.env, user, parsed.filters?.corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -258,19 +282,22 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			return c.json({ error: 'Unauthorized' }, 401)
 		}
 
-		const parsed = parseRollupReportFiltersFromQuery(c.req)
+		const parsed = parseRollupReportFiltersFromQuery(c.req, {
+			allowedSortFields: ['rollupDate', 'taxDue', 'taxPaid', 'taxDelta', 'entryCount'],
+			maxLimit: 3650,
+		})
 		if (parsed.error) {
 			return c.json({ error: parsed.error }, 400)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, parsed.filters?.corporationId)
+		const canRead = await canReadTaxReports(c.env, user, parsed.filters?.corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
 
 		try {
 			const stub = getStub<CorporationTax>(c.env.CORPORATION_TAX, 'default')
-			const report = await stub.getComplianceOverTimeReport(parsed.filters)
+			const report = await stub.getComplianceOverTimeReportPage(parsed.filters)
 			return c.json(report)
 		} catch (error) {
 			logTaxReportsRouteError(c, 'Error fetching tax compliance report', error, {
@@ -331,7 +358,7 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, corporationId)
+		const canRead = await canReadTaxReports(c.env, user, corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -431,7 +458,7 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 			return c.json({ error: parsed.error }, 400)
 		}
 
-		const canRead = await canAuditTaxFeature(c.env, user, parsed.filters?.corporationId)
+		const canRead = await canReadTaxReports(c.env, user, parsed.filters?.corporationId)
 		if (!canRead) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}
@@ -548,6 +575,8 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 		const status = c.req.query('status')
 		const limit = parseIntegerQueryParam(c.req.query('limit'))
 		const offset = parseIntegerQueryParam(c.req.query('offset'))
+		const sortBy = c.req.query('sortBy')
+		const sortDir = parseSortDirectionQueryParam(c.req.query('sortDir'))
 
 		if (format !== undefined && !TAX_EXPORT_FORMATS.has(format)) {
 			return c.json({ error: "format must be 'csv' or 'xlsx'" }, 400)
@@ -570,6 +599,21 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 		if (offset !== undefined && offset < 0) {
 			return c.json({ error: 'offset must be an integer >= 0' }, 400)
 		}
+		if (sortDir === null) {
+			return c.json({ error: "sortDir must be 'asc' or 'desc'" }, 400)
+		}
+		const exportSortFields = [
+			'requestedAt',
+			'corporationId',
+			'reportType',
+			'format',
+			'status',
+			'rowCount',
+			'completedAt',
+		] as const
+		if (sortBy && !exportSortFields.includes(sortBy as (typeof exportSortFields)[number])) {
+			return c.json({ error: `sortBy must be one of: ${exportSortFields.join(', ')}` }, 400)
+		}
 
 		const canRead = await canAuditTaxFeature(c.env, user, corporationId)
 		if (!canRead) {
@@ -584,6 +628,8 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 				status: status as 'queued' | 'running' | 'completed' | 'failed' | undefined,
 				limit,
 				offset,
+				sortBy: sortBy as (typeof exportSortFields)[number] | undefined,
+				sortDir: sortDir ?? undefined,
 			})
 			return c.json(exportsList)
 		} catch (error) {
@@ -743,6 +789,8 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 		const activeOnly = parseBooleanQueryParam(c.req.query('activeOnly'))
 		const limit = parseIntegerQueryParam(c.req.query('limit'))
 		const offset = parseIntegerQueryParam(c.req.query('offset'))
+		const sortBy = c.req.query('sortBy')
+		const sortDir = parseSortDirectionQueryParam(c.req.query('sortDir'))
 
 		if ((c.req.query('activeOnly') ?? '') !== '' && activeOnly === undefined) {
 			return c.json({ error: 'activeOnly must be true/false' }, 400)
@@ -752,6 +800,22 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 		}
 		if (offset !== undefined && offset < 0) {
 			return c.json({ error: 'offset must be an integer >= 0' }, 400)
+		}
+		if (sortDir === null) {
+			return c.json({ error: "sortDir must be 'asc' or 'desc'" }, 400)
+		}
+		const scheduleSortFields = [
+			'name',
+			'corporationId',
+			'reportType',
+			'format',
+			'frequency',
+			'isActive',
+			'nextRunAt',
+			'lastRunAt',
+		] as const
+		if (sortBy && !scheduleSortFields.includes(sortBy as (typeof scheduleSortFields)[number])) {
+			return c.json({ error: `sortBy must be one of: ${scheduleSortFields.join(', ')}` }, 400)
 		}
 
 		const canRead = await canAuditTaxFeature(c.env, user, corporationId)
@@ -766,6 +830,8 @@ export function registerCorporationTaxReportsRoutes(app: Hono<App>): void {
 				activeOnly,
 				limit,
 				offset,
+				sortBy: sortBy as (typeof scheduleSortFields)[number] | undefined,
+				sortDir: sortDir ?? undefined,
 			})
 			return c.json(schedules)
 		} catch (error) {

--- a/apps/core/src/routes/corporation-tax/shared.ts
+++ b/apps/core/src/routes/corporation-tax/shared.ts
@@ -310,12 +310,14 @@ export function parseRollupReportFiltersFromQuery(
 	request: {
 		query: (key: string) => string | undefined
 	},
-	options?: { allowedSortFields?: readonly string[] }
+	options?: { allowedSortFields?: readonly string[]; maxLimit?: number }
 ): {
 	filters?: {
 		corporationId?: string
 		fromDate?: Date
 		toDate?: Date
+		refTypes?: string[]
+		incomeMode?: 'total' | 'assessed'
 		limit?: number
 		offset?: number
 		sortBy?: string
@@ -326,10 +328,16 @@ export function parseRollupReportFiltersFromQuery(
 	const corporationId = request.query('corporationId') || undefined
 	const fromDate = parseDateQueryParam(request.query('fromDate'))
 	const toDate = parseDateQueryParam(request.query('toDate'))
+	const refTypes = request
+		.query('refTypes')
+		?.split(',')
+		.map((value) => value.trim())
+		.filter(Boolean)
 	const limit = parseIntegerQueryParam(request.query('limit'))
 	const offset = parseIntegerQueryParam(request.query('offset'))
 	const sortBy = request.query('sortBy') || undefined
 	const sortDirection = parseSortDirectionQueryParam(request.query('sortDir'))
+	const incomeMode = request.query('incomeMode') || undefined
 
 	if (fromDate === null) {
 		return { error: 'fromDate must be a valid ISO date string' }
@@ -340,14 +348,20 @@ export function parseRollupReportFiltersFromQuery(
 	if (fromDate && toDate && fromDate > toDate) {
 		return { error: 'fromDate must be before or equal to toDate' }
 	}
-	if (limit !== undefined && (limit < 1 || limit > 200)) {
-		return { error: 'limit must be an integer between 1 and 200' }
+	if (refTypes && refTypes.some((value) => !isTaxIncomeRefType(value))) {
+		return { error: 'refTypes must only include valid tax income ref types' }
+	}
+	if (limit !== undefined && (limit < 1 || limit > (options?.maxLimit ?? 200))) {
+		return { error: `limit must be an integer between 1 and ${options?.maxLimit ?? 200}` }
 	}
 	if (offset !== undefined && offset < 0) {
 		return { error: 'offset must be an integer >= 0' }
 	}
 	if (sortDirection === null) {
 		return { error: "sortDir must be 'asc' or 'desc'" }
+	}
+	if (incomeMode && incomeMode !== 'total' && incomeMode !== 'assessed') {
+		return { error: "incomeMode must be 'total' or 'assessed'" }
 	}
 	if (sortBy && options?.allowedSortFields && !options.allowedSortFields.includes(sortBy)) {
 		return { error: `sortBy must be one of: ${options.allowedSortFields.join(', ')}` }
@@ -358,6 +372,8 @@ export function parseRollupReportFiltersFromQuery(
 			corporationId,
 			fromDate: fromDate ?? undefined,
 			toDate: toDate ?? undefined,
+			refTypes: refTypes && refTypes.length > 0 ? refTypes : undefined,
+			incomeMode: incomeMode as 'total' | 'assessed' | undefined,
 			limit: limit ?? undefined,
 			offset: offset ?? undefined,
 			sortBy: sortBy ?? undefined,
@@ -435,6 +451,8 @@ export function parseAuditLogFiltersFromQuery(request: {
 		toDate?: Date
 		limit?: number
 		offset?: number
+		sortBy?: 'createdAt' | 'corporationId' | 'actorUserId' | 'action'
+		sortDir?: 'asc' | 'desc'
 	}
 	error?: string
 } {
@@ -445,6 +463,8 @@ export function parseAuditLogFiltersFromQuery(request: {
 	const toDate = parseDateQueryParam(request.query('toDate'))
 	const limit = parseIntegerQueryParam(request.query('limit'))
 	const offset = parseIntegerQueryParam(request.query('offset'))
+	const sortBy = request.query('sortBy') || undefined
+	const sortDir = parseSortDirectionQueryParam(request.query('sortDir'))
 
 	if (fromDate === null) {
 		return { error: 'fromDate must be a valid ISO date string' }
@@ -461,6 +481,12 @@ export function parseAuditLogFiltersFromQuery(request: {
 	if (offset !== undefined && offset < 0) {
 		return { error: 'offset must be an integer greater than or equal to 0' }
 	}
+	if (sortDir === null) {
+		return { error: "sortDir must be 'asc' or 'desc'" }
+	}
+	if (sortBy && !['createdAt', 'corporationId', 'actorUserId', 'action'].includes(sortBy)) {
+		return { error: 'sortBy must be one of: createdAt, corporationId, actorUserId, action' }
+	}
 
 	return {
 		filters: {
@@ -471,6 +497,8 @@ export function parseAuditLogFiltersFromQuery(request: {
 			toDate: toDate ?? undefined,
 			limit: limit ?? undefined,
 			offset: offset ?? undefined,
+			sortBy: sortBy as 'createdAt' | 'corporationId' | 'actorUserId' | 'action' | undefined,
+			sortDir: sortDir ?? undefined,
 		},
 	}
 }

--- a/apps/corporation-tax/.migrations/0003_misty_star_brand.sql
+++ b/apps/corporation-tax/.migrations/0003_misty_star_brand.sql
@@ -1,0 +1,6 @@
+CREATE INDEX "tax_assess_corp_end_id_idx" ON "tax_assessments" USING btree ("corporation_id","tax_period_end","id");--> statement-breakpoint
+CREATE INDEX "tax_disc_corp_created_id_idx" ON "tax_discrepancies" USING btree ("corporation_id","created_at","id");--> statement-breakpoint
+CREATE INDEX "tax_ledger_corp_date_id_idx" ON "tax_ledger_entries" USING btree ("corporation_id","entry_date","id");--> statement-breakpoint
+CREATE INDEX "tax_final_corp_date_end_idx" ON "tax_member_contribution_finalized_rollups" USING btree ("corporation_id","rollup_date","period_end");--> statement-breakpoint
+CREATE INDEX "tax_proj_corp_date_end_idx" ON "tax_member_contribution_projection_rollups" USING btree ("corporation_id","rollup_date","period_end");--> statement-breakpoint
+ALTER TABLE "tax_assessments" DROP COLUMN "portal_tax_rate_bps";

--- a/apps/corporation-tax/.migrations/meta/0003_snapshot.json
+++ b/apps/corporation-tax/.migrations/meta/0003_snapshot.json
@@ -1,0 +1,2927 @@
+{
+  "id": "9dbfcab2-63ed-4a2f-ac09-bc1e2f1f040a",
+  "prevId": "763706bd-32fc-415f-a9ce-177528aa600b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tax_assessment_lines": {
+      "name": "tax_assessment_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ledger_entry_id": {
+          "name": "ledger_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_rule_set_id": {
+          "name": "applied_rule_set_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate_bps": {
+          "name": "tax_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "taxable_amount": {
+          "name": "taxable_amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_assessment_lines_assessment_id_idx": {
+          "name": "tax_assessment_lines_assessment_id_idx",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assessment_lines_ledger_entry_id_idx": {
+          "name": "tax_assessment_lines_ledger_entry_id_idx",
+          "columns": [
+            {
+              "expression": "ledger_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assessment_lines_applied_rule_set_id_idx": {
+          "name": "tax_assessment_lines_applied_rule_set_id_idx",
+          "columns": [
+            {
+              "expression": "applied_rule_set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tax_assessment_lines_assessment_id_tax_assessments_id_fk": {
+          "name": "tax_assessment_lines_assessment_id_tax_assessments_id_fk",
+          "tableFrom": "tax_assessment_lines",
+          "tableTo": "tax_assessments",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_assessment_lines_assessment_ledger_unique": {
+          "name": "tax_assessment_lines_assessment_ledger_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "assessment_id",
+            "ledger_entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_assessments": {
+      "name": "tax_assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_period_start": {
+          "name": "tax_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_period_end": {
+          "name": "tax_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_scope": {
+          "name": "assessment_scope",
+          "type": "tax_assessment_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'corporation'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable_income": {
+          "name": "taxable_income",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "non_taxable_income": {
+          "name": "non_taxable_income",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_due": {
+          "name": "tax_due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_delta": {
+          "name": "tax_delta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "tax_assessment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "in_game_tax_rate_bps": {
+          "name": "in_game_tax_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_id": {
+          "name": "bill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_status": {
+          "name": "bill_status",
+          "type": "tax_bill_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_status_last_synced_at": {
+          "name": "bill_status_last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_assessments_corporation_id_idx": {
+          "name": "tax_assessments_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assessments_status_idx": {
+          "name": "tax_assessments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assessments_scope_idx": {
+          "name": "tax_assessments_scope_idx",
+          "columns": [
+            {
+              "expression": "assessment_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assessments_period_start_idx": {
+          "name": "tax_assessments_period_start_idx",
+          "columns": [
+            {
+              "expression": "tax_period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assessments_period_end_idx": {
+          "name": "tax_assessments_period_end_idx",
+          "columns": [
+            {
+              "expression": "tax_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assessments_bill_id_idx": {
+          "name": "tax_assessments_bill_id_idx",
+          "columns": [
+            {
+              "expression": "bill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_assess_corp_end_id_idx": {
+          "name": "tax_assess_corp_end_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tax_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_assessments_scope_period_unique": {
+          "name": "tax_assessments_scope_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "tax_period_start",
+            "tax_period_end",
+            "assessment_scope",
+            "scope_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_audit_log": {
+      "name": "tax_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_audit_log_corporation_id_idx": {
+          "name": "tax_audit_log_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_audit_log_created_at_idx": {
+          "name": "tax_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_bill_sync_events": {
+      "name": "tax_bill_sync_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_id": {
+          "name": "bill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_bill_sync_events_corporation_id_idx": {
+          "name": "tax_bill_sync_events_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_bill_sync_events_assessment_id_idx": {
+          "name": "tax_bill_sync_events_assessment_id_idx",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_bill_sync_events_bill_id_idx": {
+          "name": "tax_bill_sync_events_bill_id_idx",
+          "columns": [
+            {
+              "expression": "bill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_bill_sync_events_synced_at_idx": {
+          "name": "tax_bill_sync_events_synced_at_idx",
+          "columns": [
+            {
+              "expression": "synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tax_bill_sync_events_assessment_id_tax_assessments_id_fk": {
+          "name": "tax_bill_sync_events_assessment_id_tax_assessments_id_fk",
+          "tableFrom": "tax_bill_sync_events",
+          "tableTo": "tax_assessments",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_corporation_billing_configs": {
+      "name": "tax_corporation_billing_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_enabled": {
+          "name": "billing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_issuer_user_id": {
+          "name": "billing_issuer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "billing_payee_id": {
+          "name": "billing_payee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "billing_payee_type": {
+          "name": "billing_payee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "billing_due_days": {
+          "name": "billing_due_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_corporation_billing_configs_corporation_id_idx": {
+          "name": "tax_corporation_billing_configs_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_corporation_billing_configs_updated_at_idx": {
+          "name": "tax_corporation_billing_configs_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_corporation_billing_configs_one_default_per_corp": {
+          "name": "tax_corporation_billing_configs_one_default_per_corp",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tax_corporation_billing_configs\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_corporation_billing_configs_payee_tuple_unique": {
+          "name": "tax_corporation_billing_configs_payee_tuple_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "billing_payee_type",
+            "billing_payee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_corporation_exclusions": {
+      "name": "tax_corporation_exclusions",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_corporation_exclusions_updated_at_idx": {
+          "name": "tax_corporation_exclusions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_discrepancies": {
+      "name": "tax_discrepancies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discrepancy_type": {
+          "name": "discrepancy_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_discrepancies_corporation_id_idx": {
+          "name": "tax_discrepancies_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_discrepancies_assessment_id_idx": {
+          "name": "tax_discrepancies_assessment_id_idx",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_discrepancies_discrepancy_type_idx": {
+          "name": "tax_discrepancies_discrepancy_type_idx",
+          "columns": [
+            {
+              "expression": "discrepancy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_discrepancies_severity_idx": {
+          "name": "tax_discrepancies_severity_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_disc_corp_created_id_idx": {
+          "name": "tax_disc_corp_created_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tax_discrepancies_assessment_id_tax_assessments_id_fk": {
+          "name": "tax_discrepancies_assessment_id_tax_assessments_id_fk",
+          "tableFrom": "tax_discrepancies",
+          "tableTo": "tax_assessments",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_export_schedules": {
+      "name": "tax_export_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "tax_export_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "tax_export_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_export_schedules_corporation_id_idx": {
+          "name": "tax_export_schedules_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_export_schedules_created_by_idx": {
+          "name": "tax_export_schedules_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_export_schedules_is_active_idx": {
+          "name": "tax_export_schedules_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_export_schedules_next_run_at_idx": {
+          "name": "tax_export_schedules_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_exports": {
+      "name": "tax_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "tax_export_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tax_export_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_esi_version": {
+          "name": "source_esi_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_exports_corporation_id_idx": {
+          "name": "tax_exports_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_exports_requested_by_idx": {
+          "name": "tax_exports_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_exports_status_idx": {
+          "name": "tax_exports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_exports_requested_at_idx": {
+          "name": "tax_exports_requested_at_idx",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_ledger_entries": {
+      "name": "tax_ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_primary_id": {
+          "name": "source_primary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_secondary_id": {
+          "name": "source_secondary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_party_id": {
+          "name": "first_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_party_id": {
+          "name": "second_party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_ledger_entries_corporation_id_idx": {
+          "name": "tax_ledger_entries_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_ledger_entries_ref_type_idx": {
+          "name": "tax_ledger_entries_ref_type_idx",
+          "columns": [
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_ledger_entries_entry_date_idx": {
+          "name": "tax_ledger_entries_entry_date_idx",
+          "columns": [
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_ledger_corp_date_id_idx": {
+          "name": "tax_ledger_corp_date_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_ledger_entries_source_key_unique": {
+          "name": "tax_ledger_entries_source_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_member_contribution_finalized_rollups": {
+      "name": "tax_member_contribution_finalized_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_date": {
+          "name": "rollup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contribution_income": {
+          "name": "contribution_income",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "taxable_contribution_income": {
+          "name": "taxable_contribution_income",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "assessment_count": {
+          "name": "assessment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "finalized_assessment_id": {
+          "name": "finalized_assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_assessment_at": {
+          "name": "last_assessment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ledger_entry_date": {
+          "name": "last_ledger_entry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_member_final_rollups_corp_period_idx": {
+          "name": "tax_member_final_rollups_corp_period_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_member_final_rollups_corp_char_period_idx": {
+          "name": "tax_member_final_rollups_corp_char_period_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_member_final_rollups_corp_ref_rollup_date_idx": {
+          "name": "tax_member_final_rollups_corp_ref_rollup_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rollup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_member_final_rollups_assessment_id_idx": {
+          "name": "tax_member_final_rollups_assessment_id_idx",
+          "columns": [
+            {
+              "expression": "finalized_assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_final_corp_date_end_idx": {
+          "name": "tax_final_corp_date_end_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rollup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tax_member_contribution_finalized_rollups_finalized_assessment_id_tax_assessments_id_fk": {
+          "name": "tax_member_contribution_finalized_rollups_finalized_assessment_id_tax_assessments_id_fk",
+          "tableFrom": "tax_member_contribution_finalized_rollups",
+          "tableTo": "tax_assessments",
+          "columnsFrom": [
+            "finalized_assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_member_final_rollups_unique": {
+          "name": "tax_member_final_rollups_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "period_start",
+            "period_end",
+            "rollup_date",
+            "character_id",
+            "ref_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_member_contribution_projection_rollups": {
+      "name": "tax_member_contribution_projection_rollups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rollup_date": {
+          "name": "rollup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contribution_income": {
+          "name": "contribution_income",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "taxable_contribution_income": {
+          "name": "taxable_contribution_income",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "assessment_count": {
+          "name": "assessment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_assessment_at": {
+          "name": "last_assessment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ledger_entry_date": {
+          "name": "last_ledger_entry_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_member_proj_rollups_corp_period_idx": {
+          "name": "tax_member_proj_rollups_corp_period_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_member_proj_rollups_corp_char_period_idx": {
+          "name": "tax_member_proj_rollups_corp_char_period_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_member_proj_rollups_corp_ref_rollup_date_idx": {
+          "name": "tax_member_proj_rollups_corp_ref_rollup_date_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rollup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_proj_corp_date_end_idx": {
+          "name": "tax_proj_corp_date_end_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rollup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_member_proj_rollups_unique": {
+          "name": "tax_member_proj_rollups_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "period_start",
+            "period_end",
+            "rollup_date",
+            "character_id",
+            "ref_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_member_summary_versions": {
+      "name": "tax_member_summary_versions",
+      "schema": "",
+      "columns": {
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "projection_version": {
+          "name": "projection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "finalized_version": {
+          "name": "finalized_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "projection_updated_at": {
+          "name": "projection_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_updated_at": {
+          "name": "finalized_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_membership_mutated_at": {
+          "name": "rule_membership_mutated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_member_summary_versions_updated_at_idx": {
+          "name": "tax_member_summary_versions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_notification_destinations": {
+      "name": "tax_notification_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_notification_destinations_updated_at_idx": {
+          "name": "tax_notification_destinations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_periods": {
+      "name": "tax_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tax_period_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_periods_corporation_id_idx": {
+          "name": "tax_periods_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_periods_period_start_idx": {
+          "name": "tax_periods_period_start_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_periods_period_end_idx": {
+          "name": "tax_periods_period_end_idx",
+          "columns": [
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_periods_status_idx": {
+          "name": "tax_periods_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_periods_corp_period_unique": {
+          "name": "tax_periods_corp_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "period_start",
+            "period_end"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_rule_group_attachments": {
+      "name": "tax_rule_group_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_group_id": {
+          "name": "rule_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_rule_group_attachments_corporation_id_idx": {
+          "name": "tax_rule_group_attachments_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tax_rule_group_attachments_rule_group_id_tax_rule_groups_id_fk": {
+          "name": "tax_rule_group_attachments_rule_group_id_tax_rule_groups_id_fk",
+          "tableFrom": "tax_rule_group_attachments",
+          "tableTo": "tax_rule_groups",
+          "columnsFrom": [
+            "rule_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_rule_group_attachments_unique": {
+          "name": "tax_rule_group_attachments_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule_group_id",
+            "corporation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_rule_groups": {
+      "name": "tax_rule_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_global": {
+          "name": "is_default_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_rule_groups_default_global_idx": {
+          "name": "tax_rule_groups_default_global_idx",
+          "columns": [
+            {
+              "expression": "is_default_global",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_rule_groups_name_idx": {
+          "name": "tax_rule_groups_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_rule_sets": {
+      "name": "tax_rule_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_group_id": {
+          "name": "rule_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "applies_to_ref_type": {
+          "name": "applies_to_ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_rate_bps": {
+          "name": "tax_rate_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_rule_sets_rule_group_id_idx": {
+          "name": "tax_rule_sets_rule_group_id_idx",
+          "columns": [
+            {
+              "expression": "rule_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_rule_sets_is_active_idx": {
+          "name": "tax_rule_sets_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_rule_sets_priority_idx": {
+          "name": "tax_rule_sets_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_rule_sets_ref_type_idx": {
+          "name": "tax_rule_sets_ref_type_idx",
+          "columns": [
+            {
+              "expression": "applies_to_ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tax_rule_sets_rule_group_id_tax_rule_groups_id_fk": {
+          "name": "tax_rule_sets_rule_group_id_tax_rule_groups_id_fk",
+          "tableFrom": "tax_rule_sets",
+          "tableTo": "tax_rule_groups",
+          "columnsFrom": [
+            "rule_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_sync_checkpoints": {
+      "name": "tax_sync_checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "corporation_id": {
+          "name": "corporation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_sync_at": {
+          "name": "last_successful_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tax_sync_checkpoints_corporation_id_idx": {
+          "name": "tax_sync_checkpoints_corporation_id_idx",
+          "columns": [
+            {
+              "expression": "corporation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_sync_checkpoints_source_type_idx": {
+          "name": "tax_sync_checkpoints_source_type_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tax_sync_checkpoints_last_successful_sync_at_idx": {
+          "name": "tax_sync_checkpoints_last_successful_sync_at_idx",
+          "columns": [
+            {
+              "expression": "last_successful_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tax_sync_checkpoints_corp_source_unique": {
+          "name": "tax_sync_checkpoints_corp_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "corporation_id",
+            "source_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.tax_alert_discord_delivery_status": {
+      "name": "tax_alert_discord_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.tax_alert_severity": {
+      "name": "tax_alert_severity",
+      "schema": "public",
+      "values": [
+        "critical",
+        "warning",
+        "info"
+      ]
+    },
+    "public.tax_alert_status": {
+      "name": "tax_alert_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "acknowledged",
+        "resolved"
+      ]
+    },
+    "public.tax_assessment_scope": {
+      "name": "tax_assessment_scope",
+      "schema": "public",
+      "values": [
+        "corporation",
+        "division",
+        "character"
+      ]
+    },
+    "public.tax_assessment_status": {
+      "name": "tax_assessment_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "underpaid",
+        "paid",
+        "overpaid",
+        "excluded"
+      ]
+    },
+    "public.tax_bill_status": {
+      "name": "tax_bill_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "issued",
+        "paid",
+        "cancelled",
+        "overdue"
+      ]
+    },
+    "public.tax_export_format": {
+      "name": "tax_export_format",
+      "schema": "public",
+      "values": [
+        "csv",
+        "xlsx"
+      ]
+    },
+    "public.tax_export_frequency": {
+      "name": "tax_export_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.tax_export_status": {
+      "name": "tax_export_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.tax_period_status": {
+      "name": "tax_period_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "assessed",
+        "closed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/corporation-tax/.migrations/meta/_journal.json
+++ b/apps/corporation-tax/.migrations/meta/_journal.json
@@ -1,27 +1,34 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1774176427050,
-			"tag": "0000_corporation_tax_initial",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1774241268730,
-			"tag": "0001_tax_alerts_reconcile",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1774261693000,
-			"tag": "0002_drop_portal_tax_rate_bps",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1774176427050,
+      "tag": "0000_corporation_tax_initial",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1774241268730,
+      "tag": "0001_tax_alerts_reconcile",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1774261693000,
+      "tag": "0002_drop_portal_tax_rate_bps",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1786750391208,
+      "tag": "0003_misty_star_brand",
+      "breakpoints": true
+    }
+  ]
 }

--- a/apps/corporation-tax/package.json
+++ b/apps/corporation-tax/package.json
@@ -29,6 +29,7 @@
 		"@repo/do-utils": "workspace:*",
 		"@repo/eve-corporation-data": "workspace:*",
 		"@repo/hono-helpers": "workspace:*",
+		"@repo/workflow-utils": "workspace:*",
 		"drizzle-orm": "0.45.2",
 		"hono": "4.12.27",
 		"workers-tagged-logger": "0.13.7"

--- a/apps/corporation-tax/src/context.ts
+++ b/apps/corporation-tax/src/context.ts
@@ -1,3 +1,4 @@
+import type { TaxAssessmentWorkflowParams } from '@repo/corporation-tax'
 import type { HonoApp } from '@repo/hono-helpers'
 import type { SharedHonoEnv, SharedHonoVariables } from '@repo/hono-helpers/src/types'
 import type { createDb } from './db'
@@ -10,6 +11,7 @@ export type Env = SharedHonoEnv & {
 	EVE_CORPORATION_DATA: DurableObjectNamespace
 	EVE_CHARACTER_DATA: DurableObjectNamespace
 	DISCORD: DurableObjectNamespace
+	TAX_ASSESSMENT_WORKFLOW: Workflow<TaxAssessmentWorkflowParams>
 }
 
 export type Variables = SharedHonoVariables & {

--- a/apps/corporation-tax/src/db/schema.ts
+++ b/apps/corporation-tax/src/db/schema.ts
@@ -183,6 +183,7 @@ export const taxAssessments = pgTable(
 		index('tax_assessments_period_start_idx').on(table.taxPeriodStart),
 		index('tax_assessments_period_end_idx').on(table.taxPeriodEnd),
 		index('tax_assessments_bill_id_idx').on(table.billId),
+		index('tax_assess_corp_end_id_idx').on(table.corporationId, table.taxPeriodEnd, table.id),
 	]
 )
 
@@ -258,6 +259,7 @@ export const taxDiscrepancies = pgTable(
 		index('tax_discrepancies_assessment_id_idx').on(table.assessmentId),
 		index('tax_discrepancies_discrepancy_type_idx').on(table.discrepancyType),
 		index('tax_discrepancies_severity_idx').on(table.severity),
+		index('tax_disc_corp_created_id_idx').on(table.corporationId, table.createdAt, table.id),
 	]
 )
 
@@ -413,6 +415,7 @@ export const taxLedgerEntries = pgTable(
 		index('tax_ledger_entries_corporation_id_idx').on(table.corporationId),
 		index('tax_ledger_entries_ref_type_idx').on(table.refType),
 		index('tax_ledger_entries_entry_date_idx').on(table.entryDate),
+		index('tax_ledger_corp_date_id_idx').on(table.corporationId, table.entryDate, table.id),
 	]
 )
 
@@ -485,6 +488,7 @@ export const taxMemberContributionProjectionRollups = pgTable(
 			table.refType,
 			table.rollupDate
 		),
+		index('tax_proj_corp_date_end_idx').on(table.corporationId, table.rollupDate, table.periodEnd),
 	]
 )
 
@@ -539,6 +543,7 @@ export const taxMemberContributionFinalizedRollups = pgTable(
 			table.rollupDate
 		),
 		index('tax_member_final_rollups_assessment_id_idx').on(table.finalizedAssessmentId),
+		index('tax_final_corp_date_end_idx').on(table.corporationId, table.rollupDate, table.periodEnd),
 	]
 )
 

--- a/apps/corporation-tax/src/durable-object.ts
+++ b/apps/corporation-tax/src/durable-object.ts
@@ -735,6 +735,12 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		)
 	}
 
+	async getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
+		return this.rpcGuard('getTaxableIncomeRefTypes', { corporationId }, () =>
+			this.reportsRpc.getTaxableIncomeRefTypes(corporationId)
+		)
+	}
+
 	async requestExport(actorUserId: string, input: RequestTaxExportInput): Promise<TaxExportRecord> {
 		return this.operationsRpc.requestExport(actorUserId, input)
 	}

--- a/apps/corporation-tax/src/durable-object.ts
+++ b/apps/corporation-tax/src/durable-object.ts
@@ -3,6 +3,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { and, eq, inArray, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger, toErrorLogDetails } from '@repo/hono-helpers'
+import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from './db'
 import {
@@ -59,9 +60,14 @@ import type {
 	TaxAlert,
 	TaxAssessment,
 	TaxAssessmentLine,
+	TaxAssessmentPage,
 	TaxAssessmentWithBillHistory,
+	TaxAssessmentWorkflowOutput,
+	TaxAssessmentWorkflowStartResult,
+	TaxAssessmentWorkflowStatusResult,
 	TaxAuditLogEntry,
 	TaxBillingEventHistoryRow,
+	TaxBillingEventSortBy,
 	TaxBillStateSyncInput,
 	TaxBillStatusReportRow,
 	TaxCompliancePoint,
@@ -109,9 +115,40 @@ const DEFAULT_ESS_ALERT_THRESHOLD_ISK = 1_000_000_000
 const TRIGGERED_INGEST_OVERLAP_WINDOW_MS = 48 * 60 * 60 * 1000
 const TAX_PROJECTION_RETRY_TTL_MS = 7 * 24 * 60 * 60 * 1000
 const TAX_PROJECTION_RETRY_KEY_PREFIX = 'tax-projection-retry-intent:'
+const TAX_ASSESSMENT_WORKFLOW_RESERVATION_TTL_SECONDS = 60 * 60
+const TAX_ASSESSMENT_WORKFLOW_RESERVATION_PREFIX = 'tax-assessment-workflow:'
+
+function isTaxAssessmentWorkflowOutput(value: unknown): value is TaxAssessmentWorkflowOutput {
+	if (!value || typeof value !== 'object') return false
+	const output = value as Partial<TaxAssessmentWorkflowOutput>
+	return (
+		output.status === 'completed' &&
+		typeof output.assessmentId === 'string' &&
+		typeof output.lineCount === 'number' &&
+		typeof output.discrepancyCount === 'number'
+	)
+}
+
+function normalizeTaxAssessmentWorkflowStatus(
+	status: string,
+	output: TaxAssessmentWorkflowOutput | null
+): TaxAssessmentWorkflowStatusResult['status'] {
+	if (output?.status === 'completed') return 'completed'
+	if (status === 'complete') return 'completed'
+	if (status === 'errored' || status === 'terminated') return 'failed'
+	if (status === 'queued' || status === 'running' || status === 'paused' || status === 'waiting') {
+		return status
+	}
+	return 'unknown'
+}
 
 type TaxProjectionRetryIntentEnvelope = {
 	value: string
+	expiresAt: number
+}
+
+type TaxAssessmentWorkflowReservation = {
+	workflowInstanceId: string
 	expiresAt: number
 }
 export class CorporationTaxDO extends DurableObject<Env, {}> implements CorporationTax {
@@ -504,7 +541,7 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 	async listLedgerEntries(
 		corporationId: string,
 		filters?: TaxLedgerWindowFilters
-	): Promise<TaxLedgerEntry[]> {
+	): Promise<TaxPagedResult<TaxLedgerEntry>> {
 		return this.rpcGuard(
 			'listLedgerEntries',
 			{
@@ -534,7 +571,7 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		return this.ledgerRpc.trimLedgerEntries(actorUserId, corporationId, retentionDays)
 	}
 
-	async listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessment[]> {
+	async listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessmentPage> {
 		return this.ledgerRpc.listAssessments(filters)
 	}
 
@@ -543,6 +580,107 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		input: RunTaxAssessmentForPeriodInput
 	): Promise<RunTaxAssessmentForPeriodResult> {
 		return this.ledgerRpc.runAssessmentForPeriod(actorUserId, input)
+	}
+
+	async startAssessmentWorkflow(
+		actorUserId: string,
+		input: RunTaxAssessmentForPeriodInput
+	): Promise<TaxAssessmentWorkflowStartResult> {
+		if (
+			!Number.isFinite(input.periodStart.getTime()) ||
+			!Number.isFinite(input.periodEnd.getTime()) ||
+			input.periodStart >= input.periodEnd
+		) {
+			throw new Error('Assessment period must contain valid, ordered dates')
+		}
+
+		const reservationKey = this.getTaxAssessmentWorkflowReservationKey(input)
+		const workflowInstanceId = `tax-assessment-${input.corporationId}-${Date.now()}-${crypto.randomUUID()}`
+		const reservation = await this.state.storage.transaction(async (transaction) => {
+			const existing = await transaction.get<TaxAssessmentWorkflowReservation>(reservationKey)
+			if (existing && existing.expiresAt > Date.now()) return existing
+			const next = {
+				workflowInstanceId,
+				expiresAt: Date.now() + TAX_ASSESSMENT_WORKFLOW_RESERVATION_TTL_SECONDS * 1000,
+			}
+			await transaction.put(reservationKey, next)
+			return next
+		})
+
+		if (reservation.workflowInstanceId !== workflowInstanceId) {
+			return {
+				workflowInstanceId: reservation.workflowInstanceId,
+				corporationId: input.corporationId,
+				periodStart: input.periodStart.toISOString(),
+				periodEnd: input.periodEnd.toISOString(),
+				status: 'queued',
+			}
+		}
+
+		try {
+			await createWorkflow(this.env.TAX_ASSESSMENT_WORKFLOW, {
+				id: workflowInstanceId,
+				params: {
+					actorUserId,
+					corporationId: input.corporationId,
+					periodStart: input.periodStart.toISOString(),
+					periodEnd: input.periodEnd.toISOString(),
+					includeCharacterWallets: input.includeCharacterWallets ?? false,
+				},
+			})
+		} catch (error) {
+			await this.state.storage.delete(reservationKey)
+			throw error
+		}
+
+		return {
+			workflowInstanceId,
+			corporationId: input.corporationId,
+			periodStart: input.periodStart.toISOString(),
+			periodEnd: input.periodEnd.toISOString(),
+			status: 'queued',
+		}
+	}
+
+	private getTaxAssessmentWorkflowReservationKey(input: RunTaxAssessmentForPeriodInput): string {
+		return [
+			TAX_ASSESSMENT_WORKFLOW_RESERVATION_PREFIX,
+			input.corporationId,
+			input.periodStart.getTime(),
+			input.periodEnd.getTime(),
+			input.includeCharacterWallets ? 'characters' : 'corporation',
+		].join(':')
+	}
+
+	async getAssessmentWorkflowStatus(
+		corporationId: string,
+		workflowInstanceId: string
+	): Promise<TaxAssessmentWorkflowStatusResult> {
+		if (!workflowInstanceId.startsWith(`tax-assessment-${corporationId}-`)) {
+			throw new Error('Assessment workflow does not belong to this corporation')
+		}
+
+		const workflowInstance = await this.env.TAX_ASSESSMENT_WORKFLOW.get(workflowInstanceId)
+		const raw = await workflowInstance.status()
+		const output = isTaxAssessmentWorkflowOutput(raw.output) ? raw.output : null
+
+		if (raw.error) {
+			this.logger.error('[CorporationTaxDO] Assessment workflow failed', {
+				corporationId,
+				workflowInstanceId,
+				error: raw.error,
+			})
+		}
+
+		return {
+			workflowInstanceId,
+			status: normalizeTaxAssessmentWorkflowStatus(raw.status, output),
+			rawStatus: raw.status,
+			output,
+			error: raw.error
+				? { name: 'TaxAssessmentWorkflowError', message: 'Assessment workflow failed' }
+				: null,
+		}
 	}
 
 	async rebuildFinalizedRollupsForPeriod(
@@ -595,16 +733,24 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		corporationId: string,
 		limit?: number,
 		offset?: number
-	): Promise<TaxAssessmentWithBillHistory[]> {
+	): Promise<TaxPagedResult<TaxAssessmentWithBillHistory>> {
 		return this.billingRpc.getCorporationBillStatusHistory(corporationId, limit, offset)
 	}
 
 	async getCorporationBillEventHistory(
 		corporationId: string,
 		limit?: number,
-		offset?: number
+		offset?: number,
+		sortBy?: TaxBillingEventSortBy,
+		sortDir?: 'asc' | 'desc'
 	): Promise<TaxPagedResult<TaxBillingEventHistoryRow>> {
-		return this.billingRpc.getCorporationBillEventHistory(corporationId, limit, offset)
+		return this.billingRpc.getCorporationBillEventHistory(
+			corporationId,
+			limit,
+			offset,
+			sortBy,
+			sortDir
+		)
 	}
 
 	async getAssessmentBillStatusHistory(
@@ -709,6 +855,12 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		return this.reportsRpc.getComplianceOverTimeReport(filters)
 	}
 
+	async getComplianceOverTimeReportPage(
+		filters?: TaxRollupReportFilters
+	): Promise<TaxPagedResult<TaxCompliancePoint>> {
+		return this.reportsRpc.getComplianceOverTimeReportPage(filters)
+	}
+
 	async getTaxDiscrepancyReport(
 		filters?: ListTaxDiscrepancyReportFilters
 	): Promise<TaxPagedResult<TaxDiscrepancy>> {
@@ -735,7 +887,7 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		)
 	}
 
-	async getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
+	async getTaxableIncomeRefTypes(corporationId?: string): Promise<string[]> {
 		return this.rpcGuard('getTaxableIncomeRefTypes', { corporationId }, () =>
 			this.reportsRpc.getTaxableIncomeRefTypes(corporationId)
 		)
@@ -745,7 +897,7 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		return this.operationsRpc.requestExport(actorUserId, input)
 	}
 
-	async listExports(filters?: ListTaxExportsFilters): Promise<TaxExportRecord[]> {
+	async listExports(filters?: ListTaxExportsFilters): Promise<TaxPagedResult<TaxExportRecord>> {
 		return this.operationsRpc.listExports(filters)
 	}
 
@@ -764,7 +916,9 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 		return this.operationsRpc.createExportSchedule(actorUserId, input)
 	}
 
-	async listExportSchedules(filters?: ListTaxExportSchedulesFilters): Promise<TaxExportSchedule[]> {
+	async listExportSchedules(
+		filters?: ListTaxExportSchedulesFilters
+	): Promise<TaxPagedResult<TaxExportSchedule>> {
 		return this.operationsRpc.listExportSchedules(filters)
 	}
 
@@ -1294,7 +1448,7 @@ export class CorporationTaxDO extends DurableObject<Env, {}> implements Corporat
 			toDate: input?.toDate,
 			limit: 10_000,
 		})
-		const totalEssIncome = rows.reduce((sum, row) => {
+		const totalEssIncome = rows.rows.reduce((sum, row) => {
 			const amount = Number(row.amount)
 			if (!Number.isFinite(amount) || amount <= 0) {
 				return sum

--- a/apps/corporation-tax/src/index.ts
+++ b/apps/corporation-tax/src/index.ts
@@ -5,17 +5,16 @@ import { withNotFound, withOnError, withWorkersLogger } from '@repo/hono-helpers
 import { CorporationTaxDO } from './durable-object'
 import { scheduledHandler } from './scheduled'
 import { MockBills, MockDiscord, MockEveCharacterData, MockEveCorporationData } from './test-mocks'
+import { TaxAssessmentWorkflow } from './workflows/tax-assessment.workflow'
 
 import type { App, Env } from './context'
 
 const app = new Hono<App>()
-	.use(
-		'*',
-		(c, next) =>
-			withWorkersLogger(c.env.NAME, {
-				environment: c.env.ENVIRONMENT,
-				release: c.env.SENTRY_RELEASE,
-			})(c, next)
+	.use('*', (c, next) =>
+		withWorkersLogger(c.env.NAME, {
+			environment: c.env.ENVIRONMENT,
+			release: c.env.SENTRY_RELEASE,
+		})(c, next)
 	)
 	.onError(withOnError())
 	.notFound(withNotFound())
@@ -31,4 +30,5 @@ export default {
 }
 
 export { CorporationTaxDO as CorporationTax }
+export { TaxAssessmentWorkflow }
 export { MockBills, MockDiscord, MockEveCharacterData, MockEveCorporationData }

--- a/apps/corporation-tax/src/rpc/billing-rpc.ts
+++ b/apps/corporation-tax/src/rpc/billing-rpc.ts
@@ -7,6 +7,7 @@ import type {
 	TaxAssessment,
 	TaxAssessmentWithBillHistory,
 	TaxBillingEventHistoryRow,
+	TaxBillingEventSortBy,
 	TaxBillStateSyncInput,
 	TaxCorporationBillingConfig,
 	TaxPagedResult,
@@ -121,16 +122,24 @@ export class TaxBillingRpc {
 		corporationId: string,
 		limit?: number,
 		offset?: number
-	): Promise<TaxAssessmentWithBillHistory[]> {
+	): Promise<TaxPagedResult<TaxAssessmentWithBillHistory>> {
 		return this.ctx.billingService.getCorporationBillStatusHistory(corporationId, limit, offset)
 	}
 
 	async getCorporationBillEventHistory(
 		corporationId: string,
 		limit?: number,
-		offset?: number
+		offset?: number,
+		sortBy?: TaxBillingEventSortBy,
+		sortDir?: 'asc' | 'desc'
 	): Promise<TaxPagedResult<TaxBillingEventHistoryRow>> {
-		return this.ctx.billingService.getCorporationBillEventHistory(corporationId, limit, offset)
+		return this.ctx.billingService.getCorporationBillEventHistory(
+			corporationId,
+			limit,
+			offset,
+			sortBy,
+			sortDir
+		)
 	}
 
 	async getAssessmentBillStatusHistory(

--- a/apps/corporation-tax/src/rpc/ledger-rpc.ts
+++ b/apps/corporation-tax/src/rpc/ledger-rpc.ts
@@ -18,8 +18,8 @@ import type {
 	ListTaxLedgerPartiesFilters,
 	RunTaxAssessmentForPeriodInput,
 	RunTaxAssessmentForPeriodResult,
-	TaxAssessment,
 	TaxAssessmentLine,
+	TaxAssessmentPage,
 	TaxDiscrepancy,
 	TaxLedgerEntry,
 	TaxLedgerIngestionHealth,
@@ -27,6 +27,7 @@ import type {
 	TaxLedgerParty,
 	TaxLedgerRetentionResult,
 	TaxLedgerWindowFilters,
+	TaxPagedResult,
 	TriggerTaxProjectionRefreshInput,
 	TriggerTaxProjectionRefreshResult,
 } from '@repo/corporation-tax'
@@ -230,7 +231,7 @@ export class TaxLedgerRpc {
 	async listLedgerEntries(
 		corporationId: string,
 		filters?: TaxLedgerWindowFilters
-	): Promise<TaxLedgerEntry[]> {
+	): Promise<TaxPagedResult<TaxLedgerEntry>> {
 		return this.ctx.ledgerService.listLedgerEntries(corporationId, filters)
 	}
 
@@ -267,7 +268,7 @@ export class TaxLedgerRpc {
 		return result
 	}
 
-	async listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessment[]> {
+	async listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessmentPage> {
 		return this.ctx.assessmentService.listAssessments(filters)
 	}
 

--- a/apps/corporation-tax/src/rpc/operations-rpc.ts
+++ b/apps/corporation-tax/src/rpc/operations-rpc.ts
@@ -16,6 +16,7 @@ import type {
 	TaxExportRecord,
 	TaxExportSchedule,
 	TaxNotificationDestination,
+	TaxPagedResult,
 	TaxScheduledOperationsResult,
 	TriggerTaxAlertInput,
 	TriggerTaxProjectionRefreshInput,
@@ -93,7 +94,7 @@ export class TaxOperationsRpc {
 		return created
 	}
 
-	listExports(filters?: ListTaxExportsFilters): Promise<TaxExportRecord[]> {
+	listExports(filters?: ListTaxExportsFilters): Promise<TaxPagedResult<TaxExportRecord>> {
 		return this.ctx.exportService.listExports(filters)
 	}
 
@@ -128,7 +129,9 @@ export class TaxOperationsRpc {
 		return schedule
 	}
 
-	listExportSchedules(filters?: ListTaxExportSchedulesFilters): Promise<TaxExportSchedule[]> {
+	listExportSchedules(
+		filters?: ListTaxExportSchedulesFilters
+	): Promise<TaxPagedResult<TaxExportSchedule>> {
 		return this.ctx.exportService.listExportSchedules(filters)
 	}
 

--- a/apps/corporation-tax/src/rpc/reports-rpc.ts
+++ b/apps/corporation-tax/src/rpc/reports-rpc.ts
@@ -75,4 +75,8 @@ export class TaxReportsRpc {
 	): Promise<TaxPagedResult<TaxMemberSummary>> {
 		return this.ctx.reportService.getMemberSummaryReport(filters)
 	}
+
+	getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
+		return this.ctx.reportService.getTaxableIncomeRefTypes(corporationId)
+	}
 }

--- a/apps/corporation-tax/src/rpc/reports-rpc.ts
+++ b/apps/corporation-tax/src/rpc/reports-rpc.ts
@@ -52,6 +52,12 @@ export class TaxReportsRpc {
 		return this.ctx.reportService.getComplianceOverTimeReport(filters)
 	}
 
+	getComplianceOverTimeReportPage(
+		filters?: TaxRollupReportFilters
+	): Promise<TaxPagedResult<TaxCompliancePoint>> {
+		return this.ctx.reportService.getComplianceOverTimeReportPage(filters)
+	}
+
 	getTaxDiscrepancyReport(
 		filters?: ListTaxDiscrepancyReportFilters
 	): Promise<TaxPagedResult<TaxDiscrepancy>> {
@@ -76,7 +82,7 @@ export class TaxReportsRpc {
 		return this.ctx.reportService.getMemberSummaryReport(filters)
 	}
 
-	getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
+	getTaxableIncomeRefTypes(corporationId?: string): Promise<string[]> {
 		return this.ctx.reportService.getTaxableIncomeRefTypes(corporationId)
 	}
 }

--- a/apps/corporation-tax/src/services/__tests__/tax-billing.service.test.ts
+++ b/apps/corporation-tax/src/services/__tests__/tax-billing.service.test.ts
@@ -55,6 +55,11 @@ describe('TaxBillingService scope guardrails', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		mockDb = {
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn().mockResolvedValue([{ count: 2 }]),
+				})),
+			})),
 			query: {
 				taxAssessments: {
 					findFirst: vi.fn(),
@@ -130,20 +135,16 @@ describe('TaxBillingService scope guardrails', () => {
 	})
 
 	it('ignores non-corporation rows when building corporation bill history', async () => {
-		mockDb.query.taxAssessments.findMany.mockResolvedValue([
-			makeAssessment({
-				id: 'assessment-corp',
-				billId: 'bill-corp',
-				billStatus: 'issued',
-			}),
-			makeAssessment({
-				id: 'assessment-char',
-				assessmentScope: 'character',
-				scopeId: '7001',
-				billId: 'bill-char',
-				billStatus: 'issued',
-			}),
-		])
+		mockDb.query.taxAssessments.findMany.mockImplementation(async (query: { where?: unknown }) => {
+			expect(query.where).toBeDefined()
+			return [
+				makeAssessment({
+					id: 'assessment-corp',
+					billId: 'bill-corp',
+					billStatus: 'issued',
+				}),
+			]
+		})
 
 		const billsStub = {
 			getBillTimelines: vi.fn().mockResolvedValue({
@@ -166,10 +167,49 @@ describe('TaxBillingService scope guardrails', () => {
 		const service = new TaxBillingService(mockDb, {} as DurableObjectNamespace)
 		const result = await service.getCorporationBillStatusHistory('98000001')
 
-		expect(result).toHaveLength(1)
-		expect(result[0]?.assessment.id).toBe('assessment-corp')
+		expect(result.rows).toHaveLength(1)
+		expect(result.rows[0]?.assessment.id).toBe('assessment-corp')
 		expect(billsStub.getBillTimelines).toHaveBeenCalledTimes(1)
 		expect(billsStub.getBillTimelines).toHaveBeenCalledWith(['bill-corp'])
+	})
+
+	it('pages corporation billing events in Bills without loading all assessment bill IDs', async () => {
+		const billsStub = {
+			listBillStatusEventsByPayerPage: vi.fn().mockResolvedValue({
+				rows: [
+					{
+						id: 'event-1',
+						billId: 'bill-1',
+						eventType: 'issued',
+						fromStatus: 'draft',
+						toStatus: 'issued',
+						actorUserId: 'actor-1',
+						metadata: null,
+						createdAt: new Date('2026-04-01T00:00:00.000Z'),
+						externalSourceType: 'corporation_tax_assessment',
+						externalSourceId: 'assessment-1',
+					},
+				],
+				rowCount: 1,
+			}),
+		}
+		getStubMock.mockReturnValue(billsStub)
+
+		const service = new TaxBillingService(mockDb, {} as DurableObjectNamespace)
+		const result = await service.getCorporationBillEventHistory('98000001', 25, 0)
+
+		expect(result.rows).toHaveLength(1)
+		expect(result.rows[0]?.assessmentId).toBe('assessment-1')
+		expect(billsStub.listBillStatusEventsByPayerPage).toHaveBeenCalledWith({
+			payerId: '98000001',
+			payerType: 'corporation',
+			externalSourceType: 'corporation_tax_assessment',
+			limit: 25,
+			offset: 0,
+			sortBy: 'createdAt',
+			sortDir: 'desc',
+		})
+		expect(mockDb.query.taxAssessments.findMany).not.toHaveBeenCalled()
 	})
 
 	it('skips non-corporation rows during bulk status sync', async () => {

--- a/apps/corporation-tax/src/services/__tests__/tax-report.service.test.ts
+++ b/apps/corporation-tax/src/services/__tests__/tax-report.service.test.ts
@@ -17,9 +17,12 @@ function createSelectMock(
 			from: ReturnType<typeof vi.fn>
 			where: ReturnType<typeof vi.fn>
 			groupBy: ReturnType<typeof vi.fn>
+			innerJoin: ReturnType<typeof vi.fn>
+			leftJoin: ReturnType<typeof vi.fn>
 			orderBy: ReturnType<typeof vi.fn>
 			limit: ReturnType<typeof vi.fn>
 			offset: ReturnType<typeof vi.fn>
+			as: ReturnType<typeof vi.fn>
 			then: <TResult1 = unknown, TResult2 = never>(
 				onfulfilled?:
 					| ((
@@ -32,9 +35,12 @@ function createSelectMock(
 			from: vi.fn(() => chain),
 			where: vi.fn(() => chain),
 			groupBy: vi.fn(() => chain),
+			innerJoin: vi.fn(() => chain),
+			leftJoin: vi.fn(() => chain),
 			orderBy: vi.fn(() => chain),
 			limit: vi.fn(() => chain),
 			offset: vi.fn(() => chain),
+			as: vi.fn(() => chain),
 			then: (onfulfilled, onrejected) => Promise.resolve(rows).then(onfulfilled, onrejected),
 		}
 		return chain
@@ -107,11 +113,42 @@ describe('TaxReportService report scoping', () => {
 		expect(mockDb.query.taxLedgerEntries.findMany).not.toHaveBeenCalled()
 	})
 
+	it('reads assessed monthly income from assessment rollups', async () => {
+		mockDb.execute = vi.fn().mockResolvedValue({
+			rows: [
+				{
+					month_start: '2026-07-01T00:00:00.000Z',
+					ref_type: 'bounty_prizes',
+					entry_count: 12,
+					ess_entry_count: 0,
+					total_income: '123.45',
+				},
+			],
+		})
+
+		const service = new TaxReportService(mockDb, {} as any)
+		const rows = await service.getTopIncomeSourcesMonthlyReport({
+			corporationId: '1001',
+			incomeMode: 'assessed',
+		})
+
+		expect(rows).toEqual([
+			expect.objectContaining({
+				monthStart: new Date('2026-07-01T00:00:00.000Z'),
+				refType: 'bounty_prizes',
+				entryCount: 12,
+				totalIncome: '123.45',
+			}),
+		])
+		expect(mockDb.execute).toHaveBeenCalledOnce()
+	})
+
 	it('aggregates total taxes by corporation from data-backed scope and applies paging', async () => {
 		mockDb.select = createSelectMock([
 			[{ corporationId: '1001' }],
 			[{ corporationId: '1001' }],
 			[{ corporationId: '1001' }],
+			[],
 			[
 				{
 					corporationId: '1001',
@@ -153,6 +190,69 @@ describe('TaxReportService report scoping', () => {
 				taxDelta: '50.00',
 			}),
 		])
+	})
+
+	it('counts distinct assessment periods in member rollups', async () => {
+		const characterId = '2123456789'
+		const finalizedRows = [
+			{
+				rollupDate: new Date('2026-06-30T00:00:00.000Z'),
+				characterId,
+				refType: 'bounty_prizes',
+				periodStart: new Date('2026-06-01T00:00:00.000Z'),
+				periodEnd: new Date('2026-06-30T23:59:59.999Z'),
+				contributionIncome: '100.00',
+				taxableContributionIncome: '100.00',
+				sourceRowCount: 1,
+				lastAssessmentAt: new Date('2026-07-01T00:00:00.000Z'),
+			},
+			{
+				rollupDate: new Date('2026-06-30T00:00:00.000Z'),
+				characterId,
+				refType: 'bounty_prizes',
+				periodStart: new Date('2026-06-01T00:00:00.000Z'),
+				periodEnd: new Date('2026-06-30T23:59:59.999Z'),
+				contributionIncome: '50.00',
+				taxableContributionIncome: '50.00',
+				sourceRowCount: 1,
+				lastAssessmentAt: new Date('2026-07-01T00:00:00.000Z'),
+			},
+			{
+				rollupDate: new Date('2026-07-31T00:00:00.000Z'),
+				characterId,
+				refType: 'bounty_prizes',
+				periodStart: new Date('2026-07-01T00:00:00.000Z'),
+				periodEnd: new Date('2026-07-31T23:59:59.999Z'),
+				contributionIncome: '75.00',
+				taxableContributionIncome: '75.00',
+				sourceRowCount: 1,
+				lastAssessmentAt: new Date('2026-08-01T00:00:00.000Z'),
+			},
+		]
+		mockDb.query.taxMemberContributionFinalizedRollups = {
+			findMany: vi.fn().mockResolvedValue(finalizedRows),
+		}
+		mockDb.query.taxMemberContributionProjectionRollups = {
+			findMany: vi.fn().mockResolvedValue([]),
+		}
+
+		const service = new TaxReportService(mockDb, {} as any)
+		const rows = await (service as any).getMemberSummaryFromRollups({
+			corporationId: '1001',
+			scopedCharacterIds: [],
+			scopedCharacterIdSet: new Set<string>(),
+			includeUnattributedRow: false,
+			topRefTypesLimit: 5,
+		})
+
+		expect(rows).toHaveLength(1)
+		expect(rows[0]).toEqual(
+			expect.objectContaining({
+				characterId,
+				assessmentCount: 2,
+				contributionIncome: '225.00',
+			})
+		)
 	})
 
 	it('uses SQL-counted totalRows for ESS payouts with the same scoped filters', async () => {
@@ -219,6 +319,7 @@ describe('TaxReportService report scoping', () => {
 					taxDelta: '250.00',
 				},
 			],
+			[{ count: 1 }],
 		])
 
 		const service = new TaxReportService(mockDb, {} as any)
@@ -242,5 +343,43 @@ describe('TaxReportService report scoping', () => {
 				taxDelta: '250.00',
 			}),
 		])
+	})
+
+	it('checks ESI coverage only for active, taxable member corporations', async () => {
+		mockDb.select = createSelectMock([[{ corporationId: '1001' }, { corporationId: '1002' }]])
+		const status = {
+			corporationId: '1001',
+			isConfigured: true,
+			isVerified: true,
+			lastVerified: new Date('2026-08-01T00:00:00.000Z'),
+			directorCount: 1,
+			healthyDirectorCount: 1,
+			requiredScopes: ['esi-corporations.read_wallets.v1'],
+			missingRequiredScopes: [],
+			hasRequiredScopes: true,
+			hasCorporationWalletScope: true,
+			hasCharacterWalletScope: false,
+			hasCorporationMembershipScope: true,
+			grantedScopeCount: 2,
+		}
+		getStubMock.mockImplementation((_namespace: unknown, corporationId: string) => ({
+			getCorporationAuthStatus: vi
+				.fn()
+				.mockResolvedValue(
+					corporationId === '1001' ? status : { ...status, corporationId, isConfigured: false }
+				),
+		}))
+
+		const service = new TaxReportService(mockDb, {} as any)
+		const report = await service.getMissingEsiKeysReport()
+
+		expect(report.totalRows).toBe(1)
+		expect(report.rows).toEqual([
+			expect.objectContaining({
+				corporationId: '1002',
+				isConfigured: false,
+			}),
+		])
+		expect(getStubMock).toHaveBeenCalledTimes(2)
 	})
 })

--- a/apps/corporation-tax/src/services/tax-assessment.service.ts
+++ b/apps/corporation-tax/src/services/tax-assessment.service.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, isNotNull, isNull, lte, ne, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lte, ne, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 
 import {
@@ -27,6 +27,7 @@ import type {
 	RunTaxAssessmentForPeriodResult,
 	TaxAssessment,
 	TaxAssessmentLine,
+	TaxAssessmentPage,
 	TaxAssessmentScope,
 	TaxAssessmentStatus,
 	TaxDiscrepancy,
@@ -68,13 +69,14 @@ export class TaxAssessmentService {
 	private readonly TAX_DELTA_DISCREPANCY_THRESHOLD_BPS = 500
 	private readonly CLASSIFICATION_RULE_NAME_MAX_LENGTH = 48
 	private readonly ASSESSMENT_LINE_INSERT_BATCH_SIZE = 50
+	private readonly ID_FILTER_BATCH_SIZE = 1_000
 
 	constructor(
 		private db: CorporationTaxDb,
 		private eveCorporationDataNamespace: DurableObjectNamespace
 	) {}
 
-	async listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessment[]> {
+	async listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessmentPage> {
 		const conditions = []
 
 		if (filters?.corporationId) {
@@ -89,6 +91,15 @@ export class TaxAssessmentService {
 		if (filters?.withBillOnly) {
 			conditions.push(isNotNull(taxAssessments.billId))
 		}
+		if (filters?.unbilledOnly) {
+			conditions.push(
+				and(
+					isNull(taxAssessments.billId),
+					ne(taxAssessments.status, 'draft'),
+					ne(taxAssessments.status, 'excluded')
+				)
+			)
+		}
 		if (filters?.periodStart) {
 			conditions.push(gte(taxAssessments.taxPeriodStart, filters.periodStart))
 		}
@@ -99,14 +110,58 @@ export class TaxAssessmentService {
 		const limit = Math.min(Math.max(filters?.limit ?? 50, 1), 200)
 		const offset = Math.max(filters?.offset ?? 0, 0)
 
+		const where = conditions.length ? and(...conditions) : undefined
+		const sortDirection = filters?.sortDir === 'asc' ? asc : desc
+		const sortColumn =
+			filters?.sortBy === 'assessmentScope'
+				? taxAssessments.assessmentScope
+				: filters?.sortBy === 'scopeId'
+					? taxAssessments.scopeId
+					: filters?.sortBy === 'status'
+						? taxAssessments.status
+						: filters?.sortBy === 'taxDue'
+							? taxAssessments.taxDue
+							: filters?.sortBy === 'taxDelta'
+								? taxAssessments.taxDelta
+								: taxAssessments.taxPeriodEnd
+		const sortOrder =
+			filters?.sortBy === 'taxDue'
+				? filters.sortDir === 'asc'
+					? sql`CAST(${taxAssessments.taxDue} AS numeric) ASC`
+					: sql`CAST(${taxAssessments.taxDue} AS numeric) DESC`
+				: filters?.sortBy === 'taxDelta'
+					? filters.sortDir === 'asc'
+						? sql`CAST(${taxAssessments.taxDelta} AS numeric) ASC`
+						: sql`CAST(${taxAssessments.taxDelta} AS numeric) DESC`
+					: sortDirection(sortColumn)
+		const [{ count: totalRows }] = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(taxAssessments)
+			.where(where)
+
 		const rows = await this.db.query.taxAssessments.findMany({
-			where: conditions.length ? and(...conditions) : undefined,
-			orderBy: [desc(taxAssessments.taxPeriodEnd), desc(taxAssessments.createdAt)],
+			where,
+			orderBy: [sortOrder, desc(taxAssessments.createdAt), desc(taxAssessments.id)],
 			limit,
 			offset,
 		})
 
-		return rows.map((row) => this.toAssessment(row))
+		const [summary] = await this.db
+			.select({
+				corporationAssessmentCount: sql<number>`count(*) filter (where ${taxAssessments.assessmentScope} = 'corporation')::int`,
+				unbilledAssessmentCount: sql<number>`count(*) filter (where ${taxAssessments.assessmentScope} = 'corporation' and ${taxAssessments.billId} is null and ${taxAssessments.status} not in ('draft', 'excluded'))::int`,
+				overdueAssessmentCount: sql<number>`count(*) filter (where ${taxAssessments.assessmentScope} = 'corporation' and ${taxAssessments.billStatus} = 'overdue')::int`,
+			})
+			.from(taxAssessments)
+			.where(where)
+
+		return {
+			rows: rows.map((row) => this.toAssessment(row)),
+			totalRows: Number(totalRows ?? 0),
+			corporationAssessmentCount: Number(summary?.corporationAssessmentCount ?? 0),
+			unbilledAssessmentCount: Number(summary?.unbilledAssessmentCount ?? 0),
+			overdueAssessmentCount: Number(summary?.overdueAssessmentCount ?? 0),
+		} satisfies TaxAssessmentPage
 	}
 
 	async getAssessmentById(assessmentId: string): Promise<TaxAssessment | null> {
@@ -143,24 +198,18 @@ export class TaxAssessmentService {
 			lte(taxLedgerEntries.entryDate, input.periodEnd)
 		)
 
-		const attachedRuleGroups = await this.db.query.taxRuleGroupAttachments.findMany({
-			where: eq(taxRuleGroupAttachments.corporationId, input.corporationId),
-			columns: {
-				ruleGroupId: true,
-			},
-			limit: 500,
+		const activeRuleSets = await this.db.query.taxRuleSets.findMany({
+			where: and(
+				sql`EXISTS (
+					SELECT 1
+					FROM ${taxRuleGroupAttachments}
+					WHERE ${taxRuleGroupAttachments.ruleGroupId} = ${taxRuleSets.ruleGroupId}
+						AND ${taxRuleGroupAttachments.corporationId} = ${input.corporationId}
+				)`,
+				eq(taxRuleSets.isActive, true)
+			),
+			orderBy: [desc(taxRuleSets.priority), desc(taxRuleSets.createdAt)],
 		})
-		const attachedRuleGroupIds = attachedRuleGroups.map((row) => row.ruleGroupId)
-		const activeRuleSets =
-			attachedRuleGroupIds.length === 0
-				? []
-				: await this.db.query.taxRuleSets.findMany({
-						where: and(
-							inArray(taxRuleSets.ruleGroupId, attachedRuleGroupIds),
-							eq(taxRuleSets.isActive, true)
-						),
-						orderBy: [desc(taxRuleSets.priority), desc(taxRuleSets.createdAt)],
-					})
 
 		const compiledRules = activeRuleSets.map((ruleSet) => ({
 			ruleSetId: ruleSet.id,
@@ -449,13 +498,14 @@ export class TaxAssessmentService {
 				.map((assessment) => assessment.id)
 
 			if (staleAssessmentIds.length > 0) {
-				await tx
-					.delete(taxDiscrepancies)
-					.where(inArray(taxDiscrepancies.assessmentId, staleAssessmentIds))
-				await tx
-					.delete(taxAssessmentLines)
-					.where(inArray(taxAssessmentLines.assessmentId, staleAssessmentIds))
-				await tx.delete(taxAssessments).where(inArray(taxAssessments.id, staleAssessmentIds))
+				for (let start = 0; start < staleAssessmentIds.length; start += this.ID_FILTER_BATCH_SIZE) {
+					const idBatch = staleAssessmentIds.slice(start, start + this.ID_FILTER_BATCH_SIZE)
+					await tx.delete(taxDiscrepancies).where(inArray(taxDiscrepancies.assessmentId, idBatch))
+					await tx
+						.delete(taxAssessmentLines)
+						.where(inArray(taxAssessmentLines.assessmentId, idBatch))
+					await tx.delete(taxAssessments).where(inArray(taxAssessments.id, idBatch))
+				}
 			}
 
 			const persistedByScopeKey = new Map<string, typeof taxAssessments.$inferSelect>()
@@ -514,12 +564,13 @@ export class TaxAssessmentService {
 				(assessment) => assessment.id
 			)
 			if (assessmentIds.length > 0) {
-				await tx
-					.delete(taxAssessmentLines)
-					.where(inArray(taxAssessmentLines.assessmentId, assessmentIds))
-				await tx
-					.delete(taxDiscrepancies)
-					.where(inArray(taxDiscrepancies.assessmentId, assessmentIds))
+				for (let start = 0; start < assessmentIds.length; start += this.ID_FILTER_BATCH_SIZE) {
+					const idBatch = assessmentIds.slice(start, start + this.ID_FILTER_BATCH_SIZE)
+					await tx
+						.delete(taxAssessmentLines)
+						.where(inArray(taxAssessmentLines.assessmentId, idBatch))
+					await tx.delete(taxDiscrepancies).where(inArray(taxDiscrepancies.assessmentId, idBatch))
+				}
 			}
 
 			const scopedLineValues: Array<typeof taxAssessmentLines.$inferInsert> = []
@@ -812,9 +863,12 @@ export class TaxAssessmentService {
 			)
 			.map((row: { id: string }) => row.id)
 		if (staleIds.length > 0) {
-			await tx
-				.delete(taxMemberContributionProjectionRollups)
-				.where(inArray(taxMemberContributionProjectionRollups.id, staleIds))
+			for (let start = 0; start < staleIds.length; start += this.ID_FILTER_BATCH_SIZE) {
+				const idBatch = staleIds.slice(start, start + this.ID_FILTER_BATCH_SIZE)
+				await tx
+					.delete(taxMemberContributionProjectionRollups)
+					.where(inArray(taxMemberContributionProjectionRollups.id, idBatch))
+			}
 		}
 	}
 
@@ -886,9 +940,12 @@ export class TaxAssessmentService {
 			)
 			.map((row: { id: string }) => row.id)
 		if (staleIds.length > 0) {
-			await tx
-				.delete(taxMemberContributionFinalizedRollups)
-				.where(inArray(taxMemberContributionFinalizedRollups.id, staleIds))
+			for (let start = 0; start < staleIds.length; start += this.ID_FILTER_BATCH_SIZE) {
+				const idBatch = staleIds.slice(start, start + this.ID_FILTER_BATCH_SIZE)
+				await tx
+					.delete(taxMemberContributionFinalizedRollups)
+					.where(inArray(taxMemberContributionFinalizedRollups.id, idBatch))
+			}
 		}
 	}
 

--- a/apps/corporation-tax/src/services/tax-audit.service.ts
+++ b/apps/corporation-tax/src/services/tax-audit.service.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, ilike, lte, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, gte, ilike, lte, sql } from '@repo/db-utils'
 
 import { taxAuditLog } from '../db/schema'
 
@@ -52,10 +52,19 @@ export class TaxAuditService {
 		const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200)
 		const offset = Math.max(filters.offset ?? 0, 0)
 		const where = conditions.length > 0 ? and(...conditions) : undefined
+		const sortDirection = filters.sortDir === 'asc' ? asc : desc
+		const sortColumn =
+			filters.sortBy === 'corporationId'
+				? taxAuditLog.corporationId
+				: filters.sortBy === 'actorUserId'
+					? taxAuditLog.actorUserId
+					: filters.sortBy === 'action'
+						? taxAuditLog.action
+						: taxAuditLog.createdAt
 		const [rows, countRows] = await Promise.all([
 			this.db.query.taxAuditLog.findMany({
 				where,
-				orderBy: [desc(taxAuditLog.createdAt)],
+				orderBy: [sortDirection(sortColumn), desc(taxAuditLog.id)],
 				limit,
 				offset,
 			}),

--- a/apps/corporation-tax/src/services/tax-billing.service.ts
+++ b/apps/corporation-tax/src/services/tax-billing.service.ts
@@ -13,6 +13,7 @@ import type {
 	TaxAssessment,
 	TaxAssessmentWithBillHistory,
 	TaxBillingEventHistoryRow,
+	TaxBillingEventSortBy,
 	TaxBillStateSyncInput,
 	TaxBillStatus,
 	TaxCorporationBillingConfig,
@@ -595,98 +596,88 @@ export class TaxBillingService {
 		corporationId: string,
 		limit = 25,
 		offset = 0
-	): Promise<TaxAssessmentWithBillHistory[]> {
+	): Promise<TaxPagedResult<TaxAssessmentWithBillHistory>> {
 		const boundedLimit = Math.min(Math.max(limit, 1), 100)
 		const boundedOffset = Math.max(offset, 0)
+		const baseWhere = and(
+			eq(taxAssessments.corporationId, corporationId),
+			eq(taxAssessments.assessmentScope, 'corporation'),
+			isNotNull(taxAssessments.billId)
+		)
+		const [{ count: totalRows }] = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(taxAssessments)
+			.where(baseWhere)
 		const assessments = await this.db.query.taxAssessments.findMany({
-			where: and(
-				eq(taxAssessments.corporationId, corporationId),
-				eq(taxAssessments.assessmentScope, 'corporation')
-			),
+			where: baseWhere,
 			orderBy: [desc(taxAssessments.taxPeriodEnd), desc(taxAssessments.createdAt)],
 			limit: boundedLimit,
 			offset: boundedOffset,
 		})
 
-		const billedAssessments = assessments.filter(
-			(assessment) => assessment.assessmentScope === 'corporation' && assessment.billId
-		)
+		const billedAssessments = assessments
 		if (billedAssessments.length === 0) {
-			return []
+			return { rows: [], totalRows: Number(totalRows ?? 0) }
 		}
 
 		const bills = getStub<Bills>(this.billsNamespace, 'default')
 		const billIds = billedAssessments.map((assessment) => assessment.billId!)
 		const timelinesByBillId = await bills.getBillTimelines(billIds)
 
-		return billedAssessments.map((assessment) => ({
-			assessment: this.toAssessment(assessment),
-			timeline: (timelinesByBillId[assessment.billId!] ?? []).map((event) => ({
-				id: event.id,
-				billId: event.billId,
-				eventType: event.eventType,
-				fromStatus: event.fromStatus,
-				toStatus: event.toStatus,
-				actorUserId: event.actorUserId,
-				metadata: event.metadata,
-				createdAt: event.createdAt,
+		return {
+			rows: billedAssessments.map((assessment) => ({
+				assessment: this.toAssessment(assessment),
+				timeline: (timelinesByBillId[assessment.billId!] ?? []).map((event) => ({
+					id: event.id,
+					billId: event.billId,
+					eventType: event.eventType,
+					fromStatus: event.fromStatus,
+					toStatus: event.toStatus,
+					actorUserId: event.actorUserId,
+					metadata: event.metadata,
+					createdAt: event.createdAt,
+				})),
 			})),
-		}))
+			totalRows: Number(totalRows ?? 0),
+		}
 	}
 
 	async getCorporationBillEventHistory(
 		corporationId: string,
 		limit = 25,
-		offset = 0
+		offset = 0,
+		sortBy: TaxBillingEventSortBy = 'createdAt',
+		sortDir: 'asc' | 'desc' = 'desc'
 	): Promise<TaxPagedResult<TaxBillingEventHistoryRow>> {
 		const boundedLimit = Math.min(Math.max(limit, 1), 200)
 		const boundedOffset = Math.max(offset, 0)
-		const billedAssessments = await this.db.query.taxAssessments.findMany({
-			where: and(
-				eq(taxAssessments.corporationId, corporationId),
-				eq(taxAssessments.assessmentScope, 'corporation'),
-				isNotNull(taxAssessments.billId)
-			),
-			columns: { id: true, billId: true },
-		})
-		if (billedAssessments.length === 0) {
-			return { rows: [], totalRows: 0 }
-		}
-
-		const assessmentIdByBillId = new Map<string, string>()
-		for (const assessment of billedAssessments) {
-			if (assessment.billId && !assessmentIdByBillId.has(assessment.billId)) {
-				assessmentIdByBillId.set(assessment.billId, assessment.id)
-			}
-		}
-		const billIds = [...assessmentIdByBillId.keys()]
-		if (billIds.length === 0) {
-			return { rows: [], totalRows: 0 }
-		}
-
 		const bills = getStub<Bills>(this.billsNamespace, 'default')
-		const page = await bills.listBillStatusEventsPage({
-			billIds,
+		const page = await bills.listBillStatusEventsByPayerPage({
+			payerId: corporationId,
+			payerType: 'corporation',
+			externalSourceType: 'corporation_tax_assessment',
 			limit: boundedLimit,
 			offset: boundedOffset,
+			sortBy,
+			sortDir,
 		})
 
-		const scopedRows: TaxBillingEventHistoryRow[] = []
-		for (const event of page.rows) {
-			const assessmentId = assessmentIdByBillId.get(event.billId)
-			if (!assessmentId) continue
-			scopedRows.push({
-				id: event.id,
-				billId: event.billId,
-				assessmentId,
-				eventType: event.eventType,
-				fromStatus: event.fromStatus,
-				toStatus: event.toStatus,
-				actorUserId: event.actorUserId,
-				metadata: event.metadata,
-				createdAt: event.createdAt,
-			})
-		}
+		const scopedRows: TaxBillingEventHistoryRow[] = page.rows.flatMap((event) => {
+			if (!event.externalSourceId) return []
+			return [
+				{
+					id: event.id,
+					billId: event.billId,
+					assessmentId: event.externalSourceId,
+					eventType: event.eventType,
+					fromStatus: event.fromStatus,
+					toStatus: event.toStatus,
+					actorUserId: event.actorUserId,
+					metadata: event.metadata,
+					createdAt: event.createdAt,
+				},
+			]
+		})
 
 		return {
 			rows: scopedRows,

--- a/apps/corporation-tax/src/services/tax-export.service.ts
+++ b/apps/corporation-tax/src/services/tax-export.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, lte } from '@repo/db-utils'
+import { and, asc, desc, eq, lte, sql } from '@repo/db-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { taxExports, taxExportSchedules } from '../db/schema'
@@ -12,6 +12,7 @@ import type {
 	TaxExportRecord,
 	TaxExportReportType,
 	TaxExportSchedule,
+	TaxPagedResult,
 	TaxReportWindowFilters,
 } from '@repo/corporation-tax'
 import type { CorporationTaxDb } from '../db'
@@ -75,7 +76,7 @@ export class TaxExportService {
 		}
 	}
 
-	async listExports(filters: ListTaxExportsFilters = {}): Promise<TaxExportRecord[]> {
+	async listExports(filters: ListTaxExportsFilters = {}): Promise<TaxPagedResult<TaxExportRecord>> {
 		const conditions = []
 		if (filters.corporationId) {
 			conditions.push(eq(taxExports.corporationId, filters.corporationId))
@@ -89,14 +90,34 @@ export class TaxExportService {
 
 		const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200)
 		const offset = Math.max(filters.offset ?? 0, 0)
+		const where = conditions.length > 0 ? and(...conditions) : undefined
+		const sortDirection = filters.sortDir === 'asc' ? asc : desc
+		const sortColumn =
+			filters.sortBy === 'corporationId'
+				? taxExports.corporationId
+				: filters.sortBy === 'reportType'
+					? taxExports.reportType
+					: filters.sortBy === 'format'
+						? taxExports.format
+						: filters.sortBy === 'status'
+							? taxExports.status
+							: filters.sortBy === 'rowCount'
+								? taxExports.rowCount
+								: filters.sortBy === 'completedAt'
+									? taxExports.completedAt
+									: taxExports.requestedAt
+		const [{ count: totalRows }] = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(taxExports)
+			.where(where)
 		const rows = await this.db.query.taxExports.findMany({
-			where: conditions.length > 0 ? and(...conditions) : undefined,
-			orderBy: [desc(taxExports.requestedAt)],
+			where,
+			orderBy: [sortDirection(sortColumn), desc(taxExports.id)],
 			limit,
 			offset,
 		})
 
-		return rows.map((row) => this.toExportRecord(row))
+		return { rows: rows.map((row) => this.toExportRecord(row)), totalRows: Number(totalRows ?? 0) }
 	}
 
 	async getExportById(exportId: string): Promise<TaxExportRecord | null> {
@@ -202,7 +223,7 @@ export class TaxExportService {
 
 	async listExportSchedules(
 		filters: ListTaxExportSchedulesFilters = {}
-	): Promise<TaxExportSchedule[]> {
+	): Promise<TaxPagedResult<TaxExportSchedule>> {
 		const conditions = []
 		if (filters.corporationId) {
 			conditions.push(eq(taxExportSchedules.corporationId, filters.corporationId))
@@ -213,14 +234,39 @@ export class TaxExportService {
 
 		const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200)
 		const offset = Math.max(filters.offset ?? 0, 0)
+		const where = conditions.length > 0 ? and(...conditions) : undefined
+		const sortDirection = filters.sortDir === 'asc' ? asc : desc
+		const sortColumn =
+			filters.sortBy === 'name'
+				? taxExportSchedules.name
+				: filters.sortBy === 'corporationId'
+					? taxExportSchedules.corporationId
+					: filters.sortBy === 'reportType'
+						? taxExportSchedules.reportType
+						: filters.sortBy === 'format'
+							? taxExportSchedules.format
+							: filters.sortBy === 'frequency'
+								? taxExportSchedules.frequency
+								: filters.sortBy === 'isActive'
+									? taxExportSchedules.isActive
+									: filters.sortBy === 'lastRunAt'
+										? taxExportSchedules.lastRunAt
+										: taxExportSchedules.nextRunAt
+		const [{ count: totalRows }] = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(taxExportSchedules)
+			.where(where)
 		const rows = await this.db.query.taxExportSchedules.findMany({
-			where: conditions.length > 0 ? and(...conditions) : undefined,
-			orderBy: [desc(taxExportSchedules.nextRunAt)],
+			where,
+			orderBy: [sortDirection(sortColumn), desc(taxExportSchedules.id)],
 			limit,
 			offset,
 		})
 
-		return rows.map((row) => this.toExportSchedule(row))
+		return {
+			rows: rows.map((row) => this.toExportSchedule(row)),
+			totalRows: Number(totalRows ?? 0),
+		}
 	}
 
 	async runDueExportSchedules(
@@ -302,8 +348,62 @@ export class TaxExportService {
 	}
 
 	private async computeExportRowCount(input: RequestTaxExportInput): Promise<number> {
-		const rows = await this.getReportRows(input)
-		return rows.length
+		const filters = this.toReportWindowFilters(input.filters ?? null, input.corporationId)
+		switch (input.reportType) {
+			case 'summary':
+				return 1
+			case 'total_taxes_by_corporation':
+				return (
+					await this.reportService.getTotalTaxesByCorporationReport({
+						...filters,
+						limit: 1,
+						offset: 0,
+					})
+				).totalRows
+			case 'top_income_sources':
+				return (
+					await this.reportService.getTopIncomeSourcesReport({
+						...filters,
+						limit: 200,
+						offset: 0,
+					})
+				).length
+			case 'ess_payout':
+				return (
+					await this.reportService.getEssPayoutReport({
+						...filters,
+						limit: 1,
+						offset: 0,
+					})
+				).totalRows
+			case 'compliance_over_time':
+				return (
+					await this.reportService.getComplianceOverTimeReportPage({
+						...filters,
+						limit: 1,
+						offset: 0,
+					})
+				).totalRows
+			case 'discrepancies':
+				return (
+					await this.reportService.getTaxDiscrepancyReport({
+						...filters,
+						onlyOpen: this.readBoolean(input.filters, 'onlyOpen'),
+						limit: 1,
+						offset: 0,
+					})
+				).totalRows
+			case 'bill_status':
+				return (
+					await this.reportService.getBillStatusReport({
+						...filters,
+						limit: 1,
+						offset: 0,
+					})
+				).totalRows
+			default:
+				return 0
+		}
 	}
 
 	private async getReportRows(input: {
@@ -319,38 +419,77 @@ export class TaxExportService {
 				return [this.toSerializableRecord(row)]
 			}
 			case 'total_taxes_by_corporation': {
-				const report = await this.reportService.getTotalTaxesByCorporationReport(reportFilters)
-				return report.rows.map((row) => this.toSerializableRecord(row))
+				const rows = await this.getAllPagedRows(
+					(filters) => this.reportService.getTotalTaxesByCorporationReport(filters),
+					reportFilters
+				)
+				return rows.map((row) => this.toSerializableRecord(row))
 			}
 			case 'top_income_sources': {
-				const rows = await this.reportService.getTopIncomeSourcesReport(reportFilters)
+				const rows = await this.reportService.getTopIncomeSourcesReport({
+					...reportFilters,
+					limit: 200,
+					offset: 0,
+				})
 				return rows.map((row) => this.toSerializableRecord(row))
 			}
 			case 'ess_payout': {
-				const report = await this.reportService.getEssPayoutReport(reportFilters)
-				return report.rows.map((row) => this.toSerializableRecord(row))
+				const rows = await this.getAllPagedRows(
+					(filters) => this.reportService.getEssPayoutReport(filters),
+					reportFilters
+				)
+				return rows.map((row) => this.toSerializableRecord(row))
 			}
 			case 'compliance_over_time': {
-				const rows = await this.reportService.getComplianceOverTimeReport(reportFilters)
+				const rows = await this.getAllPagedRows(
+					(filters) => this.reportService.getComplianceOverTimeReportPage(filters),
+					reportFilters,
+					3650
+				)
 				return rows.map((row) => this.toSerializableRecord(row))
 			}
 			case 'discrepancies': {
-				const report = await this.reportService.getTaxDiscrepancyReport({
-					corporationId: reportFilters.corporationId,
-					fromDate: reportFilters.fromDate,
-					toDate: reportFilters.toDate,
-					onlyOpen: this.readBoolean(input.filters, 'onlyOpen'),
-					limit: reportFilters.limit,
-					offset: reportFilters.offset,
-				})
-				return report.rows.map((row) => this.toSerializableRecord(row))
+				const rows = await this.getAllPagedRows(
+					(filters) =>
+						this.reportService.getTaxDiscrepancyReport({
+							...filters,
+							onlyOpen: this.readBoolean(input.filters, 'onlyOpen'),
+						}),
+					reportFilters
+				)
+				return rows.map((row) => this.toSerializableRecord(row))
 			}
 			case 'bill_status': {
-				const report = await this.reportService.getBillStatusReport(reportFilters)
-				return report.rows.map((row) => this.toSerializableRecord(row))
+				const rows = await this.getAllPagedRows(
+					(filters) => this.reportService.getBillStatusReport(filters),
+					reportFilters
+				)
+				return rows.map((row) => this.toSerializableRecord(row))
 			}
 			default:
 				return []
+		}
+	}
+
+	private async getAllPagedRows<T>(
+		fetchPage: (filters: TaxReportWindowFilters) => Promise<TaxPagedResult<T>>,
+		filters: TaxReportWindowFilters,
+		pageSize = 200
+	): Promise<T[]> {
+		const rows: T[] = []
+		let offset = 0
+
+		while (true) {
+			const page = await fetchPage({
+				...filters,
+				limit: pageSize,
+				offset,
+			})
+			rows.push(...page.rows)
+			if (rows.length >= page.totalRows || page.rows.length === 0) {
+				return rows
+			}
+			offset += page.rows.length
 		}
 	}
 

--- a/apps/corporation-tax/src/services/tax-ledger.service.ts
+++ b/apps/corporation-tax/src/services/tax-ledger.service.ts
@@ -1,5 +1,5 @@
 import { filterTaxIncomeRefTypes, isTaxIncomeRefType } from '@repo/corporation-tax'
-import { and, desc, eq, gte, inArray, isNotNull, lt, lte, sql } from '@repo/db-utils'
+import { and, asc, desc, eq, gte, inArray, isNotNull, lt, lte, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 
 import { taxLedgerEntries, taxMemberSummaryVersions, taxSyncCheckpoints } from '../db/schema'
@@ -16,6 +16,7 @@ import type {
 	TaxLedgerRetentionResult,
 	TaxLedgerSourceType,
 	TaxLedgerWindowFilters,
+	TaxPagedResult,
 	TaxSyncCheckpoint,
 } from '@repo/corporation-tax'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
@@ -435,7 +436,7 @@ export class TaxLedgerService {
 	async listLedgerEntries(
 		corporationId: string,
 		filters: TaxLedgerWindowFilters = {}
-	): Promise<TaxLedgerEntry[]> {
+	): Promise<TaxPagedResult<TaxLedgerEntry>> {
 		const limit = Math.min(Math.max(filters.limit ?? 1000, 1), 10000)
 		const offset = Math.max(filters.offset ?? 0, 0)
 		const conditions = [eq(taxLedgerEntries.corporationId, corporationId)]
@@ -481,31 +482,59 @@ export class TaxLedgerService {
 			conditions.push(sql`CAST(${taxLedgerEntries.amount} AS numeric) <= ${maxAmount}`)
 		}
 
+		const [{ count: totalRows }] = await this.db
+			.select({ count: sql<number>`count(*)::int` })
+			.from(taxLedgerEntries)
+			.where(and(...conditions))
+
 		const rows = await this.db.query.taxLedgerEntries.findMany({
 			where: and(...conditions),
-			orderBy: [desc(taxLedgerEntries.entryDate)],
+			orderBy: [
+				filters.sortBy === 'amount'
+					? filters.sortDir === 'asc'
+						? sql`CAST(${taxLedgerEntries.amount} AS numeric) ASC`
+						: sql`CAST(${taxLedgerEntries.amount} AS numeric) DESC`
+					: filters.sortBy === 'division'
+						? filters.sortDir === 'asc'
+							? asc(taxLedgerEntries.division)
+							: desc(taxLedgerEntries.division)
+						: filters.sortBy === 'refType'
+							? filters.sortDir === 'asc'
+								? asc(taxLedgerEntries.refType)
+								: desc(taxLedgerEntries.refType)
+							: filters.sortBy === 'sourceType'
+								? filters.sortDir === 'asc'
+									? asc(taxLedgerEntries.sourceType)
+									: desc(taxLedgerEntries.sourceType)
+								: filters.sortDir === 'asc'
+									? asc(taxLedgerEntries.entryDate)
+									: desc(taxLedgerEntries.entryDate),
+			],
 			limit,
 			offset,
 		})
 
-		return rows.map((row) => ({
-			id: row.id,
-			corporationId: row.corporationId,
-			sourceType: row.sourceType,
-			sourcePrimaryId: row.sourcePrimaryId,
-			sourceSecondaryId: row.sourceSecondaryId,
-			characterId: this.extractCharacterId(row),
-			division: row.division,
-			refType: row.refType,
-			amount: row.amount,
-			balance: row.balance,
-			direction: row.direction as TaxLedgerDirection,
-			firstPartyId: row.firstPartyId,
-			secondPartyId: row.secondPartyId,
-			entryDate: row.entryDate,
-			createdAt: row.createdAt,
-			updatedAt: row.updatedAt,
-		}))
+		return {
+			totalRows: Number(totalRows ?? 0),
+			rows: rows.map((row) => ({
+				id: row.id,
+				corporationId: row.corporationId,
+				sourceType: row.sourceType,
+				sourcePrimaryId: row.sourcePrimaryId,
+				sourceSecondaryId: row.sourceSecondaryId,
+				characterId: this.extractCharacterId(row),
+				division: row.division,
+				refType: row.refType,
+				amount: row.amount,
+				balance: row.balance,
+				direction: row.direction as TaxLedgerDirection,
+				firstPartyId: row.firstPartyId,
+				secondPartyId: row.secondPartyId,
+				entryDate: row.entryDate,
+				createdAt: row.createdAt,
+				updatedAt: row.updatedAt,
+			})),
+		}
 	}
 
 	async listLedgerParties(

--- a/apps/corporation-tax/src/services/tax-report-ordering.ts
+++ b/apps/corporation-tax/src/services/tax-report-ordering.ts
@@ -8,6 +8,7 @@ import {
 	compareStrings,
 } from './tax-report-sorting'
 
+import type { SQL } from 'drizzle-orm'
 import type { TaxBillStatusReportRow, TaxMissingEsiKeyRow } from '@repo/corporation-tax'
 import type { SortDirection } from './tax-report-sorting'
 
@@ -19,7 +20,11 @@ export type BillStatusSortableRow = TaxBillStatusReportRow & {
 	sortDueDate: Date | null
 }
 
-export function resolveTotalTaxesOrderBy(sortBy: string, sortDirection: SortDirection) {
+export function resolveTotalTaxesOrderBy(
+	sortBy: string,
+	sortDirection: SortDirection,
+	taxableItemCountExpr: SQL
+) {
 	const direction = sortDirection === 'asc' ? asc : desc
 	const paidPerAssessmentExpr = sql`COALESCE((
 		SELECT SUM(CAST(bp.amount AS numeric))
@@ -30,8 +35,8 @@ export function resolveTotalTaxesOrderBy(sortBy: string, sortDirection: SortDire
 		corporationId: () => [direction(taxAssessments.corporationId)],
 		taxableItemCount: () => [
 			sortDirection === 'asc'
-				? sql`COALESCE(SUM((SELECT COUNT(*) FROM tax_assessment_lines tal WHERE tal.assessment_id = ${taxAssessments.id})), 0) ASC`
-				: sql`COALESCE(SUM((SELECT COUNT(*) FROM tax_assessment_lines tal WHERE tal.assessment_id = ${taxAssessments.id})), 0) DESC`,
+				? sql`${taxableItemCountExpr} ASC`
+				: sql`${taxableItemCountExpr} DESC`,
 			direction(taxAssessments.corporationId),
 		],
 		assessmentCount: () => [

--- a/apps/corporation-tax/src/services/tax-report.service.ts
+++ b/apps/corporation-tax/src/services/tax-report.service.ts
@@ -21,7 +21,6 @@ import {
 	parseDecimalToCenti as parseMoneyToCenti,
 } from './tax-money'
 import {
-	billStatusSortComparators,
 	missingEsiSortComparators,
 	resolveDiscrepancyOrderBy,
 	resolveEssOrderBy,
@@ -46,14 +45,20 @@ import type {
 	TaxTopIncomeSourceRow,
 	TaxTotalTaxesByCorporationRow,
 } from '@repo/corporation-tax'
-import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { CorporationAuthStatus, EveCorporationData } from '@repo/eve-corporation-data'
 import type { CorporationTaxDb } from '../db'
 
 const UNATTRIBUTED_CHARACTER_ID = '__unattributed__'
 
 export class TaxReportService {
+	private readonly REPORT_CORPORATION_ID_INLINE_LIMIT = 100
+	private readonly REPORT_CORPORATION_IDS_CACHE_TTL_MS = 5 * 60 * 1000
 	private readonly MEMBER_SUMMARY_CACHE_TTL_MS = 30 * 60 * 1000
 	private readonly MEMBER_SUMMARY_CACHE_MAX_ENTRIES = 500
+	private readonly ESI_AUTH_STATUS_CACHE_TTL_MS = 5 * 60 * 1000
+	private readonly ESI_AUTH_FAILURE_CACHE_TTL_MS = 30 * 1000
+	private readonly ESI_AUTH_STATUS_CACHE_MAX_ENTRIES = 1000
+	private readonly ESI_AUTH_STATUS_CONCURRENCY = 4
 	private memberSummaryCacheHits = 0
 	private memberSummaryCacheMisses = 0
 	private memberSummaryCacheDeltaChecks = 0
@@ -67,6 +72,17 @@ export class TaxReportService {
 			finalizedVersion: number
 		}
 	>()
+	private readonly esiAuthStatusCache = new Map<
+		string,
+		{
+			status: CorporationAuthStatus | null
+			expiresAtMs: number
+		}
+	>()
+	private dataBackedCorporationIdsCache: {
+		ids: string[]
+		expiresAtMs: number
+	} | null = null
 
 	constructor(
 		private db: CorporationTaxDb,
@@ -179,7 +195,18 @@ export class TaxReportService {
 		const sortBy = filters.sortBy ?? 'taxDue'
 		const sortDirection = toSortDirection(filters.sortDirection, 'desc')
 		const where = this.buildAssessmentWhere(filters, corporationIds, 'corporation')
-		const taxableItemCountExpr = sql<number>`COALESCE(SUM((SELECT COUNT(*) FROM tax_assessment_lines tal WHERE tal.assessment_id = ${taxAssessments.id})), 0)`
+		const assessmentLineCounts = this.db
+			.select({
+				assessmentId: taxAssessmentLines.assessmentId,
+				taxableItemCount:
+					sql<number>`COUNT(*) FILTER (WHERE CAST(${taxAssessmentLines.taxableAmount} AS numeric) > 0)::int`.as(
+						'taxable_item_count'
+					),
+			})
+			.from(taxAssessmentLines)
+			.groupBy(taxAssessmentLines.assessmentId)
+			.as('assessment_line_counts')
+		const taxableItemCountExpr = sql<number>`COALESCE(SUM(COALESCE(${assessmentLineCounts.taxableItemCount}, 0)), 0)`
 		const assessmentCountExpr = sql<number>`COUNT(*)`
 		const billedAssessmentCountExpr = sql<number>`SUM(CASE WHEN ${taxAssessments.billId} IS NOT NULL THEN 1 ELSE 0 END)`
 		const underpaidCountExpr = sql<number>`SUM(CASE WHEN ${taxAssessments.status} = 'underpaid' THEN 1 ELSE 0 END)`
@@ -197,7 +224,7 @@ export class TaxReportService {
 		const taxPaidExpr = sql<string>`COALESCE(SUM(${paidPerAssessmentExpr}), 0)::text`
 		const taxDeltaExpr = sql<string>`COALESCE(SUM(CAST(${taxAssessments.taxDue} AS numeric) - ${paidPerAssessmentExpr}), 0)::text`
 		const lastAssessmentAtExpr = sql<Date | null>`MAX(${taxAssessments.taxPeriodEnd})`
-		const orderBy = resolveTotalTaxesOrderBy(sortBy, sortDirection)
+		const orderBy = resolveTotalTaxesOrderBy(sortBy, sortDirection, taxableItemCountExpr)
 
 		const [rows, totalRowsResult] = await Promise.all([
 			this.db
@@ -218,6 +245,7 @@ export class TaxReportService {
 					lastAssessmentAt: lastAssessmentAtExpr,
 				})
 				.from(taxAssessments)
+				.leftJoin(assessmentLineCounts, eq(assessmentLineCounts.assessmentId, taxAssessments.id))
 				.where(where)
 				.groupBy(taxAssessments.corporationId)
 				.orderBy(...orderBy)
@@ -302,6 +330,10 @@ export class TaxReportService {
 			return []
 		}
 
+		if (filters.incomeMode === 'assessed') {
+			return this.getAssessedIncomeSourcesMonthlyReport(filters, corporationIds)
+		}
+
 		const monthStartExpr = sql<Date>`date_trunc('month', ${taxLedgerEntries.entryDate})`
 		const where = and(
 			this.buildLedgerWhere(filters, corporationIds),
@@ -329,6 +361,93 @@ export class TaxReportService {
 			entryCount: this.toInteger(row.entryCount),
 			essEntryCount: this.toInteger(row.essEntryCount),
 			totalIncome: this.formatCenti(this.parseDecimalToCenti(row.totalIncome)),
+		}))
+	}
+
+	private async getAssessedIncomeSourcesMonthlyReport(
+		filters: TaxRollupReportFilters,
+		corporationIds: string[]
+	): Promise<TaxTopIncomeSourceMonthlyRow[]> {
+		const fromDay = filters.fromDate ? this.toUtcDay(filters.fromDate) : undefined
+		const toDay = filters.toDate ? this.toUtcDay(filters.toDate) : undefined
+		const refTypes = filterTaxIncomeRefTypes(filters.refTypes)
+		const buildCorporationCondition = (alias: 'finalized' | 'projection') => {
+			const corporationColumn = sql.raw(`${alias}.corporation_id`)
+			if (corporationIds.length <= this.REPORT_CORPORATION_ID_INLINE_LIMIT) {
+				return sql`${corporationColumn} IN (${sql.join(
+					corporationIds.map((corporationId) => sql`${corporationId}`),
+					sql`, `
+				)})`
+			}
+
+			return sql`${corporationColumn} IN (
+				SELECT corporation_id FROM ${taxAssessments}
+				UNION
+				SELECT corporation_id FROM ${taxLedgerEntries}
+				UNION
+				SELECT corporation_id FROM ${taxDiscrepancies}
+			)`
+		}
+		const buildRollupWhere = (alias: 'finalized' | 'projection') => sql`
+			${buildCorporationCondition(alias)}
+			${fromDay ? sql`AND ${sql.raw(`${alias}.rollup_date`)} >= ${fromDay}` : sql``}
+			${toDay ? sql`AND ${sql.raw(`${alias}.rollup_date`)} <= ${toDay}` : sql``}
+			${
+				refTypes?.length
+					? sql`AND ${sql.raw(`${alias}.ref_type`)} IN (${sql.join(
+							refTypes.map((refType) => sql`${refType}`),
+							sql`, `
+						)})`
+					: sql``
+			}
+			AND CAST(${sql.raw(`${alias}.taxable_contribution_income`)} AS numeric) > 0
+		`
+
+		const result = await this.db.execute(sql`
+			WITH assessed_rows AS (
+				SELECT
+					finalized.rollup_date,
+					finalized.ref_type,
+					finalized.source_row_count,
+					finalized.taxable_contribution_income
+				FROM ${taxMemberContributionFinalizedRollups} AS finalized
+				WHERE ${buildRollupWhere('finalized')}
+				UNION ALL
+				SELECT
+					projection.rollup_date,
+					projection.ref_type,
+					projection.source_row_count,
+					projection.taxable_contribution_income
+				FROM ${taxMemberContributionProjectionRollups} AS projection
+				WHERE ${buildRollupWhere('projection')}
+					AND NOT EXISTS (
+						SELECT 1
+						FROM ${taxMemberContributionFinalizedRollups} AS finalized_match
+						WHERE finalized_match.corporation_id = projection.corporation_id
+							AND finalized_match.period_start = projection.period_start
+							AND finalized_match.period_end = projection.period_end
+							AND finalized_match.rollup_date = projection.rollup_date
+							AND finalized_match.character_id = projection.character_id
+							AND finalized_match.ref_type = projection.ref_type
+					)
+			)
+			SELECT
+				date_trunc('month', rollup_date) AS month_start,
+				ref_type,
+				SUM(source_row_count)::int AS entry_count,
+				SUM(CASE WHEN ref_type = 'ess_escrow_transfer' THEN source_row_count ELSE 0 END)::int AS ess_entry_count,
+				COALESCE(SUM(CAST(taxable_contribution_income AS numeric)), 0)::text AS total_income
+			FROM assessed_rows
+			GROUP BY date_trunc('month', rollup_date), ref_type
+			ORDER BY date_trunc('month', rollup_date) ASC, total_income DESC, ref_type ASC
+		`)
+
+		return (result.rows as Array<Record<string, unknown>>).map((row) => ({
+			monthStart: new Date(String(row.month_start)),
+			refType: String(row.ref_type),
+			entryCount: this.toInteger(String(row.entry_count ?? '0')),
+			essEntryCount: this.toInteger(String(row.ess_entry_count ?? '0')),
+			totalIncome: this.formatCenti(this.parseDecimalToCenti(String(row.total_income ?? '0'))),
 		}))
 	}
 
@@ -422,6 +541,77 @@ export class TaxReportService {
 		})
 	}
 
+	async getComplianceOverTimeReportPage(
+		filters: TaxRollupReportFilters = {}
+	): Promise<TaxPagedResult<TaxCompliancePoint>> {
+		const corporationIds = await this.resolveReportCorporationIds(filters.corporationId)
+		if (corporationIds.length === 0) {
+			return { rows: [], totalRows: 0 }
+		}
+
+		const offset = Math.max(filters.offset ?? 0, 0)
+		const limit = Math.min(Math.max(filters.limit ?? 50, 1), 3650)
+		const rollupDateExpr = sql<Date>`date_trunc('day', ${taxAssessments.taxPeriodEnd})`
+		const paidPerAssessmentExpr = sql`COALESCE((
+			SELECT SUM(CAST(bp.amount AS numeric))
+			FROM bill_payments bp
+			WHERE bp.bill_id = ${taxAssessments.billId}
+		), 0)`
+		const taxDueExpr = sql`COALESCE(SUM(CAST(${taxAssessments.taxDue} AS numeric)), 0)`
+		const taxPaidExpr = sql`COALESCE(SUM(${paidPerAssessmentExpr}), 0)`
+		const taxDeltaExpr = sql`COALESCE(SUM(CAST(${taxAssessments.taxDue} AS numeric) - ${paidPerAssessmentExpr}), 0)`
+		const entryCountExpr = sql<number>`COUNT(*)`
+		const sortDirection = filters.sortDirection === 'asc' ? 'ASC' : 'DESC'
+		const sortExpression =
+			filters.sortBy === 'taxDue'
+				? taxDueExpr
+				: filters.sortBy === 'taxPaid'
+					? taxPaidExpr
+					: filters.sortBy === 'taxDelta'
+						? taxDeltaExpr
+						: filters.sortBy === 'entryCount'
+							? entryCountExpr
+							: rollupDateExpr
+		const orderBy = sql`${sortExpression} ${sql.raw(sortDirection)}, ${rollupDateExpr} ASC`
+		const where = this.buildAssessmentWhere(filters, corporationIds, 'corporation')
+		const [rows, countRows] = await Promise.all([
+			this.db
+				.select({
+					rollupDate: rollupDateExpr,
+					entryCount: entryCountExpr,
+					taxDue: sql<string>`${taxDueExpr}::text`,
+					taxPaid: sql<string>`${taxPaidExpr}::text`,
+				})
+				.from(taxAssessments)
+				.where(where)
+				.groupBy(rollupDateExpr)
+				.orderBy(orderBy)
+				.limit(limit)
+				.offset(offset),
+			this.db
+				.select({
+					count: sql<number>`COUNT(DISTINCT ${rollupDateExpr})`,
+				})
+				.from(taxAssessments)
+				.where(where),
+		])
+
+		return {
+			rows: rows.map((row) => {
+				const taxDueCenti = this.parseDecimalToCenti(row.taxDue)
+				const taxPaidCenti = this.parseDecimalToCenti(row.taxPaid)
+				return {
+					rollupDate: new Date(row.rollupDate),
+					taxDue: this.formatCenti(taxDueCenti),
+					taxPaid: this.formatCenti(taxPaidCenti),
+					taxDelta: this.formatCenti(taxDueCenti - taxPaidCenti),
+					entryCount: this.toInteger(row.entryCount),
+				}
+			}),
+			totalRows: this.toInteger(countRows[0]?.count ?? 0),
+		}
+	}
+
 	async getTaxDiscrepancyReport(
 		filters: ListTaxDiscrepancyReportFilters = {}
 	): Promise<TaxPagedResult<TaxDiscrepancy>> {
@@ -472,11 +662,12 @@ export class TaxReportService {
 	async getMissingEsiKeysReport(
 		filters: ListTaxMissingEsiKeyReportFilters = {}
 	): Promise<TaxPagedResult<TaxMissingEsiKeyRow>> {
-		const corporationIds = await this.listKnownCorporationIds()
+		const corporationIds = await this.listTaxProcessableCorporationIds()
+		const statuses = await this.getCorporationEsiAuthStatuses(corporationIds)
 
 		const missingRows: TaxMissingEsiKeyRow[] = []
 		for (const corporationId of corporationIds) {
-			const status = await this.getCorporationEsiAuthStatus(corporationId)
+			const status = statuses.get(corporationId) ?? null
 			const hasMissingCoverage =
 				!status ||
 				!status.isConfigured ||
@@ -524,44 +715,82 @@ export class TaxReportService {
 		if (corporationIds.length === 0) {
 			return { rows: [], totalRows: 0 }
 		}
+
 		const paidPerAssessmentExpr = sql`COALESCE((
 			SELECT SUM(CAST(bp.amount AS numeric))
 			FROM bill_payments bp
 			WHERE bp.bill_id = ${taxAssessments.billId}
 		), 0)`
-
-		const rows = await this.db
-			.select({
-				assessmentId: taxAssessments.id,
-				corporationId: taxAssessments.corporationId,
-				taxPeriodStart: taxAssessments.taxPeriodStart,
-				taxPeriodEnd: taxAssessments.taxPeriodEnd,
-				billId: taxAssessments.billId,
-				billStatus: sql<string>`COALESCE(${taxAssessments.billStatus}, 'draft')`,
-				issueDate: sql<Date | null>`(
+		const issueDateExpr = sql<Date | null>`(
 					SELECT MIN(bse.created_at)
 					FROM bill_status_events bse
 					WHERE bse.bill_id = ${taxAssessments.billId}
 						AND bse.event_type = 'issued'
-				)`,
-				dueDate: sql<Date | null>`(
+				)`
+		const dueDateExpr = sql<Date | null>`(
 					SELECT b.due_date
 					FROM bills b
 					WHERE b.id = ${taxAssessments.billId}
-				)`,
-				taxDue: taxAssessments.taxDue,
-				taxPaid: sql<string>`${paidPerAssessmentExpr}::text`,
-				taxDelta: sql<string>`(CAST(${taxAssessments.taxDue} AS numeric) - ${paidPerAssessmentExpr})::text`,
-			})
-			.from(taxAssessments)
-			.where(
-				and(
-					this.buildAssessmentWhere(filters, corporationIds, 'corporation'),
-					isNotNull(taxAssessments.billId)
-				)
-			)
+				)`
+		const taxPaidExpr = sql`${paidPerAssessmentExpr}`
+		const taxDeltaExpr = sql`(CAST(${taxAssessments.taxDue} AS numeric) - ${paidPerAssessmentExpr})`
+		const where = and(
+			this.buildAssessmentWhere(filters, corporationIds, 'corporation'),
+			isNotNull(taxAssessments.billId)
+		)
+		const offset = Math.max(filters.offset ?? 0, 0)
+		const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200)
+		const sortBy = filters.sortBy ?? 'dueDate'
+		const sortDirection = toSortDirection(filters.sortDirection, 'asc')
+		const direction = sortDirection === 'asc' ? 'ASC' : 'DESC'
+		const sortExpression =
+			sortBy === 'assessmentId'
+				? taxAssessments.id
+				: sortBy === 'corporationId'
+					? taxAssessments.corporationId
+					: sortBy === 'taxPeriodStart'
+						? taxAssessments.taxPeriodStart
+						: sortBy === 'taxPeriodEnd'
+							? taxAssessments.taxPeriodEnd
+							: sortBy === 'billStatus'
+								? sql`COALESCE(${taxAssessments.billStatus}, 'draft')`
+								: sortBy === 'issueDate'
+									? issueDateExpr
+									: sortBy === 'taxPaid'
+										? taxPaidExpr
+										: sortBy === 'taxDelta'
+											? taxDeltaExpr
+											: sortBy === 'taxDue'
+												? sql`CAST(${taxAssessments.taxDue} AS numeric)`
+												: dueDateExpr
+		const orderBy = sql`${sortExpression} ${sql.raw(direction)} NULLS LAST, ${taxAssessments.id} ASC`
+		const [rows, totalRowsResult] = await Promise.all([
+			this.db
+				.select({
+					assessmentId: taxAssessments.id,
+					corporationId: taxAssessments.corporationId,
+					taxPeriodStart: taxAssessments.taxPeriodStart,
+					taxPeriodEnd: taxAssessments.taxPeriodEnd,
+					billId: taxAssessments.billId,
+					billStatus: sql<string>`COALESCE(${taxAssessments.billStatus}, 'draft')`,
+					issueDate: issueDateExpr,
+					dueDate: dueDateExpr,
+					taxDue: taxAssessments.taxDue,
+					taxPaid: sql<string>`${taxPaidExpr}::text`,
+					taxDelta: sql<string>`${taxDeltaExpr}::text`,
+				})
+				.from(taxAssessments)
+				.where(where)
+				.orderBy(orderBy)
+				.limit(limit)
+				.offset(offset),
+			this.db
+				.select({ count: sql<number>`COUNT(*)` })
+				.from(taxAssessments)
+				.where(where),
+		])
 
-		const grouped = rows.map((row) => ({
+		const pagedRows = rows.map((row) => ({
 			assessmentId: row.assessmentId,
 			corporationId: row.corporationId,
 			taxPeriodStart: new Date(row.taxPeriodStart),
@@ -576,36 +805,10 @@ export class TaxReportService {
 			taxDueCenti: this.parseDecimalToCenti(row.taxDue).toString(),
 			taxPaidCenti: this.parseDecimalToCenti(row.taxPaid).toString(),
 			taxDeltaCenti: this.parseDecimalToCenti(row.taxDelta).toString(),
-			sortDueCenti: this.parseDecimalToCenti(row.taxDue),
-			sortPaidCenti: this.parseDecimalToCenti(row.taxPaid),
-			sortDeltaCenti: this.parseDecimalToCenti(row.taxDelta),
-			sortIssueDate: this.toDateOrNull(row.issueDate),
-			sortDueDate: this.toDateOrNull(row.dueDate),
 		}))
-
-		const offset = Math.max(filters.offset ?? 0, 0)
-		const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200)
-		const sortBy = filters.sortBy ?? 'dueDate'
-		const sortDirection = toSortDirection(filters.sortDirection, 'asc')
-		const comparator =
-			billStatusSortComparators[sortBy as keyof typeof billStatusSortComparators] ??
-			billStatusSortComparators.dueDate
-		const pagedRows = grouped
-			.sort((a, b) => comparator(a, b, sortDirection))
-			.slice(offset, offset + limit)
-			.map(
-				({
-					sortDueCenti: _sortDueCenti,
-					sortPaidCenti: _sortPaidCenti,
-					sortDeltaCenti: _sortDeltaCenti,
-					sortIssueDate: _sortIssueDate,
-					sortDueDate: _sortDueDate,
-					...row
-				}) => row
-			)
 		return {
 			rows: pagedRows,
-			totalRows: grouped.length,
+			totalRows: this.toInteger(totalRowsResult[0]?.count ?? 0),
 		}
 	}
 
@@ -1025,28 +1228,69 @@ export class TaxReportService {
 		)
 	}
 
-	async getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
-		const attachments = await this.db
-			.select({ ruleGroupId: taxRuleGroupAttachments.ruleGroupId })
-			.from(taxRuleGroupAttachments)
-			.where(eq(taxRuleGroupAttachments.corporationId, corporationId))
+	async getTaxableIncomeRefTypes(corporationId?: string): Promise<string[]> {
+		const corporationIds = await this.resolveReportCorporationIds(corporationId)
+		if (corporationIds.length === 0) {
+			return []
+		}
 
-		const ruleGroupIds = attachments.map((row) => row.ruleGroupId)
+		const attachments = await this.db
+			.select({
+				corporationId: taxRuleGroupAttachments.corporationId,
+				ruleGroupId: taxRuleGroupAttachments.ruleGroupId,
+			})
+			.from(taxRuleGroupAttachments)
+			.where(
+				this.buildCorporationIdCondition(taxRuleGroupAttachments.corporationId, corporationIds)
+			)
+
+		const ruleGroupIds = [...new Set(attachments.map((row) => row.ruleGroupId))]
 		if (ruleGroupIds.length === 0) {
 			return []
 		}
 
+		const ruleGroupCondition =
+			ruleGroupIds.length <= this.REPORT_CORPORATION_ID_INLINE_LIMIT
+				? inArray(taxRuleSets.ruleGroupId, ruleGroupIds)
+				: sql`${taxRuleSets.ruleGroupId} IN (
+					SELECT DISTINCT rule_group_id
+					FROM ${taxRuleGroupAttachments}
+					WHERE ${this.buildCorporationIdCondition(taxRuleGroupAttachments.corporationId, corporationIds)}
+				)`
 		const rules = await this.db.query.taxRuleSets.findMany({
-			where: and(inArray(taxRuleSets.ruleGroupId, ruleGroupIds), eq(taxRuleSets.isActive, true)),
+			where: and(ruleGroupCondition, eq(taxRuleSets.isActive, true)),
 			orderBy: [desc(taxRuleSets.priority), desc(taxRuleSets.createdAt)],
 		})
 
-		return TAX_INCOME_REF_TYPES.filter((refType) => {
-			const effectiveRule = rules.find(
-				(rule) => rule.appliesToRefType === null || rule.appliesToRefType === refType
+		const rulesByGroup = new Map<string, typeof rules>()
+		for (const rule of rules) {
+			const groupRules = rulesByGroup.get(rule.ruleGroupId) ?? []
+			groupRules.push(rule)
+			rulesByGroup.set(rule.ruleGroupId, groupRules)
+		}
+
+		const taxableRefTypes = new Set<string>()
+		for (const corporationId of corporationIds) {
+			const corporationGroupIds = new Set(
+				attachments
+					.filter((attachment) => attachment.corporationId === corporationId)
+					.map((attachment) => attachment.ruleGroupId)
 			)
-			return (effectiveRule?.taxRateBps ?? 0) > 0
-		})
+			// Preserve the database priority ordering across all rule groups attached
+			// to a corporation when resolving the effective rule for each ref type.
+			const corporationRules = rules.filter((rule) => corporationGroupIds.has(rule.ruleGroupId))
+
+			for (const refType of TAX_INCOME_REF_TYPES) {
+				const effectiveRule = corporationRules.find(
+					(rule) => rule.appliesToRefType === null || rule.appliesToRefType === refType
+				)
+				if ((effectiveRule?.taxRateBps ?? 0) > 0) {
+					taxableRefTypes.add(refType)
+				}
+			}
+		}
+
+		return TAX_INCOME_REF_TYPES.filter((refType) => taxableRefTypes.has(refType))
 	}
 
 	private async hasMemberSummaryRollupUpdatesSince(
@@ -1149,9 +1393,10 @@ export class TaxReportService {
 				SELECT
 					finalized.character_id,
 					finalized.ref_type,
+					finalized.period_start,
+					finalized.period_end,
 					finalized.contribution_income,
 					finalized.taxable_contribution_income,
-					finalized.assessment_count,
 					finalized.source_row_count,
 					finalized.last_assessment_at
 				FROM ${taxMemberContributionFinalizedRollups} AS finalized
@@ -1160,9 +1405,10 @@ export class TaxReportService {
 				SELECT
 					projection.character_id,
 					projection.ref_type,
+					projection.period_start,
+					projection.period_end,
 					projection.contribution_income,
 					projection.taxable_contribution_income,
-					projection.assessment_count,
 					projection.source_row_count,
 					projection.last_assessment_at
 				FROM ${taxMemberContributionProjectionRollups} AS projection
@@ -1172,7 +1418,7 @@ export class TaxReportService {
 					character_id,
 					SUM(contribution_income::numeric) AS contribution_income,
 					SUM(taxable_contribution_income::numeric) AS taxable_contribution_income,
-					MAX(assessment_count)::int AS assessment_count,
+					COUNT(DISTINCT (period_start, period_end))::int AS assessment_count,
 					MAX(last_assessment_at) AS last_assessment_at
 				FROM rollup_rows
 				GROUP BY character_id
@@ -1183,6 +1429,8 @@ export class TaxReportService {
 				SELECT
 					finalized.character_id,
 					finalized.ref_type,
+					finalized.period_start,
+					finalized.period_end,
 					finalized.contribution_income,
 					finalized.taxable_contribution_income,
 					finalized.source_row_count
@@ -1192,6 +1440,8 @@ export class TaxReportService {
 				SELECT
 					projection.character_id,
 					projection.ref_type,
+					projection.period_start,
+					projection.period_end,
 					projection.contribution_income,
 					projection.taxable_contribution_income,
 					projection.source_row_count
@@ -1363,9 +1613,9 @@ export class TaxReportService {
 			{
 				characterId: string
 				refType: string
+				assessmentPeriods: Set<string>
 				contributionIncomeCenti: bigint
 				taxableContributionIncomeCenti: bigint
-				assessmentCount: number
 				lineCount: number
 				lastAssessmentAt: Date | null
 			}
@@ -1374,9 +1624,10 @@ export class TaxReportService {
 			rollupDate: Date
 			characterId: string
 			refType: string
+			periodStart: Date
+			periodEnd: Date
 			contributionIncome: string
 			taxableContributionIncome: string
-			assessmentCount: number
 			sourceRowCount: number
 			lastAssessmentAt: Date | null
 		}) => {
@@ -1394,17 +1645,19 @@ export class TaxReportService {
 			const current = rolled.get(key) ?? {
 				characterId: row.characterId,
 				refType: row.refType,
+				assessmentPeriods: new Set<string>(),
 				contributionIncomeCenti: 0n,
 				taxableContributionIncomeCenti: 0n,
-				assessmentCount: 0,
 				lineCount: 0,
 				lastAssessmentAt: null,
 			}
+			current.assessmentPeriods.add(
+				`${row.periodStart.toISOString()}:${row.periodEnd.toISOString()}`
+			)
 			current.contributionIncomeCenti += this.parseDecimalToCenti(row.contributionIncome)
 			current.taxableContributionIncomeCenti += this.parseDecimalToCenti(
 				row.taxableContributionIncome
 			)
-			current.assessmentCount = Math.max(current.assessmentCount, row.assessmentCount)
 			current.lineCount += row.sourceRowCount
 			current.lastAssessmentAt =
 				!current.lastAssessmentAt ||
@@ -1424,6 +1677,7 @@ export class TaxReportService {
 		const byCharacter = new Map<
 			string,
 			{
+				assessmentPeriods: Set<string>
 				assessmentCount: number
 				contributionIncomeCenti: bigint
 				taxableContributionIncomeCenti: bigint
@@ -1440,6 +1694,7 @@ export class TaxReportService {
 		>()
 		for (const row of rolled.values()) {
 			const current = byCharacter.get(row.characterId) ?? {
+				assessmentPeriods: new Set<string>(),
 				assessmentCount: 0,
 				contributionIncomeCenti: 0n,
 				taxableContributionIncomeCenti: 0n,
@@ -1453,7 +1708,10 @@ export class TaxReportService {
 					}
 				>(),
 			}
-			current.assessmentCount = Math.max(current.assessmentCount, row.assessmentCount)
+			for (const period of row.assessmentPeriods) {
+				current.assessmentPeriods.add(period)
+			}
+			current.assessmentCount = current.assessmentPeriods.size
 			current.contributionIncomeCenti += row.contributionIncomeCenti
 			current.taxableContributionIncomeCenti += row.taxableContributionIncomeCenti
 			current.lastAssessmentAt =
@@ -1774,15 +2032,25 @@ export class TaxReportService {
 		corporationIds: string[],
 		assessmentScope?: 'corporation' | 'division' | 'character'
 	) {
-		const conditions = [inArray(taxAssessments.corporationId, corporationIds)]
+		const conditions = [
+			this.buildCorporationIdCondition(taxAssessments.corporationId, corporationIds),
+		]
 		if (assessmentScope) {
 			conditions.push(eq(taxAssessments.assessmentScope, assessmentScope))
 		}
-		if (filters.fromDate) {
-			conditions.push(gte(taxAssessments.taxPeriodStart, filters.fromDate))
-		}
-		if (filters.toDate) {
-			conditions.push(lte(taxAssessments.taxPeriodEnd, filters.toDate))
+		// Assessments are normally monthly, while report filters may be arbitrary
+		// date ranges. Include any assessment whose period overlaps the requested
+		// window instead of requiring the entire assessment to fit inside it.
+		if (filters.fromDate && filters.toDate) {
+			const overlapCondition = and(
+				lte(taxAssessments.taxPeriodStart, filters.toDate),
+				gte(taxAssessments.taxPeriodEnd, filters.fromDate)
+			)
+			if (overlapCondition) conditions.push(overlapCondition)
+		} else if (filters.fromDate) {
+			conditions.push(gte(taxAssessments.taxPeriodEnd, filters.fromDate))
+		} else if (filters.toDate) {
+			conditions.push(lte(taxAssessments.taxPeriodStart, filters.toDate))
 		}
 		return and(...conditions)
 	}
@@ -1800,7 +2068,9 @@ export class TaxReportService {
 		corporationIds: string[],
 		options: { essOnly: boolean }
 	) {
-		const conditions = [inArray(taxLedgerEntries.corporationId, corporationIds)]
+		const conditions = [
+			this.buildCorporationIdCondition(taxLedgerEntries.corporationId, corporationIds),
+		]
 		if (options.essOnly) {
 			conditions.push(eq(taxLedgerEntries.refType, 'ess_escrow_transfer'))
 		}
@@ -1810,6 +2080,10 @@ export class TaxReportService {
 		if (filters.toDate) {
 			conditions.push(lte(taxLedgerEntries.entryDate, filters.toDate))
 		}
+		const refTypes = filterTaxIncomeRefTypes(filters.refTypes)
+		if (refTypes?.length) {
+			conditions.push(inArray(taxLedgerEntries.refType, refTypes))
+		}
 		return and(...conditions)
 	}
 
@@ -1817,7 +2091,9 @@ export class TaxReportService {
 		filters: { corporationId?: string; fromDate?: Date; toDate?: Date; onlyOpen?: boolean },
 		corporationIds: string[]
 	) {
-		const conditions = [inArray(taxDiscrepancies.corporationId, corporationIds)]
+		const conditions = [
+			this.buildCorporationIdCondition(taxDiscrepancies.corporationId, corporationIds),
+		]
 		if (filters.fromDate) {
 			conditions.push(gte(taxDiscrepancies.createdAt, filters.fromDate))
 		}
@@ -1862,7 +2138,36 @@ export class TaxReportService {
 		return this.listDataBackedCorporationIds()
 	}
 
+	private buildCorporationIdCondition(
+		column:
+			| typeof taxAssessments.corporationId
+			| typeof taxLedgerEntries.corporationId
+			| typeof taxDiscrepancies.corporationId
+			| typeof taxRuleGroupAttachments.corporationId,
+		corporationIds: string[]
+	) {
+		if (corporationIds.length <= this.REPORT_CORPORATION_ID_INLINE_LIMIT) {
+			return inArray(column, corporationIds)
+		}
+
+		// Global report scope is the union of corporations with persisted tax data.
+		// Keep that set construction in PostgreSQL instead of serializing a growing
+		// corporation roster into hundreds of query parameters.
+		return sql`${column} IN (
+			SELECT corporation_id FROM ${taxAssessments}
+			UNION
+			SELECT corporation_id FROM ${taxLedgerEntries}
+			UNION
+			SELECT corporation_id FROM ${taxDiscrepancies}
+		)`
+	}
+
 	private async listDataBackedCorporationIds(): Promise<string[]> {
+		const cached = this.dataBackedCorporationIdsCache
+		if (cached && cached.expiresAtMs > Date.now()) {
+			return cached.ids
+		}
+
 		const [assessmentRows, ledgerRows, discrepancyRows] = await Promise.all([
 			this.db
 				.select({
@@ -1884,13 +2189,18 @@ export class TaxReportService {
 				.groupBy(taxDiscrepancies.corporationId),
 		])
 
-		return Array.from(
+		const ids = Array.from(
 			new Set([
 				...assessmentRows.map((row) => row.corporationId),
 				...ledgerRows.map((row) => row.corporationId),
 				...discrepancyRows.map((row) => row.corporationId),
 			])
 		).sort((a, b) => a.localeCompare(b))
+		this.dataBackedCorporationIdsCache = {
+			ids,
+			expiresAtMs: Date.now() + this.REPORT_CORPORATION_IDS_CACHE_TTL_MS,
+		}
+		return ids
 	}
 
 	private async listKnownCorporationIds(corporationId?: string): Promise<string[]> {
@@ -1906,6 +2216,57 @@ export class TaxReportService {
 			.where(eq(managedCorporations.isActive, true))
 			.groupBy(managedCorporations.corporationId)
 		return rows.map((row) => row.corporationId)
+	}
+
+	/**
+	 * Match the corporation scope used by scheduled tax assessments. Keeping this
+	 * query in the database avoids checking ESI coverage for inactive, excluded,
+	 * or non-member corporations that cannot produce a tax assessment.
+	 */
+	private async listTaxProcessableCorporationIds(): Promise<string[]> {
+		const rows = await this.db
+			.select({ corporationId: managedCorporations.corporationId })
+			.from(managedCorporations)
+			.innerJoin(
+				taxRuleGroupAttachments,
+				eq(taxRuleGroupAttachments.corporationId, managedCorporations.corporationId)
+			)
+			.leftJoin(
+				taxCorporationExclusions,
+				eq(taxCorporationExclusions.corporationId, managedCorporations.corporationId)
+			)
+			.where(
+				and(
+					eq(managedCorporations.isActive, true),
+					eq(managedCorporations.isMemberCorporation, true),
+					isNull(taxCorporationExclusions.corporationId)
+				)
+			)
+			.groupBy(managedCorporations.corporationId)
+
+		return rows.map((row) => row.corporationId)
+	}
+
+	private async getCorporationEsiAuthStatuses(
+		corporationIds: string[]
+	): Promise<Map<string, CorporationAuthStatus | null>> {
+		const statuses = new Map<string, CorporationAuthStatus | null>()
+		let nextIndex = 0
+		const workerCount = Math.min(this.ESI_AUTH_STATUS_CONCURRENCY, corporationIds.length)
+
+		await Promise.all(
+			Array.from({ length: workerCount }, async () => {
+				while (nextIndex < corporationIds.length) {
+					const corporationId = corporationIds[nextIndex++]
+					if (!corporationId) {
+						continue
+					}
+					statuses.set(corporationId, await this.getCorporationEsiAuthStatus(corporationId))
+				}
+			})
+		)
+
+		return statuses
 	}
 
 	private async listExclusions(corporationId?: string) {
@@ -1943,26 +2304,43 @@ export class TaxReportService {
 		return Array.from(byCorporationId.values())
 	}
 
-	private async getCorporationEsiAuthStatus(corporationId: string) {
+	private async getCorporationEsiAuthStatus(
+		corporationId: string
+	): Promise<CorporationAuthStatus | null> {
+		const cached = this.esiAuthStatusCache.get(corporationId)
+		if (cached && cached.expiresAtMs > Date.now()) {
+			return cached.status
+		}
+
 		try {
 			const stub = getStub<EveCorporationData>(this.eveCorporationDataNamespace, corporationId)
 			const status = await stub.getCorporationAuthStatus(corporationId)
-			return {
-				isConfigured: status.isConfigured,
-				isVerified: status.isVerified,
-				lastVerified: status.lastVerified,
-				directorCount: status.directorCount,
-				healthyDirectorCount: status.healthyDirectorCount,
-				requiredScopes: status.requiredScopes,
-				missingRequiredScopes: status.missingRequiredScopes,
-				hasRequiredScopes: status.hasRequiredScopes,
-				hasCorporationWalletScope: status.hasCorporationWalletScope,
-				hasCharacterWalletScope: status.hasCharacterWalletScope,
-				hasCorporationMembershipScope: status.hasCorporationMembershipScope,
-				grantedScopeCount: status.grantedScopeCount,
-			}
+			this.cacheCorporationEsiAuthStatus(corporationId, {
+				status,
+				expiresAtMs: Date.now() + this.ESI_AUTH_STATUS_CACHE_TTL_MS,
+			})
+			return status
 		} catch {
+			this.cacheCorporationEsiAuthStatus(corporationId, {
+				status: null,
+				expiresAtMs: Date.now() + this.ESI_AUTH_FAILURE_CACHE_TTL_MS,
+			})
 			return null
+		}
+	}
+
+	private cacheCorporationEsiAuthStatus(
+		corporationId: string,
+		entry: { status: CorporationAuthStatus | null; expiresAtMs: number }
+	): void {
+		this.esiAuthStatusCache.delete(corporationId)
+		this.esiAuthStatusCache.set(corporationId, entry)
+		while (this.esiAuthStatusCache.size > this.ESI_AUTH_STATUS_CACHE_MAX_ENTRIES) {
+			const oldestCorporationId = this.esiAuthStatusCache.keys().next().value
+			if (!oldestCorporationId) {
+				break
+			}
+			this.esiAuthStatusCache.delete(oldestCorporationId)
 		}
 	}
 

--- a/apps/corporation-tax/src/services/tax-report.service.ts
+++ b/apps/corporation-tax/src/services/tax-report.service.ts
@@ -1,3 +1,4 @@
+import { filterTaxIncomeRefTypes, TAX_INCOME_REF_TYPES } from '@repo/corporation-tax'
 import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
@@ -13,6 +14,7 @@ import {
 	taxMemberContributionProjectionRollups,
 	taxMemberSummaryVersions,
 	taxRuleGroupAttachments,
+	taxRuleSets,
 } from '../db/schema'
 import {
 	formatCenti as formatMoneyCenti,
@@ -46,6 +48,8 @@ import type {
 } from '@repo/corporation-tax'
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { CorporationTaxDb } from '../db'
+
+const UNATTRIBUTED_CHARACTER_ID = '__unattributed__'
 
 export class TaxReportService {
 	private readonly MEMBER_SUMMARY_CACHE_TTL_MS = 30 * 60 * 1000
@@ -608,16 +612,44 @@ export class TaxReportService {
 	async getMemberSummaryReport(
 		filters: TaxMemberSummaryReportFilters
 	): Promise<TaxPagedResult<TaxMemberSummary>> {
+		const rollupReadSupported = this.supportsMemberSummaryRollupRead()
 		const requestedCharacterIds = Array.from(
 			new Set<string>((filters.characterIds ?? []).map((value) => value.trim()).filter(Boolean))
 		)
-		const memberCharacterIds = await this.getCorporationMemberIds(filters.corporationId)
+		// Privileged corporation-wide rollup reads are already scoped by corporation_id.
+		// Only resolve the DO-backed active-member roster when an individual scope is
+		// requested or when the legacy non-rollup path still needs it.
+		const memberCharacterIds =
+			rollupReadSupported && requestedCharacterIds.length === 0
+				? []
+				: await this.getCorporationMemberIds(filters.corporationId)
 		const memberIdSet = new Set(memberCharacterIds)
 		const scopedRequestedCharacterIds =
 			requestedCharacterIds.length > 0
 				? requestedCharacterIds.filter((characterId) => memberIdSet.has(characterId))
 				: []
 		const includeUnattributedRow = true
+		const refTypes = filterTaxIncomeRefTypes(filters.refTypes)
+
+		if (rollupReadSupported) {
+			if (requestedCharacterIds.length > 0 && scopedRequestedCharacterIds.length === 0) {
+				return { rows: [], totalRows: 0 }
+			}
+
+			return this.getMemberSummaryFromRollupsSql({
+				corporationId: filters.corporationId,
+				characterIds: requestedCharacterIds.length > 0 ? scopedRequestedCharacterIds : undefined,
+				includeUnattributedRow,
+				refTypes,
+				fromDate: filters.fromDate,
+				toDate: filters.toDate,
+				topRefTypesLimit: filters.topRefTypesLimit,
+				limit: filters.limit,
+				offset: filters.offset,
+				sortBy: filters.sortBy,
+				sortDirection: filters.sortDirection,
+			})
+		}
 
 		const cacheKey = this.toMemberSummaryCacheKey(filters)
 		const nowMs = Date.now()
@@ -687,6 +719,7 @@ export class TaxReportService {
 				scopedCharacterIdSet,
 				includeUnattributedRow,
 				topRefTypesLimit,
+				refTypes,
 			})
 			if (rollupRows.length > 0) {
 				this.setMemberSummaryCache(cacheKey, {
@@ -992,6 +1025,30 @@ export class TaxReportService {
 		)
 	}
 
+	async getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
+		const attachments = await this.db
+			.select({ ruleGroupId: taxRuleGroupAttachments.ruleGroupId })
+			.from(taxRuleGroupAttachments)
+			.where(eq(taxRuleGroupAttachments.corporationId, corporationId))
+
+		const ruleGroupIds = attachments.map((row) => row.ruleGroupId)
+		if (ruleGroupIds.length === 0) {
+			return []
+		}
+
+		const rules = await this.db.query.taxRuleSets.findMany({
+			where: and(inArray(taxRuleSets.ruleGroupId, ruleGroupIds), eq(taxRuleSets.isActive, true)),
+			orderBy: [desc(taxRuleSets.priority), desc(taxRuleSets.createdAt)],
+		})
+
+		return TAX_INCOME_REF_TYPES.filter((refType) => {
+			const effectiveRule = rules.find(
+				(rule) => rule.appliesToRefType === null || rule.appliesToRefType === refType
+			)
+			return (effectiveRule?.taxRateBps ?? 0) > 0
+		})
+	}
+
 	private async hasMemberSummaryRollupUpdatesSince(
 		filters: TaxMemberSummaryReportFilters,
 		cachedAtMs: number
@@ -1034,6 +1091,225 @@ export class TaxReportService {
 		return Boolean(finalizedUpdate || projectionUpdate)
 	}
 
+	private async getMemberSummaryFromRollupsSql(input: {
+		corporationId: string
+		characterIds?: string[]
+		includeUnattributedRow: boolean
+		refTypes?: string[]
+		fromDate?: Date
+		toDate?: Date
+		topRefTypesLimit?: number
+		limit?: number
+		offset?: number
+		sortBy?: TaxMemberSummaryReportFilters['sortBy']
+		sortDirection?: TaxMemberSummaryReportFilters['sortDirection']
+	}): Promise<TaxPagedResult<TaxMemberSummary>> {
+		const fromDay = input.fromDate ? this.toUtcDay(input.fromDate) : undefined
+		const toDay = input.toDate ? this.toUtcDay(input.toDate) : undefined
+		const buildRollupWhere = (alias: string) => {
+			const refTypeFilter = input.refTypes?.length
+				? sql`AND ${sql.raw(alias)}.ref_type IN (${sql.join(
+						input.refTypes.map((refType) => sql`${refType}`),
+						sql`, `
+					)})`
+				: sql``
+			const characterFilter = input.characterIds?.length
+				? sql`AND (
+					${sql.raw(alias)}.character_id IN (${sql.join(
+						input.characterIds.map((characterId) => sql`${characterId}`),
+						sql`, `
+					)})
+					${input.includeUnattributedRow ? sql`OR ${sql.raw(alias)}.character_id = ${UNATTRIBUTED_CHARACTER_ID}` : sql``}
+				)`
+				: sql``
+			return sql`
+				${sql.raw(alias)}.corporation_id = ${input.corporationId}
+				${fromDay ? sql`AND ${sql.raw(alias)}.rollup_date >= ${fromDay}` : sql``}
+				${toDay ? sql`AND ${sql.raw(alias)}.rollup_date <= ${toDay}` : sql``}
+				${characterFilter}
+				${refTypeFilter}
+			`
+		}
+		const finalizedWhere = buildRollupWhere('finalized')
+		const projectionWhere = sql`
+			${buildRollupWhere('projection')}
+			AND NOT EXISTS (
+				SELECT 1
+				FROM ${taxMemberContributionFinalizedRollups} AS finalized_match
+				WHERE finalized_match.corporation_id = projection.corporation_id
+					AND finalized_match.period_start = projection.period_start
+					AND finalized_match.period_end = projection.period_end
+					AND finalized_match.rollup_date = projection.rollup_date
+					AND finalized_match.character_id = projection.character_id
+					AND finalized_match.ref_type = projection.ref_type
+			)
+		`
+		const rollupCte = sql`
+			WITH rollup_rows AS (
+				SELECT
+					finalized.character_id,
+					finalized.ref_type,
+					finalized.contribution_income,
+					finalized.taxable_contribution_income,
+					finalized.assessment_count,
+					finalized.source_row_count,
+					finalized.last_assessment_at
+				FROM ${taxMemberContributionFinalizedRollups} AS finalized
+				WHERE ${finalizedWhere}
+				UNION ALL
+				SELECT
+					projection.character_id,
+					projection.ref_type,
+					projection.contribution_income,
+					projection.taxable_contribution_income,
+					projection.assessment_count,
+					projection.source_row_count,
+					projection.last_assessment_at
+				FROM ${taxMemberContributionProjectionRollups} AS projection
+				WHERE ${projectionWhere}
+			), character_totals AS (
+				SELECT
+					character_id,
+					SUM(contribution_income::numeric) AS contribution_income,
+					SUM(taxable_contribution_income::numeric) AS taxable_contribution_income,
+					MAX(assessment_count)::int AS assessment_count,
+					MAX(last_assessment_at) AS last_assessment_at
+				FROM rollup_rows
+				GROUP BY character_id
+			)
+		`
+		const sourceRollupCte = sql`
+			WITH rollup_rows AS (
+				SELECT
+					finalized.character_id,
+					finalized.ref_type,
+					finalized.contribution_income,
+					finalized.taxable_contribution_income,
+					finalized.source_row_count
+				FROM ${taxMemberContributionFinalizedRollups} AS finalized
+				WHERE ${finalizedWhere}
+				UNION ALL
+				SELECT
+					projection.character_id,
+					projection.ref_type,
+					projection.contribution_income,
+					projection.taxable_contribution_income,
+					projection.source_row_count
+				FROM ${taxMemberContributionProjectionRollups} AS projection
+				WHERE ${projectionWhere}
+			)
+		`
+		const sortColumn = (() => {
+			switch (input.sortBy) {
+				case 'characterId':
+					return 'character_id'
+				case 'taxableContributionIncome':
+					return 'taxable_contribution_income'
+				case 'assessmentCount':
+					return 'assessment_count'
+				case 'lastAssessmentAt':
+					return 'last_assessment_at'
+				case 'contributionIncome':
+				default:
+					return 'contribution_income'
+			}
+		})()
+		const sortDirection = input.sortDirection === 'asc' ? 'ASC' : 'DESC'
+		const limit = Math.min(Math.max(input.limit ?? 50, 1), 200)
+		const offset = Math.max(input.offset ?? 0, 0)
+
+		const pageResult = await this.db.execute(sql`
+			${rollupCte}
+			SELECT
+				character_id,
+				contribution_income,
+				taxable_contribution_income,
+				assessment_count,
+				last_assessment_at,
+				COUNT(*) OVER()::int AS total_rows
+			FROM character_totals
+			ORDER BY ${sql.raw(sortColumn)} ${sql.raw(sortDirection)}, character_id ASC
+			LIMIT ${limit}
+			OFFSET ${offset}
+		`)
+		const pageRows = pageResult.rows as Array<Record<string, unknown>>
+		let totalRows = Number(pageRows[0]?.total_rows ?? 0)
+		if (pageRows.length === 0 && offset > 0) {
+			const countResult = await this.db.execute(sql`
+				${rollupCte}
+				SELECT COUNT(*)::int AS total_rows
+				FROM character_totals
+			`)
+			totalRows = Number((countResult.rows as Array<Record<string, unknown>>)[0]?.total_rows ?? 0)
+		}
+		const pageCharacterIds = pageRows.map((row) => String(row.character_id))
+		const topRefTypeTotals = new Map<
+			string,
+			Array<{
+				refType: string
+				lineCount: number
+				contributionAmount: string
+				taxableAmount: string
+			}>
+		>()
+
+		if (pageCharacterIds.length > 0) {
+			const sourceResult = await this.db.execute(sql`
+				${sourceRollupCte}
+				SELECT
+					character_id,
+					ref_type,
+					SUM(contribution_income::numeric) AS contribution_income,
+					SUM(taxable_contribution_income::numeric) AS taxable_contribution_income,
+					SUM(source_row_count)::int AS line_count
+				FROM rollup_rows
+				WHERE character_id IN (${sql.join(
+					pageCharacterIds.map((characterId) => sql`${characterId}`),
+					sql`, `
+				)})
+				GROUP BY character_id, ref_type
+				ORDER BY character_id ASC, SUM(contribution_income::numeric) DESC, ref_type ASC
+			`)
+			for (const row of sourceResult.rows as Array<Record<string, unknown>>) {
+				const characterId = String(row.character_id)
+				const sourceRows = topRefTypeTotals.get(characterId) ?? []
+				if (input.topRefTypesLimit === undefined || sourceRows.length < input.topRefTypesLimit) {
+					sourceRows.push({
+						refType: String(row.ref_type),
+						lineCount: Number(row.line_count ?? 0),
+						contributionAmount: String(row.contribution_income ?? '0'),
+						taxableAmount: String(row.taxable_contribution_income ?? '0'),
+					})
+				}
+				topRefTypeTotals.set(characterId, sourceRows)
+			}
+		}
+
+		return {
+			rows: pageRows.map((row) => {
+				const characterId = String(row.character_id)
+				const topRefTypes = topRefTypeTotals.get(characterId) ?? []
+				return {
+					corporationId: input.corporationId,
+					characterId,
+					fromDate: input.fromDate ?? null,
+					toDate: input.toDate ?? null,
+					assessmentCount: Number(row.assessment_count ?? 0),
+					contributionIncome: String(row.contribution_income ?? '0'),
+					taxableContributionIncome: String(row.taxable_contribution_income ?? '0'),
+					lastAssessmentAt: row.last_assessment_at
+						? new Date(String(row.last_assessment_at))
+						: null,
+					topRefTypes: topRefTypes.map((source) => ({
+						...source,
+						taxAmount: source.taxableAmount,
+					})),
+				}
+			}),
+			totalRows,
+		}
+	}
+
 	private async getMemberSummaryFromRollups(input: {
 		corporationId: string
 		fromDate?: Date
@@ -1042,6 +1318,7 @@ export class TaxReportService {
 		scopedCharacterIdSet: Set<string>
 		includeUnattributedRow: boolean
 		topRefTypesLimit: number | null
+		refTypes?: string[]
 	}): Promise<TaxMemberSummary[]> {
 		const fromDay = input.fromDate ? this.toUtcDay(input.fromDate) : undefined
 		const toDay = input.toDate ? this.toUtcDay(input.toDate) : undefined
@@ -1061,6 +1338,14 @@ export class TaxReportService {
 		if (toDay) {
 			finalizedConditions.push(lte(taxMemberContributionFinalizedRollups.rollupDate, toDay))
 			projectionConditions.push(lte(taxMemberContributionProjectionRollups.rollupDate, toDay))
+		}
+		if (input.refTypes && input.refTypes.length > 0) {
+			finalizedConditions.push(
+				inArray(taxMemberContributionFinalizedRollups.refType, input.refTypes)
+			)
+			projectionConditions.push(
+				inArray(taxMemberContributionProjectionRollups.refType, input.refTypes)
+			)
 		}
 
 		const [fetchedFinalizedRows, fetchedProjectionRows] = await Promise.all([
@@ -1283,6 +1568,7 @@ export class TaxReportService {
 			filters.fromDate?.toISOString() ?? '',
 			filters.toDate?.toISOString() ?? '',
 			filters.topRefTypesLimit ?? '',
+			filterTaxIncomeRefTypes(filters.refTypes)?.join(',') ?? '',
 		].join('|')
 	}
 

--- a/apps/corporation-tax/src/services/tax-rules.service.ts
+++ b/apps/corporation-tax/src/services/tax-rules.service.ts
@@ -1,5 +1,5 @@
 import { isTaxIncomeRefType } from '@repo/corporation-tax'
-import { and, asc, desc, eq, gte, inArray } from '@repo/db-utils'
+import { and, asc, desc, eq, gte, sql } from '@repo/db-utils'
 
 import { taxRuleGroupAttachments, taxRuleGroups, taxRuleSets } from '../db/schema'
 
@@ -145,15 +145,12 @@ export class TaxRulesService {
 		if (filters?.ruleGroupId) {
 			whereConditions.push(eq(taxRuleSets.ruleGroupId, filters.ruleGroupId))
 		} else if (filters?.corporationId) {
-			const attachmentRows = await this.db
-				.select({ ruleGroupId: taxRuleGroupAttachments.ruleGroupId })
-				.from(taxRuleGroupAttachments)
-				.where(eq(taxRuleGroupAttachments.corporationId, filters.corporationId))
-			const attachedGroupIds = attachmentRows.map((row) => row.ruleGroupId)
-			if (attachedGroupIds.length === 0) {
-				return []
-			}
-			whereConditions.push(inArray(taxRuleSets.ruleGroupId, attachedGroupIds))
+			whereConditions.push(sql`EXISTS (
+				SELECT 1
+				FROM ${taxRuleGroupAttachments}
+				WHERE ${taxRuleGroupAttachments.ruleGroupId} = ${taxRuleSets.ruleGroupId}
+					AND ${taxRuleGroupAttachments.corporationId} = ${filters.corporationId}
+			)`)
 		}
 
 		const rows = await this.db.query.taxRuleSets.findMany({
@@ -180,8 +177,17 @@ export class TaxRulesService {
 		if (groupIds.length === 0) {
 			return null
 		}
+
 		const earliestRule = await this.db.query.taxRuleSets.findFirst({
-			where: and(inArray(taxRuleSets.ruleGroupId, groupIds), gte(taxRuleSets.updatedAt, since)),
+			where: and(
+				sql`EXISTS (
+					SELECT 1
+					FROM ${taxRuleGroupAttachments}
+					WHERE ${taxRuleGroupAttachments.ruleGroupId} = ${taxRuleSets.ruleGroupId}
+						AND ${taxRuleGroupAttachments.corporationId} = ${corporationId}
+				)`,
+				gte(taxRuleSets.updatedAt, since)
+			),
 			orderBy: [asc(taxRuleSets.updatedAt)],
 			columns: { updatedAt: true },
 		})

--- a/apps/corporation-tax/src/workflows/tax-assessment.workflow.ts
+++ b/apps/corporation-tax/src/workflows/tax-assessment.workflow.ts
@@ -1,0 +1,58 @@
+import { WorkflowEntrypoint } from 'cloudflare:workers'
+
+import { getStub } from '@repo/do-utils'
+
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import type {
+	CorporationTax,
+	TaxAssessmentWorkflowOutput,
+	TaxAssessmentWorkflowParams,
+} from '@repo/corporation-tax'
+import type { Env } from '../context'
+
+/**
+ * Runs one assessment behind a durable Workflow boundary so callers can queue it
+ * and poll status instead of holding an HTTP request open for the full scan.
+ */
+export class TaxAssessmentWorkflow extends WorkflowEntrypoint<Env, TaxAssessmentWorkflowParams> {
+	async run(
+		event: WorkflowEvent<TaxAssessmentWorkflowParams>,
+		step: WorkflowStep
+	): Promise<TaxAssessmentWorkflowOutput> {
+		const {
+			actorUserId,
+			corporationId,
+			periodStart,
+			periodEnd,
+			includeCharacterWallets = false,
+		} = event.payload
+
+		return step.do(
+			'run-assessment',
+			{
+				retries: {
+					limit: 2,
+					delay: '10 seconds',
+					backoff: 'exponential',
+				},
+				timeout: '10 minutes',
+			},
+			async () => {
+				const taxStub = getStub<CorporationTax>(this.env.CORPORATION_TAX, 'default')
+				const result = await taxStub.runAssessmentForPeriod(actorUserId, {
+					corporationId,
+					periodStart: new Date(periodStart),
+					periodEnd: new Date(periodEnd),
+					includeCharacterWallets,
+				})
+
+				return {
+					status: 'completed' as const,
+					assessmentId: result.assessment.id,
+					lineCount: result.lineCount,
+					discrepancyCount: result.discrepancyCount,
+				}
+			}
+		)
+	}
+}

--- a/apps/corporation-tax/wrangler.jsonc
+++ b/apps/corporation-tax/wrangler.jsonc
@@ -20,6 +20,13 @@
 	"triggers": {
 		"crons": ["0 2 * * *"]
 	},
+	"workflows": [
+		{
+			"name": "tax-assessment",
+			"binding": "TAX_ASSESSMENT_WORKFLOW",
+			"class_name": "TaxAssessmentWorkflow"
+		}
+	],
 	"durable_objects": {
 		"bindings": [
 			{

--- a/apps/ui/src/client/components/bills/bill-status-badge.tsx
+++ b/apps/ui/src/client/components/bills/bill-status-badge.tsx
@@ -4,11 +4,12 @@ import { formatBillStatus, getBillStatusColor } from '@/lib/bills-utils'
 import type { BillStatus } from '@repo/bills'
 
 interface BillStatusBadgeProps {
-	status: BillStatus
+	status: BillStatus | 'unbilled'
 }
 
 export function BillStatusBadge({ status }: BillStatusBadgeProps) {
-	const variant = getBillStatusColor(status)
+	const variant = status === 'unbilled' ? 'ghost' : getBillStatusColor(status)
+	const label = status === 'unbilled' ? 'Unbilled' : formatBillStatus(status)
 
-	return <Badge variant={variant}>{formatBillStatus(status)}</Badge>
+	return <Badge variant={variant}>{label}</Badge>
 }

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -485,6 +485,13 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 			) ||
 			hasAnyPermission('urn:tax:auditor', 'urn:tax:admin') ||
 			!!corporationAccess?.hasAccess
+		const canReadScopedTaxReports =
+			permissions.some(
+				(permission) => extractCorporationIdFromTaxViewerScopedUrn(permission.urn) !== null
+			) ||
+			(leadershipCorporationAccess?.corporations ?? []).some(
+				(corporation) => corporation.userRole === 'CEO' || corporation.userRole === 'Director'
+			)
 		const canAuditTaxFeature = isSiteAdmin || hasAnyPermission('urn:tax:auditor', 'urn:tax:admin')
 		const canManageTaxFeature = isSiteAdmin || hasAnyPermission('urn:tax:admin')
 		const { data: openTaxAlerts = [] } = useTaxAlerts({
@@ -501,11 +508,14 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 				href: '/tax/member-summary',
 			})
 
-			if (canAuditTaxFeature) {
+			if (canAuditTaxFeature || canReadScopedTaxReports) {
 				taxItems.push({
 					label: 'Reports',
 					href: '/tax/reports',
 				})
+			}
+
+			if (canAuditTaxFeature) {
 				taxItems.push({
 					label: 'Billing',
 					href: '/tax/bills',

--- a/apps/ui/src/client/components/tax-bills/bill-status-tab.tsx
+++ b/apps/ui/src/client/components/tax-bills/bill-status-tab.tsx
@@ -33,7 +33,11 @@ export function BillStatusTab({
 		defaultPageSize: 25,
 		resetOn: { effectiveCorporationId },
 	})
-	const { data, isLoading, error } = useTaxBillStatusReport({
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxBillStatusReport({
 		corporationId: effectiveCorporationId ?? undefined,
 		limit: grid.limit,
 		offset: grid.offset,
@@ -44,7 +48,6 @@ export function BillStatusTab({
 
 	const rows = data?.rows ?? []
 	const totalRows = data?.totalRows ?? 0
-	const pageCount = grid.pageCountFor(totalRows)
 
 	return (
 		<div className="space-y-3">
@@ -58,7 +61,6 @@ export function BillStatusTab({
 				onSortingChange={grid.onSortingChange}
 				pagination={grid.pagination}
 				onPaginationChange={grid.onPaginationChange}
-				pageCount={pageCount}
 				rowCount={totalRows}
 				syncBillPending={syncBillPending}
 				retractBillPending={retractBillPending}

--- a/apps/ui/src/client/components/tax-bills/billing-configuration-table.tsx
+++ b/apps/ui/src/client/components/tax-bills/billing-configuration-table.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
 	Table,
 	TableBody,
@@ -7,10 +8,9 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
-import { TaxEntityDisplay } from '@/lib/tax-display'
+import { TaxCorporationDisplay, TaxEntityDisplay } from '@/lib/tax-display'
 
 import type { TaxCorporationBillingConfig } from '@repo/corporation-tax'
-import { Button } from '@/components/ui/button'
 
 type BillingConfigurationTableProps = {
 	canIssue: boolean
@@ -78,7 +78,17 @@ export function BillingConfigurationTable({
 										<Badge variant="ghost" className="capitalize">
 											{config.billingPayeeType}
 										</Badge>
-										<TaxEntityDisplay entityId={config.billingPayeeId} entityNames={entityNames} />
+										{config.billingPayeeType === 'corporation' ? (
+											<TaxCorporationDisplay
+												corporationId={config.billingPayeeId}
+												entityNames={entityNames}
+											/>
+										) : (
+											<TaxEntityDisplay
+												entityId={config.billingPayeeId}
+												entityNames={entityNames}
+											/>
+										)}
 									</div>
 								) : (
 									'-'
@@ -89,21 +99,24 @@ export function BillingConfigurationTable({
 							{canIssue ? (
 								<TableCell className="text-right">
 									<div className="flex items-center justify-end gap-2">
-										<Button variant="ghost"
+										<Button
+											variant="ghost"
 											size="sm"
 											disabled={actionsDisabled}
 											onClick={() => onEdit(config)}
 										>
 											Edit
 										</Button>
-										<Button variant="primary"
+										<Button
+											variant="primary"
 											size="sm"
 											disabled={actionsDisabled || config.isDefault}
 											onClick={() => onSetDefault(config.id)}
 										>
 											Set Default
 										</Button>
-										<Button variant="destructive"
+										<Button
+											variant="destructive"
 											size="sm"
 											showIcon={false}
 											disabled={actionsDisabled || config.isDefault}

--- a/apps/ui/src/client/components/tax-bills/billing-operations-card.tsx
+++ b/apps/ui/src/client/components/tax-bills/billing-operations-card.tsx
@@ -1,12 +1,13 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { DateRangeInput } from '@/components/ui/date-range-input'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Select } from '@/components/ui/select'
+
 type BillingOperationsCardProps = {
 	effectiveCorporationId: string | null
 	canIssue: boolean
-	periodStartDate: string
-	periodEndDate: string
-	onPeriodChange: (range: { fromDate: string; toDate: string }) => void
+	monthValue: string
+	monthOptions: Array<{ value: string; label: string }>
+	onMonthChange: (monthValue: string) => void
 	onSyncCorporation: () => void
 	syncCorporationPending: boolean
 	syncCorporationResult:
@@ -26,14 +27,35 @@ type BillingOperationsCardProps = {
 		  }
 		| undefined
 	issuePeriodError: unknown
+	onRunAssessment: () => void
+	runAssessmentPending: boolean
+	runAssessmentResult:
+		| {
+				status: 'completed'
+				assessmentId: string
+				lineCount: number
+				discrepancyCount: number
+		  }
+		| undefined
+	runAssessmentStatus:
+		| 'queued'
+		| 'running'
+		| 'paused'
+		| 'waiting'
+		| 'completed'
+		| 'failed'
+		| 'unknown'
+		| undefined
+	runAssessmentWorkflowError: { name: string; message: string } | null
+	runAssessmentError: unknown
 }
 
 export function BillingOperationsCard({
 	effectiveCorporationId,
 	canIssue,
-	periodStartDate,
-	periodEndDate,
-	onPeriodChange,
+	monthValue,
+	monthOptions,
+	onMonthChange,
 	onSyncCorporation,
 	syncCorporationPending,
 	syncCorporationResult,
@@ -42,71 +64,121 @@ export function BillingOperationsCard({
 	issuePeriodPending,
 	issuePeriodResult,
 	issuePeriodError,
+	onRunAssessment,
+	runAssessmentPending,
+	runAssessmentResult,
+	runAssessmentStatus,
+	runAssessmentWorkflowError,
+	runAssessmentError,
 }: BillingOperationsCardProps) {
+	const assessmentActive =
+		runAssessmentPending ||
+		runAssessmentStatus === 'queued' ||
+		runAssessmentStatus === 'running' ||
+		runAssessmentStatus === 'waiting'
+
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Billing Operations</CardTitle>
+				<CardTitle>Assessment and Billing Operations</CardTitle>
 				<CardDescription>
-					Create missing bills, sync statuses from bills, and issue draft bills by period.
+					Run an assessment for the selected period, create missing bills, then issue existing draft
+					bills. Assessment and billing are separate operations.
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
 				{!effectiveCorporationId ? (
 					<div className="text-sm text-muted-foreground">
-						Select a corporation to run billing operations.
+						Select one corporation above to enable assessment and billing actions. These operations
+						cannot be run against the all-corporations scope.
 					</div>
-				) : (
-					<>
-						<div className="flex flex-wrap gap-2">
-							<Button variant="ghost"
-								disabled={!canIssue || syncCorporationPending}
-								onClick={onSyncCorporation}
-							>
-								{syncCorporationPending ? 'Syncing...' : 'Sync Corporation Bill Statuses'}
-							</Button>
-						</div>
-						{syncCorporationResult ? (
-							<div className="text-sm text-muted-foreground">
-								Processed {syncCorporationResult.processedAssessmentIds.length}, updated{' '}
-								{syncCorporationResult.updatedAssessmentIds.length}, skipped{' '}
-								{syncCorporationResult.skippedAssessmentIds.length}.
-							</div>
-						) : null}
-
-						<div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
-							<DateRangeInput
-								value={{ fromDate: periodStartDate, toDate: periodEndDate }}
-								onChange={onPeriodChange}
-								placeholder="Billing period"
-								disabled={!canIssue}
-							/>
-							<Button variant="primary" disabled={!canIssue || issuePeriodPending} onClick={onIssuePeriod}>
-								{issuePeriodPending ? 'Issuing...' : 'Issue Bills For Period'}
-							</Button>
-						</div>
-						{issuePeriodResult ? (
-							<div className="text-sm text-muted-foreground">
-								Issued {issuePeriodResult.issuedAssessmentIds.length}, skipped{' '}
-								{issuePeriodResult.skippedAssessmentIds.length}.
-							</div>
-						) : null}
-						{issuePeriodError ? (
-							<div className="text-sm text-destructive">
-								{issuePeriodError instanceof Error
-									? issuePeriodError.message
-									: 'Failed to issue bills for period'}
-							</div>
-						) : null}
-						{syncCorporationError ? (
-							<div className="text-sm text-destructive">
-								{syncCorporationError instanceof Error
-									? syncCorporationError.message
-									: 'Failed to sync corporation bill statuses'}
-							</div>
-						) : null}
-					</>
-				)}
+				) : null}
+				<div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+					<div className="flex flex-wrap gap-2">
+						<Button
+							variant="ghost"
+							disabled={!effectiveCorporationId || !canIssue || syncCorporationPending}
+							onClick={onSyncCorporation}
+						>
+							{syncCorporationPending ? 'Syncing...' : 'Sync Corporation Bill Statuses'}
+						</Button>
+						<Button
+							variant="primary"
+							disabled={!effectiveCorporationId || !canIssue || issuePeriodPending}
+							onClick={onIssuePeriod}
+						>
+							{issuePeriodPending ? 'Issuing...' : 'Issue Existing Bills'}
+						</Button>
+					</div>
+					<div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center md:justify-end">
+						<Select
+							value={monthValue}
+							onValueChange={onMonthChange}
+							options={monthOptions}
+							placeholder="Assessment period"
+							searchable
+							className="min-w-0 sm:w-64 md:w-80"
+							disabled={!effectiveCorporationId || !canIssue}
+						/>
+						<Button
+							variant="primary"
+							disabled={!effectiveCorporationId || !canIssue || assessmentActive}
+							onClick={onRunAssessment}
+						>
+							{runAssessmentPending || runAssessmentStatus === 'running'
+								? 'Assessing...'
+								: runAssessmentStatus === 'queued' || runAssessmentStatus === 'waiting'
+									? 'Queued...'
+									: 'Run Assessment'}
+						</Button>
+					</div>
+				</div>
+				{syncCorporationResult ? (
+					<div className="text-sm text-muted-foreground">
+						Processed {syncCorporationResult.processedAssessmentIds.length}, updated{' '}
+						{syncCorporationResult.updatedAssessmentIds.length}, skipped{' '}
+						{syncCorporationResult.skippedAssessmentIds.length}.
+					</div>
+				) : null}
+				{runAssessmentResult ? (
+					<div className="text-sm text-muted-foreground">
+						Assessment completed with {runAssessmentResult.lineCount.toLocaleString('en-US')}{' '}
+						line(s) and {runAssessmentResult.discrepancyCount.toLocaleString('en-US')}{' '}
+						discrepancy(ies).
+					</div>
+				) : null}
+				{runAssessmentError ? (
+					<div className="text-sm text-destructive">
+						{runAssessmentError instanceof Error
+							? runAssessmentError.message
+							: 'Failed to run assessment for period'}
+					</div>
+				) : null}
+				{runAssessmentWorkflowError ? (
+					<div className="text-sm text-destructive">
+						{runAssessmentWorkflowError.message || 'Assessment workflow failed'}
+					</div>
+				) : null}
+				{issuePeriodResult ? (
+					<div className="text-sm text-muted-foreground">
+						Issued {issuePeriodResult.issuedAssessmentIds.length}, skipped{' '}
+						{issuePeriodResult.skippedAssessmentIds.length}.
+					</div>
+				) : null}
+				{issuePeriodError ? (
+					<div className="text-sm text-destructive">
+						{issuePeriodError instanceof Error
+							? issuePeriodError.message
+							: 'Failed to issue bills for period'}
+					</div>
+				) : null}
+				{syncCorporationError ? (
+					<div className="text-sm text-destructive">
+						{syncCorporationError instanceof Error
+							? syncCorporationError.message
+							: 'Failed to sync corporation bill statuses'}
+					</div>
+				) : null}
 			</CardContent>
 		</Card>
 	)

--- a/apps/ui/src/client/components/tax-bills/corporation-bill-history-card.tsx
+++ b/apps/ui/src/client/components/tax-bills/corporation-bill-history-card.tsx
@@ -1,129 +1,129 @@
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
+import { billStatusBadgeVariant } from '@/components/tax-reports/grids/shared'
 import { useReportGridState } from '@/components/tax-reports/use-report-grid-state'
 import { Badge } from '@/components/ui/badge'
 import { useTaxCorporationBillEventHistory } from '@/hooks/corporation-tax'
 import { formatTaxDate } from '@/lib/tax-date'
 
-import { billStatusBadgeVariant } from './helpers'
+import type {
+	TaxBillingEventHistoryRow,
+	TaxBillingEventSortBy,
+	TaxBillStatus,
+} from '@repo/corporation-tax'
 
-import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
-import type { BillStatus } from '@repo/bills'
-import type { TaxBillingEventHistoryRow } from '@repo/corporation-tax'
-
-type CorporationBillHistoryCardProps = {
+export function CorporationBillHistoryCard(props: {
 	effectiveCorporationId: string | null
 	canView: boolean
-}
-
-export function CorporationBillHistoryCard({
-	effectiveCorporationId,
-	canView,
-}: CorporationBillHistoryCardProps) {
+}) {
 	const grid = useReportGridState({
 		defaultSortBy: 'createdAt',
 		defaultSortDir: 'desc',
 		defaultPageSize: 25,
-		resetOn: { effectiveCorporationId },
+		resetOn: props.effectiveCorporationId,
 	})
-	const { data, isLoading, error } = useTaxCorporationBillEventHistory(
-		effectiveCorporationId ?? undefined,
-		{
-			limit: grid.limit,
-			offset: grid.offset,
-			enabled: canView,
-		}
-	)
-	const billHistoryRows = data?.rows ?? []
-	const rowCount = data?.totalRows ?? 0
-	const pageCount = grid.pageCountFor(rowCount)
-
-	const columns = useMemo<Array<MRT_ColumnDef<TaxBillingEventHistoryRow>>>(
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxCorporationBillEventHistory(props.effectiveCorporationId ?? undefined, {
+		limit: grid.limit,
+		offset: grid.offset,
+		sortBy: grid.sortBy as TaxBillingEventSortBy,
+		sortDir: grid.sortDir,
+		enabled: props.canView,
+	})
+	const rows = data?.rows ?? []
+	const columns = useMemo(
 		() => [
 			{
 				id: 'createdAt',
-				accessorFn: (row) => new Date(row.createdAt).getTime(),
 				header: 'Event Time',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxDate(row.original.createdAt),
+				sortable: true,
+				cell: (row: TaxBillingEventHistoryRow) => formatTaxDate(row.createdAt),
 			},
 			{
-				accessorKey: 'eventType',
+				id: 'eventType',
 				header: 'Event',
-				enableSorting: true,
+				sortable: true,
+				cell: (row: TaxBillingEventHistoryRow) => row.eventType,
 			},
 			{
 				id: 'billId',
-				accessorFn: (row) => row.billId,
 				header: 'Bill',
-				enableSorting: true,
-				Cell: ({ row }) => <span className="font-mono text-xs">{row.original.billId}</span>,
+				sortable: true,
+				cell: (row: TaxBillingEventHistoryRow) => (
+					<span className="font-mono text-xs">{row.billId}</span>
+				),
 			},
 			{
 				id: 'assessmentId',
-				accessorFn: (row) => row.assessmentId,
 				header: 'Assessment',
-				enableSorting: true,
-				Cell: ({ row }) => <span className="font-mono text-xs">{row.original.assessmentId}</span>,
+				sortable: true,
+				cell: (row: TaxBillingEventHistoryRow) => (
+					<span className="font-mono text-xs">{row.assessmentId}</span>
+				),
 			},
 			{
 				id: 'statusTransition',
-				accessorFn: (row) => `${row.fromStatus ?? ''}:${row.toStatus ?? ''}`,
 				header: 'Transition',
-				enableSorting: true,
-				Cell: ({ row }) => {
-					if (!row.original.fromStatus && !row.original.toStatus) {
-						return '-'
-					}
-					const fromStatus = row.original.fromStatus as BillStatus | null
-					const toStatus = row.original.toStatus as BillStatus | null
+				sortable: false,
+				cell: (row: TaxBillingEventHistoryRow) => {
+					if (!row.fromStatus && !row.toStatus) return '-'
 					return (
 						<div className="flex items-center gap-2">
-							<Badge variant={billStatusBadgeVariant(fromStatus ?? 'unbilled')}>
-								{row.original.fromStatus ?? 'none'}
+							<Badge
+								variant={billStatusBadgeVariant(
+									(row.fromStatus as TaxBillStatus | null) ?? 'draft'
+								)}
+							>
+								{row.fromStatus ?? 'none'}
 							</Badge>
 							<span className="text-muted-foreground">→</span>
-							<Badge variant={billStatusBadgeVariant(toStatus ?? 'unbilled')}>
-								{row.original.toStatus ?? 'none'}
+							<Badge
+								variant={billStatusBadgeVariant((row.toStatus as TaxBillStatus | null) ?? 'draft')}
+							>
+								{row.toStatus ?? 'none'}
 							</Badge>
 						</div>
 					)
 				},
 			},
 			{
-				id: 'actor',
-				accessorFn: (row) => row.actorUserId ?? '',
+				id: 'actorUserId',
 				header: 'Actor',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<span className="font-mono text-xs">{row.original.actorUserId ?? '-'}</span>
+				sortable: true,
+				cell: (row: TaxBillingEventHistoryRow) => (
+					<span className="font-mono text-xs">{row.actorUserId ?? '-'}</span>
 				),
 			},
 		],
 		[]
 	)
-	const sorting: MRT_SortingState = useMemo(() => [{ id: 'createdAt', desc: true }], [])
 
-	const content = !effectiveCorporationId ? (
-		<div className="py-8 text-sm text-muted-foreground">
-			Select a corporation to view assessment bill history.
-		</div>
-	) : (
-		<TaxReportDataGrid
+	if (!props.effectiveCorporationId) {
+		return (
+			<div className="py-8 text-sm text-muted-foreground">
+				Select a corporation to view assessment bill history.
+			</div>
+		)
+	}
+
+	return (
+		<TaxReportTable
 			columns={columns}
-			rows={billHistoryRows}
+			rows={rows}
 			loading={isLoading}
 			error={error}
-			sorting={sorting}
+			emptyMessage="No bill history entries were found for this corporation."
 			pagination={grid.pagination}
 			onPaginationChange={grid.onPaginationChange}
-			rowCount={rowCount}
-			pageCount={pageCount}
-			emptyMessage="No bill history entries were found for this corporation."
+			rowCount={data?.totalRows ?? 0}
+			itemLabel="events"
+			sorting={grid.sorting}
+			onSortingChange={grid.onSortingChange}
+			getRowKey={(row) => row.id}
 		/>
 	)
-
-	return <div>{content}</div>
 }

--- a/apps/ui/src/client/components/tax-bills/scoped-assessment-snapshot-card.tsx
+++ b/apps/ui/src/client/components/tax-bills/scoped-assessment-snapshot-card.tsx
@@ -1,91 +1,112 @@
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
+import { useReportGridState } from '@/components/tax-reports/use-report-grid-state'
+import { useTaxAssessments } from '@/hooks/corporation-tax'
 import { formatTaxDate } from '@/lib/tax-date'
 import { formatTaxIskFull, TaxEntityDisplay } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef } from 'mantine-react-table'
 import type { TaxAssessment } from '@repo/corporation-tax'
 
 type ScopedAssessmentSnapshotCardProps = {
 	effectiveCorporationId: string | null
-	assessmentsLoading: boolean
-	assessmentsError: unknown
-	assessments: TaxAssessment[]
 	entityNames: Record<string, string>
+	canView: boolean
 }
 
 export function ScopedAssessmentSnapshotCard({
 	effectiveCorporationId,
-	assessmentsLoading,
-	assessmentsError,
-	assessments,
 	entityNames,
+	canView,
 }: ScopedAssessmentSnapshotCardProps) {
-	const columns = useMemo<Array<MRT_ColumnDef<TaxAssessment>>>(
+	const grid = useReportGridState({
+		defaultSortBy: 'taxPeriodEnd',
+		defaultSortDir: 'desc',
+		defaultPageSize: 25,
+		resetOn: effectiveCorporationId,
+	})
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxAssessments(effectiveCorporationId ?? undefined, {
+		limit: grid.limit,
+		offset: grid.offset,
+		sortBy: grid.sortBy as
+			| 'taxPeriodEnd'
+			| 'assessmentScope'
+			| 'scopeId'
+			| 'status'
+			| 'taxDue'
+			| 'taxDelta',
+		sortDir: grid.sortDir,
+		enabled: canView,
+	})
+	const assessments = data?.rows ?? []
+	const columns = useMemo(
 		() => [
 			{
-				accessorKey: 'assessmentScope',
+				id: 'assessmentScope',
 				header: 'Scope',
-				enableSorting: true,
+				sortable: true,
+				cell: (row: TaxAssessment) => row.assessmentScope,
 			},
 			{
-				accessorKey: 'scopeId',
+				id: 'scopeId',
 				header: 'Scope ID',
-				enableSorting: true,
-				Cell: ({ row }) => {
-					if (row.original.assessmentScope === 'division') {
-						return row.original.scopeId
-					}
-					return <TaxEntityDisplay entityId={row.original.scopeId} entityNames={entityNames} />
-				},
+				sortable: true,
+				cell: (row: TaxAssessment) =>
+					row.assessmentScope === 'division' ? (
+						row.scopeId
+					) : (
+						<TaxEntityDisplay entityId={row.scopeId} entityNames={entityNames} />
+					),
 			},
-			{
-				accessorKey: 'status',
-				header: 'Status',
-				enableSorting: true,
-			},
+			{ id: 'status', header: 'Status', sortable: true, cell: (row: TaxAssessment) => row.status },
 			{
 				id: 'taxDue',
-				accessorFn: (row) => Number(row.taxDue),
 				header: 'Tax Due',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDue),
+				sortable: true,
+				cell: (row: TaxAssessment) => formatTaxIskFull(row.taxDue),
 			},
 			{
 				id: 'taxDelta',
-				accessorFn: (row) => Number(row.taxDelta),
 				header: 'Delta',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDelta),
+				sortable: true,
+				cell: (row: TaxAssessment) => formatTaxIskFull(row.taxDelta),
 			},
 			{
 				id: 'taxPeriodEnd',
-				accessorFn: (row) => new Date(row.taxPeriodEnd).getTime(),
 				header: 'Period End',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxDate(row.original.taxPeriodEnd),
+				sortable: true,
+				cell: (row: TaxAssessment) => formatTaxDate(row.taxPeriodEnd),
 			},
 		],
 		[entityNames]
 	)
 
-	const content = !effectiveCorporationId ? (
-		<div className="py-8 text-sm text-muted-foreground">
-			Select a corporation to view scoped assessments.
-		</div>
-	) : (
-		<TaxReportDataGrid
+	if (!effectiveCorporationId) {
+		return (
+			<div className="py-8 text-sm text-muted-foreground">
+				Select a corporation to view scoped assessments.
+			</div>
+		)
+	}
+
+	return (
+		<TaxReportTable
 			columns={columns}
 			rows={assessments}
-			loading={assessmentsLoading}
-			error={assessmentsError}
+			loading={isLoading}
+			error={error}
 			emptyMessage="No assessments found for the selected corporation."
+			pagination={grid.pagination}
+			onPaginationChange={grid.onPaginationChange}
+			rowCount={data?.totalRows ?? 0}
+			itemLabel="assessments"
+			sorting={grid.sorting}
+			onSortingChange={grid.onSortingChange}
+			getRowKey={(row) => row.id}
 		/>
 	)
-
-	return <div className="space-y-4">{content}</div>
 }

--- a/apps/ui/src/client/components/tax-bills/unbilled-assessments-card.tsx
+++ b/apps/ui/src/client/components/tax-bills/unbilled-assessments-card.tsx
@@ -1,23 +1,18 @@
+import { useMemo } from 'react'
+
+import { TaxReportTable } from '@/components/tax-report-table'
+import { useReportGridState } from '@/components/tax-reports/use-report-grid-state'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from '@/components/ui/table'
+import { useTaxAssessments } from '@/hooks/corporation-tax'
 import { formatTaxDate } from '@/lib/tax-date'
 import { formatTaxIskFull } from '@/lib/tax-display'
 
 import type { TaxAssessment } from '@repo/corporation-tax'
-import { Button } from '@/components/ui/button'
 
 type UnbilledAssessmentsCardProps = {
 	effectiveCorporationId: string | null
-	assessmentsLoading: boolean
-	assessmentsError: unknown
-	unbilledAssessmentRows: TaxAssessment[]
+	canView: boolean
 	canIssue: boolean
 	createBillPending: boolean
 	createBillError: unknown
@@ -26,14 +21,68 @@ type UnbilledAssessmentsCardProps = {
 
 export function UnbilledAssessmentsCard({
 	effectiveCorporationId,
-	assessmentsLoading,
-	assessmentsError,
-	unbilledAssessmentRows,
+	canView,
 	canIssue,
 	createBillPending,
 	createBillError,
 	onCreateBill,
 }: UnbilledAssessmentsCardProps) {
+	const grid = useReportGridState({
+		defaultSortBy: 'taxPeriodEnd',
+		defaultSortDir: 'desc',
+		defaultPageSize: 25,
+		resetOn: effectiveCorporationId,
+	})
+	const { data, isFetching, error } = useTaxAssessments(effectiveCorporationId ?? undefined, {
+		assessmentScope: 'corporation',
+		unbilledOnly: true,
+		limit: grid.limit,
+		offset: grid.offset,
+		sortBy: grid.sortBy as 'taxPeriodEnd' | 'taxDue' | 'taxDelta',
+		sortDir: grid.sortDir,
+		enabled: canView,
+	})
+	const rows = data?.rows ?? []
+	const columns = useMemo(
+		() => [
+			{ id: 'assessment', header: 'Assessment', cell: (row: TaxAssessment) => row.id },
+			{
+				id: 'taxDue',
+				header: 'Tax Due',
+				sortable: true,
+				cell: (row: TaxAssessment) => formatTaxIskFull(row.taxDue),
+			},
+			{
+				id: 'taxPeriodStart',
+				header: 'Period Start',
+				cell: (row: TaxAssessment) => formatTaxDate(row.taxPeriodStart),
+			},
+			{
+				id: 'taxPeriodEnd',
+				header: 'Period End',
+				sortable: true,
+				cell: (row: TaxAssessment) => formatTaxDate(row.taxPeriodEnd),
+			},
+			{
+				id: 'action',
+				header: 'Action',
+				cell: (row: TaxAssessment) => (
+					<div className="flex justify-end">
+						<Button
+							variant="primary"
+							size="sm"
+							disabled={!canIssue || createBillPending}
+							onClick={() => onCreateBill(row.id)}
+						>
+							{createBillPending ? 'Creating...' : 'Create Bill'}
+						</Button>
+					</div>
+				),
+			},
+		],
+		[canIssue, createBillPending, onCreateBill]
+	)
+
 	return (
 		<Card>
 			<CardHeader>
@@ -48,51 +97,21 @@ export function UnbilledAssessmentsCard({
 					<div className="py-8 text-sm text-muted-foreground">
 						Select a corporation to view unbilled assessments.
 					</div>
-				) : assessmentsLoading ? (
-					<div className="py-8 text-sm text-muted-foreground">Loading assessments...</div>
-				) : assessmentsError ? (
-					<div className="py-8 text-sm text-destructive">
-						{assessmentsError instanceof Error
-							? assessmentsError.message
-							: 'Failed to load assessments'}
-					</div>
-				) : unbilledAssessmentRows.length === 0 ? (
-					<div className="py-8 text-sm text-muted-foreground">
-						No unbilled finalized assessments found.
-					</div>
 				) : (
-					<Table>
-						<TableHeader>
-							<TableRow>
-								<TableHead>Assessment</TableHead>
-								<TableHead>Tax Due</TableHead>
-								<TableHead>Period Start</TableHead>
-								<TableHead>Period End</TableHead>
-								<TableHead className="text-center">Action</TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{unbilledAssessmentRows.map((assessment) => (
-								<TableRow key={assessment.id}>
-									<TableCell className="font-mono text-xs">{assessment.id}</TableCell>
-									<TableCell>{formatTaxIskFull(assessment.taxDue)}</TableCell>
-									<TableCell>{formatTaxDate(assessment.taxPeriodStart)}</TableCell>
-									<TableCell>{formatTaxDate(assessment.taxPeriodEnd)}</TableCell>
-									<TableCell className="text-center">
-										<div className="flex justify-end">
-											<Button variant="primary"
-												size="sm"
-												disabled={!canIssue || createBillPending}
-												onClick={() => onCreateBill(assessment.id)}
-											>
-												{createBillPending ? 'Creating...' : 'Create Bill'}
-											</Button>
-										</div>
-									</TableCell>
-								</TableRow>
-							))}
-						</TableBody>
-					</Table>
+					<TaxReportTable
+						columns={columns}
+						rows={rows}
+						loading={isFetching}
+						error={error}
+						emptyMessage="No unbilled finalized assessments found."
+						pagination={grid.pagination}
+						onPaginationChange={grid.onPaginationChange}
+						rowCount={data?.totalRows ?? 0}
+						itemLabel="assessments"
+						sorting={grid.sorting}
+						onSortingChange={grid.onSortingChange}
+						getRowKey={(row) => row.id}
+					/>
 				)}
 				{createBillError ? (
 					<div className="mt-3 text-sm text-destructive">

--- a/apps/ui/src/client/components/tax-member-summary/member-summary-grid-card.tsx
+++ b/apps/ui/src/client/components/tax-member-summary/member-summary-grid-card.tsx
@@ -18,6 +18,7 @@ type MemberSummaryGridCardProps = {
 	canViewSummary: boolean
 	canSearchCharacter: boolean
 	characterQuery: string
+	refTypes: string[]
 	fromDateIso?: string
 	toDateIso?: string
 	refreshToken: number
@@ -42,6 +43,7 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 			fromDateIso: props.fromDateIso,
 			toDateIso: props.toDateIso,
 			characterQuery: props.characterQuery,
+			refTypes: props.refTypes,
 		},
 	})
 
@@ -51,6 +53,7 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 			characterQuery: props.canSearchCharacter
 				? props.characterQuery.trim() || undefined
 				: undefined,
+			refTypes: props.refTypes.length > 0 ? props.refTypes : undefined,
 			fromDate: props.fromDateIso,
 			toDate: props.toDateIso,
 			limit: grid.limit,
@@ -76,7 +79,6 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 
 	const rows = useMemo(() => data?.rows ?? [], [data?.rows])
 	const totalRows = data?.totalRows ?? 0
-	const pageCount = grid.pageCountFor(totalRows)
 
 	const entityIds = useMemo(() => {
 		const ids = new Set<string>()
@@ -121,7 +123,8 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 					<div className="space-y-1">
 						<CardTitle>Member Contribution Summary</CardTitle>
 						<CardDescription>
-							Aggregated from corporation wallet entries attributed to members in the selected period.
+							Aggregated from corporation wallet entries attributed to members in the selected
+							period.
 						</CardDescription>
 					</div>
 				</div>
@@ -145,12 +148,20 @@ export function MemberSummaryGridCard(props: MemberSummaryGridCardProps) {
 						loading={isLoading || isFetching}
 						error={error}
 						entityNames={entityNames}
-						sorting={grid.sorting}
-						onSortingChange={grid.onSortingChange}
-						pagination={grid.pagination}
-						onPaginationChange={grid.onPaginationChange}
-						pageCount={pageCount}
-						rowCount={totalRows}
+						sortBy={grid.sortBy as Parameters<typeof MemberSummaryReportGrid>[0]['sortBy']}
+						sortDir={grid.sortDir}
+						onSortChange={(field) => {
+							grid.onSortingChange([
+								{ id: field, desc: grid.sortBy === field ? grid.sortDir !== 'asc' : true },
+							])
+						}}
+						page={grid.page}
+						pageSize={grid.pageSize}
+						onPageChange={(page) =>
+							grid.onPaginationChange({ pageIndex: page, pageSize: grid.pageSize })
+						}
+						onPageSizeChange={(pageSize) => grid.onPaginationChange({ pageIndex: 0, pageSize })}
+						totalRows={totalRows}
 					/>
 				)}
 			</CardContent>

--- a/apps/ui/src/client/components/tax-report-table.tsx
+++ b/apps/ui/src/client/components/tax-report-table.tsx
@@ -1,0 +1,168 @@
+import { ArrowDown, ArrowUp, ArrowUpDown, Loader2 } from 'lucide-react'
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+
+import type { ReactNode } from 'react'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
+
+export type { TaxReportSortingState }
+
+export type TaxReportColumn<Row> = {
+	id: string
+	header: ReactNode
+	sortable?: boolean
+	cell?: (row: Row) => ReactNode
+	className?: string
+	headerClassName?: string
+}
+
+type TaxReportTableProps<Row> = {
+	columns: Array<TaxReportColumn<Row>>
+	rows: Row[]
+	loading?: boolean
+	error?: unknown
+	emptyMessage: string
+	sorting?: TaxReportSortingState
+	onSortingChange?: (sorting: TaxReportSortingState) => void
+	pagination?: {
+		pageIndex: number
+		pageSize: number
+	}
+	onPaginationChange?: (pagination: { pageIndex: number; pageSize: number }) => void
+	rowCount?: number
+	itemLabel?: string
+	getRowKey: (row: Row, index: number) => string
+}
+
+function getSortIcon(columnId: string, sorting: TaxReportSortingState) {
+	const active = sorting[0]?.id === columnId ? sorting[0] : undefined
+	if (!active) return ArrowUpDown
+	return active.desc ? ArrowDown : ArrowUp
+}
+
+export function TaxReportTable<Row>({
+	columns,
+	rows,
+	loading = false,
+	error,
+	emptyMessage,
+	sorting = [],
+	onSortingChange,
+	pagination,
+	onPaginationChange,
+	rowCount = rows.length,
+	itemLabel = 'rows',
+	getRowKey,
+}: TaxReportTableProps<Row>) {
+	const isPaginated = Boolean(pagination && onPaginationChange)
+	const page = pagination?.pageIndex ?? 0
+	const pageSize = pagination?.pageSize ?? (rows.length || 1)
+
+	const toggleSort = (column: TaxReportColumn<Row>) => {
+		if (!column.sortable || !onSortingChange) return
+		const current = sorting[0]
+		if (!current || current.id !== column.id) {
+			onSortingChange([{ id: column.id, desc: false }])
+			return
+		}
+		onSortingChange([{ id: column.id, desc: !current.desc }])
+	}
+
+	return (
+		<div className="space-y-3">
+			{error ? (
+				<div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+					{error instanceof Error ? error.message : 'Failed to load report'}
+				</div>
+			) : null}
+			{isPaginated ? (
+				<UserSearchPaginationControls
+					totalCount={rowCount}
+					page={page + 1}
+					pageSize={pageSize}
+					onPageChange={(nextPage) => onPaginationChange?.({ pageIndex: nextPage - 1, pageSize })}
+					onPageSizeChange={(nextPageSize) =>
+						onPaginationChange?.({ pageIndex: 0, pageSize: nextPageSize })
+					}
+					itemLabel={itemLabel}
+					nextButtonLoading={loading}
+				/>
+			) : null}
+			<div className="relative overflow-x-auto rounded-md border border-border">
+				<Table className="min-w-max">
+					<TableHeader>
+						<TableRow>
+							{columns.map((column) => {
+								const SortIcon = getSortIcon(column.id, sorting)
+								return (
+									<TableHead key={column.id} className={column.headerClassName}>
+										{column.sortable && onSortingChange ? (
+											<button
+												type="button"
+												className="inline-flex items-center gap-1.5 text-left hover:text-foreground"
+												onClick={() => toggleSort(column)}
+											>
+												{column.header}
+												<SortIcon aria-hidden className="h-3.5 w-3.5" />
+											</button>
+										) : (
+											column.header
+										)}
+									</TableHead>
+								)
+							})}
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{rows.length > 0 ? (
+							rows.map((row, index) => (
+								<TableRow key={getRowKey(row, index)}>
+									{columns.map((column) => (
+										<TableCell key={column.id} className={column.className}>
+											{column.cell ? column.cell(row) : null}
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						) : (
+							<TableRow>
+								<TableCell
+									colSpan={columns.length}
+									className="h-40 text-center text-muted-foreground"
+								>
+									{emptyMessage}
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+				{loading ? (
+					<div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-[1px]">
+						<Loader2 aria-label="Loading" className="h-6 w-6 animate-spin text-primary" />
+					</div>
+				) : null}
+			</div>
+			{isPaginated ? (
+				<UserSearchPaginationControls
+					totalCount={rowCount}
+					page={page + 1}
+					pageSize={pageSize}
+					onPageChange={(nextPage) => onPaginationChange?.({ pageIndex: nextPage - 1, pageSize })}
+					onPageSizeChange={(nextPageSize) =>
+						onPaginationChange?.({ pageIndex: 0, pageSize: nextPageSize })
+					}
+					itemLabel={itemLabel}
+					nextButtonLoading={loading}
+				/>
+			) : null}
+		</div>
+	)
+}

--- a/apps/ui/src/client/components/tax-reports/grids/bill-status-report-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/bill-status-report-grid.tsx
@@ -1,30 +1,23 @@
-import { createMRTColumnHelper } from 'mantine-react-table'
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
-import { Badge } from '@/components/ui/badge'
-import { formatTaxDate } from '@/lib/tax-date'
-import { formatTaxIskFull, TaxEntityDisplay } from '@/lib/tax-display'
-
-import { billStatusBadgeVariant } from './shared'
-
-import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
-import type { TaxBillStatusReportRow } from '@repo/corporation-tax'
+import { BillStatusBadge } from '@/components/bills/bill-status-badge'
+import { TaxReportTable } from '@/components/tax-report-table'
 import { Button } from '@/components/ui/button'
+import { formatTaxDate } from '@/lib/tax-date'
+import { formatTaxIskFull, TaxCorporationDisplay } from '@/lib/tax-display'
+
+import type { TaxBillStatusReportRow } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function BillStatusReportGrid(props: {
 	rows: TaxBillStatusReportRow[]
 	loading: boolean
 	error: unknown
 	entityNames: Record<string, string>
-	sorting: MRT_SortingState
-	onSortingChange: (sorting: MRT_SortingState) => void
-	pagination: {
-		pageIndex: number
-		pageSize: number
-	}
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
 	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-	pageCount: number
 	rowCount: number
 	canManage?: boolean
 	onSyncBillStatus?: (assessmentId: string) => void
@@ -32,92 +25,96 @@ export function BillStatusReportGrid(props: {
 	syncBillPending?: boolean
 	retractBillPending?: boolean
 }) {
-	const columnHelper = createMRTColumnHelper<TaxBillStatusReportRow>()
-	const columns = useMemo<Array<MRT_ColumnDef<TaxBillStatusReportRow>>>(
+	const columns = useMemo(
 		() => [
-			columnHelper.accessor('billStatus', {
+			{
+				id: 'billStatus',
 				header: 'Bill Status',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<Badge variant={billStatusBadgeVariant(row.original.billStatus)}>
-						{row.original.billStatus}
-					</Badge>
-				),
-			}),
-			columnHelper.accessor('corporationId', {
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => <BillStatusBadge status={row.billStatus} />,
+			},
+			{
+				id: 'corporationId',
 				header: 'Corporation',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.corporationId} entityNames={props.entityNames} />
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => (
+					<TaxCorporationDisplay
+						corporationId={row.corporationId}
+						entityNames={props.entityNames}
+					/>
 				),
-			}),
-			columnHelper.accessor('taxPeriodStart', {
+			},
+			{
+				id: 'taxPeriodStart',
 				header: 'Period Start',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDate(row.original.taxPeriodStart),
-			}),
-			columnHelper.accessor('taxPeriodEnd', {
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => formatTaxDate(row.taxPeriodStart),
+			},
+			{
+				id: 'taxPeriodEnd',
 				header: 'Period End',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDate(row.original.taxPeriodEnd),
-			}),
-			columnHelper.accessor('issueDate', {
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => formatTaxDate(row.taxPeriodEnd),
+			},
+			{
+				id: 'issueDate',
 				header: 'Issue Date',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDate(row.original.issueDate),
-			}),
-			columnHelper.accessor('dueDate', {
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => formatTaxDate(row.issueDate),
+			},
+			{
+				id: 'dueDate',
 				header: 'Due Date',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDate(row.original.dueDate),
-			}),
-			columnHelper.accessor('taxDueCenti', {
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => formatTaxDate(row.dueDate),
+			},
+			{
 				id: 'taxDue',
 				header: 'Tax Due',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDue),
-			}),
-			columnHelper.accessor('taxPaidCenti', {
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => formatTaxIskFull(row.taxDue),
+			},
+			{
 				id: 'taxPaid',
 				header: 'Tax Paid',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxPaid),
-			}),
-			columnHelper.accessor('taxDeltaCenti', {
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => formatTaxIskFull(row.taxPaid),
+			},
+			{
 				id: 'taxDelta',
 				header: 'Delta',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDelta),
-			}),
-			columnHelper.display({
+				sortable: true,
+				cell: (row: TaxBillStatusReportRow) => formatTaxIskFull(row.taxDelta),
+			},
+			{
 				id: 'actions',
 				header: 'Actions',
-				enableSorting: false,
-				Cell: ({ row }) => {
-					const billStatus = row.original.billStatus
-					const canSync = billStatus === 'issued' || billStatus === 'overdue'
-					const canRetract = billStatus === 'issued' || billStatus === 'overdue'
+				className: 'text-right',
+				headerClassName: 'text-right',
+				cell: (row: TaxBillStatusReportRow) => {
+					const canSync = row.billStatus === 'issued' || row.billStatus === 'overdue'
+					const canRetract = canSync
 					const busy = props.syncBillPending || props.retractBillPending
-					if (!props.canManage) {
-						return <span className="text-xs text-muted-foreground">-</span>
-					}
+					if (!props.canManage) return <span className="text-xs text-muted-foreground">-</span>
 					return (
 						<div className="flex items-center justify-end gap-2">
 							{canSync ? (
-								<Button variant="primary"
+								<Button
+									variant="primary"
 									size="sm"
 									disabled={Boolean(busy) || !props.onSyncBillStatus}
-									onClick={() => props.onSyncBillStatus?.(row.original.assessmentId)}
+									onClick={() => props.onSyncBillStatus?.(row.assessmentId)}
 								>
 									{props.syncBillPending ? 'Syncing...' : 'Sync'}
 								</Button>
 							) : null}
 							{canRetract ? (
-								<Button variant="destructive"
+								<Button
+									variant="destructive"
 									size="sm"
 									showIcon={false}
 									disabled={Boolean(busy) || !props.onRetractBill}
-									onClick={() => props.onRetractBill?.(row.original.assessmentId)}
+									onClick={() => props.onRetractBill?.(row.assessmentId)}
 								>
 									{props.retractBillPending ? 'Retracting...' : 'Retract'}
 								</Button>
@@ -128,19 +125,20 @@ export function BillStatusReportGrid(props: {
 						</div>
 					)
 				},
-			}),
+			},
 		],
 		[
-			columnHelper,
 			props.canManage,
 			props.entityNames,
+			props.onRetractBill,
+			props.onSyncBillStatus,
 			props.retractBillPending,
 			props.syncBillPending,
 		]
 	)
 
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
@@ -150,9 +148,9 @@ export function BillStatusReportGrid(props: {
 			onSortingChange={props.onSortingChange}
 			pagination={props.pagination}
 			onPaginationChange={props.onPaginationChange}
-			pageCount={props.pageCount}
 			rowCount={props.rowCount}
-			pinnedRightColumnIds={['actions']}
+			itemLabel="bills"
+			getRowKey={(row) => row.assessmentId}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/compliance-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/compliance-grid.tsx
@@ -1,80 +1,72 @@
-import { createMRTColumnHelper } from 'mantine-react-table'
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
 import { formatTaxDateTime } from '@/lib/tax-date'
 import { formatTaxIskFull, formatTaxNumber } from '@/lib/tax-display'
 
-import { compareBigIntValues, parseDecimalToCentiBigInt } from './shared'
-
-import type { MRT_ColumnDef } from 'mantine-react-table'
 import type { TaxCompliancePoint } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function ComplianceGrid(props: {
 	rows: TaxCompliancePoint[]
 	loading: boolean
 	error: unknown
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
+	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+	rowCount: number
 }) {
-	const columnHelper = createMRTColumnHelper<TaxCompliancePoint>()
-	const columns = useMemo<Array<MRT_ColumnDef<TaxCompliancePoint>>>(
+	const columns = useMemo(
 		() => [
-			columnHelper.accessor((row) => new Date(row.rollupDate).getTime(), {
+			{
 				id: 'rollupDate',
 				header: 'Date',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxDateTime(row.original.rollupDate),
-			}),
-			columnHelper.accessor('taxDue', {
+				sortable: true,
+				cell: (row: TaxCompliancePoint) => formatTaxDateTime(row.rollupDate),
+			},
+			{
 				id: 'taxDue',
 				header: 'Tax Due',
-				enableSorting: true,
-				sortingFn: (rowA, rowB) =>
-					compareBigIntValues(
-						parseDecimalToCentiBigInt(rowA.original.taxDue),
-						parseDecimalToCentiBigInt(rowB.original.taxDue)
-					),
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDue),
-			}),
-			columnHelper.accessor('taxPaid', {
+				sortable: true,
+				cell: (row: TaxCompliancePoint) => formatTaxIskFull(row.taxDue),
+			},
+			{
 				id: 'taxPaid',
 				header: 'Tax Paid',
-				enableSorting: true,
-				sortingFn: (rowA, rowB) =>
-					compareBigIntValues(
-						parseDecimalToCentiBigInt(rowA.original.taxPaid),
-						parseDecimalToCentiBigInt(rowB.original.taxPaid)
-					),
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxPaid),
-			}),
-			columnHelper.accessor('taxDelta', {
+				sortable: true,
+				cell: (row: TaxCompliancePoint) => formatTaxIskFull(row.taxPaid),
+			},
+			{
 				id: 'taxDelta',
 				header: 'Delta',
-				enableSorting: true,
-				sortingFn: (rowA, rowB) =>
-					compareBigIntValues(
-						parseDecimalToCentiBigInt(rowA.original.taxDelta),
-						parseDecimalToCentiBigInt(rowB.original.taxDelta)
-					),
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDelta),
-			}),
-			columnHelper.accessor('entryCount', {
+				sortable: true,
+				cell: (row: TaxCompliancePoint) => formatTaxIskFull(row.taxDelta),
+			},
+			{
+				id: 'entryCount',
 				header: 'Entries',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxNumber(row.original.entryCount),
-			}),
+				sortable: true,
+				cell: (row: TaxCompliancePoint) => formatTaxNumber(row.entryCount),
+			},
 		],
-		[columnHelper]
+		[]
 	)
 
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
 			error={props.error}
 			emptyMessage="No compliance trend points available."
+			sorting={props.sorting}
+			onSortingChange={props.onSortingChange}
+			pagination={props.pagination}
+			onPaginationChange={props.onPaginationChange}
+			rowCount={props.rowCount}
+			itemLabel="periods"
+			getRowKey={(row) => row.rollupDate.toISOString()}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/discrepancy-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/discrepancy-grid.tsx
@@ -1,59 +1,66 @@
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
 import { formatTaxDateTime } from '@/lib/tax-date'
-import { TaxEntityDisplay } from '@/lib/tax-display'
+import { TaxCorporationDisplay } from '@/lib/tax-display'
 
 import { toJsonPreview } from './shared'
 
-import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
 import type { TaxDiscrepancy } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function DiscrepancyGrid(props: {
 	rows: TaxDiscrepancy[]
 	loading: boolean
 	error: unknown
 	entityNames: Record<string, string>
-	sorting: MRT_SortingState
-	onSortingChange: (sorting: MRT_SortingState) => void
-	pagination: {
-		pageIndex: number
-		pageSize: number
-	}
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
 	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-	pageCount: number
 	rowCount: number
 }) {
-	const columns = useMemo<Array<MRT_ColumnDef<TaxDiscrepancy>>>(
+	const columns = useMemo(
 		() => [
 			{
-				accessorKey: 'corporationId',
+				id: 'corporationId',
 				header: 'Corporation',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.corporationId} entityNames={props.entityNames} />
+				sortable: true,
+				cell: (row: TaxDiscrepancy) => (
+					<TaxCorporationDisplay
+						corporationId={row.corporationId}
+						entityNames={props.entityNames}
+					/>
 				),
 			},
-			{ accessorKey: 'discrepancyType', header: 'Type', enableSorting: true },
-			{ accessorKey: 'severity', header: 'Severity', enableSorting: true },
 			{
-				accessorKey: 'assessmentId',
+				id: 'discrepancyType',
+				header: 'Type',
+				sortable: true,
+				cell: (row: TaxDiscrepancy) => row.discrepancyType,
+			},
+			{
+				id: 'severity',
+				header: 'Severity',
+				sortable: true,
+				cell: (row: TaxDiscrepancy) => row.severity,
+			},
+			{
+				id: 'assessmentId',
 				header: 'Assessment',
-				enableSorting: false,
-				Cell: ({ row }) => row.original.assessmentId ?? '-',
+				cell: (row: TaxDiscrepancy) => row.assessmentId ?? '-',
 			},
 			{
-				accessorKey: 'createdAt',
+				id: 'createdAt',
 				header: 'Created',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDateTime(row.original.createdAt),
+				sortable: true,
+				cell: (row: TaxDiscrepancy) => formatTaxDateTime(row.createdAt),
 			},
 			{
-				accessorKey: 'details',
+				id: 'details',
 				header: 'Details',
-				enableSorting: false,
-				Cell: ({ row }) => (
-					<div className="max-w-[24rem] truncate">{toJsonPreview(row.original.details)}</div>
+				cell: (row: TaxDiscrepancy) => (
+					<div className="max-w-[24rem] truncate">{toJsonPreview(row.details)}</div>
 				),
 			},
 		],
@@ -61,7 +68,7 @@ export function DiscrepancyGrid(props: {
 	)
 
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
@@ -71,8 +78,9 @@ export function DiscrepancyGrid(props: {
 			onSortingChange={props.onSortingChange}
 			pagination={props.pagination}
 			onPaginationChange={props.onPaginationChange}
-			pageCount={props.pageCount}
 			rowCount={props.rowCount}
+			itemLabel="discrepancies"
+			getRowKey={(row) => row.id}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/ess-payout-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/ess-payout-grid.tsx
@@ -1,69 +1,71 @@
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
 import { formatTaxDateTime } from '@/lib/tax-date'
-import { formatTaxDivisionLabel, formatTaxIskFull, TaxEntityDisplay } from '@/lib/tax-display'
+import {
+	formatTaxDivisionLabel,
+	formatTaxIskFull,
+	TaxCorporationDisplay,
+	TaxEntityDisplay,
+} from '@/lib/tax-display'
 
-import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
 import type { TaxEssPayoutRow } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function EssPayoutGrid(props: {
 	rows: TaxEssPayoutRow[]
 	loading: boolean
 	error: unknown
 	entityNames: Record<string, string>
-	sorting: MRT_SortingState
-	onSortingChange: (sorting: MRT_SortingState) => void
-	pagination: {
-		pageIndex: number
-		pageSize: number
-	}
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
 	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-	pageCount: number
 	rowCount: number
 }) {
-	const columns = useMemo<Array<MRT_ColumnDef<TaxEssPayoutRow>>>(
+	const columns = useMemo(
 		() => [
 			{
-				accessorKey: 'entryDate',
+				id: 'entryDate',
 				header: 'Date',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDateTime(row.original.entryDate),
+				sortable: true,
+				cell: (row: TaxEssPayoutRow) => formatTaxDateTime(row.entryDate),
 			},
 			{
-				accessorKey: 'corporationId',
+				id: 'corporationId',
 				header: 'Corporation',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.corporationId} entityNames={props.entityNames} />
+				sortable: true,
+				cell: (row: TaxEssPayoutRow) => (
+					<TaxCorporationDisplay
+						corporationId={row.corporationId}
+						entityNames={props.entityNames}
+					/>
 				),
 			},
 			{
-				accessorKey: 'division',
+				id: 'division',
 				header: 'Division',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDivisionLabel(row.original.division),
+				sortable: true,
+				cell: (row: TaxEssPayoutRow) => formatTaxDivisionLabel(row.division),
 			},
 			{
-				accessorKey: 'amount',
+				id: 'amount',
 				header: 'Amount',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxIskFull(row.original.amount),
+				sortable: true,
+				cell: (row: TaxEssPayoutRow) => formatTaxIskFull(row.amount),
 			},
 			{
-				accessorKey: 'firstPartyId',
+				id: 'firstPartyId',
 				header: 'Sender',
-				enableSorting: false,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.firstPartyId} entityNames={props.entityNames} />
+				cell: (row: TaxEssPayoutRow) => (
+					<TaxEntityDisplay entityId={row.firstPartyId} entityNames={props.entityNames} />
 				),
 			},
 			{
-				accessorKey: 'secondPartyId',
+				id: 'secondPartyId',
 				header: 'Recipient',
-				enableSorting: false,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.secondPartyId} entityNames={props.entityNames} />
+				cell: (row: TaxEssPayoutRow) => (
+					<TaxEntityDisplay entityId={row.secondPartyId} entityNames={props.entityNames} />
 				),
 			},
 		],
@@ -71,7 +73,7 @@ export function EssPayoutGrid(props: {
 	)
 
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
@@ -81,8 +83,9 @@ export function EssPayoutGrid(props: {
 			onSortingChange={props.onSortingChange}
 			pagination={props.pagination}
 			onPaginationChange={props.onPaginationChange}
-			pageCount={props.pageCount}
 			rowCount={props.rowCount}
+			itemLabel="ESS rows"
+			getRowKey={(row) => row.id}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/export-history-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/export-history-grid.tsx
@@ -1,13 +1,13 @@
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatTaxDateTime } from '@/lib/tax-date'
-import { formatTaxNumber, TaxEntityDisplay } from '@/lib/tax-display'
+import { formatTaxNumber, TaxCorporationDisplay } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef } from 'mantine-react-table'
 import type { TaxExportRecord } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function ExportHistoryGrid(props: {
 	rows: TaxExportRecord[]
@@ -16,89 +16,99 @@ export function ExportHistoryGrid(props: {
 	entityNames: Record<string, string>
 	onDownload: (exportId: string) => void
 	downloading: boolean
+	pagination: { pageIndex: number; pageSize: number }
+	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+	rowCount: number
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
 }) {
-	const columns = useMemo<Array<MRT_ColumnDef<TaxExportRecord>>>(
+	const columns = useMemo(
 		() => [
 			{
 				id: 'requestedAt',
-				accessorFn: (row) => new Date(row.requestedAt).getTime(),
 				header: 'Requested At',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxDateTime(row.original.requestedAt),
+				sortable: true,
+				cell: (row: TaxExportRecord) => formatTaxDateTime(row.requestedAt),
 			},
 			{
-				accessorKey: 'corporationId',
+				id: 'corporationId',
 				header: 'Corporation',
-				enableSorting: true,
-				Cell: ({ row }) =>
-					row.original.corporationId ? (
-						<TaxEntityDisplay
-							entityId={row.original.corporationId}
+				sortable: true,
+				cell: (row: TaxExportRecord) =>
+					row.corporationId ? (
+						<TaxCorporationDisplay
+							corporationId={row.corporationId}
 							entityNames={props.entityNames}
 						/>
 					) : (
 						'Global'
 					),
 			},
-			{ accessorKey: 'reportType', header: 'Report', enableSorting: true },
 			{
-				accessorKey: 'format',
-				header: 'Format',
-				enableSorting: true,
-				Cell: ({ row }) => row.original.format.toUpperCase(),
+				id: 'reportType',
+				header: 'Report',
+				sortable: true,
+				cell: (row: TaxExportRecord) => row.reportType,
 			},
 			{
-				accessorKey: 'status',
+				id: 'format',
+				header: 'Format',
+				sortable: true,
+				cell: (row: TaxExportRecord) => row.format.toUpperCase(),
+			},
+			{
+				id: 'status',
 				header: 'Status',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<Badge variant={row.original.status === 'failed' ? 'destructive' : 'ghost'}>
-						{row.original.status}
-					</Badge>
+				sortable: true,
+				cell: (row: TaxExportRecord) => (
+					<Badge variant={row.status === 'failed' ? 'destructive' : 'ghost'}>{row.status}</Badge>
 				),
 			},
 			{
-				accessorKey: 'rowCount',
+				id: 'rowCount',
 				header: 'Rows',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxNumber(row.original.rowCount),
+				sortable: true,
+				cell: (row: TaxExportRecord) => formatTaxNumber(row.rowCount),
 			},
 			{
 				id: 'completedAt',
-				accessorFn: (row) =>
-					row.completedAt ? new Date(row.completedAt).getTime() : Number.NEGATIVE_INFINITY,
 				header: 'Completed',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxDateTime(row.original.completedAt),
+				sortable: true,
+				cell: (row: TaxExportRecord) => formatTaxDateTime(row.completedAt),
 			},
 			{
 				id: 'download',
 				header: 'Download',
-				enableSorting: false,
-				Cell: ({ row }) => (
+				className: 'text-right',
+				headerClassName: 'text-right',
+				cell: (row: TaxExportRecord) => (
 					<Button
 						variant="ghost"
 						size="sm"
-						disabled={row.original.status !== 'completed' || props.downloading}
-						onClick={() => props.onDownload(row.original.id)}
+						disabled={row.status !== 'completed' || props.downloading}
+						onClick={() => props.onDownload(row.id)}
 					>
 						{props.downloading ? 'Preparing...' : 'Download'}
 					</Button>
 				),
 			},
 		],
-		[props.entityNames, props.downloading, props.onDownload]
+		[props.downloading, props.entityNames, props.onDownload]
 	)
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
 			error={props.error}
 			emptyMessage="No export runs found."
+			pagination={props.pagination}
+			onPaginationChange={props.onPaginationChange}
+			rowCount={props.rowCount}
+			itemLabel="exports"
+			sorting={props.sorting}
+			onSortingChange={props.onSortingChange}
+			getRowKey={(row) => row.id}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/export-schedules-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/export-schedules-grid.tsx
@@ -1,82 +1,98 @@
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
 import { Badge } from '@/components/ui/badge'
 import { formatTaxDateTime } from '@/lib/tax-date'
-import { TaxEntityDisplay } from '@/lib/tax-display'
+import { TaxCorporationDisplay } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef } from 'mantine-react-table'
 import type { TaxExportSchedule } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function ExportSchedulesGrid(props: {
 	rows: TaxExportSchedule[]
 	loading: boolean
 	error: unknown
 	entityNames: Record<string, string>
+	pagination: { pageIndex: number; pageSize: number }
+	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+	rowCount: number
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
 }) {
-	const columns = useMemo<Array<MRT_ColumnDef<TaxExportSchedule>>>(
+	const columns = useMemo(
 		() => [
-			{ accessorKey: 'name', header: 'Name', enableSorting: true },
+			{ id: 'name', header: 'Name', sortable: true, cell: (row: TaxExportSchedule) => row.name },
 			{
-				accessorKey: 'corporationId',
+				id: 'corporationId',
 				header: 'Corporation',
-				enableSorting: true,
-				Cell: ({ row }) =>
-					row.original.corporationId ? (
-						<TaxEntityDisplay
-							entityId={row.original.corporationId}
+				sortable: true,
+				cell: (row: TaxExportSchedule) =>
+					row.corporationId ? (
+						<TaxCorporationDisplay
+							corporationId={row.corporationId}
 							entityNames={props.entityNames}
 						/>
 					) : (
 						'Global'
 					),
 			},
-			{ accessorKey: 'reportType', header: 'Report', enableSorting: true },
 			{
-				accessorKey: 'format',
-				header: 'Format',
-				enableSorting: true,
-				Cell: ({ row }) => row.original.format.toUpperCase(),
+				id: 'reportType',
+				header: 'Report',
+				sortable: true,
+				cell: (row: TaxExportSchedule) => row.reportType,
 			},
-			{ accessorKey: 'frequency', header: 'Frequency', enableSorting: true },
 			{
-				accessorKey: 'isActive',
+				id: 'format',
+				header: 'Format',
+				sortable: true,
+				cell: (row: TaxExportSchedule) => row.format.toUpperCase(),
+			},
+			{
+				id: 'frequency',
+				header: 'Frequency',
+				sortable: true,
+				cell: (row: TaxExportSchedule) => row.frequency,
+			},
+			{
+				id: 'isActive',
 				header: 'Active',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<Badge variant={row.original.isActive ? 'default' : 'secondary'}>
-						{row.original.isActive ? 'active' : 'paused'}
+				sortable: true,
+				cell: (row: TaxExportSchedule) => (
+					<Badge variant={row.isActive ? 'default' : 'secondary'}>
+						{row.isActive ? 'active' : 'paused'}
 					</Badge>
 				),
 			},
 			{
 				id: 'nextRunAt',
-				accessorFn: (row) =>
-					row.nextRunAt ? new Date(row.nextRunAt).getTime() : Number.NEGATIVE_INFINITY,
 				header: 'Next Run',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxDateTime(row.original.nextRunAt),
+				sortable: true,
+				cell: (row: TaxExportSchedule) => formatTaxDateTime(row.nextRunAt),
 			},
 			{
 				id: 'lastRunAt',
-				accessorFn: (row) =>
-					row.lastRunAt ? new Date(row.lastRunAt).getTime() : Number.NEGATIVE_INFINITY,
 				header: 'Last Run',
-				enableSorting: true,
-				sortingFn: 'basic',
-				Cell: ({ row }) => formatTaxDateTime(row.original.lastRunAt),
+				sortable: true,
+				cell: (row: TaxExportSchedule) => formatTaxDateTime(row.lastRunAt),
 			},
 		],
 		[props.entityNames]
 	)
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
 			error={props.error}
 			emptyMessage="No export schedules found."
+			pagination={props.pagination}
+			onPaginationChange={props.onPaginationChange}
+			rowCount={props.rowCount}
+			itemLabel="schedules"
+			sorting={props.sorting}
+			onSortingChange={props.onSortingChange}
+			getRowKey={(row) => row.id}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/member-summary-report-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/member-summary-report-grid.tsx
@@ -1,7 +1,15 @@
-import { createMRTColumnHelper } from 'mantine-react-table'
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
 import { useState } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { formatTaxDateTime } from '@/lib/tax-date'
 import {
 	formatTaxIskFull,
@@ -11,28 +19,91 @@ import {
 	TaxEntityDisplay,
 } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
 import type { TaxMemberSummary } from '@repo/corporation-tax'
 
 const UNATTRIBUTED_CHARACTER_ID = '__unattributed__'
+
+type MemberSummarySortField =
+	| 'characterId'
+	| 'contributionIncome'
+	| 'taxableContributionIncome'
+	| 'assessmentCount'
+	| 'lastAssessmentAt'
 
 type MemberSummaryReportGridProps = {
 	rows: TaxMemberSummary[]
 	loading?: boolean
 	error?: unknown
 	entityNames: Record<string, string>
-	sorting: MRT_SortingState
-	onSortingChange: (sorting: MRT_SortingState) => void
-	pagination: { pageIndex: number; pageSize: number }
-	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-	pageCount: number
-	rowCount: number
+	sortBy: MemberSummarySortField
+	sortDir: 'asc' | 'desc'
+	onSortChange: (field: MemberSummarySortField) => void
+	page: number
+	pageSize: number
+	onPageChange: (page: number) => void
+	onPageSizeChange: (pageSize: number) => void
+	totalRows: number
+}
+
+function MemberSummaryPagination({
+	totalRows,
+	page,
+	pageSize,
+	onPageChange,
+	onPageSizeChange,
+	loading,
+}: Pick<
+	MemberSummaryReportGridProps,
+	'totalRows' | 'page' | 'pageSize' | 'onPageChange' | 'onPageSizeChange' | 'loading'
+>) {
+	return (
+		<UserSearchPaginationControls
+			totalCount={totalRows}
+			page={page + 1}
+			pageSize={pageSize}
+			onPageChange={(nextPage) => onPageChange(nextPage - 1)}
+			onPageSizeChange={onPageSizeChange}
+			pageSizeOptions={[25, 50, 100]}
+			itemLabel="members"
+			nextButtonLoading={loading}
+		/>
+	)
 }
 
 function parseIsk(value: string): number {
 	const normalized = value.trim().replace(/,/g, '')
 	const parsed = Number(normalized)
 	return Number.isFinite(parsed) ? parsed : 0
+}
+
+function SortableHead({
+	label,
+	field,
+	sortBy,
+	sortDir,
+	onSortChange,
+}: {
+	label: string
+	field: MemberSummarySortField
+	sortBy: MemberSummarySortField
+	sortDir: 'asc' | 'desc'
+	onSortChange: (field: MemberSummarySortField) => void
+}) {
+	const isActive = sortBy === field
+	const SortIcon = !isActive ? ArrowUpDown : sortDir === 'asc' ? ArrowUp : ArrowDown
+
+	return (
+		<TableHead>
+			<button
+				type="button"
+				className="inline-flex items-center gap-1.5 text-left hover:text-foreground"
+				onClick={() => onSortChange(field)}
+			>
+				{label}
+				<SortIcon aria-hidden className="h-3.5 w-3.5" />
+			</button>
+		</TableHead>
+	)
 }
 
 function SourceSplitSegment({
@@ -91,28 +162,18 @@ function SourceSplitSegment({
 	)
 }
 
-function TopSourceBreakdown({
-	topRefTypes,
-}: {
-	topRefTypes: Array<{
-		refType: string
-		contributionAmount?: string
-		taxableAmount: string
-		lineCount?: number
-	}>
-}) {
+function TopSourceBreakdown({ topRefTypes }: { topRefTypes: TaxMemberSummary['topRefTypes'] }) {
 	if (topRefTypes.length === 0) {
 		return <span>-</span>
 	}
 
-	const segmentWeights = topRefTypes.map((source) => {
-		const contributionValue = parseIsk(source.contributionAmount ?? source.taxableAmount)
-		return Math.max(1, contributionValue)
-	})
+	const segmentWeights = topRefTypes.map((source) =>
+		Math.max(1, parseIsk(source.contributionAmount))
+	)
 	const totalWeight = segmentWeights.reduce((sum, value) => sum + value, 0)
 
 	return (
-		<div>
+		<div className="min-w-[15rem] text-xs">
 			<div className="flex h-5 w-full overflow-hidden rounded bg-muted">
 				{topRefTypes.map((source, index) => {
 					const weight = segmentWeights[index] ?? 1
@@ -123,7 +184,7 @@ function TopSourceBreakdown({
 							key={`${source.refType}:${index}:segment`}
 							color={getTaxRefTypeColor(source.refType)}
 							label={label}
-							amount={source.taxableAmount}
+							amount={source.contributionAmount}
 							share={share}
 							widthPercent={share}
 						/>
@@ -135,69 +196,104 @@ function TopSourceBreakdown({
 }
 
 export function MemberSummaryReportGrid(props: MemberSummaryReportGridProps) {
-	const columnHelper = createMRTColumnHelper<TaxMemberSummary>()
-	const columns: Array<MRT_ColumnDef<TaxMemberSummary>> = [
-		columnHelper.accessor('characterId', {
-			id: 'characterId',
-			header: 'Character',
-			enableSorting: true,
-			Cell: ({ row }) =>
-				row.original.characterId === UNATTRIBUTED_CHARACTER_ID ? (
-					<div className="font-medium">Unattributed</div>
-				) : (
-					<TaxEntityDisplay entityId={row.original.characterId} entityNames={props.entityNames} />
-				),
-		}),
-		columnHelper.accessor('contributionIncome', {
-			id: 'contributionIncome',
-			header: 'Contribution',
-			enableSorting: true,
-			Cell: ({ cell }) => formatTaxIskFull(cell.getValue()),
-		}),
-		columnHelper.accessor('taxableContributionIncome', {
-			id: 'taxableContributionIncome',
-			header: 'Taxable',
-			enableSorting: true,
-			Cell: ({ cell }) => formatTaxIskFull(cell.getValue()),
-		}),
-		columnHelper.accessor('assessmentCount', {
-			id: 'assessmentCount',
-			header: 'Assessments',
-			enableSorting: true,
-			Cell: ({ cell }) => formatTaxNumber(cell.getValue()),
-		}),
-		columnHelper.accessor('lastAssessmentAt', {
-			id: 'lastAssessmentAt',
-			header: 'Last Assessment',
-			enableSorting: true,
-			Cell: ({ cell }) => formatTaxDateTime(cell.getValue()),
-		}),
-		columnHelper.display({
-			id: 'sourceSplit',
-			header: 'Source Split',
-			enableSorting: false,
-			size: 300,
-			Cell: ({ row }) => (
-				<div className="min-w-[15rem] text-xs">
-					<TopSourceBreakdown topRefTypes={row.original.topRefTypes} />
-				</div>
-			),
-		}),
-	]
+	const errorMessage =
+		props.error instanceof Error ? props.error.message : 'Unable to load member summary.'
 
 	return (
-		<TaxReportDataGrid
-			columns={columns}
-			rows={props.rows}
-			loading={props.loading}
-			error={props.error}
-			emptyMessage="No member contribution records were found for the selected scope and period."
-			sorting={props.sorting}
-			onSortingChange={props.onSortingChange}
-			pagination={props.pagination}
-			onPaginationChange={props.onPaginationChange}
-			pageCount={props.pageCount}
-			rowCount={props.rowCount}
-		/>
+		<div className="space-y-3">
+			{props.error ? <div className="text-sm text-destructive">{errorMessage}</div> : null}
+			<MemberSummaryPagination {...props} />
+			<div className="relative overflow-hidden rounded-md border border-border">
+				<Table className="min-w-[70rem]">
+					<TableHeader>
+						<TableRow>
+							<SortableHead
+								label="Character"
+								field="characterId"
+								sortBy={props.sortBy}
+								sortDir={props.sortDir}
+								onSortChange={props.onSortChange}
+							/>
+							<SortableHead
+								label="Contribution"
+								field="contributionIncome"
+								sortBy={props.sortBy}
+								sortDir={props.sortDir}
+								onSortChange={props.onSortChange}
+							/>
+							<SortableHead
+								label="Taxable"
+								field="taxableContributionIncome"
+								sortBy={props.sortBy}
+								sortDir={props.sortDir}
+								onSortChange={props.onSortChange}
+							/>
+							<SortableHead
+								label="Assessments"
+								field="assessmentCount"
+								sortBy={props.sortBy}
+								sortDir={props.sortDir}
+								onSortChange={props.onSortChange}
+							/>
+							<SortableHead
+								label="Last Assessment"
+								field="lastAssessmentAt"
+								sortBy={props.sortBy}
+								sortDir={props.sortDir}
+								onSortChange={props.onSortChange}
+							/>
+							<TableHead>Source Split</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{props.rows.length > 0 ? (
+							props.rows.map((row) => (
+								<TableRow key={row.characterId}>
+									<TableCell>
+										{row.characterId === UNATTRIBUTED_CHARACTER_ID ? (
+											<div className="font-medium">Unattributed</div>
+										) : (
+											<TaxEntityDisplay
+												entityId={row.characterId}
+												entityNames={props.entityNames}
+											/>
+										)}
+									</TableCell>
+									<TableCell className="whitespace-nowrap">
+										{formatTaxIskFull(row.contributionIncome)}
+									</TableCell>
+									<TableCell className="whitespace-nowrap">
+										{formatTaxIskFull(row.taxableContributionIncome)}
+									</TableCell>
+									<TableCell className="whitespace-nowrap">
+										{formatTaxNumber(row.assessmentCount)}
+									</TableCell>
+									<TableCell className="whitespace-nowrap">
+										{formatTaxDateTime(row.lastAssessmentAt)}
+									</TableCell>
+									<TableCell>
+										<TopSourceBreakdown topRefTypes={row.topRefTypes} />
+									</TableCell>
+								</TableRow>
+							))
+						) : (
+							<TableRow>
+								<TableCell colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
+									{props.loading
+										? 'Loading member contribution records...'
+										: 'No member contribution records were found for the selected scope and period.'}
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+				{props.loading && props.rows.length > 0 ? (
+					<div className="absolute inset-0 flex items-center justify-center bg-background/45 text-sm text-muted-foreground backdrop-blur-[1px]">
+						Loading...
+					</div>
+				) : null}
+			</div>
+			<MemberSummaryPagination {...props} />
+		</div>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/member-summary-report-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/member-summary-report-grid.tsx
@@ -10,7 +10,7 @@ import {
 	TableRow,
 } from '@/components/ui/table'
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
-import { formatTaxDateTime } from '@/lib/tax-date'
+import { formatMonthYear } from '@/lib/date-utils'
 import {
 	formatTaxIskFull,
 	formatTaxNumber,
@@ -236,7 +236,7 @@ export function MemberSummaryReportGrid(props: MemberSummaryReportGridProps) {
 								onSortChange={props.onSortChange}
 							/>
 							<SortableHead
-								label="Last Assessment"
+								label="Most Recent Assessment"
 								field="lastAssessmentAt"
 								sortBy={props.sortBy}
 								sortDir={props.sortDir}
@@ -269,7 +269,7 @@ export function MemberSummaryReportGrid(props: MemberSummaryReportGridProps) {
 										{formatTaxNumber(row.assessmentCount)}
 									</TableCell>
 									<TableCell className="whitespace-nowrap">
-										{formatTaxDateTime(row.lastAssessmentAt)}
+										{row.lastAssessmentAt ? formatMonthYear(row.lastAssessmentAt) : '-'}
 									</TableCell>
 									<TableCell>
 										<TopSourceBreakdown topRefTypes={row.topRefTypes} />

--- a/apps/ui/src/client/components/tax-reports/grids/missing-esi-keys-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/missing-esi-keys-grid.tsx
@@ -1,71 +1,70 @@
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
+import { Badge } from '@/components/ui/badge'
 import { formatTaxDateTime } from '@/lib/tax-date'
-import { formatTaxNumber, TaxEntityDisplay } from '@/lib/tax-display'
+import { formatTaxNumber, TaxCorporationDisplay } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
 import type { TaxMissingEsiKeyRow } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function MissingEsiKeysGrid(props: {
 	rows: TaxMissingEsiKeyRow[]
 	loading: boolean
 	error: unknown
 	entityNames: Record<string, string>
-	sorting: MRT_SortingState
-	onSortingChange: (sorting: MRT_SortingState) => void
-	pagination: {
-		pageIndex: number
-		pageSize: number
-	}
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
 	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-	pageCount: number
 	rowCount: number
 }) {
-	const columns = useMemo<Array<MRT_ColumnDef<TaxMissingEsiKeyRow>>>(
+	const columns = useMemo(
 		() => [
 			{
-				accessorKey: 'corporationId',
+				id: 'corporationId',
 				header: 'Corporation',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.corporationId} entityNames={props.entityNames} />
+				sortable: true,
+				cell: (row: TaxMissingEsiKeyRow) => (
+					<TaxCorporationDisplay
+						corporationId={row.corporationId}
+						entityNames={props.entityNames}
+					/>
 				),
 			},
 			{
-				accessorKey: 'isConfigured',
+				id: 'isConfigured',
 				header: 'Configured',
-				enableSorting: false,
-				Cell: ({ row }) => (row.original.isConfigured ? 'yes' : 'no'),
+				cell: (row: TaxMissingEsiKeyRow) => (row.isConfigured ? 'yes' : 'no'),
 			},
 			{
-				accessorKey: 'missingRequiredScopes',
+				id: 'missingRequiredScopes',
 				header: 'Required Scopes',
-				enableSorting: false,
-				Cell: ({ row }) =>
-					row.original.missingRequiredScopes.length > 0
-						? row.original.missingRequiredScopes.join(', ')
-						: 'complete',
+				cell: (row: TaxMissingEsiKeyRow) =>
+					row.missingRequiredScopes.length > 0 ? row.missingRequiredScopes.join(', ') : 'complete',
 			},
 			{
-				accessorKey: 'healthyDirectorCount',
+				id: 'healthyDirectorCount',
 				header: 'Healthy Directors',
-				enableSorting: true,
-				Cell: ({ row }) =>
-					`${formatTaxNumber(row.original.healthyDirectorCount)}/${formatTaxNumber(row.original.directorCount)}`,
+				sortable: true,
+				cell: (row: TaxMissingEsiKeyRow) => (
+					<Badge variant={row.healthyDirectorCount > 0 ? 'success' : 'destructive'}>
+						{`${formatTaxNumber(row.healthyDirectorCount)}/${formatTaxNumber(row.directorCount)}`}
+					</Badge>
+				),
 			},
 			{
-				accessorKey: 'lastVerified',
+				id: 'lastVerified',
 				header: 'Last Verified',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxDateTime(row.original.lastVerified),
+				sortable: true,
+				cell: (row: TaxMissingEsiKeyRow) => formatTaxDateTime(row.lastVerified),
 			},
 		],
 		[props.entityNames]
 	)
 
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
@@ -75,8 +74,9 @@ export function MissingEsiKeysGrid(props: {
 			onSortingChange={props.onSortingChange}
 			pagination={props.pagination}
 			onPaginationChange={props.onPaginationChange}
-			pageCount={props.pageCount}
 			rowCount={props.rowCount}
+			itemLabel="corporations"
+			getRowKey={(row) => row.corporationId}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/grids/tax-audit-log-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/tax-audit-log-grid.tsx
@@ -1,7 +1,7 @@
-import { createMRTColumnHelper } from 'mantine-react-table'
 import { useMemo, useState } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
+import { Button } from '@/components/ui/button'
 import {
 	Dialog,
 	DialogContent,
@@ -10,10 +10,10 @@ import {
 	DialogTitle,
 } from '@/components/ui/dialog'
 import { formatTaxDateTime } from '@/lib/tax-date'
+import { TaxCorporationDisplay } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef } from 'mantine-react-table'
 import type { TaxAuditLogEntry } from '@repo/corporation-tax'
-import { Button } from '@/components/ui/button'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 type TaxAuditLogGridProps = {
 	rows: TaxAuditLogEntry[]
@@ -21,9 +21,10 @@ type TaxAuditLogGridProps = {
 	error?: unknown
 	entityNames: Record<string, string>
 	actorDisplayNames: Record<string, string>
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
 	pagination: { pageIndex: number; pageSize: number }
 	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-	pageCount: number
 	rowCount: number
 }
 
@@ -202,26 +203,25 @@ export function TaxAuditLogGrid(props: TaxAuditLogGridProps) {
 		[selectedEntry]
 	)
 
-	const columnHelper = createMRTColumnHelper<TaxAuditLogEntry>()
-	const columns: Array<MRT_ColumnDef<TaxAuditLogEntry>> = [
-		columnHelper.accessor('createdAt', {
+	const columns = [
+		{
 			id: 'createdAt',
 			header: 'Time',
-			enableSorting: false,
-			Cell: ({ row }) => formatTaxDateTime(row.original.createdAt),
-		}),
-		columnHelper.accessor('action', {
+			sortable: true,
+			cell: (row: TaxAuditLogEntry) => formatTaxDateTime(row.createdAt),
+		},
+		{
 			id: 'action',
 			header: 'Action',
-			enableSorting: false,
-			Cell: ({ row }) => <span className="font-medium">{row.original.action}</span>,
-		}),
-		columnHelper.accessor('actorUserId', {
+			sortable: true,
+			cell: (row: TaxAuditLogEntry) => <span className="font-medium">{row.action}</span>,
+		},
+		{
 			id: 'actorUserId',
 			header: 'Actor',
-			enableSorting: false,
-			Cell: ({ row }) => {
-				const actorUserId = row.original.actorUserId
+			sortable: true,
+			cell: (row: TaxAuditLogEntry) => {
+				const actorUserId = row.actorUserId
 				const actorName = props.actorDisplayNames[actorUserId]
 				return (
 					<div className="flex flex-col">
@@ -232,47 +232,52 @@ export function TaxAuditLogGrid(props: TaxAuditLogGridProps) {
 					</div>
 				)
 			},
-		}),
-		columnHelper.accessor('corporationId', {
+		},
+		{
 			id: 'corporationId',
 			header: 'Corporation',
-			enableSorting: false,
-			Cell: ({ row }) => {
-				const corporationId = row.original.corporationId
+			sortable: true,
+			cell: (row: TaxAuditLogEntry) => {
+				const corporationId = row.corporationId
 				if (!corporationId) {
 					return <span>Global</span>
 				}
-				return <span>{props.entityNames[corporationId] ?? corporationId}</span>
+				return (
+					<TaxCorporationDisplay corporationId={corporationId} entityNames={props.entityNames} />
+				)
 			},
-		}),
-		columnHelper.display({
+		},
+		{
 			id: 'actions',
 			header: 'Actions',
-			enableSorting: false,
-			Cell: ({ row }) => (
-				<Button variant="ghost"
+			cell: (row: TaxAuditLogEntry) => (
+				<Button
+					variant="ghost"
 					type="button"
 					className="h-8 px-3"
-					onClick={() => setSelectedEntry(row.original)}
+					onClick={() => setSelectedEntry(row)}
 				>
 					View
 				</Button>
 			),
-		}),
+		},
 	]
 
 	return (
 		<>
-			<TaxReportDataGrid
+			<TaxReportTable
 				columns={columns}
 				rows={props.rows}
 				loading={props.loading}
 				error={props.error}
 				emptyMessage="No audit entries matched the selected filters."
+				sorting={props.sorting}
+				onSortingChange={props.onSortingChange}
 				pagination={props.pagination}
 				onPaginationChange={props.onPaginationChange}
-				pageCount={props.pageCount}
 				rowCount={props.rowCount}
+				itemLabel="audit entries"
+				getRowKey={(row) => row.id}
 			/>
 
 			<Dialog

--- a/apps/ui/src/client/components/tax-reports/grids/total-taxes-report-grid.tsx
+++ b/apps/ui/src/client/components/tax-reports/grids/total-taxes-report-grid.tsx
@@ -1,66 +1,65 @@
-import { createMRTColumnHelper } from 'mantine-react-table'
 import { useMemo } from 'react'
 
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
-import { formatTaxIskFull, formatTaxNumber, TaxEntityDisplay } from '@/lib/tax-display'
+import { TaxReportTable } from '@/components/tax-report-table'
+import { formatTaxIskFull, formatTaxNumber, TaxCorporationDisplay } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef, MRT_SortingState } from 'mantine-react-table'
 import type { TaxTotalTaxesByCorporationRow } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 export function TotalTaxesReportGrid(props: {
 	rows: TaxTotalTaxesByCorporationRow[]
 	loading: boolean
 	error: unknown
 	entityNames: Record<string, string>
-	sorting: MRT_SortingState
-	onSortingChange: (sorting: MRT_SortingState) => void
-	pagination: {
-		pageIndex: number
-		pageSize: number
-	}
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
 	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-	pageCount: number
 	rowCount: number
 }) {
-	const columnHelper = createMRTColumnHelper<TaxTotalTaxesByCorporationRow>()
-	const columns = useMemo<Array<MRT_ColumnDef<TaxTotalTaxesByCorporationRow>>>(
+	const columns = useMemo(
 		() => [
-			columnHelper.accessor('corporationId', {
+			{
+				id: 'corporationId',
 				header: 'Corporation',
-				enableSorting: true,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.corporationId} entityNames={props.entityNames} />
+				sortable: true,
+				cell: (row: TaxTotalTaxesByCorporationRow) => (
+					<TaxCorporationDisplay
+						corporationId={row.corporationId}
+						entityNames={props.entityNames}
+					/>
 				),
-			}),
-			columnHelper.accessor('taxableItemCount', {
+			},
+			{
+				id: 'taxableItemCount',
 				header: 'Taxable Items',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxNumber(row.original.taxableItemCount),
-			}),
-			columnHelper.accessor('taxDueCenti', {
+				sortable: true,
+				cell: (row: TaxTotalTaxesByCorporationRow) => formatTaxNumber(row.taxableItemCount),
+			},
+			{
 				id: 'taxDue',
 				header: 'Tax Due',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDue),
-			}),
-			columnHelper.accessor('taxPaidCenti', {
+				sortable: true,
+				cell: (row: TaxTotalTaxesByCorporationRow) => formatTaxIskFull(row.taxDue),
+			},
+			{
 				id: 'taxPaid',
 				header: 'Tax Paid',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxPaid),
-			}),
-			columnHelper.accessor('taxDeltaCenti', {
+				sortable: true,
+				cell: (row: TaxTotalTaxesByCorporationRow) => formatTaxIskFull(row.taxPaid),
+			},
+			{
 				id: 'taxDelta',
 				header: 'Delta',
-				enableSorting: true,
-				Cell: ({ row }) => formatTaxIskFull(row.original.taxDelta),
-			}),
+				sortable: true,
+				cell: (row: TaxTotalTaxesByCorporationRow) => formatTaxIskFull(row.taxDelta),
+			},
 		],
-		[columnHelper, props.entityNames]
+		[props.entityNames]
 	)
 
 	return (
-		<TaxReportDataGrid
+		<TaxReportTable
 			columns={columns}
 			rows={props.rows}
 			loading={props.loading}
@@ -70,8 +69,9 @@ export function TotalTaxesReportGrid(props: {
 			onSortingChange={props.onSortingChange}
 			pagination={props.pagination}
 			onPaginationChange={props.onPaginationChange}
-			pageCount={props.pageCount}
 			rowCount={props.rowCount}
+			itemLabel="corporations"
+			getRowKey={(row) => row.corporationId}
 		/>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/report-display.tsx
+++ b/apps/ui/src/client/components/tax-reports/report-display.tsx
@@ -5,6 +5,7 @@ import { formatTaxIskCompact } from '@/lib/tax-display'
 import { parseTaxAmount } from '@/lib/tax-report-utils'
 
 import type { TaxCompliancePoint } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 interface TaxReportSelectorProps {
 	selectedReportView: string
@@ -27,7 +28,8 @@ export function TaxReportSelector(props: TaxReportSelectorProps) {
 					query={props.reportSelectorQuery}
 					onQueryChange={props.onReportSelectorQueryChange}
 					searchable
-					options={props.visibleReportOptions.map((option) => ({ value: option.value,
+					options={props.visibleReportOptions.map((option) => ({
+						value: option.value,
 						label: option.label,
 					}))}
 					placeholder="Choose report"
@@ -55,8 +57,13 @@ export function TaxComplianceReportSection(props: {
 	error: unknown
 	rows: TaxCompliancePoint[]
 	chartRows: TaxCompliancePoint[]
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
+	pagination: { pageIndex: number; pageSize: number }
+	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+	rowCount: number
 }) {
-	if (props.loading) {
+	if (props.loading && props.rows.length === 0 && props.chartRows.length === 0) {
 		return <div className="py-8 text-sm text-muted-foreground">Loading compliance trend...</div>
 	}
 
@@ -68,7 +75,7 @@ export function TaxComplianceReportSection(props: {
 		)
 	}
 
-	if (props.rows.length === 0) {
+	if (props.rows.length === 0 && props.chartRows.length === 0) {
 		return (
 			<div className="py-8 text-sm text-muted-foreground">
 				No compliance trend points available.
@@ -180,7 +187,16 @@ export function TaxComplianceReportSection(props: {
 				</div>
 			</div>
 
-			<ComplianceGrid rows={props.rows} loading={false} error={null} />
+			<ComplianceGrid
+				rows={props.rows}
+				loading={props.loading}
+				error={null}
+				sorting={props.sorting}
+				onSortingChange={props.onSortingChange}
+				pagination={props.pagination}
+				onPaginationChange={props.onPaginationChange}
+				rowCount={props.rowCount}
+			/>
 		</div>
 	)
 }

--- a/apps/ui/src/client/components/tax-reports/report-panels.tsx
+++ b/apps/ui/src/client/components/tax-reports/report-panels.tsx
@@ -1,6 +1,9 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
 import { TaxCorporationScopeSelector } from '@/components/tax-corporation-scope-selector'
 import { ExportHistoryGrid, ExportSchedulesGrid } from '@/components/tax-reports/grids'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { DateRangeInput } from '@/components/ui/date-range-input'
 import {
@@ -14,7 +17,6 @@ import {
 import { FilterField } from '@/components/ui/filter-field'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
-import { Button } from '@/components/ui/button'
 import { formatTaxIskCompact } from '@/lib/tax-display'
 
 import type { ReactNode } from 'react'
@@ -24,6 +26,8 @@ import type {
 	TaxExportSchedule,
 	TaxSummaryReport,
 } from '@repo/corporation-tax'
+import type { TaxReportQuickRange } from '@/lib/tax-date'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 interface TaxPanelCardProps {
 	title: string
@@ -60,6 +64,9 @@ interface TaxReportFiltersCardProps {
 	fromDate: string
 	toDate: string
 	onDateRangeChange: (next: { fromDate: string; toDate: string }) => void
+	onMoveMonth: (monthOffset: number) => void
+	onSelectQuickRange: (range: TaxReportQuickRange) => void
+	onReset: () => void
 	accessibleCorporations: Array<{ corporationId: string; name: string }>
 	effectiveCorporationId?: string
 	selectedCorporationId?: string
@@ -74,14 +81,60 @@ export function TaxReportFiltersCard(props: TaxReportFiltersCardProps) {
 			description="These filters apply to the active report and are persisted into export payloads."
 			contentClassName="grid gap-3 md:grid-cols-4"
 		>
-			<FilterField label="Date range">
-				<DateRangeInput
-					value={{ fromDate: props.fromDate, toDate: props.toDate }}
-					onChange={props.onDateRangeChange}
-					placeholder="Date range"
-				/>
+			<FilterField label="Date range" className="md:col-span-2">
+				<div className="flex items-center gap-1">
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						showIcon={false}
+						className="h-10 w-10 shrink-0 p-0"
+						aria-label="Previous month"
+						onClick={() => props.onMoveMonth(-1)}
+					>
+						<ChevronLeft className="h-4 w-4" aria-hidden="true" />
+					</Button>
+					<DateRangeInput
+						value={{ fromDate: props.fromDate, toDate: props.toDate }}
+						onChange={props.onDateRangeChange}
+						placeholder="Date range"
+						className="min-w-0 flex-1 [&_.themed-date-picker__input]:h-10 [&_.themed-date-picker__input]:w-full"
+					/>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						showIcon={false}
+						className="h-10 w-10 shrink-0 p-0"
+						aria-label="Next month"
+						onClick={() => props.onMoveMonth(1)}
+					>
+						<ChevronRight className="h-4 w-4" aria-hidden="true" />
+					</Button>
+				</div>
+				<div className="flex flex-wrap gap-1.5 pt-1">
+					{[
+						{ range: 'current-month' as const, label: 'Current month' },
+						{ range: 'previous-month' as const, label: 'Previous month' },
+						{ range: 'last-3-months' as const, label: 'Last 3 months' },
+						{ range: 'last-6-months' as const, label: 'Last 6 months' },
+						{ range: 'last-year' as const, label: 'Last year' },
+					].map((option) => (
+						<Button
+							key={option.range}
+							type="button"
+							variant="ghost"
+							size="sm"
+							showIcon={false}
+							className="h-7 px-2 text-xs"
+							onClick={() => props.onSelectQuickRange(option.range)}
+						>
+							{option.label}
+						</Button>
+					))}
+				</div>
 			</FilterField>
-			<FilterField label="Corporation">
+			<FilterField label="Corporation" className="md:col-span-2">
 				<TaxCorporationScopeSelector
 					corporations={props.accessibleCorporations}
 					effectiveCorporationId={props.effectiveCorporationId}
@@ -92,6 +145,11 @@ export function TaxReportFiltersCard(props: TaxReportFiltersCardProps) {
 					className="sm:max-w-none"
 				/>
 			</FilterField>
+			<div className="flex justify-end md:col-span-4">
+				<Button type="button" variant="ghost" size="sm" showIcon={false} onClick={props.onReset}>
+					Reset filters
+				</Button>
+			</div>
 		</TaxPanelCard>
 	)
 }
@@ -165,6 +223,11 @@ export function TaxExportHistoryPanel(props: {
 	downloadError: unknown
 	downloading: boolean
 	onDownload: (exportId: string) => void
+	pagination: { pageIndex: number; pageSize: number }
+	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+	rowCount: number
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
 }) {
 	return (
 		<TaxPanelCard
@@ -186,6 +249,11 @@ export function TaxExportHistoryPanel(props: {
 				entityNames={props.entityNames}
 				downloading={props.downloading}
 				onDownload={props.onDownload}
+				pagination={props.pagination}
+				onPaginationChange={props.onPaginationChange}
+				rowCount={props.rowCount}
+				sorting={props.sorting}
+				onSortingChange={props.onSortingChange}
 			/>
 			{props.downloadError ? (
 				<div className="text-sm text-destructive">
@@ -204,6 +272,11 @@ export function TaxExportSchedulesPanel(props: {
 	error: unknown
 	entityNames: Record<string, string>
 	createScheduleError: unknown
+	pagination: { pageIndex: number; pageSize: number }
+	onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+	rowCount: number
+	sorting: TaxReportSortingState
+	onSortingChange: (sorting: TaxReportSortingState) => void
 }) {
 	return (
 		<TaxPanelCard
@@ -223,6 +296,11 @@ export function TaxExportSchedulesPanel(props: {
 				loading={props.loading}
 				error={props.error}
 				entityNames={props.entityNames}
+				pagination={props.pagination}
+				onPaginationChange={props.onPaginationChange}
+				rowCount={props.rowCount}
+				sorting={props.sorting}
+				onSortingChange={props.onSortingChange}
 			/>
 		</TaxPanelCard>
 	)
@@ -272,7 +350,8 @@ export function TaxExportDialog(props: {
 						<Select
 							value={props.selectedExportFormat}
 							onValueChange={(value) => props.onSelectExportFormat(value as TaxExportFormat)}
-							options={props.exportFormatOptions.map((option) => ({ value: option.value,
+							options={props.exportFormatOptions.map((option) => ({
+								value: option.value,
 								label: option.label,
 							}))}
 							placeholder="Format"
@@ -283,7 +362,8 @@ export function TaxExportDialog(props: {
 					<Button variant="cancel" showIcon={false} onClick={() => props.onOpenChange(false)}>
 						Cancel
 					</Button>
-					<Button variant="primary"
+					<Button
+						variant="primary"
 						onClick={props.onSubmit}
 						disabled={!props.canExport || !props.canSubmit || props.submitting}
 					>
@@ -334,7 +414,8 @@ export function TaxScheduleDialog(props: {
 						<Select
 							value={props.selectedScheduleFormat}
 							onValueChange={(value) => props.onSelectScheduleFormat(value as TaxExportFormat)}
-							options={props.exportFormatOptions.map((option) => ({ value: option.value,
+							options={props.exportFormatOptions.map((option) => ({
+								value: option.value,
 								label: option.label,
 							}))}
 							placeholder="Format"
@@ -344,7 +425,8 @@ export function TaxScheduleDialog(props: {
 							onValueChange={(value) =>
 								props.onSelectScheduleFrequency(value as 'weekly' | 'monthly')
 							}
-							options={props.scheduleFrequencyOptions.map((option) => ({ value: option.value,
+							options={props.scheduleFrequencyOptions.map((option) => ({
+								value: option.value,
 								label: option.label,
 							}))}
 							placeholder="Frequency"
@@ -365,7 +447,8 @@ export function TaxScheduleDialog(props: {
 					<Button variant="cancel" showIcon={false} onClick={() => props.onOpenChange(false)}>
 						Cancel
 					</Button>
-					<Button variant="primary"
+					<Button
+						variant="primary"
 						onClick={props.onSubmit}
 						disabled={!props.canCreateSchedule || !props.canSubmit || props.submitting}
 					>

--- a/apps/ui/src/client/components/tax-reports/report-sections.tsx
+++ b/apps/ui/src/client/components/tax-reports/report-sections.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 import {
 	BillStatusReportGrid,
@@ -10,7 +10,10 @@ import {
 import { TaxComplianceReportSection } from '@/components/tax-reports/report-display'
 import { TopIncomeSourcesMonthlyChart } from '@/components/tax-reports/top-income-sources-monthly-chart'
 import { useReportGridState } from '@/components/tax-reports/use-report-grid-state'
+import { Button } from '@/components/ui/button'
+import { Select } from '@/components/ui/select'
 import {
+	useTaxableIncomeRefTypes,
 	useTaxBillStatusReport,
 	useTaxComplianceReport,
 	useTaxDiscrepancyReport,
@@ -20,6 +23,7 @@ import {
 	useTaxTotalTaxesReport,
 } from '@/hooks/corporation-tax'
 import { useEntityNames } from '@/hooks/useEntityNames'
+import { TAX_REF_TYPE_OPTIONS } from '@/lib/tax-display'
 
 import type { TaxRollupReportQueryFilters } from '@/lib/tax-report-types'
 import type { SortDirection } from '@/lib/tax-report-utils'
@@ -39,7 +43,11 @@ export function TotalTaxesReportSection(props: {
 		onSortChange: props.onSortChange,
 	})
 
-	const { data, isLoading, error } = useTaxTotalTaxesReport({
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxTotalTaxesReport({
 		...props.filters,
 		limit: gridState.limit,
 		offset: gridState.offset,
@@ -49,7 +57,6 @@ export function TotalTaxesReportSection(props: {
 	})
 	const rows = data?.rows ?? []
 	const totalRows = data?.totalRows ?? 0
-	const pageCount = gridState.pageCountFor(totalRows)
 	const entityIds = useMemo(() => rows.map((row) => row.corporationId), [rows])
 	const { data: entityNames = {} } = useEntityNames(entityIds, { enabled: props.enabled })
 
@@ -63,7 +70,6 @@ export function TotalTaxesReportSection(props: {
 			onSortingChange={gridState.onSortingChange}
 			pagination={gridState.pagination}
 			onPaginationChange={gridState.onPaginationChange}
-			pageCount={pageCount}
 			rowCount={totalRows}
 		/>
 	)
@@ -73,27 +79,83 @@ export function TopIncomeSourcesReportSection(props: {
 	filters: TaxRollupReportQueryFilters
 	enabled: boolean
 }) {
+	const [incomeTypes, setIncomeTypes] = useState<string[]>([])
+	const [incomeMode, setIncomeMode] = useState<'total' | 'assessed'>('total')
+	const { data: taxableIncomeTypes = [] } = useTaxableIncomeRefTypes(
+		props.filters.corporationId,
+		props.enabled
+	)
 	const {
 		data = [],
 		isLoading,
 		error,
 	} = useTaxTopIncomeSourcesMonthlyReport({
 		...props.filters,
+		refTypes: incomeTypes,
+		incomeMode,
 		enabled: props.enabled,
 	})
 
-	if (isLoading) {
-		return <div className="py-8 text-sm text-muted-foreground">Loading income sources...</div>
-	}
-
-	if (error) {
-		return (
-			<div className="py-8 text-sm text-destructive">
-				{error instanceof Error ? error.message : 'Failed to load income sources report'}
+	return (
+		<div className="space-y-4">
+			<div className="max-w-3xl space-y-2">
+				<div className="text-sm font-medium">Income Types</div>
+				<div className="flex items-center gap-2">
+					<div className="min-w-0 flex-1">
+						<Select
+							options={TAX_REF_TYPE_OPTIONS}
+							values={incomeTypes}
+							onValuesChange={setIncomeTypes}
+							multiple
+							searchable
+							placeholder="All income types"
+							inputClassName="h-10"
+							contentClassName="w-[min(20rem,calc(100vw-2rem))] min-w-[min(20rem,calc(100vw-2rem))]"
+						/>
+					</div>
+					<Button
+						type="button"
+						variant="secondary"
+						className="h-10 shrink-0"
+						showIcon={false}
+						disabled={taxableIncomeTypes.length === 0}
+						onClick={() => setIncomeTypes(taxableIncomeTypes)}
+					>
+						Taxable only
+					</Button>
+					<Button
+						type="button"
+						variant="secondary"
+						className="h-10 shrink-0"
+						showIcon={false}
+						onClick={() => setIncomeMode((current) => (current === 'total' ? 'assessed' : 'total'))}
+					>
+						{incomeMode === 'total' ? 'Show Assessed' : 'Show Total'}
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						className="h-10 shrink-0"
+						showIcon={false}
+						disabled={incomeTypes.length === 0}
+						onClick={() => setIncomeTypes([])}
+					>
+						Reset
+					</Button>
+				</div>
 			</div>
-		)
-	}
-	return <TopIncomeSourcesMonthlyChart rows={data} />
+
+			{isLoading ? (
+				<div className="py-8 text-sm text-muted-foreground">Loading income sources...</div>
+			) : error ? (
+				<div className="py-8 text-sm text-destructive">
+					{error instanceof Error ? error.message : 'Failed to load income sources report'}
+				</div>
+			) : (
+				<TopIncomeSourcesMonthlyChart rows={data} incomeMode={incomeMode} />
+			)}
+		</div>
+	)
 }
 
 export function EssPayoutReportSection(props: {
@@ -109,7 +171,11 @@ export function EssPayoutReportSection(props: {
 		onSortChange: props.onSortChange,
 	})
 
-	const { data, isLoading, error } = useTaxEssPayoutReport({
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxEssPayoutReport({
 		...props.filters,
 		limit: gridState.limit,
 		offset: gridState.offset,
@@ -119,7 +185,6 @@ export function EssPayoutReportSection(props: {
 	})
 	const rows = data?.rows ?? []
 	const totalRows = data?.totalRows ?? 0
-	const pageCount = gridState.pageCountFor(totalRows)
 	const entityIds = useMemo(() => {
 		const ids = new Set<string>()
 		for (const row of rows) {
@@ -141,7 +206,6 @@ export function EssPayoutReportSection(props: {
 			onSortingChange={gridState.onSortingChange}
 			pagination={gridState.pagination}
 			onPaginationChange={gridState.onPaginationChange}
-			pageCount={pageCount}
 			rowCount={totalRows}
 		/>
 	)
@@ -160,7 +224,11 @@ export function DiscrepancyReportSection(props: {
 		onSortChange: props.onSortChange,
 	})
 
-	const { data, isLoading, error } = useTaxDiscrepancyReport({
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxDiscrepancyReport({
 		corporationId: props.filters.corporationId,
 		fromDate: props.filters.fromDate,
 		toDate: props.filters.toDate,
@@ -173,7 +241,6 @@ export function DiscrepancyReportSection(props: {
 	})
 	const rows = data?.rows ?? []
 	const totalRows = data?.totalRows ?? 0
-	const pageCount = gridState.pageCountFor(totalRows)
 	const entityIds = useMemo(() => rows.map((row) => row.corporationId), [rows])
 	const { data: entityNames = {} } = useEntityNames(entityIds, { enabled: props.enabled })
 
@@ -187,7 +254,6 @@ export function DiscrepancyReportSection(props: {
 			onSortingChange={gridState.onSortingChange}
 			pagination={gridState.pagination}
 			onPaginationChange={gridState.onPaginationChange}
-			pageCount={pageCount}
 			rowCount={totalRows}
 		/>
 	)
@@ -206,7 +272,11 @@ export function BillStatusReportSection(props: {
 		onSortChange: props.onSortChange,
 	})
 
-	const { data, isLoading, error } = useTaxBillStatusReport({
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxBillStatusReport({
 		...props.filters,
 		limit: gridState.limit,
 		offset: gridState.offset,
@@ -216,7 +286,6 @@ export function BillStatusReportSection(props: {
 	})
 	const rows = data?.rows ?? []
 	const totalRows = data?.totalRows ?? 0
-	const pageCount = gridState.pageCountFor(totalRows)
 	const entityIds = useMemo(() => rows.map((row) => row.corporationId), [rows])
 	const { data: entityNames = {} } = useEntityNames(entityIds, { enabled: props.enabled })
 
@@ -230,7 +299,6 @@ export function BillStatusReportSection(props: {
 			onSortingChange={gridState.onSortingChange}
 			pagination={gridState.pagination}
 			onPaginationChange={gridState.onPaginationChange}
-			pageCount={pageCount}
 			rowCount={totalRows}
 		/>
 	)
@@ -240,23 +308,52 @@ export function ComplianceOverTimeReportSection(props: {
 	filters: TaxRollupReportQueryFilters
 	enabled: boolean
 }) {
+	const gridState = useReportGridState({
+		defaultSortBy: 'rollupDate',
+		defaultSortDir: 'asc',
+		defaultPageSize: REPORT_PAGE_SIZE_DEFAULT,
+		resetOn: props.filters,
+	})
+
 	const {
-		data: rows = [],
-		isLoading,
-		error,
+		data: chartPage,
+		isFetching: chartLoading,
+		error: chartError,
 	} = useTaxComplianceReport({
 		...props.filters,
+		limit: 3650,
+		offset: 0,
+		sortBy: 'rollupDate',
+		sortDir: 'asc',
+		enabled: props.enabled,
+	})
+	const {
+		data: tablePage,
+		isFetching: tableLoading,
+		error: tableError,
+	} = useTaxComplianceReport({
+		...props.filters,
+		limit: gridState.limit,
+		offset: gridState.offset,
+		sortBy: gridState.sortBy,
+		sortDir: gridState.sortDir,
 		enabled: props.enabled,
 	})
 
-	const chartRows = useMemo(() => rows, [rows])
+	const chartRows = useMemo(() => chartPage?.rows ?? [], [chartPage?.rows])
+	const rows = tablePage?.rows ?? []
 
 	return (
 		<TaxComplianceReportSection
-			loading={isLoading}
-			error={error}
+			loading={chartLoading || tableLoading}
+			error={chartError ?? tableError}
 			rows={rows}
 			chartRows={chartRows}
+			sorting={gridState.sorting}
+			onSortingChange={gridState.onSortingChange}
+			pagination={gridState.pagination}
+			onPaginationChange={gridState.onPaginationChange}
+			rowCount={tablePage?.totalRows ?? 0}
 		/>
 	)
 }
@@ -268,7 +365,11 @@ export function MissingEsiKeysReportSection(props: { enabled: boolean }) {
 		defaultPageSize: REPORT_PAGE_SIZE_DEFAULT,
 	})
 
-	const { data, isLoading, error } = useTaxMissingEsiKeysReport({
+	const {
+		data,
+		isFetching: isLoading,
+		error,
+	} = useTaxMissingEsiKeysReport({
 		limit: gridState.limit,
 		offset: gridState.offset,
 		sortBy: gridState.sortBy,
@@ -277,7 +378,6 @@ export function MissingEsiKeysReportSection(props: { enabled: boolean }) {
 	})
 	const rows = data?.rows ?? []
 	const totalRows = data?.totalRows ?? 0
-	const pageCount = gridState.pageCountFor(totalRows)
 	const entityIds = useMemo(() => rows.map((row) => row.corporationId), [rows])
 	const { data: entityNames = {} } = useEntityNames(entityIds, { enabled: props.enabled })
 
@@ -291,7 +391,6 @@ export function MissingEsiKeysReportSection(props: { enabled: boolean }) {
 			onSortingChange={gridState.onSortingChange}
 			pagination={gridState.pagination}
 			onPaginationChange={gridState.onPaginationChange}
-			pageCount={pageCount}
 			rowCount={totalRows}
 		/>
 	)

--- a/apps/ui/src/client/components/tax-reports/report-workspace.tsx
+++ b/apps/ui/src/client/components/tax-reports/report-workspace.tsx
@@ -16,10 +16,11 @@ import {
 	TopIncomeSourcesReportSection,
 	TotalTaxesReportSection,
 } from '@/components/tax-reports/report-sections'
+import { Button } from '@/components/ui/button'
+
 import type { TaxExportFormat, TaxExportReportType } from '@repo/corporation-tax'
 import type { TaxRollupReportQueryFilters } from '@/hooks/corporation-tax'
 import type { SortDirection } from '@/lib/tax-report-utils'
-import { Button } from '@/components/ui/button'
 
 export type TaxReportView = TaxExportReportType | 'missing_esi_keys'
 
@@ -102,14 +103,16 @@ export function TaxReportWorkspace({
 				description={selectedReportDescription}
 				actions={
 					<>
-						<Button variant="ghost"
+						<Button
+							variant="ghost"
 							onClick={() => setExportModalOpen(true)}
 							disabled={!canExport || !activeReportIsExportable}
 						>
 							<Download className="h-4 w-4" />
 							Export
 						</Button>
-						<Button variant="ghost"
+						<Button
+							variant="ghost"
 							onClick={() => setScheduleModalOpen(true)}
 							disabled={!canCreateSchedule || !activeReportIsExportable}
 						>
@@ -185,7 +188,9 @@ export function TaxReportWorkspace({
 				canSubmit={Boolean(activeExportReportType)}
 				submitting={exportSubmitting}
 				onSubmit={() => {
-					void Promise.resolve(onSubmitExport()).then(() => setExportModalOpen(false))
+					void Promise.resolve(onSubmitExport())
+						.then(() => setExportModalOpen(false))
+						.catch(() => undefined)
 				}}
 			/>
 
@@ -206,7 +211,9 @@ export function TaxReportWorkspace({
 				canSubmit={Boolean(activeExportReportType)}
 				submitting={scheduleSubmitting}
 				onSubmit={() => {
-					void Promise.resolve(onSubmitSchedule()).then(() => setScheduleModalOpen(false))
+					void Promise.resolve(onSubmitSchedule())
+						.then(() => setScheduleModalOpen(false))
+						.catch(() => undefined)
 				}}
 			/>
 		</>

--- a/apps/ui/src/client/components/tax-reports/top-income-sources-monthly-chart.tsx
+++ b/apps/ui/src/client/components/tax-reports/top-income-sources-monthly-chart.tsx
@@ -74,7 +74,13 @@ function getStackSegmentPath(input: {
 	].join(' ')
 }
 
-export function TopIncomeSourcesMonthlyChart({ rows }: { rows: TaxTopIncomeSourceMonthlyRow[] }) {
+export function TopIncomeSourcesMonthlyChart({
+	rows,
+	incomeMode,
+}: {
+	rows: TaxTopIncomeSourceMonthlyRow[]
+	incomeMode: 'total' | 'assessed'
+}) {
 	const [hoveredSegment, setHoveredSegment] = useState<{
 		key: string
 		x: number
@@ -132,7 +138,11 @@ export function TopIncomeSourcesMonthlyChart({ rows }: { rows: TaxTopIncomeSourc
 	const baselineY = MONTHLY_INCOME_CHART_HEIGHT - 28
 	const drawableHeight = MONTHLY_INCOME_CHART_HEIGHT - 56
 	const maxTotal = Math.max(chartData.maxMonthTotal, 1)
-	const formatter = new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric' })
+	const formatter = new Intl.DateTimeFormat('en-US', {
+		month: 'short',
+		year: 'numeric',
+		timeZone: 'UTC',
+	})
 	const colorMap = new Map<string, string>(
 		chartData.refTypes.map((refType) => [refType, getTaxRefTypeColor(refType)])
 	)
@@ -145,7 +155,7 @@ export function TopIncomeSourcesMonthlyChart({ rows }: { rows: TaxTopIncomeSourc
 						viewBox={`0 0 ${chartWidth} ${MONTHLY_INCOME_CHART_HEIGHT}`}
 						className="h-72 min-w-[680px] w-full"
 						role="img"
-						aria-label="Monthly taxable inflow stacked by income type"
+						aria-label={`${incomeMode === 'assessed' ? 'Monthly assessed tax' : 'Monthly total income'} stacked by income type`}
 					>
 						<line
 							x1={36}

--- a/apps/ui/src/client/components/tax-reports/use-report-grid-state.ts
+++ b/apps/ui/src/client/components/tax-reports/use-report-grid-state.ts
@@ -2,8 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { applySorting, toSorting } from '@/lib/tax-report-utils'
 
-import type { MRT_SortingState } from 'mantine-react-table'
-import type { SortDirection } from '@/lib/tax-report-utils'
+import type { SortDirection, TaxReportSortingState } from '@/lib/tax-report-utils'
 
 interface UseReportGridStateOptions {
 	defaultSortBy: string
@@ -20,11 +19,10 @@ interface UseReportGridStateResult {
 	sortDir: SortDirection
 	limit: number
 	offset: number
-	sorting: MRT_SortingState
+	sorting: TaxReportSortingState
 	pagination: { pageIndex: number; pageSize: number }
-	onSortingChange: (next: MRT_SortingState) => void
+	onSortingChange: (next: TaxReportSortingState) => void
 	onPaginationChange: (next: { pageIndex: number; pageSize: number }) => void
-	pageCountFor: (rowCount: number) => number
 }
 
 export function useReportGridState(options: UseReportGridStateOptions): UseReportGridStateResult {
@@ -52,7 +50,7 @@ export function useReportGridState(options: UseReportGridStateOptions): UseRepor
 
 	const sorting = useMemo(() => toSorting(sortBy, sortDir), [sortBy, sortDir])
 
-	const onSortingChange = (next: MRT_SortingState) => {
+	const onSortingChange = (next: TaxReportSortingState) => {
 		applySorting(next, defaultSortBy, defaultSortDir, setSortBy, setSortDir, () => setPage(0))
 	}
 
@@ -74,6 +72,5 @@ export function useReportGridState(options: UseReportGridStateOptions): UseRepor
 		pagination,
 		onSortingChange,
 		onPaginationChange,
-		pageCountFor: (rowCount: number) => Math.max(1, Math.ceil(rowCount / pageSize)),
 	}
 }

--- a/apps/ui/src/client/dev/tax-demo-mode.ts
+++ b/apps/ui/src/client/dev/tax-demo-mode.ts
@@ -464,12 +464,14 @@ function buildDemoState(seed: number) {
 					{
 						refType: 'bounty_prizes',
 						lineCount: 8 + index,
+						contributionAmount: amount(9_850_000_000 + index * 1_120_000_000),
 						taxableAmount: amount(9_850_000_000 + index * 1_120_000_000),
 						taxAmount: amount(738_750_000 + index * 84_000_000),
 					},
 					{
 						refType: 'ess_escrow_transfer',
 						lineCount: 2 + index,
+						contributionAmount: amount(1_480_000_000 + index * 280_000_000),
 						taxableAmount: amount(1_480_000_000 + index * 280_000_000),
 						taxAmount: amount(140_600_000 + index * 26_600_000),
 					},
@@ -1928,6 +1930,7 @@ export const taxDemoApi = {
 		corporationId: string,
 		filters?: {
 			characterQuery?: string
+			refTypes?: string[]
 			limit?: number
 			offset?: number
 			sortBy?:
@@ -1956,11 +1959,25 @@ export const taxDemoApi = {
 			}
 			return true
 		})
+		if (filters?.refTypes?.length) {
+			rows = rows.map((row) => ({
+				...row,
+				topRefTypes: row.topRefTypes.filter((source) => filters.refTypes?.includes(source.refType)),
+			}))
+		}
 		rows = sortRows(rows as any, filters?.sortBy, filters?.sortDir ?? 'desc') as TaxMemberSummary[]
 		return withLatency({
 			rows: applyLimitOffset(rows, filters?.limit, filters?.offset),
 			totalRows: rows.length,
 		})
+	},
+	async getTaxableIncomeRefTypes(corporationId: string) {
+		const hasDemoRows = ensureDemoState().memberSummary.some(
+			(row) => row.corporationId === corporationId
+		)
+		return withLatency(
+			hasDemoRows ? ['bounty_prizes', 'ess_escrow_transfer'] : []
+		)
 	},
 	async requestExport(input: {
 		corporationId?: string

--- a/apps/ui/src/client/dev/tax-demo-mode.ts
+++ b/apps/ui/src/client/dev/tax-demo-mode.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from '@tanstack/react-query'
 import type {
 	CreateTaxCorporationBillingConfigInput,
 	IssueBillsForPeriodResult,
+	RunTaxAssessmentForPeriodResult,
 	SyncCorporationBillStatusesResult,
 	TaxAlert,
 	TaxAlertSeverity,
@@ -854,6 +855,7 @@ function updateDemoConfig(input?: Partial<DemoTaxConfig> | null): DemoTaxConfig 
 function filterLedgerEntries(rows: TaxLedgerEntry[], filters?: TaxReportFilters): TaxLedgerEntry[] {
 	return rows.filter((row) => {
 		if (filters?.corporationId && row.corporationId !== filters.corporationId) return false
+		if (filters?.refTypes?.length && !filters.refTypes.includes(row.refType)) return false
 		if (!matchesDate(row.entryDate, filters?.fromDate, filters?.toDate)) return false
 		return true
 	})
@@ -1443,8 +1445,11 @@ export const taxDemoApi = {
 			status?: string
 			assessmentScope?: string
 			withBillOnly?: boolean
+			unbilledOnly?: boolean
 			limit?: number
 			offset?: number
+			sortBy?: 'taxPeriodEnd' | 'assessmentScope' | 'scopeId' | 'status' | 'taxDue' | 'taxDelta'
+			sortDir?: 'asc' | 'desc'
 		}
 	) {
 		const rows = ensureDemoState().assessments.filter((row) => {
@@ -1452,13 +1457,64 @@ export const taxDemoApi = {
 			if (filters?.status && row.status !== filters.status) return false
 			if (filters?.assessmentScope && row.assessmentScope !== filters.assessmentScope) return false
 			if (filters?.withBillOnly && !row.billId) return false
+			if (
+				filters?.unbilledOnly &&
+				(row.billId || row.status === 'draft' || row.status === 'excluded')
+			)
+				return false
 			return true
 		})
-		return withLatency(applyLimitOffset(rows, filters?.limit, filters?.offset))
+		const sortedRows = sortRows(rows, filters?.sortBy, filters?.sortDir)
+		const corporationRows = rows.filter((row) => row.assessmentScope === 'corporation')
+		return withLatency({
+			rows: applyLimitOffset(sortedRows, filters?.limit, filters?.offset),
+			totalRows: rows.length,
+			corporationAssessmentCount: corporationRows.length,
+			unbilledAssessmentCount: corporationRows.filter(
+				(row) => !row.billId && row.status !== 'draft' && row.status !== 'excluded'
+			).length,
+			overdueAssessmentCount: corporationRows.filter((row) => row.billStatus === 'overdue').length,
+		})
+	},
+	async runAssessmentForPeriod(
+		corporationId: string,
+		input: { periodStart: string; periodEnd: string }
+	): Promise<RunTaxAssessmentForPeriodResult> {
+		const state = ensureDemoState()
+		const assessment = state.assessments.find(
+			(row) => row.corporationId === corporationId && row.assessmentScope === 'corporation'
+		)
+		if (!assessment) {
+			throw new Error('No demo corporation assessment is available')
+		}
+
+		const now = new Date()
+		return withLatency({
+			assessment,
+			period: {
+				id: `period-${corporationId}-${input.periodStart}`,
+				corporationId,
+				periodStart: new Date(input.periodStart),
+				periodEnd: new Date(input.periodEnd),
+				status: 'assessed',
+				closedAt: null,
+				createdAt: now,
+				updatedAt: now,
+			},
+			lineCount: 0,
+			discrepancyCount: 0,
+			divisionSummaries: [],
+			refTypeSummaries: [],
+		})
 	},
 	async getLedgerEntries(
 		corporationId: string,
-		filters?: TaxReportFilters & { sourceTypes?: string[]; characterId?: string }
+		filters?: TaxReportFilters & {
+			sourceTypes?: string[]
+			characterId?: string
+			sortBy?: 'entryDate' | 'amount' | 'division' | 'refType' | 'sourceType'
+			sortDir?: 'asc' | 'desc'
+		}
 	) {
 		const rows = filterLedgerEntries(
 			ensureDemoState().ledgerEntries.filter((row) => row.corporationId === corporationId),
@@ -1470,7 +1526,11 @@ export const taxDemoApi = {
 				return false
 			return true
 		})
-		return withLatency(applyLimitOffset(rows, filters?.limit, filters?.offset))
+		const sortedRows = sortRows(rows, filters?.sortBy, filters?.sortDir)
+		return withLatency({
+			rows: applyLimitOffset(sortedRows, filters?.limit, filters?.offset),
+			totalRows: rows.length,
+		})
 	},
 	async getLedgerParties(
 		corporationId: string,
@@ -1775,19 +1835,22 @@ export const taxDemoApi = {
 		corporationId: string,
 		filters?: { limit?: number; offset?: number }
 	) {
-		return withLatency(
-			applyLimitOffset(
-				ensureDemoState().billHistory.filter(
-					(row) => row.assessment?.corporationId === corporationId
-				),
-				filters?.limit,
-				filters?.offset
-			)
+		const rows = ensureDemoState().billHistory.filter(
+			(row) => row.assessment?.corporationId === corporationId
 		)
+		return withLatency({
+			rows: applyLimitOffset(rows, filters?.limit, filters?.offset),
+			totalRows: rows.length,
+		})
 	},
 	async getCorporationBillEventHistory(
 		corporationId: string,
-		filters?: { limit?: number; offset?: number }
+		filters?: {
+			limit?: number
+			offset?: number
+			sortBy?: 'createdAt' | 'eventType' | 'billId' | 'actorUserId'
+			sortDir?: 'asc' | 'desc'
+		}
 	): Promise<TaxPagedResult<TaxBillingEventHistoryRow>> {
 		const rows = ensureDemoState()
 			.billHistory.filter((row) => row.assessment?.corporationId === corporationId)
@@ -1804,11 +1867,9 @@ export const taxDemoApi = {
 					createdAt: event.createdAt,
 				}))
 			)
-			.sort(
-				(left, right) => new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
-			)
+		const sortedRows = sortRows(rows, filters?.sortBy ?? 'createdAt', filters?.sortDir ?? 'desc')
 		return withLatency({
-			rows: applyLimitOffset(rows, filters?.limit, filters?.offset),
+			rows: applyLimitOffset(sortedRows, filters?.limit, filters?.offset),
 			totalRows: rows.length,
 		})
 	},
@@ -1841,7 +1902,7 @@ export const taxDemoApi = {
 			}
 		>()
 		for (const row of rows) {
-			const amount = parseAmount(row.amount)
+			const amount = parseAmount(row.amount) * (filters?.incomeMode === 'assessed' ? 0.075 : 1)
 			if (amount <= 0) continue
 			const monthStart = new Date(
 				Date.UTC(row.entryDate.getUTCFullYear(), row.entryDate.getUTCMonth(), 1)
@@ -1888,8 +1949,12 @@ export const taxDemoApi = {
 		})
 	},
 	async getComplianceReport(filters?: TaxReportFilters) {
-		const rows = deriveComplianceRows(ensureDemoState(), filters)
-		return withLatency(applyLimitOffset(rows, filters?.limit, filters?.offset))
+		let rows = deriveComplianceRows(ensureDemoState(), filters)
+		rows = sortRows(rows as any, filters?.sortBy, filters?.sortDir) as TaxCompliancePoint[]
+		return withLatency({
+			rows: applyLimitOffset(rows, filters?.limit, filters?.offset),
+			totalRows: rows.length,
+		})
 	},
 	async getDiscrepancyReport(filters?: {
 		corporationId?: string
@@ -1971,13 +2036,11 @@ export const taxDemoApi = {
 			totalRows: rows.length,
 		})
 	},
-	async getTaxableIncomeRefTypes(corporationId: string) {
-		const hasDemoRows = ensureDemoState().memberSummary.some(
-			(row) => row.corporationId === corporationId
-		)
-		return withLatency(
-			hasDemoRows ? ['bounty_prizes', 'ess_escrow_transfer'] : []
-		)
+	async getTaxableIncomeRefTypes(corporationId?: string) {
+		const hasDemoRows = corporationId
+			? ensureDemoState().memberSummary.some((row) => row.corporationId === corporationId)
+			: ensureDemoState().memberSummary.length > 0
+		return withLatency(hasDemoRows ? ['bounty_prizes', 'ess_escrow_transfer'] : [])
 	},
 	async requestExport(input: {
 		corporationId?: string
@@ -2005,6 +2068,15 @@ export const taxDemoApi = {
 		status?: TaxExportStatus
 		limit?: number
 		offset?: number
+		sortBy?:
+			| 'requestedAt'
+			| 'corporationId'
+			| 'reportType'
+			| 'format'
+			| 'status'
+			| 'rowCount'
+			| 'completedAt'
+		sortDir?: 'asc' | 'desc'
 	}) {
 		const rows = ensureDemoState().exports.filter((row) => {
 			if (filters?.corporationId && row.corporationId !== filters.corporationId) return false
@@ -2012,7 +2084,11 @@ export const taxDemoApi = {
 			if (filters?.status && row.status !== filters.status) return false
 			return true
 		})
-		return withLatency(applyLimitOffset(rows, filters?.limit, filters?.offset))
+		const sortedRows = sortRows(rows, filters?.sortBy, filters?.sortDir)
+		return withLatency({
+			rows: applyLimitOffset(sortedRows, filters?.limit, filters?.offset),
+			totalRows: rows.length,
+		})
 	},
 	async getExportArtifact(exportId: string) {
 		const record =
@@ -2056,13 +2132,27 @@ export const taxDemoApi = {
 		activeOnly?: boolean
 		limit?: number
 		offset?: number
+		sortBy?:
+			| 'name'
+			| 'corporationId'
+			| 'reportType'
+			| 'format'
+			| 'frequency'
+			| 'isActive'
+			| 'nextRunAt'
+			| 'lastRunAt'
+		sortDir?: 'asc' | 'desc'
 	}) {
 		const rows = ensureDemoState().schedules.filter((row) => {
 			if (filters?.corporationId && row.corporationId !== filters.corporationId) return false
 			if (filters?.activeOnly && !row.isActive) return false
 			return true
 		})
-		return withLatency(applyLimitOffset(rows, filters?.limit, filters?.offset))
+		const sortedRows = sortRows(rows, filters?.sortBy, filters?.sortDir)
+		return withLatency({
+			rows: applyLimitOffset(sortedRows, filters?.limit, filters?.offset),
+			totalRows: rows.length,
+		})
 	},
 	async listAuditLog(filters?: {
 		corporationId?: string
@@ -2072,6 +2162,8 @@ export const taxDemoApi = {
 		toDate?: string
 		limit?: number
 		offset?: number
+		sortBy?: 'createdAt' | 'corporationId' | 'actorUserId' | 'action'
+		sortDir?: 'asc' | 'desc'
 	}) {
 		const rows = ensureDemoState().auditLog.filter((row) => {
 			if (filters?.corporationId && row.corporationId !== filters.corporationId) return false
@@ -2082,8 +2174,9 @@ export const taxDemoApi = {
 			if (filters?.toDate && row.createdAt > new Date(filters.toDate)) return false
 			return true
 		})
+		const sortedRows = sortRows(rows, filters?.sortBy, filters?.sortDir)
 		return withLatency({
-			rows: applyLimitOffset(rows, filters?.limit, filters?.offset),
+			rows: applyLimitOffset(sortedRows, filters?.limit, filters?.offset),
 			totalRows: rows.length,
 		})
 	},

--- a/apps/ui/src/client/hooks/corporation-tax/alerts.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/alerts.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { corporationTaxApi } from '@/lib/tax-api'
 
@@ -56,11 +56,14 @@ export function useTaxAuditLog(filters?: {
 	toDate?: string
 	limit?: number
 	offset?: number
+	sortBy?: 'createdAt' | 'corporationId' | 'actorUserId' | 'action'
+	sortDir?: 'asc' | 'desc'
 	enabled?: boolean
 }) {
 	return useQuery({
 		queryKey: corporationTaxKeys.auditLogList(filters),
 		queryFn: () => corporationTaxApi.listAuditLog(filters),
+		placeholderData: keepPreviousData,
 		staleTime: 1000 * 30,
 		enabled: filters?.enabled ?? true,
 	})

--- a/apps/ui/src/client/hooks/corporation-tax/billing.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/billing.ts
@@ -1,4 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
 
 import { corporationTaxApi } from '@/lib/tax-api'
 
@@ -15,6 +16,7 @@ export function useTaxCorporationBillHistory(
 	return useQuery({
 		queryKey: corporationTaxKeys.billHistory(corporationId ?? 'none', filters),
 		queryFn: () => corporationTaxApi.getCorporationBillHistory(corporationId!, filters),
+		placeholderData: keepPreviousData,
 		staleTime: 1000 * 30,
 		enabled: Boolean(corporationId) && (filters?.enabled ?? true),
 	})
@@ -25,12 +27,15 @@ export function useTaxCorporationBillEventHistory(
 	filters?: {
 		limit?: number
 		offset?: number
+		sortBy?: 'createdAt' | 'eventType' | 'billId' | 'actorUserId'
+		sortDir?: 'asc' | 'desc'
 		enabled?: boolean
 	}
 ) {
 	return useQuery({
 		queryKey: corporationTaxKeys.billEventHistory(corporationId ?? 'none', filters),
 		queryFn: () => corporationTaxApi.getCorporationBillEventHistory(corporationId!, filters),
+		placeholderData: keepPreviousData,
 		staleTime: 1000 * 30,
 		enabled: Boolean(corporationId) && (filters?.enabled ?? true),
 	})
@@ -40,7 +45,7 @@ export function useTaxBillingConfigs(corporationId: string | undefined, enabled 
 	return useQuery({
 		queryKey: corporationTaxKeys.billingConfigs(corporationId ?? 'none'),
 		queryFn: () => corporationTaxApi.listBillingConfigs(corporationId!),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 15,
 		enabled: Boolean(corporationId) && enabled,
 	})
 }
@@ -82,17 +87,72 @@ export function useTaxAssessments(
 		status?: 'draft' | 'underpaid' | 'paid' | 'overpaid' | 'excluded'
 		assessmentScope?: 'corporation' | 'division' | 'character'
 		withBillOnly?: boolean
+		unbilledOnly?: boolean
 		limit?: number
 		offset?: number
+		sortBy?: 'taxPeriodEnd' | 'assessmentScope' | 'scopeId' | 'status' | 'taxDue' | 'taxDelta'
+		sortDir?: 'asc' | 'desc'
 		enabled?: boolean
 	}
 ) {
 	return useQuery({
 		queryKey: corporationTaxKeys.assessments(corporationId ?? 'none', filters),
 		queryFn: () => corporationTaxApi.listAssessments(corporationId!, filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: 1000 * 60 * 2,
 		enabled: Boolean(corporationId) && (filters?.enabled ?? true),
 	})
+}
+
+export function useRunTaxAssessmentForPeriod() {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: (input: { corporationId: string; periodStart: string; periodEnd: string }) =>
+			corporationTaxApi.runAssessmentForPeriod(input.corporationId, {
+				periodStart: input.periodStart,
+				periodEnd: input.periodEnd,
+			}),
+		onSuccess: (result) => {
+			void queryClient.invalidateQueries({
+				queryKey: corporationTaxKeys.all,
+			})
+			void queryClient.invalidateQueries({
+				queryKey: corporationTaxKeys.assessments(result.corporationId),
+			})
+		},
+	})
+}
+
+export function useTaxAssessmentWorkflowStatus(
+	corporationId: string | undefined,
+	workflowInstanceId: string | undefined
+) {
+	const queryClient = useQueryClient()
+	const query = useQuery({
+		queryKey: corporationTaxKeys.assessmentWorkflow(
+			corporationId ?? 'none',
+			workflowInstanceId ?? 'none'
+		),
+		queryFn: () =>
+			corporationTaxApi.getAssessmentWorkflowStatus(corporationId!, workflowInstanceId!),
+		enabled: Boolean(corporationId && workflowInstanceId),
+		staleTime: 0,
+		refetchInterval: (query) => {
+			const status = query.state.data?.status
+			return status === 'queued' || status === 'running' || status === 'waiting' ? 2000 : false
+		},
+		refetchOnWindowFocus: true,
+	})
+
+	useEffect(() => {
+		if (query.data?.status === 'completed' && corporationId) {
+			void queryClient.invalidateQueries({
+				queryKey: corporationTaxKeys.assessments(corporationId),
+			})
+		}
+	}, [corporationId, query.data?.status, queryClient])
+
+	return query
 }
 
 export function useTaxLedgerEntries(
@@ -115,13 +175,16 @@ export function useTaxLedgerEntries(
 		maxAmount?: string
 		limit?: number
 		offset?: number
+		sortBy?: 'entryDate' | 'amount' | 'division' | 'refType' | 'sourceType'
+		sortDir?: 'asc' | 'desc'
 		enabled?: boolean
 	}
 ) {
 	return useQuery({
 		queryKey: corporationTaxKeys.ledgerEntries(corporationId ?? 'none', filters),
 		queryFn: () => corporationTaxApi.getLedgerEntries(corporationId!, filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: 1000 * 60 * 2,
 		enabled: Boolean(corporationId) && (filters?.enabled ?? true),
 	})
 }

--- a/apps/ui/src/client/hooks/corporation-tax/exports.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/exports.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { corporationTaxApi } from '@/lib/tax-api'
 
@@ -12,11 +12,21 @@ export function useTaxExports(filters?: {
 	status?: TaxExportStatus
 	limit?: number
 	offset?: number
+	sortBy?:
+		| 'requestedAt'
+		| 'corporationId'
+		| 'reportType'
+		| 'format'
+		| 'status'
+		| 'rowCount'
+		| 'completedAt'
+	sortDir?: 'asc' | 'desc'
 	enabled?: boolean
 }) {
 	return useQuery({
 		queryKey: corporationTaxKeys.exports(filters),
 		queryFn: () => corporationTaxApi.listExports(filters),
+		placeholderData: keepPreviousData,
 		staleTime: 1000 * 30,
 		enabled: filters?.enabled ?? true,
 	})
@@ -49,11 +59,22 @@ export function useTaxExportSchedules(filters?: {
 	activeOnly?: boolean
 	limit?: number
 	offset?: number
+	sortBy?:
+		| 'name'
+		| 'corporationId'
+		| 'reportType'
+		| 'format'
+		| 'frequency'
+		| 'isActive'
+		| 'nextRunAt'
+		| 'lastRunAt'
+	sortDir?: 'asc' | 'desc'
 	enabled?: boolean
 }) {
 	return useQuery({
 		queryKey: corporationTaxKeys.exportSchedules(filters),
 		queryFn: () => corporationTaxApi.listExportSchedules(filters),
+		placeholderData: keepPreviousData,
 		staleTime: 1000 * 30,
 		enabled: filters?.enabled ?? true,
 	})

--- a/apps/ui/src/client/hooks/corporation-tax/index.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/index.ts
@@ -39,6 +39,7 @@ export {
 	useTaxMemberSummary,
 	useTaxMissingEsiKeysReport,
 	useTaxSummaryReport,
+	useTaxableIncomeRefTypes,
 	useTaxTopIncomeSourcesMonthlyReport,
 	useTaxTopIncomeSourcesReport,
 	useTaxTotalTaxesReport,

--- a/apps/ui/src/client/hooks/corporation-tax/index.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/index.ts
@@ -50,6 +50,8 @@ export {
 	useDeleteTaxBillingConfig,
 	useIssueTaxBillsForPeriod,
 	useRetractTaxAssessmentBill,
+	useRunTaxAssessmentForPeriod,
+	useTaxAssessmentWorkflowStatus,
 	useSearchTaxBillingPayeeCharacters,
 	useSearchTaxBillingPayeeCorporations,
 	useSetDefaultTaxBillingConfig,

--- a/apps/ui/src/client/hooks/corporation-tax/keys.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/keys.ts
@@ -149,6 +149,7 @@ export const corporationTaxKeys = {
 		corporationId: string,
 		filters?: {
 			characterQuery?: string
+			refTypes?: string[]
 			fromDate?: string
 			toDate?: string
 			topRefTypesLimit?: number
@@ -163,6 +164,8 @@ export const corporationTaxKeys = {
 			sortDir?: 'asc' | 'desc'
 		}
 	) => [...corporationTaxKeys.all, 'member-summary', corporationId, filters] as const,
+	memberSummaryTaxableRefTypes: (corporationId: string) =>
+		[...corporationTaxKeys.all, 'member-summary-taxable-ref-types', corporationId] as const,
 	exports: (filters?: {
 		corporationId?: string
 		format?: TaxExportFormat

--- a/apps/ui/src/client/hooks/corporation-tax/keys.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/keys.ts
@@ -111,6 +111,8 @@ export const corporationTaxKeys = {
 			offset?: number
 		}
 	) => [...corporationTaxKeys.all, 'assessments', corporationId, filters] as const,
+	assessmentWorkflow: (corporationId: string, workflowInstanceId: string) =>
+		[...corporationTaxKeys.all, 'assessment-workflow', corporationId, workflowInstanceId] as const,
 	ledgerEntries: (
 		corporationId: string,
 		filters?: {

--- a/apps/ui/src/client/hooks/corporation-tax/reports.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/reports.ts
@@ -6,11 +6,30 @@ import { corporationTaxKeys } from './keys'
 
 import type { TaxRollupReportQueryOptions } from './types'
 
+const TAX_REPORT_LIVE_STALE_TIME = 1000 * 60 * 5
+const TAX_REPORT_HISTORICAL_STALE_TIME = 1000 * 60 * 15
+
+function getTaxReportStaleTime(filters?: TaxRollupReportQueryOptions): number {
+	if (!filters?.toDate) {
+		return TAX_REPORT_LIVE_STALE_TIME
+	}
+
+	const toDate = Date.parse(filters.toDate)
+	if (!Number.isFinite(toDate)) {
+		return TAX_REPORT_LIVE_STALE_TIME
+	}
+
+	const now = new Date()
+	const currentMonthStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
+	return toDate < currentMonthStart ? TAX_REPORT_HISTORICAL_STALE_TIME : TAX_REPORT_LIVE_STALE_TIME
+}
+
 export function useTaxBillStatusReport(filters?: TaxRollupReportQueryOptions) {
 	return useQuery({
 		queryKey: corporationTaxKeys.billStatusReport(filters),
 		queryFn: () => corporationTaxApi.getBillStatusReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -19,7 +38,8 @@ export function useTaxTotalTaxesReport(filters?: TaxRollupReportQueryOptions) {
 	return useQuery({
 		queryKey: corporationTaxKeys.totalTaxesReport(filters),
 		queryFn: () => corporationTaxApi.getTotalTaxesReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -28,7 +48,8 @@ export function useTaxTopIncomeSourcesReport(filters?: TaxRollupReportQueryOptio
 	return useQuery({
 		queryKey: corporationTaxKeys.topIncomeReport(filters),
 		queryFn: () => corporationTaxApi.getTopIncomeSourcesReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -37,7 +58,8 @@ export function useTaxTopIncomeSourcesMonthlyReport(filters?: TaxRollupReportQue
 	return useQuery({
 		queryKey: corporationTaxKeys.topIncomeMonthlyReport(filters),
 		queryFn: () => corporationTaxApi.getTopIncomeSourcesMonthlyReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -46,7 +68,8 @@ export function useTaxEssPayoutReport(filters?: TaxRollupReportQueryOptions) {
 	return useQuery({
 		queryKey: corporationTaxKeys.essPayoutReport(filters),
 		queryFn: () => corporationTaxApi.getEssPayoutReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -55,7 +78,8 @@ export function useTaxComplianceReport(filters?: TaxRollupReportQueryOptions) {
 	return useQuery({
 		queryKey: corporationTaxKeys.complianceReport(filters),
 		queryFn: () => corporationTaxApi.getComplianceReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -74,7 +98,8 @@ export function useTaxDiscrepancyReport(filters?: {
 	return useQuery({
 		queryKey: corporationTaxKeys.discrepancyReport(filters),
 		queryFn: () => corporationTaxApi.getDiscrepancyReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -89,7 +114,8 @@ export function useTaxMissingEsiKeysReport(filters?: {
 	return useQuery({
 		queryKey: corporationTaxKeys.missingEsiKeysReport(filters),
 		queryFn: () => corporationTaxApi.getMissingEsiKeysReport(filters),
-		staleTime: 1000 * 30,
+		placeholderData: keepPreviousData,
+		staleTime: 1000 * 60 * 5,
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -98,7 +124,7 @@ export function useTaxSummaryReport(filters?: TaxRollupReportQueryOptions) {
 	return useQuery({
 		queryKey: corporationTaxKeys.summary(filters),
 		queryFn: () => corporationTaxApi.getSummaryReport(filters),
-		staleTime: 1000 * 30,
+		staleTime: getTaxReportStaleTime(filters),
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -141,12 +167,9 @@ export function useTaxableIncomeRefTypes(corporationId: string | undefined, enab
 	return useQuery({
 		queryKey: corporationTaxKeys.memberSummaryTaxableRefTypes(corporationId ?? 'none'),
 		queryFn: () => {
-			if (!corporationId) {
-				throw new Error('Corporation id is required for taxable income types')
-			}
 			return corporationTaxApi.getTaxableIncomeRefTypes(corporationId)
 		},
 		staleTime: 1000 * 60 * 10,
-		enabled: Boolean(corporationId) && enabled,
+		enabled,
 	})
 }

--- a/apps/ui/src/client/hooks/corporation-tax/reports.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/reports.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 import { corporationTaxApi } from '@/lib/tax-api'
 
@@ -107,6 +107,7 @@ export function useTaxMemberSummary(
 	corporationId: string | undefined,
 	filters?: {
 		characterQuery?: string
+		refTypes?: string[]
 		fromDate?: string
 		toDate?: string
 		topRefTypesLimit?: number
@@ -130,7 +131,22 @@ export function useTaxMemberSummary(
 			}
 			return corporationTaxApi.getMemberSummary(corporationId, filters)
 		},
+		placeholderData: keepPreviousData,
 		staleTime: 1000 * 60 * 10,
 		enabled: Boolean(corporationId) && (filters?.enabled ?? true),
+	})
+}
+
+export function useTaxableIncomeRefTypes(corporationId: string | undefined, enabled = true) {
+	return useQuery({
+		queryKey: corporationTaxKeys.memberSummaryTaxableRefTypes(corporationId ?? 'none'),
+		queryFn: () => {
+			if (!corporationId) {
+				throw new Error('Corporation id is required for taxable income types')
+			}
+			return corporationTaxApi.getTaxableIncomeRefTypes(corporationId)
+		},
+		staleTime: 1000 * 60 * 10,
+		enabled: Boolean(corporationId) && enabled,
 	})
 }

--- a/apps/ui/src/client/hooks/corporation-tax/rules.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/rules.ts
@@ -15,7 +15,7 @@ export function useTaxRuleSets(filters?: {
 	return useQuery({
 		queryKey: corporationTaxKeys.rules(filters),
 		queryFn: () => corporationTaxApi.listRuleSets(filters),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 15,
 		enabled: hasFilter && (filters?.enabled ?? true),
 	})
 }
@@ -80,7 +80,7 @@ export function useTaxRuleGroups(filters?: {
 	return useQuery({
 		queryKey: corporationTaxKeys.ruleGroups(filters),
 		queryFn: () => corporationTaxApi.listRuleGroups(filters),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 15,
 		enabled: filters?.enabled ?? true,
 	})
 }
@@ -124,7 +124,7 @@ export function useTaxRuleGroupAttachments(ruleGroupId: string | undefined, enab
 	return useQuery({
 		queryKey: corporationTaxKeys.ruleGroupAttachments(ruleGroupId ?? 'none'),
 		queryFn: () => corporationTaxApi.listRuleGroupAttachments(ruleGroupId!),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 15,
 		enabled: Boolean(ruleGroupId) && enabled,
 	})
 }

--- a/apps/ui/src/client/hooks/corporation-tax/scope.ts
+++ b/apps/ui/src/client/hooks/corporation-tax/scope.ts
@@ -56,7 +56,7 @@ export function useTaxCapabilities(corporationId?: string, enabled = true) {
 	return useQuery({
 		queryKey: corporationTaxKeys.capabilities(corporationId),
 		queryFn: () => corporationTaxApi.getCapabilities(corporationId),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 5,
 		enabled,
 	})
 }
@@ -90,13 +90,13 @@ export function useTaxCorporations(filters?: {
 	const taxCorporationsQuery = useQuery({
 		queryKey: corporationTaxKeys.corporationList(filters),
 		queryFn: () => corporationTaxApi.listCorporations(filters),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 10,
 		enabled: enabled && scopeMode === 'admin',
 	})
 	const demoCorporationsQuery = useQuery({
 		queryKey: [...corporationTaxKeys.corporationList(filters), 'demo'],
 		queryFn: () => taxDemoApi.listCorporations(filters),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 10,
 		enabled: enabled && demoEnabled,
 	})
 
@@ -158,7 +158,7 @@ export function useTaxWalletDivisions(corporationId: string | undefined, enabled
 	return useQuery({
 		queryKey: corporationTaxKeys.walletDivisions(corporationId ?? 'none'),
 		queryFn: () => corporationTaxApi.listWalletDivisions(corporationId!),
-		staleTime: 1000 * 60 * 5,
+		staleTime: 1000 * 60 * 30,
 		enabled: Boolean(corporationId) && enabled,
 	})
 }
@@ -167,7 +167,7 @@ export function useTaxExclusions(filters?: { limit?: number; offset?: number; en
 	return useQuery({
 		queryKey: corporationTaxKeys.exclusionsList(filters),
 		queryFn: () => corporationTaxApi.listExclusions(filters),
-		staleTime: 1000 * 30,
+		staleTime: 1000 * 60 * 5,
 		enabled: filters?.enabled ?? true,
 	})
 }

--- a/apps/ui/src/client/lib/date-utils.ts
+++ b/apps/ui/src/client/lib/date-utils.ts
@@ -9,7 +9,11 @@ function parseDate(value: DateInput): Date | null {
 	return Number.isNaN(date.getTime()) ? null : date
 }
 
-function formatWithOptions(value: DateInput, options: Intl.DateTimeFormatOptions, fallback: string): string {
+function formatWithOptions(
+	value: DateInput,
+	options: Intl.DateTimeFormatOptions,
+	fallback: string
+): string {
 	const date = parseDate(value)
 	if (!date) return fallback
 	return new Intl.DateTimeFormat('en-US', options).format(date)
@@ -21,10 +25,7 @@ function formatWithOptions(value: DateInput, options: Intl.DateTimeFormatOptions
  * @param options - Intl.DateTimeFormatOptions for customization
  * @returns Formatted date string
  */
-export function formatDate(
-	dateString: DateInput,
-	options?: Intl.DateTimeFormatOptions
-): string {
+export function formatDate(dateString: DateInput, options?: Intl.DateTimeFormatOptions): string {
 	const defaultOptions: Intl.DateTimeFormatOptions = {
 		year: 'numeric',
 		month: 'short',
@@ -40,13 +41,17 @@ export function formatDate(
  * @returns Formatted date and time string
  */
 export function formatDateTime(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
-	}, 'N/A')
+	return formatWithOptions(
+		dateString,
+		{
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+		},
+		'N/A'
+	)
 }
 
 /**
@@ -97,91 +102,139 @@ export function formatDateShort(dateString: string | Date | null | undefined): s
  * @returns Long formatted date string
  */
 export function formatDateLong(dateString: string | Date | null | undefined): string {
-	return formatWithOptions(dateString, {
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
-	}, 'N/A')
-}
-
-export function formatDateNumeric(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		year: 'numeric',
-		month: '2-digit',
-		day: '2-digit',
-	}, 'N/A')
-}
-
-export function formatMonthDay(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		month: 'short',
-		day: 'numeric',
-	}, 'N/A')
-}
-
-export function formatTime(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		hour: '2-digit',
-		minute: '2-digit',
-	}, 'N/A')
-}
-
-export function formatDateTimeWithSeconds(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
-		second: '2-digit',
-	}, 'N/A')
-}
-
-export function formatDateTimeLong(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		dateStyle: 'long',
-		timeStyle: 'short',
-	}, 'N/A')
-}
-
-export function formatDateTimeFull(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		dateStyle: 'full',
-		timeStyle: 'long',
-	}, 'N/A')
-}
-
-export function formatDateTimeWithZone(dateString: DateInput): string {
-	return formatWithOptions(dateString, {
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-		timeZoneName: 'short',
-	}, 'N/A')
-}
-
-export function formatUtcDateTime(dateString: DateInput, compact = false): string {
-	return formatWithOptions(dateString, compact
-		? {
-			year: '2-digit',
-			month: 'short',
-			day: '2-digit',
-			hour: '2-digit',
-			minute: '2-digit',
-			hour12: false,
-			timeZone: 'UTC',
-		}
-		: {
+	return formatWithOptions(
+		dateString,
+		{
 			year: 'numeric',
 			month: 'long',
 			day: 'numeric',
 			hour: '2-digit',
 			minute: '2-digit',
-			hour12: false,
+		},
+		'N/A'
+	)
+}
+
+export function formatDateNumeric(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit',
+		},
+		'N/A'
+	)
+}
+
+export function formatMonthDay(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			month: 'short',
+			day: 'numeric',
+		},
+		'N/A'
+	)
+}
+
+export function formatMonthYear(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			month: 'long',
+			year: 'numeric',
 			timeZone: 'UTC',
-		}, 'N/A')
+		},
+		'N/A'
+	)
+}
+
+export function formatTime(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			hour: '2-digit',
+			minute: '2-digit',
+		},
+		'N/A'
+	)
+}
+
+export function formatDateTimeWithSeconds(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit',
+		},
+		'N/A'
+	)
+}
+
+export function formatDateTimeLong(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			dateStyle: 'long',
+			timeStyle: 'short',
+		},
+		'N/A'
+	)
+}
+
+export function formatDateTimeFull(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			dateStyle: 'full',
+			timeStyle: 'long',
+		},
+		'N/A'
+	)
+}
+
+export function formatDateTimeWithZone(dateString: DateInput): string {
+	return formatWithOptions(
+		dateString,
+		{
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit',
+			timeZoneName: 'short',
+		},
+		'N/A'
+	)
+}
+
+export function formatUtcDateTime(dateString: DateInput, compact = false): string {
+	return formatWithOptions(
+		dateString,
+		compact
+			? {
+					year: '2-digit',
+					month: 'short',
+					day: '2-digit',
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: false,
+					timeZone: 'UTC',
+				}
+			: {
+					year: 'numeric',
+					month: 'long',
+					day: 'numeric',
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: false,
+					timeZone: 'UTC',
+				},
+		'N/A'
+	)
 }

--- a/apps/ui/src/client/lib/tax-api.ts
+++ b/apps/ui/src/client/lib/tax-api.ts
@@ -10,9 +10,13 @@ import type {
 	TaxAlertSeverity,
 	TaxAlertStatus,
 	TaxAssessment,
+	TaxAssessmentPage,
 	TaxAssessmentWithBillHistory,
+	TaxAssessmentWorkflowStartResult,
+	TaxAssessmentWorkflowStatusResult,
 	TaxAuditLogEntry,
 	TaxBillingEventHistoryRow,
+	TaxBillingEventSortBy,
 	TaxBillStatusReportRow,
 	TaxCompliancePoint,
 	TaxCorporationBillingConfig,
@@ -72,6 +76,18 @@ export interface TaxAuditActorSearchFilters {
 	limit?: number
 }
 
+export interface ListTaxAuditLogFilters {
+	corporationId?: string
+	actorUserId?: string
+	action?: string
+	fromDate?: string
+	toDate?: string
+	limit?: number
+	offset?: number
+	sortBy?: 'createdAt' | 'corporationId' | 'actorUserId' | 'action'
+	sortDir?: 'asc' | 'desc'
+}
+
 export interface TaxAuditActorSearchRow {
 	userId: string
 	name: string | null
@@ -114,6 +130,8 @@ export interface TaxLedgerFilters {
 	maxAmount?: string
 	limit?: number
 	offset?: number
+	sortBy?: 'entryDate' | 'amount' | 'division' | 'refType' | 'sourceType'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface TaxLedgerPartySearchFilters {
@@ -136,6 +154,15 @@ export interface ListTaxExportsFilters {
 	status?: TaxExportStatus
 	limit?: number
 	offset?: number
+	sortBy?:
+		| 'requestedAt'
+		| 'corporationId'
+		| 'reportType'
+		| 'format'
+		| 'status'
+		| 'rowCount'
+		| 'completedAt'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface ListTaxExportSchedulesFilters {
@@ -143,6 +170,16 @@ export interface ListTaxExportSchedulesFilters {
 	activeOnly?: boolean
 	limit?: number
 	offset?: number
+	sortBy?:
+		| 'name'
+		| 'corporationId'
+		| 'reportType'
+		| 'format'
+		| 'frequency'
+		| 'isActive'
+		| 'nextRunAt'
+		| 'lastRunAt'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface ListTaxDiscrepancyReportFilters {
@@ -207,8 +244,11 @@ export interface ListTaxAssessmentsFilters {
 	status?: 'draft' | 'underpaid' | 'paid' | 'overpaid' | 'excluded'
 	assessmentScope?: 'corporation' | 'division' | 'character'
 	withBillOnly?: boolean
+	unbilledOnly?: boolean
 	limit?: number
 	offset?: number
+	sortBy?: 'taxPeriodEnd' | 'assessmentScope' | 'scopeId' | 'status' | 'taxDue' | 'taxDelta'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface CreateTaxRuleSetInput {
@@ -223,16 +263,6 @@ export interface CreateTaxRuleSetInput {
 export interface CreateTaxRuleGroupInput {
 	name: string
 	description?: string | null
-}
-
-export interface ListTaxAuditLogFilters {
-	corporationId?: string
-	actorUserId?: string
-	action?: string
-	fromDate?: string
-	toDate?: string
-	limit?: number
-	offset?: number
 }
 
 export interface ListTaxNotificationDestinationsFilters {
@@ -261,6 +291,8 @@ export class CorporationTaxApiClient extends ApiClient {
 		if (filters.corporationId) params.set('corporationId', filters.corporationId)
 		if (filters.fromDate) params.set('fromDate', filters.fromDate)
 		if (filters.toDate) params.set('toDate', filters.toDate)
+		if (filters.refTypes?.length) params.set('refTypes', filters.refTypes.join(','))
+		if (filters.incomeMode) params.set('incomeMode', filters.incomeMode)
 		if (filters.limit !== undefined) params.set('limit', String(filters.limit))
 		if (filters.offset !== undefined) params.set('offset', String(filters.offset))
 		if (filters.sortBy) params.set('sortBy', filters.sortBy)
@@ -495,25 +527,72 @@ export class CorporationTaxApiClient extends ApiClient {
 	async listAssessments(
 		corporationId: string,
 		filters?: ListTaxAssessmentsFilters
-	): Promise<TaxAssessment[]> {
+	): Promise<TaxAssessmentPage> {
 		if (this.shouldUseDemo()) return taxDemoApi.listAssessments(corporationId, filters)
 		const params = new URLSearchParams()
 		if (filters?.status) params.set('status', filters.status)
 		if (filters?.assessmentScope) params.set('assessmentScope', filters.assessmentScope)
 		if (filters?.withBillOnly !== undefined)
 			params.set('withBillOnly', String(filters.withBillOnly))
+		if (filters?.unbilledOnly !== undefined)
+			params.set('unbilledOnly', String(filters.unbilledOnly))
 		if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
 		if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+		if (filters?.sortBy) params.set('sortBy', filters.sortBy)
+		if (filters?.sortDir) params.set('sortDir', filters.sortDir)
 		const query = params.toString()
 		return this.get(
 			`${TAX_API_BASE}/corporations/${corporationId}/assessments${query ? `?${query}` : ''}`
 		)
 	}
 
+	async runAssessmentForPeriod(
+		corporationId: string,
+		input: { periodStart: string; periodEnd: string }
+	): Promise<TaxAssessmentWorkflowStartResult> {
+		if (this.shouldUseDemo()) {
+			await taxDemoApi.runAssessmentForPeriod(corporationId, input)
+			return {
+				workflowInstanceId: `demo-tax-assessment-${corporationId}-${Date.now()}`,
+				corporationId,
+				periodStart: input.periodStart,
+				periodEnd: input.periodEnd,
+				status: 'queued',
+			}
+		}
+		return this.post(`${TAX_API_BASE}/corporations/${corporationId}/assessments/run`, {
+			...input,
+			includeCharacterWallets: false,
+		})
+	}
+
+	async getAssessmentWorkflowStatus(
+		corporationId: string,
+		workflowInstanceId: string
+	): Promise<TaxAssessmentWorkflowStatusResult> {
+		if (this.shouldUseDemo()) {
+			return {
+				workflowInstanceId,
+				status: 'completed',
+				rawStatus: 'complete',
+				output: {
+					status: 'completed',
+					assessmentId: `demo-assessment-${corporationId}`,
+					lineCount: 0,
+					discrepancyCount: 0,
+				},
+				error: null,
+			}
+		}
+		return this.get(
+			`${TAX_API_BASE}/corporations/${corporationId}/assessments/runs/${workflowInstanceId}`
+		)
+	}
+
 	async getLedgerEntries(
 		corporationId: string,
 		filters?: TaxLedgerFilters
-	): Promise<TaxLedgerEntry[]> {
+	): Promise<TaxPagedResult<TaxLedgerEntry>> {
 		if (this.shouldUseDemo()) return taxDemoApi.getLedgerEntries(corporationId, filters as any)
 		const params = new URLSearchParams()
 		if (filters?.division !== undefined) params.set('division', String(filters.division))
@@ -532,6 +611,8 @@ export class CorporationTaxApiClient extends ApiClient {
 		if (filters?.maxAmount) params.set('maxAmount', filters.maxAmount)
 		if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
 		if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+		if (filters?.sortBy) params.set('sortBy', filters.sortBy)
+		if (filters?.sortDir) params.set('sortDir', filters.sortDir)
 
 		const query = params.toString()
 		return this.get(
@@ -683,7 +764,7 @@ export class CorporationTaxApiClient extends ApiClient {
 	async getCorporationBillHistory(
 		corporationId: string,
 		filters?: { limit?: number; offset?: number }
-	): Promise<TaxAssessmentWithBillHistory[]> {
+	): Promise<TaxPagedResult<TaxAssessmentWithBillHistory>> {
 		if (this.shouldUseDemo()) return taxDemoApi.getCorporationBillHistory(corporationId, filters)
 		const params = new URLSearchParams()
 		if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
@@ -697,13 +778,20 @@ export class CorporationTaxApiClient extends ApiClient {
 
 	async getCorporationBillEventHistory(
 		corporationId: string,
-		filters?: { limit?: number; offset?: number }
+		filters?: {
+			limit?: number
+			offset?: number
+			sortBy?: TaxBillingEventSortBy
+			sortDir?: 'asc' | 'desc'
+		}
 	): Promise<TaxPagedResult<TaxBillingEventHistoryRow>> {
 		if (this.shouldUseDemo())
 			return taxDemoApi.getCorporationBillEventHistory(corporationId, filters)
 		const params = new URLSearchParams()
 		if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
 		if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+		if (filters?.sortBy) params.set('sortBy', filters.sortBy)
+		if (filters?.sortDir) params.set('sortDir', filters.sortDir)
 		const query = params.toString()
 
 		return this.get(
@@ -755,7 +843,9 @@ export class CorporationTaxApiClient extends ApiClient {
 		return this.get(`${TAX_API_BASE}/reports/ess${query ? `?${query}` : ''}`)
 	}
 
-	async getComplianceReport(filters?: TaxReportFilters): Promise<TaxCompliancePoint[]> {
+	async getComplianceReport(
+		filters?: TaxReportFilters
+	): Promise<TaxPagedResult<TaxCompliancePoint>> {
 		if (this.shouldUseDemo()) return taxDemoApi.getComplianceReport(filters)
 		const params = new URLSearchParams()
 		this.appendTaxReportFilters(params, filters)
@@ -818,14 +908,12 @@ export class CorporationTaxApiClient extends ApiClient {
 		)
 	}
 
-	async getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
-		if (!corporationId?.trim()) {
-			throw new Error('Corporation id is required for taxable income types')
-		}
+	async getTaxableIncomeRefTypes(corporationId?: string): Promise<string[]> {
 		if (this.shouldUseDemo()) return taxDemoApi.getTaxableIncomeRefTypes(corporationId)
-		const result = await this.get<{ refTypes: string[] }>(
-			`${TAX_API_BASE}/corporations/${corporationId}/member-summary/taxable-ref-types`
-		)
+		const endpoint = corporationId
+			? `${TAX_API_BASE}/corporations/${corporationId}/member-summary/taxable-ref-types`
+			: `${TAX_API_BASE}/reports/taxable-ref-types`
+		const result = await this.get<{ refTypes: string[] }>(endpoint)
 		return result.refTypes
 	}
 
@@ -840,7 +928,7 @@ export class CorporationTaxApiClient extends ApiClient {
 		return this.post(`${TAX_API_BASE}/exports`, input)
 	}
 
-	async listExports(filters?: ListTaxExportsFilters): Promise<TaxExportRecord[]> {
+	async listExports(filters?: ListTaxExportsFilters): Promise<TaxPagedResult<TaxExportRecord>> {
 		if (this.shouldUseDemo()) return taxDemoApi.listExports(filters)
 		const params = new URLSearchParams()
 		if (filters?.corporationId) params.set('corporationId', filters.corporationId)
@@ -848,6 +936,8 @@ export class CorporationTaxApiClient extends ApiClient {
 		if (filters?.status) params.set('status', filters.status)
 		if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
 		if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+		if (filters?.sortBy) params.set('sortBy', filters.sortBy)
+		if (filters?.sortDir) params.set('sortDir', filters.sortDir)
 		const query = params.toString()
 		return this.get(`${TAX_API_BASE}/exports${query ? `?${query}` : ''}`)
 	}
@@ -871,13 +961,17 @@ export class CorporationTaxApiClient extends ApiClient {
 		return this.post(`${TAX_API_BASE}/export-schedules`, input)
 	}
 
-	async listExportSchedules(filters?: ListTaxExportSchedulesFilters): Promise<TaxExportSchedule[]> {
+	async listExportSchedules(
+		filters?: ListTaxExportSchedulesFilters
+	): Promise<TaxPagedResult<TaxExportSchedule>> {
 		if (this.shouldUseDemo()) return taxDemoApi.listExportSchedules(filters)
 		const params = new URLSearchParams()
 		if (filters?.corporationId) params.set('corporationId', filters.corporationId)
 		if (filters?.activeOnly !== undefined) params.set('activeOnly', String(filters.activeOnly))
 		if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
 		if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+		if (filters?.sortBy) params.set('sortBy', filters.sortBy)
+		if (filters?.sortDir) params.set('sortDir', filters.sortDir)
 		const query = params.toString()
 		return this.get(`${TAX_API_BASE}/export-schedules${query ? `?${query}` : ''}`)
 	}
@@ -892,6 +986,8 @@ export class CorporationTaxApiClient extends ApiClient {
 		if (filters?.toDate) params.set('toDate', filters.toDate)
 		if (filters?.limit !== undefined) params.set('limit', String(filters.limit))
 		if (filters?.offset !== undefined) params.set('offset', String(filters.offset))
+		if (filters?.sortBy) params.set('sortBy', filters.sortBy)
+		if (filters?.sortDir) params.set('sortDir', filters.sortDir)
 		const query = params.toString()
 		return this.get(`${TAX_API_BASE}/audit-log${query ? `?${query}` : ''}`)
 	}

--- a/apps/ui/src/client/lib/tax-api.ts
+++ b/apps/ui/src/client/lib/tax-api.ts
@@ -81,6 +81,7 @@ export type TaxReportFilters = TaxRollupReportQueryFilters
 
 export interface TaxMemberSummaryFilters {
 	characterQuery?: string
+	refTypes?: string[]
 	fromDate?: string
 	toDate?: string
 	topRefTypesLimit?: number
@@ -802,6 +803,7 @@ export class CorporationTaxApiClient extends ApiClient {
 		if (this.shouldUseDemo()) return taxDemoApi.getMemberSummary(corporationId, filters)
 		const params = new URLSearchParams()
 		if (filters?.characterQuery) params.set('character', filters.characterQuery)
+		if (filters?.refTypes?.length) params.set('refTypes', filters.refTypes.join(','))
 		if (filters?.fromDate) params.set('fromDate', filters.fromDate)
 		if (filters?.toDate) params.set('toDate', filters.toDate)
 		if (filters?.topRefTypesLimit !== undefined)
@@ -814,6 +816,17 @@ export class CorporationTaxApiClient extends ApiClient {
 		return this.get(
 			`${TAX_API_BASE}/corporations/${corporationId}/member-summary${query ? `?${query}` : ''}`
 		)
+	}
+
+	async getTaxableIncomeRefTypes(corporationId: string): Promise<string[]> {
+		if (!corporationId?.trim()) {
+			throw new Error('Corporation id is required for taxable income types')
+		}
+		if (this.shouldUseDemo()) return taxDemoApi.getTaxableIncomeRefTypes(corporationId)
+		const result = await this.get<{ refTypes: string[] }>(
+			`${TAX_API_BASE}/corporations/${corporationId}/member-summary/taxable-ref-types`
+		)
+		return result.refTypes
 	}
 
 	async requestExport(input: {

--- a/apps/ui/src/client/lib/tax-date.ts
+++ b/apps/ui/src/client/lib/tax-date.ts
@@ -14,12 +14,93 @@ function toDateInputValue(date: Date): string {
 	return date.toISOString().slice(0, 10)
 }
 
+export type TaxReportQuickRange =
+	| 'current-month'
+	| 'previous-month'
+	| 'last-3-months'
+	| 'last-6-months'
+	| 'last-year'
+
+export function shiftMonthRange(
+	fromDate: string,
+	monthOffset: number
+): { fromDate: string; toDate: string } {
+	const anchor = fromDate ? new Date(`${fromDate}T00:00:00.000Z`) : new Date()
+	const year = anchor.getUTCFullYear()
+	const month = anchor.getUTCMonth() + monthOffset
+	return {
+		fromDate: toDateInputValue(new Date(Date.UTC(year, month, 1))),
+		toDate: toDateInputValue(new Date(Date.UTC(year, month + 1, 0))),
+	}
+}
+
 export function getCurrentMonthDateRange(today = new Date()): { fromDate: string; toDate: string } {
 	const year = today.getUTCFullYear()
 	const month = today.getUTCMonth()
 
 	return {
 		fromDate: toDateInputValue(new Date(Date.UTC(year, month, 1))),
+		toDate: toDateInputValue(new Date(Date.UTC(year, month + 1, 0))),
+	}
+}
+
+export function getMonthDateRange(monthValue: string): { fromDate: string; toDate: string } {
+	const match = /^(\d{4})-(\d{2})$/.exec(monthValue)
+	if (!match) return getCurrentMonthDateRange()
+
+	const year = Number(match[1])
+	const month = Number(match[2]) - 1
+	if (!Number.isInteger(year) || !Number.isInteger(month) || month < 0 || month > 11) {
+		return getCurrentMonthDateRange()
+	}
+
+	return {
+		fromDate: toDateInputValue(new Date(Date.UTC(year, month, 1))),
+		toDate: toDateInputValue(new Date(Date.UTC(year, month + 1, 0))),
+	}
+}
+
+export function getMonthPeriodOptions(
+	monthCount = 24,
+	today = new Date()
+): Array<{ value: string; label: string }> {
+	const count = Math.max(1, Math.trunc(monthCount))
+	const currentMonth = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1)
+	return Array.from({ length: count }, (_, index) => {
+		const date = new Date(currentMonth)
+		date.setUTCMonth(date.getUTCMonth() - index)
+		const value = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`
+		return {
+			value,
+			label: date.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' }),
+		}
+	})
+}
+
+export function getPreviousCompletedMonthRange(
+	monthCount: number,
+	today = new Date()
+): { fromDate: string; toDate: string } {
+	const count = Math.max(1, Math.trunc(monthCount))
+	const year = today.getUTCFullYear()
+	const month = today.getUTCMonth()
+
+	return {
+		fromDate: toDateInputValue(new Date(Date.UTC(year, month - count, 1))),
+		toDate: toDateInputValue(new Date(Date.UTC(year, month, 0))),
+	}
+}
+
+export function getCurrentMonthWindowRange(
+	monthCount: number,
+	today = new Date()
+): { fromDate: string; toDate: string } {
+	const count = Math.max(1, Math.trunc(monthCount))
+	const year = today.getUTCFullYear()
+	const month = today.getUTCMonth()
+
+	return {
+		fromDate: toDateInputValue(new Date(Date.UTC(year, month - count + 1, 1))),
 		toDate: toDateInputValue(new Date(Date.UTC(year, month + 1, 0))),
 	}
 }

--- a/apps/ui/src/client/lib/tax-display.tsx
+++ b/apps/ui/src/client/lib/tax-display.tsx
@@ -1,5 +1,7 @@
 import { TAX_INCOME_REF_TYPES } from '@repo/corporation-tax'
 
+import { CorporationLogo } from '@/components/corporation-logo'
+
 import type { TaxAlert, TaxExportReportType } from '@repo/corporation-tax'
 
 const FULL_ISK_FORMATTER = new Intl.NumberFormat('en-US', {
@@ -298,6 +300,36 @@ export function TaxEntityDisplay({
 		<div className="leading-tight">
 			<div>{resolvedName}</div>
 			<div className="font-mono text-[11px] text-muted-foreground">{entityId}</div>
+		</div>
+	)
+}
+
+export function TaxCorporationDisplay({
+	corporationId,
+	entityNames,
+	emptyLabel = '-',
+}: {
+	corporationId: string | null | undefined
+	entityNames?: Record<string, string>
+	emptyLabel?: string
+}) {
+	if (!corporationId) {
+		return <>{emptyLabel}</>
+	}
+
+	const corporationName = entityNames?.[corporationId]
+
+	return (
+		<div className="flex min-w-0 items-center gap-2">
+			<CorporationLogo corporationId={corporationId} corporationName={corporationName} />
+			<div className="min-w-0 leading-tight">
+				<div className="truncate" title={corporationName ?? corporationId}>
+					{corporationName ?? corporationId}
+				</div>
+				{corporationName ? (
+					<div className="font-mono text-[11px] text-muted-foreground">{corporationId}</div>
+				) : null}
+			</div>
 		</div>
 	)
 }

--- a/apps/ui/src/client/lib/tax-report-types.ts
+++ b/apps/ui/src/client/lib/tax-report-types.ts
@@ -2,6 +2,8 @@ export type TaxRollupReportQueryFilters = {
 	corporationId?: string
 	fromDate?: string
 	toDate?: string
+	refTypes?: string[]
+	incomeMode?: 'total' | 'assessed'
 	limit?: number
 	offset?: number
 	sortBy?: string

--- a/apps/ui/src/client/lib/tax-report-utils.ts
+++ b/apps/ui/src/client/lib/tax-report-utils.ts
@@ -1,6 +1,5 @@
-import type { MRT_SortingState } from 'mantine-react-table'
-
 export type SortDirection = 'asc' | 'desc'
+export type TaxReportSortingState = Array<{ id: string; desc: boolean }>
 
 export function toStartOfDayIso(dateText: string): string {
 	return new Date(`${dateText}T00:00:00.000Z`).toISOString()
@@ -65,12 +64,12 @@ export function downloadBase64File(
 	URL.revokeObjectURL(url)
 }
 
-export function toSorting(sortBy?: string, sortDir?: SortDirection): MRT_SortingState {
+export function toSorting(sortBy?: string, sortDir?: SortDirection): TaxReportSortingState {
 	return sortBy ? [{ id: sortBy, desc: sortDir === 'desc' }] : []
 }
 
 export function applySorting(
-	sorting: MRT_SortingState,
+	sorting: TaxReportSortingState,
 	defaultSortBy: string,
 	defaultSortDir: SortDirection,
 	setSortBy: (value: string) => void,

--- a/apps/ui/src/client/routes/tax-alerts.tsx
+++ b/apps/ui/src/client/routes/tax-alerts.tsx
@@ -1,6 +1,5 @@
 import { RefreshCcw } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import toast from '@/lib/toast'
 
 import { TaxCorporationScopeSelector } from '@/components/tax-corporation-scope-selector'
 import { Badge } from '@/components/ui/badge'
@@ -46,8 +45,9 @@ import {
 	formatTaxAlertPayloadSummary,
 	formatTaxAlertTypeLabel,
 	formatTaxNumber,
-	TaxEntityDisplay,
+	TaxCorporationDisplay,
 } from '@/lib/tax-display'
+import toast from '@/lib/toast'
 
 import type { TaxAlert, TaxAlertSeverity, TaxAlertStatus } from '@repo/corporation-tax'
 
@@ -228,7 +228,8 @@ export default function TaxAlertsPage() {
 				description="Monitor discrepancy alerts and delivery status for corporation tax automation."
 				action={
 					canRetryFailedDeliveries ? (
-						<Button variant="ghost"
+						<Button
+							variant="ghost"
 							onClick={() => retryMutation.mutate(100)}
 							disabled={retryMutation.isPending}
 						>
@@ -284,7 +285,8 @@ export default function TaxAlertsPage() {
 												? `${currentDestination.name} • Guild ${currentDestination.guildId} • Channel ${currentDestination.channelId}`
 												: 'No Discord destination configured'}
 								</div>
-								<Button variant="ghost"
+								<Button
+									variant="ghost"
 									onClick={() => {
 										setDestinationName(currentDestination?.name ?? '')
 										setGuildId(currentDestination?.guildId ?? '')
@@ -379,8 +381,8 @@ export default function TaxAlertsPage() {
 												</TableCell>
 												<TableCell>
 													{alert.corporationId ? (
-														<TaxEntityDisplay
-															entityId={alert.corporationId}
+														<TaxCorporationDisplay
+															corporationId={alert.corporationId}
 															entityNames={entityNames}
 														/>
 													) : (
@@ -401,7 +403,8 @@ export default function TaxAlertsPage() {
 												<TableCell>
 													<div className="flex gap-2">
 														{canAcknowledge && alert.status === 'open' ? (
-															<Button variant="primary"
+															<Button
+																variant="primary"
 																size="sm"
 																onClick={() => acknowledgeMutation.mutate(alert.id)}
 																disabled={acknowledgeMutation.isPending}
@@ -410,7 +413,8 @@ export default function TaxAlertsPage() {
 															</Button>
 														) : null}
 														{canResolve && alert.status !== 'resolved' ? (
-															<Button variant="confirm"
+															<Button
+																variant="confirm"
 																size="sm"
 																showIcon={false}
 																onClick={() => resolveMutation.mutate(alert.id)}
@@ -469,14 +473,16 @@ export default function TaxAlertsPage() {
 								</div>
 							</div>
 							<DialogFooter>
-								<Button variant="cancel"
+								<Button
+									variant="cancel"
 									type="button"
 									showIcon={false}
 									onClick={() => setDestinationModalOpen(false)}
 								>
 									Cancel
 								</Button>
-								<Button variant="primary"
+								<Button
+									variant="primary"
 									type="button"
 									disabled={upsertDestinationMutation.isPending}
 									onClick={() => void handleSaveDestination()}

--- a/apps/ui/src/client/routes/tax-audit-log.tsx
+++ b/apps/ui/src/client/routes/tax-audit-log.tsx
@@ -7,8 +7,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Container } from '@/components/ui/container'
 import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
-import { Select } from '@/components/ui/select'
 import { Section } from '@/components/ui/section'
+import { Select } from '@/components/ui/select'
 import { useTaxAuditActors, useTaxAuditLog, useTaxCapabilities } from '@/hooks/corporation-tax'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useEntityNames } from '@/hooks/useEntityNames'
@@ -53,7 +53,7 @@ export default function TaxAuditLogPage() {
 
 	const {
 		data: auditLogPage,
-		isLoading,
+		isFetching: isLoading,
 		error,
 	} = useTaxAuditLog({
 		corporationId: effectiveCorporationId,
@@ -61,11 +61,12 @@ export default function TaxAuditLogPage() {
 		action: actionFilter.trim() || undefined,
 		limit: grid.limit,
 		offset: grid.offset,
+		sortBy: grid.sortBy as 'createdAt' | 'corporationId' | 'actorUserId' | 'action',
+		sortDir: grid.sortDir,
 		enabled: canView,
 	})
 	const auditLogRows = auditLogPage?.rows ?? []
 	const totalRows = auditLogPage?.totalRows ?? 0
-	const pageCount = grid.pageCountFor(totalRows)
 
 	const corporationIds = useMemo(
 		() =>
@@ -115,7 +116,8 @@ export default function TaxAuditLogPage() {
 	}, [resolvedActors])
 	const actorSearchOptions = useMemo(
 		() =>
-			actorSearchResults.map((actor) => ({ value: actor.userId,
+			actorSearchResults.map((actor) => ({
+				value: actor.userId,
 				label: actor.name ?? actor.userId,
 				description: actor.name ? actor.userId : undefined,
 			})),
@@ -199,29 +201,18 @@ export default function TaxAuditLogPage() {
 						<CardDescription>Most recent entries first.</CardDescription>
 					</CardHeader>
 					<CardContent>
-						{isLoading ? (
-							<div className="py-8 text-sm text-muted-foreground">Loading audit log...</div>
-						) : error ? (
-							<div className="py-8 text-sm text-destructive">
-								{error instanceof Error ? error.message : 'Failed to load tax audit log'}
-							</div>
-						) : auditLogRows.length === 0 ? (
-							<div className="py-8 text-sm text-muted-foreground">
-								No audit entries matched the selected filters.
-							</div>
-						) : (
-							<TaxAuditLogGrid
-								rows={auditLogRows}
-								loading={isLoading}
-								error={error}
-								entityNames={entityNames}
-								actorDisplayNames={actorDisplayNames}
-								pagination={grid.pagination}
-								onPaginationChange={grid.onPaginationChange}
-								pageCount={pageCount}
-								rowCount={totalRows}
-							/>
-						)}
+						<TaxAuditLogGrid
+							rows={auditLogRows}
+							loading={isLoading}
+							error={error}
+							entityNames={entityNames}
+							actorDisplayNames={actorDisplayNames}
+							sorting={grid.sorting}
+							onSortingChange={grid.onSortingChange}
+							pagination={grid.pagination}
+							onPaginationChange={grid.onPaginationChange}
+							rowCount={totalRows}
+						/>
 					</CardContent>
 				</Card>
 			</Section>

--- a/apps/ui/src/client/routes/tax-bills.tsx
+++ b/apps/ui/src/client/routes/tax-bills.tsx
@@ -20,17 +20,21 @@ import {
 	useCreateTaxBillForAssessment,
 	useIssueTaxBillsForPeriod,
 	useRetractTaxAssessmentBill,
+	useRunTaxAssessmentForPeriod,
 	useSyncTaxAssessmentBillStatus,
 	useSyncTaxCorporationBillStatuses,
 	useTaxAssessments,
+	useTaxAssessmentWorkflowStatus,
 	useTaxCapabilities,
 } from '@/hooks/corporation-tax'
 import { useEntityNames } from '@/hooks/useEntityNames'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useTaxCorporationAccessScope } from '@/hooks/useTaxCorporationAccessScope'
-import { getCurrentMonthDateRange } from '@/lib/tax-date'
+import { getCurrentMonthDateRange, getMonthDateRange, getMonthPeriodOptions } from '@/lib/tax-date'
 
 const DEFAULT_MONTH_RANGE = getCurrentMonthDateRange()
+const DEFAULT_MONTH_VALUE = DEFAULT_MONTH_RANGE.fromDate.slice(0, 7)
+const TAX_ASSESSMENT_MONTH_OPTIONS = getMonthPeriodOptions(24)
 
 export default function TaxBillsPage() {
 	usePageTitle('Tax Billing')
@@ -44,6 +48,7 @@ export default function TaxBillsPage() {
 		setSelectedCorporationId,
 		effectiveCorporationId,
 	} = useTaxCorporationAccessScope(canAdminScope)
+	const [monthValue, setMonthValue] = useState(DEFAULT_MONTH_VALUE)
 	const [periodStartDate, setPeriodStartDate] = useState(DEFAULT_MONTH_RANGE.fromDate)
 	const [periodEndDate, setPeriodEndDate] = useState(DEFAULT_MONTH_RANGE.toDate)
 	const [retractingAssessmentId, setRetractingAssessmentId] = useState<string | null>(null)
@@ -52,18 +57,14 @@ export default function TaxBillsPage() {
 		effectiveCorporationId,
 		Boolean(effectiveCorporationId)
 	)
-	const canViewScoped = scopedCapabilities?.scoped.canAudit ?? false
+	const canViewScoped = scopedCapabilities?.scoped.canRead ?? false
 	const canView = canAdminScope || canViewScoped
 	const canIssue =
 		(globalCapabilities?.global.canManage ?? false) ||
 		(scopedCapabilities?.scoped.canManage ?? false)
 
-	const {
-		data: assessments = [],
-		isLoading: assessmentsLoading,
-		error: assessmentsError,
-	} = useTaxAssessments(effectiveCorporationId, {
-		limit: 500,
+	const { data: assessmentsPage } = useTaxAssessments(effectiveCorporationId, {
+		limit: 25,
 		enabled: canView,
 	})
 
@@ -71,20 +72,17 @@ export default function TaxBillsPage() {
 	const syncAssessmentMutation = useSyncTaxAssessmentBillStatus()
 	const retractAssessmentMutation = useRetractTaxAssessmentBill()
 	const issuePeriodMutation = useIssueTaxBillsForPeriod()
+	const runAssessmentMutation = useRunTaxAssessmentForPeriod()
+	const assessmentWorkflowStatusQuery = useTaxAssessmentWorkflowStatus(
+		effectiveCorporationId,
+		runAssessmentMutation.data?.workflowInstanceId
+	)
 	const syncCorporationMutation = useSyncTaxCorporationBillStatuses()
 
-	const corporationAssessments = assessments.filter(
-		(assessment) => assessment.assessmentScope === 'corporation'
-	)
-	const totalAssessments = corporationAssessments.length
-	const unbilledAssessmentRows = corporationAssessments.filter(
-		(assessment) =>
-			!assessment.billId && assessment.status !== 'draft' && assessment.status !== 'excluded'
-	)
-	const unbilledAssessmentCount = unbilledAssessmentRows.length
-	const overdueAssessments = corporationAssessments.filter(
-		(assessment) => assessment.billStatus === 'overdue'
-	).length
+	const assessments = assessmentsPage?.rows ?? []
+	const totalAssessments = assessmentsPage?.corporationAssessmentCount ?? 0
+	const unbilledAssessmentCount = assessmentsPage?.unbilledAssessmentCount ?? 0
+	const overdueAssessments = assessmentsPage?.overdueAssessmentCount ?? 0
 
 	const entityIds = useMemo(() => {
 		const ids = new Set<string>()
@@ -95,7 +93,14 @@ export default function TaxBillsPage() {
 		return [...ids]
 	}, [assessments])
 
-	const { data: entityNames = {} } = useEntityNames(entityIds, { enabled: canView })
+	const { data: resolvedEntityNames = {} } = useEntityNames(entityIds, { enabled: canView })
+	const entityNames = useMemo(() => {
+		const names = { ...resolvedEntityNames }
+		for (const corporation of accessibleCorporations) {
+			if (corporation.name) names[corporation.corporationId] = corporation.name
+		}
+		return names
+	}, [accessibleCorporations, resolvedEntityNames])
 	const retractableAssessment = assessments.find((row) => row.id === retractingAssessmentId)
 
 	if (!corporationAccessLoading && !scopedCapabilitiesLoading && !canView) {
@@ -133,20 +138,24 @@ export default function TaxBillsPage() {
 					overdueAssessments={overdueAssessments}
 				/>
 
-				<BillingConfigurationCard
-					effectiveCorporationId={effectiveCorporationId}
-					canIssue={canIssue}
-					canView={canView}
-				/>
+				{canAdminScope && (
+					<BillingConfigurationCard
+						effectiveCorporationId={effectiveCorporationId}
+						canIssue={canIssue}
+						canView={canAdminScope}
+					/>
+				)}
 
 				<BillingOperationsCard
 					effectiveCorporationId={effectiveCorporationId ?? null}
 					canIssue={canIssue}
-					periodStartDate={periodStartDate}
-					periodEndDate={periodEndDate}
-					onPeriodChange={({ fromDate, toDate }) => {
-						setPeriodStartDate(fromDate)
-						setPeriodEndDate(toDate)
+					monthValue={monthValue}
+					monthOptions={TAX_ASSESSMENT_MONTH_OPTIONS}
+					onMonthChange={(nextMonthValue) => {
+						const range = getMonthDateRange(nextMonthValue)
+						setMonthValue(nextMonthValue)
+						setPeriodStartDate(range.fromDate)
+						setPeriodEndDate(range.toDate)
 					}}
 					onSyncCorporation={() => {
 						if (!effectiveCorporationId) return
@@ -169,13 +178,24 @@ export default function TaxBillsPage() {
 					issuePeriodPending={issuePeriodMutation.isPending}
 					issuePeriodResult={issuePeriodMutation.data}
 					issuePeriodError={issuePeriodMutation.error}
+					onRunAssessment={() => {
+						if (!effectiveCorporationId || !periodStartDate || !periodEndDate) return
+						runAssessmentMutation.mutate({
+							corporationId: effectiveCorporationId,
+							periodStart: new Date(`${periodStartDate}T00:00:00.000Z`).toISOString(),
+							periodEnd: new Date(`${periodEndDate}T23:59:59.999Z`).toISOString(),
+						})
+					}}
+					runAssessmentPending={runAssessmentMutation.isPending}
+					runAssessmentResult={assessmentWorkflowStatusQuery.data?.output ?? undefined}
+					runAssessmentStatus={assessmentWorkflowStatusQuery.data?.status}
+					runAssessmentWorkflowError={assessmentWorkflowStatusQuery.data?.error ?? null}
+					runAssessmentError={runAssessmentMutation.error}
 				/>
 
 				<UnbilledAssessmentsCard
 					effectiveCorporationId={effectiveCorporationId ?? null}
-					assessmentsLoading={assessmentsLoading}
-					assessmentsError={assessmentsError}
-					unbilledAssessmentRows={unbilledAssessmentRows}
+					canView={canView}
 					canIssue={canIssue}
 					createBillPending={createBillMutation.isPending}
 					createBillError={createBillMutation.error}
@@ -229,10 +249,8 @@ export default function TaxBillsPage() {
 							<TabsContent value="assessments" className="mt-2">
 								<ScopedAssessmentSnapshotCard
 									effectiveCorporationId={effectiveCorporationId ?? null}
-									assessmentsLoading={assessmentsLoading}
-									assessmentsError={assessmentsError}
-									assessments={assessments}
 									entityNames={entityNames}
+									canView={canView}
 								/>
 							</TabsContent>
 

--- a/apps/ui/src/client/routes/tax-exclusions.tsx
+++ b/apps/ui/src/client/routes/tax-exclusions.tsx
@@ -6,8 +6,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Container } from '@/components/ui/container'
 import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
-import { Select } from '@/components/ui/select'
 import { Section } from '@/components/ui/section'
+import { Select } from '@/components/ui/select'
 import {
 	Table,
 	TableBody,
@@ -41,7 +41,7 @@ export default function TaxExclusionsPage() {
 		data: exclusions = [],
 		isLoading: exclusionsLoading,
 		error: exclusionsError,
-	} = useTaxExclusions({ limit: 500, enabled: canManage })
+	} = useTaxExclusions({ limit: 200, enabled: canManage })
 	const upsertMutation = useUpsertTaxExclusion()
 	const deleteMutation = useDeleteTaxExclusion()
 
@@ -108,10 +108,7 @@ export default function TaxExclusionsPage() {
 			selectableCorporations.map((corporation) => {
 				const corporationId = corporation.corporationId
 				const name = corporationNameById.get(corporationId) ?? `Corporation ${corporationId}`
-				return { value: corporationId,
-					label: name,
-					description: corporationId,
-				}
+				return { value: corporationId, label: name, description: corporationId }
 			}),
 		[corporationNameById, selectableCorporations]
 	)
@@ -171,7 +168,8 @@ export default function TaxExclusionsPage() {
 								disabled={!selectedCorporationId}
 							/>
 						</div>
-						<Button variant="primary"
+						<Button
+							variant="primary"
 							type="button"
 							onClick={() => {
 								if (!selectedCorporationId) return

--- a/apps/ui/src/client/routes/tax-ledger.tsx
+++ b/apps/ui/src/client/routes/tax-ledger.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 
 import { TaxCorporationScopeSelector } from '@/components/tax-corporation-scope-selector'
-import { TaxReportDataGrid } from '@/components/tax-report-data-grid'
+import { TaxReportTable } from '@/components/tax-report-table'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
@@ -33,8 +33,8 @@ import {
 	TaxEntityDisplay,
 } from '@/lib/tax-display'
 
-import type { MRT_ColumnDef } from 'mantine-react-table'
 import type { TaxLedgerEntry } from '@repo/corporation-tax'
+import type { TaxReportSortingState } from '@/lib/tax-report-utils'
 
 const PAGE_SIZE = 50
 const DEFAULT_MONTH_RANGE = getCurrentMonthDateRange()
@@ -84,6 +84,10 @@ export default function TaxLedgerPage() {
 	} = useTaxCorporationAccessScope(false)
 	const [page, setPage] = useState(0)
 	const [pageSize, setPageSize] = useState(PAGE_SIZE)
+	const [sortBy, setSortBy] = useState<
+		'entryDate' | 'amount' | 'division' | 'refType' | 'sourceType'
+	>('entryDate')
+	const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
 	const [fromDate, setFromDate] = useState(DEFAULT_MONTH_RANGE.fromDate)
 	const [toDate, setToDate] = useState(DEFAULT_MONTH_RANGE.toDate)
 	const [divisionFilter, setDivisionFilter] = useState(ALL_DIVISIONS_VALUE)
@@ -215,8 +219,8 @@ export default function TaxLedgerPage() {
 	])
 
 	const {
-		data: ledgerEntries = [],
-		isLoading: ledgerLoading,
+		data: ledgerPage,
+		isFetching: ledgerLoading,
 		error: ledgerError,
 	} = useTaxLedgerEntries(effectiveCorporationId, {
 		division: divisionValue,
@@ -229,12 +233,21 @@ export default function TaxLedgerPage() {
 		minAmount: minAmountValue,
 		limit: pageSize,
 		offset: page * pageSize,
+		sortBy,
+		sortDir,
 		enabled: canView && Boolean(effectiveCorporationId),
 	})
 
-	const hasNextPage = ledgerEntries.length === pageSize
-	const approximateRowCount = page * pageSize + ledgerEntries.length + (hasNextPage ? 1 : 0)
-	const pageCount = Math.max(1, Math.ceil(approximateRowCount / pageSize))
+	const ledgerEntries = ledgerPage?.rows ?? []
+	const ledgerRowCount = ledgerPage?.totalRows ?? 0
+	const ledgerSorting: TaxReportSortingState = [{ id: sortBy, desc: sortDir === 'desc' }]
+	const onLedgerSortingChange = (next: TaxReportSortingState) => {
+		const first = next[0]
+		if (!first) return
+		setSortBy(first.id as typeof sortBy)
+		setSortDir(first.desc ? 'desc' : 'asc')
+		setPage(0)
+	}
 
 	const ledgerEntityIds = useMemo(() => {
 		const ids = new Set<string>()
@@ -286,60 +299,58 @@ export default function TaxLedgerPage() {
 		[senderPartyOptions, recipientPartyOptions]
 	)
 
-	const ledgerColumns = useMemo<Array<MRT_ColumnDef<TaxLedgerEntry>>>(
+	const ledgerColumns = useMemo(
 		() => [
 			{
-				accessorKey: 'entryDate',
+				id: 'entryDate',
 				header: 'Date',
-				enableSorting: false,
-				Cell: ({ row }) => formatTaxDateTime(row.original.entryDate),
+				sortable: true,
+				cell: (row: TaxLedgerEntry) => formatTaxDateTime(row.entryDate),
 			},
 			{
-				accessorKey: 'refType',
+				id: 'refType',
 				header: 'Income Type',
-				enableSorting: false,
-				Cell: ({ row }) => (
+				sortable: true,
+				cell: (row: TaxLedgerEntry) => (
 					<div className="flex items-center gap-2">
 						<span
 							className="h-2.5 w-2.5 rounded-full"
-							style={{ backgroundColor: getTaxRefTypeColor(row.original.refType) }}
+							style={{ backgroundColor: getTaxRefTypeColor(row.refType) }}
 						/>
-						<span>{formatTaxRefTypeLabel(row.original.refType)}</span>
+						<span>{formatTaxRefTypeLabel(row.refType)}</span>
 					</div>
 				),
 			},
 			{
-				accessorKey: 'amount',
+				id: 'amount',
 				header: 'Amount',
-				enableSorting: false,
-				Cell: ({ row }) => formatTaxIskFull(row.original.amount),
+				sortable: true,
+				cell: (row: TaxLedgerEntry) => formatTaxIskFull(row.amount),
 			},
 			{
-				accessorKey: 'division',
+				id: 'division',
 				header: 'Division',
-				enableSorting: false,
-				Cell: ({ row }) => formatTaxDivisionLabel(row.original.division),
+				sortable: true,
+				cell: (row: TaxLedgerEntry) => formatTaxDivisionLabel(row.division),
 			},
 			{
-				accessorKey: 'sourceType',
+				id: 'sourceType',
 				header: 'Source',
-				enableSorting: false,
-				Cell: ({ row }) => formatTaxLedgerSourceTypeLabel(row.original.sourceType),
+				sortable: true,
+				cell: (row: TaxLedgerEntry) => formatTaxLedgerSourceTypeLabel(row.sourceType),
 			},
 			{
-				accessorKey: 'firstPartyId',
+				id: 'firstPartyId',
 				header: 'Sender',
-				enableSorting: false,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.firstPartyId} entityNames={entityNames} />
+				cell: (row: TaxLedgerEntry) => (
+					<TaxEntityDisplay entityId={row.firstPartyId} entityNames={entityNames} />
 				),
 			},
 			{
-				accessorKey: 'secondPartyId',
+				id: 'secondPartyId',
 				header: 'Recipient',
-				enableSorting: false,
-				Cell: ({ row }) => (
-					<TaxEntityDisplay entityId={row.original.secondPartyId} entityNames={entityNames} />
+				cell: (row: TaxLedgerEntry) => (
+					<TaxEntityDisplay entityId={row.secondPartyId} entityNames={entityNames} />
 				),
 			},
 		],
@@ -565,28 +576,23 @@ export default function TaxLedgerPage() {
 						</CardDescription>
 					</CardHeader>
 					<CardContent>
-						{ledgerLoading ? (
-							<div className="py-8 text-sm text-muted-foreground">Loading ledger entries...</div>
-						) : ledgerError ? (
-							<div className="py-8 text-sm text-destructive">
-								{ledgerError instanceof Error
-									? ledgerError.message
-									: 'Failed to load ledger entries'}
-							</div>
-						) : (
-							<TaxReportDataGrid
-								columns={ledgerColumns}
-								rows={ledgerEntries}
-								emptyMessage="No ledger entries found."
-								pagination={{ pageIndex: page, pageSize }}
-								onPaginationChange={(next) => {
-									setPageSize(next.pageSize)
-									setPage(next.pageSize === pageSize ? Math.max(0, next.pageIndex) : 0)
-								}}
-								pageCount={pageCount}
-								rowCount={approximateRowCount}
-							/>
-						)}
+						<TaxReportTable
+							columns={ledgerColumns}
+							rows={ledgerEntries}
+							loading={ledgerLoading}
+							error={ledgerError}
+							emptyMessage="No ledger entries found."
+							sorting={ledgerSorting}
+							onSortingChange={onLedgerSortingChange}
+							pagination={{ pageIndex: page, pageSize }}
+							onPaginationChange={(next) => {
+								setPageSize(next.pageSize)
+								setPage(next.pageSize === pageSize ? Math.max(0, next.pageIndex) : 0)
+							}}
+							rowCount={ledgerRowCount}
+							itemLabel="ledger entries"
+							getRowKey={(row) => row.id}
+						/>
 					</CardContent>
 				</Card>
 			</Section>

--- a/apps/ui/src/client/routes/tax-member-summary.tsx
+++ b/apps/ui/src/client/routes/tax-member-summary.tsx
@@ -20,27 +20,10 @@ import {
 } from '@/hooks/corporation-tax'
 import { useEntityNames } from '@/hooks/useEntityNames'
 import { usePageTitle } from '@/hooks/usePageTitle'
-import { getCurrentMonthDateRange } from '@/lib/tax-date'
+import { getCurrentMonthDateRange, shiftMonthRange } from '@/lib/tax-date'
 import { formatTaxIskCompact, formatTaxNumber, TAX_REF_TYPE_OPTIONS } from '@/lib/tax-display'
 
 const DEFAULT_MONTH_RANGE = getCurrentMonthDateRange()
-
-function toDateInputValue(date: Date): string {
-	return date.toISOString().slice(0, 10)
-}
-
-function shiftMonthRange(
-	fromDate: string,
-	monthOffset: number
-): { fromDate: string; toDate: string } {
-	const anchor = fromDate ? new Date(`${fromDate}T00:00:00.000Z`) : new Date()
-	const year = anchor.getUTCFullYear()
-	const month = anchor.getUTCMonth() + monthOffset
-	return {
-		fromDate: toDateInputValue(new Date(Date.UTC(year, month, 1))),
-		toDate: toDateInputValue(new Date(Date.UTC(year, month + 1, 0))),
-	}
-}
 
 export default function TaxMemberSummaryPage() {
 	usePageTitle('Tax Member Summary')
@@ -274,29 +257,31 @@ export default function TaxMemberSummaryPage() {
 								</div>
 							</div>
 							<div className="space-y-2">
-								<div className="flex h-5 items-center justify-between gap-2">
-									<div className="text-sm font-medium">Income Types</div>
+								<div className="text-sm font-medium">Income Types</div>
+								<div className="flex items-center gap-2">
+									<div className="min-w-0 flex-1">
+										<Select
+											options={TAX_REF_TYPE_OPTIONS}
+											values={incomeTypes}
+											onValuesChange={setIncomeTypes}
+											multiple
+											searchable
+											placeholder="All income types"
+											inputClassName="h-10"
+											contentClassName="w-[min(20rem,calc(100vw-2rem))] min-w-[min(20rem,calc(100vw-2rem))]"
+										/>
+									</div>
 									<Button
 										type="button"
-										variant="ghost"
-										size="sm"
+										variant="secondary"
+										className="h-10 shrink-0"
 										showIcon={false}
-										className="h-5 px-1.5 text-xs"
 										disabled={taxableIncomeTypes.length === 0}
 										onClick={() => setIncomeTypes(taxableIncomeTypes)}
 									>
 										Taxable only
 									</Button>
 								</div>
-								<Select
-									options={TAX_REF_TYPE_OPTIONS}
-									values={incomeTypes}
-									onValuesChange={setIncomeTypes}
-									multiple
-									searchable
-									placeholder="All income types"
-									inputClassName="h-10"
-								/>
 							</div>
 							<div className="space-y-2">
 								<div className="h-5" aria-hidden="true" />
@@ -317,7 +302,7 @@ export default function TaxMemberSummaryPage() {
 											setRefreshToken((value) => value + 1)
 										}}
 										disabled={isRefreshing}
-										variant="ghost"
+										variant="primary"
 										className="h-10 w-28"
 									>
 										{isRefreshing ? 'Refreshing…' : 'Refresh'}

--- a/apps/ui/src/client/routes/tax-member-summary.tsx
+++ b/apps/ui/src/client/routes/tax-member-summary.tsx
@@ -1,16 +1,19 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 
 import { TaxCorporationScopeSelector } from '@/components/tax-corporation-scope-selector'
 import { MemberSummaryGridCard } from '@/components/tax-member-summary/member-summary-grid-card'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
-import { Button } from '@/components/ui/button'
 import { DateRangeInput } from '@/components/ui/date-range-input'
 import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/ui/page-header'
 import { Section } from '@/components/ui/section'
+import { Select } from '@/components/ui/select'
 import { useCorporationAccess } from '@/features/corporations'
 import {
+	useTaxableIncomeRefTypes,
 	useTaxCapabilities,
 	useTaxCorporations,
 	useTaxSummaryReport,
@@ -18,9 +21,27 @@ import {
 import { useEntityNames } from '@/hooks/useEntityNames'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { getCurrentMonthDateRange } from '@/lib/tax-date'
-import { formatTaxIskCompact, formatTaxNumber } from '@/lib/tax-display'
+import { formatTaxIskCompact, formatTaxNumber, TAX_REF_TYPE_OPTIONS } from '@/lib/tax-display'
 
 const DEFAULT_MONTH_RANGE = getCurrentMonthDateRange()
+
+function toDateInputValue(date: Date): string {
+	return date.toISOString().slice(0, 10)
+}
+
+function shiftMonthRange(
+	fromDate: string,
+	monthOffset: number
+): { fromDate: string; toDate: string } {
+	const anchor = fromDate ? new Date(`${fromDate}T00:00:00.000Z`) : new Date()
+	const year = anchor.getUTCFullYear()
+	const month = anchor.getUTCMonth() + monthOffset
+	return {
+		fromDate: toDateInputValue(new Date(Date.UTC(year, month, 1))),
+		toDate: toDateInputValue(new Date(Date.UTC(year, month + 1, 0))),
+	}
+}
+
 export default function TaxMemberSummaryPage() {
 	usePageTitle('Tax Member Summary')
 
@@ -28,10 +49,11 @@ export default function TaxMemberSummaryPage() {
 	const canReadWithUrn = globalCapabilities?.global.canRead ?? false
 	const { data: corporationAccess, isLoading: corporationAccessLoading } = useCorporationAccess()
 
-	const { data: corporationSettings = [], isLoading: corporationSettingsLoading } = useTaxCorporations({
-		limit: 1000,
-		enabled: canReadWithUrn,
-	})
+	const { data: corporationSettings = [], isLoading: corporationSettingsLoading } =
+		useTaxCorporations({
+			limit: 1000,
+			enabled: canReadWithUrn,
+		})
 	const isCorporationScopeLoading =
 		globalCapabilitiesLoading || corporationAccessLoading || corporationSettingsLoading
 
@@ -67,10 +89,16 @@ export default function TaxMemberSummaryPage() {
 			}
 		}
 		return Array.from(map.entries()).map(([corporationId, name]) => ({ corporationId, name }))
-	}, [isCorporationScopeLoading, corporationAccess?.corporations, corporationSettings, resolvedCorporationNames])
+	}, [
+		isCorporationScopeLoading,
+		corporationAccess?.corporations,
+		corporationSettings,
+		resolvedCorporationNames,
+	])
 
 	const [selectedCorporationId, setSelectedCorporationId] = useState<string | undefined>(undefined)
 	const [characterQuery, setCharacterQuery] = useState('')
+	const [incomeTypes, setIncomeTypes] = useState<string[]>([])
 	const [fromDate, setFromDate] = useState(DEFAULT_MONTH_RANGE.fromDate)
 	const [toDate, setToDate] = useState(DEFAULT_MONTH_RANGE.toDate)
 	const [refreshToken, setRefreshToken] = useState(0)
@@ -119,6 +147,26 @@ export default function TaxMemberSummaryPage() {
 		canReadWithUrn ||
 		(scopedCapabilities?.scoped.canRead ?? false) ||
 		(corporationAccess?.hasAccess ?? false)
+	const { data: taxableIncomeTypes = [] } = useTaxableIncomeRefTypes(
+		effectiveCorporationId,
+		canViewMemberSummary
+	)
+	const hasActiveFilters =
+		characterQuery.trim().length > 0 ||
+		incomeTypes.length > 0 ||
+		fromDate !== DEFAULT_MONTH_RANGE.fromDate ||
+		toDate !== DEFAULT_MONTH_RANGE.toDate
+	const clearFilters = () => {
+		setCharacterQuery('')
+		setIncomeTypes([])
+		setFromDate(DEFAULT_MONTH_RANGE.fromDate)
+		setToDate(DEFAULT_MONTH_RANGE.toDate)
+	}
+	const moveMonth = (monthOffset: number) => {
+		const nextRange = shiftMonthRange(fromDate, monthOffset)
+		setFromDate(nextRange.fromDate)
+		setToDate(nextRange.toDate)
+	}
 
 	const fromDateIso = fromDate ? new Date(`${fromDate}T00:00:00.000Z`).toISOString() : undefined
 	const toDateIso = toDate ? new Date(`${toDate}T23:59:59.999Z`).toISOString() : undefined
@@ -176,29 +224,46 @@ export default function TaxMemberSummaryPage() {
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-2">
-						<div className="hidden md:grid md:grid-cols-2 md:gap-3">
-							<div className="text-sm font-medium">Date Range</div>
-							<div className="grid grid-cols-[1fr_auto] gap-3">
+						<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto]">
+							<div className="space-y-2">
+								<div className="text-sm font-medium">Date Range</div>
+								<div className="flex items-center gap-1">
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon"
+										showIcon={false}
+										className="h-10 w-10 shrink-0 p-0"
+										aria-label="Previous month"
+										onClick={() => moveMonth(-1)}
+									>
+										<ChevronLeft className="h-4 w-4" aria-hidden="true" />
+									</Button>
+									<DateRangeInput
+										value={{ fromDate, toDate }}
+										onChange={({ fromDate: nextFromDate, toDate: nextToDate }) => {
+											setFromDate(nextFromDate)
+											setToDate(nextToDate)
+										}}
+										placeholder="Date range"
+										className="min-w-0 flex-1 [&_.themed-date-picker__input]:h-10 [&_.themed-date-picker__input]:w-full"
+									/>
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon"
+										showIcon={false}
+										className="h-10 w-10 shrink-0 p-0"
+										aria-label="Next month"
+										onClick={() => moveMonth(1)}
+									>
+										<ChevronRight className="h-4 w-4" aria-hidden="true" />
+									</Button>
+								</div>
+							</div>
+							<div className="space-y-2">
 								<div className="text-sm font-medium">Character</div>
-								<div />
-							</div>
-						</div>
-						<div className="grid gap-3 md:grid-cols-2">
-							<div className="space-y-2 md:space-y-0">
-								<div className="text-sm font-medium md:hidden">Date Range</div>
-								<DateRangeInput
-									value={{ fromDate, toDate }}
-									onChange={({ fromDate: nextFromDate, toDate: nextToDate }) => {
-										setFromDate(nextFromDate)
-										setToDate(nextToDate)
-									}}
-									placeholder="Date range"
-									className="[&_.themed-date-picker__input]:h-10"
-								/>
-							</div>
-							<div className="grid gap-3 md:grid-cols-[1fr_auto] md:items-center">
 								<div className="space-y-2 md:space-y-0">
-									<div className="text-sm font-medium md:hidden">Character</div>
 									<Input
 										value={characterQuery}
 										onChange={(event) => setCharacterQuery(event.target.value)}
@@ -207,18 +272,57 @@ export default function TaxMemberSummaryPage() {
 										className="h-10"
 									/>
 								</div>
-								<Button
-									type="button"
-									onClick={() => {
-										void refetchSummaryReport()
-										setRefreshToken((value) => value + 1)
-									}}
-									disabled={isRefreshing}
-									variant="ghost"
-									className="h-10"
-								>
-									{isRefreshing ? 'Refreshing…' : 'Refresh'}
-								</Button>
+							</div>
+							<div className="space-y-2">
+								<div className="flex h-5 items-center justify-between gap-2">
+									<div className="text-sm font-medium">Income Types</div>
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										showIcon={false}
+										className="h-5 px-1.5 text-xs"
+										disabled={taxableIncomeTypes.length === 0}
+										onClick={() => setIncomeTypes(taxableIncomeTypes)}
+									>
+										Taxable only
+									</Button>
+								</div>
+								<Select
+									options={TAX_REF_TYPE_OPTIONS}
+									values={incomeTypes}
+									onValuesChange={setIncomeTypes}
+									multiple
+									searchable
+									placeholder="All income types"
+									inputClassName="h-10"
+								/>
+							</div>
+							<div className="space-y-2">
+								<div className="h-5" aria-hidden="true" />
+								<div className="flex justify-end gap-2">
+									<Button
+										type="button"
+										variant="ghost"
+										className="h-10"
+										onClick={clearFilters}
+										disabled={!hasActiveFilters}
+									>
+										Clear Filters
+									</Button>
+									<Button
+										type="button"
+										onClick={() => {
+											void refetchSummaryReport()
+											setRefreshToken((value) => value + 1)
+										}}
+										disabled={isRefreshing}
+										variant="ghost"
+										className="h-10 w-28"
+									>
+										{isRefreshing ? 'Refreshing…' : 'Refresh'}
+									</Button>
+								</div>
 							</div>
 						</div>
 					</CardContent>
@@ -267,6 +371,7 @@ export default function TaxMemberSummaryPage() {
 					canViewSummary={canViewMemberSummary}
 					canSearchCharacter={canSearchCharacter}
 					characterQuery={characterQuery}
+					refTypes={incomeTypes}
 					fromDateIso={fromDateIso}
 					toDateIso={toDateIso}
 					refreshToken={refreshToken}

--- a/apps/ui/src/client/routes/tax-reports.tsx
+++ b/apps/ui/src/client/routes/tax-reports.tsx
@@ -7,6 +7,7 @@ import {
 	TaxSummaryCards,
 } from '@/components/tax-reports/report-panels'
 import { TaxReportWorkspace } from '@/components/tax-reports/report-workspace'
+import { useReportGridState } from '@/components/tax-reports/use-report-grid-state'
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { PageHeader } from '@/components/ui/page-header'
@@ -23,10 +24,17 @@ import {
 import { useEntityNames } from '@/hooks/useEntityNames'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useTaxCorporationAccessScope } from '@/hooks/useTaxCorporationAccessScope'
-import { getCurrentMonthDateRange } from '@/lib/tax-date'
+import {
+	getCurrentMonthDateRange,
+	getCurrentMonthWindowRange,
+	getPreviousCompletedMonthRange,
+	shiftMonthRange,
+} from '@/lib/tax-date'
 import { downloadBase64File, toEndOfDayIso, toStartOfDayIso } from '@/lib/tax-report-utils'
+import toast from '@/lib/toast'
 
 import type { TaxExportFormat, TaxExportReportType } from '@repo/corporation-tax'
+import type { TaxReportQuickRange } from '@/lib/tax-date'
 import type { SortDirection } from '@/lib/tax-report-utils'
 
 type TaxReportView = TaxExportReportType | 'missing_esi_keys'
@@ -47,7 +55,7 @@ const reportViewOptions: Array<{
 	{
 		value: 'top_income_sources',
 		label: 'Income Sources',
-		description: 'Taxable inflow grouped by income type.',
+		description: 'Income or assessed tax grouped by income type.',
 		exportable: true,
 	},
 	{
@@ -76,7 +84,7 @@ const reportViewOptions: Array<{
 	},
 	{
 		value: 'missing_esi_keys',
-		label: 'Missing ESI Keys',
+		label: 'ESI Coverage',
 		description: 'Corporations with incomplete ESI key or scope coverage.',
 		exportable: false,
 		requiresAdminScope: true,
@@ -120,6 +128,28 @@ export default function TaxReportsPage() {
 	const [scheduleFrequency, setScheduleFrequency] = useState<'weekly' | 'monthly'>('weekly')
 	const [fromDate, setFromDate] = useState(DEFAULT_MONTH_RANGE.fromDate)
 	const [toDate, setToDate] = useState(DEFAULT_MONTH_RANGE.toDate)
+	const moveMonth = (monthOffset: number) => {
+		const nextRange = shiftMonthRange(fromDate, monthOffset)
+		setFromDate(nextRange.fromDate)
+		setToDate(nextRange.toDate)
+	}
+	const selectQuickRange = (range: TaxReportQuickRange) => {
+		const nextRange =
+			range === 'current-month'
+				? getCurrentMonthDateRange()
+				: range === 'previous-month'
+					? getPreviousCompletedMonthRange(1)
+					: getCurrentMonthWindowRange(
+							range === 'last-3-months' ? 3 : range === 'last-6-months' ? 6 : 12
+						)
+		setFromDate(nextRange.fromDate)
+		setToDate(nextRange.toDate)
+	}
+	const resetFilters = () => {
+		setFromDate(DEFAULT_MONTH_RANGE.fromDate)
+		setToDate(DEFAULT_MONTH_RANGE.toDate)
+		setSelectedCorporationId(undefined)
+	}
 	const [totalTaxesExportSort, setTotalTaxesExportSort] = useState<{
 		sortBy: string
 		sortDir: SortDirection
@@ -141,16 +171,27 @@ export default function TaxReportsPage() {
 		sortBy: 'createdAt',
 		sortDir: 'desc',
 	})
+	const exportGrid = useReportGridState({
+		defaultSortBy: 'requestedAt',
+		defaultSortDir: 'desc',
+		defaultPageSize: 25,
+		resetOn: effectiveCorporationId,
+	})
+	const scheduleGrid = useReportGridState({
+		defaultSortBy: 'nextRunAt',
+		defaultSortDir: 'desc',
+		defaultPageSize: 25,
+		resetOn: effectiveCorporationId,
+	})
 
 	const { data: scopedCapabilities, isLoading: scopedCapabilitiesLoading } = useTaxCapabilities(
 		effectiveCorporationId,
 		Boolean(effectiveCorporationId)
 	)
-	const canAuditScoped = scopedCapabilities?.scoped.canAudit ?? false
-	const canManageScoped = canAuditScoped
-	const canView = canAdminScope || canAuditScoped
-	const canExport = canAdminExport || canAuditScoped
-	const canCreateSchedule = canAdminManageSchedules || canManageScoped
+	const canReadScoped = scopedCapabilities?.scoped.canRead ?? false
+	const canView = canAdminScope || canReadScoped
+	const canExport = canAdminExport
+	const canCreateSchedule = canAdminManageSchedules
 
 	const visibleReportOptions = useMemo(
 		() => reportViewOptions.filter((option) => !option.requiresAdminScope || canAdminScope),
@@ -197,25 +238,48 @@ export default function TaxReportsPage() {
 	})
 
 	const {
-		data: exportsList = [],
-		isLoading: exportsLoading,
+		data: exportsPage,
+		isFetching: exportsLoading,
 		error: exportsError,
 	} = useTaxExports({
 		corporationId: effectiveCorporationId,
-		limit: 100,
+		limit: exportGrid.limit,
+		offset: exportGrid.offset,
+		sortBy: exportGrid.sortBy as
+			| 'requestedAt'
+			| 'corporationId'
+			| 'reportType'
+			| 'format'
+			| 'status'
+			| 'rowCount'
+			| 'completedAt',
+		sortDir: exportGrid.sortDir,
 		enabled: canView,
 	})
 
 	const {
-		data: schedules = [],
-		isLoading: schedulesLoading,
+		data: schedulesPage,
+		isFetching: schedulesLoading,
 		error: schedulesError,
 	} = useTaxExportSchedules({
 		corporationId: effectiveCorporationId,
 		activeOnly: false,
-		limit: 100,
+		limit: scheduleGrid.limit,
+		offset: scheduleGrid.offset,
+		sortBy: scheduleGrid.sortBy as
+			| 'name'
+			| 'corporationId'
+			| 'reportType'
+			| 'format'
+			| 'frequency'
+			| 'isActive'
+			| 'nextRunAt'
+			| 'lastRunAt',
+		sortDir: scheduleGrid.sortDir,
 		enabled: canView,
 	})
+	const exportsList = exportsPage?.rows ?? []
+	const schedules = schedulesPage?.rows ?? []
 
 	const requestExportMutation = useRequestTaxExport()
 	const createScheduleMutation = useCreateTaxExportSchedule()
@@ -301,6 +365,9 @@ export default function TaxReportsPage() {
 				<TaxReportFiltersCard
 					fromDate={fromDate}
 					toDate={toDate}
+					onMoveMonth={moveMonth}
+					onSelectQuickRange={selectQuickRange}
+					onReset={resetFilters}
 					onDateRangeChange={({ fromDate: nextFromDate, toDate: nextToDate }) => {
 						setFromDate(nextFromDate)
 						setToDate(nextToDate)
@@ -352,13 +419,23 @@ export default function TaxReportsPage() {
 					scheduleSubmitting={createScheduleMutation.isPending}
 					onSubmitExport={async () => {
 						if (!activeExportReportType) return
-						await requestExportMutation.mutateAsync({
-							corporationId: effectiveCorporationId,
-							format: selectedExportFormat,
-							reportType: activeExportReportType,
-							filters: exportFilters,
-							sourceEsiVersion: 'esi-v1',
-						})
+						try {
+							await requestExportMutation.mutateAsync({
+								corporationId: effectiveCorporationId,
+								format: selectedExportFormat,
+								reportType: activeExportReportType,
+								filters: exportFilters,
+								sourceEsiVersion: 'esi-v1',
+							})
+							toast.success('Tax export request submitted', {
+								description: 'The export will appear in Recent Exports when it is ready.',
+							})
+						} catch (error) {
+							toast.error('Failed to request tax export', {
+								description: error instanceof Error ? error.message : 'Please try again.',
+							})
+							throw error
+						}
 					}}
 					onSubmitSchedule={async () => {
 						if (!activeExportReportType) return
@@ -388,6 +465,11 @@ export default function TaxReportsPage() {
 							},
 						})
 					}
+					pagination={exportGrid.pagination}
+					onPaginationChange={exportGrid.onPaginationChange}
+					rowCount={exportsPage?.totalRows ?? 0}
+					sorting={exportGrid.sorting}
+					onSortingChange={exportGrid.onSortingChange}
 				/>
 
 				<TaxExportSchedulesPanel
@@ -396,6 +478,11 @@ export default function TaxReportsPage() {
 					error={schedulesError}
 					entityNames={entityNames}
 					createScheduleError={createScheduleMutation.error}
+					pagination={scheduleGrid.pagination}
+					onPaginationChange={scheduleGrid.onPaginationChange}
+					rowCount={schedulesPage?.totalRows ?? 0}
+					sorting={scheduleGrid.sorting}
+					onSortingChange={scheduleGrid.onSortingChange}
 				/>
 			</Section>
 		</Container>

--- a/apps/ui/src/test/unit/corporation-tax-member-summary.test.ts
+++ b/apps/ui/src/test/unit/corporation-tax-member-summary.test.ts
@@ -9,6 +9,7 @@ const { useQueryMock } = vi.hoisted(() => ({
 
 vi.mock('@tanstack/react-query', () => ({
 	useQuery: (...args: unknown[]) => useQueryMock(...args),
+	keepPreviousData: Symbol('keepPreviousData'),
 }))
 
 describe('useTaxMemberSummary', () => {

--- a/apps/ui/src/test/unit/routes/tax-member-summary.route.test.tsx
+++ b/apps/ui/src/test/unit/routes/tax-member-summary.route.test.tsx
@@ -1,8 +1,9 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import TaxMemberSummaryPage from '@/routes/tax-member-summary'
+
+import type { ReactNode } from 'react'
 
 const {
 	useCorporationAccessMock,
@@ -11,6 +12,7 @@ const {
 	useTaxCapabilitiesMock,
 	useTaxCorporationsMock,
 	useTaxSummaryReportMock,
+	useTaxableIncomeRefTypesMock,
 } = vi.hoisted(() => ({
 	useCorporationAccessMock: vi.fn(),
 	useEntityNamesMock: vi.fn(),
@@ -18,6 +20,7 @@ const {
 	useTaxCapabilitiesMock: vi.fn(),
 	useTaxCorporationsMock: vi.fn(),
 	useTaxSummaryReportMock: vi.fn(),
+	useTaxableIncomeRefTypesMock: vi.fn(),
 }))
 
 vi.mock('@/features/corporations', () => ({
@@ -36,6 +39,7 @@ vi.mock('@/hooks/corporation-tax', () => ({
 	useTaxCapabilities: (...args: unknown[]) => useTaxCapabilitiesMock(...args),
 	useTaxCorporations: (...args: unknown[]) => useTaxCorporationsMock(...args),
 	useTaxSummaryReport: (...args: unknown[]) => useTaxSummaryReportMock(...args),
+	useTaxableIncomeRefTypes: (...args: unknown[]) => useTaxableIncomeRefTypesMock(...args),
 }))
 
 vi.mock('@/components/tax-corporation-scope-selector', () => ({
@@ -137,6 +141,7 @@ describe('TaxMemberSummaryPage corporation scope gating', () => {
 			isLoading: false,
 			refetch: vi.fn(),
 		})
+		useTaxableIncomeRefTypesMock.mockReturnValue({ data: [] })
 
 		const html = renderToStaticMarkup(<TaxMemberSummaryPage />)
 
@@ -193,6 +198,7 @@ describe('TaxMemberSummaryPage corporation scope gating', () => {
 			isLoading: false,
 			refetch: vi.fn(),
 		})
+		useTaxableIncomeRefTypesMock.mockReturnValue({ data: [] })
 
 		const html = renderToStaticMarkup(<TaxMemberSummaryPage />)
 

--- a/packages/bills/src/index.ts
+++ b/packages/bills/src/index.ts
@@ -82,10 +82,32 @@ export interface BillStatusEventPageQuery {
 	billIds: string[]
 	limit: number
 	offset: number
+	sortBy?: 'createdAt' | 'eventType' | 'billId' | 'actorUserId'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface BillStatusEventPage {
 	rows: BillStatusEvent[]
+	rowCount: number
+}
+
+export interface BillStatusEventByPayerPageQuery {
+	payerId: string
+	payerType: EntityType
+	externalSourceType?: string
+	limit: number
+	offset: number
+	sortBy?: 'createdAt' | 'eventType' | 'billId' | 'actorUserId'
+	sortDir?: 'asc' | 'desc'
+}
+
+export interface BillStatusEventByPayerRow extends BillStatusEvent {
+	externalSourceType: string | null
+	externalSourceId: string | null
+}
+
+export interface BillStatusEventByPayerPage {
+	rows: BillStatusEventByPayerRow[]
 	rowCount: number
 }
 
@@ -517,6 +539,9 @@ export interface Bills {
 
 	/** Get bill status timeline events for a bill set with pagination */
 	listBillStatusEventsPage(query: BillStatusEventPageQuery): Promise<BillStatusEventPage>
+	listBillStatusEventsByPayerPage(
+		query: BillStatusEventByPayerPageQuery
+	): Promise<BillStatusEventByPayerPage>
 
 	/** Update a bill (permissions enforced by caller route; blocked when paid or any payments exist) */
 	updateBill(actorUserId: string, billId: string, data: UpdateBillInput): Promise<Bill>
@@ -564,7 +589,10 @@ export interface Bills {
 	cancelGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult>
 
 	/** Revert all eligible sub-bills sharing a groupBillId to draft */
-	revertGroupBillToDraft(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult>
+	revertGroupBillToDraft(
+		actorUserId: string,
+		groupBillId: string
+	): Promise<GroupBillOperationResult>
 
 	/** Delete all eligible (draft) sub-bills sharing a groupBillId */
 	deleteGroupBill(actorUserId: string, groupBillId: string): Promise<GroupBillOperationResult>

--- a/packages/corporation-tax/src/index.ts
+++ b/packages/corporation-tax/src/index.ts
@@ -35,9 +35,13 @@ import type {
 	TaxAlert,
 	TaxAssessment,
 	TaxAssessmentLine,
+	TaxAssessmentPage,
 	TaxAssessmentWithBillHistory,
+	TaxAssessmentWorkflowStartResult,
+	TaxAssessmentWorkflowStatusResult,
 	TaxAuditLogEntry,
 	TaxBillingEventHistoryRow,
+	TaxBillingEventSortBy,
 	TaxBillStateSyncInput,
 	TaxBillStatusReportRow,
 	TaxCompliancePoint,
@@ -48,6 +52,7 @@ import type {
 	TaxExportArtifact,
 	TaxExportRecord,
 	TaxExportSchedule,
+	TaxIncomeDisplayMode,
 	TaxLedgerEntry,
 	TaxLedgerIngestionHealth,
 	TaxLedgerIngestionResult,
@@ -199,7 +204,7 @@ export interface CorporationTax {
 	/**
 	 * List tax assessments.
 	 */
-	listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessment[]>
+	listAssessments(filters?: ListTaxAssessmentsFilters): Promise<TaxAssessmentPage>
 
 	/**
 	 * Compute or recompute corporation tax assessment for a period.
@@ -208,6 +213,22 @@ export interface CorporationTax {
 		actorUserId: string,
 		input: RunTaxAssessmentForPeriodInput
 	): Promise<RunTaxAssessmentForPeriodResult>
+
+	/**
+	 * Queue a long-running assessment for asynchronous execution.
+	 */
+	startAssessmentWorkflow(
+		actorUserId: string,
+		input: RunTaxAssessmentForPeriodInput
+	): Promise<TaxAssessmentWorkflowStartResult>
+
+	/**
+	 * Read the status of a previously queued assessment workflow.
+	 */
+	getAssessmentWorkflowStatus(
+		corporationId: string,
+		workflowInstanceId: string
+	): Promise<TaxAssessmentWorkflowStatusResult>
 
 	/**
 	 * Explicit closed-period finalized rollup rebuild/backfill command.
@@ -269,7 +290,7 @@ export interface CorporationTax {
 		corporationId: string,
 		limit?: number,
 		offset?: number
-	): Promise<TaxAssessmentWithBillHistory[]>
+	): Promise<TaxPagedResult<TaxAssessmentWithBillHistory>>
 
 	/**
 	 * Get billing-domain event history for a corporation's billed corporation-scope assessments.
@@ -277,7 +298,9 @@ export interface CorporationTax {
 	getCorporationBillEventHistory(
 		corporationId: string,
 		limit?: number,
-		offset?: number
+		offset?: number,
+		sortBy?: TaxBillingEventSortBy,
+		sortDir?: 'asc' | 'desc'
 	): Promise<TaxPagedResult<TaxBillingEventHistoryRow>>
 
 	/**
@@ -385,7 +408,7 @@ export interface CorporationTax {
 	listLedgerEntries(
 		corporationId: string,
 		filters?: TaxLedgerWindowFilters
-	): Promise<TaxLedgerEntry[]>
+	): Promise<TaxPagedResult<TaxLedgerEntry>>
 
 	/**
 	 * List distinct sender/recipient entity IDs present in ledger entries.
@@ -442,6 +465,9 @@ export interface CorporationTax {
 	 * Tax compliance trend points over time.
 	 */
 	getComplianceOverTimeReport(filters?: TaxRollupReportFilters): Promise<TaxCompliancePoint[]>
+	getComplianceOverTimeReportPage(
+		filters?: TaxRollupReportFilters
+	): Promise<TaxPagedResult<TaxCompliancePoint>>
 
 	/**
 	 * Tax discrepancy report with optional open-only filtering.
@@ -474,7 +500,7 @@ export interface CorporationTax {
 	/**
 	 * Income types whose effective active rule for a corporation is taxable.
 	 */
-	getTaxableIncomeRefTypes(corporationId: string): Promise<string[]>
+	getTaxableIncomeRefTypes(corporationId?: string): Promise<string[]>
 
 	/**
 	 * Request a tax report export run.
@@ -484,7 +510,7 @@ export interface CorporationTax {
 	/**
 	 * List export run history.
 	 */
-	listExports(filters?: ListTaxExportsFilters): Promise<TaxExportRecord[]>
+	listExports(filters?: ListTaxExportsFilters): Promise<TaxPagedResult<TaxExportRecord>>
 
 	/**
 	 * Get one export record by id.
@@ -507,7 +533,9 @@ export interface CorporationTax {
 	/**
 	 * List export schedules.
 	 */
-	listExportSchedules(filters?: ListTaxExportSchedulesFilters): Promise<TaxExportSchedule[]>
+	listExportSchedules(
+		filters?: ListTaxExportSchedulesFilters
+	): Promise<TaxPagedResult<TaxExportSchedule>>
 
 	/**
 	 * Run scheduled export + alert retry operations for the tax domain.
@@ -609,7 +637,9 @@ export type {
 	TaxLedgerRetentionResult,
 	TaxLedgerWindowFilters,
 	TaxAssessment,
+	TaxAssessmentPage,
 	TaxBillingEventHistoryRow,
+	TaxBillingEventSortBy,
 	TaxAssessmentScope,
 	TaxAssessmentStatus,
 	TaxAssessmentWithBillHistory,
@@ -625,6 +655,7 @@ export type {
 	TaxBillingPayeeType,
 	TaxCorporationEsiAuthStatus,
 	TaxCompliancePoint,
+	TaxComplianceSortBy,
 	TaxCorporationBillingConfig,
 	TaxCorporationExclusion,
 	TaxNotificationDestination,
@@ -633,6 +664,10 @@ export type {
 	TaxRuleGroupAttachment,
 	TaxRuleSet,
 	TaxScheduledOperationsResult,
+	TaxAssessmentWorkflowOutput,
+	TaxAssessmentWorkflowParams,
+	TaxAssessmentWorkflowStartResult,
+	TaxAssessmentWorkflowStatusResult,
 	TaxSyncCheckpoint,
 	TaxSummaryReport,
 	TaxTopIncomeSourceMonthlyRow,
@@ -647,6 +682,7 @@ export type {
 	TaxRollupReportFilters,
 	TaxReportWindowFilters,
 	TaxMemberSummaryTopRefType,
+	TaxIncomeDisplayMode,
 	TriggerTaxProjectionRefreshInput,
 	TriggerTaxProjectionRefreshResult,
 	TriggerTaxAlertInput,

--- a/packages/corporation-tax/src/index.ts
+++ b/packages/corporation-tax/src/index.ts
@@ -472,6 +472,11 @@ export interface CorporationTax {
 	): Promise<TaxPagedResult<TaxMemberSummary>>
 
 	/**
+	 * Income types whose effective active rule for a corporation is taxable.
+	 */
+	getTaxableIncomeRefTypes(corporationId: string): Promise<string[]>
+
+	/**
 	 * Request a tax report export run.
 	 */
 	requestExport(actorUserId: string, input: RequestTaxExportInput): Promise<TaxExportRecord>

--- a/packages/corporation-tax/src/types.ts
+++ b/packages/corporation-tax/src/types.ts
@@ -632,7 +632,7 @@ export type TaxMemberComplianceStatus = 'underpaid' | 'paid' | 'overpaid' | 'no_
 export interface TaxMemberSummaryTopRefType {
 	refType: string
 	lineCount: number
-	contributionAmount?: string
+	contributionAmount: string
 	taxableAmount: string
 	taxAmount: string
 }
@@ -652,6 +652,7 @@ export interface TaxMemberSummary {
 export interface TaxMemberSummaryReportFilters {
 	corporationId: string
 	characterIds?: string[]
+	refTypes?: string[]
 	fromDate?: Date
 	toDate?: Date
 	topRefTypesLimit?: number

--- a/packages/corporation-tax/src/types.ts
+++ b/packages/corporation-tax/src/types.ts
@@ -55,6 +55,8 @@ export interface ListTaxAuditLogFilters {
 	toDate?: Date
 	limit?: number
 	offset?: number
+	sortBy?: 'createdAt' | 'corporationId' | 'actorUserId' | 'action'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface TaxRuleSet {
@@ -200,10 +202,19 @@ export interface ListTaxAssessmentsFilters {
 	status?: TaxAssessmentStatus
 	assessmentScope?: TaxAssessmentScope
 	withBillOnly?: boolean
+	unbilledOnly?: boolean
 	periodStart?: Date
 	periodEnd?: Date
 	limit?: number
 	offset?: number
+	sortBy?: 'taxPeriodEnd' | 'assessmentScope' | 'scopeId' | 'status' | 'taxDue' | 'taxDelta'
+	sortDir?: 'asc' | 'desc'
+}
+
+export interface TaxAssessmentPage extends TaxPagedResult<TaxAssessment> {
+	corporationAssessmentCount: number
+	unbilledAssessmentCount: number
+	overdueAssessmentCount: number
 }
 
 export interface RunTaxAssessmentForPeriodInput {
@@ -211,6 +222,37 @@ export interface RunTaxAssessmentForPeriodInput {
 	periodStart: Date
 	periodEnd: Date
 	includeCharacterWallets?: boolean
+}
+
+export interface TaxAssessmentWorkflowParams {
+	actorUserId: string
+	corporationId: string
+	periodStart: string
+	periodEnd: string
+	includeCharacterWallets?: boolean
+}
+
+export interface TaxAssessmentWorkflowOutput {
+	status: 'completed'
+	assessmentId: string
+	lineCount: number
+	discrepancyCount: number
+}
+
+export interface TaxAssessmentWorkflowStartResult {
+	workflowInstanceId: string
+	corporationId: string
+	periodStart: string
+	periodEnd: string
+	status: 'queued'
+}
+
+export interface TaxAssessmentWorkflowStatusResult {
+	workflowInstanceId: string
+	status: 'queued' | 'running' | 'paused' | 'waiting' | 'completed' | 'failed' | 'unknown'
+	rawStatus: string
+	output: TaxAssessmentWorkflowOutput | null
+	error: { name: string; message: string } | null
 }
 
 export interface RunTaxAssessmentForPeriodResult {
@@ -296,6 +338,8 @@ export interface TaxBillingEventHistoryRow {
 	metadata: Record<string, string | number | boolean | null> | null
 	createdAt: Date
 }
+
+export type TaxBillingEventSortBy = 'createdAt' | 'eventType' | 'billId' | 'actorUserId'
 
 export interface IssueBillsForPeriodInput {
 	corporationId: string
@@ -429,6 +473,8 @@ export interface TaxLedgerWindowFilters {
 	maxAmount?: string
 	limit?: number
 	offset?: number
+	sortBy?: 'entryDate' | 'amount' | 'division' | 'refType' | 'sourceType'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface ListTaxLedgerPartiesFilters {
@@ -516,11 +562,15 @@ export interface TaxRollupReportFilters {
 	corporationId?: string
 	fromDate?: Date
 	toDate?: Date
+	refTypes?: string[]
+	incomeMode?: TaxIncomeDisplayMode
 	limit?: number
 	offset?: number
 	sortBy?: string
 	sortDirection?: 'asc' | 'desc'
 }
+
+export type TaxIncomeDisplayMode = 'total' | 'assessed'
 
 export interface TaxPagedResult<TRow> {
 	rows: TRow[]
@@ -598,6 +648,8 @@ export interface TaxCompliancePoint {
 	taxDelta: string
 	entryCount: number
 }
+
+export type TaxComplianceSortBy = 'rollupDate' | 'taxDue' | 'taxPaid' | 'taxDelta' | 'entryCount'
 
 export interface TaxMissingEsiKeyRow {
 	corporationId: string
@@ -711,6 +763,15 @@ export interface ListTaxExportsFilters {
 	status?: TaxExportStatus
 	limit?: number
 	offset?: number
+	sortBy?:
+		| 'requestedAt'
+		| 'corporationId'
+		| 'reportType'
+		| 'format'
+		| 'status'
+		| 'rowCount'
+		| 'completedAt'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface TaxExportRecord {
@@ -760,6 +821,16 @@ export interface ListTaxExportSchedulesFilters {
 	activeOnly?: boolean
 	limit?: number
 	offset?: number
+	sortBy?:
+		| 'name'
+		| 'corporationId'
+		| 'reportType'
+		| 'format'
+		| 'frequency'
+		| 'isActive'
+		| 'nextRunAt'
+		| 'lastRunAt'
+	sortDir?: 'asc' | 'desc'
 }
 
 export interface TaxExportSchedule {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,9 @@ importers:
       '@repo/hono-helpers':
         specifier: workspace:*
         version: link:../../packages/hono-helpers
+      '@repo/workflow-utils':
+        specifier: workspace:*
+        version: link:../../packages/workflow-utils
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@cloudflare/workers-types@5.20260724.1)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(bun-types@1.3.2(@types/react@19.2.6))(mysql2@3.15.3)


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Overhauls the corporation tax UX: replaces the mantine-react-table-based report grids with a shared `TaxReportTable` built on the app's own table primitives, and reworks the member summary view with income-type filtering and clearer sorting. Backs these UX changes with new server-side sorting/filtering/paging support, a taxable-ref-types endpoint, and a new async tax assessment workflow.

## Changes
- Replace `mantine-react-table` in all tax report grids (bill-status, compliance, discrepancy, ess-payout, export-history, export-schedules, missing-esi-keys, tax-audit-log, total-taxes, member-summary) with a new shared `TaxReportTable` component and custom `SortableHead`, removing the MRT dependency.
- Rework the member summary route/grid: add an "Income Types" multi-select filter, "Taxable only" quick filter, prev/next month navigation, and a "Clear Filters" button; switch grid state to explicit `sortBy`/`sortDir`/`page`/`pageSize` props.
- Add `GET /corporations/:id/member-summary/taxable-ref-types` endpoint and thread a new `refTypes` filter through the member summary API, service, and SQL.
- Add a SQL-backed rollup path (`getMemberSummaryFromRollupsSql`) for server-side sorted/paginated member summary queries, with a new migration adding composite indexes on assessments/discrepancies/ledger/rollup tables and dropping the stale `portal_tax_rate_bps` column.
- Add `TaxAssessmentWorkflow` for durable/async tax assessment runs, wired into `wrangler.jsonc`.
- Page/sort corporation bill event history via a new `listBillStatusEventsByPayerPage` service/DO method instead of loading all assessment bill IDs.
- Fix tax reports nav visibility so CEO/Director corp roles see the Reports item without needing the auditor/admin permission.

## Testing
- Updated/added unit tests for the new `refTypes` filtering and taxable-ref-types route (`corporation-tax.route.test.ts`).
- New tests for bill event paging without loading all bill IDs, and for rollup-based member summary sorting/paging and ESI-coverage filtering (`tax-billing.service.test.ts`, `tax-report.service.test.ts`).
- Updated UI unit tests for member summary filters and `useTaxableIncomeRefTypes` (`corporation-tax-member-summary.test.ts`, `tax-member-summary.route.test.tsx`).
<!-- claude:end -->