### PR TITLE
add character selection to SRP killmail fetches

### DIFF
--- a/apps/core/src/routes/__tests__/srp.route.test.ts
+++ b/apps/core/src/routes/__tests__/srp.route.test.ts
@@ -797,6 +797,83 @@ describe('srp routes - permissions', () => {
 		})
 	})
 
+	it('passes only selected linked characters to recent loss refreshes', async () => {
+		const app = createApp(
+			makeUser({
+				id: 'loss-refresh-selected',
+				characters: [
+					{
+						id: 'char-link-1',
+						characterOwnerHash: 'owner-hash-1',
+						characterId: '7001',
+						characterName: 'Pilot One',
+						is_primary: true,
+						hasValidToken: true,
+					},
+					{
+						id: 'char-link-2',
+						characterOwnerHash: 'owner-hash-2',
+						characterId: '7002',
+						characterName: 'Pilot Two',
+						is_primary: false,
+						hasValidToken: true,
+					},
+				],
+			})
+		)
+
+		const response = await app.request(
+			'/api/srp/losses/refresh',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ characterIds: ['7002'] }),
+			},
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(refreshCoordinatorStub.startRecentLossRefresh).toHaveBeenCalledWith(
+			'loss-refresh-selected',
+			[{ characterId: '7002', characterName: 'Pilot Two' }],
+			30
+		)
+	})
+
+	it('rejects recent loss refreshes for characters not linked to the user', async () => {
+		const app = createApp(
+			makeUser({
+				id: 'loss-refresh-unlinked',
+				characters: [
+					{
+						id: 'char-link-1',
+						characterOwnerHash: 'owner-hash-1',
+						characterId: '7001',
+						characterName: 'Pilot One',
+						is_primary: true,
+						hasValidToken: true,
+					},
+				],
+			})
+		)
+
+		const response = await app.request(
+			'/api/srp/losses/refresh',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ characterIds: ['9999'] }),
+			},
+			env
+		)
+
+		expect(response.status).toBe(400)
+		expect(await response.json()).toEqual({
+			error: 'One or more selected characters are not linked to this user: 9999',
+		})
+		expect(refreshCoordinatorStub.startRecentLossRefresh).not.toHaveBeenCalled()
+	})
+
 	it('returns current recent-loss refresh status', async () => {
 		const app = createApp(makeUser({ id: 'loss-refresh-status' }))
 		refreshCoordinatorStub.getRecentLossRefreshStatus.mockResolvedValue({

--- a/apps/core/src/routes/srp.ts
+++ b/apps/core/src/routes/srp.ts
@@ -109,6 +109,33 @@ function isValidSrpRequestId(requestId: string): boolean {
 	return SRP_REQUEST_ID_PATTERN.test(requestId)
 }
 
+function resolveSrpCharacters(user: App['Variables']['user'], rawCharacterIds?: string) {
+	const characters = (user?.characters ?? []).map((character) => ({
+		characterId: character.characterId,
+		characterName: character.characterName,
+	}))
+	const normalizedRawIds = rawCharacterIds?.trim()
+	if (!normalizedRawIds) return { characters }
+
+	const requestedIds = [
+		...new Set(
+			normalizedRawIds
+				.split(',')
+				.map((id) => id.trim())
+				.filter(Boolean)
+		),
+	]
+	const characterById = new Map(characters.map((character) => [character.characterId, character]))
+	const invalidIds = requestedIds.filter((characterId) => !characterById.has(characterId))
+	if (invalidIds.length > 0) {
+		return {
+			error: `One or more selected characters are not linked to this user: ${invalidIds.join(', ')}`,
+		}
+	}
+
+	return { characters: requestedIds.map((characterId) => characterById.get(characterId)!) }
+}
+
 function normalizeUtcStartOfDay(date: Date): Date {
 	return new Date(
 		Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0)
@@ -712,7 +739,7 @@ srp.use('*', async (c, next) => {
 // =============================================================================
 
 /**
- * Get recent losses for all user's characters with SRP status.
+ * Get recent losses for selected user characters, or all when omitted, with SRP status.
  * The backend configuration is the source of truth for the lookback window.
  */
 srp.get('/losses', async (c) => {
@@ -730,10 +757,9 @@ srp.get('/losses', async (c) => {
 		return c.json({ error: pagination.error }, pagination.status)
 	}
 
-	// Get all character IDs for the user
-	const characters = user.characters.map((char) => ({
-		characterId: char.characterId,
-		characterName: char.characterName,
+	const characters = user.characters.map((character) => ({
+		characterId: character.characterId,
+		characterName: character.characterName,
 	}))
 
 	if (characters.length === 0) {
@@ -797,12 +823,30 @@ srp.post('/losses/:killmailId/dismiss', async (c) => {
 })
 
 /**
- * Trigger killmail refresh for all of the user's characters
+ * Trigger killmail refresh for selected user characters, or all when omitted
  * POST /api/srp/losses/refresh
  * Starts the background workflow and returns its handle for polling.
  */
 srp.post('/losses/refresh', async (c) => {
 	const user = c.get('user')!
+	let body: { characterIds?: unknown } = {}
+	try {
+		body = await c.req.json<{ characterIds?: unknown }>()
+	} catch {
+		// An empty request body is equivalent to selecting all characters.
+	}
+	const rawCharacterIds = Array.isArray(body.characterIds)
+		? body.characterIds.every((id) => typeof id === 'string')
+			? body.characterIds.join(',')
+			: undefined
+		: undefined
+	if (body.characterIds !== undefined && rawCharacterIds === undefined) {
+		return c.json({ error: 'characterIds must be an array of strings' }, 400)
+	}
+	const characterSelection = resolveSrpCharacters(user, rawCharacterIds)
+	if ('error' in characterSelection) {
+		return c.json({ error: characterSelection.error }, 400)
+	}
 	const srpStub = getStub<Srp>(c.env.SRP, 'default')
 	const refreshCoordinator = getStub<RecentLossRefreshCoordinator>(
 		c.env.SRP_RECENT_LOSS_REFRESH_COORDINATOR,
@@ -811,10 +855,7 @@ srp.post('/losses/refresh', async (c) => {
 	const config = await srpStub.getConfig()
 	const refreshAttempt = await refreshCoordinator.startRecentLossRefresh(
 		user.id,
-		user.characters.map((char) => ({
-			characterId: char.characterId,
-			characterName: char.characterName,
-		})),
+		characterSelection.characters,
 		config?.maxLossAgeDays ?? 30
 	)
 	if (!refreshAttempt.allowed) {

--- a/apps/ui/src/client/features/srp/hooks.ts
+++ b/apps/ui/src/client/features/srp/hooks.ts
@@ -1,9 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useMemo, useRef } from 'react'
 
-import { NotFoundError, api } from '@/lib/api'
-
-import type { UpdateSRPConfig } from '@repo/srp'
+import { api, NotFoundError } from '@/lib/api'
 
 import { srpKeys } from './query-keys'
 import {
@@ -31,18 +29,23 @@ import {
 	upsertRequestAcrossReviewQueueSnapshots,
 } from './state/review-queue-snapshot-store'
 
+import type { UpdateSRPConfig } from '@repo/srp'
+import type { FittingWithItems } from '@/lib/api'
+import type {
+	LossListEntry,
+	MyRequestsQueryData,
+	RecentLossesQueryData,
+} from './state/cache-updates'
 import type {
 	CommentVisibility,
+	RecentLossesResponse,
 	RequestListResponse,
 	RequestStatus,
-	RecentLossesResponse,
 	SRPCommentResponse,
-	SRPRequestResponse,
 	SRPPaymentMismatchAlert,
+	SRPRequestResponse,
 	SRPReviewSubmission,
 } from './types'
-import type { FittingWithItems } from '@/lib/api'
-import type { LossListEntry, MyRequestsQueryData, RecentLossesQueryData } from './state/cache-updates'
 
 function setLossStateAcrossCaches(
 	queryClient: ReturnType<typeof useQueryClient>,
@@ -53,10 +56,7 @@ function setLossStateAcrossCaches(
 			predicate: (query) => isSrpLossesQueryKey(query.queryKey),
 		},
 		(old) =>
-			patchLossesForRequest(
-				old as LossListEntry[] | RecentLossesQueryData | undefined,
-				request
-			)
+			patchLossesForRequest(old as LossListEntry[] | RecentLossesQueryData | undefined, request)
 	)
 }
 
@@ -64,8 +64,9 @@ function setRequestStatusAcrossCaches(
 	queryClient: ReturnType<typeof useQueryClient>,
 	request: SRPRequestResponse
 ): void {
-	queryClient.setQueryData(srpKeys.request(request.id), (existing: SRPRequestResponse | undefined) =>
-		existing ? { ...existing, ...request } : request
+	queryClient.setQueryData(
+		srpKeys.request(request.id),
+		(existing: SRPRequestResponse | undefined) => (existing ? { ...existing, ...request } : request)
 	)
 	queryClient.setQueriesData(
 		{
@@ -370,7 +371,7 @@ export function useSRPStats(params?: {
 export function useRefreshKillmails() {
 	const queryClient = useQueryClient()
 	return useMutation({
-		mutationFn: () => api.refreshLosses(),
+		mutationFn: (characterIds?: string[]) => api.refreshLosses(characterIds),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: srpKeys.lossRefreshStatus() })
 		},
@@ -400,7 +401,9 @@ export function useDoctrineFittingsForShip(shipTypeId: string | undefined) {
 			const candidates = await api.getFittings({ shipTypeId })
 			if (candidates.length === 0) return []
 			const uniqueCandidateIds = [...new Set(candidates.map((fitting) => fitting.id))]
-			const full = await Promise.all(uniqueCandidateIds.map((fittingId) => api.getFitting(fittingId)))
+			const full = await Promise.all(
+				uniqueCandidateIds.map((fittingId) => api.getFitting(fittingId))
+			)
 			const uniqueById = new Map(full.map((fitting) => [fitting.id, fitting]))
 			return [...uniqueById.values()]
 		},
@@ -571,7 +574,7 @@ export function useWithdrawRequest() {
 	return useMutation({
 		mutationFn: ({ id, notes }: { id: string; notes?: string }) =>
 			api.withdrawSRPRequest(id, notes ? { notes } : undefined),
-	onSuccess: (request: SRPRequestResponse) => {
+		onSuccess: (request: SRPRequestResponse) => {
 			updateOverlayRequestStatus({
 				requestId: request.id,
 				requestStatus: request.requestStatus,
@@ -663,15 +666,15 @@ export function useAddComment() {
 				createdAt: nowIso,
 			}
 
-			queryClient.setQueryData<SRPCommentResponse[]>(srpKeys.comments(requestId, true), (old = []) => [
-				...old,
-				optimisticComment,
-			])
+			queryClient.setQueryData<SRPCommentResponse[]>(
+				srpKeys.comments(requestId, true),
+				(old = []) => [...old, optimisticComment]
+			)
 			if (data.visibility === 'public') {
-				queryClient.setQueryData<SRPCommentResponse[]>(srpKeys.comments(requestId, false), (old = []) => [
-					...old,
-					optimisticComment,
-				])
+				queryClient.setQueryData<SRPCommentResponse[]>(
+					srpKeys.comments(requestId, false),
+					(old = []) => [...old, optimisticComment]
+				)
 			}
 
 			return { previousPublic, previousInternal, requestId, tempId }
@@ -684,11 +687,19 @@ export function useAddComment() {
 		onSuccess: (
 			comment: SRPCommentResponse,
 			variables: { requestId: string; data: { content: string; visibility: CommentVisibility } },
-			context: { previousPublic?: SRPCommentResponse[]; previousInternal?: SRPCommentResponse[]; requestId: string; tempId: string } | undefined
+			context:
+				| {
+						previousPublic?: SRPCommentResponse[]
+						previousInternal?: SRPCommentResponse[]
+						requestId: string
+						tempId: string
+				  }
+				| undefined
 		) => {
 			if (context) {
-				queryClient.setQueryData<SRPCommentResponse[]>(srpKeys.comments(variables.requestId, true), (old = []) =>
-					old.map((row) => (row.id === context.tempId ? comment : row))
+				queryClient.setQueryData<SRPCommentResponse[]>(
+					srpKeys.comments(variables.requestId, true),
+					(old = []) => old.map((row) => (row.id === context.tempId ? comment : row))
 				)
 				if (variables.data.visibility === 'public') {
 					queryClient.setQueryData<SRPCommentResponse[]>(
@@ -743,17 +754,19 @@ export function useMarkPaid() {
 			})
 			transitionRequestStatusAcrossReviewQueueSnapshots(id, 'paid')
 			let approvedAmountDelta = 0
-			const pendingPaymentQueries = queryClient.getQueriesData<{ requests?: SRPRequestResponse[] }>({
-				predicate: (query) => {
-					const key = query.queryKey
-					return (
-						Array.isArray(key) &&
-						key[0] === 'srp' &&
-						key[1] === 'payments' &&
-						key[2] === 'pending'
-					)
-				},
-			})
+			const pendingPaymentQueries = queryClient.getQueriesData<{ requests?: SRPRequestResponse[] }>(
+				{
+					predicate: (query) => {
+						const key = query.queryKey
+						return (
+							Array.isArray(key) &&
+							key[0] === 'srp' &&
+							key[1] === 'payments' &&
+							key[2] === 'pending'
+						)
+					},
+				}
+			)
 			for (const [, value] of pendingPaymentQueries) {
 				const request = value?.requests?.find((entry) => entry.id === id)
 				if (!request) continue

--- a/apps/ui/src/client/features/srp/query-keys.ts
+++ b/apps/ui/src/client/features/srp/query-keys.ts
@@ -4,7 +4,8 @@ export const srpKeys = {
 	all: ['srp'] as const,
 
 	// Losses
-	losses: (params?: { limit?: number; offset?: number }) => [...srpKeys.all, 'losses', params] as const,
+	losses: (params?: { limit?: number; offset?: number }) =>
+		[...srpKeys.all, 'losses', params] as const,
 	lossRefreshStatus: () => [...srpKeys.losses(), 'refresh-status'] as const,
 
 	// Requests
@@ -24,8 +25,7 @@ export const srpKeys = {
 			dateFrom?: string
 			dateTo?: string
 		}
-	) =>
-		[...srpKeys.requests(), 'by-status', status, params] as const,
+	) => [...srpKeys.requests(), 'by-status', status, params] as const,
 
 	// Pending reviews
 	pending: () => [...srpKeys.all, 'pending'] as const,

--- a/apps/ui/src/client/features/srp/routes/index.tsx
+++ b/apps/ui/src/client/features/srp/routes/index.tsx
@@ -1,17 +1,20 @@
 import { useEffect, useMemo, useState } from 'react'
 
+import { TableRefreshFrame } from '@/components/table-refresh-frame'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { PageHeader } from '@/components/ui/page-header'
-import { TableRefreshFrame } from '@/components/table-refresh-frame'
+import { Select } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 
 import {
 	LossTable,
-	RecentLossRefreshButton,
 	RecentLossesStatusAlerts,
+	RecentLossRefreshButton,
 } from '../components/LossTable'
 import { RequestTable } from '../components/RequestTable'
 import {
@@ -22,25 +25,43 @@ import {
 	useRefreshKillmails,
 	useSRPConfig,
 } from '../hooks'
-import {
-	setRecentLossesPage,
-	setRecentLossesPageSize,
-	setRecentLossesSnapshot,
-	useRecentLossesUiState,
-} from '../state/recent-losses-store'
+import { useSrpCharacterSelection } from '../state/character-selection'
 import {
 	setMyRequestsPage,
 	setMyRequestsPageSize,
 	setMyRequestsSnapshot,
 	useMyRequestsUiState,
 } from '../state/my-requests-store'
+import {
+	setRecentLossesPage,
+	setRecentLossesPageSize,
+	setRecentLossesSnapshot,
+	useRecentLossesUiState,
+} from '../state/recent-losses-store'
 
 import type { LossWithSRPStatus, RecentLossesResponse } from '../types'
 
 export default function SRPIndex() {
 	usePageTitle('SRP')
+	const { user } = useAuth()
 	const { data: config } = useSRPConfig()
 	const [activeTab, setActiveTab] = useState<'losses' | 'requests'>('losses')
+	const characterOptions = useMemo(
+		() =>
+			(user?.characters ?? []).map((character) => ({
+				value: character.characterId,
+				label: character.characterName,
+			})),
+		[user?.characters]
+	)
+	const {
+		selectedCharacterIds,
+		setSelectedCharacterIds,
+		isLoaded: characterSelectionLoaded,
+	} = useSrpCharacterSelection(
+		user?.id,
+		characterOptions.map((character) => character.value)
+	)
 	const lossPage = useRecentLossesUiState((state) => state.page)
 	const lossPageSize = useRecentLossesUiState((state) => state.pageSize)
 	const requestPage = useMyRequestsUiState((state) => state.page)
@@ -59,7 +80,7 @@ export default function SRPIndex() {
 			offset: (lossPage - 1) * lossPageSize,
 		},
 		{
-			enabled: activeTab === 'losses',
+			enabled: activeTab === 'losses' && Boolean(user?.id),
 		}
 	)
 	const lossOffset = (lossPage - 1) * lossPageSize
@@ -131,7 +152,9 @@ export default function SRPIndex() {
 	const lossRefreshAction = (
 		<RecentLossRefreshButton
 			isRefreshing={refreshMutation.isPending || lossesFetching}
-			onRefresh={() => refreshMutation.mutate()}
+			onRefresh={() =>
+				refreshMutation.mutate(selectedCharacterIds.length > 0 ? selectedCharacterIds : undefined)
+			}
 			refreshStatus={refreshStatusQuery.data?.status ?? null}
 			refreshCooldownUntil={refreshStatusQuery.data?.cooldownUntil ?? null}
 		/>
@@ -186,6 +209,37 @@ export default function SRPIndex() {
 											refreshErrorMessage={lossRefreshErrorMessage}
 											loadFailures={effectiveLossesData?.failedCharacters ?? loadFailures}
 										/>
+										<div className="w-full space-y-2 md:w-1/2">
+											<div className="text-sm font-medium">Characters to fetch</div>
+											<div className="flex min-w-0 gap-2">
+												<div className="min-w-0 flex-1">
+													<Select
+														options={characterOptions}
+														values={selectedCharacterIds}
+														onValuesChange={setSelectedCharacterIds}
+														multiple
+														searchable
+														placeholder="All characters"
+														disabled={!characterSelectionLoaded}
+														inputClassName="h-10"
+														contentClassName="w-[min(28rem,calc(100vw-2rem))] min-w-[min(28rem,calc(100vw-2rem))]"
+													/>
+												</div>
+												<Button
+													type="button"
+													variant="ghost"
+													size="sm"
+													showIcon={false}
+													disabled={!characterSelectionLoaded || selectedCharacterIds.length === 0}
+													onClick={() => setSelectedCharacterIds([])}
+												>
+													Reset
+												</Button>
+											</div>
+											<p className="text-xs text-muted-foreground">
+												Leave empty to fetch losses for all characters.
+											</p>
+										</div>
 										<TableRefreshFrame
 											isRefreshing={lossGridRefreshing || refreshMutation.isPending}
 											refreshMessage="Refreshing recent losses..."
@@ -203,7 +257,7 @@ export default function SRPIndex() {
 													}}
 													dismissingKillmailId={
 														dismissLossMutation.isPending
-															? dismissLossMutation.variables?.killmailId ?? null
+															? (dismissLossMutation.variables?.killmailId ?? null)
 															: null
 													}
 												/>
@@ -217,7 +271,7 @@ export default function SRPIndex() {
 													}}
 													dismissingKillmailId={
 														dismissLossMutation.isPending
-															? dismissLossMutation.variables?.killmailId ?? null
+															? (dismissLossMutation.variables?.killmailId ?? null)
 															: null
 													}
 												/>
@@ -232,7 +286,9 @@ export default function SRPIndex() {
 									<div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-center">
 										<p className="text-sm text-red-500">Failed to load requests</p>
 										<p className="text-xs text-muted-foreground">
-											{requestLoadError instanceof Error ? requestLoadError.message : 'Unknown error'}
+											{requestLoadError instanceof Error
+												? requestLoadError.message
+												: 'Unknown error'}
 										</p>
 									</div>
 								) : !effectiveRequestsData && requestGridLoading ? (

--- a/apps/ui/src/client/features/srp/state/character-selection.ts
+++ b/apps/ui/src/client/features/srp/state/character-selection.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+const STORAGE_KEY_PREFIX = 'srp.losses.selected-character-ids'
+
+function normalizeCharacterIds(characterIds: string[]): string[] {
+	return [...new Set(characterIds.map((characterId) => characterId.trim()).filter(Boolean))].sort()
+}
+
+function readStoredCharacterIds(storageKey: string): string[] {
+	try {
+		const value = window.localStorage.getItem(storageKey)
+		if (!value) return []
+		const parsed: unknown = JSON.parse(value)
+		return Array.isArray(parsed) && parsed.every((value) => typeof value === 'string')
+			? normalizeCharacterIds(parsed)
+			: []
+	} catch {
+		return []
+	}
+}
+
+export function useSrpCharacterSelection(
+	userId: string | undefined,
+	availableCharacterIds: string[]
+) {
+	const storageKey = userId ? `${STORAGE_KEY_PREFIX}:${userId}` : null
+	const availableCharacterIdsKey = availableCharacterIds.join(',')
+	const availableIds = useMemo(
+		() => normalizeCharacterIds(availableCharacterIds),
+		[availableCharacterIdsKey]
+	)
+	const availableIdSet = useMemo(() => new Set(availableIds), [availableIds])
+	const [selectedCharacterIds, setSelectedCharacterIdsState] = useState<string[]>([])
+	const [isLoaded, setIsLoaded] = useState(false)
+	const [loadedStorageKey, setLoadedStorageKey] = useState<string | null>(null)
+
+	useEffect(() => {
+		if (!storageKey) {
+			setSelectedCharacterIdsState([])
+			setIsLoaded(true)
+			setLoadedStorageKey(null)
+			return
+		}
+
+		setIsLoaded(false)
+		setSelectedCharacterIdsState(
+			readStoredCharacterIds(storageKey).filter((id) => availableIdSet.has(id))
+		)
+		setIsLoaded(true)
+		setLoadedStorageKey(storageKey)
+	}, [availableIdSet, storageKey])
+
+	useEffect(() => {
+		if (!isLoaded || !storageKey || loadedStorageKey !== storageKey) return
+		const validSelection = selectedCharacterIds.filter((id) => availableIdSet.has(id))
+		if (validSelection.length !== selectedCharacterIds.length) {
+			setSelectedCharacterIdsState(validSelection)
+			return
+		}
+		try {
+			window.localStorage.setItem(storageKey, JSON.stringify(validSelection))
+		} catch {
+			// Browser storage is optional; the in-memory selection remains usable.
+		}
+	}, [availableIdSet, isLoaded, loadedStorageKey, selectedCharacterIds, storageKey])
+
+	const setSelectedCharacterIds = useCallback(
+		(nextCharacterIds: string[]) => {
+			setSelectedCharacterIdsState(
+				normalizeCharacterIds(nextCharacterIds).filter((id) => availableIdSet.has(id))
+			)
+		},
+		[availableIdSet]
+	)
+
+	return {
+		selectedCharacterIds,
+		setSelectedCharacterIds,
+		isLoaded: isLoaded && loadedStorageKey === storageKey,
+	}
+}

--- a/apps/ui/src/client/lib/api.ts
+++ b/apps/ui/src/client/lib/api.ts
@@ -5128,7 +5128,7 @@ export class ApiClient {
 		return this.get(`/srp/stats${query ? `?${query}` : ''}`)
 	}
 
-	async refreshLosses(): Promise<{
+	async refreshLosses(characterIds?: string[]): Promise<{
 		allowed: boolean
 		retryAfterMs: number
 		cooldownUntil: string
@@ -5136,7 +5136,7 @@ export class ApiClient {
 		status?: 'queued' | 'running' | 'completed' | 'failed'
 		totalCharacters?: number
 	}> {
-		return this.post('/srp/losses/refresh', {})
+		return this.post('/srp/losses/refresh', characterIds?.length ? { characterIds } : {})
 	}
 
 	async getRecentLossRefreshStatus(): Promise<{


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Lets users pick which linked characters to include when refreshing SRP recent losses, instead of always fetching for every character on the account.

## Changes
- `apps/core/src/routes/srp.ts`: add `resolveSrpCharacters` to validate an optional `characterIds` list against the user's linked characters, returning a 400 error if any requested ID isn't linked; wire it into `POST /api/srp/losses/refresh` so the refresh coordinator is started only for the selected characters (all characters when omitted).
- `apps/ui/src/client/features/srp/state/character-selection.ts`: new `useSrpCharacterSelection` hook that persists a per-user character selection in `localStorage`, filtered against the currently available character IDs.
- `apps/ui/src/client/features/srp/routes/index.tsx`: add a multi-select "Characters to fetch" control (with a reset button) to the losses tab, and pass the selected character IDs through to the refresh mutation.
- `apps/ui/src/client/lib/api.ts` / `apps/ui/src/client/features/srp/hooks.ts`: thread an optional `characterIds` argument through `refreshLosses` / `useRefreshKillmails` to the API call.
- Minor formatting/import-order cleanup in `hooks.ts` and `query-keys.ts` (no behavioral change).

## Testing
- Added route tests in `apps/core/src/routes/__tests__/srp.route.test.ts` covering: refreshing losses for a selected subset of linked characters, and rejecting refresh requests that include character IDs not linked to the user.
<!-- claude:end -->