### PR TITLE
fix moon scans navigation and add QoL UX filtering and display

### DIFF
--- a/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
+++ b/apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts
@@ -153,6 +153,7 @@ describe('moon-scan profitability and batching behavior', () => {
 			getMoonsBySystemId: vi.fn().mockResolvedValue([]),
 			getRegionsBySystemIds: vi.fn().mockResolvedValue({}),
 			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({}),
+			resolveSolarSystemGeographyByIds: vi.fn().mockResolvedValue({}),
 			resolveStaticMoonsByIds: vi.fn().mockResolvedValue({}),
 			getMoonRegionIds: vi.fn().mockResolvedValue({}),
 			resolveRegionsByIds: vi.fn().mockResolvedValue({}),
@@ -336,6 +337,45 @@ describe('moon-scan profitability and batching behavior', () => {
 		expect(body.moons.find((m) => m.moonId === 'moon-2')?.composition).toBeNull()
 	})
 
+	it('returns composition IDs when ore name hydration is unavailable', async () => {
+		universeStub.resolveSolarSystemsByIds.mockResolvedValue({
+			'sys-1': { solarSystemId: 'sys-1', solarSystemName: 'Jita', securityStatus: '0.5' },
+		})
+		universeStub.resolveTypeNamesByIds.mockRejectedValue(
+			new Error('Universe temporarily unavailable')
+		)
+		universeStub.getMoonsBySystemId.mockResolvedValue([
+			{ moonId: 'moon-1', moonName: 'Moon 1', solarSystemId: 'sys-1' },
+		])
+		moonScanStub.getMoonCoverage.mockResolvedValue([
+			{ moonId: 'moon-1', hasScans: true, isVerified: true },
+		])
+		moonScanStub.getVerifiedCompositions.mockResolvedValue([
+			{
+				moonId: 'moon-1',
+				sourceScanId: 'scan-1',
+				verifiedAt: '2026-05-01T00:00:00.000Z',
+				verifiedBy: null,
+				ores: [{ oreTypeId: '45490', quantity: '1' }],
+			},
+		])
+
+		const app = createApp(makeUser())
+		const res = await app.request('/api/moon-scan/moons/system/sys-1', {}, env)
+		const body = (await res.json()) as {
+			moons: Array<{
+				composition: { ores: Array<{ oreTypeId: string; oreTypeName?: string }> } | null
+			}>
+		}
+
+		expect(res.status).toBe(200)
+		expect(body.moons[0]?.composition?.ores[0]).toEqual({
+			oreTypeId: '45490',
+			oreTypeName: '45490',
+			quantity: '1',
+		})
+	})
+
 	it('uses the database-backed page query for both pagination and profitability sorting', async () => {
 		moonScanStub.getVerifiedMoonPage.mockResolvedValue({
 			items: [
@@ -421,8 +461,16 @@ describe('moon-scan profitability and batching behavior', () => {
 		universeStub.resolveStaticMoonsByIds.mockResolvedValue({
 			'moon-1': { moonId: 'moon-1', moonName: 'Moon 1', solarSystemId: 'sys-1' },
 		})
-		universeStub.resolveSolarSystemsByIds.mockResolvedValue({
-			'sys-1': { solarSystemId: 'sys-1', solarSystemName: 'Jita', securityStatus: '0.5' },
+		universeStub.resolveSolarSystemGeographyByIds.mockResolvedValue({
+			'sys-1': {
+				solarSystemId: 'sys-1',
+				solarSystemName: 'Jita',
+				regionId: 'region-1',
+				regionName: 'The Forge',
+				constellationId: 'const-1',
+				constellationName: 'Kimotoro',
+				securityStatus: '0.5',
+			},
 		})
 		universeStub.getTypeMaterials.mockResolvedValue({
 			'45490': [{ materialTypeId: '16633', quantity: 100 }],

--- a/apps/core/src/routes/moon-scan.ts
+++ b/apps/core/src/routes/moon-scan.ts
@@ -425,6 +425,7 @@ type VerifiedMoonRegionCount = Awaited<
 
 type MoonRegionResponse = {
 	regionId: string
+	regionName: string
 	systems: Array<{
 		solarSystemId: string
 		solarSystemName: string
@@ -450,6 +451,33 @@ type MoonSystemResponse = {
 		isVerified: boolean
 		composition: VerifiedComposition | null
 	}>
+}
+
+async function hydrateCompositionOres(
+	universe: Universe,
+	compositions: VerifiedComposition[]
+): Promise<VerifiedComposition[]> {
+	const oreTypeIds = [
+		...new Set(compositions.flatMap((composition) => composition.ores.map((ore) => ore.oreTypeId))),
+	]
+	if (oreTypeIds.length === 0) return compositions
+
+	let typeNames: Record<string, InvType | null> = {}
+	try {
+		typeNames = await universe.resolveTypeNamesByIds(oreTypeIds)
+	} catch (error) {
+		logger.warn('[moon-scan] failed to hydrate composition ore names; returning IDs', {
+			error,
+			oreTypeIds,
+		})
+	}
+	return compositions.map((composition) => ({
+		...composition,
+		ores: composition.ores.map((ore) => ({
+			...ore,
+			oreTypeName: typeNames[ore.oreTypeId]?.typeName ?? ore.oreTypeId,
+		})),
+	}))
 }
 
 type MoonLeaderboardResponse = Awaited<ReturnType<MoonScanDO['getLeaderboard']>>
@@ -1074,8 +1102,20 @@ moonScanRoutes.get('/moons/region/:regionId', async (c) => {
 	const universe = getUniverseStub(c.env)
 	const moonScan = getMoonScanStub(c.env)
 
-	// Get all systems and stargates for the region
-	const systems = await universe.getSystemsByRegionId(regionId)
+	// Get all systems and static region metadata for the response payload.
+	const [systems, regionData]: [
+		Awaited<ReturnType<Universe['getSystemsByRegionId']>>,
+		Record<string, { regionId: string; regionName: string } | null>,
+	] = await Promise.all([
+		universe.getSystemsByRegionId(regionId),
+		universe.resolveRegionsByIds([regionId]).catch((error) => {
+			logger.warn('[moon-scan] failed to hydrate region name; returning region ID', {
+				error,
+				regionId,
+			})
+			return {} as Record<string, { regionId: string; regionName: string } | null>
+		}),
+	])
 
 	const [stargates, moonsBySystem] = await Promise.all([
 		universe.getStargatesBySystemIds(systems.map((s) => s.solarSystemId)),
@@ -1123,6 +1163,7 @@ moonScanRoutes.get('/moons/region/:regionId', async (c) => {
 
 	const response: MoonRegionResponse = {
 		regionId,
+		regionName: regionData[regionId]?.regionName ?? regionId,
 		systems: systems.map((s) => ({
 			solarSystemId: s.solarSystemId,
 			solarSystemName: s.solarSystemName,
@@ -1167,7 +1208,8 @@ moonScanRoutes.get('/moons/system/:systemId', async (c) => {
 
 	const verifiedMoonIds = compositions.filter((c) => c.isVerified).map((c) => c.moonId)
 	const verifiedComps = await moonScan.getVerifiedCompositions(verifiedMoonIds)
-	const verifiedCompMap = new Map(verifiedComps.map((v) => [v.moonId, v]))
+	const hydratedComps = await hydrateCompositionOres(universe, verifiedComps)
+	const verifiedCompMap = new Map(hydratedComps.map((v) => [v.moonId, v]))
 
 	const response: MoonSystemResponse = {
 		system: {
@@ -1485,12 +1527,9 @@ moonScanRoutes.get('/moons/:moonId', async (c) => {
 	if (!moon) return c.json({ error: 'Moon not found' }, 404)
 
 	// Enrich moon with system name
-	const systemsById = await universe.resolveSolarSystemsByIds([moon.solarSystemId])
+	const systemsById = await universe.resolveSolarSystemGeographyByIds([moon.solarSystemId])
 	const system = systemsById[moon.solarSystemId]
-
-	const profitability = composition
-		? await computeProfitability(composition, c.env, moonScan)
-		: null
+	if (!system) return c.json({ error: 'System not found' }, 404)
 
 	// Resolve character IDs to names via the cache
 	const characterIds = [
@@ -1499,24 +1538,50 @@ moonScanRoutes.get('/moons/:moonId', async (c) => {
 			...(composition?.verifiedBy ? [composition.verifiedBy] : []),
 		]),
 	]
-	const nameMap = await moonScan.resolveCharacterNames(characterIds)
-
+	const scanOreTypeIds = [
+		...new Set(scans.items.flatMap((scan) => scan.ores.map((ore) => ore.oreTypeId))),
+	]
+	const [hydratedComposition, profitability, nameMap, scanTypeNames] = await Promise.all([
+		composition
+			? hydrateCompositionOres(universe, [composition]).then(([value]) => value ?? null)
+			: null,
+		composition ? computeProfitability(composition, c.env, moonScan) : null,
+		moonScan.resolveCharacterNames(characterIds),
+		scanOreTypeIds.length > 0
+			? universe.resolveTypeNamesByIds(scanOreTypeIds).catch((error) => {
+					logger.warn('[moon-scan] failed to hydrate scan ore names; returning IDs', {
+						error,
+						scanOreTypeIds,
+					})
+					return {} as Record<string, InvType | null>
+				})
+			: ({} as Record<string, InvType | null>),
+	])
 	const enrichedScans = scans.items.map((s) => ({
 		...s,
+		ores: s.ores.map((ore) => ({
+			...ore,
+			oreTypeName: scanTypeNames[ore.oreTypeId]?.typeName ?? ore.oreTypeId,
+		})),
 		submittedByName: s.submittedBy ? (nameMap[s.submittedBy] ?? s.submittedBy) : null,
 	}))
 
-	const enrichedComposition = composition
+	const enrichedComposition = hydratedComposition
 		? {
-				...composition,
-				verifiedByName: composition.verifiedBy
-					? (nameMap[composition.verifiedBy] ?? composition.verifiedBy)
+				...hydratedComposition,
+				verifiedByName: hydratedComposition.verifiedBy
+					? (nameMap[hydratedComposition.verifiedBy] ?? hydratedComposition.verifiedBy)
 					: null,
 			}
 		: null
 
 	return c.json({
-		moon: { ...moon, solarSystemName: system?.solarSystemName ?? '' },
+		moon: {
+			...moon,
+			solarSystemName: system.solarSystemName,
+			regionName: system.regionName,
+			constellationName: system.constellationName,
+		},
 		scans: enrichedScans,
 		composition: enrichedComposition,
 		profitability,

--- a/apps/ui/src/client/features/moon-scan/components/OreCompositionBar.tsx
+++ b/apps/ui/src/client/features/moon-scan/components/OreCompositionBar.tsx
@@ -1,14 +1,59 @@
-import { getOreColor, getOreRarity } from '../ore-rarities'
+import { HoverPopover } from '@/components/ui/hover-popover'
 
-import type { MoonScanOre } from '../types'
+import { getOreColor, getOreRarity, RARITY_COLORS } from '../ore-rarities'
+
+import type { MoonScanOre, OreRarity } from '../types'
 
 interface Props {
 	ores: MoonScanOre[]
 	className?: string
 }
 
+const ORE_VARIANT_FILTERS = [
+	'brightness(0.78)',
+	'brightness(1)',
+	'brightness(1.22)',
+	'brightness(1.42)',
+]
+
+function RarityBadge({ rarity }: { rarity: OreRarity }) {
+	return (
+		<span
+			className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold text-white"
+			style={{ backgroundColor: RARITY_COLORS[rarity] }}
+		>
+			{rarity}
+		</span>
+	)
+}
+
+function getOreVariantIndexes(ores: MoonScanOre[]): Map<string, number> {
+	const oresByRarity = new Map<string, string[]>()
+	for (const ore of ores) {
+		const rarity = getOreRarity(ore.oreTypeId) ?? `unknown:${ore.oreTypeId}`
+		const typeIds = oresByRarity.get(rarity) ?? []
+		if (!typeIds.includes(ore.oreTypeId)) typeIds.push(ore.oreTypeId)
+		oresByRarity.set(rarity, typeIds)
+	}
+
+	const variantIndexes = new Map<string, number>()
+	for (const typeIds of oresByRarity.values()) {
+		if (typeIds.length < 2) continue
+		for (const [index, typeId] of [...typeIds].sort().entries()) {
+			variantIndexes.set(typeId, index % ORE_VARIANT_FILTERS.length)
+		}
+	}
+	return variantIndexes
+}
+
+function getOreVariantFilter(variantIndexes: Map<string, number>, oreTypeId: string) {
+	const variantIndex = variantIndexes.get(oreTypeId)
+	return variantIndex === undefined ? undefined : ORE_VARIANT_FILTERS[variantIndex]
+}
+
 export function OreCompositionBar({ ores, className = '' }: Props) {
 	const sorted = [...ores].sort((a, b) => parseFloat(b.quantity) - parseFloat(a.quantity))
+	const variantIndexes = getOreVariantIndexes(ores)
 	const filledPct = sorted.reduce((sum, ore) => sum + parseFloat(ore.quantity) * 100, 0)
 	const remainderPct = Math.max(0, 100 - filledPct)
 
@@ -17,12 +62,31 @@ export function OreCompositionBar({ ores, className = '' }: Props) {
 			<div className="flex h-4 w-full overflow-hidden rounded-sm border border-border/60 bg-muted/20">
 				{sorted.map((ore) => {
 					const pct = parseFloat(ore.quantity) * 100
+					const rarity = getOreRarity(ore.oreTypeId)
 					return (
-						<div
-							key={ore.oreTypeId}
-							title={`Type ${ore.oreTypeId} (${getOreRarity(ore.oreTypeId) ?? '?'}) — ${pct.toFixed(1)}%`}
-							style={{ width: `${pct}%`, backgroundColor: getOreColor(ore.oreTypeId) }}
-						/>
+						<div key={ore.oreTypeId} className="h-full" style={{ width: `${pct}%` }}>
+							<HoverPopover
+								fullWidth
+								triggerClassName="h-full w-full"
+								trigger={
+									<span
+										aria-label={ore.oreTypeName ?? `Type ${ore.oreTypeId}`}
+										className="block h-full cursor-help"
+										style={{
+											backgroundColor: getOreColor(ore.oreTypeId),
+											filter: getOreVariantFilter(variantIndexes, ore.oreTypeId),
+										}}
+									/>
+								}
+								className="border border-border bg-popover px-3 py-2 text-popover-foreground shadow-lg"
+							>
+								<div className="flex items-center gap-2 text-sm font-medium">
+									{rarity ? <RarityBadge rarity={rarity} /> : null}
+									<span>{ore.oreTypeName ?? `Type ${ore.oreTypeId}`}</span>
+								</div>
+								<div className="text-xs text-muted-foreground">{pct.toFixed(1)}% composition</div>
+							</HoverPopover>
+						</div>
 					)
 				})}
 				{remainderPct > 0 && (
@@ -37,9 +101,18 @@ export function OreCompositionBar({ ores, className = '' }: Props) {
 				{sorted.map((ore) => {
 					const pct = parseFloat(ore.quantity) * 100
 					return (
-						<span key={ore.oreTypeId} className="flex items-center gap-1 text-xs text-muted-foreground">
-							<span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: getOreColor(ore.oreTypeId) }} />
-							{getOreRarity(ore.oreTypeId) ?? ore.oreTypeId} {pct.toFixed(1)}%
+						<span
+							key={ore.oreTypeId}
+							className="flex items-center gap-1 text-xs text-muted-foreground"
+						>
+							<span
+								className="inline-block h-2 w-2 rounded-sm"
+								style={{
+									backgroundColor: getOreColor(ore.oreTypeId),
+									filter: getOreVariantFilter(variantIndexes, ore.oreTypeId),
+								}}
+							/>
+							{ore.oreTypeName ?? ore.oreTypeId} {pct.toFixed(1)}%
 						</span>
 					)
 				})}

--- a/apps/ui/src/client/features/moon-scan/components/RegionMap.tsx
+++ b/apps/ui/src/client/features/moon-scan/components/RegionMap.tsx
@@ -14,6 +14,7 @@ interface Props {
 	jumpLinks: JumpLink[]
 	coords: DotlanCoords
 	borderRegions: Record<string, { regionId: string; regionName: string }>
+	from: string
 	highlightedSystemIds?: Set<string>
 }
 
@@ -22,8 +23,8 @@ interface Props {
 // The visual rect center is at coord + (OX, OY).
 const RW = 58
 const RH = 16
-const OX = 29    // half cell width → horizontal center
-const OY = 14.5  // cell center height (rect at y+3.5, size 22, center = y+14.5)
+const OX = 29 // half cell width → horizontal center
+const OY = 14.5 // cell center height (rect at y+3.5, size 22, center = y+14.5)
 
 function sysFill(moonCount: number, verifiedCount: number, scannedCount: number): string {
 	if (moonCount === 0) return '#151c24'
@@ -62,6 +63,7 @@ export function RegionMap({
 	jumpLinks,
 	coords,
 	borderRegions = {},
+	from,
 	highlightedSystemIds,
 }: Props) {
 	const navigate = useNavigate()
@@ -75,7 +77,9 @@ export function RegionMap({
 	// Border nodes = systems in the dotlan JSON that aren't in this region,
 	// but only those with an actual stargate connection in jumpLinks.
 	const borderSystemIds = new Set(
-		jumpLinks.flatMap((l) => [l.from, l.to]).filter((id) => !systemIds.has(id) && id in coordSystems)
+		jumpLinks
+			.flatMap((l) => [l.from, l.to])
+			.filter((id) => !systemIds.has(id) && id in coordSystems)
 	)
 	// Expand the viewbox so nodes at the edges get equal breathing room on all sides.
 	const PAD = 20
@@ -83,7 +87,8 @@ export function RegionMap({
 	const minX = (allCoords.length ? Math.min(...allCoords.map((p) => p[0])) : 0) - RW / 2 - PAD
 	const minY = (allCoords.length ? Math.min(...allCoords.map((p) => p[1])) : 0) + OY - RH / 2 - PAD
 	const maxX = (allCoords.length ? Math.max(...allCoords.map((p) => p[0])) : 1024) + RW / 2 + PAD
-	const maxY = (allCoords.length ? Math.max(...allCoords.map((p) => p[1])) : 768) + OY + RH / 2 + PAD
+	const maxY =
+		(allCoords.length ? Math.max(...allCoords.map((p) => p[1])) : 768) + OY + RH / 2 + PAD
 	const [vx, vy, vw, vh] = [minX, minY, maxX - minX, maxY - minY]
 
 	function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
@@ -142,7 +147,12 @@ export function RegionMap({
 						<g
 							key={`border-${sysId}`}
 							style={{ cursor: region ? 'pointer' : 'default' }}
-							onClick={() => region && navigate(`/moon-scan/region/${region.regionId}`)}
+							onClick={() =>
+								region &&
+								navigate(`/moon-scan/region/${region.regionId}`, {
+									state: { regionName: region.regionName },
+								})
+							}
 						>
 							<rect
 								x={cx - RW / 2}
@@ -192,7 +202,12 @@ export function RegionMap({
 							key={sysId}
 							opacity={dimmed ? 0.2 : 1}
 							style={{ cursor: eligible ? 'pointer' : 'default' }}
-							onClick={() => eligible && navigate(`/moon-scan/system/${sysId}`)}
+							onClick={() =>
+								eligible &&
+								navigate(`/moon-scan/system/${sysId}`, {
+									state: { from, systemName: sys.solarSystemName },
+								})
+							}
 							onMouseEnter={() =>
 								setTooltip({
 									name: sys.solarSystemName,
@@ -254,8 +269,7 @@ export function RegionMap({
 						zIndex: 10,
 					}}
 				>
-					<span style={{ color: '#3d9ae8', fontWeight: 600 }}>{tooltip.name}</span>
-					{' '}
+					<span style={{ color: '#3d9ae8', fontWeight: 600 }}>{tooltip.name}</span>{' '}
 					<span style={{ color: '#6b7c8f' }}>({tooltip.sec})</span>
 					{tooltip.moonCount > 0 ? (
 						<>
@@ -264,8 +278,11 @@ export function RegionMap({
 							{tooltip.moonCount}
 							{'  '}
 							<span style={{ color: '#6b7c8f' }}>Verified: </span>
-							{tooltip.verifiedCount}
-							{' '}({tooltip.moonCount > 0 ? Math.round(tooltip.verifiedCount / tooltip.moonCount * 100) : 0}%)
+							{tooltip.verifiedCount} (
+							{tooltip.moonCount > 0
+								? Math.round((tooltip.verifiedCount / tooltip.moonCount) * 100)
+								: 0}
+							%)
 						</>
 					) : null}
 				</div>
@@ -274,23 +291,38 @@ export function RegionMap({
 			{/* Legend */}
 			<div className="flex flex-wrap items-center gap-4 border-t px-3 py-2 text-xs text-muted-foreground">
 				<span className="flex items-center gap-1.5">
-					<span className="inline-block h-3 w-8 rounded" style={{ background: '#1a3320', border: '1px solid #28a745' }} />
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{ background: '#1a3320', border: '1px solid #28a745' }}
+					/>
 					100% Verified
 				</span>
 				<span className="flex items-center gap-1.5">
-					<span className="inline-block h-3 w-8 rounded" style={{ background: '#332a10', border: '1px solid #c89b20' }} />
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{ background: '#332a10', border: '1px solid #c89b20' }}
+					/>
 					Partially Scanned
 				</span>
 				<span className="flex items-center gap-1.5">
-					<span className="inline-block h-3 w-8 rounded" style={{ background: '#1e2830', border: '1px solid #4a5a6a' }} />
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{ background: '#1e2830', border: '1px solid #4a5a6a' }}
+					/>
 					Has Moons
 				</span>
 				<span className="flex items-center gap-1.5">
-					<span className="inline-block h-3 w-8 rounded" style={{ background: '#151c24', border: '1px solid #2a3644' }} />
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{ background: '#151c24', border: '1px solid #2a3644' }}
+					/>
 					No Moons
 				</span>
 				<span className="flex items-center gap-1.5">
-					<span className="inline-block h-3 w-8 rounded" style={{ background: '#0d1a26', border: '1px dashed #3a5a7a' }} />
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{ background: '#0d1a26', border: '1px dashed #3a5a7a' }}
+					/>
 					Other Region
 				</span>
 				<span className="text-muted-foreground/60">Click eligible system to view details</span>

--- a/apps/ui/src/client/features/moon-scan/routes/index.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/index.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 
 import { Card, CardContent } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
@@ -18,33 +18,76 @@ import { usePageTitle } from '@/hooks/usePageTitle'
 
 import { useMoonRegions } from '../hooks'
 import { useMoonScanPermissions } from '../permissions'
+
 import type { RegionSummary } from '../types'
 
 // Dotlan-exact region center coordinates for the universe map.
 // Excludes inaccessible Jove regions (10000004 UUA-F4, 10000017 J7HZ-F, 10000019 A821-A)
 // and Pochven (10000070) which is not k-space moon mining territory.
 const DOTLAN_COORDS: Record<string, [number, number]> = {
-	'10000001': [441.5, 371.5], '10000002': [422.5, 214.5], '10000003': [434.5, 136.5],
-	'10000005': [602.5, 474.5], '10000006': [556.5, 432.5], '10000007': [676.5, 298.5],
-	'10000008': [570.5, 382.5], '10000009': [646.5, 396.5], '10000010': [368.5, 106.5],
-	'10000011': [562.5, 328.5], '10000012': [470.5, 416.5], '10000013': [587.5, 185.5],
-	'10000014': [382.5, 486.5], '10000015': [378.5, 66.5],  '10000016': [367.5, 156.5],
-	'10000018': [644.5, 217.5], '10000020': [249.5, 419.5], '10000021': [676.5, 160.5],
-	'10000022': [309.5, 511.5], '10000023': [299.5, 112.5], '10000025': [464.5, 464.5],
-	'10000027': [530.5, 211.5], '10000028': [498.5, 318.5], '10000029': [472.5, 178.5],
-	'10000030': [438.5, 309.5], '10000031': [404.5, 530.5], '10000032': [288.5, 269.5],
-	'10000033': [352.5, 213.5], '10000034': [526.5, 149.5], '10000035': [281.5, 34.5],
-	'10000036': [347.5, 385.5], '10000037': [225.5, 262.5], '10000038': [347.5, 340.5],
-	'10000039': [284.5, 552.5], '10000040': [644.5, 111.5], '10000041': [121.5, 188.5],
-	'10000042': [465.5, 268.5], '10000043': [278.5, 374.5], '10000044': [113.5, 281.5],
-	'10000045': [415.5, 18.5],  '10000046': [275.5, 72.5],  '10000047': [347.5, 440.5],
-	'10000048': [208.5, 168.5], '10000049': [149.5, 426.5], '10000050': [189.5, 482.5],
-	'10000051': [172.5, 101.5], '10000052': [219.5, 352.5], '10000053': [679.5, 74.5],
-	'10000054': [93.5, 361.5],  '10000055': [341.5, 15.5],  '10000056': [398.5, 579.5],
-	'10000057': [76.5, 123.5],  '10000058': [28.5, 233.5],  '10000059': [219.5, 575.5],
-	'10000060': [70.5, 462.5],  '10000061': [479.5, 510.5], '10000062': [469.5, 560.5],
-	'10000063': [96.5, 542.5],  '10000064': [220.5, 206.5], '10000065': [172.5, 384.5],
-	'10000066': [582.5, 124.5], '10000067': [162.5, 329.5], '10000068': [160.5, 240.5],
+	'10000001': [441.5, 371.5],
+	'10000002': [422.5, 214.5],
+	'10000003': [434.5, 136.5],
+	'10000005': [602.5, 474.5],
+	'10000006': [556.5, 432.5],
+	'10000007': [676.5, 298.5],
+	'10000008': [570.5, 382.5],
+	'10000009': [646.5, 396.5],
+	'10000010': [368.5, 106.5],
+	'10000011': [562.5, 328.5],
+	'10000012': [470.5, 416.5],
+	'10000013': [587.5, 185.5],
+	'10000014': [382.5, 486.5],
+	'10000015': [378.5, 66.5],
+	'10000016': [367.5, 156.5],
+	'10000018': [644.5, 217.5],
+	'10000020': [249.5, 419.5],
+	'10000021': [676.5, 160.5],
+	'10000022': [309.5, 511.5],
+	'10000023': [299.5, 112.5],
+	'10000025': [464.5, 464.5],
+	'10000027': [530.5, 211.5],
+	'10000028': [498.5, 318.5],
+	'10000029': [472.5, 178.5],
+	'10000030': [438.5, 309.5],
+	'10000031': [404.5, 530.5],
+	'10000032': [288.5, 269.5],
+	'10000033': [352.5, 213.5],
+	'10000034': [526.5, 149.5],
+	'10000035': [281.5, 34.5],
+	'10000036': [347.5, 385.5],
+	'10000037': [225.5, 262.5],
+	'10000038': [347.5, 340.5],
+	'10000039': [284.5, 552.5],
+	'10000040': [644.5, 111.5],
+	'10000041': [121.5, 188.5],
+	'10000042': [465.5, 268.5],
+	'10000043': [278.5, 374.5],
+	'10000044': [113.5, 281.5],
+	'10000045': [415.5, 18.5],
+	'10000046': [275.5, 72.5],
+	'10000047': [347.5, 440.5],
+	'10000048': [208.5, 168.5],
+	'10000049': [149.5, 426.5],
+	'10000050': [189.5, 482.5],
+	'10000051': [172.5, 101.5],
+	'10000052': [219.5, 352.5],
+	'10000053': [679.5, 74.5],
+	'10000054': [93.5, 361.5],
+	'10000055': [341.5, 15.5],
+	'10000056': [398.5, 579.5],
+	'10000057': [76.5, 123.5],
+	'10000058': [28.5, 233.5],
+	'10000059': [219.5, 575.5],
+	'10000060': [70.5, 462.5],
+	'10000061': [479.5, 510.5],
+	'10000062': [469.5, 560.5],
+	'10000063': [96.5, 542.5],
+	'10000064': [220.5, 206.5],
+	'10000065': [172.5, 384.5],
+	'10000066': [582.5, 124.5],
+	'10000067': [162.5, 329.5],
+	'10000068': [160.5, 240.5],
 	'10000069': [310.5, 174.5],
 }
 
@@ -168,6 +211,7 @@ export default function MoonScanIndex() {
 	const { canView, canSubmit, canValidate, canAdmin, canAccessMoonScan, canLeaderboard } =
 		useMoonScanPermissions()
 	const navigate = useNavigate()
+	const [searchParams, setSearchParams] = useSearchParams()
 	const mapWrapRef = useRef<HTMLDivElement>(null)
 
 	const { data, isLoading, error } = useMoonRegions(canView)
@@ -176,12 +220,15 @@ export default function MoonScanIndex() {
 
 	const [tooltip, setTooltip] = useState<TooltipState | null>(null)
 	const [tooltipPx, setTooltipPx] = useState<{ x: number; y: number } | null>(null)
-	const [regionSearch, setRegionSearch] = useState('')
+	const regionSearch = searchParams.get('region') ?? ''
 
 	if (!canAccessMoonScan) {
 		return (
 			<Container>
-				<PageHeader title="Moon Scanning" description="You do not have permission to view moon data." />
+				<PageHeader
+					title="Moon Scanning"
+					description="You do not have permission to view moon data."
+				/>
 			</Container>
 		)
 	}
@@ -189,8 +236,16 @@ export default function MoonScanIndex() {
 	const accessTiles: Array<{ to: string; title: string; description: string }> = []
 	if (canSubmit) {
 		accessTiles.push(
-			{ to: '/moon-scan/submit', title: 'Submit Scan', description: 'Paste and submit moon scan results.' },
-			{ to: '/moon-scan/my-scans', title: 'My Scans', description: 'Review scans you have submitted.' },
+			{
+				to: '/moon-scan/submit',
+				title: 'Submit Scan',
+				description: 'Paste and submit moon scan results.',
+			},
+			{
+				to: '/moon-scan/my-scans',
+				title: 'My Scans',
+				description: 'Review scans you have submitted.',
+			}
 		)
 	}
 	if (canLeaderboard) {
@@ -210,7 +265,11 @@ export default function MoonScanIndex() {
 	if (canView) {
 		accessTiles.push(
 			{ to: '/moon-scan', title: 'Regions', description: 'Browse k-space regions and coverage.' },
-			{ to: '/moon-scan/scanned', title: 'Scanned Moons', description: 'Inspect verified moon compositions.' }
+			{
+				to: '/moon-scan/scanned',
+				title: 'Scanned Moons',
+				description: 'Inspect verified moon compositions.',
+			}
 		)
 	}
 	if (canAdmin) {
@@ -225,7 +284,10 @@ export default function MoonScanIndex() {
 		return (
 			<Container>
 				<div className="mb-4">
-					<PageHeader title="Moon Scanning" description="Choose one of the available moon scan tools." />
+					<PageHeader
+						title="Moon Scanning"
+						description="Choose one of the available moon scan tools."
+					/>
 				</div>
 				<Card className="mt-section">
 					<CardContent className="grid gap-3 p-4 sm:grid-cols-2 xl:grid-cols-3">
@@ -240,6 +302,12 @@ export default function MoonScanIndex() {
 
 	const sorted = [...(regions ?? [])].sort((a, b) => a.regionName.localeCompare(b.regionName))
 	const normalizedRegionSearch = regionSearch.trim().toLowerCase()
+	const updateRegionSearch = (value: string) => {
+		const next = new URLSearchParams(searchParams)
+		if (value.trim()) next.set('region', value)
+		else next.delete('region')
+		setSearchParams(next, { replace: true })
+	}
 	const filteredRegions = normalizedRegionSearch
 		? sorted.filter((r) => r.regionName.toLowerCase().includes(normalizedRegionSearch))
 		: sorted
@@ -261,9 +329,7 @@ export default function MoonScanIndex() {
 	return (
 		<Container>
 			<div className="mb-4">
-				<PageHeader
-					title="Moon Scanning"
-				/>
+				<PageHeader title="Moon Scanning" />
 			</div>
 
 			{error && (
@@ -277,10 +343,10 @@ export default function MoonScanIndex() {
 				<Skeleton className="h-[500px] w-full rounded-md" />
 			) : (
 				<Card
-						ref={mapWrapRef}
-						className="relative"
-						style={{ background: MAP_COLORS.background }}
-						onMouseMove={handleMouseMove}
+					ref={mapWrapRef}
+					className="relative"
+					style={{ background: MAP_COLORS.background }}
+					onMouseMove={handleMouseMove}
 					onMouseLeave={() => setTooltip(null)}
 				>
 					<svg
@@ -300,10 +366,10 @@ export default function MoonScanIndex() {
 									key={i}
 									x1={fromPos[0]}
 									y1={fromPos[1]}
-										x2={toPos[0]}
-										y2={toPos[1]}
-										stroke={MAP_COLORS.connection}
-										strokeWidth={1}
+									x2={toPos[0]}
+									y2={toPos[1]}
+									stroke={MAP_COLORS.connection}
+									strokeWidth={1}
 									opacity={0.7}
 								/>
 							)
@@ -316,7 +382,11 @@ export default function MoonScanIndex() {
 								region={r}
 								dimmed={hasActiveRegionFilter && !highlightedRegionIds.has(r.regionId)}
 								onHover={handleNodeHover}
-								onClick={() => navigate(`/moon-scan/region/${r.regionId}`)}
+								onClick={() =>
+									navigate(`/moon-scan/region/${r.regionId}`, {
+										state: { regionName: r.regionName },
+									})
+								}
 							/>
 						))}
 					</svg>
@@ -324,32 +394,36 @@ export default function MoonScanIndex() {
 					{/* Tooltip */}
 					{tooltip && tooltipPx && (
 						<div
-								style={{
-									position: 'absolute',
-									left: tooltipPx.x,
-									top: tooltipPx.y,
-									background: MAP_COLORS.tooltipBackground,
-									border: `1px solid ${MAP_COLORS.tooltipBorder}`,
-									color: MAP_COLORS.tooltipText,
-									padding: '6px 10px',
+							style={{
+								position: 'absolute',
+								left: tooltipPx.x,
+								top: tooltipPx.y,
+								background: MAP_COLORS.tooltipBackground,
+								border: `1px solid ${MAP_COLORS.tooltipBorder}`,
+								color: MAP_COLORS.tooltipText,
+								padding: '6px 10px',
 								borderRadius: 4,
 								fontSize: '0.8rem',
 								pointerEvents: 'none',
 								whiteSpace: 'nowrap',
 								zIndex: 10,
 							}}
-							>
-								<span style={{ color: MAP_COLORS.tooltipBorder, fontWeight: 600 }}>{tooltip.region.regionName}</span>
-								<br />
-								<span style={{ color: MAP_COLORS.tooltipMuted }}>Systems: </span>{tooltip.region.systemCount}
-								{'  '}
-								<span style={{ color: MAP_COLORS.tooltipMuted }}>Moons: </span>{tooltip.region.moonCount}
-								{tooltip.region.moonCount > 0 && (
-									<>
-										<br />
-										<span style={{ color: MAP_COLORS.tooltipMuted }}>Verified: </span>
-										{tooltip.region.verifiedCount}
-										{' '}({Math.round(tooltip.region.verifiedCount / tooltip.region.moonCount * 100)}%)
+						>
+							<span style={{ color: MAP_COLORS.tooltipBorder, fontWeight: 600 }}>
+								{tooltip.region.regionName}
+							</span>
+							<br />
+							<span style={{ color: MAP_COLORS.tooltipMuted }}>Systems: </span>
+							{tooltip.region.systemCount}
+							{'  '}
+							<span style={{ color: MAP_COLORS.tooltipMuted }}>Moons: </span>
+							{tooltip.region.moonCount}
+							{tooltip.region.moonCount > 0 && (
+								<>
+									<br />
+									<span style={{ color: MAP_COLORS.tooltipMuted }}>Verified: </span>
+									{tooltip.region.verifiedCount} (
+									{Math.round((tooltip.region.verifiedCount / tooltip.region.moonCount) * 100)}%)
 								</>
 							)}
 						</div>
@@ -358,85 +432,117 @@ export default function MoonScanIndex() {
 			)}
 
 			{/* Legend */}
-				<div className="mt-2 mb-4 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
-					<span className="flex items-center gap-1.5">
-						<span className="inline-block h-3 w-8 rounded" style={{ background: MAP_COLORS.verifiedFill, border: `1px solid ${MAP_COLORS.verifiedStroke}` }} />
-						100% Verified
-					</span>
-					<span className="flex items-center gap-1.5">
-						<span className="inline-block h-3 w-8 rounded" style={{ background: MAP_COLORS.partialFill, border: `1px solid ${MAP_COLORS.partialStroke}` }} />
-						Partially Scanned
-					</span>
-					<span className="flex items-center gap-1.5">
-						<span className="inline-block h-3 w-8 rounded" style={{ background: MAP_COLORS.hasMoonFill, border: `1px solid ${MAP_COLORS.hasMoonStroke}` }} />
-						Has Moons
-					</span>
-					<span className="flex items-center gap-1.5">
-						<span className="inline-block h-3 w-8 rounded" style={{ background: MAP_COLORS.emptyFill, border: `1px solid ${MAP_COLORS.emptyStroke}` }} />
-						No Moon Data
-					</span>
+			<div className="mt-2 mb-4 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+				<span className="flex items-center gap-1.5">
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{
+							background: MAP_COLORS.verifiedFill,
+							border: `1px solid ${MAP_COLORS.verifiedStroke}`,
+						}}
+					/>
+					100% Verified
+				</span>
+				<span className="flex items-center gap-1.5">
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{
+							background: MAP_COLORS.partialFill,
+							border: `1px solid ${MAP_COLORS.partialStroke}`,
+						}}
+					/>
+					Partially Scanned
+				</span>
+				<span className="flex items-center gap-1.5">
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{
+							background: MAP_COLORS.hasMoonFill,
+							border: `1px solid ${MAP_COLORS.hasMoonStroke}`,
+						}}
+					/>
+					Has Moons
+				</span>
+				<span className="flex items-center gap-1.5">
+					<span
+						className="inline-block h-3 w-8 rounded"
+						style={{
+							background: MAP_COLORS.emptyFill,
+							border: `1px solid ${MAP_COLORS.emptyStroke}`,
+						}}
+					/>
+					No Moon Data
+				</span>
 				<span className="text-muted-foreground/60">Click region to open</span>
 			</div>
 
-				{/* Regions Table */}
-				<Card>
-					<div className="border-b px-4 py-2.5">
-						<div className="flex items-center justify-between gap-2">
-							<div className="text-sm font-medium">Regions</div>
-							<Input
-								value={regionSearch}
-								onChange={(e) => setRegionSearch(e.target.value)}
-								placeholder="Filter regions..."
-								className="h-8 w-full sm:w-64"
-							/>
-						</div>
+			{/* Regions Table */}
+			<Card>
+				<div className="border-b px-4 py-2.5">
+					<div className="flex items-center justify-between gap-2">
+						<div className="text-sm font-medium">Regions</div>
+						<Input
+							value={regionSearch}
+							onChange={(e) => updateRegionSearch(e.target.value)}
+							placeholder="Filter regions..."
+							className="h-8 w-full sm:w-64"
+						/>
 					</div>
-					<div className="overflow-x-auto">
-						<Table>
-							<TableHeader>
+				</div>
+				<div className="overflow-x-auto">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Region</TableHead>
+								<TableHead className="text-right">Systems</TableHead>
+								<TableHead className="text-right">Moons</TableHead>
+								<TableHead className="text-right">Verified</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading
+								? Array.from({ length: 10 }).map((_, i) => (
+										<TableRow key={i}>
+											<TableCell colSpan={4}>
+												<Skeleton className="h-4 w-32" />
+											</TableCell>
+										</TableRow>
+									))
+								: filteredRegions.map((r) => (
+										<TableRow
+											key={r.regionId}
+											className="cursor-pointer hover:bg-accent/50 transition-colors"
+											onClick={() =>
+												navigate(`/moon-scan/region/${r.regionId}`, {
+													state: { regionName: r.regionName },
+												})
+											}
+										>
+											<TableCell className="font-medium">{r.regionName}</TableCell>
+											<TableCell className="text-right tabular-nums text-muted-foreground">
+												{r.systemCount}
+											</TableCell>
+											<TableCell className="text-right tabular-nums">
+												{r.moonCount || '—'}
+											</TableCell>
+											<TableCell className="text-right tabular-nums">
+												{r.moonCount > 0
+													? `${r.verifiedCount} (${Math.round((r.verifiedCount / r.moonCount) * 100)}%)`
+													: '—'}
+											</TableCell>
+										</TableRow>
+									))}
+							{!isLoading && filteredRegions.length === 0 && (
 								<TableRow>
-									<TableHead>Region</TableHead>
-									<TableHead className="text-right">Systems</TableHead>
-									<TableHead className="text-right">Moons</TableHead>
-									<TableHead className="text-right">Verified</TableHead>
+									<TableCell colSpan={4} className="py-8 text-center text-sm text-muted-foreground">
+										No regions match the current filter.
+									</TableCell>
 								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{isLoading
-									? Array.from({ length: 10 }).map((_, i) => (
-											<TableRow key={i}>
-												<TableCell colSpan={4}>
-													<Skeleton className="h-4 w-32" />
-												</TableCell>
-											</TableRow>
-										))
-									: filteredRegions.map((r) => (
-											<TableRow
-												key={r.regionId}
-												className="cursor-pointer hover:bg-accent/50 transition-colors"
-												onClick={() => navigate(`/moon-scan/region/${r.regionId}`)}
-											>
-												<TableCell className="font-medium">{r.regionName}</TableCell>
-												<TableCell className="text-right tabular-nums text-muted-foreground">{r.systemCount}</TableCell>
-												<TableCell className="text-right tabular-nums">{r.moonCount || '—'}</TableCell>
-												<TableCell className="text-right tabular-nums">
-													{r.moonCount > 0
-														? `${r.verifiedCount} (${Math.round(r.verifiedCount / r.moonCount * 100)}%)`
-														: '—'}
-												</TableCell>
-											</TableRow>
-										))}
-								{!isLoading && filteredRegions.length === 0 && (
-									<TableRow>
-										<TableCell colSpan={4} className="py-8 text-center text-sm text-muted-foreground">
-											No regions match the current filter.
-										</TableCell>
-									</TableRow>
-								)}
-							</TableBody>
-						</Table>
-					</div>
-				</Card>
-			</Container>
+							)}
+						</TableBody>
+					</Table>
+				</div>
+			</Card>
+		</Container>
 	)
 }

--- a/apps/ui/src/client/features/moon-scan/routes/moon.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/moon.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft } from 'lucide-react'
-import { Link, useParams } from 'react-router'
+import { Link, useLocation, useParams } from 'react-router'
 
 import { MoonProfitabilityTable } from '@/components/moon-profitability-table'
 import { Badge } from '@/components/ui/badge'
@@ -198,10 +198,25 @@ function ProfitabilityCard({
 
 export default function MoonPage() {
 	const { moonId } = useParams<{ moonId: string }>()
+	const location = useLocation()
+	const navigationState =
+		location.state && typeof location.state === 'object'
+			? (location.state as {
+					from?: unknown
+					systemFrom?: unknown
+					moonName?: unknown
+					solarSystemName?: unknown
+				})
+			: null
+	const immediateMoonName =
+		typeof navigationState?.moonName === 'string' ? navigationState.moonName : null
+	const immediateSystemName =
+		typeof navigationState?.solarSystemName === 'string' ? navigationState.solarSystemName : null
 	const { canView } = useMoonScanPermissions()
 
 	const { data: detail, isLoading, error } = useMoonDetail(moonId!, canView)
-	usePageTitle(detail?.moon?.moonName ? `${detail.moon.moonName} — Moon` : 'Moon Detail')
+	const resolvedMoonName = detail?.moon?.moonName ?? immediateMoonName
+	usePageTitle(resolvedMoonName ? `${resolvedMoonName} — Moon` : 'Moon Detail')
 
 	if (!canView) {
 		return (
@@ -216,11 +231,31 @@ export default function MoonPage() {
 	const moon = detail?.moon
 	const composition = detail?.composition
 	const profitability = detail?.profitability
+	const backTo =
+		typeof navigationState?.from === 'string' && navigationState.from.startsWith('/moon-scan')
+			? navigationState.from
+			: moon?.solarSystemId
+				? `/moon-scan/system/${moon.solarSystemId}`
+				: '/moon-scan'
+	const backLabel = backTo.startsWith('/moon-scan/scanned')
+		? 'Back to Scanned Moons'
+		: backTo.startsWith('/moon-scan/system/')
+			? 'Back to System'
+			: 'Back to Regions'
+	const systemNavigationState = backTo.startsWith('/moon-scan/system/')
+		? {
+				from:
+					typeof navigationState?.systemFrom === 'string'
+						? navigationState.systemFrom
+						: '/moon-scan',
+				systemName: immediateSystemName,
+			}
+		: undefined
 
 	return (
 		<Container>
 			<PageHeader
-				title={moon?.moonName ?? moonId!}
+				title={moon?.moonName ?? immediateMoonName ?? 'Moon'}
 				description={moon ? `Moon ID: ${moon.moonId}` : undefined}
 				action={
 					<div className="flex flex-col items-end gap-2">
@@ -231,29 +266,24 @@ export default function MoonPage() {
 							{moon?.solarSystemId && (
 								<>
 									<span>/</span>
-									<Link to={`/moon-scan/system/${moon.solarSystemId}`} className="hover:underline">
-										{moon.solarSystemName || 'System'}
+									<Link
+										to={`/moon-scan/system/${moon.solarSystemId}`}
+										state={systemNavigationState}
+										className="hover:underline"
+									>
+										{moon.solarSystemName || immediateSystemName || 'System'}
 									</Link>
 								</>
 							)}
 							<span>/</span>
-							<span>{moon?.moonName ?? moonId}</span>
+							<span>{moon?.moonName ?? immediateMoonName ?? 'Moon'}</span>
 						</div>
-						{moon?.solarSystemId ? (
-							<Button variant="ghost" size="sm" asChild>
-								<Link to={`/moon-scan/system/${moon.solarSystemId}`}>
-									<ArrowLeft className="mr-2 h-4 w-4" />
-									Back to System
-								</Link>
-							</Button>
-						) : (
-							<Button variant="ghost" size="sm" asChild>
-								<Link to="/moon-scan">
-									<ArrowLeft className="mr-2 h-4 w-4" />
-									Back to Regions
-								</Link>
-							</Button>
-						)}
+						<Button variant="ghost" size="sm" asChild>
+							<Link to={backTo} state={systemNavigationState}>
+								<ArrowLeft className="mr-2 h-4 w-4" />
+								{backLabel}
+							</Link>
+						</Button>
 					</div>
 				}
 			/>

--- a/apps/ui/src/client/features/moon-scan/routes/region.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/region.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import { Link, useParams } from 'react-router'
+import { useMemo } from 'react'
+import { Link, useLocation, useParams, useSearchParams } from 'react-router'
 
 import { Button } from '@/components/ui/button'
 import { Container } from '@/components/ui/container'
@@ -48,17 +48,28 @@ function CoverageBar({ moonCount, verifiedCount }: { moonCount: number; verified
 
 export default function RegionPage() {
 	const { regionId } = useParams<{ regionId: string }>()
+	const location = useLocation()
+	const [searchParams, setSearchParams] = useSearchParams()
 	const { canView } = useMoonScanPermissions()
-	const [systemSearch, setSystemSearch] = useState('')
+	const systemSearch = searchParams.get('system') ?? ''
+	const navigationState =
+		location.state && typeof location.state === 'object'
+			? (location.state as { regionName?: unknown })
+			: null
+	const immediateRegionName =
+		typeof navigationState?.regionName === 'string' ? navigationState.regionName : null
 
 	const { data: regionsData } = useMoonRegions(canView)
 	const { data: detail, isLoading, error } = useMoonRegionDetail(regionId!, canView)
 
 	const regionName =
-		regionsData?.regions.find((r) => r.regionId === regionId)?.regionName ?? regionId
+		immediateRegionName ??
+		detail?.regionName ??
+		regionsData?.regions.find((r) => r.regionId === regionId)?.regionName ??
+		'Region'
 	usePageTitle(regionName ? `Region — ${regionName}` : 'Region')
 	const dotlanFile = useMemo(
-		() => (regionName && regionName !== regionId ? regionNameToFile(regionName) : ''),
+		() => (regionName !== 'Region' ? regionNameToFile(regionName) : ''),
 		[regionId, regionName]
 	)
 	const { data: coords, error: coordsError } = useDotlanRegionCoords(
@@ -90,6 +101,12 @@ export default function RegionPage() {
 		a.solarSystemName.localeCompare(b.solarSystemName)
 	)
 	const normalizedSystemSearch = systemSearch.trim().toLowerCase()
+	const updateSystemSearch = (value: string) => {
+		const next = new URLSearchParams(searchParams)
+		if (value.trim()) next.set('system', value)
+		else next.delete('system')
+		setSearchParams(next, { replace: true })
+	}
 	const filteredSystems = normalizedSystemSearch
 		? sortedSystems.filter((s) => s.solarSystemName.toLowerCase().includes(normalizedSystemSearch))
 		: sortedSystems
@@ -101,7 +118,7 @@ export default function RegionPage() {
 	return (
 		<Container>
 			<PageHeader
-				title={regionName as string}
+				title={regionName}
 				action={
 					<div className="flex flex-col items-end gap-2">
 						<div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -178,6 +195,7 @@ export default function RegionPage() {
 						jumpLinks={detail.jumpLinks}
 						coords={coords}
 						borderRegions={detail.borderRegions}
+						from={`${location.pathname}${location.search}`}
 						highlightedSystemIds={highlightedSystemIds}
 					/>
 				</div>
@@ -198,7 +216,7 @@ export default function RegionPage() {
 							</div>
 							<Input
 								value={systemSearch}
-								onChange={(e) => setSystemSearch(e.target.value)}
+								onChange={(e) => updateSystemSearch(e.target.value)}
 								placeholder="Filter systems..."
 								className="h-8 w-full sm:w-64"
 							/>
@@ -228,6 +246,10 @@ export default function RegionPage() {
 												{eligible ? (
 													<Link
 														to={`/moon-scan/system/${sys.solarSystemId}`}
+														state={{
+															from: `${location.pathname}${location.search}`,
+															systemName: sys.solarSystemName,
+														}}
 														className="font-medium hover:underline"
 													>
 														{sys.solarSystemName}

--- a/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/scanned-moons.tsx
@@ -1,9 +1,9 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router'
-import { ArrowDown, ArrowUp, ChevronDown, ChevronRight } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
+import { ArrowDown, ArrowUp, ChevronDown, ChevronRight } from 'lucide-react'
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useSearchParams } from 'react-router'
 
-import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
@@ -21,19 +21,19 @@ import {
 	TableHeader,
 	TableRow,
 } from '@/components/ui/table'
-import { TableRefreshFrame } from '@/components/table-refresh-frame'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { useDebounce } from '@/hooks/useDebounce'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { formatISK } from '@/lib/format-utils'
 import toast from '@/lib/toast'
 
-import { RARITY_COLORS } from '../ore-rarities'
 import {
 	downloadScannedMoonsExport,
 	getScannedMoonsExportStatus,
 	requestScannedMoonsExport,
 } from '../api'
-import { useScannedMoons, useMoonRegions } from '../hooks'
+import { useMoonRegions, useScannedMoons } from '../hooks'
+import { RARITY_COLORS } from '../ore-rarities'
 import { useMoonScanPermissions } from '../permissions'
 import { parseSecurityStatus, securityStatusTextClass } from '../security-status'
 
@@ -50,6 +50,41 @@ type SortBy =
 	| 'tataraProfit'
 type SortDir = 'asc' | 'desc'
 type ViewMode = 'grouped' | 'ungrouped'
+
+const SORT_BY_VALUES: readonly SortBy[] = [
+	'moonName',
+	'solarSystemName',
+	'regionName',
+	'securityStatus',
+	'highestRarity',
+	'metenoxProfit',
+	'tataraProfit',
+]
+
+function parseSortBy(value: string | null): SortBy {
+	return value && SORT_BY_VALUES.includes(value as SortBy) ? (value as SortBy) : 'moonName'
+}
+
+function parseSortDir(value: string | null): SortDir {
+	return value === 'desc' ? 'desc' : 'asc'
+}
+
+function parsePage(value: string | null): number {
+	const page = Number(value)
+	return Number.isInteger(page) && page > 0 ? page : 1
+}
+
+function parsePageSize(value: string | null): number {
+	const pageSize = Number(value)
+	return [25, 50, 100].includes(pageSize) ? pageSize : 50
+}
+
+function parseRarities(value: string | null): OreRarity[] {
+	if (!value) return []
+	return value
+		.split(',')
+		.filter((rarity): rarity is OreRarity => RARITY_VALUES.includes(rarity as OreRarity))
+}
 
 function RarityBadge({ rarity }: { rarity: OreRarity }) {
 	return (
@@ -72,17 +107,34 @@ function ProfitCell({ value }: { value: string | null }) {
 	)
 }
 
-function MoonRow({ moon }: { moon: ScannedMoonEntry }) {
+function MoonRow({ moon, backTo }: { moon: ScannedMoonEntry; backTo: string }) {
 	const sec = parseSecurityStatus(moon.securityStatus)
 	return (
 		<TableRow>
 			<TableCell>
-				<Link to={`/moon-scan/moon/${moon.moonId}`} className="hover:underline text-foreground font-medium">
+				<Link
+					to={`/moon-scan/moon/${moon.moonId}`}
+					state={{
+						from: backTo,
+						moonName: moon.moonName,
+						solarSystemName: moon.solarSystemName,
+						regionName: moon.regionName,
+					}}
+					className="font-medium text-foreground hover:underline"
+				>
 					{moon.moonName}
 				</Link>
 			</TableCell>
 			<TableCell>
-				<Link to={`/moon-scan/system/${moon.solarSystemId}`} className="hover:underline text-muted-foreground text-sm">
+				<Link
+					to={`/moon-scan/system/${moon.solarSystemId}`}
+					state={{
+						from: backTo,
+						systemName: moon.solarSystemName,
+						regionName: moon.regionName,
+					}}
+					className="hover:underline text-muted-foreground text-sm"
+				>
 					{moon.solarSystemName}
 				</Link>
 			</TableCell>
@@ -91,7 +143,11 @@ function MoonRow({ moon }: { moon: ScannedMoonEntry }) {
 				{sec === null ? '—' : sec.toFixed(1)}
 			</TableCell>
 			<TableCell>
-				{moon.highestRarity ? <RarityBadge rarity={moon.highestRarity as OreRarity} /> : <span className="text-muted-foreground">—</span>}
+				{moon.highestRarity ? (
+					<RarityBadge rarity={moon.highestRarity as OreRarity} />
+				) : (
+					<span className="text-muted-foreground">—</span>
+				)}
 			</TableCell>
 			<TableCell className="text-right tabular-nums">
 				<ProfitCell value={moon.metenoxProfit} />
@@ -105,25 +161,47 @@ function MoonRow({ moon }: { moon: ScannedMoonEntry }) {
 
 export default function ScannedMoonsPage() {
 	usePageTitle('Scanned Moons')
+	const location = useLocation()
+	const [searchParams, setSearchParams] = useSearchParams()
+	const moonDetailBackTo = `${location.pathname}${location.search}`
 
 	const { canView } = useMoonScanPermissions()
 
-	const [selectedRarities, setSelectedRarities] = useState<OreRarity[]>([])
-	const [regionFilter, setRegionFilter] = useState<string>('all')
-	const [constellationFilter, setConstellationFilter] = useState<string>('all')
-	const [search, setSearch] = useState('')
-	const [page, setPage] = useState(1)
-	const [pageSize, setPageSize] = useState(50)
-	const [sortBy, setSortBy] = useState<SortBy>('moonName')
-	const [sortDir, setSortDir] = useState<SortDir>('asc')
+	const regionFilter = searchParams.get('regionId') ?? 'all'
+	const constellationFilter = searchParams.get('constellationId') ?? 'all'
+	const search = searchParams.get('search') ?? ''
+	const page = parsePage(searchParams.get('page'))
+	const pageSize = parsePageSize(searchParams.get('pageSize'))
+	const selectedRarities = parseRarities(searchParams.get('rarity'))
+	const sortBy = parseSortBy(searchParams.get('sortBy'))
+	const sortDir = parseSortDir(searchParams.get('sortDir'))
 	const [viewMode, setViewMode] = useState<ViewMode>('grouped')
 	const [collapsedConstellations, setCollapsedConstellations] = useState<Set<string>>(new Set())
-	const [pendingExport, setPendingExport] = useState<{ workflowInstanceId: string; fileName: string } | null>(null)
+	const [pendingExport, setPendingExport] = useState<{
+		workflowInstanceId: string
+		fileName: string
+	} | null>(null)
 	const [isExporting, setIsExporting] = useState(false)
 	const debouncedSearch = useDebounce(search, 400)
+	const updateUrl = useCallback(
+		(updates: Record<string, string | null>) => {
+			const next = new URLSearchParams(searchParams)
+			for (const [key, value] of Object.entries(updates)) {
+				if (value === null || value === '') next.delete(key)
+				else next.set(key, value)
+			}
+			setSearchParams(next, { replace: true })
+		},
+		[searchParams, setSearchParams]
+	)
 
 	const exportStatusQuery = useQuery({
-		queryKey: ['moon-scan', 'verified-moons', 'export-status', pendingExport?.workflowInstanceId ?? null],
+		queryKey: [
+			'moon-scan',
+			'verified-moons',
+			'export-status',
+			pendingExport?.workflowInstanceId ?? null,
+		],
 		queryFn: () => getScannedMoonsExportStatus(pendingExport!.workflowInstanceId),
 		enabled: Boolean(pendingExport?.workflowInstanceId),
 		refetchInterval: (query) => {
@@ -134,7 +212,8 @@ export default function ScannedMoonsPage() {
 	})
 	const exportStatus = exportStatusQuery.data?.status
 	const isExportPolling =
-		Boolean(pendingExport) && (exportStatus === undefined || exportStatus === 'queued' || exportStatus === 'running')
+		Boolean(pendingExport) &&
+		(exportStatus === undefined || exportStatus === 'queued' || exportStatus === 'running')
 	const isExportBusy = isExporting || isExportPolling
 
 	useEffect(() => {
@@ -165,22 +244,25 @@ export default function ScannedMoonsPage() {
 	}, [exportStatusQuery.data, pendingExport])
 
 	const toggleRarity = (rarity: OreRarity) => {
-		setSelectedRarities((prev) =>
-			prev.includes(rarity) ? prev.filter((r) => r !== rarity) : [...prev, rarity]
-		)
-		setPage(1)
+		const nextRarities = selectedRarities.includes(rarity)
+			? selectedRarities.filter((r) => r !== rarity)
+			: [...selectedRarities, rarity]
+		updateUrl({ rarity: nextRarities.length > 0 ? nextRarities.join(',') : null, page: '1' })
 	}
 
-	const { data, isLoading, isFetching, error } = useScannedMoons({
-		page,
-		pageSize,
-		regionId: regionFilter,
-		constellationId: constellationFilter,
-		rarities: selectedRarities,
-		search: debouncedSearch,
-		sortBy,
-		sortDir,
-	}, canView)
+	const { data, isLoading, isFetching, error } = useScannedMoons(
+		{
+			page,
+			pageSize,
+			regionId: regionFilter,
+			constellationId: constellationFilter,
+			rarities: selectedRarities,
+			search: debouncedSearch,
+			sortBy,
+			sortDir,
+		},
+		canView
+	)
 	const { data: regionsData } = useMoonRegions(canView)
 
 	const regions = useMemo(() => {
@@ -205,7 +287,10 @@ export default function ScannedMoonsPage() {
 
 	const groupedItems = useMemo(() => {
 		const items = data?.items ?? []
-		const groups = new Map<string, { constellationId: string; constellationName: string; moons: ScannedMoonEntry[] }>()
+		const groups = new Map<
+			string,
+			{ constellationId: string; constellationName: string; moons: ScannedMoonEntry[] }
+		>()
 		for (const moon of items) {
 			const key = moon.constellationId || '_unknown'
 			let group = groups.get(key)
@@ -233,21 +318,28 @@ export default function ScannedMoonsPage() {
 
 	const totalCount = data?.total ?? 0
 	const hasPagination = Math.ceil(totalCount / pageSize) > 1
+	const hasActiveFilters =
+		regionFilter !== 'all' ||
+		constellationFilter !== 'all' ||
+		search.length > 0 ||
+		selectedRarities.length > 0
 	const hasExportScope = regionFilter !== 'all' || constellationFilter !== 'all'
 	const canExportCsv = canView && hasExportScope
 	const exportHelpMessage = 'Select a region or constellation to export this scope.'
 	const toggleSort = (column: SortBy) => {
-		if (sortBy === column) {
-			setSortDir((dir) => (dir === 'asc' ? 'desc' : 'asc'))
-		} else {
-			setSortBy(column)
-			setSortDir('asc')
-		}
-		setPage(1)
+		updateUrl({
+			sortBy: column,
+			sortDir: sortBy === column && sortDir === 'asc' ? 'desc' : 'asc',
+			page: '1',
+		})
 	}
 	const SortIndicator = ({ column }: { column: SortBy }) => {
 		if (sortBy !== column) return null
-		return sortDir === 'asc' ? <ArrowUp className="h-3.5 w-3.5" /> : <ArrowDown className="h-3.5 w-3.5" />
+		return sortDir === 'asc' ? (
+			<ArrowUp className="h-3.5 w-3.5" />
+		) : (
+			<ArrowDown className="h-3.5 w-3.5" />
+		)
 	}
 	const SortableHead = ({
 		label,
@@ -276,10 +368,9 @@ export default function ScannedMoonsPage() {
 			totalCount={totalCount}
 			page={page}
 			pageSize={pageSize}
-			onPageChange={setPage}
+			onPageChange={(nextPage) => updateUrl({ page: String(nextPage) })}
 			onPageSizeChange={(size) => {
-				setPageSize(size)
-				setPage(1)
+				updateUrl({ pageSize: String(size), page: '1' })
 			}}
 			itemLabel="moons"
 		/>
@@ -323,7 +414,10 @@ export default function ScannedMoonsPage() {
 	if (!canView) {
 		return (
 			<Container>
-				<PageHeader title="Scanned Moons" description="You do not have permission to view moon data." />
+				<PageHeader
+					title="Scanned Moons"
+					description="You do not have permission to view moon data."
+				/>
 			</Container>
 		)
 	}
@@ -336,7 +430,9 @@ export default function ScannedMoonsPage() {
 				action={
 					<div className="flex items-center gap-3">
 						{isExportPolling && (
-							<span className="text-xs text-muted-foreground">Waiting for export to generate...</span>
+							<span className="text-xs text-muted-foreground">
+								Waiting for export to generate...
+							</span>
 						)}
 						{!canExportCsv && !isExportBusy ? (
 							<HoverPopover
@@ -375,77 +471,80 @@ export default function ScannedMoonsPage() {
 				<div className="mt-4 rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-sm text-red-500">
 					Failed to load moon data
 				</div>
-				)}
+			)}
 
 			{/* Filters */}
 			<div className="mt-section flex flex-wrap items-center gap-3">
-					{/* Rarity multi-select chips */}
-					<div className="flex items-center gap-1 rounded-md border bg-card p-1">
-						<button
-							type="button"
-							onClick={() => {
-								setSelectedRarities([])
-								setPage(1)
-							}}
-							className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
-								selectedRarities.length === 0
-									? 'bg-muted text-foreground'
-									: 'text-muted-foreground hover:text-foreground'
-							}`}
-						>
-							All
-						</button>
-						{RARITY_VALUES.map((rarity) => {
-							const active = selectedRarities.includes(rarity)
-							return (
-								<button
-									key={rarity}
-									type="button"
-									onClick={() => toggleRarity(rarity)}
-									aria-pressed={active}
-									className={`rounded px-2.5 py-1 text-xs font-semibold transition-colors ${
-										active ? 'text-white' : 'hover:bg-muted/50'
-									}`}
-									style={{
-										color: active ? '#fff' : RARITY_COLORS[rarity],
-										backgroundColor: active ? RARITY_COLORS[rarity] : undefined,
-									}}
-								>
-									{rarity}
-								</button>
-							)
-						})}
-					</div>
+				{/* Rarity multi-select chips */}
+				<div className="flex items-center gap-1 rounded-md border bg-card p-1">
+					<button
+						type="button"
+						onClick={() => {
+							updateUrl({ rarity: null, page: '1' })
+						}}
+						className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+							selectedRarities.length === 0
+								? 'bg-muted text-foreground'
+								: 'text-muted-foreground hover:text-foreground'
+						}`}
+					>
+						All
+					</button>
+					{RARITY_VALUES.map((rarity) => {
+						const active = selectedRarities.includes(rarity)
+						return (
+							<button
+								key={rarity}
+								type="button"
+								onClick={() => toggleRarity(rarity)}
+								aria-pressed={active}
+								className={`rounded px-2.5 py-1 text-xs font-semibold transition-colors ${
+									active ? 'text-white' : 'hover:bg-muted/50'
+								}`}
+								style={{
+									color: active ? '#fff' : RARITY_COLORS[rarity],
+									backgroundColor: active ? RARITY_COLORS[rarity] : undefined,
+								}}
+							>
+								{rarity}
+							</button>
+						)
+					})}
+				</div>
 
 				{/* Region dropdown */}
-					<Select
-						value={regionFilter}
-						onValueChange={(value) => {
-							setRegionFilter(value)
-							setConstellationFilter('all')
-							setPage(1)
-						}}
-						options={regionOptions}
-						searchable
-						placeholder="Filter region..."
-						className="w-56"
-						inputClassName="h-9"
-					/>
+				<Select
+					value={regionFilter}
+					onValueChange={(value) => {
+						updateUrl({
+							regionId: value === 'all' ? null : value,
+							constellationId: null,
+							page: '1',
+						})
+					}}
+					options={regionOptions}
+					searchable
+					placeholder="Filter region..."
+					className="w-56"
+					inputClassName="h-9"
+				/>
 
 				{/* Constellation dropdown */}
-					<Select
-						value={constellationFilter}
-						onValueChange={(value) => {
-							setConstellationFilter(value)
-							setPage(1)
-						}}
-						options={constellationOptions}
-						searchable
-						placeholder="Filter constellation..."
-						className="w-56"
-						inputClassName="h-9"
-						disabled={constellationOptions.length <= 1}
-					/>
+				<Select
+					value={constellationFilter}
+					onValueChange={(value) => {
+						updateUrl({
+							constellationId: value === 'all' ? null : value,
+							page: '1',
+						})
+					}}
+					options={constellationOptions}
+					searchable
+					placeholder="Filter constellation..."
+					className="w-56"
+					inputClassName="h-9"
+					disabled={constellationOptions.length <= 1}
+				/>
 
 				{/* Name / system search */}
 				<Input
@@ -453,10 +552,27 @@ export default function ScannedMoonsPage() {
 					placeholder="Search moon or system…"
 					value={search}
 					onChange={(e) => {
-						setSearch(e.target.value)
-						setPage(1)
+						updateUrl({ search: e.target.value, page: '1' })
 					}}
 				/>
+
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					onClick={() =>
+						updateUrl({
+							regionId: null,
+							constellationId: null,
+							search: null,
+							rarity: null,
+							page: null,
+						})
+					}
+					disabled={!hasActiveFilters}
+				>
+					Clear Filters
+				</Button>
 
 				{/* Grouped / ungrouped view toggle */}
 				<div className="flex items-center gap-1 rounded-md border bg-card p-1">
@@ -477,15 +593,16 @@ export default function ScannedMoonsPage() {
 					))}
 				</div>
 
-			{!isLoading && data?.pricingSnapshotDate && (
-				<span className="ml-auto flex items-center gap-x-2 text-xs text-muted-foreground">
-					<span>Pricing Source: Global Daily Average</span>
-					<span aria-hidden="true">•</span>
-					<span className="flex items-center gap-1">
-						Snapshot: <EveTimeDisplay dateStr={`${data.pricingSnapshotDate}T00:00:00Z`} format="date" />
+				{!isLoading && data?.pricingSnapshotDate && (
+					<span className="ml-auto flex items-center gap-x-2 text-xs text-muted-foreground">
+						<span>Pricing Source: Global Daily Average</span>
+						<span aria-hidden="true">•</span>
+						<span className="flex items-center gap-1">
+							Snapshot:{' '}
+							<EveTimeDisplay dateStr={`${data.pricingSnapshotDate}T00:00:00Z`} format="date" />
+						</span>
 					</span>
-				</span>
-			)}
+				)}
 			</div>
 
 			<Card className="mt-4 overflow-hidden">
@@ -528,34 +645,38 @@ export default function ScannedMoonsPage() {
 										</TableRow>
 									))
 								: viewMode === 'ungrouped'
-									? (data?.items ?? []).map((moon) => <MoonRow key={moon.moonId} moon={moon} />)
+									? (data?.items ?? []).map((moon) => (
+											<MoonRow key={moon.moonId} moon={moon} backTo={moonDetailBackTo} />
+										))
 									: groupedItems.map((group) => {
-										const collapsed = collapsedConstellations.has(group.constellationId)
-										return (
-											<Fragment key={group.constellationId || '_unknown'}>
-												<TableRow
-													className="bg-muted/30 cursor-pointer hover:bg-muted/40"
-													onClick={() => toggleConstellationCollapse(group.constellationId)}
-												>
-													<TableCell colSpan={7} className="py-2">
-														<div className="flex items-center gap-2 text-sm font-medium">
-															{collapsed ? (
-																<ChevronRight className="h-4 w-4 text-muted-foreground" />
-															) : (
-																<ChevronDown className="h-4 w-4 text-muted-foreground" />
-															)}
-															<span>{group.constellationName}</span>
-															<span className="text-xs font-normal text-muted-foreground">
-																{group.moons.length} moon{group.moons.length === 1 ? '' : 's'}
-															</span>
-														</div>
-													</TableCell>
-												</TableRow>
-												{!collapsed &&
-													group.moons.map((moon) => <MoonRow key={moon.moonId} moon={moon} />)}
-											</Fragment>
-										)
-									})}
+											const collapsed = collapsedConstellations.has(group.constellationId)
+											return (
+												<Fragment key={group.constellationId || '_unknown'}>
+													<TableRow
+														className="bg-muted/30 cursor-pointer hover:bg-muted/40"
+														onClick={() => toggleConstellationCollapse(group.constellationId)}
+													>
+														<TableCell colSpan={7} className="py-2">
+															<div className="flex items-center gap-2 text-sm font-medium">
+																{collapsed ? (
+																	<ChevronRight className="h-4 w-4 text-muted-foreground" />
+																) : (
+																	<ChevronDown className="h-4 w-4 text-muted-foreground" />
+																)}
+																<span>{group.constellationName}</span>
+																<span className="text-xs font-normal text-muted-foreground">
+																	{group.moons.length} moon{group.moons.length === 1 ? '' : 's'}
+																</span>
+															</div>
+														</TableCell>
+													</TableRow>
+													{!collapsed &&
+														group.moons.map((moon) => (
+															<MoonRow key={moon.moonId} moon={moon} backTo={moonDetailBackTo} />
+														))}
+												</Fragment>
+											)
+										})}
 							{!isLoading && (data?.items.length ?? 0) === 0 && (
 								<TableRow>
 									<TableCell colSpan={7} className="py-8 text-center text-sm text-muted-foreground">

--- a/apps/ui/src/client/features/moon-scan/routes/system.tsx
+++ b/apps/ui/src/client/features/moon-scan/routes/system.tsx
@@ -1,10 +1,14 @@
-import { ArrowLeft } from 'lucide-react'
-import { Link, useParams } from 'react-router'
+import { ArrowDown, ArrowLeft, ArrowUp } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useLocation, useParams, useSearchParams } from 'react-router'
+
+import { RARITY_ORDER } from '@repo/moon-scan'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Container } from '@/components/ui/container'
 import { PageHeader } from '@/components/ui/page-header'
+import { Select } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
 	Table,
@@ -19,15 +23,360 @@ import { usePageTitle } from '@/hooks/usePageTitle'
 import { OreCompositionBar } from '../components/OreCompositionBar'
 import { ScanStatusBadge } from '../components/ScanStatusBadge'
 import { useMoonSystemDetail } from '../hooks'
+import { getOreRarity, RARITY_COLORS } from '../ore-rarities'
 import { useMoonScanPermissions } from '../permissions'
 import { securityStatusTextClass } from '../security-status'
+import { filterValidOreTypeIds, getValidCompositionSortOreTypeId } from '../system-view'
+
+import type { OreRarity } from '../types'
+
+interface OreOption {
+	value: string
+	label: string
+	rarity?: OreRarity
+}
+
+type SortColumn = 'moonName' | 'composition'
+type SortDirection = 'asc' | 'desc'
+
+interface PersistedSystemView {
+	selectedOreTypeIds: string[]
+	compositionSortOreTypeId: string
+	activeSortColumn: SortColumn
+	activeSortDirection: SortDirection
+}
+
+const SYSTEM_VIEW_STORAGE_PREFIX = 'moon-scan:system-view:'
+
+function readPersistedSystemView(systemId: string | undefined): PersistedSystemView | null {
+	if (!systemId || typeof window === 'undefined') return null
+	try {
+		const raw = window.localStorage.getItem(`${SYSTEM_VIEW_STORAGE_PREFIX}${systemId}`)
+		if (!raw) return null
+		const parsed = JSON.parse(raw) as Partial<PersistedSystemView>
+		return {
+			selectedOreTypeIds: Array.isArray(parsed.selectedOreTypeIds)
+				? parsed.selectedOreTypeIds.filter((value): value is string => typeof value === 'string')
+				: [],
+			compositionSortOreTypeId:
+				typeof parsed.compositionSortOreTypeId === 'string' ? parsed.compositionSortOreTypeId : '',
+			activeSortColumn: parsed.activeSortColumn === 'composition' ? 'composition' : 'moonName',
+			activeSortDirection: parsed.activeSortDirection === 'desc' ? 'desc' : 'asc',
+		}
+	} catch {
+		return null
+	}
+}
+
+function getUrlList(value: string | null): string[] | null {
+	return value === null ? null : value.split(',').filter(Boolean)
+}
+
+function resolveActiveSortColumn(
+	searchParams: URLSearchParams,
+	persistedView: PersistedSystemView | null,
+	compositionSortOreTypeId: string
+): SortColumn {
+	if (searchParams.get('sortColumn') === 'composition' && compositionSortOreTypeId) {
+		return 'composition'
+	}
+	if (
+		searchParams.has('sortColumn') ||
+		searchParams.has('compositionSort') ||
+		searchParams.has('sort')
+	) {
+		return 'moonName'
+	}
+	return persistedView?.activeSortColumn === 'composition' && persistedView.compositionSortOreTypeId
+		? 'composition'
+		: 'moonName'
+}
+
+function resolveActiveSortDirection(
+	searchParams: URLSearchParams,
+	persistedView: PersistedSystemView | null
+): SortDirection {
+	if (searchParams.has('sortColumn')) {
+		return searchParams.get('sortDir') === 'desc' ? 'desc' : 'asc'
+	}
+	if (searchParams.has('compositionSort') || searchParams.has('sort')) return 'asc'
+	return persistedView?.activeSortDirection ?? 'asc'
+}
+
+function RarityBadge({ rarity }: { rarity: OreRarity }) {
+	return (
+		<span
+			className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold text-white"
+			style={{ backgroundColor: RARITY_COLORS[rarity] }}
+		>
+			{rarity}
+		</span>
+	)
+}
+
+function renderOreOption(option: OreOption) {
+	return (
+		<div className="flex min-w-0 items-center gap-2">
+			{option.rarity ? <RarityBadge rarity={option.rarity} /> : null}
+			<span className="truncate">{option.label}</span>
+		</div>
+	)
+}
 
 export default function SystemPage() {
 	const { systemId } = useParams<{ systemId: string }>()
+	const location = useLocation()
+	const [searchParams, setSearchParams] = useSearchParams()
 	const { canView } = useMoonScanPermissions()
 
 	const { data: detail, isLoading, error } = useMoonSystemDetail(systemId!, canView)
-	usePageTitle(detail?.system?.solarSystemName ? `${detail.system.solarSystemName}` : 'System')
+	const searchParamString = searchParams.toString()
+	const persistedView = useMemo(() => readPersistedSystemView(systemId), [systemId])
+	const lastSearchParamStringRef = useRef(searchParamString)
+	const lastSystemIdRef = useRef(systemId)
+	const skipUrlSyncRef = useRef(false)
+	const [selectedOreTypeIds, setSelectedOreTypeIds] = useState<string[]>(
+		() =>
+			getUrlList(searchParams.get('ore')) ??
+			getUrlList(searchParams.get('composition')) ??
+			persistedView?.selectedOreTypeIds ??
+			[]
+	)
+	const [compositionSortOreTypeId, setCompositionSortOreTypeId] = useState(
+		() =>
+			searchParams.get('compositionSort') ??
+			searchParams.get('sort') ??
+			persistedView?.compositionSortOreTypeId ??
+			''
+	)
+	const [activeSortColumn, setActiveSortColumn] = useState<SortColumn>(() =>
+		resolveActiveSortColumn(
+			searchParams,
+			persistedView,
+			searchParams.get('compositionSort') ??
+				searchParams.get('sort') ??
+				persistedView?.compositionSortOreTypeId ??
+				''
+		)
+	)
+	const [activeSortDirection, setActiveSortDirection] = useState<SortDirection>(() =>
+		resolveActiveSortDirection(searchParams, persistedView)
+	)
+	const navigationState =
+		location.state && typeof location.state === 'object'
+			? (location.state as { from?: unknown; systemName?: unknown })
+			: null
+	const immediateSystemName =
+		typeof navigationState?.systemName === 'string' ? navigationState.systemName : null
+	const backTo =
+		typeof navigationState?.from === 'string' && navigationState.from.startsWith('/moon-scan')
+			? navigationState.from
+			: '/moon-scan'
+	const backLabel = backTo.startsWith('/moon-scan/scanned')
+		? 'Back to Scanned Moons'
+		: 'Back to Regions'
+	usePageTitle(detail?.system?.solarSystemName ?? immediateSystemName ?? 'System')
+	useEffect(() => {
+		const systemChanged = lastSystemIdRef.current !== systemId
+		const urlChanged = lastSearchParamStringRef.current !== searchParamString
+		lastSystemIdRef.current = systemId
+		lastSearchParamStringRef.current = searchParamString
+		if (!systemChanged && !urlChanged) return
+		if (!systemChanged && skipUrlSyncRef.current) {
+			skipUrlSyncRef.current = false
+			return
+		}
+		skipUrlSyncRef.current = false
+		const urlSelectedOreTypeIds =
+			getUrlList(searchParams.get('ore')) ?? getUrlList(searchParams.get('composition'))
+		const urlCompositionSortOreTypeId =
+			searchParams.get('compositionSort') ?? searchParams.get('sort')
+		if (urlSelectedOreTypeIds !== null) setSelectedOreTypeIds(urlSelectedOreTypeIds)
+		else setSelectedOreTypeIds(persistedView?.selectedOreTypeIds ?? [])
+		if (urlCompositionSortOreTypeId !== null) {
+			setCompositionSortOreTypeId(urlCompositionSortOreTypeId)
+		} else {
+			setCompositionSortOreTypeId(persistedView?.compositionSortOreTypeId ?? '')
+		}
+		setActiveSortColumn(
+			resolveActiveSortColumn(searchParams, persistedView, urlCompositionSortOreTypeId ?? '')
+		)
+		setActiveSortDirection(resolveActiveSortDirection(searchParams, persistedView))
+	}, [persistedView, searchParamString, searchParams, systemId])
+	useEffect(() => {
+		if (!systemId || typeof window === 'undefined') return
+		try {
+			window.localStorage.setItem(
+				`${SYSTEM_VIEW_STORAGE_PREFIX}${systemId}`,
+				JSON.stringify({
+					selectedOreTypeIds,
+					compositionSortOreTypeId,
+					activeSortColumn,
+					activeSortDirection,
+				} satisfies PersistedSystemView)
+			)
+		} catch {
+			// Local storage is an enhancement; private browsing or quota errors are non-fatal.
+		}
+	}, [
+		activeSortColumn,
+		activeSortDirection,
+		compositionSortOreTypeId,
+		selectedOreTypeIds,
+		systemId,
+	])
+	const updateUrl = (updates: Record<string, string | null>) => {
+		const next = new URLSearchParams(searchParams)
+		for (const [key, value] of Object.entries(updates)) {
+			if (value === null || value === '') next.delete(key)
+			else next.set(key, value)
+		}
+		if (next.toString() === searchParamString) return
+		skipUrlSyncRef.current = true
+		setSearchParams(next, { replace: true })
+	}
+	const updateSystemView = (updates: Record<string, string | null>) => {
+		updateUrl(updates)
+	}
+	const sys = detail?.system
+	const secStatus =
+		sys?.securityStatus !== null && sys?.securityStatus !== undefined
+			? parseFloat(sys.securityStatus)
+			: null
+
+	const secColor = securityStatusTextClass(secStatus)
+	const oreOptions = useMemo<OreOption[]>(() => {
+		const options = new Map<string, OreOption>()
+		for (const moon of detail?.moons ?? []) {
+			for (const ore of moon.composition?.ores ?? []) {
+				if (options.has(ore.oreTypeId)) continue
+				const rarity = getOreRarity(ore.oreTypeId)
+				options.set(ore.oreTypeId, {
+					value: ore.oreTypeId,
+					label: ore.oreTypeName ?? ore.oreTypeId,
+					rarity,
+				})
+			}
+		}
+		return [...options.values()].sort((a, b) => {
+			const rarityComparison =
+				(b.rarity ? RARITY_ORDER[b.rarity] : Number.MIN_SAFE_INTEGER) -
+				(a.rarity ? RARITY_ORDER[a.rarity] : Number.MIN_SAFE_INTEGER)
+			return rarityComparison || a.label.localeCompare(b.label)
+		})
+	}, [detail?.moons])
+	const compositionSortOptions = oreOptions
+	const availableOreTypeIds = useMemo(
+		() => new Set(oreOptions.map((option) => option.value)),
+		[oreOptions]
+	)
+	const validSelectedOreTypeIds = useMemo(
+		() => filterValidOreTypeIds(selectedOreTypeIds, availableOreTypeIds),
+		[availableOreTypeIds, selectedOreTypeIds]
+	)
+	const validCompositionSortOreTypeId = getValidCompositionSortOreTypeId(
+		compositionSortOreTypeId,
+		availableOreTypeIds
+	)
+	const effectiveSortColumn =
+		activeSortColumn === 'composition' && validCompositionSortOreTypeId
+			? activeSortColumn
+			: 'moonName'
+	useEffect(() => {
+		if (!detail) return
+		if (validSelectedOreTypeIds.length !== selectedOreTypeIds.length) {
+			setSelectedOreTypeIds(validSelectedOreTypeIds)
+		}
+		if (validCompositionSortOreTypeId !== compositionSortOreTypeId) {
+			setCompositionSortOreTypeId(validCompositionSortOreTypeId)
+		}
+		if (activeSortColumn === 'composition' && !validCompositionSortOreTypeId) {
+			setActiveSortColumn('moonName')
+		}
+	}, [
+		activeSortColumn,
+		compositionSortOreTypeId,
+		detail,
+		selectedOreTypeIds.length,
+		validCompositionSortOreTypeId,
+		validSelectedOreTypeIds,
+	])
+	const visibleMoons = useMemo(() => {
+		const filteredMoons = (detail?.moons ?? []).filter(
+			(moon) =>
+				validSelectedOreTypeIds.length === 0 ||
+				validSelectedOreTypeIds.some((oreTypeId) =>
+					moon.composition?.ores.some((ore) => ore.oreTypeId === oreTypeId)
+				)
+		)
+
+		return [...filteredMoons].sort((a, b) => {
+			if (effectiveSortColumn === 'moonName') {
+				const comparison = a.moonName.localeCompare(b.moonName)
+				return activeSortDirection === 'asc' ? comparison : -comparison
+			}
+			const aQuantity = Number.parseFloat(
+				a.composition?.ores.find((ore) => ore.oreTypeId === validCompositionSortOreTypeId)
+					?.quantity ?? '0'
+			)
+			const bQuantity = Number.parseFloat(
+				b.composition?.ores.find((ore) => ore.oreTypeId === validCompositionSortOreTypeId)
+					?.quantity ?? '0'
+			)
+			const aPercentage = aQuantity * 100
+			const bPercentage = bQuantity * 100
+			const comparison = bPercentage - aPercentage || a.moonName.localeCompare(b.moonName)
+			return activeSortDirection === 'asc' ? comparison : -comparison
+		})
+	}, [
+		activeSortColumn,
+		activeSortDirection,
+		effectiveSortColumn,
+		validCompositionSortOreTypeId,
+		detail?.moons,
+		validSelectedOreTypeIds,
+	])
+	const handleSort = (column: SortColumn) => {
+		if (column === 'composition' && !validCompositionSortOreTypeId) return
+		const nextDirection =
+			activeSortColumn === column
+				? activeSortDirection === 'asc'
+					? 'desc'
+					: 'asc'
+				: column === 'composition'
+					? 'desc'
+					: 'asc'
+		setActiveSortColumn(column)
+		setActiveSortDirection(nextDirection)
+		updateSystemView({ sortColumn: column, sortDir: nextDirection })
+	}
+	const resetSystemView = () => {
+		setSelectedOreTypeIds([])
+		setCompositionSortOreTypeId('')
+		setActiveSortColumn('moonName')
+		setActiveSortDirection('asc')
+		updateSystemView({
+			ore: null,
+			composition: null,
+			compositionSort: null,
+			sort: null,
+			sortColumn: null,
+			sortDir: null,
+		})
+	}
+	const hasActiveSystemView =
+		validSelectedOreTypeIds.length > 0 ||
+		validCompositionSortOreTypeId !== '' ||
+		effectiveSortColumn !== 'moonName' ||
+		activeSortDirection !== 'asc'
+	const SortIndicator = ({ column }: { column: SortColumn }) => {
+		if (effectiveSortColumn !== column) return null
+		return activeSortDirection === 'asc' ? (
+			<ArrowUp className="h-3.5 w-3.5" />
+		) : (
+			<ArrowDown className="h-3.5 w-3.5" />
+		)
+	}
 	if (!canView) {
 		return (
 			<Container>
@@ -39,14 +388,6 @@ export default function SystemPage() {
 		)
 	}
 
-	const sys = detail?.system
-	const secStatus =
-		sys?.securityStatus !== null && sys?.securityStatus !== undefined
-			? parseFloat(sys.securityStatus)
-			: null
-
-	const secColor = securityStatusTextClass(secStatus)
-
 	const verifiedMoons = (detail?.moons ?? []).filter((m) => m.isVerified).length
 	const scannedMoons = (detail?.moons ?? []).filter((m) => m.hasScans).length
 
@@ -57,7 +398,7 @@ export default function SystemPage() {
 					<div className="space-y-3">
 						<div className="flex items-center gap-3">
 							<h1 className="text-4xl md:text-5xl font-bold leading-none gradient-text">
-								{sys?.solarSystemName ?? systemId!}
+								{sys?.solarSystemName ?? immediateSystemName ?? 'System'}
 							</h1>
 							{sys && (
 								<span className="inline-flex items-center gap-2 rounded-md border bg-card px-3 py-1.5 text-sm">
@@ -80,12 +421,12 @@ export default function SystemPage() {
 								Moon Scanning
 							</Link>
 							<span>/</span>
-							<span>{sys?.solarSystemName ?? systemId}</span>
+							<span>{sys?.solarSystemName ?? immediateSystemName ?? 'System'}</span>
 						</div>
 						<Button variant="ghost" size="sm" asChild>
-							<Link to="/moon-scan">
+							<Link to={backTo}>
 								<ArrowLeft className="mr-2 h-4 w-4" />
-								Back to Regions
+								{backLabel}
 							</Link>
 						</Button>
 					</div>
@@ -98,13 +439,95 @@ export default function SystemPage() {
 				</div>
 			)}
 
-			<div className="mt-section rounded-md border bg-card">
+			<div className="mt-4 flex flex-wrap items-end gap-3 rounded-md border bg-card p-4">
+				<div className="w-full sm:w-72">
+					<div className="mb-1.5 text-xs font-medium text-muted-foreground">
+						Compositions present
+					</div>
+					<Select<OreOption>
+						options={oreOptions}
+						values={validSelectedOreTypeIds}
+						onValuesChange={(values) => {
+							setSelectedOreTypeIds(values)
+							updateUrl({ ore: values.length > 0 ? values.join(',') : null, composition: null })
+						}}
+						multiple
+						searchable
+						placeholder="All compositions"
+						disabled={oreOptions.length === 0}
+						renderOption={renderOreOption}
+						inputClassName="h-9"
+					/>
+				</div>
+				<div className="w-full sm:w-72">
+					<div className="mb-1.5 text-xs font-medium text-muted-foreground">
+						Sort composition by
+					</div>
+					<Select<OreOption>
+						options={compositionSortOptions}
+						value={validCompositionSortOreTypeId}
+						onValueChange={(value) => {
+							setCompositionSortOreTypeId(value)
+							updateUrl({ compositionSort: value || null, sort: null })
+						}}
+						placeholder="No composition sort"
+						searchable
+						renderOption={renderOreOption}
+						inputClassName="h-9"
+					/>
+				</div>
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					onClick={resetSystemView}
+					disabled={!hasActiveSystemView}
+				>
+					Reset
+				</Button>
+			</div>
+
+			<div className="mt-8 rounded-md border bg-card">
 				<Table>
 					<TableHeader>
 						<TableRow>
-							<TableHead>Moon</TableHead>
+							<TableHead
+								aria-sort={
+									activeSortColumn === 'moonName'
+										? activeSortDirection === 'asc'
+											? 'ascending'
+											: 'descending'
+										: 'none'
+								}
+							>
+								<button
+									type="button"
+									onClick={() => handleSort('moonName')}
+									className="inline-flex items-center gap-1.5 hover:text-foreground"
+								>
+									Moon <SortIndicator column="moonName" />
+								</button>
+							</TableHead>
 							<TableHead>Status</TableHead>
-							<TableHead className="w-96">Composition</TableHead>
+							<TableHead
+								className="w-96"
+								aria-sort={
+									activeSortColumn === 'composition'
+										? activeSortDirection === 'asc'
+											? 'ascending'
+											: 'descending'
+										: 'none'
+								}
+							>
+								<button
+									type="button"
+									onClick={() => handleSort('composition')}
+									disabled={!compositionSortOreTypeId}
+									className="inline-flex items-center gap-1.5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+								>
+									Composition <SortIndicator column="composition" />
+								</button>
+							</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -118,11 +541,17 @@ export default function SystemPage() {
 										))}
 									</TableRow>
 								))
-							: (detail?.moons ?? []).map((moon) => (
+							: visibleMoons.map((moon) => (
 									<TableRow key={moon.moonId}>
 										<TableCell>
 											<Link
 												to={`/moon-scan/moon/${moon.moonId}`}
+												state={{
+													from: `${location.pathname}${location.search}`,
+													systemFrom: backTo,
+													moonName: moon.moonName,
+													solarSystemName: sys?.solarSystemName,
+												}}
 												className="hover:underline text-foreground"
 											>
 												{moon.moonName}
@@ -148,10 +577,12 @@ export default function SystemPage() {
 										</TableCell>
 									</TableRow>
 								))}
-						{!isLoading && detail?.moons.length === 0 && (
+						{!isLoading && visibleMoons.length === 0 && (
 							<TableRow>
 								<TableCell colSpan={3} className="py-8 text-center text-sm text-muted-foreground">
-									No moons found in this system.
+									{detail?.moons.length
+										? 'No moons match the current filters.'
+										: 'No moons found in this system.'}
 								</TableCell>
 							</TableRow>
 						)}

--- a/apps/ui/src/client/features/moon-scan/system-view.ts
+++ b/apps/ui/src/client/features/moon-scan/system-view.ts
@@ -1,0 +1,13 @@
+export function filterValidOreTypeIds(
+	selectedOreTypeIds: string[],
+	availableOreTypeIds: Set<string>
+) {
+	return selectedOreTypeIds.filter((oreTypeId) => availableOreTypeIds.has(oreTypeId))
+}
+
+export function getValidCompositionSortOreTypeId(
+	compositionSortOreTypeId: string,
+	availableOreTypeIds: Set<string>
+) {
+	return availableOreTypeIds.has(compositionSortOreTypeId) ? compositionSortOreTypeId : ''
+}

--- a/apps/ui/src/client/features/moon-scan/types.ts
+++ b/apps/ui/src/client/features/moon-scan/types.ts
@@ -7,6 +7,7 @@ export type OreRarity = 'R4' | 'R8' | 'R16' | 'R32' | 'R64'
 export interface MoonScanOre {
 	oreTypeId: string
 	quantity: string
+	oreTypeName?: string
 }
 
 export interface ScanQueueOre extends MoonScanOre {
@@ -119,6 +120,7 @@ export interface JumpLink {
 
 export interface RegionDetail {
 	regionId: string
+	regionName?: string
 	systems: RegionSystemEntry[]
 	jumpLinks: JumpLink[]
 	borderRegions: Record<string, { regionId: string; regionName: string }>
@@ -156,6 +158,8 @@ export interface StaticMoon {
 	moonName: string
 	solarSystemId: string
 	solarSystemName: string
+	regionName?: string
+	constellationName?: string
 }
 
 export interface OreRefineProduct {

--- a/apps/ui/src/test/unit/features/moon-scan/system-view.unit.test.ts
+++ b/apps/ui/src/test/unit/features/moon-scan/system-view.unit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	filterValidOreTypeIds,
+	getValidCompositionSortOreTypeId,
+} from '../../../../client/features/moon-scan/system-view'
+
+describe('moon scan system view state', () => {
+	it('removes persisted ore filters that are not present in the current system', () => {
+		expect(filterValidOreTypeIds(['ore-a', 'stale-ore', 'ore-a'], new Set(['ore-a']))).toEqual([
+			'ore-a',
+			'ore-a',
+		])
+	})
+
+	it('clears a persisted composition sort key that is not present in the current system', () => {
+		expect(getValidCompositionSortOreTypeId('stale-ore', new Set(['ore-a']))).toBe('')
+		expect(getValidCompositionSortOreTypeId('ore-a', new Set(['ore-a']))).toBe('ore-a')
+	})
+})

--- a/apps/universe/src/durable-object.ts
+++ b/apps/universe/src/durable-object.ts
@@ -74,6 +74,7 @@ import type {
 	UniversePosition,
 	UniverseRegion,
 	UniverseSolarSystem,
+	UniverseSolarSystemGeography,
 	UniverseStargate,
 	UniverseStaticMoon,
 	UniverseStructureFuelModifier,
@@ -1666,6 +1667,53 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 			logger.error('Failed to resolve solar systems by IDs', error)
 			throw error
 		}
+	}
+
+	/**
+	 * Resolve solar systems with their related geography names in one RPC response.
+	 * Name lookups are best-effort because the system record itself is still useful
+	 * when a geography cache or fallback resolver is temporarily unavailable.
+	 */
+	async resolveSolarSystemGeographyByIds(
+		solarSystemIds: string[]
+	): Promise<Record<string, UniverseSolarSystemGeography | null>> {
+		if (solarSystemIds.length === 0) return {}
+
+		const systems = await this.resolveSolarSystemsByIds([...new Set(solarSystemIds)])
+		const resolvedSystems = Object.values(systems).filter(
+			(system): system is UniverseSolarSystem => system !== null
+		)
+		const regionIds = [...new Set(resolvedSystems.map((system) => system.regionId))]
+		const constellationIds = [...new Set(resolvedSystems.map((system) => system.constellationId))]
+		const [regions, constellations] = await Promise.all([
+			this.resolveRegionsByIds(regionIds).catch((error) => {
+				logger.warn('Failed to resolve system region names; returning region IDs', error)
+				return {} as Record<string, UniverseRegion | null>
+			}),
+			this.resolveConstellationsByIds(constellationIds).catch((error) => {
+				logger.warn(
+					'Failed to resolve system constellation names; returning constellation IDs',
+					error
+				)
+				return {} as Record<string, UniverseConstellation | null>
+			}),
+		])
+
+		return Object.fromEntries(
+			solarSystemIds.map((solarSystemId) => {
+				const system = systems[solarSystemId]
+				if (!system) return [solarSystemId, null]
+				return [
+					solarSystemId,
+					{
+						...system,
+						regionName: regions[system.regionId]?.regionName ?? system.regionId,
+						constellationName:
+							constellations[system.constellationId]?.constellationName ?? system.constellationId,
+					},
+				]
+			})
+		) as Record<string, UniverseSolarSystemGeography | null>
 	}
 
 	/**

--- a/packages/moon-scan/src/index.ts
+++ b/packages/moon-scan/src/index.ts
@@ -123,6 +123,7 @@ export const RARITY_ORDER: Record<OreRarity, number> = { R4: 1, R8: 2, R16: 3, R
 export interface MoonScanOre {
 	oreTypeId: string
 	quantity: string
+	oreTypeName?: string
 }
 
 export interface MoonScan {

--- a/packages/universe/src/geography.ts
+++ b/packages/universe/src/geography.ts
@@ -27,6 +27,14 @@ export interface UniverseSolarSystem {
 }
 
 /**
+ * Solar system metadata with the related constellation and region names.
+ */
+export interface UniverseSolarSystemGeography extends UniverseSolarSystem {
+	constellationName: string
+	regionName: string
+}
+
+/**
  * 3D position metadata.
  */
 export interface UniversePosition {

--- a/packages/universe/src/index.ts
+++ b/packages/universe/src/index.ts
@@ -9,6 +9,7 @@ import type {
 	UniversePosition,
 	UniverseRegion,
 	UniverseSolarSystem,
+	UniverseSolarSystemGeography,
 	UniverseStargate,
 	UniverseStaticMoon,
 } from './geography'
@@ -280,6 +281,12 @@ export interface Universe {
 	resolveSolarSystemsByIds(
 		solarSystemIds: string[]
 	): Promise<Record<string, UniverseSolarSystem | null>>
+	/**
+	 * Resolve solar systems and their related constellation/region names in one RPC response.
+	 */
+	resolveSolarSystemGeographyByIds(
+		solarSystemIds: string[]
+	): Promise<Record<string, UniverseSolarSystemGeography | null>>
 
 	/**
 	 * Resolve solar systems by names.


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes moon scan region/system navigation so a page doesn't lose context (region/system names, back-link target) when linked from another page, and adds several quality-of-life improvements to moon scan browsing: ore composition names/tooltips, region/constellation names on system and moon detail, and URL-persisted filtering/sorting for the scanned-moons and system views.

## Changes
- **API (`apps/core/src/routes/moon-scan.ts`)**: hydrate ore type IDs to names for verified compositions and scans (`hydrateCompositionOres`, with graceful fallback to IDs if name resolution fails); include `regionName` on the region endpoint and `regionName`/`constellationName` on the moon detail endpoint; moon detail now 404s if the system can't be resolved.
- **Universe (`apps/universe`, `packages/universe`)**: add `resolveSolarSystemGeographyByIds` RPC that resolves solar systems together with their region/constellation names in one call, replacing separate `resolveSolarSystemsByIds` lookups where geography names are needed.
- **`packages/moon-scan`**: add optional `oreTypeName` to `MoonScanOre`.
- **UI navigation**: pass `from`/name context via `react-router` location `state` between the moon-scan index, region, system, moon, and scanned-moons pages so back buttons and titles/breadcrumbs resolve correctly and show immediately (before data loads) instead of falling back to raw IDs.
- **UI filtering/sorting persisted to URL**: region search (index page), system search (region page), and filters/sort/pagination (scanned-moons page) now live in URL search params instead of local component state, making views shareable/bookmarkable; scanned-moons page gains a "Clear Filters" button.
- **System page (`system.tsx`)**: new composition filter (multi-select by ore type) and composition-based column sorting, synced to both URL params and per-system `localStorage`; new `system-view.ts` helpers (`filterValidOreTypeIds`, `getValidCompositionSortOreTypeId`) to drop stale persisted ore selections that no longer exist for the current system.
- **`OreCompositionBar`**: replace plain `title` tooltips with a `HoverPopover` showing rarity badge and ore name, and apply brightness variants to visually distinguish same-rarity ore segments.
- Minor formatting/lint cleanup across touched files (e.g. `RegionMap.tsx`, `routes/index.tsx`).

## Testing
- Added/updated integration tests in `apps/core/src/routes/__tests__/moon-scan.profitability-and-batching.route.test.ts` covering ore name hydration (including fallback to IDs when name resolution fails) and the new `resolveSolarSystemGeographyByIds` usage.
- Added `apps/ui/src/test/unit/features/moon-scan/system-view.unit.test.ts` for the new `system-view.ts` helper functions.
<!-- claude:end -->