### PR TITLE
fix RPC dispose

### DIFF
--- a/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
+++ b/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
@@ -9,6 +9,20 @@ import type { SessionUser } from '../../context'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async (rpcCall: Promise<unknown>, consume: (result: any) => unknown) => {
+		const result = await rpcCall
+		try {
+			return await consume(result)
+		} finally {
+			if (result !== null && (typeof result === 'object' || typeof result === 'function')) {
+				const disposeSymbol = Reflect.get(Symbol, 'dispose')
+				if (typeof disposeSymbol === 'symbol') {
+					const disposer = Reflect.get(result, disposeSymbol)
+					if (typeof disposer === 'function') disposer.call(result)
+				}
+			}
+		}
+	},
 }))
 
 const getStubMock = vi.mocked(getStub)
@@ -233,6 +247,36 @@ describe('users corporation access', () => {
 		expect(hrStub.getUserRoles).toHaveBeenCalledWith('user-1')
 		expect(corpStub.getMembers).toHaveBeenCalledWith('1001')
 		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('disposes RPC results for the full corporation access response', async () => {
+		dbStub.query.userCharacters.findMany.mockResolvedValueOnce([
+			{
+				characterId: '2001',
+				characterName: 'Alpha One',
+				corporationId: '1001',
+				status: 'active',
+				hasValidToken: true,
+			},
+		] as any)
+
+		const corporationResult = makeRpcResult({ ceoId: '2001' })
+		const directorsResult = makeRpcResult([])
+		const hrCorporationsResult = makeRpcResult([])
+		const membersResult = makeRpcResult([{ characterId: '2001' }])
+		corpStub.getCorporationInfo.mockResolvedValue(corporationResult.value)
+		corpStub.getDirectors.mockResolvedValue(directorsResult.value)
+		corpStub.getMembers.mockResolvedValue(membersResult.value)
+		hrStub.getUserHrCorporations.mockResolvedValue(hrCorporationsResult.value)
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/users/corporation-access', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(corporationResult.dispose).toHaveBeenCalledOnce()
+		expect(directorsResult.dispose).toHaveBeenCalledOnce()
+		expect(hrCorporationsResult.dispose).toHaveBeenCalledOnce()
+		expect(membersResult.dispose).toHaveBeenCalledOnce()
 	})
 
 	it('returns all managed corporations for site admins without character lookups', async () => {

--- a/apps/core/src/routes/users.ts
+++ b/apps/core/src/routes/users.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 
 import { and, eq, inArray, or } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
@@ -617,11 +617,14 @@ users.get('/corporation-access', async (c) => {
 						c.env.EVE_CORPORATION_DATA,
 						'default'
 					)
-					using missingCorpMap = await corpStub.getCorporationIdsByCharacterIds(missingCharacterIds)
-
-					for (const [characterId, corporationId] of Object.entries(missingCorpMap)) {
-						characterCorpMap.set(characterId, corporationId)
-					}
+					await withRpcResult(
+						corpStub.getCorporationIdsByCharacterIds(missingCharacterIds),
+						(missingCorpMap) => {
+							for (const [characterId, corporationId] of Object.entries(missingCorpMap)) {
+								characterCorpMap.set(characterId, corporationId)
+							}
+						}
+					)
 				} catch (error) {
 					logger.warn('[Corporation Access] Error fetching missing character corporation IDs', {
 						error: error instanceof Error ? error.message : String(error),
@@ -666,14 +669,12 @@ users.get('/corporation-access', async (c) => {
 					// Get corporation info and directors in parallel while disposing each result
 					// within the async scope that owns it.
 					const [corpInfo, directors] = await Promise.all([
-						(async () => {
-							using result = await corpStub.getCorporationInfo(corp.corporationId)
-							return result ? { ceoId: result.ceoId } : null
-						})(),
-						(async () => {
-							using result = await corpStub.getDirectors(corp.corporationId)
-							return result.map((director) => ({ characterId: director.characterId }))
-						})(),
+						withRpcResult(corpStub.getCorporationInfo(corp.corporationId), (result) =>
+							result ? { ceoId: result.ceoId } : null
+						),
+						withRpcResult(corpStub.getDirectors(corp.corporationId), (result) =>
+							result.map((director) => ({ characterId: director.characterId }))
+						),
 					])
 
 					// Create director lookup Set for O(1) checks
@@ -773,7 +774,9 @@ users.get('/corporation-access', async (c) => {
 		if (!user.is_admin) {
 			const accessibleCorpIds = new Set(accessibleCorporations.map((c) => c.corporationId))
 			const hrStub = getStub<Rpc.Provider<Hr>>(c.env.HR, 'default')
-			using hrCorpIds = await hrStub.getUserHrCorporations(user.id)
+			const hrCorpIds = await withRpcResult(hrStub.getUserHrCorporations(user.id), (result) => [
+				...result,
+			])
 			const managedCorpById = new Map(managedCorps.map((corp) => [corp.corporationId, corp]))
 			const uniqueHrCorpIds = [...new Set(hrCorpIds)].filter((id) => {
 				if (accessibleCorpIds.has(id)) return false
@@ -786,7 +789,9 @@ users.get('/corporation-access', async (c) => {
 					hr_reviewer: 2,
 					hr_viewer: 1,
 				}
-				using explicitHrRoles = await hrStub.getUserRoles(user.id)
+				const explicitHrRoles = await withRpcResult(hrStub.getUserRoles(user.id), (result) => [
+					...result,
+				])
 				const highestExplicitRoleByCorp = new Map<
 					string,
 					'hr_admin' | 'hr_reviewer' | 'hr_viewer'
@@ -836,13 +841,12 @@ users.get('/corporation-access', async (c) => {
 						c.env.EVE_CORPORATION_DATA,
 						corp.corporationId
 					)
-					using members = await corpStub.getMembers(corp.corporationId)
-					return {
+					return await withRpcResult(corpStub.getMembers(corp.corporationId), (members) => ({
 						corporationId: corp.corporationId,
 						members: members.map((member) => ({
 							characterId: String(member.characterId),
 						})),
-					}
+					}))
 				} catch (error) {
 					logger.warn('[Corporation Access] Failed to hydrate corporation stats', {
 						corporationId: corp.corporationId,

--- a/apps/eve-corporation-data/src/services/director-manager.ts
+++ b/apps/eve-corporation-data/src/services/director-manager.ts
@@ -136,6 +136,24 @@ async function settleInBatches<T, R>(
 	return { results, skippedCount }
 }
 
+function compareDirectorVerificationStaleness(a: DirectorHealth, b: DirectorHealth): number {
+	// A director that has never completed a health check must be considered
+	// staler than one with any recorded check, regardless of configured priority.
+	const aHasHealthCheck = a.lastHealthCheck !== null
+	const bHasHealthCheck = b.lastHealthCheck !== null
+	if (aHasHealthCheck !== bHasHealthCheck) return aHasHealthCheck ? 1 : -1
+
+	const aHealthCheck = a.lastHealthCheck?.getTime() ?? Number.NEGATIVE_INFINITY
+	const bHealthCheck = b.lastHealthCheck?.getTime() ?? Number.NEGATIVE_INFINITY
+	const aUpdatedAt = a.updatedAt?.getTime() ?? Number.NEGATIVE_INFINITY
+	const bUpdatedAt = b.updatedAt?.getTime() ?? Number.NEGATIVE_INFINITY
+	const aLastAttempt = Math.max(aHealthCheck, aUpdatedAt)
+	const bLastAttempt = Math.max(bHealthCheck, bUpdatedAt)
+	if (aLastAttempt !== bLastAttempt) return aLastAttempt - bLastAttempt
+
+	return a.priority - b.priority || a.directorId.localeCompare(b.directorId)
+}
+
 /**
  * DirectorManager handles director selection, health tracking, and failover logic
  */
@@ -1238,14 +1256,16 @@ export class DirectorManager {
 			}
 		}
 
-		const nonPermanentDirectors = activeDirectors
+		const nonPermanentDirectors = [...activeDirectors].sort(compareDirectorVerificationStaleness)
 		const permanentDirectorsToAffiliationCheck =
 			!includePermanent && bypassPermanentFailures
-				? directors.filter(
-						(director) =>
-							this.isPermanentlyFailed(director) &&
-							!(director.nextRetryAt && director.nextRetryAt.getTime() > now)
-					)
+				? directors
+						.filter(
+							(director) =>
+								this.isPermanentlyFailed(director) &&
+								!(director.nextRetryAt && director.nextRetryAt.getTime() > now)
+						)
+						.sort(compareDirectorVerificationStaleness)
 				: []
 
 		const deadlineMs =

--- a/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/director-manager.test.ts
@@ -971,6 +971,57 @@ describe('DirectorManager.verifyAllDirectorsHealth', () => {
 		expect(maxActiveChecks).toBe(1)
 	})
 
+	it('prioritizes never-checked and stalest directors before recently checked ones', async () => {
+		const where = vi.fn().mockResolvedValue(undefined)
+		const set = vi.fn().mockReturnValue({ where })
+		const update = vi.fn().mockReturnValue({ set })
+		const manager = new DirectorManager({ update } as never, '98000001', {} as never)
+		const now = Date.now()
+
+		vi.spyOn(manager, 'getAllDirectors').mockResolvedValue([
+			{
+				directorId: 'recent',
+				characterId: '111',
+				characterName: 'Recently attempted',
+				isHealthy: true,
+				lastHealthCheck: new Date(now - 7 * 24 * 60 * 60 * 1000),
+				lastUsed: null,
+				failureCount: 0,
+				lastFailureReason: null,
+				priority: 1,
+				updatedAt: new Date(now - 60 * 60 * 1000),
+			},
+			{
+				directorId: 'never',
+				characterId: '222',
+				characterName: 'Never checked',
+				isHealthy: true,
+				lastHealthCheck: null,
+				lastUsed: null,
+				failureCount: 0,
+				lastFailureReason: null,
+				priority: 100,
+			},
+			{
+				directorId: 'old',
+				characterId: '333',
+				characterName: 'Old check',
+				isHealthy: true,
+				lastHealthCheck: new Date(now - 2 * 24 * 60 * 60 * 1000),
+				lastUsed: null,
+				failureCount: 0,
+				lastFailureReason: null,
+				priority: 50,
+			},
+		])
+		const verifyDirectorHealth = vi.spyOn(manager, 'verifyDirectorHealth').mockResolvedValue(true)
+
+		await expect(manager.verifyAllDirectorsHealth()).resolves.toEqual({ verified: 3, failed: 0 })
+		expect(verifyDirectorHealth).toHaveBeenNthCalledWith(1, 'never')
+		expect(verifyDirectorHealth).toHaveBeenNthCalledWith(2, 'old')
+		expect(verifyDirectorHealth).toHaveBeenNthCalledWith(3, 'recent')
+	})
+
 	it('marks corporation unverified when all director checks fail', async () => {
 		const where = vi.fn().mockResolvedValue(undefined)
 		const set = vi.fn().mockReturnValue({ where })


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes RPC result handling in the corporation-access endpoint so each Durable Object RPC result is properly disposed even when consumed across `Promise.all`/parallel branches, and corrects director health-check ordering so directors are re-verified by staleness instead of raw list order.

## Changes
- `apps/core/src/routes/users.ts`: replace inline `using result = await stub.method()` blocks with `withRpcResult(rpcCall, consume)` from `@repo/do-utils` for `getCorporationIdsByCharacterIds`, `getCorporationInfo`, `getDirectors`, `getUserHrCorporations`, `getUserRoles`, and `getMembers`, ensuring correct disposal of RPC results in each of these code paths.
- `apps/eve-corporation-data/src/services/director-manager.ts`: add `compareDirectorVerificationStaleness` and sort non-permanent (and bypassed permanent) directors by it before health-checking, so never-checked and longest-stale directors are verified first regardless of configured priority.
- Adds/updates tests: a `withRpcResult` mock plus a new test asserting all RPC results are disposed in `users.corporation-access.route.test.ts`, and a new `director-manager.test.ts` case verifying the never-checked/staleness-based ordering.

## Testing
- Added a route test asserting `dispose` is called once for each RPC result (`getCorporationInfo`, `getDirectors`, `getUserHrCorporations`, `getMembers`) in the corporation-access response.
- Added a `DirectorManager.verifyAllDirectorsHealth` unit test verifying directors are checked in never-checked → stalest → most-recent order.
<!-- claude:end -->