### PR TITLE
HR UX workflow QoL tweaks and optimizations

### DIFF
--- a/apps/core/src/__tests__/session-middleware.test.ts
+++ b/apps/core/src/__tests__/session-middleware.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldBypassSessionMiddleware } from '../middleware/session'
+
+describe('session middleware public-route bypasses', () => {
+	it('bypasses session work for image requests', () => {
+		expect(shouldBypassSessionMiddleware('/images/characters/123/portrait')).toBe(true)
+		expect(shouldBypassSessionMiddleware('/images')).toBe(true)
+	})
+
+	it('does not bypass session work for protected routes', () => {
+		expect(shouldBypassSessionMiddleware('/api/users/me')).toBe(false)
+		expect(shouldBypassSessionMiddleware('/image/characters/123/portrait')).toBe(false)
+	})
+})

--- a/apps/core/src/lib/groups-cache.ts
+++ b/apps/core/src/lib/groups-cache.ts
@@ -1,4 +1,4 @@
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { TimeCache } from '@repo/hono-helpers'
 
 import type {
@@ -61,7 +61,12 @@ export async function getCachedUserPermissions(
 	const cacheKey = `permissions:${userId}`
 	return permissionsCache.getOrSet(cacheKey, async () => {
 		const groupsStub = getStub<Groups>(env.GROUPS, 'default')
-		return await groupsStub.getUserPermissions(userId)
+		return withRpcResult(groupsStub.getUserPermissions(userId), (result) =>
+			result.map((permission) => ({
+				...permission,
+				category: permission.category ? { ...permission.category } : null,
+			}))
+		)
 	})
 }
 
@@ -75,7 +80,9 @@ export async function getCachedUserMemberships(
 	const cacheKey = `memberships:${userId}`
 	return membershipsCache.getOrSet(cacheKey, async () => {
 		const groupsStub = getStub<Groups>(env.GROUPS, 'default')
-		return await groupsStub.getUserMemberships(userId)
+		return withRpcResult(groupsStub.getUserMemberships(userId), (result) =>
+			result.map((membership) => ({ ...membership }))
+		)
 	})
 }
 
@@ -90,7 +97,15 @@ export async function getCachedGroup(
 	const cacheKey = `group:${groupId}:${userId}`
 	return groupsCache.getOrSet(cacheKey, async () => {
 		const groupsStub = getStub<Groups>(env.GROUPS, 'default')
-		return await groupsStub.getGroup(groupId, userId)
+		return withRpcResult(groupsStub.getGroup(groupId, userId), (result) =>
+			result
+				? {
+						...result,
+						category: { ...result.category },
+						adminUserIds: result.adminUserIds ? [...result.adminUserIds] : result.adminUserIds,
+					}
+				: null
+		)
 	})
 }
 
@@ -104,7 +119,12 @@ export async function getCachedCharacterPermissions(
 	const cacheKey = `character-permissions:${characterId}`
 	return characterPermissionsCache.getOrSet(cacheKey, async () => {
 		const groupsStub = getStub<Groups>(env.GROUPS, 'default')
-		return await groupsStub.getCharacterPermissions(characterId)
+		return withRpcResult(groupsStub.getCharacterPermissions(characterId), (result) =>
+			result.map((permission) => ({
+				...permission,
+				category: permission.category ? { ...permission.category } : null,
+			}))
+		)
 	})
 }
 
@@ -118,10 +138,17 @@ export async function getCachedUserRoles(
 	const cacheKey = `roles:${userId}`
 	return rolesCache.getOrSet(cacheKey, async () => {
 		const groupsStub = getStub<Groups>(env.GROUPS, 'default')
-		return await groupsStub.getRolesFor({
-			attachedToType: 'user' as RoleAttachmentType,
-			attachedToId: userId,
-		})
+		return withRpcResult(
+			groupsStub.getRolesFor({
+				attachedToType: 'user' as RoleAttachmentType,
+				attachedToId: userId,
+			}),
+			(result) =>
+				result.map((attachment) => ({
+					...attachment,
+					role: { ...attachment.role },
+				}))
+		)
 	})
 }
 
@@ -131,7 +158,12 @@ export async function getCachedUserRoles(
 export async function getCachedGlobalPermissions(env: GroupsEnv): Promise<PermissionWithDetails[]> {
 	return globalPermissionsCache.getOrSet('permissions:global', async () => {
 		const groupsStub = getStub<Groups>(env.GROUPS, 'default')
-		return await groupsStub.listPermissions()
+		return withRpcResult(groupsStub.listPermissions(), (result) =>
+			result.map((permission) => ({
+				...permission,
+				category: permission.category ? { ...permission.category } : null,
+			}))
+		)
 	})
 }
 

--- a/apps/core/src/middleware/session.ts
+++ b/apps/core/src/middleware/session.ts
@@ -17,6 +17,11 @@ import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Hr } from '@repo/hr'
 import type { App, SessionUser } from '../context'
 
+/** Public image requests do not need session resolution or its RPC lookups. */
+export function shouldBypassSessionMiddleware(pathname: string): boolean {
+	return pathname === '/images' || pathname.startsWith('/images/')
+}
+
 /**
  * Session middleware
  *
@@ -25,6 +30,10 @@ import type { App, SessionUser } from '../context'
  */
 export const sessionMiddleware = (): MiddlewareHandler<App> => {
 	return async (c, next) => {
+		if (shouldBypassSessionMiddleware(c.req.path)) {
+			return next()
+		}
+
 		// Get session token from Authorization header or cookie
 		const authHeader = c.req.header('Authorization')
 		const cookieToken = getCookie(c, 'session')

--- a/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
+++ b/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
@@ -44,6 +44,8 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 const backgroundTasks: Array<Promise<unknown>> = []

--- a/apps/core/src/routes/__tests__/corporations.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporations.access.route.test.ts
@@ -10,6 +10,8 @@ import type { SessionUser } from '../../context'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../lib/groups-cache', () => ({
@@ -19,14 +21,14 @@ vi.mock('../../lib/groups-cache', () => ({
 vi.mock('../../middleware/session', () => ({
 	requireAuth:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 	requireAdmin:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 }))
 
 const getStubMock = vi.mocked(getStub)

--- a/apps/core/src/routes/__tests__/corporations.detail.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporations.detail.route.test.ts
@@ -9,19 +9,21 @@ import type { SessionUser } from '../../context'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../middleware/session', () => ({
 	requireAuth:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 	requireAdmin:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 }))
 
 const getStubMock = vi.mocked(getStub)
@@ -83,10 +85,9 @@ describe('corporations detail route', () => {
 			},
 		}
 		const corpStub = {
-			getHealthyDirectors: vi.fn().mockResolvedValue([
-				{ directorId: 'dir-1' },
-				{ directorId: 'dir-2' },
-			]),
+			getHealthyDirectors: vi
+				.fn()
+				.mockResolvedValue([{ directorId: 'dir-1' }, { directorId: 'dir-2' }]),
 			getConfiguration: vi.fn().mockResolvedValue({
 				corporationId: 'corp-1',
 				isVerified: false,

--- a/apps/core/src/routes/__tests__/corporations.members.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporations.members.access.route.test.ts
@@ -4,22 +4,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getStub } from '@repo/do-utils'
 
 import { getCachedUserPermissions } from '../../lib/groups-cache'
-import { CoreRpcService } from '../../services/core-rpc.service'
 import corporationsRoutes from '../corporations'
 
 import type { SessionUser } from '../../context'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../lib/groups-cache', () => ({
 	getCachedUserPermissions: vi.fn(),
 }))
 
-vi.mock('../../services/core-rpc.service', () => ({
-	CoreRpcService: vi.fn(),
-}))
+vi.mock('../../services/core-rpc.service', () => ({}))
 
 const getStubMock = vi.mocked(getStub)
 const getCachedUserPermissionsMock = vi.mocked(getCachedUserPermissions)
@@ -161,10 +160,6 @@ describe('corporations members access matrix', () => {
 		getCorporationRoles: ReturnType<typeof vi.fn>
 		fetchCoreData: ReturnType<typeof vi.fn>
 	}
-	let coreStub: {
-		searchUsers: ReturnType<typeof vi.fn>
-		getUserDetails: ReturnType<typeof vi.fn>
-	}
 	let charStub: {
 		getCharacterInfo: ReturnType<typeof vi.fn>
 	}
@@ -189,18 +184,6 @@ describe('corporations members access matrix', () => {
 		charStub = {
 			getCharacterInfo: vi.fn().mockResolvedValue(null),
 		}
-		coreStub = {
-			searchUsers: vi.fn().mockResolvedValue({
-				users: [],
-				total: 0,
-				limit: 10,
-				offset: 0,
-			}),
-			getUserDetails: vi.fn().mockResolvedValue(null),
-		}
-		vi.mocked(CoreRpcService).mockImplementation(function () {
-			return coreStub as any
-		})
 		tokenStoreStub = makeTokenStoreStub()
 		corpStub = {
 			getCorporationInfo: vi.fn().mockResolvedValue({ ceoId: '9999', allianceId: null }),
@@ -453,6 +436,10 @@ describe('corporations members access matrix', () => {
 				hasValidToken: false,
 			},
 		])
+		dbStub.query.users.findMany.mockResolvedValue([
+			{ id: 'target-user-a', mainCharacterId: '2001' },
+			{ id: 'target-user-b', mainCharacterId: '2003' },
+		] as any)
 		getStubMock.mockImplementation((binding: unknown) => {
 			if (binding === env.HR) return hrStub as any
 			if (binding === env.EVE_CHARACTER_DATA) return charStub as any
@@ -531,6 +518,24 @@ describe('corporations members access matrix', () => {
 				linkedUsers: 2,
 			},
 		})
+
+		const mainsResponse = await app.request(
+			'/api/corporations/1001/members?mainsOnly=true&sortField=name&sortOrder=asc',
+			{},
+			env
+		)
+		expect(mainsResponse.status).toBe(200)
+		const mainsBody = (await mainsResponse.json()) as {
+			items: Array<{ characterId: string; mainCharacterId?: string }>
+			pagination: { totalItems: number }
+		}
+		expect(new Set(mainsBody.items.map((member) => member.characterId))).toEqual(
+			new Set(['2001', '2003'])
+		)
+		expect(mainsBody.items.every((member) => member.characterId === member.mainCharacterId)).toBe(
+			true
+		)
+		expect(mainsBody.pagination.totalItems).toBe(2)
 	})
 
 	it('sorts auth account rows by auth account id first and esi status second', async () => {
@@ -871,178 +876,6 @@ describe('corporations members access matrix', () => {
 			partial: 2,
 			none: 0,
 			unlinked: 0,
-		})
-	})
-
-	it('returns a user search dialog payload with all linked characters', async () => {
-		getCachedUserPermissionsMock.mockResolvedValue([
-			{
-				permissionId: 'perm-auditor',
-				urn: 'urn:hr:auditor',
-				name: 'HR Auditor',
-				description: null,
-				category: null,
-				groupId: 'g-1',
-				groupName: 'HR',
-				targetType: 'all_members',
-				source: 'global',
-			},
-		] as any)
-
-		dbStub.query.managedCorporations.findFirst.mockResolvedValue({
-			corporationId: '1001',
-			name: 'Alpha Corp',
-			ticker: 'ALP',
-			isActive: true,
-			isMemberCorporation: true,
-		} as any)
-
-		coreStub.searchUsers.mockResolvedValue({
-			users: [
-				{
-					id: 'user-1',
-					mainCharacterId: '1001',
-					mainCharacterName: 'Main Pilot',
-					characterCount: 2,
-					is_admin: false,
-					discordUserId: 'discord-1',
-					discordUsername: 'pilot#1234',
-					matchedCharacterId: '2002',
-					matchedCharacterName: 'Alt Pilot',
-					matchedBy: 'character_name',
-					createdAt: new Date('2026-04-01T00:00:00.000Z'),
-					updatedAt: new Date('2026-04-02T00:00:00.000Z'),
-				},
-			],
-			total: 1,
-			limit: 10,
-			offset: 0,
-		})
-		coreStub.getUserDetails.mockResolvedValue({
-			id: 'user-1',
-			mainCharacterId: '1001',
-			is_admin: false,
-			discordUserId: 'discord-1',
-			discord: null,
-			characters: [
-				{
-					characterId: '1001',
-					characterName: 'Main Pilot',
-					characterOwnerHash: 'hash-main',
-					corporationId: '1001',
-					corporationName: 'Alpha Corp',
-					allianceId: '5001',
-					allianceName: 'Alliance One',
-					is_primary: true,
-					linkedAt: new Date('2026-04-01T00:00:00.000Z'),
-					hasValidToken: true,
-					isBlacklisted: false,
-				},
-				{
-					characterId: '2002',
-					characterName: 'Alt Pilot',
-					characterOwnerHash: 'hash-alt',
-					corporationId: '2001',
-					corporationName: 'Bravo Corp',
-					allianceId: null,
-					allianceName: null,
-					is_primary: false,
-					linkedAt: new Date('2026-04-01T00:00:00.000Z'),
-					hasValidToken: false,
-					isBlacklisted: true,
-				},
-			],
-			groupMemberships: [],
-			permissionGrants: [],
-			createdAt: new Date('2026-04-01T00:00:00.000Z'),
-			updatedAt: new Date('2026-04-02T00:00:00.000Z'),
-		} as any)
-
-		const app = createApp({ user: makeUser(), db: dbStub })
-		const res = await app.request(
-			'/api/corporations/1001/members/user-search?search=pilot&limit=10&offset=0',
-			{},
-			env
-		)
-
-		expect(res.status).toBe(200)
-		const body = (await res.json()) as {
-			users: Array<{
-				summary: { id: string; matchedCharacterId: string | null; mainCharacterName: string | null }
-				details: {
-					characters: Array<{
-						characterId: string
-						corporationName?: string | null
-						allianceName?: string | null
-						is_primary: boolean
-					}>
-				} | null
-			}>
-			total: number
-			limit: number
-			offset: number
-		}
-
-		expect(body.total).toBe(1)
-		expect(body.limit).toBe(10)
-		expect(body.offset).toBe(0)
-		expect(body.users).toHaveLength(1)
-		expect(body.users[0].summary).toMatchObject({
-			id: 'user-1',
-			matchedCharacterId: '2002',
-			mainCharacterName: 'Main Pilot',
-		})
-		expect(body.users[0].details?.characters).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					characterId: '1001',
-					corporationName: 'Alpha Corp',
-					allianceName: 'Alliance One',
-					is_primary: true,
-				}),
-				expect.objectContaining({
-					characterId: '2002',
-					corporationName: 'Bravo Corp',
-					allianceName: null,
-					is_primary: false,
-				}),
-			])
-		)
-	})
-
-	it('denies user search for non-member corporations', async () => {
-		getCachedUserPermissionsMock.mockResolvedValue([
-			{
-				permissionId: 'perm-auditor',
-				urn: 'urn:hr:auditor',
-				name: 'HR Auditor',
-				description: null,
-				category: null,
-				groupId: 'g-1',
-				groupName: 'HR',
-				targetType: 'all_members',
-				source: 'global',
-			},
-		] as any)
-
-		dbStub.query.managedCorporations.findFirst.mockResolvedValue({
-			corporationId: '1001',
-			name: 'Alpha Corp',
-			ticker: 'ALP',
-			isActive: true,
-			isMemberCorporation: false,
-		} as any)
-
-		const app = createApp({ user: makeUser(), db: dbStub })
-		const res = await app.request(
-			'/api/corporations/1001/members/user-search?search=pilot&limit=10&offset=0',
-			{},
-			env
-		)
-
-		expect(res.status).toBe(403)
-		expect(await res.json()).toEqual({
-			error: 'User search is only available for member corporations',
 		})
 	})
 

--- a/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
@@ -10,6 +10,8 @@ import type { SessionUser } from '../../context'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../lib/groups-cache', () => ({

--- a/apps/core/src/routes/__tests__/hr.access-matrix.route.test.ts
+++ b/apps/core/src/routes/__tests__/hr.access-matrix.route.test.ts
@@ -10,6 +10,8 @@ import type { SessionUser } from '../../context'
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../lib/groups-cache', () => ({
@@ -18,6 +20,15 @@ vi.mock('../../lib/groups-cache', () => ({
 
 const getStubMock = vi.mocked(getStub)
 const getCachedUserPermissionsMock = vi.mocked(getCachedUserPermissions)
+const { searchUsersForHrAccessMock } = vi.hoisted(() => ({
+	searchUsersForHrAccessMock: vi.fn(),
+}))
+
+vi.mock('../../services/core-rpc.service', () => ({
+	CoreRpcService: class {
+		searchUsersForHrAccess = searchUsersForHrAccessMock
+	},
+}))
 
 function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 	return {
@@ -45,7 +56,10 @@ function makeHrStub() {
 	return {
 		getUserRoles: vi.fn().mockResolvedValue([]),
 		getUserHrCorporations: vi.fn().mockResolvedValue([]),
+		isUserBlacklisted: vi.fn().mockResolvedValue(false),
 		checkPermission: vi.fn().mockResolvedValue(false),
+		checkCharactersBlacklisted: vi.fn().mockResolvedValue({}),
+		checkBlacklistTargets: vi.fn().mockResolvedValue([]),
 		listApplications: vi.fn().mockResolvedValue([]),
 		listApplicationsPaged: vi.fn().mockResolvedValue({
 			items: [],
@@ -60,6 +74,7 @@ function makeHrStub() {
 				withdrawn: 0,
 			},
 		}),
+		getApplicationCountsByCorporation: vi.fn().mockResolvedValue([]),
 		getApplication: vi.fn().mockResolvedValue({
 			id: 'app-1',
 			userId: 'target-user-1',
@@ -247,10 +262,7 @@ function makeDbStub() {
 	}
 }
 
-function createApp(opts: {
-	user?: SessionUser
-	db?: ReturnType<typeof makeDbStub>
-}) {
+function createApp(opts: { user?: SessionUser; db?: ReturnType<typeof makeDbStub> }) {
 	const app = new Hono<{
 		Bindings: any
 		Variables: {
@@ -279,22 +291,21 @@ describe('hr route access matrix', () => {
 		ESI_TYPE_RESOLVER: { name: 'ESI_TYPE_RESOLVER' },
 		ESI: { name: 'ESI' },
 		CORE: {
-			getCharacterOwner: vi.fn().mockResolvedValue({
-				userId: 'target-user-1',
-			}),
+			getCharacterOwner: vi.fn().mockResolvedValue({ userId: 'target-user-1' }),
+			getUserCharacters: vi.fn().mockResolvedValue([]),
 		},
 		ADMIN: {
 			searchUsers: vi.fn().mockResolvedValue({ users: [], total: 0 }),
 			getUserDetails: vi.fn().mockResolvedValue(null),
-	},
-	LEGACY: {
-		listHistory: vi.fn().mockResolvedValue({
-			items: [],
-			pagination: { total: 0, page: 1, pageSize: 25 },
-		}),
-		getHistoryApplication: vi.fn().mockResolvedValue(null),
-	},
-} as any
+		},
+		LEGACY: {
+			listHistory: vi.fn().mockResolvedValue({
+				items: [],
+				pagination: { total: 0, page: 1, pageSize: 25 },
+			}),
+			getHistoryApplication: vi.fn().mockResolvedValue(null),
+		},
+	} as any
 
 	let hrStub: ReturnType<typeof makeHrStub>
 	let resolverStub: ReturnType<typeof makeResolverStub>
@@ -309,6 +320,7 @@ describe('hr route access matrix', () => {
 		dbStub = makeDbStub()
 
 		getCachedUserPermissionsMock.mockResolvedValue([])
+		searchUsersForHrAccessMock.mockResolvedValue({ users: [], total: 0, limit: 10, offset: 0 })
 		getStubMock.mockImplementation((binding: unknown) => {
 			if (binding === env.HR) return hrStub as any
 			if (binding === env.ESI_TYPE_RESOLVER) return resolverStub as any
@@ -560,6 +572,65 @@ describe('hr route access matrix', () => {
 		)
 	})
 
+	it('uses one grouped application-count request for auditor-visible member corporations', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([
+			{
+				permissionId: 'perm-auditor',
+				urn: 'urn:hr:auditor',
+				name: 'HR Auditor',
+				description: null,
+				category: null,
+				groupId: 'g-1',
+				groupName: 'HR',
+				targetType: 'all_members',
+				source: 'global',
+			},
+		] as any)
+		hrStub.getApplicationCountsByCorporation.mockResolvedValue([
+			{ corporationId: '1001', pending: 2, underReview: 1 },
+		])
+		dbStub.query.managedCorporations.findMany.mockResolvedValue([
+			{
+				corporationId: '1001',
+				isActive: true,
+				isMemberCorporation: true,
+			},
+		] as any)
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/hr/applications/counts', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({
+			corporations: [{ corporationId: '1001', pending: 2, underReview: 1 }],
+		})
+		expect(hrStub.getApplicationCountsByCorporation).toHaveBeenCalledTimes(1)
+		expect(hrStub.getApplicationCountsByCorporation).toHaveBeenCalledWith(['1001'], 'user-1', {
+			isAdmin: false,
+			isAuditor: true,
+		})
+	})
+
+	it('passes only active member corporations to the HR authorization boundary', async () => {
+		hrStub.getUserHrCorporations.mockResolvedValue(['1001', '2001'])
+		dbStub.query.managedCorporations.findMany.mockResolvedValue([
+			{
+				corporationId: '1001',
+				isActive: true,
+				isMemberCorporation: true,
+			},
+		] as any)
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/hr/applications/counts', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(hrStub.getApplicationCountsByCorporation).toHaveBeenCalledWith(['1001'], 'user-1', {
+			isAdmin: false,
+			isAuditor: false,
+		})
+	})
+
 	it('passes auditor=true into listApplicationsPaged for auditors', async () => {
 		getCachedUserPermissionsMock.mockResolvedValue([
 			{
@@ -575,7 +646,11 @@ describe('hr route access matrix', () => {
 			},
 		] as any)
 		const app = createApp({ user: makeUser(), db: dbStub })
-		const res = await app.request('/api/hr/applications/paged?corporationId=1001&limit=10&offset=0', {}, env)
+		const res = await app.request(
+			'/api/hr/applications/paged?corporationId=1001&limit=10&offset=0',
+			{},
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(hrStub.listApplicationsPaged).toHaveBeenCalledWith(
@@ -597,7 +672,11 @@ describe('hr route access matrix', () => {
 			},
 		])
 		const app = createApp({ user: makeUser(), db: dbStub })
-		const res = await app.request('/api/hr/applications/paged?corporationId=2001&limit=10&offset=0', {}, env)
+		const res = await app.request(
+			'/api/hr/applications/paged?corporationId=2001&limit=10&offset=0',
+			{},
+			env
+		)
 
 		expect(res.status).toBe(403)
 		expect(await res.json()).toEqual({
@@ -619,7 +698,11 @@ describe('hr route access matrix', () => {
 		])
 
 		const app = createApp({ user: makeUser(), db: dbStub })
-		const res = await app.request('/api/hr/applications?corporationId=2001&userId=target-user-1', {}, env)
+		const res = await app.request(
+			'/api/hr/applications?corporationId=2001&userId=target-user-1',
+			{},
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(hrStub.listApplications).toHaveBeenCalledWith(
@@ -631,7 +714,11 @@ describe('hr route access matrix', () => {
 
 	it('passes admin=true into listApplicationsPaged for site admins', async () => {
 		const app = createApp({ user: makeUser({ is_admin: true }), db: dbStub })
-		const res = await app.request('/api/hr/applications/paged?corporationId=1001&limit=10&offset=0', {}, env)
+		const res = await app.request(
+			'/api/hr/applications/paged?corporationId=1001&limit=10&offset=0',
+			{},
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(hrStub.listApplicationsPaged).toHaveBeenCalledWith(
@@ -655,7 +742,11 @@ describe('hr route access matrix', () => {
 			],
 		})
 		const app = createApp({ user: ceoUser, db: dbStub })
-		const res = await app.request('/api/hr/applications/paged?corporationId=1001&limit=10&offset=0', {}, env)
+		const res = await app.request(
+			'/api/hr/applications/paged?corporationId=1001&limit=10&offset=0',
+			{},
+			env
+		)
 
 		expect(res.status).toBe(200)
 		expect(hrStub.listApplicationsPaged).toHaveBeenCalledWith(
@@ -705,12 +796,10 @@ describe('hr route access matrix', () => {
 
 		const detailRes = await app.request('/api/hr/recommendations/applications/app-1', {}, env)
 		expect(detailRes.status).toBe(200)
-		expect(hrStub.getApplicationForRecommender).toHaveBeenCalledWith(
-			'app-1',
-			'user-1',
-			['1001'],
-			{ isAdmin: false, isAuditor: false }
-		)
+		expect(hrStub.getApplicationForRecommender).toHaveBeenCalledWith('app-1', 'user-1', ['1001'], {
+			isAdmin: false,
+			isAuditor: false,
+		})
 
 		const submitRes = await app.request(
 			'/api/hr/applications/app-1/recommendations',
@@ -768,7 +857,8 @@ describe('hr route access matrix', () => {
 		const detailRes = await app.request('/api/hr/recommendations/applications/app-2', {}, env)
 		expect(detailRes.status).toBe(403)
 		expect(await detailRes.json()).toEqual({
-			error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+			error:
+				'Access denied. Recommendations are only available for member corporations you are attached to.',
 		})
 
 		const submitRes = await app.request(
@@ -788,7 +878,8 @@ describe('hr route access matrix', () => {
 
 		expect(submitRes.status).toBe(403)
 		expect(await submitRes.json()).toEqual({
-			error: 'Access denied. Recommendations are only available for member corporations you are attached to.',
+			error:
+				'Access denied. Recommendations are only available for member corporations you are attached to.',
 		})
 		expect(hrStub.addRecommendation).not.toHaveBeenCalled()
 	})
@@ -825,12 +916,10 @@ describe('hr route access matrix', () => {
 
 		const detailRes = await app.request('/api/hr/recommendations/applications/app-1', {}, env)
 		expect(detailRes.status).toBe(200)
-		expect(hrStub.getApplicationForRecommender).toHaveBeenCalledWith(
-			'app-1',
-			'user-1',
-			[],
-			{ isAdmin: false, isAuditor: true }
-		)
+		expect(hrStub.getApplicationForRecommender).toHaveBeenCalledWith('app-1', 'user-1', [], {
+			isAdmin: false,
+			isAuditor: true,
+		})
 
 		const submitRes = await app.request(
 			'/api/hr/applications/app-1/recommendations',
@@ -1130,6 +1219,101 @@ describe('hr route access matrix', () => {
 		expect(res.status).toBe(403)
 	})
 
+	it('denies HR user search without HR access', async () => {
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/hr/users/search?search=pilot', {}, env)
+
+		expect(res.status).toBe(403)
+		expect(searchUsersForHrAccessMock).not.toHaveBeenCalled()
+	})
+
+	it('requires at least two search characters before querying the directory', async () => {
+		const app = createApp({ user: makeUser({ is_admin: true }), db: dbStub })
+		const oneCharacter = await app.request('/api/hr/users/search?search=a', {}, env)
+		const empty = await app.request('/api/hr/users/search', {}, env)
+
+		expect(oneCharacter.status).toBe(400)
+		expect(empty.status).toBe(400)
+		expect(searchUsersForHrAccessMock).not.toHaveBeenCalled()
+	})
+
+	it('uses HR access only as the search gate and does not scope results to a corporation', async () => {
+		hrStub.getUserHrCorporations.mockResolvedValue(['1001', '2001', 'not-managed'])
+		searchUsersForHrAccessMock.mockResolvedValue({
+			users: [
+				{
+					summary: {
+						id: 'target-user-1',
+						mainCharacterId: '1001',
+						mainCharacterName: 'Main Pilot',
+						characterCount: 1,
+						is_admin: false,
+						discordUserId: null,
+						discordUsername: null,
+						matchedCharacterId: '1001',
+						matchedCharacterName: 'Main Pilot',
+						matchedBy: 'main_character_name',
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					},
+					characters: [
+						{
+							characterId: '1001',
+							characterName: 'Main Pilot',
+							corporationId: '1001',
+							corporationName: 'Alpha Corp',
+							allianceId: null,
+							allianceName: null,
+							is_primary: true,
+							hasValidToken: true,
+						},
+					],
+				},
+			],
+			total: 1,
+			limit: 10,
+			offset: 0,
+		})
+		hrStub.checkBlacklistTargets.mockResolvedValue([
+			{
+				targetType: 'user',
+				targetValue: 'target-user-1',
+				isBlacklisted: true,
+				reason: null,
+				createdAt: null,
+				blacklistedBy: null,
+				entryMode: null,
+			},
+			{
+				targetType: 'character_id',
+				targetValue: '1001',
+				isBlacklisted: true,
+				reason: null,
+				createdAt: null,
+				blacklistedBy: null,
+				entryMode: null,
+			},
+		])
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/hr/users/search?search=pilot', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(searchUsersForHrAccessMock).toHaveBeenCalledWith({
+			search: 'pilot',
+			limit: 10,
+			offset: 0,
+		})
+		expect(await res.json()).toMatchObject({
+			users: [
+				{
+					summary: { id: 'target-user-1', isBlacklisted: true },
+					characters: [{ characterId: '1001', isBlacklisted: true }],
+				},
+			],
+		})
+	})
+
 	it('allows /audit/users for auditor', async () => {
 		getCachedUserPermissionsMock.mockResolvedValue([
 			{
@@ -1152,6 +1336,90 @@ describe('hr route access matrix', () => {
 			{ search: 'pilot', limit: 10, offset: 5 },
 			'user-1'
 		)
+	})
+
+	it('includes blocklist status for displayed auditor-search characters', async () => {
+		getCachedUserPermissionsMock.mockResolvedValue([
+			{
+				permissionId: 'perm-auditor',
+				urn: 'urn:hr:auditor',
+				name: 'HR Auditor',
+				description: null,
+				category: null,
+				groupId: 'g-1',
+				groupName: 'HR',
+				targetType: 'all_members',
+				source: 'global',
+			},
+		] as any)
+		env.ADMIN.searchUsers.mockResolvedValue({
+			users: [
+				{
+					id: 'target-user-1',
+					mainCharacterId: '1001',
+					mainCharacterName: 'Main Pilot',
+					characterCount: 2,
+					is_admin: false,
+					discordUserId: null,
+					discordUsername: null,
+					matchedCharacterId: '2002',
+					matchedCharacterName: 'Alt Pilot',
+					matchedBy: 'character_name',
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			],
+			total: 1,
+			limit: 25,
+			offset: 0,
+		})
+		hrStub.checkCharactersBlacklisted.mockResolvedValue({ '1001': false, '2002': true })
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/hr/audit/users?search=pilot', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toMatchObject({
+			users: [
+				{
+					mainCharacterIsBlacklisted: false,
+					matchedCharacterIsBlacklisted: true,
+				},
+			],
+		})
+		expect(hrStub.checkCharactersBlacklisted).toHaveBeenCalledWith(['1001', '2002'])
+	})
+
+	it('includes blocklist status on HR user character summaries', async () => {
+		env.CORE.getUserCharacters.mockResolvedValue([
+			{
+				characterId: '1001',
+				characterName: 'Main Pilot',
+				hasValidToken: true,
+				isDeleted: false,
+				corporationId: '1001',
+				corporationName: 'Alpha Corp',
+			},
+		])
+		hrStub.checkCharactersBlacklisted.mockResolvedValue({ '1001': true })
+
+		const app = createApp({ user: makeUser({ is_admin: true }), db: dbStub })
+		const res = await app.request('/api/hr/users/target-user-1/characters', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toMatchObject([{ characterId: '1001', isBlacklisted: true }])
+		expect(hrStub.checkCharactersBlacklisted).toHaveBeenCalledWith(['1001'])
+	})
+
+	it('includes account-level blocklist status for HR user profiles', async () => {
+		hrStub.isUserBlacklisted.mockResolvedValue(true)
+
+		const app = createApp({ user: makeUser({ is_admin: true }), db: dbStub })
+		const res = await app.request('/api/hr/users/target-user-1/blocklist-status', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ isBlacklisted: true })
+		expect(hrStub.isUserBlacklisted).toHaveBeenCalledWith('target-user-1')
 	})
 
 	it('allows auditors to create hr notes via hasAnyHrAccess', async () => {
@@ -1257,7 +1525,13 @@ describe('hr route access matrix', () => {
 			env
 		)
 		expect(reviewerRes.status).toBe(201)
-		expect(hrStub.grantRole).toHaveBeenCalledWith('1001', 'target-user-1', 'hr_reviewer', 'user-1', undefined)
+		expect(hrStub.grantRole).toHaveBeenCalledWith(
+			'1001',
+			'target-user-1',
+			'hr_reviewer',
+			'user-1',
+			undefined
+		)
 
 		const adminRes = await app.request(
 			'/api/hr/1001/roles',
@@ -1315,7 +1589,13 @@ describe('hr route access matrix', () => {
 		)
 
 		expect(res.status).toBe(201)
-		expect(hrStub.grantRole).toHaveBeenCalledWith('1001', 'target-user-1', 'hr_admin', 'user-1', undefined)
+		expect(hrStub.grantRole).toHaveBeenCalledWith(
+			'1001',
+			'target-user-1',
+			'hr_admin',
+			'user-1',
+			undefined
+		)
 	})
 
 	it('denies HR role management for alt corporations even for site admins', async () => {

--- a/apps/core/src/routes/__tests__/hr.application-alerts.test.ts
+++ b/apps/core/src/routes/__tests__/hr.application-alerts.test.ts
@@ -35,6 +35,8 @@ const serviceMocks = vi.hoisted(() => ({
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../services/corporation-alerts.service', () => ({

--- a/apps/core/src/routes/__tests__/hr.application-enrichment.test.ts
+++ b/apps/core/src/routes/__tests__/hr.application-enrichment.test.ts
@@ -11,6 +11,7 @@ const hoisted = vi.hoisted(() => ({
 	hrMocks: {
 		listApplications: vi.fn(),
 		getApplication: vi.fn(),
+		checkBlacklistTargets: vi.fn(),
 	},
 	resolverMocks: {
 		resolveIds: vi.fn(),
@@ -22,6 +23,8 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../lib/hr-access', () => ({
@@ -84,6 +87,7 @@ describe('HR application hydration', () => {
 				return {
 					listApplications: hoisted.hrMocks.listApplications,
 					getApplication: hoisted.hrMocks.getApplication,
+					checkBlacklistTargets: hoisted.hrMocks.checkBlacklistTargets,
 				}
 			}
 			if (binding?.name === 'ESI_TYPE_RESOLVER') {
@@ -94,6 +98,7 @@ describe('HR application hydration', () => {
 			throw new Error(`Unexpected binding: ${binding?.name ?? 'unknown'}`)
 		})
 		hoisted.resolverMocks.resolveIds.mockResolvedValue({})
+		hoisted.hrMocks.checkBlacklistTargets.mockResolvedValue([])
 	})
 
 	it('falls back to managed corporation names for application lists', async () => {
@@ -118,22 +123,41 @@ describe('HR application hydration', () => {
 				isFirstApplication: true,
 			},
 		])
+		hoisted.hrMocks.checkBlacklistTargets.mockResolvedValue([
+			{
+				targetType: 'user',
+				targetValue: 'user-1',
+				isBlacklisted: true,
+				reason: 'test',
+				createdAt: null,
+				blacklistedBy: null,
+				entryMode: 'manual',
+			},
+			{
+				targetType: 'character_id',
+				targetValue: 'char-1',
+				isBlacklisted: true,
+				reason: 'test',
+				createdAt: null,
+				blacklistedBy: null,
+				entryMode: 'manual',
+			},
+		])
 
 		const app = createApp(makeUser(), db)
-		const response = await app.request(
-			'/api/hr/applications',
-			{},
-			{
-				HR: { name: 'HR' },
-				ESI_TYPE_RESOLVER: { name: 'ESI_TYPE_RESOLVER' },
-			} as any
-		)
+		const response = await app.request('/api/hr/applications', {}, {
+			HR: { name: 'HR' },
+			ESI_TYPE_RESOLVER: { name: 'ESI_TYPE_RESOLVER' },
+		} as any)
 
 		expect(response.status).toBe(200)
 		expect(await response.json()).toEqual([
 			expect.objectContaining({
 				corporationId: 'corp-1',
 				corporationName: 'Managed Corp',
+				isUserBlacklisted: true,
+				isCharacterBlacklisted: true,
+				isBlacklisted: true,
 			}),
 		])
 	})
@@ -163,14 +187,10 @@ describe('HR application hydration', () => {
 		})
 
 		const app = createApp(makeUser(), db)
-		const response = await app.request(
-			'/api/hr/applications/app-1',
-			{},
-			{
-				HR: { name: 'HR' },
-				ESI_TYPE_RESOLVER: { name: 'ESI_TYPE_RESOLVER' },
-			} as any
-		)
+		const response = await app.request('/api/hr/applications/app-1', {}, {
+			HR: { name: 'HR' },
+			ESI_TYPE_RESOLVER: { name: 'ESI_TYPE_RESOLVER' },
+		} as any)
 
 		expect(response.status).toBe(200)
 		expect(await response.json()).toEqual(

--- a/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
+++ b/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
@@ -3,9 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStub } from '@repo/do-utils'
 
+import { hasHrAuditorPermission } from '../../lib/hr-access'
 import usersRoutes from '../users'
 
 import type { SessionUser } from '../../context'
+
+vi.mock('../../lib/hr-access', () => ({
+	hasHrAuditorPermission: vi.fn().mockResolvedValue(false),
+}))
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
@@ -26,6 +31,7 @@ vi.mock('@repo/do-utils', () => ({
 }))
 
 const getStubMock = vi.mocked(getStub)
+const hasHrAuditorPermissionMock = vi.mocked(hasHrAuditorPermission)
 
 function makeRpcResult<T extends object>(
 	value: T
@@ -102,7 +108,9 @@ describe('users corporation access', () => {
 	}
 
 	beforeEach(() => {
+		vi.unstubAllGlobals()
 		vi.clearAllMocks()
+		hasHrAuditorPermissionMock.mockResolvedValue(false)
 
 		dbStub = {
 			query: {
@@ -236,16 +244,12 @@ describe('users corporation access', () => {
 					isMemberCorporation: true,
 					isAltCorp: false,
 					isSpecialPurpose: false,
-					memberCount: 4,
-					linkedMemberCount: 2,
-					unlinkedMemberCount: 1,
-					validEsiKeyMemberCount: 3,
 				},
 			],
 		})
 		expect(hrStub.getUserHrCorporations).toHaveBeenCalledWith('user-1')
 		expect(hrStub.getUserRoles).toHaveBeenCalledWith('user-1')
-		expect(corpStub.getMembers).toHaveBeenCalledWith('1001')
+		expect(corpStub.getMembers).not.toHaveBeenCalled()
 		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
 	})
 
@@ -263,10 +267,8 @@ describe('users corporation access', () => {
 		const corporationResult = makeRpcResult({ ceoId: '2001' })
 		const directorsResult = makeRpcResult([])
 		const hrCorporationsResult = makeRpcResult([])
-		const membersResult = makeRpcResult([{ characterId: '2001' }])
 		corpStub.getCorporationInfo.mockResolvedValue(corporationResult.value)
 		corpStub.getDirectors.mockResolvedValue(directorsResult.value)
-		corpStub.getMembers.mockResolvedValue(membersResult.value)
 		hrStub.getUserHrCorporations.mockResolvedValue(hrCorporationsResult.value)
 
 		const app = createApp({ user: makeUser(), db: dbStub })
@@ -276,7 +278,7 @@ describe('users corporation access', () => {
 		expect(corporationResult.dispose).toHaveBeenCalledOnce()
 		expect(directorsResult.dispose).toHaveBeenCalledOnce()
 		expect(hrCorporationsResult.dispose).toHaveBeenCalledOnce()
-		expect(membersResult.dispose).toHaveBeenCalledOnce()
+		expect(corpStub.getMembers).not.toHaveBeenCalled()
 	})
 
 	it('returns all managed corporations for site admins without character lookups', async () => {
@@ -303,10 +305,6 @@ describe('users corporation access', () => {
 					isMemberCorporation: true,
 					isAltCorp: false,
 					isSpecialPurpose: false,
-					memberCount: 1,
-					linkedMemberCount: 0,
-					unlinkedMemberCount: 1,
-					validEsiKeyMemberCount: 0,
 				},
 				{
 					corporationId: '2001',
@@ -318,10 +316,6 @@ describe('users corporation access', () => {
 					isMemberCorporation: false,
 					isAltCorp: true,
 					isSpecialPurpose: false,
-					memberCount: 1,
-					linkedMemberCount: 0,
-					unlinkedMemberCount: 1,
-					validEsiKeyMemberCount: 0,
 				},
 				{
 					corporationId: '3001',
@@ -333,17 +327,13 @@ describe('users corporation access', () => {
 					isMemberCorporation: false,
 					isAltCorp: false,
 					isSpecialPurpose: true,
-					memberCount: 1,
-					linkedMemberCount: 0,
-					unlinkedMemberCount: 1,
-					validEsiKeyMemberCount: 0,
 				},
 			],
 		})
 		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
 		expect(corpStub.getCorporationInfo).not.toHaveBeenCalled()
 		expect(corpStub.getDirectors).not.toHaveBeenCalled()
-		expect(corpStub.getMembers).toHaveBeenCalledTimes(3)
+		expect(corpStub.getMembers).not.toHaveBeenCalled()
 	})
 
 	it('disposes RPC results when checking quick corporation access', async () => {
@@ -374,5 +364,64 @@ describe('users corporation access', () => {
 		expect(corporationResult.dispose).toHaveBeenCalledOnce()
 		expect(directorsResult.dispose).toHaveBeenCalledOnce()
 		expect(hrCorporationsResult.dispose).toHaveBeenCalledOnce()
+	})
+
+	it('returns coverage only for corporations in the user HR scope', async () => {
+		hrStub.getUserHrCorporations.mockResolvedValue(['1001'])
+		corpStub.getMembers.mockResolvedValue([
+			{ characterId: '2001' },
+			{ characterId: '2002' },
+			{ characterId: '2003' },
+			{ characterId: '2004' },
+		])
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{ characterId: '2001', userId: 'user-a', status: 'active', hasValidToken: true },
+			{ characterId: '2002', userId: 'user-a', status: 'active', hasValidToken: false },
+			{ characterId: '2003', userId: 'user-b', status: 'active', hasValidToken: true },
+		])
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const res = await app.request('/api/users/corporation-coverage', {}, env)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({
+			corporations: [
+				{
+					corporationId: '1001',
+					memberCount: 4,
+					linkedMemberCount: 2,
+					unlinkedMemberCount: 1,
+					validEsiKeyMemberCount: 2,
+				},
+			],
+		})
+		expect(corpStub.getMembers).toHaveBeenCalledWith('1001')
+		expect(hrStub.getUserHrCorporations).toHaveBeenCalledWith('user-1')
+	})
+
+	it('reuses the corporation coverage cache across users', async () => {
+		const responses = new Map<string, Response>()
+		vi.stubGlobal('caches', {
+			default: {
+				match: vi.fn(async (key: string) => responses.get(key)?.clone()),
+				put: vi.fn(async (key: string, response: Response) => {
+					responses.set(key, response.clone())
+				}),
+			},
+		})
+		hrStub.getUserHrCorporations.mockResolvedValue(['1001'])
+		corpStub.getMembers.mockResolvedValue([{ characterId: '2001' }])
+		dbStub.query.userCharacters.findMany.mockResolvedValue([
+			{ characterId: '2001', userId: 'user-a', status: 'active', hasValidToken: true },
+		])
+
+		const app = createApp({ user: makeUser(), db: dbStub })
+		const firstResponse = await app.request('/api/users/corporation-coverage', {}, env)
+		const secondResponse = await app.request('/api/users/corporation-coverage', {}, env)
+
+		expect(firstResponse.status).toBe(200)
+		expect(secondResponse.status).toBe(200)
+		expect(corpStub.getMembers).toHaveBeenCalledTimes(1)
+		expect(dbStub.query.userCharacters.findMany).toHaveBeenCalledTimes(1)
 	})
 })

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 
 import { and, asc, desc, eq, ilike, inArray, or, sql } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { buildCsvLine } from '@repo/worker-utils'
 
@@ -18,7 +18,6 @@ import {
 } from '../../lib/corporation-list-cache'
 import { getCachedUserPermissions } from '../../lib/groups-cache'
 import { requireAdmin, requireAuth } from '../../middleware/session'
-import { CoreRpcService } from '../../services/core-rpc.service'
 import corporationsAlertsRoutes from './alerts-routes'
 import corporationsDirectorsRoutes from './directors-routes'
 import corporationsDiscordRoutes from './discord-routes'
@@ -38,6 +37,13 @@ const app = new Hono<App>()
 const MS_PER_DAY = 86_400_000
 const ACTIVE_MEMBER_THRESHOLD_MS = 7 * MS_PER_DAY
 const DISCORD_USERNAME_LOOKUP_BATCH_SIZE = 25
+
+function cloneRpcResult<T>(result: T): T {
+	if (result === null || (typeof result !== 'object' && typeof result !== 'function')) {
+		return result
+	}
+	return structuredClone(result)
+}
 
 /**
  * Cache duration for corporation member data (5 minutes)
@@ -222,18 +228,6 @@ type CorporationMemberListItem = {
 	isBlacklisted: boolean
 }
 
-type CorporationUserSearchEntry = {
-	summary: Awaited<ReturnType<CoreRpcService['searchUsers']>>['users'][number]
-	details: NonNullable<Awaited<ReturnType<CoreRpcService['getUserDetails']>>>
-}
-
-type CorporationUserSearchResponse = {
-	users: CorporationUserSearchEntry[]
-	total: number
-	limit: number
-	offset: number
-}
-
 type MembersAuthFilter =
 	| 'all'
 	| 'linked'
@@ -251,6 +245,7 @@ type MembersQuery = {
 	page: number
 	limit: number
 	search: string
+	mainsOnly: boolean
 	authFilter: MembersAuthFilter
 	coverageFilter: MembersCoverageFilter
 	activityFilter: MembersActivityFilter
@@ -414,6 +409,7 @@ function hasAnyMembersQueryParams(c: Context<App>): boolean {
 		typeof c.req.query('page') === 'string' ||
 		typeof c.req.query('limit') === 'string' ||
 		typeof c.req.query('search') === 'string' ||
+		typeof c.req.query('mainsOnly') === 'string' ||
 		typeof c.req.query('authFilter') === 'string' ||
 		typeof c.req.query('activityFilter') === 'string' ||
 		typeof c.req.query('roleFilter') === 'string' ||
@@ -434,6 +430,7 @@ function parseMembersQuery(c: Context<App>): MembersQuery {
 	const page = parsePositiveInt(c.req.query('page'), 1)
 	const limit = Math.min(parsePositiveInt(c.req.query('limit'), 50), 200)
 	const search = (c.req.query('search') ?? '').trim().toLowerCase()
+	const mainsOnly = parseBoolean(c.req.query('mainsOnly'))
 	const authFilterRaw = c.req.query('authFilter')
 	const coverageFilterRaw = c.req.query('coverageFilter')
 	const activityFilterRaw = c.req.query('activityFilter')
@@ -482,6 +479,7 @@ function parseMembersQuery(c: Context<App>): MembersQuery {
 		page,
 		limit,
 		search,
+		mainsOnly,
 		authFilter,
 		coverageFilter,
 		activityFilter,
@@ -494,12 +492,19 @@ function parseMembersQuery(c: Context<App>): MembersQuery {
 function canUseBackendPaginatedMembersPath(query: MembersQuery): boolean {
 	return (
 		!query.search &&
+		!query.mainsOnly &&
 		query.authFilter === 'all' &&
 		query.coverageFilter === 'all' &&
 		query.activityFilter === 'all' &&
 		query.roleFilter === 'all' &&
 		query.sortField === 'role' &&
 		query.sortOrder === 'asc'
+	)
+}
+
+function isMainCharacterMember(member: CorporationMemberListItem): boolean {
+	return Boolean(
+		member.hasAuthAccount && member.mainCharacterId && member.characterId === member.mainCharacterId
 	)
 }
 
@@ -539,6 +544,7 @@ function filterSortAndPaginateMembers(
 	}
 
 	const filtered = [...members]
+		.filter((member) => !query.mainsOnly || isMainCharacterMember(member))
 		.filter((member) => {
 			if (!query.search) return true
 			return (
@@ -700,6 +706,7 @@ function filterSortMembers(
 	}
 
 	const filtered = [...members]
+		.filter((member) => !query.mainsOnly || isMainCharacterMember(member))
 		.filter((member) => {
 			if (!query.search) return true
 			return (
@@ -849,8 +856,18 @@ async function hydrateCorporationMembers(
 	}
 
 	const [corpInfo, coreData] = await Promise.all([
-		corpStub.getCorporationInfo(corporationId),
-		corpStub.getCoreData(corporationId),
+		withRpcResult(corpStub.getCorporationInfo(corporationId), (result) =>
+			result ? { ...result } : null
+		),
+		withRpcResult(corpStub.getCoreData(corporationId), (result) =>
+			result
+				? {
+						...result,
+						members: result.members?.map((member) => ({ ...member })),
+						memberTracking: result.memberTracking?.map((member) => ({ ...member })),
+					}
+				: null
+		),
 	])
 
 	if (!coreData || !coreData.members) {
@@ -865,10 +882,16 @@ async function hydrateCorporationMembers(
 				})
 			: []
 	const linkedCharacterMap = new Map(linkedCharacters.map((row) => [row.characterId, row]))
-	const directors = await corpStub.getDirectors(corporationId)
+	const directors = await withRpcResult(corpStub.getDirectors(corporationId), (result) =>
+		result.map((director) => ({ ...director }))
+	)
 	const directorIds = new Set(directors.map((director) => director.characterId))
 	const characterNameMap =
-		memberCharacterIds.length > 0 ? await tokenStoreStub.resolveIds(memberCharacterIds) : {}
+		memberCharacterIds.length > 0
+			? await withRpcResult(tokenStoreStub.resolveIds(memberCharacterIds), (result) => ({
+					...result,
+				}))
+			: {}
 	const linkedUserIds = [...new Set(linkedCharacters.map((row) => row.userId))]
 	const linkedUsers =
 		linkedUserIds.length > 0
@@ -878,7 +901,11 @@ async function hydrateCorporationMembers(
 			: []
 	const mainCharacterIds = linkedUsers.map((user) => user.mainCharacterId)
 	const mainCharacterNameMap =
-		mainCharacterIds.length > 0 ? await tokenStoreStub.resolveIds(mainCharacterIds) : {}
+		mainCharacterIds.length > 0
+			? await withRpcResult(tokenStoreStub.resolveIds(mainCharacterIds), (result) => ({
+					...result,
+				}))
+			: {}
 	const userIdToMainCharacterName = new Map(
 		linkedUsers.map((user) => [user.id, mainCharacterNameMap[user.mainCharacterId] || 'Unknown'])
 	)
@@ -901,7 +928,10 @@ async function hydrateCorporationMembers(
 			const statuses = await Promise.all(
 				batch.map(async (user) => {
 					try {
-						const status = await discordStub.getDiscordUserStatus(user.id)
+						const status = await withRpcResult(
+							discordStub.getDiscordUserStatus(user.id),
+							(result) => (result ? { username: result.username } : null)
+						)
 						return { userId: user.id, username: status?.username ?? null }
 					} catch (error) {
 						logger.warn('[Corporations] Failed to resolve Discord username for member export', {
@@ -920,7 +950,11 @@ async function hydrateCorporationMembers(
 	}
 	const hrStub = getStub<Hr>(c.env.HR, 'default')
 	const blacklistStatuses =
-		memberCharacterIds.length > 0 ? await hrStub.checkCharactersBlacklisted(memberCharacterIds) : {}
+		memberCharacterIds.length > 0
+			? await withRpcResult(hrStub.checkCharactersBlacklisted(memberCharacterIds), (result) => ({
+					...result,
+				}))
+			: {}
 	const now = Date.now()
 
 	return coreData.members.map((member) => {
@@ -1061,8 +1095,12 @@ async function checkCorporationAccess(
 	let userRole: 'CEO' | 'Director' | null = null
 	const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
 	const [corpInfo, directors] = await Promise.all([
-		corpStub.getCorporationInfo(corporationId),
-		corpStub.getDirectors(corporationId),
+		withRpcResult(corpStub.getCorporationInfo(corporationId), (result) =>
+			result ? { ceoId: result.ceoId } : null
+		),
+		withRpcResult(corpStub.getDirectors(corporationId), (result) =>
+			result.map((director) => ({ characterId: director.characterId }))
+		),
 	])
 	const directorIds = new Set(directors.map((d) => d.characterId))
 
@@ -1100,7 +1138,10 @@ async function checkCorporationAccess(
 		try {
 			// Check if character is in this corporation
 			const charStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, character.characterId)
-			const charData = await charStub.getCharacterInfo(character.characterId)
+			const charData = await withRpcResult(
+				charStub.getCharacterInfo(character.characterId),
+				(result) => (result ? { corporationId: result.corporationId } : null)
+			)
 
 			// Skip if character is not in the target corporation
 			if (!charData || String(charData.corporationId) !== corporationId) {
@@ -1788,7 +1829,9 @@ app.get('/:corporationId', requireAuth(), requireAdmin(), async (c) => {
 		let doConfig = null
 		try {
 			const stub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
-			doConfig = await stub.getConfiguration()
+			doConfig = await withRpcResult(stub.getConfiguration(), (result) =>
+				result ? { ...result } : null
+			)
 		} catch (error) {
 			logger.error('Error fetching DO config:', error)
 		}
@@ -1874,14 +1917,33 @@ app.put('/:corporationId', requireAuth(), requireAdmin(), async (c) => {
 					)
 
 					// First, get all permissions to find the TEST alliance permission ID
-					const allPermissions = await groupsStub.listPermissions()
+					const allPermissions = await withRpcResult(groupsStub.listPermissions(), (result) =>
+						result.map((permission) => ({
+							...permission,
+							category: permission.category ? { ...permission.category } : null,
+						}))
+					)
 					const testAlliancePermission = allPermissions.find((p) => p.urn === testAllianceUrn)
 
 					if (testAlliancePermission) {
 						// Check if permission is already attached
-						const existingPermissions = await groupsStub.listCorporationPermissions(corporationId)
+						const existingPermissions = await withRpcResult(
+							groupsStub.listCorporationPermissions(corporationId),
+							(result) =>
+								result.map((permission) => ({
+									...permission,
+									permission: permission.permission
+										? {
+												...permission.permission,
+												category: permission.permission.category
+													? { ...permission.permission.category }
+													: null,
+											}
+										: null,
+								}))
+						)
 						const alreadyAttached = existingPermissions.some(
-							(cp) => cp.permission.urn === testAllianceUrn
+							(cp) => cp.permission?.urn === testAllianceUrn
 						)
 
 						if (!alreadyAttached) {
@@ -1919,9 +1981,23 @@ app.put('/:corporationId', requireAuth(), requireAdmin(), async (c) => {
 					)
 
 					// Get corporation permissions to find the one to remove
-					const corpPermissions = await groupsStub.listCorporationPermissions(corporationId)
+					const corpPermissions = await withRpcResult(
+						groupsStub.listCorporationPermissions(corporationId),
+						(result) =>
+							result.map((permission) => ({
+								...permission,
+								permission: permission.permission
+									? {
+											...permission.permission,
+											category: permission.permission.category
+												? { ...permission.permission.category }
+												: null,
+										}
+									: null,
+							}))
+					)
 					const testAllianceCorpPermission = corpPermissions.find(
-						(cp) => cp.permission.urn === testAllianceUrn
+						(cp) => cp.permission?.urn === testAllianceUrn
 					)
 
 					if (testAllianceCorpPermission) {
@@ -2096,7 +2172,7 @@ app.post('/:corporationId/verify', requireAuth(), requireAdmin(), async (c) => {
 		const stub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
 
 		logger.info('[Corporations] Verifying corporation access', { corporationId })
-		const verification = await stub.verifyAccess(corporationId)
+		const verification = await withRpcResult(stub.verifyAccess(corporationId), cloneRpcResult)
 
 		const healthyDirectorCount = await stub.getHealthyDirectorCount(corporationId)
 
@@ -2255,54 +2331,72 @@ app.get('/:corporationId/data', requireAuth(), requireAdmin(), async (c) => {
 		logger.info('[Corporations] Fetching all data from DO', { corporationId })
 		const [publicInfo, coreData, financialData, assetsData, marketData, killmails] =
 			await Promise.all([
-				stub.getCorporationInfo(corporationId).catch((e: unknown) => {
-					logger.error('[Corporations] getCorporationInfo failed', {
-						corporationId,
-						error: e instanceof Error ? e.message : String(e),
-						stack: e instanceof Error ? e.stack : undefined,
-					})
-					return null
-				}),
-				stub.getCoreData(corporationId).catch((e: unknown) => {
-					logger.error('[Corporations] getCoreData failed', {
-						corporationId,
-						error: e instanceof Error ? e.message : String(e),
-						stack: e instanceof Error ? e.stack : undefined,
-					})
-					return null
-				}),
-				stub.getFinancialData(corporationId).catch((e: unknown) => {
-					logger.error('[Corporations] getFinancialData failed', {
-						corporationId,
-						error: e instanceof Error ? e.message : String(e),
-						stack: e instanceof Error ? e.stack : undefined,
-					})
-					return null
-				}),
-				stub.getAssetsData(corporationId).catch((e: unknown) => {
-					logger.error('[Corporations] getAssetsData failed', {
-						corporationId,
-						error: e instanceof Error ? e.message : String(e),
-						stack: e instanceof Error ? e.stack : undefined,
-					})
-					return null
-				}),
-				stub.getMarketData(corporationId).catch((e: unknown) => {
-					logger.error('[Corporations] getMarketData failed', {
-						corporationId,
-						error: e instanceof Error ? e.message : String(e),
-						stack: e instanceof Error ? e.stack : undefined,
-					})
-					return null
-				}),
-				stub.getKillmails(corporationId, 10).catch((e: unknown) => {
-					logger.error('[Corporations] getKillmails failed', {
-						corporationId,
-						error: e instanceof Error ? e.message : String(e),
-						stack: e instanceof Error ? e.stack : undefined,
-					})
-					return []
-				}),
+				withRpcResult(
+					stub.getCorporationInfo(corporationId).catch((e: unknown) => {
+						logger.error('[Corporations] getCorporationInfo failed', {
+							corporationId,
+							error: e instanceof Error ? e.message : String(e),
+							stack: e instanceof Error ? e.stack : undefined,
+						})
+						return null
+					}),
+					cloneRpcResult
+				),
+				withRpcResult(
+					stub.getCoreData(corporationId).catch((e: unknown) => {
+						logger.error('[Corporations] getCoreData failed', {
+							corporationId,
+							error: e instanceof Error ? e.message : String(e),
+							stack: e instanceof Error ? e.stack : undefined,
+						})
+						return null
+					}),
+					cloneRpcResult
+				),
+				withRpcResult(
+					stub.getFinancialData(corporationId).catch((e: unknown) => {
+						logger.error('[Corporations] getFinancialData failed', {
+							corporationId,
+							error: e instanceof Error ? e.message : String(e),
+							stack: e instanceof Error ? e.stack : undefined,
+						})
+						return null
+					}),
+					cloneRpcResult
+				),
+				withRpcResult(
+					stub.getAssetsData(corporationId).catch((e: unknown) => {
+						logger.error('[Corporations] getAssetsData failed', {
+							corporationId,
+							error: e instanceof Error ? e.message : String(e),
+							stack: e instanceof Error ? e.stack : undefined,
+						})
+						return null
+					}),
+					cloneRpcResult
+				),
+				withRpcResult(
+					stub.getMarketData(corporationId).catch((e: unknown) => {
+						logger.error('[Corporations] getMarketData failed', {
+							corporationId,
+							error: e instanceof Error ? e.message : String(e),
+							stack: e instanceof Error ? e.stack : undefined,
+						})
+						return null
+					}),
+					cloneRpcResult
+				),
+				withRpcResult(
+					stub.getKillmails(corporationId, 10).catch((e: unknown) => {
+						logger.error('[Corporations] getKillmails failed', {
+							corporationId,
+							error: e instanceof Error ? e.message : String(e),
+							stack: e instanceof Error ? e.stack : undefined,
+						})
+						return []
+					}),
+					cloneRpcResult
+				),
 			])
 
 		logger.info('[Corporations] Data fetched successfully', {
@@ -2410,7 +2504,11 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
 		const hrStub = getStub<Hr>(c.env.HR, 'default')
 		const hrRoles =
-			query.sortField === 'hrRole' ? await hrStub.getCorporationRoles(corporationId, true) : []
+			query.sortField === 'hrRole'
+				? await withRpcResult(hrStub.getCorporationRoles(corporationId, true), (result) =>
+						result.map((role) => ({ ...role }))
+					)
+				: []
 		const hrRoleMap =
 			hrRoles.length > 0 ? new Map(hrRoles.map((role) => [role.userId, role.role])) : undefined
 
@@ -2421,38 +2519,46 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 				'function'
 
 		if (useBackendPagination) {
-			const paged = await (
-				corpStub as unknown as {
-					getMembersPaginated: (
-						corporationId: string,
-						page: number,
-						limit: number
-					) => Promise<{
-						items: Array<{
-							characterId: string
-							role: 'CEO' | 'Director' | 'Member'
-							joinDate: Date | null
-							lastLogin: Date | null
-							lastEsiUpdate: Date
-							activityStatus: 'active' | 'inactive' | 'unknown'
-						}>
-						pagination: {
-							page: number
+			const paged = await withRpcResult(
+				(
+					corpStub as unknown as {
+						getMembersPaginated: (
+							corporationId: string,
+							page: number,
 							limit: number
-							totalItems: number
-							totalPages: number
-							hasNextPage: boolean
-							hasPreviousPage: boolean
-						}
-						summary: {
-							total: number
-							active: number
-							inactive: number
-							directors: number
-						}
-					}>
-				}
-			).getMembersPaginated(corporationId, query.page, query.limit)
+						) => Promise<{
+							items: Array<{
+								characterId: string
+								role: 'CEO' | 'Director' | 'Member'
+								joinDate: Date | null
+								lastLogin: Date | null
+								lastEsiUpdate: Date
+								activityStatus: 'active' | 'inactive' | 'unknown'
+							}>
+							pagination: {
+								page: number
+								limit: number
+								totalItems: number
+								totalPages: number
+								hasNextPage: boolean
+								hasPreviousPage: boolean
+							}
+							summary: {
+								total: number
+								active: number
+								inactive: number
+								directors: number
+							}
+						}>
+					}
+				).getMembersPaginated(corporationId, query.page, query.limit),
+				(result) => ({
+					...result,
+					items: result.items.map((item) => ({ ...item })),
+					pagination: { ...result.pagination },
+					summary: { ...result.summary },
+				})
+			)
 
 			const pageCharacterIds = paged.items.map((item) => item.characterId)
 			const linkedCharacters =
@@ -2463,7 +2569,11 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 					: []
 			const linkedCharacterMap = new Map(linkedCharacters.map((row) => [row.characterId, row]))
 			const characterNameMap =
-				pageCharacterIds.length > 0 ? await tokenStoreStub.resolveIds(pageCharacterIds) : {}
+				pageCharacterIds.length > 0
+					? await withRpcResult(tokenStoreStub.resolveIds(pageCharacterIds), (result) => ({
+							...result,
+						}))
+					: {}
 
 			const linkedUserIds = [...new Set(linkedCharacters.map((row) => row.userId))]
 			const linkedUsers =
@@ -2474,14 +2584,22 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 					: []
 			const mainCharacterIds = linkedUsers.map((u) => u.mainCharacterId)
 			const mainCharacterNameMap =
-				mainCharacterIds.length > 0 ? await tokenStoreStub.resolveIds(mainCharacterIds) : {}
+				mainCharacterIds.length > 0
+					? await withRpcResult(tokenStoreStub.resolveIds(mainCharacterIds), (result) => ({
+							...result,
+						}))
+					: {}
 			const userIdToMainCharacterName = new Map(
 				linkedUsers.map((u) => [u.id, mainCharacterNameMap[u.mainCharacterId] || 'Unknown'])
 			)
 			const userIdToMainCharacterId = new Map(linkedUsers.map((u) => [u.id, u.mainCharacterId]))
 
 			const blacklistStatuses =
-				pageCharacterIds.length > 0 ? await hrStub.checkCharactersBlacklisted(pageCharacterIds) : {}
+				pageCharacterIds.length > 0
+					? await withRpcResult(hrStub.checkCharactersBlacklisted(pageCharacterIds), (result) => ({
+							...result,
+						}))
+					: {}
 
 			// These are lightweight member-summary fields used by list/search pages.
 			// They intentionally stop short of private character hydration so they
@@ -2544,7 +2662,10 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 				totalCharacters: 0,
 			}
 			try {
-				const coverageMemberRows = await corpStub.getMembers(corporationId)
+				const coverageMemberRows = await withRpcResult(
+					corpStub.getMembers(corporationId),
+					(result) => result.map((member) => ({ characterId: String(member.characterId) }))
+				)
 				const coverageMemberIds = coverageMemberRows.map((row) => String(row.characterId))
 				const coverageLinkedCharacters =
 					coverageMemberIds.length > 0
@@ -2598,15 +2719,27 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 				search: query.search,
 			})
 			const response = returnUnpaginated
-				? buildUnpaginatedMembersResponse(cached)
+				? buildUnpaginatedMembersResponse(
+						query.mainsOnly ? cached.filter(isMainCharacterMember) : cached
+					)
 				: filterSortAndPaginateMembers(cached, query, hrRoleMap)
 			return c.json(response)
 		}
 
 		// Get corporation members from DO
 		const [corpInfo, coreData] = await Promise.all([
-			corpStub.getCorporationInfo(corporationId),
-			corpStub.getCoreData(corporationId),
+			withRpcResult(corpStub.getCorporationInfo(corporationId), (result) =>
+				result ? { ...result } : null
+			),
+			withRpcResult(corpStub.getCoreData(corporationId), (result) =>
+				result
+					? {
+							...result,
+							members: result.members?.map((member) => ({ ...member })),
+							memberTracking: result.memberTracking?.map((member) => ({ ...member })),
+						}
+					: null
+			),
 		])
 
 		if (!coreData || !coreData.members) {
@@ -2627,12 +2760,17 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		const linkedCharacterMap = new Map(linkedCharacters.map((c) => [c.characterId, c]))
 
 		// Fetch directors list once for role determination
-		const directors = await corpStub.getDirectors(corporationId)
+		const directors = await withRpcResult(corpStub.getDirectors(corporationId), (result) =>
+			result.map((director) => ({ ...director }))
+		)
 		const directorIds = new Set(directors.map((d) => d.characterId))
 
 		// Batch resolve all character names using ESI bulk endpoint
 		// Character ID → name mappings are cached for 1 year (essentially permanent)
-		const characterNameMap = await tokenStoreStub.resolveIds(memberCharacterIds)
+		const characterNameMap = await withRpcResult(
+			tokenStoreStub.resolveIds(memberCharacterIds),
+			(result) => ({ ...result })
+		)
 
 		logger.info('[Corporations Members] Resolved character names', {
 			corporationId,
@@ -2653,7 +2791,11 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		// Resolve main character IDs to character names
 		const mainCharacterIds = linkedUsers.map((u) => u.mainCharacterId)
 		const mainCharacterNameMap =
-			mainCharacterIds.length > 0 ? await tokenStoreStub.resolveIds(mainCharacterIds) : {}
+			mainCharacterIds.length > 0
+				? await withRpcResult(tokenStoreStub.resolveIds(mainCharacterIds), (result) => ({
+						...result,
+					}))
+				: {}
 
 		// Create a map from userId to main character name
 		const userIdToMainCharacterName = new Map(
@@ -2670,7 +2812,9 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		// Bulk check blacklist status for all members
 		const blacklistStatuses =
 			memberCharacterIds.length > 0
-				? await hrStub.checkCharactersBlacklisted(memberCharacterIds)
+				? await withRpcResult(hrStub.checkCharactersBlacklisted(memberCharacterIds), (result) => ({
+						...result,
+					}))
 				: {}
 
 		// Process members with comprehensive data
@@ -2746,7 +2890,9 @@ app.get('/:corporationId/members', requireAuth(), async (c) => {
 		await cacheJson(cacheKey, membersWithDetails, CACHE_TTL)
 
 		const response = returnUnpaginated
-			? buildUnpaginatedMembersResponse(membersWithDetails)
+			? buildUnpaginatedMembersResponse(
+					query.mainsOnly ? membersWithDetails.filter(isMainCharacterMember) : membersWithDetails
+				)
 			: filterSortAndPaginateMembers(membersWithDetails, query, hrRoleMap)
 		return c.json(response)
 	} catch (error) {
@@ -2813,7 +2959,9 @@ app.get('/:corporationId/members/export', requireAuth(), async (c) => {
 			corpStub,
 			tokenStoreStub
 		)
-		const hrRoles = await hrStub.getCorporationRoles(corporationId, true)
+		const hrRoles = await withRpcResult(hrStub.getCorporationRoles(corporationId, true), (result) =>
+			result.map((role) => ({ ...role }))
+		)
 		const hrRoleMap = new Map(hrRoles.map((role) => [role.userId, role.role]))
 		const filteredMembers = filterSortMembers(members, query, hrRoleMap)
 		const csv = buildCorporationMembersCsv(filteredMembers, hrRoleMap)
@@ -2839,105 +2987,6 @@ app.get('/:corporationId/members/export', requireAuth(), async (c) => {
 			stack: error instanceof Error ? error.stack : undefined,
 		})
 		return c.json({ error: 'Failed to export corporation members' }, 500)
-	}
-})
-
-/**
- * GET /corporations/:corporationId/members/user-search
- * Search users for the corp member lookup dialog.
- */
-app.get('/:corporationId/members/user-search', requireAuth(), async (c) => {
-	const corporationId = c.req.param('corporationId')
-	const user = c.get('user')!
-	const db = c.get('db')
-	const search = (c.req.query('search') ?? '').trim()
-	const limit = Math.min(parsePositiveInt(c.req.query('limit'), 10), 50)
-	const parsedOffset = Number.parseInt(c.req.query('offset') ?? '', 10)
-	const offset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0
-
-	if (!db) {
-		return c.json({ error: 'Database not available' }, 500)
-	}
-
-	try {
-		const managedCorp = await db.query.managedCorporations.findFirst({
-			where: and(
-				eq(managedCorporations.corporationId, corporationId),
-				eq(managedCorporations.isActive, true)
-			),
-		})
-
-		if (!managedCorp) {
-			return c.json({ error: 'Corporation not found or not managed' }, 404)
-		}
-		if (!managedCorp.isMemberCorporation) {
-			return c.json({ error: 'User search is only available for member corporations' }, 403)
-		}
-
-		let userRole: 'admin' | 'CEO' | 'Director' | 'hr_admin' | 'hr_reviewer' | 'hr_viewer'
-		try {
-			userRole = await resolveCorporationMembersAccess(c, corporationId, managedCorp)
-		} catch (error) {
-			if (error instanceof Error && error.message === MEMBERS_ACCESS_DENIED_MESSAGE) {
-				return c.json({ error: error.message }, 403)
-			}
-			throw error
-		}
-
-		logger.info('[Corporations] User search request', {
-			corporationId,
-			userId: user.id,
-			search,
-			limit,
-			offset,
-			userRole,
-		})
-
-		if (search.length === 0) {
-			return c.json({
-				users: [],
-				total: 0,
-				limit,
-				offset,
-			} satisfies CorporationUserSearchResponse)
-		}
-
-		const coreService = new CoreRpcService(db, c.env)
-		const result = await coreService.searchUsers({
-			search,
-			limit,
-			offset,
-		})
-
-		const usersWithDetails = (
-			await Promise.all(
-				result.users.map(async (summary) => {
-					const details = await coreService.getUserDetails(summary.id)
-					if (!details) {
-						return null
-					}
-					return {
-						summary,
-						details,
-					}
-				})
-			)
-		).filter((entry): entry is CorporationUserSearchEntry => entry !== null)
-
-		return c.json({
-			users: usersWithDetails,
-			total: result.total,
-			limit: result.limit,
-			offset: result.offset,
-		} satisfies CorporationUserSearchResponse)
-	} catch (error) {
-		logger.error('[Corporations] Error searching users for corporation member dialog', {
-			corporationId,
-			userId: user.id,
-			error: error instanceof Error ? error.message : String(error),
-			stack: error instanceof Error ? error.stack : undefined,
-		})
-		return c.json({ error: 'Failed to search users' }, 500)
 	}
 })
 
@@ -3000,10 +3049,24 @@ app.get('/:corporationId/members/:accountId', requireAuth(), async (c) => {
 		const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
 		const tokenStoreStub = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
 		const [corpInfo, coreData, currentMembers, directors] = await Promise.all([
-			corpStub.getCorporationInfo(corporationId),
-			corpStub.getCoreData(corporationId),
-			corpStub.getMembers(corporationId),
-			corpStub.getDirectors(corporationId),
+			withRpcResult(corpStub.getCorporationInfo(corporationId), (result) =>
+				result ? { ...result } : null
+			),
+			withRpcResult(corpStub.getCoreData(corporationId), (result) =>
+				result
+					? {
+							...result,
+							members: result.members?.map((member) => ({ ...member })),
+							memberTracking: result.memberTracking?.map((member) => ({ ...member })),
+						}
+					: null
+			),
+			withRpcResult(corpStub.getMembers(corporationId), (result) =>
+				result.map((member) => ({ ...member }))
+			),
+			withRpcResult(corpStub.getDirectors(corporationId), (result) =>
+				result.map((director) => ({ ...director }))
+			),
 		])
 
 		const directorIds = new Set(directors.map((d) => d.characterId))
@@ -3020,18 +3083,27 @@ app.get('/:corporationId/members/:accountId', requireAuth(), async (c) => {
 		}
 
 		const characterIds = matchingMembers.map((member) => String(member.characterId))
-		const characterNameMap = await tokenStoreStub.resolveIds(characterIds)
+		const characterNameMap = await withRpcResult(
+			tokenStoreStub.resolveIds(characterIds),
+			(result) => ({
+				...result,
+			})
+		)
 
 		const linkedUser = await db.query.users.findFirst({
 			where: eq(users.id, accountId),
 		})
 		const discordUsername =
 			linkedUser?.discordUserId && accountId
-				? ((await getStub<Discord>(c.env.DISCORD, 'default').getDiscordUserStatus(accountId))
-						?.username ?? null)
+				? await withRpcResult(
+						getStub<Discord>(c.env.DISCORD, 'default').getDiscordUserStatus(accountId),
+						(result) => result?.username ?? null
+					)
 				: null
 		const mainCharacterNameMap = linkedUser?.mainCharacterId
-			? await tokenStoreStub.resolveIds([linkedUser.mainCharacterId])
+			? await withRpcResult(tokenStoreStub.resolveIds([linkedUser.mainCharacterId]), (result) => ({
+					...result,
+				}))
 			: {}
 		const mainCharacterName = linkedUser?.mainCharacterId
 			? (mainCharacterNameMap[linkedUser.mainCharacterId] ?? undefined)
@@ -3039,7 +3111,11 @@ app.get('/:corporationId/members/:accountId', requireAuth(), async (c) => {
 
 		const hrStub = getStub<Hr>(c.env.HR, 'default')
 		const blacklistStatuses =
-			characterIds.length > 0 ? await hrStub.checkCharactersBlacklisted(characterIds) : {}
+			characterIds.length > 0
+				? await withRpcResult(hrStub.checkCharactersBlacklisted(characterIds), (result) => ({
+						...result,
+					}))
+				: {}
 
 		const memberRows: CorporationMemberListItem[] = matchingMembers.map((member) => {
 			const characterId = String(member.characterId)
@@ -3254,7 +3330,9 @@ app.patch('/:corporationId/members/:characterId/status', requireAuth(), async (c
 
 		// Get corporation info to check if character is CEO
 		const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
-		const corpInfo = await corpStub.getCorporationInfo(corporationId)
+		const corpInfo = await withRpcResult(corpStub.getCorporationInfo(corporationId), (result) =>
+			result ? { ceoId: result.ceoId } : null
+		)
 
 		// Prevent marking CEO as emeritus
 		if (corpInfo && String(corpInfo.ceoId) === characterId && status === 'emeritus') {
@@ -3274,7 +3352,13 @@ app.patch('/:corporationId/members/:characterId/status', requireAuth(), async (c
 		}
 
 		// Verify character is actually a member of this corporation
-		const coreData = await corpStub.getCoreData(corporationId)
+		const coreData = await withRpcResult(corpStub.getCoreData(corporationId), (result) =>
+			result
+				? {
+						members: result.members?.map((member) => ({ characterId: member.characterId })),
+					}
+				: null
+		)
 		const isMember = coreData?.members.some((m) => String(m.characterId) === characterId)
 
 		if (!isMember) {

--- a/apps/core/src/routes/doctrines.ts
+++ b/apps/core/src/routes/doctrines.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import {
 	AddFittingToDoctrineSchema,
 	CreateCategorySchema,
@@ -112,7 +112,10 @@ doctrines.get('/search/types', async (c) => {
 	}
 
 	const doctrinesStub = getStub<Doctrines>(c.env.DOCTRINES, 'default')
-	const results = await doctrinesStub.searchShipTypes(q.trim().slice(0, 500))
+	const results = await withRpcResult(
+		doctrinesStub.searchShipTypes(q.trim().slice(0, 500)),
+		(value) => value.map((result) => ({ ...result }))
+	)
 
 	return c.json(results)
 })

--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 import { isOpenApplicationStatus } from '@repo/hr'
 
@@ -36,6 +36,20 @@ function getHrStub(c: Context<App>): Hr {
 
 function getCoreStub(c: Context<App>): Core {
 	return getStub<Core>(c.env.CORE, 'default')
+}
+
+async function getReportAccessSnapshot(
+	fulcrum: Fulcrum,
+	reportId: string
+): Promise<{ status: string; requestorCorporationId: string } | null> {
+	return withRpcResult(fulcrum.getReportStatus(reportId), (report) =>
+		report
+			? {
+					status: report.status,
+					requestorCorporationId: report.requestorCorporationId,
+				}
+			: null
+	)
 }
 
 function getExecutionContextOrNull(c: Context<App>): Pick<ExecutionContext, 'waitUntil'> | null {
@@ -85,9 +99,11 @@ async function getCharacterCorporationId(
 	characterId: string
 ): Promise<string | null> {
 	const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
-	const characterInstance = await characterStub.getInstance(characterId)
-	const characterInfo = await characterInstance.getCharacterInfo()
-	return characterInfo?.corporationId ? String(characterInfo.corporationId) : null
+	return withRpcResult(characterStub.getInstance(characterId), (characterInstance) =>
+		withRpcResult(characterInstance.getCharacterInfo(), (characterInfo) =>
+			characterInfo?.corporationId ? String(characterInfo.corporationId) : null
+		)
+	)
 }
 
 type FulcrumCorporationResolution = {
@@ -101,10 +117,13 @@ async function resolveApplicationFulcrumCorporationForTargetUser(
 	requestor: SessionUser,
 	targetUserId: string
 ): Promise<FulcrumCorporationResolution> {
-	const applications = await hr.listApplications({ userId: targetUserId }, requestor.id, {
-		isAdmin: false,
-		isAuditor: false,
-	})
+	const applications = await withRpcResult(
+		hr.listApplications({ userId: targetUserId }, requestor.id, {
+			isAdmin: false,
+			isAuditor: false,
+		}),
+		(result) => result.map((application) => ({ ...application }))
+	)
 
 	let sawPermission = false
 	let sawOpenApplication = false
@@ -159,7 +178,9 @@ async function resolveSharedFulcrumCorporationForTargetUser(
 	targetUserId: string
 ): Promise<FulcrumSharedCorporationResolution> {
 	const core = getCoreStub(c)
-	const corporations = await core.getUserCorporations(targetUserId)
+	const corporations = await withRpcResult(core.getUserCorporations(targetUserId), (result) =>
+		result.map((corporation) => ({ ...corporation }))
+	)
 	if (corporations.length === 0) {
 		return {
 			corporationId: null,
@@ -253,9 +274,18 @@ async function buildFulcrumCharacterReportRows(
 			const snapshotPromise = (async () => {
 				const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corpId)
 				const [corpInfo, directors, memberTracking] = await Promise.all([
-					corpStub.getCorporationInfo(corpId),
-					corpStub.getDirectors(corpId),
-					corpStub.getMemberTracking(corpId),
+					withRpcResult(corpStub.getCorporationInfo(corpId), (result) =>
+						result ? { ceoId: result.ceoId } : null
+					),
+					withRpcResult(corpStub.getDirectors(corpId), (result) =>
+						result.map((director) => ({ characterId: director.characterId }))
+					),
+					withRpcResult(corpStub.getMemberTracking(corpId), (result) =>
+						result.map((tracking) => ({
+							characterId: tracking.characterId,
+							logonDate: tracking.logonDate,
+						}))
+					),
 				])
 
 				return {
@@ -276,7 +306,10 @@ async function buildFulcrumCharacterReportRows(
 		characters.map(async (char) => {
 			let reports: Awaited<ReturnType<Fulcrum['listReports']>> = []
 			try {
-				reports = await fulcrum.listReports({ characterId: char.characterId }, 50)
+				reports = await withRpcResult(
+					fulcrum.listReports({ characterId: char.characterId }, 50),
+					(result) => result.map((report) => ({ ...report }))
+				)
 			} catch (error) {
 				logger.warn('[Fulcrum] Failed to list reports for character while building user data', {
 					userId,
@@ -325,10 +358,13 @@ async function resolveFallbackFulcrumCorporationId(
 	targetUserId: string,
 	characterId: string
 ): Promise<string | null> {
-	const applications = await hr.listApplications({ userId: targetUserId }, requestor.id, {
-		isAdmin: requestor.is_admin,
-		isAuditor: await isHrAuditorUser(c, requestor),
-	})
+	const applications = await withRpcResult(
+		hr.listApplications({ userId: targetUserId }, requestor.id, {
+			isAdmin: requestor.is_admin,
+			isAuditor: await isHrAuditorUser(c, requestor),
+		}),
+		(result) => result.map((application) => ({ ...application }))
+	)
 	const applicationCorporationId = applications[0]?.corporationId ?? null
 	if (applicationCorporationId) {
 		return applicationCorporationId
@@ -344,8 +380,13 @@ async function isMemberCorpCeo(c: Context<App>, characterId: string): Promise<bo
 	}
 
 	const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
-	const characterInstance = await characterStub.getInstance(characterId)
-	const characterInfo = await characterInstance.getCharacterInfo()
+	const characterInfo = await withRpcResult(
+		characterStub.getInstance(characterId),
+		(characterInstance) =>
+			withRpcResult(characterInstance.getCharacterInfo(), (result) =>
+				result ? { corporationId: result.corporationId } : null
+			)
+	)
 	if (!characterInfo?.corporationId) {
 		return false
 	}
@@ -360,7 +401,9 @@ async function isMemberCorpCeo(c: Context<App>, characterId: string): Promise<bo
 	}
 
 	const corpStub = getStub<EveCorporationData>(c.env.EVE_CORPORATION_DATA, corporationId)
-	const corpInfo = await corpStub.getCorporationInfo(corporationId)
+	const corpInfo = await withRpcResult(corpStub.getCorporationInfo(corporationId), (result) =>
+		result ? { ceoId: result.ceoId } : null
+	)
 	return corpInfo?.ceoId === characterId
 }
 
@@ -433,7 +476,9 @@ app.get('/users/:userId/characters', requireAuth(), async (c) => {
 		}
 
 		const core = getCoreStub(c)
-		const characters = await core.getUserCharacters(userId, false)
+		const characters = await withRpcResult(core.getUserCharacters(userId, false), (result) =>
+			result.map((character) => ({ ...character }))
+		)
 		const reportRows = await buildFulcrumCharacterReportRows(c, userId, characters)
 		const results = reportRows.map((row, index) => {
 			const char = characters[index]
@@ -491,7 +536,9 @@ app.get('/users/:userId/reports', requireAuth(), async (c) => {
 		}
 
 		const core = getCoreStub(c)
-		const characters = await core.getUserCharacters(userId, false)
+		const characters = await withRpcResult(core.getUserCharacters(userId, false), (result) =>
+			result.map((character) => ({ ...character }))
+		)
 		const reportRows = await buildFulcrumCharacterReportRows(c, userId, characters)
 
 		return c.json(reportRows)
@@ -560,7 +607,9 @@ app.get('/characters/:characterId/reports', requireAuth(), async (c) => {
 		}
 
 		const fulcrum = getFulcrumStub(c)
-		const reports = await fulcrum.listReports({ characterId }, 50)
+		const reports = await withRpcResult(fulcrum.listReports({ characterId }, 50), (result) =>
+			result.map((report) => ({ ...report }))
+		)
 
 		return c.json(reports)
 	} catch (error) {
@@ -879,15 +928,18 @@ app.post('/reports/batch', requireAuth(), async (c) => {
 				)
 			}
 			const fulcrum = getFulcrumStub(c)
-			const result = await fulcrum.createBulkCharacterReports({
-				characterIds: body.characterIds,
-				requestorUserId: user.id,
-				requestorCorporationId: resolvedCorporationId,
-				requestSource: body.requestSource,
-				applicationId: body.applicationId,
-				targetUserId: resolvedTargetUserId,
-				sendDm: body.sendDm ?? true,
-			})
+			const result = await withRpcResult(
+				fulcrum.createBulkCharacterReports({
+					characterIds: body.characterIds,
+					requestorUserId: user.id,
+					requestorCorporationId: resolvedCorporationId,
+					requestSource: body.requestSource,
+					applicationId: body.applicationId,
+					targetUserId: resolvedTargetUserId,
+					sendDm: body.sendDm ?? true,
+				}),
+				(value) => ({ ...value })
+			)
 
 			logger.info('[Fulcrum] Bulk report batch requested', {
 				batchId: result.batchId,
@@ -948,15 +1000,18 @@ app.post('/reports/batch', requireAuth(), async (c) => {
 		}
 
 		const fulcrum = getFulcrumStub(c)
-		const result = await fulcrum.createBulkCharacterReports({
-			characterIds: body.characterIds,
-			requestorUserId: user.id,
-			requestorCorporationId: resolvedCorporationId,
-			requestSource: body.requestSource,
-			applicationId: body.applicationId,
-			sendDm: body.sendDm ?? true,
-			targetUserId: resolvedTargetUserId ?? user.id,
-		})
+		const result = await withRpcResult(
+			fulcrum.createBulkCharacterReports({
+				characterIds: body.characterIds,
+				requestorUserId: user.id,
+				requestorCorporationId: resolvedCorporationId,
+				requestSource: body.requestSource,
+				applicationId: body.applicationId,
+				sendDm: body.sendDm ?? true,
+				targetUserId: resolvedTargetUserId ?? user.id,
+			}),
+			(value) => ({ ...value })
+		)
 
 		logger.info('[Fulcrum] Bulk report batch requested', {
 			batchId: result.batchId,
@@ -996,7 +1051,7 @@ app.get('/reports/:reportId/sections', requireAuth(), async (c) => {
 
 	try {
 		const fulcrum = getFulcrumStub(c)
-		const report = await fulcrum.getReportStatus(reportId)
+		const report = await getReportAccessSnapshot(fulcrum, reportId)
 
 		if (!report) {
 			return c.json({ error: 'Report not found' }, 404)
@@ -1018,12 +1073,12 @@ app.get('/reports/:reportId/sections', requireAuth(), async (c) => {
 			return c.json({ error: 'Report not ready', status: report.status }, 400)
 		}
 
-		const manifest = await fulcrum.getReportSections(reportId)
-		if (!manifest) {
-			return c.json({ error: 'Report manifest not found' }, 404)
-		}
-
-		return c.json(manifest)
+		return withRpcResult(fulcrum.getReportSections(reportId), (manifest) => {
+			if (!manifest) {
+				return c.json({ error: 'Report manifest not found' }, 404)
+			}
+			return c.json(manifest)
+		})
 	} catch (error) {
 		return c.json(
 			{ error: error instanceof Error ? error.message : 'Failed to get report sections' },
@@ -1049,7 +1104,7 @@ app.get('/reports/:reportId/sections/:section', requireAuth(), async (c) => {
 
 	try {
 		const fulcrum = getFulcrumStub(c)
-		const report = await fulcrum.getReportStatus(reportId)
+		const report = await getReportAccessSnapshot(fulcrum, reportId)
 
 		if (!report) {
 			return c.json({ error: 'Report not found' }, 404)
@@ -1092,21 +1147,20 @@ app.get('/reports/:reportId/sections/:section', requireAuth(), async (c) => {
 		}
 
 		if (page === undefined) {
-			const manifest = await fulcrum.getReportSections(reportId)
+			const manifest = await withRpcResult(fulcrum.getReportSections(reportId), (result) =>
+				result ? { sections: { ...result.sections } } : null
+			)
 			if ((manifest?.sections[section]?.chunks ?? 0) > 0) {
 				return c.json({ error: 'A page parameter is required for chunked report sections' }, 400)
 			}
 		}
 
-		const data =
+		return withRpcResult(
 			page === undefined && pageSize === undefined
-				? await fulcrum.getReportSectionData(reportId, section)
-				: await fulcrum.getReportSectionData(reportId, section, page, pageSize)
-		if (!data) {
-			return c.json({ error: 'Section data not found' }, 404)
-		}
-
-		return c.json(data)
+				? fulcrum.getReportSectionData(reportId, section)
+				: fulcrum.getReportSectionData(reportId, section, page, pageSize),
+			(data) => (data ? c.json(data) : c.json({ error: 'Section data not found' }, 404))
+		)
 	} catch (error) {
 		return c.json(
 			{ error: error instanceof Error ? error.message : 'Failed to get section data' },
@@ -1127,7 +1181,7 @@ app.get('/reports/:reportId/mails/:mailId/content', requireAuth(), async (c) => 
 
 	try {
 		const fulcrum = getFulcrumStub(c)
-		const report = await fulcrum.getReportStatus(reportId)
+		const report = await getReportAccessSnapshot(fulcrum, reportId)
 
 		if (!report) {
 			return c.json({ error: 'Report not found' }, 404)

--- a/apps/core/src/routes/hr.ts
+++ b/apps/core/src/routes/hr.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 
 import { and, eq, ilike, inArray, or } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { captureException, logger } from '@repo/hono-helpers'
 import { APPLICATION_STATUSES } from '@repo/hr'
 
@@ -17,13 +17,23 @@ import { getIpHashMatches, getUserIpHistory } from '../lib/ip-history'
 import { getUserCorporationAffiliationIds } from '../lib/user-corporation-affiliations'
 import { validatePagination } from '../lib/validation'
 import { requireAdmin, requireAuth } from '../middleware/session'
+import { CoreRpcService } from '../services/core-rpc.service'
 import { dispatchCorporationAlert } from '../services/corporation-alerts.service'
 
 import type { Context } from 'hono'
 import type { Core } from '@repo/core'
 import type { Discord } from '@repo/discord'
 import type { Esi, EsiTypeResolver } from '@repo/esi'
-import type { Application, ApplicationFilters, Hr, HrNote, NoteFilters } from '@repo/hr'
+import type {
+	Application,
+	ApplicationDetail,
+	ApplicationFilters,
+	BlacklistTargetCheckItem,
+	Hr,
+	HrAccessContext,
+	HrNote,
+	NoteFilters,
+} from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
 import type { App } from '../context'
 
@@ -43,6 +53,36 @@ const upsertApplicationStaffNoteSchema = z.object({
  */
 function getHrStub(c: Context<App>): Hr {
 	return getStub<Hr>(c.env.HR, 'default')
+}
+
+function toPlainApplication<T extends Application>(application: T): T {
+	const detail = application as unknown as ApplicationDetail
+	return {
+		...application,
+		altCharacterIds: application.altCharacterIds
+			? [...application.altCharacterIds]
+			: application.altCharacterIds,
+		...(Array.isArray(detail.recommendations)
+			? { recommendations: detail.recommendations.map((recommendation) => ({ ...recommendation })) }
+			: {}),
+		...(Array.isArray(detail.activityLog)
+			? {
+					activityLog: detail.activityLog.map((entry) => ({
+						...entry,
+						metadata: entry.metadata ? { ...entry.metadata } : null,
+					})),
+				}
+			: {}),
+	} as T
+}
+
+async function getApplicationSnapshot(
+	hr: Hr,
+	applicationId: string,
+	userId: string,
+	access: HrAccessContext
+): Promise<ApplicationDetail> {
+	return withRpcResult(hr.getApplication(applicationId, userId, access), toPlainApplication)
 }
 
 function queueApplicationApplicantUpdateNotification(
@@ -119,8 +159,9 @@ async function resolveApplicationDiscordUsername(
 
 	try {
 		const discordStub = getStub<Discord>(c.env.DISCORD, 'default')
-		const status = await discordStub.getDiscordUserStatus(userId)
-		return status?.username ?? null
+		return await withRpcResult(discordStub.getDiscordUserStatus(userId), (status) =>
+			status ? (status.username ?? null) : null
+		)
 	} catch {
 		return null
 	}
@@ -247,13 +288,34 @@ async function resolveUserPrimaryCharacterIdentity(
 /**
  * Enrich a list of applications with resolved corporation and reviewer names.
  */
-async function enrichApplications<T extends { corporationId: string; reviewedBy: string | null }>(
+async function enrichApplications<
+	T extends {
+		corporationId: string
+		reviewedBy: string | null
+		userId: string
+		characterId: string
+	},
+>(
 	items: T[],
 	resolver: { resolveIds: (ids: string[]) => Promise<Record<string, string>> },
-	db: NonNullable<Context<App>['var']['db']>
-): Promise<Array<T & { corporationName: string; reviewedByCharacterName: string | null }>> {
+	db: NonNullable<Context<App>['var']['db']>,
+	hr: Hr
+): Promise<
+	Array<
+		T & {
+			corporationName: string
+			reviewedByCharacterName: string | null
+			isUserBlacklisted: boolean
+			isCharacterBlacklisted: boolean
+			isBlacklisted: boolean
+		}
+	>
+> {
 	const corpIds = [...new Set(items.map((a) => a.corporationId))]
-	const corpNames = corpIds.length > 0 ? await resolver.resolveIds(corpIds) : {}
+	const corpNames =
+		corpIds.length > 0
+			? await withRpcResult(resolver.resolveIds(corpIds), (result) => ({ ...result }))
+			: {}
 	const managedCorpNames =
 		corpIds.length > 0
 			? await db.query.managedCorporations.findMany({
@@ -279,10 +341,43 @@ async function enrichApplications<T extends { corporationId: string; reviewedBy:
 	const reviewerIds = items.map((a) => a.reviewedBy).filter((id): id is string => id !== null)
 	const reviewerNames = await resolveUserCharacterNames(db, reviewerIds)
 
+	const blacklistTargets: BlacklistTargetCheckItem[] = [
+		...new Set(items.map((application) => application.userId)),
+	].map((userId) => ({ targetType: 'user', targetValue: userId }))
+	blacklistTargets.push(
+		...[...new Set(items.map((application) => application.characterId))].map((characterId) => ({
+			targetType: 'character_id' as const,
+			targetValue: characterId,
+		}))
+	)
+
+	let blacklistedTargets = new Set<string>()
+	try {
+		const blacklistResults =
+			blacklistTargets.length > 0
+				? await withRpcResult(hr.checkBlacklistTargets(blacklistTargets), (result) => [...result])
+				: []
+		blacklistedTargets = new Set(
+			blacklistResults
+				.filter((result) => result.isBlacklisted)
+				.map((result) => `${result.targetType}:${result.targetValue}`)
+		)
+	} catch (error) {
+		logger.warn('[HR] Failed to load application blacklist statuses', {
+			applicationCount: items.length,
+			error: error instanceof Error ? error.message : String(error),
+		})
+	}
+
 	return items.map((a) => ({
 		...a,
 		corporationName: corpNameMap.get(a.corporationId) ?? `Corporation ${a.corporationId}`,
 		reviewedByCharacterName: a.reviewedBy ? (reviewerNames[a.reviewedBy] ?? null) : null,
+		isUserBlacklisted: blacklistedTargets.has(`user:${a.userId}`),
+		isCharacterBlacklisted: blacklistedTargets.has(`character_id:${a.characterId}`),
+		isBlacklisted:
+			blacklistedTargets.has(`user:${a.userId}`) ||
+			blacklistedTargets.has(`character_id:${a.characterId}`),
 	}))
 }
 
@@ -470,7 +565,10 @@ async function getHrRoleManagementAccess(
 	})
 
 	const esiStub = getStub<Esi>(c.env.ESI, 'default')
-	const corporationInfo = await esiStub.fetchCorporationPublicInfo(corporationId)
+	const corporationInfo = await withRpcResult(
+		esiStub.fetchCorporationPublicInfo(corporationId),
+		(result) => (result ? { ...result } : result)
+	)
 	const isCeo = corporationInfo && userCharacterSet.has(corporationInfo.ceo_id)
 
 	if (isCeo) {
@@ -645,7 +743,7 @@ app.get('/applications', requireAuth(), async (c) => {
 		})
 
 		const resolver = getStub<EsiTypeResolver>(c.env.ESI_TYPE_RESOLVER, 'global')
-		const enriched = await enrichApplications(applications, resolver, db)
+		const enriched = await enrichApplications(applications, resolver, db, hr)
 
 		return c.json(enriched)
 	} catch (error) {
@@ -712,7 +810,7 @@ app.get('/applications/paged', requireAuth(), async (c) => {
 		})
 
 		const resolver = getStub<EsiTypeResolver>(c.env.ESI_TYPE_RESOLVER, 'global')
-		const enriched = await enrichApplications(result.items, resolver, db)
+		const enriched = await enrichApplications(result.items, resolver, db, hr)
 
 		return c.json({
 			items: enriched,
@@ -730,6 +828,45 @@ app.get('/applications/paged', requireAuth(), async (c) => {
 })
 
 /**
+ * GET /api/hr/applications/counts
+ * Return pending and under-review counts for the current user's accessible
+ * active member corporations. Corporation scope is resolved server-side.
+ */
+app.get('/applications/counts', requireAuth(), async (c) => {
+	const user = c.get('user')!
+	const db = c.get('db')
+
+	if (!db) {
+		return c.json({ error: 'Database not available' }, 500)
+	}
+
+	try {
+		const memberCorporations = await db.query.managedCorporations.findMany({
+			where: and(
+				eq(managedCorporations.isActive, true),
+				eq(managedCorporations.isMemberCorporation, true)
+			),
+			columns: { corporationId: true },
+		})
+		const memberCorporationIds = memberCorporations.map((corporation) => corporation.corporationId)
+
+		const isAuditor = user.is_admin ? false : await hasHrAuditorPermission(c)
+		const hr = getHrStub(c)
+		const counts = await hr.getApplicationCountsByCorporation(memberCorporationIds, user.id, {
+			isAdmin: user.is_admin,
+			isAuditor,
+		})
+
+		return c.json({ corporations: counts })
+	} catch (error) {
+		return c.json(
+			{ error: error instanceof Error ? error.message : 'Failed to count applications' },
+			500
+		)
+	}
+})
+
+/**
  * GET /api/hr/applications/:id
  * Get a single application with recommendations
  */
@@ -740,7 +877,7 @@ app.get('/applications/:id', requireAuth(), async (c) => {
 	try {
 		const hr = getHrStub(c)
 		const isAuditor = await hasHrAuditorPermission(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
@@ -760,7 +897,12 @@ app.get('/applications/:id', requireAuth(), async (c) => {
 
 		const resolver = getStub<EsiTypeResolver>(c.env.ESI_TYPE_RESOLVER, 'global')
 		const db = c.get('db')!
-		const [enriched] = await enrichApplications([{ ...application, discordUsername }], resolver, db)
+		const [enriched] = await enrichApplications(
+			[{ ...application, discordUsername }],
+			resolver,
+			db,
+			hr
+		)
 
 		return c.json(enriched)
 	} catch (error) {
@@ -795,7 +937,7 @@ app.patch('/applications/:id', requireAuth(), async (c) => {
 	try {
 		const hr = getHrStub(c)
 		const isAuditor = await hasHrAuditorPermission(c)
-		const applicationBeforeUpdate = await hr.getApplication(applicationId, user.id, {
+		const applicationBeforeUpdate = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
@@ -850,7 +992,7 @@ app.patch('/applications/:id', requireAuth(), async (c) => {
 				c.executionCtx,
 				'hr-application-first-time-accepted-alert',
 				async () => {
-					const currentApplication = await hr.getApplication(applicationId, user.id, {
+					const currentApplication = await getApplicationSnapshot(hr, applicationId, user.id, {
 						isAdmin: user.is_admin,
 						isAuditor,
 					})
@@ -1171,7 +1313,7 @@ app.patch('/applications/:applicationId/recommendations/:id', requireAuth(), asy
 
 	try {
 		const hr = getHrStub(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor: false,
 		})
@@ -1218,7 +1360,7 @@ app.delete('/applications/:applicationId/recommendations/:id', requireAuth(), as
 
 	try {
 		const hr = getHrStub(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor: false,
 		})
@@ -1259,7 +1401,7 @@ app.post('/applications/:applicationId/messages', requireAuth(), async (c) => {
 		const hr = getHrStub(c)
 
 		// Check if sender is the applicant — if not, require hr_reviewer
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor: false,
 		})
@@ -1363,7 +1505,7 @@ app.get('/applications/:applicationId/messages/count', requireAuth(), async (c) 
 	try {
 		const hr = getHrStub(c)
 		const isAuditor = await hasHrAuditorPermission(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
@@ -1404,7 +1546,7 @@ app.get('/applications/:applicationId/staff-notes', requireAuth(), async (c) => 
 	try {
 		const hr = getHrStub(c)
 		const isAuditor = await hasHrAuditorPermission(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
@@ -1451,7 +1593,7 @@ app.post('/applications/:applicationId/staff-notes', requireAuth(), async (c) =>
 	try {
 		const hr = getHrStub(c)
 		const isAuditor = await hasHrAuditorPermission(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
@@ -1511,7 +1653,7 @@ app.patch('/applications/:applicationId/staff-notes/:noteId', requireAuth(), asy
 	try {
 		const hr = getHrStub(c)
 		const isAuditor = await hasHrAuditorPermission(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
@@ -1578,7 +1720,7 @@ app.delete('/applications/:applicationId/staff-notes/:noteId', requireAuth(), as
 	try {
 		const hr = getHrStub(c)
 		const isAuditor = await hasHrAuditorPermission(c)
-		const application = await hr.getApplication(applicationId, user.id, {
+		const application = await getApplicationSnapshot(hr, applicationId, user.id, {
 			isAdmin: user.is_admin,
 			isAuditor,
 		})
@@ -2176,7 +2318,9 @@ app.post('/:corporationId/roles', requireAuth(), async (c) => {
 
 	// Get character name
 	const coreStub = getCoreStub(c)
-	const characterOwner = await coreStub.getCharacterOwner(characterId)
+	const characterOwner = await withRpcResult(coreStub.getCharacterOwner(characterId), (result) =>
+		result ? { ...result } : result
+	)
 
 	if (!characterOwner) {
 		return c.json({ error: 'Character not linked to any user' }, 404)
@@ -2467,6 +2611,86 @@ app.delete('/:corporationId/roles/:roleId', requireAuth(), async (c) => {
 // ==================== Auditor Routes ====================
 
 /**
+ * GET /api/hr/users/search
+ * Search the surface-level user directory for an authenticated HR user.
+ * HR access is required, but results are intentionally not corporation-scoped.
+ */
+app.get('/users/search', requireAuth(), async (c) => {
+	const user = c.get('user')!
+	const db = c.get('db')
+	if (!db) return c.json({ error: 'Database not available' }, 500)
+
+	const search = c.req.query('search')?.trim() ?? ''
+	const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!, 10) : 10
+	const offset = c.req.query('offset') ? parseInt(c.req.query('offset')!, 10) : 0
+	if (!Number.isInteger(limit) || limit < 1 || limit > 50) {
+		return c.json({ error: 'limit must be between 1 and 50' }, 400)
+	}
+	if (!Number.isInteger(offset) || offset < 0) {
+		return c.json({ error: 'offset must be a non-negative integer' }, 400)
+	}
+	if (search.length < 2) {
+		return c.json({ error: 'search must be at least 2 characters' }, 400)
+	}
+
+	try {
+		const hasGlobalHrSearchAccess =
+			user.is_admin || (await hasHrAuditorPermissionForUser({ env: c.env, userId: user.id }))
+		if (!hasGlobalHrSearchAccess) {
+			const corporationIds = await withRpcResult(
+				getHrStub(c).getUserHrCorporations(user.id),
+				(ids) => [...new Set(ids)]
+			)
+			if (corporationIds.length === 0) return c.json({ error: 'Forbidden' }, 403)
+		}
+		const result = await new CoreRpcService(db, c.env).searchUsersForHrAccess({
+			search,
+			limit,
+			offset,
+		})
+
+		const blacklistTargets = result.users.flatMap((entry) => [
+			{ targetType: 'user' as const, targetValue: entry.summary.id },
+			...entry.characters.map((character) => ({
+				targetType: 'character_id' as const,
+				targetValue: character.characterId,
+			})),
+		])
+		const blacklistStatuses = new Map(
+			(blacklistTargets.length > 0
+				? await withRpcResult(getHrStub(c).checkBlacklistTargets(blacklistTargets), (statuses) =>
+						statuses.map((status) => ({ ...status }))
+					)
+				: []
+			).map(
+				(status) => [`${status.targetType}:${status.targetValue}`, status.isBlacklisted] as const
+			)
+		)
+
+		return c.json({
+			...result,
+			users: result.users.map((entry) => ({
+				summary: {
+					...entry.summary,
+					isBlacklisted: blacklistStatuses.get(`user:${entry.summary.id}`) ?? false,
+				},
+				characters: entry.characters.map((character) => ({
+					...character,
+					isBlacklisted: blacklistStatuses.get(`character_id:${character.characterId}`) ?? false,
+				})),
+			})),
+		})
+	} catch (error) {
+		logger.error('[HR] Failed to search users within HR scope', {
+			userId: user.id,
+			search,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return c.json({ error: 'Failed to search users' }, 500)
+	}
+})
+
+/**
  * GET /api/hr/audit/users
  * Search users across all corporations — requires urn:hr:auditor permission or site admin
  */
@@ -2482,7 +2706,41 @@ app.get('/audit/users', requireAuth(), async (c) => {
 
 	try {
 		const result = await c.env.ADMIN.searchUsers({ search, limit, offset }, user.id)
-		return c.json(result)
+		const characterIds = [
+			...new Set(
+				result.users.flatMap((summary) =>
+					[summary.mainCharacterId, summary.matchedCharacterId].filter(
+						(characterId): characterId is string => Boolean(characterId)
+					)
+				)
+			),
+		]
+		let blacklistStatuses: Record<string, boolean> = {}
+		try {
+			if (characterIds.length > 0) {
+				blacklistStatuses = await withRpcResult(
+					getHrStub(c).checkCharactersBlacklisted(characterIds),
+					(result) => ({ ...result })
+				)
+			}
+		} catch (error) {
+			logger.error('[HR Audit] Failed to load blocklist statuses for user search', {
+				userId: user.id,
+				characterCount: characterIds.length,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
+
+		return c.json({
+			...result,
+			users: result.users.map((summary) => ({
+				...summary,
+				mainCharacterIsBlacklisted: blacklistStatuses[summary.mainCharacterId] ?? false,
+				matchedCharacterIsBlacklisted: summary.matchedCharacterId
+					? (blacklistStatuses[summary.matchedCharacterId] ?? false)
+					: null,
+			})),
+		})
 	} catch (error) {
 		logger.error('[HR Audit] Failed to search users', {
 			userId: user.id,
@@ -2551,6 +2809,30 @@ app.get('/audit/users/:userId/ip-history', requireAuth(), async (c) => {
 })
 
 /**
+ * GET /api/hr/users/:userId/blocklist-status
+ * Return the account-level blocklist state for HR profile surfaces.
+ */
+app.get('/users/:userId/blocklist-status', requireAuth(), async (c) => {
+	const user = c.get('user')!
+	if (!user.is_admin && !(await hasAnyHrAccess(c))) {
+		return c.json({ error: 'Forbidden' }, 403)
+	}
+
+	const targetUserId = c.req.param('userId')
+	try {
+		const isBlacklisted = await getHrStub(c).isUserBlacklisted(targetUserId)
+		return c.json({ isBlacklisted })
+	} catch (error) {
+		logger.error('[HR] Failed to get user blocklist status', {
+			userId: user.id,
+			targetUserId,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return c.json({ error: 'Failed to get user blocklist status' }, 500)
+	}
+})
+
+/**
  * GET /api/hr/users/:userId/characters
  * Return HR-owned character summary data for profile pages and application ESI overlays.
  */
@@ -2564,9 +2846,32 @@ app.get('/users/:userId/characters', requireAuth(), async (c) => {
 
 	try {
 		const core = getCoreStub(c)
-		const characters = await core.getUserCharacters(targetUserId, false)
+		const characters = await withRpcResult(core.getUserCharacters(targetUserId, false), (result) =>
+			result.map((character) => ({ ...character }))
+		)
+		let blacklistStatuses: Record<string, boolean> = {}
+		try {
+			const characterIds = characters.map((character) => character.characterId)
+			if (characterIds.length > 0) {
+				blacklistStatuses = await withRpcResult(
+					getHrStub(c).checkCharactersBlacklisted(characterIds),
+					(result) => ({ ...result })
+				)
+			}
+		} catch (error) {
+			logger.error('[HR] Failed to load blocklist statuses for user characters', {
+				userId: user.id,
+				targetUserId,
+				error: error instanceof Error ? error.message : String(error),
+			})
+		}
 
-		return c.json(characters)
+		return c.json(
+			characters.map((character) => ({
+				...character,
+				isBlacklisted: blacklistStatuses[character.characterId] ?? false,
+			}))
+		)
 	} catch (error) {
 		logger.error('[HR] Failed to get user characters', {
 			userId: user.id,

--- a/apps/core/src/routes/users.ts
+++ b/apps/core/src/routes/users.ts
@@ -9,6 +9,7 @@ import { managedCorporations, userCharacters } from '../db/schema'
 import { waitUntilWithTelemetry } from '../lib/background-task'
 import { isNpcCorporationId } from '../lib/corporation-id'
 import { getDiscordStatus } from '../lib/discord-helpers'
+import { hasHrAuditorPermission } from '../lib/hr-access'
 import { triggerUserRefreshWorkflow } from '../lib/workflow-triggers'
 import { requireAuth } from '../middleware/session'
 import { ActivityService } from '../services/activity.service'
@@ -26,6 +27,7 @@ import type { App } from '../context'
  */
 const CACHE_TTL = 5 * 60 // 5 minutes in seconds
 const CORPORATION_ACCESS_CACHE_TTL = 30 // 30 seconds
+const CORPORATION_COVERAGE_CACHE_TTL = 15 * 60 // 15 minutes in seconds
 
 function filterManagedNonNpcCorps<T extends { corporationId: string }>(rows: T[]): T[] {
 	return rows.filter((row) => !isNpcCorporationId(row.corporationId))
@@ -48,6 +50,10 @@ function getUserCorpsCacheKey(userId: string): string {
 
 function getCorporationAccessCacheKey(userId: string): string {
 	return `https://cache.local/users/${userId}/corporation-access`
+}
+
+function getCorporationCoverageCacheKey(corporationId: string): string {
+	return `https://cache.local/corporations/${corporationId}/esi-coverage`
 }
 
 /**
@@ -440,8 +446,9 @@ users.get('/has-corporation-access', async (c) => {
 		const charCorpPromises = characters.map(async (character) => {
 			const charStub = getStub<Rpc.Provider<EveCharacterData>>(c.env.EVE_CHARACTER_DATA, 'default')
 			try {
-				using charData = await charStub.getCharacterInfo(character.characterId)
-				return charData ? String(charData.corporationId) : null
+				return withRpcResult(charStub.getCharacterInfo(character.characterId), (result) =>
+					result ? String(result.corporationId) : null
+				)
 			} catch {
 				return null
 			}
@@ -461,14 +468,12 @@ users.get('/has-corporation-access', async (c) => {
 				)
 				try {
 					const [corpInfo, directors] = await Promise.all([
-						(async () => {
-							using result = await corpStub.getCorporationInfo(corpId)
-							return result ? { ceoId: result.ceoId } : null
-						})(),
-						(async () => {
-							using result = await corpStub.getDirectors(corpId)
-							return result.map((director) => ({ characterId: director.characterId }))
-						})(),
+						withRpcResult(corpStub.getCorporationInfo(corpId), (result) =>
+							result ? { ceoId: result.ceoId } : null
+						),
+						withRpcResult(corpStub.getDirectors(corpId), (result) =>
+							result.map((director) => ({ characterId: director.characterId }))
+						),
 					])
 
 					// Check if any character is CEO or director
@@ -492,7 +497,9 @@ users.get('/has-corporation-access', async (c) => {
 		// Also check if user has any HR roles
 		const hrStub = getStub<Rpc.Provider<Hr>>(c.env.HR, 'default')
 		try {
-			using hrCorpIds = await hrStub.getUserHrCorporations(user.id)
+			const hrCorpIds = await withRpcResult(hrStub.getUserHrCorporations(user.id), (result) => [
+				...result,
+			])
 			if (hrCorpIds.length > 0) {
 				return c.json({ hasAccess: true })
 			}
@@ -534,10 +541,6 @@ users.get('/corporation-access', async (c) => {
 				isMemberCorporation: boolean
 				isAltCorp: boolean
 				isSpecialPurpose: boolean
-				memberCount: number
-				linkedMemberCount: number
-				unlinkedMemberCount: number
-				validEsiKeyMemberCount: number
 			}>
 		}>(cacheKey)
 		if (cached) {
@@ -584,10 +587,6 @@ users.get('/corporation-access', async (c) => {
 			isMemberCorporation: boolean
 			isAltCorp: boolean
 			isSpecialPurpose: boolean
-			memberCount: number
-			linkedMemberCount: number
-			unlinkedMemberCount: number
-			validEsiKeyMemberCount: number
 		}> = []
 
 		if (characters.length > 0 && managedCorps.length > 0) {
@@ -726,10 +725,6 @@ users.get('/corporation-access', async (c) => {
 							isMemberCorporation: corp.isMemberCorporation,
 							isAltCorp: corp.isAltCorp,
 							isSpecialPurpose: corp.isSpecialPurpose,
-							memberCount: 0,
-							linkedMemberCount: 0,
-							unlinkedMemberCount: 0,
-							validEsiKeyMemberCount: 0,
 						}
 					}
 				} catch (error) {
@@ -762,10 +757,6 @@ users.get('/corporation-access', async (c) => {
 					isMemberCorporation: corp.isMemberCorporation,
 					isAltCorp: corp.isAltCorp,
 					isSpecialPurpose: corp.isSpecialPurpose,
-					memberCount: 0,
-					linkedMemberCount: 0,
-					unlinkedMemberCount: 0,
-					validEsiKeyMemberCount: 0,
 				})
 			}
 		}
@@ -821,10 +812,6 @@ users.get('/corporation-access', async (c) => {
 						isMemberCorporation: corp.isMemberCorporation,
 						isAltCorp: corp.isAltCorp,
 						isSpecialPurpose: corp.isSpecialPurpose,
-						memberCount: 0,
-						linkedMemberCount: 0,
-						unlinkedMemberCount: 0,
-						validEsiKeyMemberCount: 0,
 					}
 				})
 
@@ -834,85 +821,16 @@ users.get('/corporation-access', async (c) => {
 			}
 		}
 
-		const accessibleCorpData = await Promise.all(
-			accessibleCorporations.map(async (corp) => {
-				try {
-					const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
-						c.env.EVE_CORPORATION_DATA,
-						corp.corporationId
-					)
-					return await withRpcResult(corpStub.getMembers(corp.corporationId), (members) => ({
-						corporationId: corp.corporationId,
-						members: members.map((member) => ({
-							characterId: String(member.characterId),
-						})),
-					}))
-				} catch (error) {
-					logger.warn('[Corporation Access] Failed to hydrate corporation stats', {
-						corporationId: corp.corporationId,
-						error: error instanceof Error ? error.message : String(error),
-					})
-					return {
-						corporationId: corp.corporationId,
-						members: [],
-					}
-				}
-			})
-		)
-
-		const accessibleMemberCharIds = new Set<string>()
-		for (const corpData of accessibleCorpData) {
-			for (const member of corpData.members) {
-				accessibleMemberCharIds.add(String(member.characterId))
-			}
-		}
-
-		const accessibleLinkedCharacters =
-			accessibleMemberCharIds.size > 0
-				? await db.query.userCharacters.findMany({
-						where: inArray(userCharacters.characterId, Array.from(accessibleMemberCharIds)),
-						columns: {
-							characterId: true,
-							userId: true,
-							status: true,
-							hasValidToken: true,
-						},
-					})
-				: []
-
-		const accessibleEmeritusCharacterIds = new Set(
-			accessibleLinkedCharacters
-				.filter((character) => character.status === 'emeritus')
-				.map((character) => character.characterId)
-		)
-
-		const accessibleCorporationsWithStats = accessibleCorporations.map((corp) => {
-			const corpData = accessibleCorpData.find((item) => item.corporationId === corp.corporationId)
-			const stats = buildCorporationMemberStats(
-				corpData?.members ?? [],
-				accessibleLinkedCharacters,
-				accessibleEmeritusCharacterIds
-			)
-
-			return {
-				...corp,
-				memberCount: stats.memberCount,
-				linkedMemberCount: stats.linkedMemberCount,
-				unlinkedMemberCount: stats.unlinkedMemberCount,
-				validEsiKeyMemberCount: stats.validEsiKeyMemberCount,
-			}
-		})
-
 		const result = {
-			hasAccess: accessibleCorporationsWithStats.length > 0,
-			corporations: accessibleCorporationsWithStats,
+			hasAccess: accessibleCorporations.length > 0,
+			corporations: accessibleCorporations,
 		}
 
 		logger.info('[Corporation Access] Access check complete', {
 			userId: user.id,
 			hasAccess: result.hasAccess,
-			corporationCount: accessibleCorporationsWithStats.length,
-			corporations: accessibleCorporationsWithStats.map((c) => ({
+			corporationCount: accessibleCorporations.length,
+			corporations: accessibleCorporations.map((c) => ({
 				corporationId: c.corporationId,
 				name: c.name,
 				userRole: c.userRole,
@@ -924,6 +842,145 @@ users.get('/corporation-access', async (c) => {
 	} catch (error) {
 		logger.error('Error checking corporation access:', error)
 		return c.json({ error: 'Failed to check corporation access' }, 500)
+	}
+})
+
+/**
+ * GET /users/corporation-coverage
+ *
+ * Return ESI coverage statistics for corporations visible to the current user.
+ * Access is resolved independently from the statistics, while each
+ * corporation's counts are cached for reuse by other authorized users.
+ */
+users.get('/corporation-coverage', async (c) => {
+	const user = c.get('user')!
+	const db = c.get('db') || createDb(c.env.DATABASE_URL)
+
+	try {
+		const managedCorps = filterManagedNonNpcCorps(
+			await db.query.managedCorporations.findMany({
+				where: and(
+					eq(managedCorporations.isActive, true),
+					or(
+						eq(managedCorporations.isMemberCorporation, true),
+						eq(managedCorporations.isAltCorp, true),
+						eq(managedCorporations.isSpecialPurpose, true)
+					)
+				),
+				columns: { corporationId: true },
+			})
+		)
+
+		let corporationIds: string[]
+		const isSiteAdminOrAuditor =
+			user.is_admin || (await hasHrAuditorPermission({ env: c.env, userId: user.id }))
+
+		if (isSiteAdminOrAuditor) {
+			corporationIds = managedCorps.map((corporation) => corporation.corporationId)
+		} else {
+			const hrStub = getStub<Rpc.Provider<Hr>>(c.env.HR, 'default')
+			const hrCorporationIds = await withRpcResult(
+				hrStub.getUserHrCorporations(user.id),
+				(result) => [...result]
+			)
+			const managedCorporationIds = new Set(
+				managedCorps.map((corporation) => corporation.corporationId)
+			)
+			corporationIds = [...new Set(hrCorporationIds)].filter((corporationId) =>
+				managedCorporationIds.has(corporationId)
+			)
+		}
+
+		const coverageByCorporationId = new Map<string, CorporationMemberStats>()
+		const uncachedCorporationIds: string[] = []
+
+		await Promise.all(
+			corporationIds.map(async (corporationId) => {
+				const cached = await getCachedJson<CorporationMemberStats>(
+					getCorporationCoverageCacheKey(corporationId)
+				)
+				if (cached) {
+					coverageByCorporationId.set(corporationId, cached)
+				} else {
+					uncachedCorporationIds.push(corporationId)
+				}
+			})
+		)
+
+		const uncachedCorporationMembers = await Promise.all(
+			uncachedCorporationIds.map(async (corporationId) => {
+				try {
+					const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
+						c.env.EVE_CORPORATION_DATA,
+						corporationId
+					)
+					const members = await withRpcResult(corpStub.getMembers(corporationId), (result) =>
+						result.map((member) => ({ characterId: String(member.characterId) }))
+					)
+					return { corporationId, members }
+				} catch (error) {
+					logger.warn('[Corporation Coverage] Failed to fetch corporation members', {
+						corporationId,
+						error: error instanceof Error ? error.message : String(error),
+					})
+					return null
+				}
+			})
+		)
+
+		const memberCharacterIds = new Set<string>()
+		for (const corporation of uncachedCorporationMembers) {
+			if (!corporation) continue
+			for (const member of corporation.members) memberCharacterIds.add(member.characterId)
+		}
+
+		const linkedCharacters =
+			memberCharacterIds.size > 0
+				? await db.query.userCharacters.findMany({
+						where: inArray(userCharacters.characterId, [...memberCharacterIds]),
+						columns: {
+							characterId: true,
+							userId: true,
+							status: true,
+							hasValidToken: true,
+						},
+					})
+				: []
+		const emeritusCharacterIds = new Set(
+			linkedCharacters
+				.filter((character) => character.status === 'emeritus')
+				.map((character) => character.characterId)
+		)
+
+		await Promise.all(
+			uncachedCorporationMembers.map(async (corporation) => {
+				if (!corporation) return
+				const stats = buildCorporationMemberStats(
+					corporation.members,
+					linkedCharacters,
+					emeritusCharacterIds
+				)
+				coverageByCorporationId.set(corporation.corporationId, stats)
+				await cacheJson(
+					getCorporationCoverageCacheKey(corporation.corporationId),
+					stats,
+					CORPORATION_COVERAGE_CACHE_TTL
+				)
+			})
+		)
+
+		return c.json({
+			corporations: corporationIds.flatMap((corporationId) => {
+				const coverage = coverageByCorporationId.get(corporationId)
+				return coverage ? [{ corporationId, ...coverage }] : []
+			}),
+		})
+	} catch (error) {
+		logger.error('[Corporation Coverage] Failed to load coverage statistics', {
+			userId: user.id,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return c.json({ error: 'Failed to load corporation coverage' }, 500)
 	}
 })
 
@@ -982,7 +1039,16 @@ users.get('/my-corporations', async (c) => {
 						c.env.EVE_CORPORATION_DATA,
 						corp.corporationId
 					)
-					using coreData = await corpStub.getCoreData(corp.corporationId)
+					const coreData = await withRpcResult(
+						corpStub.getCoreData(corp.corporationId),
+						(result) =>
+							result
+								? {
+										...result,
+										members: result.members?.map((member) => ({ ...member })),
+									}
+								: null
+					)
 					const linkedChars =
 						coreData?.members && coreData.members.length > 0
 							? await db.query.userCharacters.findMany({
@@ -1068,7 +1134,10 @@ users.get('/my-corporations', async (c) => {
 		await Promise.all(
 			characters.map(async (char) => {
 				try {
-					using charData = await charStub.getCharacterInfo(char.characterId)
+					const charData = await withRpcResult(
+						charStub.getCharacterInfo(char.characterId),
+						(result) => (result ? { corporationId: result.corporationId } : null)
+					)
 					if (charData) {
 						characterDataMap.set(char.characterId, {
 							corporationId: charData.corporationId,
@@ -1106,24 +1175,21 @@ users.get('/my-corporations', async (c) => {
 
 				// Fetch all corp data in parallel for each corporation
 				const [corpInfo, directors, coreData] = await Promise.all([
-					(async () => {
-						using result = await corpStub.getCorporationInfo(corp.corporationId)
-						return result ? { ceoId: result.ceoId, allianceId: result.allianceId } : null
-					})(),
-					(async () => {
-						using result = await corpStub.getDirectors(corp.corporationId)
-						return result.map((director) => ({ characterId: director.characterId }))
-					})(),
-					(async () => {
-						using result = await corpStub.getCoreData(corp.corporationId)
-						return result
+					withRpcResult(corpStub.getCorporationInfo(corp.corporationId), (result) =>
+						result ? { ceoId: result.ceoId, allianceId: result.allianceId } : null
+					),
+					withRpcResult(corpStub.getDirectors(corp.corporationId), (result) =>
+						result.map((director) => ({ characterId: director.characterId }))
+					),
+					withRpcResult(corpStub.getCoreData(corp.corporationId), (result) =>
+						result
 							? {
 									members: result.members?.map((member) => ({
 										characterId: member.characterId,
 									})),
 								}
 							: null
-					})(),
+					),
 				])
 
 				return { corp, corpInfo, directors, coreData }

--- a/apps/core/src/services/__tests__/mumble.service.test.ts
+++ b/apps/core/src/services/__tests__/mumble.service.test.ts
@@ -12,6 +12,8 @@ import {
 
 vi.mock('@repo/do-utils', () => ({
 	getStub: vi.fn(),
+	withRpcResult: async <T, R>(rpcCall: Promise<T>, consume: (result: T) => R | Promise<R>) =>
+		consume(await rpcCall),
 }))
 
 vi.mock('../../db', () => ({
@@ -182,9 +184,9 @@ describe('syncUsersMumbleGroups', () => {
 			isUserBlacklisted: vi.fn().mockResolvedValue(false),
 		}
 		const groupsStub = {
-			getUserMemberships: vi.fn().mockResolvedValue([
-				{ groupName: 'Fleet', mumbleSyncEnabled: true },
-			]),
+			getUserMemberships: vi
+				.fn()
+				.mockResolvedValue([{ groupName: 'Fleet', mumbleSyncEnabled: true }]),
 			getRolesFor: vi.fn().mockResolvedValue([]),
 		}
 		const mumbleStub = {
@@ -403,9 +405,11 @@ describe('syncUsersMumbleProfiles', () => {
 			}),
 		}
 		const groupsStub = {
-			getUserMemberships: vi.fn().mockResolvedValue([
-				{ groupName: 'Fleet', mumbleSyncEnabled: true, mumbleTicker: 'fc-123!' },
-			]),
+			getUserMemberships: vi
+				.fn()
+				.mockResolvedValue([
+					{ groupName: 'Fleet', mumbleSyncEnabled: true, mumbleTicker: 'fc-123!' },
+				]),
 			getRolesFor: vi.fn().mockResolvedValue([]),
 		}
 
@@ -459,9 +463,11 @@ describe('syncUsersMumbleProfiles', () => {
 			}),
 		}
 		const groupsStub = {
-			getUserMemberships: vi.fn().mockResolvedValue([
-				{ groupName: 'Fleet', mumbleSyncEnabled: true, mumbleTicker: 'fc-123!' },
-			]),
+			getUserMemberships: vi
+				.fn()
+				.mockResolvedValue([
+					{ groupName: 'Fleet', mumbleSyncEnabled: true, mumbleTicker: 'fc-123!' },
+				]),
 			getRolesFor: vi.fn().mockResolvedValue([]),
 		}
 

--- a/apps/core/src/services/__tests__/user.service.test.ts
+++ b/apps/core/src/services/__tests__/user.service.test.ts
@@ -126,4 +126,26 @@ describe('UserService.getUserProfile', () => {
 		expect(profile.characters).toHaveLength(2)
 		expect(profile.characters.map((character) => character.characterId)).toEqual(['1001', '1002'])
 	})
+
+	it('uses default preferences when the optional preferences query fails', async () => {
+		const db = createDbMock()
+		const now = new Date('2026-06-16T08:00:00.000Z')
+		db.usersFindFirst.mockResolvedValue({
+			id: 'user-1',
+			mainCharacterId: '1001',
+			discordUserId: null,
+			is_admin: false,
+			legacyAuthUserId: null,
+			legacyAuthUserUsername: null,
+			createdAt: now,
+			updatedAt: now,
+		})
+		db.userCharactersFindMany.mockResolvedValue([])
+		db.userPreferencesFindFirst.mockRejectedValue(new Error('temporary database failure'))
+
+		const service = new UserService(db.db as never)
+		const profile = await service.getUserProfile('user-1')
+
+		expect(profile.preferences).toEqual({})
+	})
 })

--- a/apps/core/src/services/core-rpc.service.ts
+++ b/apps/core/src/services/core-rpc.service.ts
@@ -1,5 +1,5 @@
 import { and, asc, desc, eq, gt, ilike, inArray, or, sql } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
 import { discordServers, managedCorporations, userCharacters, users } from '../db/schema'
@@ -41,6 +41,228 @@ export class CoreRpcService {
 	) {}
 
 	/**
+	 * Search the surface-level user directory for an authenticated HR caller.
+	 * The route controls access; this query is intentionally not corporation-scoped.
+	 */
+	async searchUsersForHrAccess(params: { search?: string; limit?: number; offset?: number }) {
+		const limit = Math.min(Math.max(params.limit ?? 10, 1), 50)
+		const offset = Math.max(params.offset ?? 0, 0)
+		const rawSearch = params.search?.trim() ?? ''
+		const search = rawSearch.length > 0 ? rawSearch : null
+		const searchLike = search ? `%${search}%` : null
+		const lowerSearch = search?.toLowerCase() ?? null
+		const isSearchUuid =
+			search !== null &&
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(search)
+		const isSearchNumeric = search !== null && /^\d+$/.test(search)
+		const discordUsernameMatchedCoreUserIds = new Set<string>()
+		if (search) {
+			try {
+				const discordStub = getStub<Discord>(this.env.DISCORD, 'default')
+				const discordMatches = await withRpcResult(
+					discordStub.searchCoreUsersByUsername(search, 200),
+					(matches) => matches.map((match) => ({ ...match }))
+				)
+				for (const match of discordMatches) {
+					discordUsernameMatchedCoreUserIds.add(match.coreUserId)
+				}
+			} catch (error) {
+				logger.error('[CoreRpcService.searchUsersForHrAccess] Discord username search failed', {
+					search,
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+		}
+
+		const hasActiveCharacter = sql<boolean>`exists (
+			select 1
+			from user_characters uc
+			where uc.user_id = ${users.id}
+			and uc.deleted = false
+		)`
+		let whereCondition: SQL<unknown> = hasActiveCharacter
+
+		if (search && searchLike) {
+			const conditions: Array<SQL<unknown>> = [
+				and(ilike(users.legacyAuthUserUsername, searchLike), hasActiveCharacter) as SQL<unknown>,
+				eq(users.discordUserId, search),
+				sql<boolean>`exists (
+					select 1
+					from user_characters uc
+					where uc.user_id = ${users.id}
+					and uc.deleted = false
+					and (
+						uc.character_name ilike ${searchLike}
+						${isSearchNumeric ? sql`or uc.character_id = ${search}` : sql``}
+					)
+				)`,
+			]
+
+			if (isSearchUuid) conditions.push(eq(users.id, search))
+			if (discordUsernameMatchedCoreUserIds.size > 0) {
+				conditions.push(inArray(users.id, [...discordUsernameMatchedCoreUserIds]))
+			}
+
+			whereCondition = and(hasActiveCharacter, or(...conditions)) as SQL<unknown>
+		}
+
+		const paginatedUsers = await this.db
+			.select({
+				id: users.id,
+				mainCharacterId: users.mainCharacterId,
+				is_admin: users.is_admin,
+				discordUserId: users.discordUserId,
+				createdAt: users.createdAt,
+				updatedAt: users.updatedAt,
+			})
+			.from(users)
+			.where(whereCondition)
+			.orderBy(desc(users.updatedAt), desc(users.createdAt))
+			.limit(limit)
+			.offset(offset)
+
+		const pageUserIds = paginatedUsers.map((user) => user.id)
+		const pageCharacters =
+			pageUserIds.length > 0
+				? await this.db.query.userCharacters.findMany({
+						where: and(
+							inArray(userCharacters.userId, pageUserIds),
+							eq(userCharacters.isDeleted, false)
+						),
+						columns: {
+							userId: true,
+							characterId: true,
+							characterName: true,
+							corporationId: true,
+							corporationName: true,
+							allianceId: true,
+							allianceName: true,
+							is_primary: true,
+							hasValidToken: true,
+						},
+					})
+				: []
+
+		const charactersByUserId = new Map<string, typeof pageCharacters>()
+		for (const character of pageCharacters) {
+			const characters = charactersByUserId.get(character.userId) ?? []
+			characters.push(character)
+			charactersByUserId.set(character.userId, characters)
+		}
+
+		const discordUsernameByUserId = new Map<string, string>()
+		if (pageUserIds.length > 0) {
+			try {
+				const discordStub = getStub<Discord>(this.env.DISCORD, 'default')
+				const statuses = await withRpcResult(
+					discordStub.getDiscordUserStatuses(pageUserIds),
+					(result) =>
+						new Map(
+							Object.entries(result).map(([userId, status]) => [userId, status.username] as const)
+						)
+				)
+				for (const user of paginatedUsers) {
+					const username = statuses.get(user.id)
+					if (username) discordUsernameByUserId.set(user.id, username)
+				}
+			} catch (error) {
+				logger.error('[CoreRpcService.searchUsersForHrAccess] Discord status lookup failed', {
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+		}
+
+		const usersWithCharacters = paginatedUsers.map((user) => {
+			const characters = [...(charactersByUserId.get(user.id) ?? [])].sort((a, b) => {
+				if (a.is_primary !== b.is_primary) return a.is_primary ? -1 : 1
+				return a.characterName.localeCompare(b.characterName)
+			})
+			const matched = search
+				? (characters
+						.map((character) => {
+							const lowerName = character.characterName.toLowerCase()
+							const score =
+								isSearchNumeric && character.characterId === search
+									? 400
+									: lowerName === lowerSearch
+										? 300
+										: lowerSearch && lowerName.startsWith(lowerSearch)
+											? 200
+											: lowerSearch && lowerName.includes(lowerSearch)
+												? 100
+												: 0
+							return { character, score }
+						})
+						.filter((entry) => entry.score > 0)
+						.sort((a, b) => b.score - a.score)[0]?.character ?? null)
+				: null
+			const displayCharacter = characters[0]
+			const matchedBy:
+				| 'main_character_name'
+				| 'character_name'
+				| 'character_id'
+				| 'user_id'
+				| 'discord_user_id'
+				| 'discord_username'
+				| 'legacy_auth_username'
+				| null = !search
+				? null
+				: isSearchUuid && user.id === search
+					? 'user_id'
+					: user.discordUserId === search
+						? 'discord_user_id'
+						: discordUsernameMatchedCoreUserIds.has(user.id)
+							? 'discord_username'
+							: matched
+								? isSearchNumeric && matched.characterId === search
+									? 'character_id'
+									: matched.is_primary
+										? 'main_character_name'
+										: 'character_name'
+								: 'legacy_auth_username'
+
+			return {
+				summary: {
+					id: user.id,
+					mainCharacterId: displayCharacter.characterId,
+					mainCharacterName: displayCharacter.characterName,
+					characterCount: characters.length,
+					is_admin: user.is_admin,
+					discordUserId: user.discordUserId,
+					discordUsername: discordUsernameByUserId.get(user.id) ?? null,
+					matchedCharacterId: matched?.characterId ?? null,
+					matchedCharacterName: matched?.characterName ?? null,
+					matchedBy,
+					createdAt: user.createdAt,
+					updatedAt: user.updatedAt,
+				},
+				characters: characters.map((character) => ({
+					characterId: character.characterId,
+					characterName: character.characterName,
+					corporationId: character.corporationId,
+					corporationName: character.corporationName,
+					allianceId: character.allianceId,
+					allianceName: character.allianceName,
+					is_primary: character.is_primary,
+					hasValidToken: character.hasValidToken === true,
+				})),
+			}
+		})
+
+		const totalResult = await this.db
+			.select({ count: sql<number>`count(*)` })
+			.from(users)
+			.where(whereCondition)
+
+		return {
+			users: usersWithCharacters,
+			total: Number(totalResult[0]?.count ?? 0),
+			limit,
+			offset,
+		}
+	}
+
+	/**
 	 * Search users with pagination
 	 */
 	async searchUsers(params: SearchUsersParams): Promise<SearchUsersResult> {
@@ -58,7 +280,10 @@ export class CoreRpcService {
 		if (search) {
 			try {
 				const discordStub = getStub<Discord>(this.env.DISCORD, 'default')
-				const discordMatches = await discordStub.searchCoreUsersByUsername(search, 200)
+				const discordMatches = await withRpcResult(
+					discordStub.searchCoreUsersByUsername(search, 200),
+					(matches) => matches.map((match) => ({ ...match }))
+				)
 				for (const match of discordMatches) {
 					discordUsernameMatchedCoreUserIds.add(match.coreUserId)
 				}
@@ -220,22 +445,17 @@ export class CoreRpcService {
 		if (pageUserIds.length > 0) {
 			try {
 				const discordStub = getStub<Discord>(this.env.DISCORD, 'default')
-				const statuses = await Promise.all(
-					paginatedUsers.map(async (user) => {
-						if (!user.discordUserId) {
-							return { userId: user.id, username: null }
-						}
-						try {
-							const status = await discordStub.getDiscordUserStatus(user.id)
-							return { userId: user.id, username: status?.username ?? null }
-						} catch {
-							return { userId: user.id, username: null }
-						}
-					})
+				const statuses = await withRpcResult(
+					discordStub.getDiscordUserStatuses(pageUserIds),
+					(result) =>
+						new Map(
+							Object.entries(result).map(([userId, status]) => [userId, status.username] as const)
+						)
 				)
-				for (const status of statuses) {
-					if (status.username) {
-						discordUsernameByUserId.set(status.userId, status.username)
+				for (const user of paginatedUsers) {
+					const username = statuses.get(user.id)
+					if (username) {
+						discordUsernameByUserId.set(user.id, username)
 					}
 				}
 			} catch (error) {
@@ -310,7 +530,10 @@ export class CoreRpcService {
 	/**
 	 * Get detailed user information
 	 */
-	async getUserDetails(userId: string): Promise<UserDetails | null> {
+	async getUserDetails(
+		userId: string,
+		options: { includeUserBlacklist?: boolean } = {}
+	): Promise<UserDetails | null> {
 		// 1. Query user
 		const user = await this.db.query.users.findFirst({
 			where: eq(users.id, userId),
@@ -334,13 +557,25 @@ export class CoreRpcService {
 
 		// 5. Bulk check blacklist status for all characters
 		const characterIds = chars.map((c) => c.characterId)
-		const blacklistStatuses =
-			characterIds.length > 0 ? await hrStub.checkCharactersBlacklisted(characterIds) : {}
+		const blacklistStatusPromise: Promise<Record<string, boolean>> =
+			characterIds.length > 0
+				? withRpcResult(hrStub.checkCharactersBlacklisted(characterIds), (result) => ({
+						...result,
+					}))
+				: Promise.resolve({})
+		const [blacklistStatuses, isBlacklisted] = await Promise.all([
+			blacklistStatusPromise,
+			options.includeUserBlacklist === false
+				? Promise.resolve(false)
+				: hrStub.isUserBlacklisted(userId),
+		])
 
 		// 5.5 Fetch group memberships for admin visibility.
 		let groupMemberships: UserDetails['groupMemberships'] = []
 		try {
-			const memberships = await groupsStub.getUserMemberships(userId)
+			const memberships = await withRpcResult(groupsStub.getUserMemberships(userId), (result) =>
+				result.map((membership) => ({ ...membership }))
+			)
 			groupMemberships = memberships.map((membership) => ({
 				groupId: membership.groupId,
 				groupName: membership.groupName,
@@ -354,7 +589,9 @@ export class CoreRpcService {
 		// 5.6 Fetch resolved permission grants for admin visibility.
 		let permissionGrants: UserDetails['permissionGrants'] = []
 		try {
-			const grants = await groupsStub.getUserPermissionGrants(userId)
+			const grants = await withRpcResult(groupsStub.getUserPermissionGrants(userId), (result) =>
+				result.map((grant) => ({ ...grant }))
+			)
 			permissionGrants = grants.map((grant) => ({
 				permissionId: grant.permissionId ?? null,
 				urn: grant.urn,
@@ -409,7 +646,9 @@ export class CoreRpcService {
 		if (user.discordUserId) {
 			try {
 				const discordStub = getStub<Discord>(this.env.DISCORD, 'default')
-				const status = await discordStub.getDiscordUserStatus(userId)
+				const status = await withRpcResult(discordStub.getDiscordUserStatus(userId), (result) =>
+					result ? { ...result } : null
+				)
 				if (status) {
 					discordStatus = {
 						userId: status.userId,
@@ -430,6 +669,7 @@ export class CoreRpcService {
 			id: user.id,
 			mainCharacterId: user.mainCharacterId,
 			is_admin: user.is_admin,
+			isBlacklisted,
 			discordUserId: user.discordUserId,
 			discord: discordStatus,
 			characters: characterSummaries,

--- a/apps/core/src/services/user.service.ts
+++ b/apps/core/src/services/user.service.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq } from '@repo/db-utils'
+import { logger, toErrorLogDetails } from '@repo/hono-helpers'
 
 import { userCharacters, userPreferences, users } from '../db/schema'
 
@@ -10,7 +11,6 @@ import type {
 	UserProfileDTO,
 } from '@repo/core'
 import type { createDb } from '../db'
-import { logger } from '@repo/hono-helpers'
 
 /**
  * Thrown when a character cannot be claimed because it is already attached to an account.
@@ -156,13 +156,30 @@ export class UserService {
 	 * Get full user profile with characters and preferences
 	 * Optimized to fetch all data in parallel rather than sequentially
 	 */
-	async getUserProfile(userId: string, options?: { includeDeleted?: boolean }): Promise<UserProfileDTO> {
+	async getUserProfile(
+		userId: string,
+		options?: { includeDeleted?: boolean }
+	): Promise<UserProfileDTO> {
 		const includeDeleted = options?.includeDeleted === true
 		const characterWhere = includeDeleted
 			? eq(userCharacters.userId, userId)
 			: and(eq(userCharacters.userId, userId), eq(userCharacters.isDeleted, false))
 
-		// Execute all 3 queries in parallel for better performance
+		// Preferences are optional profile metadata. Keep their failure isolated so a
+		// transient preferences query does not prevent session authentication.
+		const preferencesPromise = this.db.query.userPreferences
+			.findFirst({
+				where: eq(userPreferences.userId, userId),
+			})
+			.catch((error) => {
+				logger.warn('[UserService] Preferences query failed; using defaults', {
+					userId,
+					...toErrorLogDetails(error),
+				})
+				return null
+			})
+
+		// Execute all profile queries in parallel for better performance.
 		let user, characters, preferences
 		try {
 			;[user, characters, preferences] = await Promise.all([
@@ -184,15 +201,12 @@ export class UserService {
 						linkedAt: true,
 					},
 				}),
-				this.db.query.userPreferences.findFirst({
-					where: eq(userPreferences.userId, userId),
-				}),
+				preferencesPromise,
 			])
 		} catch (error) {
 			logger.error('[UserService] Database query failed', {
 				userId,
-				error: error instanceof Error ? error.message : String(error),
-				stack: error instanceof Error ? error.stack : undefined,
+				...toErrorLogDetails(error),
 			})
 			throw error
 		}
@@ -202,7 +216,9 @@ export class UserService {
 			throw new Error('User not found')
 		}
 
-		const activeCharacters = includeDeleted ? characters : characters.filter((char) => !char.isDeleted)
+		const activeCharacters = includeDeleted
+			? characters
+			: characters.filter((char) => !char.isDeleted)
 
 		const charactersDTO: UserCharacterDTO[] = activeCharacters.map((char) => ({
 			id: char.id,

--- a/apps/discord/src/durable-object.ts
+++ b/apps/discord/src/durable-object.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from 'cloudflare:workers'
 
-import { and, eq, ilike, isNotNull, sql } from '@repo/db-utils'
+import { and, eq, ilike, inArray, isNotNull, sql } from '@repo/db-utils'
 import {
 	buildDiscordWebhookMessagePayload,
 	DISCORD_CHANNEL_TYPE,
@@ -34,6 +34,7 @@ import type {
 	DiscordRegisteredSlashCommand,
 	DiscordSlashCommandDefinition,
 	DiscordTokenResponse,
+	DiscordUserStatus,
 	MessageContent,
 	SendMessageResult,
 } from '@repo/discord'
@@ -368,6 +369,38 @@ export class DiscordDO extends DurableObject<Env> implements Discord {
 			createdAt: user.createdAt,
 			updatedAt: user.updatedAt,
 		}
+	}
+
+	/**
+	 * Get Discord statuses for multiple core users with one indexed query.
+	 */
+	async getDiscordUserStatuses(coreUserIds: string[]): Promise<Record<string, DiscordUserStatus>> {
+		const ids = [...new Set(coreUserIds)].filter(Boolean)
+		if (ids.length === 0) return {}
+
+		const users = await this.db.query.discordUsers.findMany({
+			where: inArray(discordUsers.coreUserId, ids),
+		})
+
+		return Object.fromEntries(
+			users
+				.filter((user): user is typeof user & { coreUserId: string } => user.coreUserId !== null)
+				.map((user) => [
+					user.coreUserId,
+					{
+						userId: user.userId,
+						username: user.username,
+						discriminator: user.discriminator,
+						coreUserId: user.coreUserId,
+						authRevoked: user.authRevoked,
+						authRevokedAt: user.authRevokedAt,
+						lastSuccessfulAuth: user.lastSuccessfulAuth,
+						lastRefreshed: user.lastRefreshed,
+						createdAt: user.createdAt,
+						updatedAt: user.updatedAt,
+					},
+				])
+		)
 	}
 
 	/**

--- a/apps/doctrines/src/durable-object.ts
+++ b/apps/doctrines/src/durable-object.ts
@@ -1,7 +1,7 @@
 import { DurableObject } from 'cloudflare:workers'
 import { and, asc, eq, ilike, isNull, like, or } from 'drizzle-orm'
 
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { EftParser } from '@repo/eve-parsers'
 
 import { createDb } from './db'
@@ -26,8 +26,8 @@ import type {
 	SetDoctrineStagingRequest,
 	StagingSystem,
 	UpdateCategoryRequest,
-	UpdateDoctrineRequest,
 	UpdateDoctrineFittingRequest,
+	UpdateDoctrineRequest,
 	UpdateFittingRequest,
 	UpdateStagingSystemRequest,
 } from '@repo/doctrines'
@@ -137,7 +137,10 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 
 	async getStagingSystems(): Promise<StagingSystem[]> {
 		return await this.db.query.doctrinesStagingSystems.findMany({
-			orderBy: [asc(schema.doctrinesStagingSystems.sortOrder), asc(schema.doctrinesStagingSystems.solarSystemName)],
+			orderBy: [
+				asc(schema.doctrinesStagingSystems.sortOrder),
+				asc(schema.doctrinesStagingSystems.solarSystemName),
+			],
 		})
 	}
 
@@ -282,7 +285,10 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 		return doctrine?.name ?? null
 	}
 
-	async updateDoctrine(id: string, data: UpdateDoctrineRequest & { updatedBy?: string }): Promise<Doctrine> {
+	async updateDoctrine(
+		id: string,
+		data: UpdateDoctrineRequest & { updatedBy?: string }
+	): Promise<Doctrine> {
 		const updates: Partial<typeof schema.doctrinesDoctrines.$inferInsert> = {
 			updatedAt: new Date(),
 		}
@@ -422,13 +428,11 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 		if (filters.srpEligible !== undefined) {
 			conditions.push(eq(schema.doctrinesFittings.srpEligible, filters.srpEligible))
 		}
-			if (filters.search) {
-				const nameMatch = ilike(schema.doctrinesFittings.name, `%${filters.search}%`)
-				const shipMatch = ilike(schema.doctrinesFittings.shipName, `%${filters.search}%`)
-				conditions.push(
-					or(nameMatch, shipMatch) ?? nameMatch
-				)
-			}
+		if (filters.search) {
+			const nameMatch = ilike(schema.doctrinesFittings.name, `%${filters.search}%`)
+			const shipMatch = ilike(schema.doctrinesFittings.shipName, `%${filters.search}%`)
+			conditions.push(or(nameMatch, shipMatch) ?? nameMatch)
+		}
 
 		const whereClause = conditions.length > 0 ? and(...conditions) : undefined
 
@@ -568,14 +572,20 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 
 	async addFittingToDoctrine(doctrineId: string, data: AddFittingToDoctrineRequest): Promise<void> {
 		const doctrine = await this.db.query.doctrinesDoctrines.findFirst({
-			where: and(eq(schema.doctrinesDoctrines.id, doctrineId), isNull(schema.doctrinesDoctrines.deletedAt)),
+			where: and(
+				eq(schema.doctrinesDoctrines.id, doctrineId),
+				isNull(schema.doctrinesDoctrines.deletedAt)
+			),
 		})
 		if (!doctrine) {
 			throw new Error('Doctrine not found')
 		}
 
 		const fitting = await this.db.query.doctrinesFittings.findFirst({
-			where: and(eq(schema.doctrinesFittings.id, data.fittingId), isNull(schema.doctrinesFittings.deletedAt)),
+			where: and(
+				eq(schema.doctrinesFittings.id, data.fittingId),
+				isNull(schema.doctrinesFittings.deletedAt)
+			),
 		})
 		if (!fitting) {
 			throw new Error('Fitting not found')
@@ -636,9 +646,15 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 	// DOCTRINE-STAGING RELATIONSHIP
 	// ============================================
 
-	async setDoctrineStagingSystem(doctrineId: string, data: SetDoctrineStagingRequest): Promise<void> {
+	async setDoctrineStagingSystem(
+		doctrineId: string,
+		data: SetDoctrineStagingRequest
+	): Promise<void> {
 		const doctrine = await this.db.query.doctrinesDoctrines.findFirst({
-			where: and(eq(schema.doctrinesDoctrines.id, doctrineId), isNull(schema.doctrinesDoctrines.deletedAt)),
+			where: and(
+				eq(schema.doctrinesDoctrines.id, doctrineId),
+				isNull(schema.doctrinesDoctrines.deletedAt)
+			),
 		})
 		if (!doctrine) {
 			throw new Error('Doctrine not found')
@@ -652,7 +668,10 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 				note: data.note,
 			})
 			.onConflictDoUpdate({
-				target: [schema.doctrinesDoctrineStagingSystems.doctrineId, schema.doctrinesDoctrineStagingSystems.stagingSystemId],
+				target: [
+					schema.doctrinesDoctrineStagingSystems.doctrineId,
+					schema.doctrinesDoctrineStagingSystems.stagingSystemId,
+				],
 				set: { note: data.note },
 			})
 	}
@@ -674,8 +693,9 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 
 	async searchShipTypes(query: string): Promise<Array<{ typeId: string; typeName: string }>> {
 		const universeStub = getStub<Universe>(this.env.UNIVERSE, 'default')
-		const results = await universeStub.searchTypes(query, 20)
-		return results.map((r) => ({ typeId: r.typeId, typeName: r.typeName }))
+		return withRpcResult(universeStub.searchShipTypes(query, 20), (results) =>
+			results.map((result) => ({ ...result }))
+		)
 	}
 
 	// ============================================
@@ -692,5 +712,4 @@ export class DoctrinesDO extends DurableObject<Env> implements Doctrines {
 			unresolvedItems: parsed.unresolvedItems,
 		}
 	}
-
 }

--- a/apps/esi/src/durable-object.ts
+++ b/apps/esi/src/durable-object.ts
@@ -628,7 +628,7 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 
 	@UseCharacterAuth
 	async fetchCharacterWalletJournal(characterId: string): Promise<CharacterWalletJournalEntry[]> {
-		const result = await this.esiFetcher.fetchEsi<EsiCharacterWalletJournalEntry[]>(
+		const result = await this.esiFetcher.fetchEsiPaginated<EsiCharacterWalletJournalEntry>(
 			`/characters/${characterId}/wallet/journal`,
 			{ cacheMode: 'no-store' }
 		)
@@ -772,7 +772,7 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 		corporationId: string,
 		division: number
 	): Promise<CorporationWalletJournalEntry[]> {
-		const result = await this.esiFetcher.fetchEsi<EsiCorporationWalletJournalEntry[]>(
+		const result = await this.esiFetcher.fetchEsiPaginated<EsiCorporationWalletJournalEntry>(
 			`/corporations/${corporationId}/wallets/${division}/journal`,
 			{ cacheMode: 'no-store' }
 		)

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -166,10 +166,30 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			// Initialize the SQLite-backed cache tables before the DO can serve requests.
 			// This avoids cache clear/read paths racing a cold start and resetting the object.
 			await this.initializeEsiCache()
-		})
 
-		// Schedule alarm for token refresh (check every 5 minutes)
-		void this.state.storage.setAlarm(Date.now() + 5 * 60 * 1000)
+			// Do not overwrite an existing alarm during a DO restart or relocation.
+			// Keeping the existing alarm also preserves Cloudflare's automatic retry state.
+			if ((await state.storage.getAlarm()) === null) {
+				await this.scheduleRefreshAlarm(TOKEN_REFRESH_ALARM_INTERVAL_MS, 'constructor')
+			}
+		})
+	}
+
+	private async scheduleRefreshAlarm(delayMs: number, source: string): Promise<void> {
+		try {
+			await this.state.storage.setAlarm(Date.now() + delayMs)
+		} catch (error) {
+			// A relocation can make the current isolate's storage handle invalid. Re-throw
+			// so Cloudflare retries the alarm on the object's new machine.
+			logger
+				.withTags({ operation: 'scheduleRefreshAlarm', source })
+				.warn('Failed to schedule token refresh alarm; allowing platform retry', {
+					delayMs,
+					error: error instanceof Error ? error.message : String(error),
+					errorDetails: toErrorLogDetails(error),
+				})
+			throw error
+		}
 	}
 
 	/**
@@ -267,7 +287,22 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	}
 
 	private async getTokenRefreshCooldownUntil(characterId: string): Promise<number> {
-		return (await this.state.storage.get<number>(this.getTokenRefreshCooldownKey(characterId))) ?? 0
+		const storageKey = this.getTokenRefreshCooldownKey(characterId)
+		try {
+			const value = await this.state.storage.get<number>(storageKey)
+			return typeof value === 'number' && Number.isFinite(value) ? value : 0
+		} catch (error) {
+			// The cooldown is advisory. A transient DO storage failure must not turn a
+			// usable refresh token into a failed refresh attempt.
+			logger
+				.withTags({ operation: 'getTokenRefreshCooldownUntil', characterId })
+				.warn('Failed to read token refresh cooldown; continuing without persisted cooldown', {
+					storageKey,
+					error: error instanceof Error ? error.message : String(error),
+					errorDetails: toErrorLogDetails(error),
+				})
+			return 0
+		}
 	}
 
 	private async setTokenRefreshCooldownUntil(
@@ -280,13 +315,12 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		} catch (error) {
 			logger
 				.withTags({ operation: 'setTokenRefreshCooldownUntil', characterId })
-				.error('Failed to persist token refresh cooldown to Durable Object storage', {
+				.warn('Failed to persist token refresh cooldown to Durable Object storage', {
 					storageKey,
 					cooldownUntil: new Date(cooldownUntilMs).toISOString(),
 					error: error instanceof Error ? error.message : String(error),
 					errorDetails: toErrorLogDetails(error),
 				})
-			throw error
 		}
 	}
 
@@ -297,12 +331,11 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		} catch (error) {
 			logger
 				.withTags({ operation: 'clearTokenRefreshCooldown', characterId })
-				.error('Failed to clear token refresh cooldown from Durable Object storage', {
+				.warn('Failed to clear token refresh cooldown from Durable Object storage', {
 					storageKey,
 					error: error instanceof Error ? error.message : String(error),
 					errorDetails: toErrorLogDetails(error),
 				})
-			throw error
 		}
 	}
 
@@ -2584,7 +2617,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			processedBatchSize === TOKEN_REFRESH_ALARM_BATCH_SIZE
 				? TOKEN_REFRESH_ALARM_CONTINUE_DELAY_MS
 				: TOKEN_REFRESH_ALARM_INTERVAL_MS
-		await this.state.storage.setAlarm(Date.now() + nextAlarmDelayMs)
+		await this.scheduleRefreshAlarm(nextAlarmDelayMs, 'alarm')
 	}
 
 	/**

--- a/apps/hr/src/durable-object.ts
+++ b/apps/hr/src/durable-object.ts
@@ -25,6 +25,7 @@ import type {
 	BlacklistTargetCheckResult,
 	CharacterIdNameBlacklistResult,
 	CharacterIdNamePair,
+	CorporationApplicationCounts,
 	CreateCharacterBlacklistParams,
 	CreateDiscordBlacklistParams,
 	CreateUserBlacklistParams,
@@ -166,6 +167,24 @@ export class HrDO extends DurableObject<Env> implements Hr {
 		return await this.applicationService.listApplicationsPaged(
 			filters,
 			userId,
+			access.isAdmin,
+			access.isAuditor,
+			userHrCorporations
+		)
+	}
+
+	async getApplicationCountsByCorporation(
+		corporationIds: string[],
+		userId: string,
+		access: { isAdmin: boolean; isAuditor: boolean }
+	): Promise<CorporationApplicationCounts[]> {
+		const userHrCorporations =
+			access.isAdmin || access.isAuditor
+				? []
+				: await this.hrRoleService.getUserHrCorporations(userId)
+
+		return await this.applicationService.getApplicationCountsByCorporation(
+			corporationIds,
 			access.isAdmin,
 			access.isAuditor,
 			userHrCorporations

--- a/apps/hr/src/services/application.service.ts
+++ b/apps/hr/src/services/application.service.ts
@@ -15,6 +15,7 @@ import type {
 	ApplicationFilters,
 	ApplicationListResult,
 	ApplicationStatus,
+	CorporationApplicationCounts,
 	HrAccessContext,
 	RecommendableApplication,
 	RecommendationSentiment,
@@ -305,6 +306,62 @@ export class ApplicationService {
 			offset,
 			counts,
 		}
+	}
+
+	async getApplicationCountsByCorporation(
+		corporationIds: string[],
+		isAdmin: boolean,
+		isAuditor: boolean,
+		userHrCorporations: string[] = []
+	): Promise<CorporationApplicationCounts[]> {
+		const requestedCorporationIds = [...new Set(corporationIds)]
+		if (requestedCorporationIds.length === 0) return []
+
+		const authorizedCorporationIds =
+			isAdmin || isAuditor
+				? requestedCorporationIds
+				: requestedCorporationIds.filter((corporationId) =>
+						userHrCorporations.includes(corporationId)
+					)
+
+		const countsByCorporation = new Map<string, CorporationApplicationCounts>(
+			authorizedCorporationIds.map((corporationId) => [
+				corporationId,
+				{
+					corporationId,
+					pending: 0,
+					underReview: 0,
+				},
+			])
+		)
+
+		if (authorizedCorporationIds.length === 0) {
+			return [...countsByCorporation.values()]
+		}
+
+		const rows = await this.ctx.db
+			.select({
+				corporationId: applications.corporationId,
+				status: applications.status,
+				total: sql<number>`count(*)::int`,
+			})
+			.from(applications)
+			.where(
+				and(
+					inArray(applications.corporationId, authorizedCorporationIds),
+					inArray(applications.status, ['pending', 'under_review'])
+				)
+			)
+			.groupBy(applications.corporationId, applications.status)
+
+		for (const row of rows) {
+			const counts = countsByCorporation.get(row.corporationId)
+			if (!counts) continue
+			if (row.status === 'pending') counts.pending = row.total
+			if (row.status === 'under_review') counts.underReview = row.total
+		}
+
+		return [...countsByCorporation.values()]
 	}
 
 	/**

--- a/apps/hr/src/test/unit/application.service.counts.test.ts
+++ b/apps/hr/src/test/unit/application.service.counts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ApplicationService } from '../../services/application.service'
+
+import type { ServiceContext } from '../../services/context'
+
+function makeService(rows: Array<{ corporationId: string; status: string; total: number }>) {
+	const groupedQuery = {
+		from: vi.fn().mockReturnThis(),
+		where: vi.fn().mockReturnThis(),
+		groupBy: vi.fn().mockResolvedValue(rows),
+	}
+	const db = {
+		select: vi.fn().mockReturnValue(groupedQuery),
+	} as unknown as ServiceContext['db']
+
+	return {
+		service: new ApplicationService({ db, env: {} } as ServiceContext),
+		groupedQuery,
+	}
+}
+
+describe('ApplicationService.getApplicationCountsByCorporation', () => {
+	it('returns only authorized corporations and groups open statuses in one query', async () => {
+		const { service, groupedQuery } = makeService([
+			{ corporationId: 'corp-1', status: 'pending', total: 2 },
+			{ corporationId: 'corp-1', status: 'under_review', total: 1 },
+			{ corporationId: 'corp-2', status: 'pending', total: 7 },
+		])
+
+		const result = await service.getApplicationCountsByCorporation(
+			['corp-1', 'corp-2'],
+			false,
+			false,
+			['corp-1']
+		)
+
+		expect(result).toEqual([{ corporationId: 'corp-1', pending: 2, underReview: 1 }])
+		expect(groupedQuery.groupBy).toHaveBeenCalledTimes(1)
+	})
+
+	it('returns zero counts for authorized corporations with no open applications', async () => {
+		const { service } = makeService([])
+
+		await expect(
+			service.getApplicationCountsByCorporation(['corp-1'], true, false)
+		).resolves.toEqual([{ corporationId: 'corp-1', pending: 0, underReview: 0 }])
+	})
+})

--- a/apps/ui/src/client/components/layout.tsx
+++ b/apps/ui/src/client/components/layout.tsx
@@ -47,8 +47,10 @@ export default function Layout() {
 	const sidebarOpenRef = useRef(sidebarOpen)
 	const location = useLocation()
 	const isStructuresPage = location.pathname === '/structures'
+	const isHrUserSearchPage = location.pathname === '/hr/users'
 	const [isPageScrollEnabled, setIsPageScrollEnabled] = useState(false)
 	const isClampedStructuresPage = isStructuresPage && !isPageScrollEnabled
+	const isClampedRoute = isClampedStructuresPage || isHrUserSearchPage
 
 	useEffect(() => {
 		window.localStorage.setItem(SIDEBAR_OPEN_STORAGE_KEY, sidebarOpen ? '1' : '0')
@@ -116,7 +118,7 @@ export default function Layout() {
 			<div
 				className={cn(
 					'relative min-h-screen flex overflow-x-hidden',
-					isClampedStructuresPage && 'lg:h-dvh lg:overflow-hidden'
+					isClampedRoute && 'lg:h-dvh lg:overflow-hidden'
 				)}
 			>
 				{/* Starfield Background */}
@@ -152,7 +154,7 @@ export default function Layout() {
 				<div
 					className={cn(
 						'relative z-10 flex-1 flex flex-col min-w-0 overflow-x-hidden overflow-y-auto transition-[padding-left] duration-300 ease-in-out',
-						isClampedStructuresPage && 'lg:min-h-0 lg:overflow-y-hidden',
+						isClampedRoute && 'lg:min-h-0 lg:overflow-y-hidden',
 						sidebarOpen ? 'lg:pl-64' : 'lg:pl-0'
 					)}
 				>
@@ -175,15 +177,10 @@ export default function Layout() {
 					<main
 						className={cn(
 							'flex flex-1 flex-col relative z-10 p-4 md:p-6 lg:p-8',
-							isClampedStructuresPage && 'lg:min-h-0 lg:overflow-hidden'
+							isClampedRoute && 'lg:min-h-0 lg:overflow-hidden'
 						)}
 					>
-						<div
-							className={cn(
-								'w-full mx-auto max-w-[120rem]',
-								isClampedStructuresPage && 'lg:h-full'
-							)}
-						>
+						<div className={cn('w-full mx-auto max-w-[120rem]', isClampedRoute && 'lg:h-full')}>
 							<Outlet />
 						</div>
 					</main>

--- a/apps/ui/src/client/components/member-avatar.tsx
+++ b/apps/ui/src/client/components/member-avatar.tsx
@@ -1,7 +1,9 @@
-import type { CSSProperties } from 'react'
+import { X } from 'lucide-react'
 
-import { cn } from '@/lib/utils'
 import { characterPortraitUrl } from '@/lib/eve-images'
+import { cn } from '@/lib/utils'
+
+import type { CSSProperties } from 'react'
 
 interface MemberAvatarProps {
 	characterId?: string | number
@@ -10,6 +12,7 @@ interface MemberAvatarProps {
 	className?: string
 	style?: CSSProperties
 	imageSize?: 64 | 128 | 256 | 512
+	isBlacklisted?: boolean
 }
 
 const sizeClasses = {
@@ -31,19 +34,24 @@ export function MemberAvatar({
 	className,
 	style,
 	imageSize,
+	isBlacklisted = false,
 }: MemberAvatarProps) {
 	const sizeClass = sizeClasses[size]
 	const portraitSize = imageSize ?? 64
 
 	return (
-		<div className={cn(sizeClass, 'flex-shrink-0 overflow-hidden rounded-md', className)} style={style}>
+		<div
+			className={cn(sizeClass, 'relative flex-shrink-0 overflow-hidden rounded-md', className)}
+			style={style}
+		>
 			{characterId ? (
 				<img
 					src={characterPortraitUrl(characterId, portraitSize)}
 					alt={characterName || 'Character portrait'}
 					className={cn(
 						'h-full w-full rounded-md',
-						size === 'auto' ? 'object-contain' : 'object-cover'
+						size === 'auto' ? 'object-contain' : 'object-cover',
+						isBlacklisted && 'grayscale'
 					)}
 					loading="lazy"
 				/>
@@ -51,6 +59,12 @@ export function MemberAvatar({
 				<div className="h-full w-full rounded bg-muted flex items-center justify-center text-muted-foreground text-xs">
 					?
 				</div>
+			)}
+			{isBlacklisted && (
+				<X
+					className="pointer-events-none absolute inset-0 m-auto h-[78%] w-[78%] stroke-[3] text-red-500 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
+					aria-hidden="true"
+				/>
 			)}
 		</div>
 	)

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -287,7 +287,9 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 			})
 		}
 
-		if (isAuditor || isSiteAdmin) {
+		const canUseCorporationUserSearch =
+			isAuditor || isSiteAdmin || (hrCorporations?.length ?? 0) > 0
+		if (canUseCorporationUserSearch) {
 			hrItems.push({
 				label: 'User Search',
 				href: '/hr/users',

--- a/apps/ui/src/client/components/user-search-results-table.tsx
+++ b/apps/ui/src/client/components/user-search-results-table.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink, Users } from 'lucide-react'
 import { Link } from 'react-router'
 
+import { MemberAvatar } from '@/components/member-avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -12,7 +13,7 @@ import {
 	TableRow,
 } from '@/components/ui/table'
 import { formatDateTime, formatRelativeTime } from '@/lib/date-utils'
-import { characterPortraitUrl } from '@/lib/eve-images'
+import { cn } from '@/lib/utils'
 
 type SearchResultUser = {
 	id: string
@@ -24,6 +25,8 @@ type SearchResultUser = {
 	discordUsername: string | null
 	matchedCharacterId: string | null
 	matchedCharacterName: string | null
+	mainCharacterIsBlacklisted?: boolean
+	matchedCharacterIsBlacklisted?: boolean | null
 	createdAt: string
 	updatedAt: string
 }
@@ -64,25 +67,38 @@ export function UserSearchResultsTable({
 					const displayName = isAltMatch
 						? `${user.matchedCharacterName}${user.mainCharacterName ? ` (${user.mainCharacterName})` : ''}`
 						: user.mainCharacterName || user.matchedCharacterName || 'Unknown Character'
+					const isDisplayedCharacterBlacklisted = isAltMatch
+						? user.matchedCharacterIsBlacklisted
+						: user.mainCharacterIsBlacklisted
 
 					return (
 						<TableRow key={user.id}>
 							<TableCell>
 								<div className="flex items-center gap-3">
-									<img
-										src={characterPortraitUrl(portraitCharacterId, 64)}
-										alt={displayName}
+									<MemberAvatar
+										characterId={portraitCharacterId}
+										characterName={displayName}
+										isBlacklisted={Boolean(isDisplayedCharacterBlacklisted)}
+										size="auto"
 										className="h-10 w-10 rounded-full"
 									/>
 									<div>
 										<Link
 											to={userDetailsPath(user.id)}
-											className="inline-flex items-center gap-2 font-medium hover:text-primary transition-colors"
+											className={cn(
+												'inline-flex items-center gap-2 font-medium hover:text-primary transition-colors',
+												isDisplayedCharacterBlacklisted && 'text-red-500'
+											)}
 										>
 											{displayName}
 											{isAltMatch && <Badge variant="default">Alt</Badge>}
+											{isDisplayedCharacterBlacklisted && (
+												<Badge variant="destructive">Blocklisted</Badge>
+											)}
 										</Link>
-										<div className="text-xs text-muted-foreground">ID: {user.id.slice(0, 8)}...</div>
+										<div className="text-xs text-muted-foreground">
+											ID: {user.id.slice(0, 8)}...
+										</div>
 									</div>
 								</div>
 							</TableCell>
@@ -118,9 +134,7 @@ export function UserSearchResultsTable({
 									<span className="text-sm text-muted-foreground">Not linked</span>
 								)}
 							</TableCell>
-							<TableCell>
-								{user.is_admin && <Badge variant="default">Admin</Badge>}
-							</TableCell>
+							<TableCell>{user.is_admin && <Badge variant="default">Admin</Badge>}</TableCell>
 							<TableCell>
 								<div className="text-sm" title={formatDateTime(user.updatedAt)}>
 									{formatRelativeTime(user.updatedAt)}

--- a/apps/ui/src/client/features/applications/api.ts
+++ b/apps/ui/src/client/features/applications/api.ts
@@ -50,6 +50,9 @@ export interface Application {
 	recommendationCount?: number
 	altCharacterIds?: string[]
 	isFirstApplication?: boolean
+	isUserBlacklisted?: boolean
+	isCharacterBlacklisted?: boolean
+	isBlacklisted?: boolean
 }
 
 export interface ApplicationStaffNote {
@@ -219,6 +222,12 @@ export interface ApplicationsListResult {
 	}
 }
 
+export interface CorporationApplicationCounts {
+	corporationId: string
+	pending: number
+	underReview: number
+}
+
 /**
  * Request body for submitting an application
  */
@@ -368,6 +377,13 @@ export const applicationsApi = {
 		return apiClient.get(`/hr/applications/paged${query ? `?${query}` : ''}`)
 	},
 
+	async getApplicationCountsByCorporation(): Promise<CorporationApplicationCounts[]> {
+		const result = await apiClient.get<{ corporations: CorporationApplicationCounts[] }>(
+			'/hr/applications/counts'
+		)
+		return result.corporations
+	},
+
 	/**
 	 * Get a single application by ID
 	 */
@@ -498,10 +514,7 @@ export const applicationsApi = {
 	/**
 	 * Send a message for an application
 	 */
-	async sendMessage(
-		applicationId: string,
-		data: SendMessageRequest
-	): Promise<ApplicationMessage> {
+	async sendMessage(applicationId: string, data: SendMessageRequest): Promise<ApplicationMessage> {
 		return apiClient.post(`/hr/applications/${applicationId}/messages`, data)
 	},
 
@@ -624,10 +637,7 @@ export const applicationsApi = {
 	/**
 	 * Update a message template
 	 */
-	async updateTemplate(
-		templateId: string,
-		data: UpdateTemplateRequest
-	): Promise<MessageTemplate> {
+	async updateTemplate(templateId: string, data: UpdateTemplateRequest): Promise<MessageTemplate> {
 		return apiClient.patch(`/hr/templates/${templateId}`, data)
 	},
 
@@ -808,10 +818,10 @@ export const fulcrumApi = {
 	 */
 	async getUserCharactersWithReports(
 		userId: string,
-		corporationId: string,
+		corporationId: string
 	): Promise<FulcrumCharacterData[]> {
 		return apiClient.get(
-			`/fulcrum/users/${userId}/characters?corporationId=${encodeURIComponent(corporationId)}`,
+			`/fulcrum/users/${userId}/characters?corporationId=${encodeURIComponent(corporationId)}`
 		)
 	},
 
@@ -838,7 +848,7 @@ export const fulcrumApi = {
 		characterId: string,
 		requestSource: ReportRequestSource,
 		applicationId?: string,
-		sendDm = true,
+		sendDm = true
 	): Promise<{ reportId: string; status: string }> {
 		return apiClient.post(`/fulcrum/characters/${characterId}/reports`, {
 			requestSource,
@@ -856,7 +866,7 @@ export const fulcrumApi = {
 		characterIds: string[],
 		requestSource: ReportRequestSource,
 		applicationId?: string,
-		sendDm = true,
+		sendDm = true
 	): Promise<{ batchId: string; status: string }> {
 		return apiClient.post('/fulcrum/reports/batch', {
 			characterIds,
@@ -880,7 +890,7 @@ export const fulcrumApi = {
 		reportId: string,
 		section: ReportSectionName,
 		page?: number,
-		pageSize?: number,
+		pageSize?: number
 	): Promise<T> {
 		const params = new URLSearchParams()
 		if (page !== undefined) params.set('page', String(page))
@@ -892,10 +902,7 @@ export const fulcrumApi = {
 	/**
 	 * Fetch a single mail's content on-demand from ESI
 	 */
-	async fetchMailContent(
-		reportId: string,
-		mailId: string,
-	): Promise<{ body: string }> {
+	async fetchMailContent(reportId: string, mailId: string): Promise<{ body: string }> {
 		return apiClient.get(`/fulcrum/reports/${reportId}/mails/${mailId}/content`)
 	},
 }

--- a/apps/ui/src/client/features/applications/components/application-character-stack.tsx
+++ b/apps/ui/src/client/features/applications/components/application-character-stack.tsx
@@ -1,9 +1,12 @@
+import { X } from 'lucide-react'
 import { useRef, useState } from 'react'
 
+import { MemberAvatar } from '@/components/member-avatar'
 import { Badge } from '@/components/ui/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Separator } from '@/components/ui/separator'
 import { characterPortraitUrl } from '@/lib/eve-images'
+import { cn } from '@/lib/utils'
 
 import { CharacterRoleBadge } from './character-role-badge'
 
@@ -16,6 +19,7 @@ export interface ApplicationCharacterStackProps {
 	mainCharacterName: string
 	altCharacterIds: string[]
 	altCharacterNames: Record<string, string>
+	blacklistedCharacterIds?: string[]
 	size?: 'sm' | 'md' | 'lg'
 }
 
@@ -62,7 +66,11 @@ function placeholderPos(cfg: SizeConfig) {
 	}
 }
 
-function containerSize(cfg: SizeConfig, visibleCount: number, hasPlaceholder: boolean): { width: number; height: number } {
+function containerSize(
+	cfg: SizeConfig,
+	visibleCount: number,
+	hasPlaceholder: boolean
+): { width: number; height: number } {
 	let w = cfg.mainPx
 	let h = cfg.mainPx
 
@@ -92,6 +100,7 @@ export function ApplicationCharacterStack({
 	mainCharacterName,
 	altCharacterIds,
 	altCharacterNames,
+	blacklistedCharacterIds = [],
 	size = 'lg',
 }: ApplicationCharacterStackProps) {
 	const [open, setOpen] = useState(false)
@@ -103,6 +112,7 @@ export function ApplicationCharacterStack({
 	// Show a blank placeholder slot when there are more alts than we can show as portraits
 	const showPlaceholder = altCount > MAX_PORTRAIT_ALTS
 	const { width: cw, height: ch } = containerSize(cfg, visibleAlts.length, showPlaceholder)
+	const blacklistedIds = new Set(blacklistedCharacterIds)
 
 	const clearClose = () => {
 		if (closeTimeoutRef.current !== null) {
@@ -111,7 +121,10 @@ export function ApplicationCharacterStack({
 		}
 	}
 
-	const openPopover = () => { clearClose(); setOpen(true) }
+	const openPopover = () => {
+		clearClose()
+		setOpen(true)
+	}
 	const closePopoverSoon = () => {
 		clearClose()
 		closeTimeoutRef.current = window.setTimeout(() => setOpen(false), 80)
@@ -129,16 +142,24 @@ export function ApplicationCharacterStack({
 					onBlur={closePopoverSoon}
 				>
 					{/* Blank placeholder slot (behind all portraits) — shown when 4+ alts */}
-					{showPlaceholder && (() => {
-						const { x, y } = placeholderPos(cfg)
-						const px = altPx(cfg, MAX_PORTRAIT_ALTS)
-						return (
-							<div
-								style={{ position: 'absolute', left: x, top: y, width: px, height: px, zIndex: 0 }}
-								className="rounded border-2 border-background bg-muted shadow-md"
-							/>
-						)
-					})()}
+					{showPlaceholder &&
+						(() => {
+							const { x, y } = placeholderPos(cfg)
+							const px = altPx(cfg, MAX_PORTRAIT_ALTS)
+							return (
+								<div
+									style={{
+										position: 'absolute',
+										left: x,
+										top: y,
+										width: px,
+										height: px,
+										zIndex: 0,
+									}}
+									className="rounded border-2 border-background bg-muted shadow-md"
+								/>
+							)
+						})()}
 
 					{/* Alt portraits — rendered back-to-front so earlier alts sit in front */}
 					{[...visibleAlts].reverse().map((altId, reverseIdx) => {
@@ -146,10 +167,8 @@ export function ApplicationCharacterStack({
 						const { x, y } = altPos(cfg, i)
 						const px = altPx(cfg, i)
 						return (
-							<img
+							<div
 								key={altId}
-								src={characterPortraitUrl(altId, 32)}
-								alt={altCharacterNames[altId] ?? altId}
 								style={{
 									position: 'absolute',
 									left: x,
@@ -158,16 +177,29 @@ export function ApplicationCharacterStack({
 									height: px,
 									zIndex: MAX_PORTRAIT_ALTS - i,
 								}}
-								className="rounded object-cover border-2 border-background shadow-md"
-								loading="lazy"
-							/>
+								className="relative"
+							>
+								<img
+									src={characterPortraitUrl(altId, 32)}
+									alt={altCharacterNames[altId] ?? altId}
+									className={cn(
+										'h-full w-full rounded object-cover border-2 border-background shadow-md',
+										blacklistedIds.has(altId) && 'grayscale'
+									)}
+									loading="lazy"
+								/>
+								{blacklistedIds.has(altId) && (
+									<X
+										className="pointer-events-none absolute inset-0 m-auto h-[75%] w-[75%] stroke-[3] text-red-500 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
+										aria-hidden="true"
+									/>
+								)}
+							</div>
 						)
 					})}
 
 					{/* Main portrait — frontmost */}
-					<img
-						src={characterPortraitUrl(mainCharacterId, cfg.portraitPx)}
-						alt={mainCharacterName}
+					<div
 						style={{
 							position: 'absolute',
 							left: 0,
@@ -176,9 +208,24 @@ export function ApplicationCharacterStack({
 							height: cfg.mainPx,
 							zIndex: MAX_PORTRAIT_ALTS + 1,
 						}}
-						className="rounded object-cover shadow-lg"
-						loading="lazy"
-					/>
+						className="relative"
+					>
+						<img
+							src={characterPortraitUrl(mainCharacterId, cfg.portraitPx)}
+							alt={mainCharacterName}
+							className={cn(
+								'h-full w-full rounded object-cover shadow-lg',
+								blacklistedIds.has(mainCharacterId) && 'grayscale'
+							)}
+							loading="lazy"
+						/>
+						{blacklistedIds.has(mainCharacterId) && (
+							<X
+								className="pointer-events-none absolute inset-0 m-auto h-[78%] w-[78%] stroke-[3] text-red-500 drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
+								aria-hidden="true"
+							/>
+						)}
+					</div>
 
 					{/* Persistent alt count badge — anchored to bottom-right corner of main portrait */}
 					{altCount > 0 && (
@@ -212,14 +259,21 @@ export function ApplicationCharacterStack({
 							Main Character
 						</p>
 						<div className="flex items-center gap-2">
-							<img
-								src={characterPortraitUrl(mainCharacterId, 32)}
-								alt={mainCharacterName}
-								className="h-8 w-8 rounded object-cover"
-								loading="lazy"
+							<MemberAvatar
+								characterId={mainCharacterId}
+								characterName={mainCharacterName}
+								isBlacklisted={blacklistedIds.has(mainCharacterId)}
+								size="sm"
 							/>
 							<span className="inline-flex min-w-0 items-center gap-2">
-								<span className="truncate text-sm font-medium">{mainCharacterName}</span>
+								<span
+									className={cn(
+										'truncate text-sm font-medium',
+										blacklistedIds.has(mainCharacterId) && 'text-red-500'
+									)}
+								>
+									{mainCharacterName}
+								</span>
 								<CharacterRoleBadge role="main" />
 							</span>
 						</div>
@@ -235,14 +289,21 @@ export function ApplicationCharacterStack({
 								<div className="space-y-2">
 									{altCharacterIds.map((altId) => (
 										<div key={altId} className="flex items-center gap-2">
-											<img
-												src={characterPortraitUrl(altId, 32)}
-												alt={altCharacterNames[altId] ?? altId}
-												className="h-8 w-8 rounded object-cover"
-												loading="lazy"
+											<MemberAvatar
+												characterId={altId}
+												characterName={altCharacterNames[altId] ?? altId}
+												isBlacklisted={blacklistedIds.has(altId)}
+												size="sm"
 											/>
 											<span className="inline-flex min-w-0 items-center gap-2">
-												<span className="truncate text-sm">{altCharacterNames[altId] ?? altId}</span>
+												<span
+													className={cn(
+														'truncate text-sm',
+														blacklistedIds.has(altId) && 'text-red-500'
+													)}
+												>
+													{altCharacterNames[altId] ?? altId}
+												</span>
 												<CharacterRoleBadge role="alt" />
 											</span>
 										</div>

--- a/apps/ui/src/client/features/applications/components/application-history-panel.tsx
+++ b/apps/ui/src/client/features/applications/components/application-history-panel.tsx
@@ -8,11 +8,13 @@
 
 import { formatDistanceToNow } from 'date-fns'
 import { FileText, History, User, Users } from 'lucide-react'
-import { useNavigate, useParams } from 'react-router'
+import { Link } from 'react-router'
 
 import { MemberAvatar } from '@/components/member-avatar'
 import { LoadingSpinner } from '@/components/ui/loading'
+import { useAuth } from '@/hooks/useAuth'
 
+import { useHrAccessibleCorporations } from '../../hr/hooks'
 import { useCharacterApplicationHistory, useUserApplicationHistory } from '../hooks'
 import { ApplicationStatusBadge } from './application-status-badge'
 
@@ -24,17 +26,15 @@ import type { Application } from '../api'
 
 function HistoryEntry({
 	app,
-	onNavigate,
+	href,
+	canAccess,
 }: {
 	app: Application
-	onNavigate: (applicationId: string) => void
+	href: string
+	canAccess: boolean
 }) {
-	return (
-		<button
-			type="button"
-			onClick={() => onNavigate(app.id)}
-			className="flex w-full cursor-pointer items-start gap-4 rounded-lg border p-4 text-left transition-colors hover:bg-accent/50"
-		>
+	const content = (
+		<>
 			<MemberAvatar characterId={app.characterId} characterName={app.characterName} size="md" />
 			<div className="min-w-0 flex-1 space-y-1">
 				<div className="flex items-center gap-2">
@@ -47,8 +47,28 @@ function HistoryEntry({
 				<p className="text-xs text-muted-foreground">
 					{formatDistanceToNow(new Date(app.createdAt), { addSuffix: true })}
 				</p>
+				{!canAccess && (
+					<p className="text-xs text-amber-500">You do not have HR access to this corporation.</p>
+				)}
 			</div>
-		</button>
+		</>
+	)
+
+	if (!canAccess) {
+		return (
+			<div className="flex w-full items-start gap-4 rounded-lg border p-4 text-left opacity-75">
+				{content}
+			</div>
+		)
+	}
+
+	return (
+		<Link
+			to={href}
+			className="flex w-full cursor-pointer items-start gap-4 rounded-lg border p-4 text-left transition-colors hover:bg-accent/50"
+		>
+			{content}
+		</Link>
 	)
 }
 
@@ -57,13 +77,15 @@ function HistorySection({
 	icon: Icon,
 	apps,
 	emptyMessage,
-	onNavigate,
+	getHref,
+	canAccessApplication,
 }: {
 	title: string
 	icon: typeof User
 	apps: Application[]
 	emptyMessage: string
-	onNavigate: (applicationId: string) => void
+	getHref: (application: Application) => string
+	canAccessApplication: (application: Application) => boolean
 }) {
 	return (
 		<div className="space-y-3">
@@ -75,7 +97,14 @@ function HistorySection({
 			{apps.length === 0 ? (
 				<p className="py-2 text-sm text-muted-foreground/70">{emptyMessage}</p>
 			) : (
-				apps.map((app) => <HistoryEntry key={app.id} app={app} onNavigate={onNavigate} />)
+				apps.map((app) => (
+					<HistoryEntry
+						key={app.id}
+						app={app}
+						href={getHref(app)}
+						canAccess={canAccessApplication(app)}
+					/>
+				))
 			)}
 		</div>
 	)
@@ -96,8 +125,15 @@ export function ApplicationHistoryPanel({
 	userId,
 	applicationId,
 }: ApplicationHistoryPanelProps) {
-	const { corporationId } = useParams<{ corporationId: string }>()
-	const navigate = useNavigate()
+	const { user, permissions } = useAuth()
+	const hasGlobalAccess =
+		user?.is_admin === true || permissions.some((permission) => permission.urn === 'urn:hr:auditor')
+	const { data: hrAccessibleCorporations } = useHrAccessibleCorporations({
+		enabled: !hasGlobalAccess,
+	})
+	const accessibleCorporationIds = new Set(
+		hrAccessibleCorporations?.map((corporation) => corporation.corporationId) ?? []
+	)
 	const {
 		data: charHistory,
 		isLoading: charLoading,
@@ -109,9 +145,10 @@ export function ApplicationHistoryPanel({
 		error: userError,
 	} = useUserApplicationHistory(userId, applicationId)
 
-	const handleNavigate = (targetApplicationId: string) => {
-		void navigate(`/corporations/${corporationId}/applications/${targetApplicationId}`)
-	}
+	const getApplicationHref = (application: Application) =>
+		`/corporations/${application.corporationId}/applications/${application.id}`
+	const canAccessApplication = (application: Application) =>
+		hasGlobalAccess || accessibleCorporationIds.has(application.corporationId)
 
 	const isLoading = charLoading || userLoading
 	const error = charError || userError
@@ -158,14 +195,16 @@ export function ApplicationHistoryPanel({
 				icon={User}
 				apps={charHistory ?? []}
 				emptyMessage="No prior applications from this character"
-				onNavigate={handleNavigate}
+				getHref={getApplicationHref}
+				canAccessApplication={canAccessApplication}
 			/>
 			<HistorySection
 				title="This Account (Other Characters)"
 				icon={Users}
 				apps={otherAccountApps}
 				emptyMessage="No applications from other characters on this account"
-				onNavigate={handleNavigate}
+				getHref={getApplicationHref}
+				canAccessApplication={canAccessApplication}
 			/>
 		</div>
 	)

--- a/apps/ui/src/client/features/applications/components/applications-table.tsx
+++ b/apps/ui/src/client/features/applications/components/applications-table.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router'
 
 import { MemberAvatar } from '@/components/member-avatar'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
 	mrtPaperProps,
@@ -70,16 +71,25 @@ function buildColumns(
 							characterId={row.original.characterId}
 							characterName={row.original.characterName}
 							size="sm"
+							isBlacklisted={row.original.isBlacklisted === true}
 						/>
 						<div className="flex flex-col min-w-0">
 							<span className="inline-flex min-w-0 items-center gap-2">
 								<Link
 									to={href}
 									onClick={(event) => event.stopPropagation()}
-									className="truncate text-left font-medium text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+									className={cn(
+										'truncate text-left font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+										row.original.isBlacklisted ? 'text-red-500' : 'text-foreground'
+									)}
 								>
 									{row.original.characterName}
 								</Link>
+								{row.original.isBlacklisted && (
+									<Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
+										Blocklisted
+									</Badge>
+								)}
 								{row.original.isFirstApplication !== undefined && (
 									<span
 										className={cn(

--- a/apps/ui/src/client/features/applications/components/character-identity-summary.tsx
+++ b/apps/ui/src/client/features/applications/components/character-identity-summary.tsx
@@ -1,15 +1,17 @@
-import { useLayoutEffect, useRef, useState } from 'react'
-import type { ReactNode } from 'react'
 import { Check, Copy } from 'lucide-react'
+import { useLayoutEffect, useRef, useState } from 'react'
 
-import { MemberAvatar } from '@/components/member-avatar'
+import { formatSkillPoints } from '@repo/eve-types'
+
 import { EsiStatusBadge } from '@/components/esi-status-badge'
+import { MemberAvatar } from '@/components/member-avatar'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { allianceLogoUrl, corporationLogoUrl } from '@/lib/eve-images'
 import { formatISKShort } from '@/lib/format-utils'
 import { cn } from '@/lib/utils'
-import { formatSkillPoints } from '@repo/eve-types'
+
+import type { ReactNode } from 'react'
 
 interface CharacterSpWalletLineProps {
 	skillPoints: number | null | undefined
@@ -34,6 +36,7 @@ interface CharacterIdentitySummaryProps {
 	privateDataUnavailableNote?: string | null
 	portraitSize?: 'sm' | 'md' | 'lg' | 'xl' | 'auto'
 	nameBadges?: ReactNode
+	isBlacklisted?: boolean
 	enableCopyName?: boolean
 	isNameCopied?: boolean
 	onCopyName?: () => void
@@ -99,6 +102,7 @@ export function CharacterIdentitySummary({
 	isMetricsLoading = false,
 	portraitSize = 'auto',
 	nameBadges,
+	isBlacklisted = false,
 	enableCopyName = false,
 	isNameCopied = false,
 	onCopyName,
@@ -123,13 +127,24 @@ export function CharacterIdentitySummary({
 		const observer = new ResizeObserver(update)
 		observer.observe(element)
 		return () => observer.disconnect()
-	}, [isAutoPortrait, showMetrics, isMetricsLoading, characterName, corporationName, allianceName, nameBadges, skillPoints, walletBalance])
+	}, [
+		isAutoPortrait,
+		showMetrics,
+		isMetricsLoading,
+		characterName,
+		corporationName,
+		allianceName,
+		nameBadges,
+		skillPoints,
+		walletBalance,
+	])
 
 	return (
 		<div className={cn('flex min-w-0 items-start gap-3', className)}>
 			<MemberAvatar
 				characterId={characterId}
 				characterName={characterName}
+				isBlacklisted={isBlacklisted}
 				size={portraitSize}
 				imageSize={
 					isAutoPortrait && detailsHeight != null
@@ -139,9 +154,9 @@ export function CharacterIdentitySummary({
 				style={
 					isAutoPortrait && detailsHeight != null
 						? {
-							height: detailsHeight,
-							width: detailsHeight,
-						}
+								height: detailsHeight,
+								width: detailsHeight,
+							}
 						: undefined
 				}
 			/>
@@ -155,14 +170,24 @@ export function CharacterIdentitySummary({
 								event.stopPropagation()
 								onCopyName()
 							}}
-							className="truncate text-left text-lg font-semibold text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm cursor-copy"
+							className={cn(
+								'truncate text-left text-lg font-semibold transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm cursor-copy',
+								isBlacklisted ? 'text-red-500' : 'text-foreground'
+							)}
 							aria-label={`Copy ${characterName} to clipboard`}
 							title={isNameCopied ? 'Copied' : 'Copy character name'}
 						>
 							{characterName}
 						</button>
 					) : (
-						<p className="truncate text-lg font-semibold text-foreground">{characterName}</p>
+						<p
+							className={cn(
+								'truncate text-lg font-semibold',
+								isBlacklisted ? 'text-red-500' : 'text-foreground'
+							)}
+						>
+							{characterName}
+						</p>
 					)}
 					{enableCopyName && onCopyName ? (
 						<button
@@ -208,7 +233,11 @@ export function CharacterIdentitySummary({
 							>
 								{corporationName}
 							</span>
-							{npcCorp && <Badge variant="ghost" className="h-5 px-1.5 text-[10px]">NPC Corp</Badge>}
+							{npcCorp && (
+								<Badge variant="ghost" className="h-5 px-1.5 text-[10px]">
+									NPC Corp
+								</Badge>
+							)}
 						</div>
 					) : (
 						<span className="text-xs text-muted-foreground">Corporation unknown</span>

--- a/apps/ui/src/client/features/applications/components/hr-user-search-content.tsx
+++ b/apps/ui/src/client/features/applications/components/hr-user-search-content.tsx
@@ -1,0 +1,145 @@
+import { Search } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { LoadingSpinner } from '@/components/ui/loading'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { useDebounce } from '@/hooks/useDebounce'
+import { cn } from '@/lib/utils'
+
+import { UserSearchCard } from '../../corporations/components/user-search-card'
+import { useHrUserSearch } from '../../hr/hooks'
+
+export function HrUserSearchContent({
+	autoFocus = false,
+	enabled = true,
+	fillAvailableHeight = false,
+}: {
+	autoFocus?: boolean
+	enabled?: boolean
+	fillAvailableHeight?: boolean
+}) {
+	const [searchQuery, setSearchQuery] = useState('')
+	const [page, setPage] = useState(1)
+	const [pageSize, setPageSize] = useState(10)
+	const debouncedQuery = useDebounce(searchQuery.trim(), 400)
+
+	useEffect(() => {
+		setPage(1)
+	}, [debouncedQuery])
+
+	const { data, isLoading, isFetching, error } = useHrUserSearch(
+		{ search: debouncedQuery, limit: pageSize, offset: (page - 1) * pageSize },
+		{ enabled: enabled && debouncedQuery.length >= 2 }
+	)
+	const users = data?.users ?? []
+	const total = data?.total ?? 0
+	const hasPagination = Math.ceil(total / pageSize) > 1
+	const isSearching = isLoading || isFetching
+
+	return (
+		<div
+			className={cn('space-y-4', fillAvailableHeight && 'lg:flex lg:min-h-0 lg:flex-1 lg:flex-col')}
+		>
+			<Card>
+				<CardContent className="pt-6">
+					<div className="space-y-2">
+						<div className="relative">
+							<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								autoFocus={autoFocus}
+								placeholder="Search character name, character ID, Discord username, or Discord ID"
+								value={searchQuery}
+								onChange={(event) => setSearchQuery(event.target.value)}
+								className="pl-9"
+							/>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							Search users and linked characters visible to your HR roles.
+						</p>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card
+				className={cn(
+					fillAvailableHeight && 'lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:overflow-hidden'
+				)}
+			>
+				<CardContent
+					className={cn(
+						'space-y-4 pt-6',
+						fillAvailableHeight && 'lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:pb-8'
+					)}
+				>
+					{error ? (
+						<p className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+							{error instanceof Error ? error.message : 'Failed to search users'}
+						</p>
+					) : null}
+
+					{debouncedQuery.length < 2 ? (
+						<p className="py-10 text-center text-sm text-muted-foreground">
+							Enter at least 2 characters to search the HR user directory.
+						</p>
+					) : isSearching ? (
+						<div className="flex justify-center py-10">
+							<LoadingSpinner size="md" />
+						</div>
+					) : users.length === 0 ? (
+						<p className="py-10 text-center text-sm text-muted-foreground">
+							No users matched that search.
+						</p>
+					) : (
+						<div
+							className={cn(
+								'space-y-4',
+								fillAvailableHeight && 'lg:flex lg:min-h-0 lg:flex-1 lg:flex-col'
+							)}
+						>
+							<UserSearchPaginationControls
+								totalCount={total}
+								page={page}
+								pageSize={pageSize}
+								onPageChange={setPage}
+								onPageSizeChange={(nextPageSize) => {
+									setPageSize(nextPageSize)
+									setPage(1)
+								}}
+								pageSizeOptions={[10, 25, 50]}
+								itemLabel="users"
+							/>
+							<div
+								className={cn(
+									'space-y-3 pr-1',
+									fillAvailableHeight && 'lg:min-h-0 lg:flex-1 lg:overflow-y-auto'
+								)}
+							>
+								{users.map((user) => (
+									<UserSearchCard key={user.summary.id} user={user} />
+								))}
+							</div>
+							{hasPagination && (
+								<div className="border-t border-border pt-4">
+									<UserSearchPaginationControls
+										totalCount={total}
+										page={page}
+										pageSize={pageSize}
+										onPageChange={setPage}
+										onPageSizeChange={(nextPageSize) => {
+											setPageSize(nextPageSize)
+											setPage(1)
+										}}
+										pageSizeOptions={[10, 25, 50]}
+										itemLabel="users"
+									/>
+								</div>
+							)}
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	)
+}

--- a/apps/ui/src/client/features/applications/components/report-sections/contacts-section.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/contacts-section.tsx
@@ -5,6 +5,7 @@
 import { Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -17,10 +18,12 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 
+import { isNpcCharacterContact } from '../../utils/contacts'
+import { formatStandingLabel, getStandingColorClass } from '../../utils/standing'
 import { BlacklistHighlight } from './blacklist-highlighting'
 import { EntityNameLink } from './entity-name-link'
+
 import type { BlacklistHighlights } from './blacklist-highlighting'
-import { formatStandingLabel, getStandingColorClass } from '../../utils/standing'
 
 interface ProcessedContact {
 	contact_id: number
@@ -76,7 +79,7 @@ function FilterButton({
 				'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
 				active
 					? 'bg-primary text-primary-foreground'
-					: 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground',
+					: 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'
 			)}
 		>
 			{children}
@@ -119,12 +122,12 @@ export function ContactsSection({
 
 		if (search.trim()) {
 			const q = search.toLowerCase()
-				result = result.filter(
-					(c) =>
-						c.contactDisplayName?.toLowerCase().includes(q) ||
-						c.contactName?.toLowerCase().includes(q) ||
-						c.contact_type?.toLowerCase().includes(q),
-				)
+			result = result.filter(
+				(c) =>
+					c.contactDisplayName?.toLowerCase().includes(q) ||
+					c.contactName?.toLowerCase().includes(q) ||
+					c.contact_type?.toLowerCase().includes(q)
+			)
 		}
 
 		return result
@@ -161,7 +164,7 @@ export function ContactsSection({
 								>
 									<span className="capitalize">{type}</span>
 								</FilterButton>
-							),
+							)
 					)}
 				</div>
 
@@ -208,9 +211,7 @@ export function ContactsSection({
 			{/* Results */}
 			<p className="text-sm text-muted-foreground">
 				{filtered.length} contact{filtered.length !== 1 ? 's' : ''}
-				{search || typeFilter !== 'all' || standingFilter !== 'all'
-					? ` (of ${data.length})`
-					: ''}
+				{search || typeFilter !== 'all' || standingFilter !== 'all' ? ` (of ${data.length})` : ''}
 			</p>
 
 			{filtered.length === 0 ? (
@@ -230,25 +231,25 @@ export function ContactsSection({
 						<TableBody>
 							{visible.map((contact) => (
 								<TableRow key={contact.contact_id}>
-								<TableCell
-									className={cn(
-										'font-medium',
-									)}
-								>
-									<BlacklistHighlight
-										value={contact.contact_id}
-										blacklist={blacklistHighlights}
-									>
-										<EntityNameLink
-											entityId={contact.contact_id}
-											entityType={contact.contact_type}
-											href={contact.contactDisplayHref}
-											className="hover:underline underline-offset-2"
-										>
-											{contact.contactDisplayName || contact.contactName || `ID: ${contact.contact_id}`}
-										</EntityNameLink>
-									</BlacklistHighlight>
-								</TableCell>
+									<TableCell className={cn('font-medium')}>
+										<BlacklistHighlight value={contact.contact_id} blacklist={blacklistHighlights}>
+											<EntityNameLink
+												entityId={contact.contact_id}
+												entityType={contact.contact_type}
+												href={contact.contactDisplayHref}
+												className="hover:underline underline-offset-2"
+											>
+												{contact.contactDisplayName ||
+													contact.contactName ||
+													`ID: ${contact.contact_id}`}
+											</EntityNameLink>
+											{isNpcCharacterContact(contact) ? (
+												<Badge variant="secondary" className="ml-2 px-1.5 py-0 text-[10px]">
+													NPC
+												</Badge>
+											) : null}
+										</BlacklistHighlight>
+									</TableCell>
 									<TableCell className="text-sm capitalize text-muted-foreground">
 										{contact.contact_type?.replace('_', ' ') || '-'}
 									</TableCell>
@@ -256,7 +257,7 @@ export function ContactsSection({
 										<span
 											className={cn(
 												'font-mono text-sm font-semibold',
-												getStandingColorClass(contact.standing),
+												getStandingColorClass(contact.standing)
 											)}
 										>
 											{formatStandingLabel(contact.standing)}
@@ -278,11 +279,7 @@ export function ContactsSection({
 					>
 						Show more
 					</Button>
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => setVisibleCount(filtered.length)}
-					>
+					<Button variant="ghost" size="sm" onClick={() => setVisibleCount(filtered.length)}>
 						Show all ({filtered.length})
 					</Button>
 				</div>

--- a/apps/ui/src/client/features/applications/components/user-profile-page-shell.tsx
+++ b/apps/ui/src/client/features/applications/components/user-profile-page-shell.tsx
@@ -1,10 +1,8 @@
-import type { ReactNode } from 'react'
-import { Link } from 'react-router'
 import { ArrowLeft } from 'lucide-react'
+import { Link } from 'react-router'
 
 import { MemberAvatar } from '@/components/member-avatar'
 import { Badge } from '@/components/ui/badge'
-import type { BadgeVariant } from '@/components/ui/badge'
 import {
 	Breadcrumb,
 	BreadcrumbItem,
@@ -17,6 +15,10 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+
+import type { ReactNode } from 'react'
+import type { BadgeVariant } from '@/components/ui/badge'
 
 export function UserProfilePageShell({
 	rootLabel,
@@ -28,6 +30,8 @@ export function UserProfilePageShell({
 	userId,
 	mainCharacterId,
 	mainCharacterName,
+	isMainCharacterBlacklisted = false,
+	isAccountBlacklisted = false,
 	sidebarBadges,
 	sidebarStats,
 	sidebarFooter,
@@ -42,6 +46,8 @@ export function UserProfilePageShell({
 	userId: string
 	mainCharacterId?: string | null
 	mainCharacterName?: string | null
+	isMainCharacterBlacklisted?: boolean
+	isAccountBlacklisted?: boolean
 	sidebarBadges?: ReactNode
 	sidebarStats?: ReactNode
 	sidebarFooter?: ReactNode
@@ -82,11 +88,19 @@ export function UserProfilePageShell({
 									<MemberAvatar
 										characterId={mainCharacterId}
 										characterName={mainCharacterName}
+										isBlacklisted={isMainCharacterBlacklisted}
 										size="lg"
 									/>
 								)}
 								<div className="space-y-1">
-									<h1 className="text-xl font-bold">{accountName}</h1>
+									<h1
+										className={cn(
+											'text-xl font-bold',
+											(isMainCharacterBlacklisted || isAccountBlacklisted) && 'text-red-500'
+										)}
+									>
+										{accountName}
+									</h1>
 									<p className="font-mono text-xs text-muted-foreground">User ID: {userId}</p>
 								</div>
 								<div className="flex flex-wrap items-center justify-center gap-2">
@@ -98,9 +112,7 @@ export function UserProfilePageShell({
 
 					{sidebarStats ? (
 						<Card>
-							<CardContent className="space-y-3 pt-6">
-								{sidebarStats}
-							</CardContent>
+							<CardContent className="space-y-3 pt-6">{sidebarStats}</CardContent>
 						</Card>
 					) : null}
 
@@ -113,13 +125,7 @@ export function UserProfilePageShell({
 	)
 }
 
-export function UserProfileStatRow({
-	label,
-	value,
-}: {
-	label: string
-	value: ReactNode
-}) {
+export function UserProfileStatRow({ label, value }: { label: string; value: ReactNode }) {
 	return (
 		<div className="flex justify-between text-sm">
 			<span className="text-muted-foreground">{label}</span>

--- a/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
+++ b/apps/ui/src/client/features/applications/components/user-profile-sections.tsx
@@ -9,6 +9,7 @@ import {
 	User,
 	Users,
 } from 'lucide-react'
+import { Link } from 'react-router'
 
 import { MemberAvatar } from '@/components/member-avatar'
 import { Badge } from '@/components/ui/badge'
@@ -34,7 +35,7 @@ export interface SharedProfileCharacter {
 	role?: 'CEO' | 'Director' | 'Member' | null
 	activityStatus?: 'active' | 'inactive' | 'unknown' | null
 	isPrimary?: boolean
-	isBlacklisted?: boolean
+	isBlacklisted?: boolean | null
 	lastLogin?: string
 	joinDate?: string
 	locationSystem?: string
@@ -58,6 +59,11 @@ export interface SharedProfileApplication {
 	createdAt: string
 }
 
+interface ProfileNavigationTarget {
+	to: string
+	state?: Record<string, unknown>
+}
+
 export function ProfileCharactersSection({
 	characters,
 	fulcrumLoading = false,
@@ -73,7 +79,9 @@ export function ProfileCharactersSection({
 	isScanPendingFor,
 	onScan,
 	onViewReport,
+	getReportTarget,
 	onViewDetails,
+	getDetailsTarget,
 	noDataText = 'No linked characters found',
 }: {
 	characters: SharedProfileCharacter[]
@@ -89,8 +97,10 @@ export function ProfileCharactersSection({
 	onScanAll?: () => void
 	isScanPendingFor?: (characterId: string) => boolean
 	onScan: (character: SharedProfileCharacter) => void
-	onViewReport: (character: SharedProfileCharacter) => void
+	onViewReport?: (character: SharedProfileCharacter) => void
+	getReportTarget?: (character: SharedProfileCharacter) => ProfileNavigationTarget
 	onViewDetails?: (character: SharedProfileCharacter) => void
+	getDetailsTarget?: (character: SharedProfileCharacter) => ProfileNavigationTarget
 	noDataText?: string
 }) {
 	return (
@@ -126,22 +136,40 @@ export function ProfileCharactersSection({
 						{characters.map((character) => {
 							const isScanPending = isScanPendingFor?.(character.characterId) ?? false
 							const canRequestCharacter = canRequestCharacterReport?.(character) ?? true
+							const reportTarget =
+								character.latestReport?.status === 'completed' && character.corporationId
+									? getReportTarget?.(character)
+									: undefined
 							return (
 								<div
 									key={character.characterId}
 									className="card-gradient relative space-y-2 rounded-lg border border-border/50 bg-card px-3 py-2 shadow-elevated"
 								>
-									{showViewDetailsButton && onViewDetails && (
+									{showViewDetailsButton && (getDetailsTarget || onViewDetails) && (
 										<div className="absolute right-2 top-2">
-											<Button variant="ghost" size="sm" onClick={() => onViewDetails(character)}>
-												<ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-												View Details
-											</Button>
+											{getDetailsTarget ? (
+												<Button asChild variant="ghost" size="sm">
+													<Link {...getDetailsTarget(character)}>
+														<ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+														View Details
+													</Link>
+												</Button>
+											) : (
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={() => onViewDetails?.(character)}
+												>
+													<ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+													View Details
+												</Button>
+											)}
 										</div>
 									)}
 									<CharacterIdentitySummary
 										characterId={character.characterId}
 										characterName={character.characterName}
+										isBlacklisted={character.isBlacklisted ?? false}
 										hasValidToken={character.hasValidToken}
 										corporationId={character.corporationId}
 										corporationName={character.corporationName}
@@ -215,54 +243,79 @@ export function ProfileCharactersSection({
 									</div>
 									{showFulcrumReports && (
 										<div className="flex items-center gap-2">
-											<div
-												className={cn(
-													'flex min-w-0 flex-1 items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs',
-													character.latestReport?.status === 'completed' &&
-														character.corporationId &&
+											{reportTarget ? (
+												<Link
+													to={reportTarget.to}
+													state={reportTarget.state}
+													className={cn(
+														'flex min-w-0 flex-1 items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs',
 														'cursor-pointer transition-colors hover:bg-muted/50'
-												)}
-												onClick={() => onViewReport(character)}
-											>
-												<Scan className="h-3 w-3 shrink-0 text-muted-foreground" />
-												<span className="shrink-0 font-medium text-muted-foreground">
-													Fulcrum Report
-												</span>
-												<span className="shrink-0 text-muted-foreground">·</span>
-												{character.latestReport ? (
-													character.latestReport.status === 'completed' ? (
-														<>
-															<span className="truncate text-foreground">
-																View latest report (
+													)}
+												>
+													<Scan className="h-3 w-3 shrink-0 text-muted-foreground" />
+													<span className="shrink-0 font-medium text-muted-foreground">
+														Fulcrum Report
+													</span>
+													<span className="shrink-0 text-muted-foreground">·</span>
+													<span className="truncate text-foreground">
+														View latest report (
+														{formatDistanceToNow(new Date(character.latestReport!.createdAt), {
+															addSuffix: true,
+														})}
+														)
+													</span>
+													<ExternalLink className="ml-auto h-3 w-3 shrink-0 text-muted-foreground" />
+												</Link>
+											) : (
+												<div
+													className={cn(
+														'flex min-w-0 flex-1 items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs',
+														character.latestReport?.status === 'completed' &&
+															character.corporationId &&
+															'cursor-pointer transition-colors hover:bg-muted/50'
+													)}
+													onClick={() => onViewReport?.(character)}
+												>
+													<Scan className="h-3 w-3 shrink-0 text-muted-foreground" />
+													<span className="shrink-0 font-medium text-muted-foreground">
+														Fulcrum Report
+													</span>
+													<span className="shrink-0 text-muted-foreground">·</span>
+													{character.latestReport ? (
+														character.latestReport.status === 'completed' ? (
+															<>
+																<span className="truncate text-foreground">
+																	View latest report (
+																	{formatDistanceToNow(new Date(character.latestReport.createdAt), {
+																		addSuffix: true,
+																	})}
+																	)
+																</span>
+																<ExternalLink className="ml-auto h-3 w-3 shrink-0 text-muted-foreground" />
+															</>
+														) : character.latestReport.status === 'pending' ||
+														  character.latestReport.status === 'processing' ? (
+															<span className="truncate text-muted-foreground">
+																Processing... (
 																{formatDistanceToNow(new Date(character.latestReport.createdAt), {
 																	addSuffix: true,
 																})}
 																)
 															</span>
-															<ExternalLink className="ml-auto h-3 w-3 shrink-0 text-muted-foreground" />
-														</>
-													) : character.latestReport.status === 'pending' ||
-													  character.latestReport.status === 'processing' ? (
-														<span className="truncate text-muted-foreground">
-															Processing... (
-															{formatDistanceToNow(new Date(character.latestReport.createdAt), {
-																addSuffix: true,
-															})}
-															)
-														</span>
+														) : (
+															<span className="truncate text-muted-foreground">
+																Failed (
+																{formatDistanceToNow(new Date(character.latestReport.createdAt), {
+																	addSuffix: true,
+																})}
+																)
+															</span>
+														)
 													) : (
-														<span className="truncate text-muted-foreground">
-															Failed (
-															{formatDistanceToNow(new Date(character.latestReport.createdAt), {
-																addSuffix: true,
-															})}
-															)
-														</span>
-													)
-												) : (
-													<span className="truncate text-muted-foreground">No report yet</span>
-												)}
-											</div>
+														<span className="truncate text-muted-foreground">No report yet</span>
+													)}
+												</div>
+											)}
 
 											<Button
 												variant={character.latestReport ? 'ghost' : 'primary'}
@@ -390,14 +443,14 @@ export function ProfileApplicationHistorySection({
 	applications,
 	loading = false,
 	linked = true,
-	onOpenApplication,
+	getApplicationHref,
 	emptyText = 'No application history',
 	unlinkedText = 'Unregistered member — no application data',
 }: {
 	applications: SharedProfileApplication[]
 	loading?: boolean
 	linked?: boolean
-	onOpenApplication: (application: SharedProfileApplication) => void
+	getApplicationHref: (application: SharedProfileApplication) => string
 	emptyText?: string
 	unlinkedText?: string
 }) {
@@ -427,10 +480,10 @@ export function ProfileApplicationHistorySection({
 					) : applications.length > 0 ? (
 						<div className="space-y-2">
 							{applications.map((application) => (
-								<div
+								<Link
 									key={application.id}
+									to={getApplicationHref(application)}
 									className="flex cursor-pointer items-center justify-between rounded-lg border p-3 transition-colors hover:bg-muted/50"
-									onClick={() => onOpenApplication(application)}
 								>
 									<div className="flex items-center gap-3">
 										<MemberAvatar
@@ -449,7 +502,7 @@ export function ProfileApplicationHistorySection({
 										<ApplicationStatusBadge status={application.status} size="sm" />
 										<ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
 									</div>
-								</div>
+								</Link>
 							))}
 						</div>
 					) : (

--- a/apps/ui/src/client/features/applications/hooks.ts
+++ b/apps/ui/src/client/features/applications/hooks.ts
@@ -9,6 +9,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 
 import { useApiMutation } from '@/hooks/useApiMutation'
+import { useAuth } from '@/hooks/useAuth'
 import { apiClient } from '@/lib/api'
 
 import { applicationsApi, fulcrumApi } from './api'
@@ -23,6 +24,7 @@ import type {
 	ApplicationsParams,
 	ApplicationStaffNote,
 	CharacterReportMetadata,
+	CorporationApplicationCounts,
 	CreateTemplateRequest,
 	FulcrumCharacterData,
 	FulcrumCharacterReportData,
@@ -101,6 +103,7 @@ const REPORT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 export const hrUserKeys = {
 	all: ['hr', 'users'] as const,
 	characters: (userId: string) => [...hrUserKeys.all, userId, 'characters'] as const,
+	blocklistStatus: (userId: string) => [...hrUserKeys.all, userId, 'blocklist-status'] as const,
 }
 
 export interface HrUserCharacterData {
@@ -112,6 +115,7 @@ export interface HrUserCharacterData {
 	corporationName?: string | null
 	allianceId?: string | null
 	allianceName?: string | null
+	isBlacklisted?: boolean
 }
 
 // ============================================================================
@@ -131,6 +135,19 @@ export function useApplications(params?: ApplicationsParams, options?: { enabled
 		staleTime: 1000 * 60 * 2, // 2 minutes
 		gcTime: 1000 * 60 * 5, // 5 minutes
 		enabled: options?.enabled ?? true,
+	})
+}
+
+export function useCorporationApplicationCounts(options?: { enabled?: boolean }) {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
+	return useQuery<CorporationApplicationCounts[]>({
+		queryKey: [...applicationKeys.all, 'corporation-counts', userId],
+		queryFn: () => applicationsApi.getApplicationCountsByCorporation(),
+		staleTime: 1000 * 30,
+		gcTime: 1000 * 60 * 2,
+		enabled: (options?.enabled ?? true) && userId !== null,
 	})
 }
 
@@ -282,6 +299,19 @@ export function useHrUserCharacters(userId: string, options?: { enabled?: boolea
 	return useQuery<HrUserCharacterData[]>({
 		queryKey: hrUserKeys.characters(userId),
 		queryFn: () => apiClient.get(`/hr/users/${userId}/characters`),
+		staleTime: 1000 * 30,
+		gcTime: 1000 * 60 * 3,
+		enabled: options?.enabled ?? !!userId,
+		meta: {
+			suppressErrorToast: true,
+		},
+	})
+}
+
+export function useHrUserBlocklistStatus(userId: string, options?: { enabled?: boolean }) {
+	return useQuery<{ isBlacklisted: boolean }>({
+		queryKey: hrUserKeys.blocklistStatus(userId),
+		queryFn: () => apiClient.get(`/hr/users/${userId}/blocklist-status`),
 		staleTime: 1000 * 30,
 		gcTime: 1000 * 60 * 3,
 		enabled: options?.enabled ?? !!userId,

--- a/apps/ui/src/client/features/applications/routes/corporations.tsx
+++ b/apps/ui/src/client/features/applications/routes/corporations.tsx
@@ -1,26 +1,27 @@
-import { useQueries } from '@tanstack/react-query'
 import { AlertCircle, Building2, FileText, Settings2, Users } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Navigate } from 'react-router'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { Label } from '@/components/ui/label'
-import { Progress } from '@/components/ui/progress'
-import { Skeleton } from '@/components/ui/skeleton'
 import { LoadingSpinner } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
+import { Progress } from '@/components/ui/progress'
 import { Select } from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useHrAccessibleCorporations } from '@/features/hr'
 import { HrRoleBadge } from '@/features/hr/components/hr-role-badge'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
-
 import { corporationLogoUrl } from '@/lib/eve-images'
-import { applicationsApi } from '../api'
-import { Button } from '@/components/ui/button'
-import { useCorporationAccess, useMyCorporations } from '../../corporations/hooks'
+
+import { useCorporationAccess, useCorporationCoverage } from '../../corporations/hooks'
+import { useCorporationApplicationCounts } from '../hooks'
+
+import type { CorporationCoverageStats } from '../../corporations/api'
 
 type CorporationTypeFilter = 'member' | 'alt' | 'special'
 
@@ -46,19 +47,14 @@ function matchesCorporationType(
 	return corporation.isSpecialPurpose
 }
 
-interface CorporationCoverageStats {
-	memberCount: number
-	linkedMemberCount: number
-	unlinkedMemberCount: number
-	validEsiKeyMemberCount: number
-}
-
 function CorporationCoverageBars({ coverage }: { coverage: CorporationCoverageStats }) {
 	const authLinkedUnits = coverage.linkedMemberCount + coverage.unlinkedMemberCount
 	const authLinkedPercentage =
 		authLinkedUnits > 0 ? Math.round((coverage.linkedMemberCount / authLinkedUnits) * 100) : 0
 	const esiCoveragePercentage =
-		coverage.memberCount > 0 ? Math.round((coverage.validEsiKeyMemberCount / coverage.memberCount) * 100) : 0
+		coverage.memberCount > 0
+			? Math.round((coverage.validEsiKeyMemberCount / coverage.memberCount) * 100)
+			: 0
 
 	return (
 		<div className="w-44 space-y-2">
@@ -96,15 +92,18 @@ export default function CorporationsPage() {
 		() => permissions.some((permission) => permission.urn === 'urn:hr:auditor'),
 		[permissions]
 	)
-	const [corporationTypeFilter, setCorporationTypeFilter] =
-		useState<CorporationTypeFilter | null>(null)
+	const [corporationTypeFilter, setCorporationTypeFilter] = useState<CorporationTypeFilter | null>(
+		null
+	)
 	const {
 		data: corporations = [],
 		isLoading: corporationsLoading,
 		error,
 	} = useHrAccessibleCorporations()
 	const { data: corporationAccess } = useCorporationAccess()
-	const { data: myCorporations = [] } = useMyCorporations()
+	const { data: corporationCoverage } = useCorporationCoverage()
+	const { data: applicationCounts = [], isLoading: applicationCountsLoading } =
+		useCorporationApplicationCounts()
 	const availableCorporationTypes = useMemo(() => {
 		const types = new Set<CorporationTypeFilter>()
 		for (const corporation of corporations) {
@@ -116,9 +115,8 @@ export default function CorporationsPage() {
 	}, [corporations])
 	const defaultCorporationTypeFilter = useMemo(() => {
 		return (
-			CORPORATION_TYPE_OPTIONS.find((option) =>
-				availableCorporationTypes.includes(option.value)
-			)?.value ?? null
+			CORPORATION_TYPE_OPTIONS.find((option) => availableCorporationTypes.includes(option.value))
+				?.value ?? null
 		)
 	}, [availableCorporationTypes])
 	const canFilterCorporations =
@@ -126,6 +124,16 @@ export default function CorporationsPage() {
 	const accessibleCorporationIds = useMemo(
 		() => new Set((corporationAccess?.corporations ?? []).map((corp) => corp.corporationId)),
 		[corporationAccess]
+	)
+	const coverageByCorporationId = useMemo(
+		() =>
+			new Map(
+				(corporationCoverage?.corporations ?? []).map((coverage) => [
+					coverage.corporationId,
+					coverage,
+				])
+			),
+		[corporationCoverage]
 	)
 
 	useEffect(() => {
@@ -142,7 +150,7 @@ export default function CorporationsPage() {
 	])
 
 	const activeCorporationTypeFilter = canFilterCorporations
-		? corporationTypeFilter ?? defaultCorporationTypeFilter
+		? (corporationTypeFilter ?? defaultCorporationTypeFilter)
 		: null
 
 	const visibleCorporations = useMemo(() => {
@@ -156,22 +164,10 @@ export default function CorporationsPage() {
 			matchesCorporationType(corporation, activeCorporationTypeFilter)
 		)
 	}, [activeCorporationTypeFilter, canFilterCorporations, corporations])
-	const applicationQueries = useQueries({
-		queries: visibleCorporations.map((corporation) => {
-			const canViewApplications =
-				corporation.isMemberCorporation &&
-				(user?.is_admin === true ||
-					isAuditor ||
-					accessibleCorporationIds.has(corporation.corporationId))
-			return {
-				queryKey: ['hr', 'corporation-application-counts', corporation.corporationId],
-				queryFn: () => applicationsApi.getApplications({ corporationId: corporation.corporationId }),
-				staleTime: 1000 * 30, // 30s
-				gcTime: 1000 * 60 * 2, // 2m
-				enabled: Boolean(corporation.corporationId && canViewApplications),
-			}
-		}),
-	})
+	const applicationCountsByCorporationId = useMemo(
+		() => new Map(applicationCounts.map((counts) => [counts.corporationId, counts])),
+		[applicationCounts]
+	)
 
 	usePageTitle('Corporations')
 
@@ -203,7 +199,9 @@ export default function CorporationsPage() {
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="text-center">
-						<Button variant="ghost" onClick={() => window.location.reload()}>Try Again</Button>
+						<Button variant="ghost" onClick={() => window.location.reload()}>
+							Try Again
+						</Button>
 					</CardContent>
 				</Card>
 			</Container>
@@ -262,31 +260,25 @@ export default function CorporationsPage() {
 			) : null}
 
 			<div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
-				{visibleCorporations.map((corporation, index) => {
-					const applicationQuery = applicationQueries[index]
-					const applications = applicationQuery?.data ?? []
-					const myCorporation = myCorporations.find((c) => c.corporationId === corporation.corporationId)
+				{visibleCorporations.map((corporation) => {
 					const corporationAccessEntry = (corporationAccess?.corporations ?? []).find(
 						(corp) => corp.corporationId === corporation.corporationId
 					)
-					const coverageStats: CorporationCoverageStats | null = myCorporation ?? corporationAccessEntry ?? null
+					const coverageStats = coverageByCorporationId.get(corporation.corporationId) ?? null
 					const canAccessMembers =
 						user?.is_admin === true ||
 						isAuditor ||
 						accessibleCorporationIds.has(corporation.corporationId)
-						const canViewApplications =
-							corporation.isMemberCorporation &&
-							(user?.is_admin === true ||
-								isAuditor ||
-								accessibleCorporationIds.has(corporation.corporationId))
-						const canConfigureCorporation =
-							user?.is_admin === true || corporationAccessEntry?.userRole === 'CEO'
-						const pendingCount = canViewApplications
-							? applications.filter((application) => application.status === 'pending').length
-							: 0
-					const underReviewCount = canViewApplications
-						? applications.filter((application) => application.status === 'under_review').length
-						: 0
+					const canViewApplications =
+						corporation.isMemberCorporation &&
+						(user?.is_admin === true ||
+							isAuditor ||
+							accessibleCorporationIds.has(corporation.corporationId))
+					const canConfigureCorporation =
+						user?.is_admin === true || corporationAccessEntry?.userRole === 'CEO'
+					const applicationCounts = applicationCountsByCorporationId.get(corporation.corporationId)
+					const pendingCount = canViewApplications ? (applicationCounts?.pending ?? 0) : 0
+					const underReviewCount = canViewApplications ? (applicationCounts?.underReview ?? 0) : 0
 					const hasVisibleCounts = canViewApplications && (pendingCount > 0 || underReviewCount > 0)
 
 					return (
@@ -327,33 +319,38 @@ export default function CorporationsPage() {
 												</Link>
 											</Button>
 										)}
-											{canViewApplications && (
-												<Button variant={canAccessMembers ? 'ghost' : 'primary'} asChild className="w-full sm:w-auto">
-													<Link to={`/corporations/${corporation.corporationId}/applications`}>
-														<FileText className="h-4 w-4" />
-														Applications
-													</Link>
-												</Button>
-											)}
-											{canConfigureCorporation && (
-												<Button variant="ghost" asChild className="w-full sm:w-auto">
-													<Link to={`/corporations/${corporation.corporationId}/settings`}>
-														<Settings2 className="h-4 w-4" />
-														Configure
-													</Link>
-												</Button>
-											)}
-										</div>
+										{canViewApplications && (
+											<Button
+												variant={canAccessMembers ? 'ghost' : 'primary'}
+												asChild
+												className="w-full sm:w-auto"
+											>
+												<Link to={`/corporations/${corporation.corporationId}/applications`}>
+													<FileText className="h-4 w-4" />
+													Applications
+												</Link>
+											</Button>
+										)}
+										{canConfigureCorporation && (
+											<Button variant="ghost" asChild className="w-full sm:w-auto">
+												<Link to={`/corporations/${corporation.corporationId}/settings`}>
+													<Settings2 className="h-4 w-4" />
+													Configure
+												</Link>
+											</Button>
+										)}
 									</div>
+								</div>
 								<div className="justify-self-end self-end">
-									{applicationQuery?.isLoading ? (
-										<div className="flex gap-2">
-											<Skeleton className="h-5 w-20" />
-										</div>
-										) : hasVisibleCounts || coverageStats ? (
+									{coverageStats ||
+									hasVisibleCounts ||
+									(canViewApplications && applicationCountsLoading) ? (
 										<div className="flex flex-col items-end gap-2">
 											{coverageStats && <CorporationCoverageBars coverage={coverageStats} />}
 											<div className="flex flex-wrap items-center justify-end gap-2">
+												{canViewApplications && applicationCountsLoading && (
+													<Skeleton className="h-5 w-20" />
+												)}
 												{pendingCount > 0 && (
 													<Badge variant="warning">Pending: {pendingCount}</Badge>
 												)}

--- a/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-application-review.tsx
@@ -9,8 +9,8 @@
 import { useQueries } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import { AlertCircle, ArrowLeft, Briefcase, Lock } from 'lucide-react'
-import { useState } from 'react'
-import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router'
+import { useEffect, useState } from 'react'
+import { Link, Navigate, useParams, useSearchParams } from 'react-router'
 
 import { Badge } from '@/components/ui/badge'
 import {
@@ -34,6 +34,7 @@ import { useMessage } from '@/hooks/useMessage'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { apiClient } from '@/lib/api'
 import toast from '@/lib/toast'
+import { cn } from '@/lib/utils'
 
 import { useCanAccessCorporation } from '../../corporations/hooks'
 import { useHrPermissionCheck } from '../../hr/hooks'
@@ -58,6 +59,7 @@ import {
 	useDeleteHRNote,
 	useHRNote,
 	useHRNotes,
+	useHrUserBlocklistStatus,
 	useHrUserCharacters,
 	useMessageCount,
 	useRecommendations,
@@ -81,9 +83,16 @@ export default function HrApplicationReview() {
 		corporationId: string
 		applicationId: string
 	}>()
-	const navigate = useNavigate()
 	const [searchParams] = useSearchParams()
-	const initialTab = searchParams.get('tab') || 'details'
+	const tabStorageKey = `hr-application-review-tab:${corporationId ?? ''}:${applicationId ?? ''}`
+	const [activeTab, setActiveTab] = useState(() => {
+		const requestedTab = searchParams.get('tab')
+		if (requestedTab) return requestedTab
+		if (typeof window !== 'undefined') {
+			return window.sessionStorage.getItem(tabStorageKey) ?? 'details'
+		}
+		return 'details'
+	})
 	const { user, isAuthenticated, isLoading: authLoading, permissions } = useAuth()
 	const isAuditor = permissions.some((permission) => permission.urn === 'urn:hr:auditor')
 	const {
@@ -145,6 +154,9 @@ export default function HrApplicationReview() {
 	const { data: hrCharacters = [] } = useHrUserCharacters(application?.userId ?? '', {
 		enabled: !!application?.userId && canViewCorporationApplications,
 	})
+	const { data: userBlocklistStatus } = useHrUserBlocklistStatus(application?.userId ?? '', {
+		enabled: !!application?.userId && canViewCorporationApplications,
+	})
 	const canViewApplicationPrivateData =
 		!!application &&
 		canViewCorporationApplications &&
@@ -157,6 +169,28 @@ export default function HrApplicationReview() {
 		currentRole: permission?.currentRole,
 		isAdmin: user?.is_admin === true,
 	})
+	const canShowStaffTabs = Boolean(user?.is_admin || permission?.hasPermission)
+
+	useEffect(() => {
+		if (typeof window === 'undefined') return
+		window.sessionStorage.setItem(tabStorageKey, activeTab)
+	}, [activeTab, tabStorageKey])
+
+	useEffect(() => {
+		const alwaysAvailableTabs = new Set([
+			'details',
+			'alts',
+			'recommendations',
+			'history',
+			'messages',
+			'prior-apps',
+		])
+		const isAvailable =
+			alwaysAvailableTabs.has(activeTab) ||
+			(canShowStaffTabs && (activeTab === 'staff-notes' || activeTab === 'global-notes')) ||
+			(canShowFulcrumTab && activeTab === 'fulcrum')
+		if (!isAvailable) setActiveTab('details')
+	}, [activeTab, canShowFulcrumTab, canShowStaffTabs])
 	const applicationActionRole = resolveApplicationActionRole({
 		isSiteAdmin: user?.is_admin === true,
 		corporationRole: accessUserRole,
@@ -325,7 +359,7 @@ export default function HrApplicationReview() {
 				<AccessDeniedCard
 					message="You don't have HR permissions for this corporation. Contact an HR Admin to request access."
 					backLabel={`Back to ${rootCorporationsLabel}`}
-					onBack={() => navigate(rootCorporationsPath)}
+					backHref={rootCorporationsPath}
 				/>
 			</Container>
 		)
@@ -445,6 +479,14 @@ export default function HrApplicationReview() {
 							mainCharacterName={application.characterName}
 							altCharacterIds={altCharacterIds}
 							altCharacterNames={altCharacterNames}
+							blacklistedCharacterIds={[
+								...(hrCharacterById.get(application.characterId)?.isBlacklisted
+									? [application.characterId]
+									: []),
+								...altCharacterIds.filter((characterId) =>
+									Boolean(hrCharacterById.get(characterId)?.isBlacklisted)
+								),
+							]}
 							size="lg"
 						/>
 
@@ -455,12 +497,22 @@ export default function HrApplicationReview() {
 									<Link
 										to={memberProfilePath}
 										state={memberProfileState}
-										className="truncate text-left transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
+										className={cn(
+											'truncate text-left transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm',
+											hrCharacterById.get(application.characterId)?.isBlacklisted && 'text-red-500'
+										)}
 									>
 										{application.characterName}
 									</Link>
 								) : (
-									<span className="min-w-0 truncate">{application.characterName}</span>
+									<span
+										className={cn(
+											'min-w-0 truncate',
+											hrCharacterById.get(application.characterId)?.isBlacklisted && 'text-red-500'
+										)}
+									>
+										{application.characterName}
+									</span>
 								)}
 								{application.isFirstApplication !== undefined && (
 									<Badge
@@ -468,6 +520,11 @@ export default function HrApplicationReview() {
 										className="h-5 shrink-0 px-1.5 text-[10px] font-semibold leading-none"
 									>
 										{application.isFirstApplication ? 'First' : 'Repeat'}
+									</Badge>
+								)}
+								{userBlocklistStatus?.isBlacklisted && (
+									<Badge variant="destructive" className="h-5 shrink-0 px-1.5 text-[10px]">
+										Blocklisted
 									</Badge>
 								)}
 								{altCharacterIds.length > 0 && (
@@ -500,7 +557,7 @@ export default function HrApplicationReview() {
 			</Card>
 
 			{/* Tabbed Content */}
-			<Tabs defaultValue={initialTab} className="space-y-6">
+			<Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
 				<TabsList className="w-full flex-wrap gap-2 sm:w-auto sm:flex-nowrap">
 					<TabsTrigger value="details" className={reviewTabTriggerClassName}>
 						Details
@@ -649,6 +706,9 @@ export default function HrApplicationReview() {
 								<CharacterIdentitySummary
 									characterId={application.characterId}
 									characterName={application.characterName}
+									isBlacklisted={Boolean(
+										hrCharacterById.get(application.characterId)?.isBlacklisted
+									)}
 									hasValidToken={esiStateByCharacterId[application.characterId]}
 									corporationId={
 										hrCharacterById.get(application.characterId)?.corporationId ?? null
@@ -663,6 +723,13 @@ export default function HrApplicationReview() {
 									isMetricsLoading={metricsLoadingByCharacterId[application.characterId]}
 									enableCopyName
 									isNameCopied={copiedCharacterIds.has(application.characterId)}
+									nameBadges={
+										hrCharacterById.get(application.characterId)?.isBlacklisted ? (
+											<Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
+												Blocklisted
+											</Badge>
+										) : undefined
+									}
 									onCopyName={() =>
 										void markCharacterNameCopied(application.characterId, application.characterName)
 									}
@@ -690,6 +757,7 @@ export default function HrApplicationReview() {
 											<CharacterIdentitySummary
 												characterId={charId}
 												characterName={altCharacterNames[charId] ?? charId}
+												isBlacklisted={Boolean(hrCharacterById.get(charId)?.isBlacklisted)}
 												hasValidToken={esiStateByCharacterId[charId]}
 												corporationId={hrCharacterById.get(charId)?.corporationId ?? null}
 												corporationName={hrCharacterById.get(charId)?.corporationName ?? null}
@@ -698,6 +766,13 @@ export default function HrApplicationReview() {
 												skillPoints={spByCharacterId[charId]}
 												walletBalance={walletByCharacterId[charId]}
 												isMetricsLoading={metricsLoadingByCharacterId[charId]}
+												nameBadges={
+													hrCharacterById.get(charId)?.isBlacklisted ? (
+														<Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
+															Blocklisted
+														</Badge>
+													) : undefined
+												}
 												enableCopyName
 												isNameCopied={copiedCharacterIds.has(charId)}
 												onCopyName={() =>

--- a/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
@@ -2,7 +2,7 @@ import { useQueries, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import { AlertCircle, ArrowLeft, Users } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router'
+import { Link, Navigate, useLocation, useParams } from 'react-router'
 
 import { CopyableMetaPill } from '@/components/copyable-meta-pill'
 import { IpHistoryCard } from '@/components/ip-history-card'
@@ -43,6 +43,7 @@ import {
 	useRequestFulcrumReportBatch,
 } from '../hooks'
 import { getPrivateDataUnavailableMessage } from '../utils/private-data'
+import { getApplicationProfileNavigationFromReferrer } from '../utils/profile-navigation'
 
 import type { CharacterReportMetadata, FulcrumCharacterReportData } from '../api'
 
@@ -63,6 +64,7 @@ interface AuditorCharacterRow {
 	role: 'CEO' | 'Director' | 'Member' | null
 	activityStatus: 'active' | 'inactive' | 'unknown' | null
 	hasValidToken: boolean | null
+	isBlacklisted: boolean
 	latestReport: CharacterReportMetadata | null
 	hasPendingReport: boolean
 }
@@ -77,7 +79,6 @@ function getLatestReport(character: FulcrumCharacterReportData): CharacterReport
 export default function HrAuditorUserProfilePage() {
 	const { userId } = useParams<{ userId: string }>()
 	const location = useLocation()
-	const navigate = useNavigate()
 	const queryClient = useQueryClient()
 	const { user, isAuthenticated, isLoading: authLoading } = useAuth()
 	const { hasAnyPermission } = useUserPermissions()
@@ -141,7 +142,9 @@ export default function HrAuditorUserProfilePage() {
 		)
 	}, [applications])
 
-	const navigationState = location.state as AuditorProfileNavigationState | null
+	const [referrerNavigationState] = useState(getApplicationProfileNavigationFromReferrer)
+	const navigationState =
+		(location.state as AuditorProfileNavigationState | null) ?? referrerNavigationState
 	const source = navigationState?.source
 	const returnTo = navigationState?.returnTo
 	const fromApplications = source === 'applications' || returnTo?.includes('/applications')
@@ -190,6 +193,7 @@ export default function HrAuditorUserProfilePage() {
 					allianceName: hrCharacter?.allianceName ?? null,
 					role: reportCharacter?.role ?? null,
 					activityStatus: reportCharacter?.activityStatus ?? null,
+					isBlacklisted: userCharacter?.isBlacklisted ?? hrCharacter?.isBlacklisted ?? false,
 					latestReport,
 					hasPendingReport,
 					hasValidToken: userCharacter?.hasValidToken ?? hrCharacter?.hasValidToken ?? null,
@@ -345,32 +349,6 @@ export default function HrAuditorUserProfilePage() {
 		)
 	}
 
-	const handleViewDetails = (character: AuditorCharacterRow) => {
-		void navigate(`/character/${character.characterId}`, {
-			state: {
-				source: 'hr-auditor-user-profile',
-				backTo: `/hr/users/${userId}`,
-				backLabel: 'Back to User Details',
-				corporationId: character.corporationId ?? undefined,
-			},
-		})
-	}
-
-	const handleViewLatestReport = (character: AuditorCharacterRow) => {
-		if (character.latestReport?.status !== 'completed' || !character.corporationId) return
-		const returnTo = `${location.pathname}${location.search}`
-		void navigate(`/hr/users/${userId}/reports/${character.latestReport.id}`, {
-			state: {
-				characterName: character.characterName,
-				userId: userId ?? undefined,
-				corporationId: character.corporationId,
-				returnTo,
-				backLabel: 'Back to User Profile',
-				breadcrumbParentLabel: 'User Profile',
-			},
-		})
-	}
-
 	const scanEligibleCharacters = rows.filter(
 		(character) =>
 			!!character.corporationId &&
@@ -454,10 +432,15 @@ export default function HrAuditorUserProfilePage() {
 			userId={userDetails.id}
 			mainCharacterId={mainCharacter?.characterId}
 			mainCharacterName={mainCharacter?.characterName}
+			isMainCharacterBlacklisted={Boolean(mainCharacter?.isBlacklisted)}
+			isAccountBlacklisted={Boolean(userDetails.isBlacklisted)}
 			sidebarBadges={
 				<>
 					{userDetails.is_admin && (
 						<UserProfileStatusBadge variant="default">Site Admin</UserProfileStatusBadge>
+					)}
+					{userDetails.isBlacklisted && (
+						<UserProfileStatusBadge variant="destructive">Blocklisted</UserProfileStatusBadge>
 					)}
 					{userDetails.discordUserId ? (
 						<UserProfileStatusBadge variant="success">Discord Linked</UserProfileStatusBadge>
@@ -529,6 +512,7 @@ export default function HrAuditorUserProfilePage() {
 							role: character.role,
 							activityStatus: character.activityStatus,
 							isPrimary: character.isPrimary,
+							isBlacklisted: character.isBlacklisted,
 							latestReport: character.latestReport,
 							hasPendingReport: character.hasPendingReport,
 							skillPoints: spByCharacterId.get(character.characterId),
@@ -559,14 +543,25 @@ export default function HrAuditorUserProfilePage() {
 						isScanPendingFor={(characterId) =>
 							requestReport.isPending && requestingCharacterId === characterId
 						}
-						onViewReport={(character) => {
-							const full = rows.find((row) => row.characterId === character.characterId)
-							if (full) handleViewLatestReport(full)
-						}}
-						onViewDetails={(character) => {
-							const full = rows.find((row) => row.characterId === character.characterId)
-							if (full) handleViewDetails(full)
-						}}
+						getReportTarget={(character) => ({
+							to: `/hr/users/${userId}/reports/${character.latestReport!.id}`,
+							state: {
+								characterName: character.characterName,
+								userId: userId ?? undefined,
+								returnTo: `${location.pathname}${location.search}`,
+								backLabel: 'Back to User Profile',
+								breadcrumbParentLabel: 'User Profile',
+							},
+						})}
+						getDetailsTarget={(character) => ({
+							to: `/character/${character.characterId}`,
+							state: {
+								source: 'hr-auditor-user-profile',
+								backTo: `/hr/users/${userId}`,
+								backLabel: 'Back to User Details',
+								corporationId: character.corporationId ?? undefined,
+							},
+						})}
 						onScan={(character) => {
 							const full = rows.find((row) => row.characterId === character.characterId)
 							if (full) handleOpenSingleScanDialog(full)
@@ -592,8 +587,8 @@ export default function HrAuditorUserProfilePage() {
 							createdAt: application.createdAt,
 						}))}
 						loading={appsLoading}
-						onOpenApplication={(application) =>
-							navigate(`/corporations/${application.corporationId}/applications/${application.id}`)
+						getApplicationHref={(application) =>
+							`/corporations/${application.corporationId}/applications/${application.id}`
 						}
 					/>
 					<IpHistoryCard

--- a/apps/ui/src/client/features/applications/routes/hr-auditor-users.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-auditor-users.tsx
@@ -2,30 +2,49 @@ import { Search, Users } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Navigate } from 'react-router'
 
-import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
-import { UserSearchResultsTable } from '@/components/user-search-results-table'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { Input } from '@/components/ui/input'
 import { LoadingSpinner } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
+import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
+import { UserSearchResultsTable } from '@/components/user-search-results-table'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 
 import { useAuditorUsers } from '../../../hooks/useAuditorUsers'
+import { HrUserSearchContent } from '../components/hr-user-search-content'
 
 export default function HrAuditorUsersPage() {
 	const { user, isAuthenticated, isLoading: authLoading } = useAuth()
 	const { hasAnyPermission } = useUserPermissions()
 	const isAuditor = hasAnyPermission('urn:hr:auditor')
 
+	usePageTitle('User Search')
+
+	if (!authLoading && !isAuthenticated) {
+		return <Navigate to="/login" replace />
+	}
+
+	if (authLoading) {
+		return (
+			<Container>
+				<div className="flex min-h-[320px] items-center justify-center">
+					<LoadingSpinner size="lg" />
+				</div>
+			</Container>
+		)
+	}
+
+	return isAuditor || user?.is_admin ? <HrAuditorUsersAdminPage /> : <HrScopedUsersPage />
+}
+
+function HrAuditorUsersAdminPage() {
 	const [searchQuery, setSearchQuery] = useState('')
 	const [debouncedQuery, setDebouncedQuery] = useState('')
 	const [page, setPage] = useState(1)
 	const [pageSize, setPageSize] = useState<number>(25)
-
-	usePageTitle('User Search')
 
 	useEffect(() => {
 		const timer = setTimeout(() => {
@@ -42,48 +61,16 @@ export default function HrAuditorUsersPage() {
 		offset,
 	})
 
-	if (!authLoading && !isAuthenticated) {
-		return <Navigate to="/login" replace />
-	}
-
-	if (authLoading) {
-		return (
-			<Container>
-				<div className="flex items-center justify-center min-h-[320px]">
-					<LoadingSpinner size="lg" />
-				</div>
-			</Container>
-		)
-	}
-
-	if (!isAuditor && !user?.is_admin) {
-		return (
-			<Container>
-				<Card className="max-w-2xl mx-auto border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950">
-					<CardHeader className="text-center">
-						<CardTitle className="text-2xl text-red-900 dark:text-red-100">Access Denied</CardTitle>
-						<CardDescription className="mt-2 text-red-700 dark:text-red-300">
-							HR Auditor permission is required to access this page.
-						</CardDescription>
-					</CardHeader>
-				</Card>
-			</Container>
-		)
-	}
-
 	const users = data?.users ?? []
 	const total = data?.total ?? 0
 	const totalPages = Math.ceil(total / pageSize)
 	const hasPagination = totalPages > 1
 
 	return (
-		<Container>
-			<PageHeader
-				title="User Search"
-				description="Search all users for HR audit purposes"
-			/>
+		<Container className="lg:flex lg:h-full lg:min-h-0 lg:flex-col">
+			<PageHeader title="User Search" description="Search all users for HR audit purposes" />
 
-			<div className="mt-6 space-y-4">
+			<div className="mt-6 flex flex-col space-y-4 lg:min-h-0 lg:flex-1">
 				{/* Search */}
 				<Card>
 					<CardContent className="pt-6">
@@ -100,7 +87,7 @@ export default function HrAuditorUsersPage() {
 				</Card>
 
 				{/* Results */}
-				<Card>
+				<Card className="lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:overflow-hidden">
 					<CardHeader>
 						<div className="space-y-4">
 							<div>
@@ -108,12 +95,8 @@ export default function HrAuditorUsersPage() {
 									<Users className="h-5 w-5" />
 									Users
 								</CardTitle>
-							<CardDescription>
-									{isLoading
-										? 'Searching...'
-										: debouncedQuery
-											? 'Search results'
-											: 'All users'}
+								<CardDescription>
+									{isLoading ? 'Searching...' : debouncedQuery ? 'Search results' : 'All users'}
 								</CardDescription>
 							</div>
 							<UserSearchPaginationControls
@@ -128,7 +111,7 @@ export default function HrAuditorUsersPage() {
 							/>
 						</div>
 					</CardHeader>
-					<CardContent>
+					<CardContent className="lg:flex lg:min-h-0 lg:flex-1 lg:flex-col">
 						{isLoading ? (
 							<div className="flex justify-center py-8">
 								<LoadingSpinner size="md" />
@@ -138,10 +121,12 @@ export default function HrAuditorUsersPage() {
 								{debouncedQuery ? 'No users match your search' : 'Enter a search term above'}
 							</p>
 						) : (
-							<UserSearchResultsTable
-								users={users}
-								userDetailsPath={(userId) => `/hr/users/${userId}`}
-							/>
+							<div className="lg:min-h-0 lg:flex-1 lg:overflow-auto">
+								<UserSearchResultsTable
+									users={users}
+									userDetailsPath={(userId) => `/hr/users/${userId}`}
+								/>
+							</div>
 						)}
 						{!isLoading && users.length > 0 && hasPagination && (
 							<div className="mt-4 border-t border-border pt-4">
@@ -159,6 +144,21 @@ export default function HrAuditorUsersPage() {
 						)}
 					</CardContent>
 				</Card>
+			</div>
+		</Container>
+	)
+}
+
+function HrScopedUsersPage() {
+	return (
+		<Container className="lg:flex lg:h-full lg:min-h-0 lg:flex-col">
+			<PageHeader
+				title="User Search"
+				description="Search surface-level users and linked characters within your HR access scope."
+			/>
+
+			<div className="mt-6 flex min-h-0 flex-1 flex-col">
+				<HrUserSearchContent fillAvailableHeight />
 			</div>
 		</Container>
 	)

--- a/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
@@ -34,6 +34,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 import { apiClient } from '@/lib/api'
+import { cn } from '@/lib/utils'
 
 import { useCanAccessCorporation, useCorporationMemberAccount } from '../../corporations/hooks'
 import { useHrPermissionCheck } from '../../hr/hooks'
@@ -78,6 +79,7 @@ interface UnifiedCharacter {
 		corporationName?: string | null
 		allianceId?: string | null
 		allianceName?: string | null
+		isBlacklisted?: boolean
 	}
 	report?: FulcrumCharacterReportData
 }
@@ -438,10 +440,18 @@ export default function HrMemberProfile() {
 								<MemberAvatar
 									characterId={representative.characterId}
 									characterName={accountName}
+									isBlacklisted={representative.isBlacklisted}
 									size="lg"
 								/>
 								<div className="space-y-1">
-									<h1 className="text-xl font-bold">{accountName}</h1>
+									<h1
+										className={cn(
+											'text-xl font-bold',
+											(representative.isBlacklisted || account.hasBlacklisted) && 'text-red-500'
+										)}
+									>
+										{accountName}
+									</h1>
 									<p className="text-sm text-muted-foreground">{representative.corporationName}</p>
 									{representative.allianceName && (
 										<p className="text-xs text-muted-foreground">{representative.allianceName}</p>
@@ -567,7 +577,7 @@ export default function HrMemberProfile() {
 							role: char.member?.role ?? char.report?.role ?? null,
 							activityStatus: char.member?.activityStatus ?? char.report?.activityStatus ?? null,
 							isExternal: !char.isInCorp,
-							isBlacklisted: char.member?.isBlacklisted,
+							isBlacklisted: char.member?.isBlacklisted ?? char.hr?.isBlacklisted,
 							lastLogin: char.member?.lastLogin,
 							joinDate: char.member?.joinDate,
 							skillPoints: spByCharacterId.get(char.characterId),
@@ -648,8 +658,8 @@ export default function HrMemberProfile() {
 						loading={appsLoading}
 						linked={account.isLinked}
 						emptyText="No applications found"
-						onOpenApplication={(application) =>
-							navigate(`/corporations/${corporationId}/applications/${application.id}`)
+						getApplicationHref={(application) =>
+							`/corporations/${corporationId}/applications/${application.id}`
 						}
 					/>
 				</div>

--- a/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
@@ -1,7 +1,7 @@
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { AlertCircle } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { Navigate, useLocation, useNavigate, useParams } from 'react-router'
+import { Navigate, useLocation, useParams } from 'react-router'
 
 import { LoadingSpinner } from '@/components/ui/loading'
 import { useAuth } from '@/hooks/useAuth'
@@ -27,11 +27,13 @@ import {
 } from '../components/user-profile-sections'
 import {
 	useFulcrumUserReports,
+	useHrUserBlocklistStatus,
 	useHrUserCharacters,
 	useRequestFulcrumReport,
 	useRequestFulcrumReportBatch,
 } from '../hooks'
 import { getPrivateDataUnavailableMessage } from '../utils/private-data'
+import { getApplicationProfileNavigationFromReferrer } from '../utils/profile-navigation'
 
 import type { Application, CharacterReportMetadata, FulcrumCharacterReportData } from '../api'
 
@@ -52,6 +54,7 @@ interface ReviewerCharacterRow {
 	role: 'CEO' | 'Director' | 'Member' | null
 	activityStatus: 'active' | 'inactive' | 'unknown' | null
 	hasValidToken: boolean | null
+	isBlacklisted: boolean | null | undefined
 	latestReport: CharacterReportMetadata | null
 	hasPendingReport: boolean
 }
@@ -75,7 +78,6 @@ function isForbiddenError(error: unknown): boolean {
 export default function HrUserProfilePage() {
 	const { userId } = useParams<{ userId: string }>()
 	const location = useLocation()
-	const navigate = useNavigate()
 	const { isAuthenticated, isLoading: authLoading } = useAuth()
 	const [requestingCharacterId, setRequestingCharacterId] = useState<string | null>(null)
 	const [isScanningAll, setIsScanningAll] = useState(false)
@@ -87,7 +89,9 @@ export default function HrUserProfilePage() {
 	const { data: accessibleCorporations, isLoading: accessibleCorporationsLoading } =
 		useHrAccessibleCorporations()
 
-	const navigationState = location.state as ReviewerProfileNavigationState | null
+	const [referrerNavigationState] = useState(getApplicationProfileNavigationFromReferrer)
+	const navigationState =
+		(location.state as ReviewerProfileNavigationState | null) ?? referrerNavigationState
 	const source = navigationState?.source
 	const returnTo = navigationState?.returnTo
 	const fromApplications = source === 'applications' || returnTo?.includes('/applications')
@@ -117,6 +121,9 @@ export default function HrUserProfilePage() {
 	})
 
 	const characterQuery = useHrUserCharacters(userId ?? '', {
+		enabled: !!userId,
+	})
+	const { data: userBlocklistStatus } = useHrUserBlocklistStatus(userId ?? '', {
 		enabled: !!userId,
 	})
 
@@ -172,6 +179,7 @@ export default function HrUserProfilePage() {
 					role: report?.role ?? null,
 					activityStatus: report?.activityStatus ?? null,
 					hasValidToken: character.hasValidToken,
+					isBlacklisted: character.isBlacklisted,
 					latestReport,
 					hasPendingReport,
 				}
@@ -389,6 +397,13 @@ export default function HrUserProfilePage() {
 			userId={userId}
 			mainCharacterId={mainCharacter?.characterId}
 			mainCharacterName={mainCharacter?.characterName}
+			isMainCharacterBlacklisted={Boolean(mainCharacter?.isBlacklisted)}
+			isAccountBlacklisted={Boolean(userBlocklistStatus?.isBlacklisted)}
+			sidebarBadges={
+				userBlocklistStatus?.isBlacklisted ? (
+					<UserProfileStatusBadge variant="destructive">Blocklisted</UserProfileStatusBadge>
+				) : undefined
+			}
 			sidebarStats={
 				<>
 					<UserProfileStatRow label="Characters" value={rows.length} />
@@ -451,6 +466,7 @@ export default function HrUserProfilePage() {
 					role: character.role,
 					activityStatus: character.activityStatus,
 					isPrimary: character.isPrimary,
+					isBlacklisted: character.isBlacklisted,
 					latestReport: character.latestReport,
 					hasPendingReport: character.hasPendingReport,
 					skillPoints: spByCharacterId.get(character.characterId),
@@ -480,32 +496,24 @@ export default function HrUserProfilePage() {
 				isScanPendingFor={(characterId) =>
 					requestReport.isPending && requestingCharacterId === characterId
 				}
-				onViewReport={(character) => {
-					const full = rows.find((row) => row.characterId === character.characterId)
-					if (full?.latestReport?.status === 'completed') {
-						void navigate(`/hr/users/${userId}/reports/${full.latestReport.id}`, {
-							state: {
-								characterName: character.characterName,
-								userId: userId ?? undefined,
-								backTo: location.pathname + location.search,
-								backLabel: 'Back to User Details',
-								breadcrumbParentLabel: 'User Details',
-							},
-						})
-					}
-				}}
-				onViewDetails={(character) => {
-					const full = rows.find((row) => row.characterId === character.characterId)
-					if (full) {
-						void navigate(`/character/${character.characterId}`, {
-							state: {
-								source: 'hr-member-profile',
-								backTo: `/hr/users/${userId}`,
-								backLabel: 'Back to User Details',
-							},
-						})
-					}
-				}}
+				getReportTarget={(character) => ({
+					to: `/hr/users/${userId}/reports/${character.latestReport!.id}`,
+					state: {
+						characterName: character.characterName,
+						userId: userId ?? undefined,
+						backTo: location.pathname + location.search,
+						backLabel: 'Back to User Details',
+						breadcrumbParentLabel: 'User Details',
+					},
+				})}
+				getDetailsTarget={(character) => ({
+					to: `/character/${character.characterId}`,
+					state: {
+						source: 'hr-member-profile',
+						backTo: `/hr/users/${userId}`,
+						backLabel: 'Back to User Details',
+					},
+				})}
 				onScan={(character) => {
 					const full = rows.find((row) => row.characterId === character.characterId)
 					if (full) {
@@ -525,8 +533,8 @@ export default function HrUserProfilePage() {
 					createdAt: application.createdAt,
 				}))}
 				loading={applicationsQuery.isLoading}
-				onOpenApplication={(application) =>
-					navigate(`/corporations/${application.corporationId}/applications/${application.id}`)
+				getApplicationHref={(application) =>
+					`/corporations/${application.corporationId}/applications/${application.id}`
 				}
 			/>
 

--- a/apps/ui/src/client/features/applications/utils/contacts.ts
+++ b/apps/ui/src/client/features/applications/utils/contacts.ts
@@ -1,0 +1,11 @@
+import { getIdClassification } from '@repo/eve-types'
+
+export function isNpcCharacterContact(contact: {
+	contact_id: string | number
+	contact_type?: string | null
+}): boolean {
+	return (
+		contact.contact_type === 'character' &&
+		getIdClassification(contact.contact_id).type === 'npc_character'
+	)
+}

--- a/apps/ui/src/client/features/applications/utils/profile-navigation.ts
+++ b/apps/ui/src/client/features/applications/utils/profile-navigation.ts
@@ -1,0 +1,32 @@
+export interface ProfileNavigationState {
+	source?: 'applications' | 'members'
+	returnTo?: string
+	corporationId?: string
+}
+
+/**
+ * Recover application context for a profile opened in a new tab.
+ * React Router state is not transferred to a new browsing context, but the
+ * browser normally sends the same-origin application URL as the referrer.
+ */
+export function getApplicationProfileNavigationFromReferrer(): ProfileNavigationState | null {
+	if (typeof window === 'undefined' || typeof document === 'undefined' || !document.referrer) {
+		return null
+	}
+
+	try {
+		const referrer = new URL(document.referrer)
+		if (referrer.origin !== window.location.origin) return null
+
+		const match = /^\/corporations\/([^/]+)\/applications\/([^/]+)\/?$/.exec(referrer.pathname)
+		if (!match) return null
+
+		return {
+			source: 'applications',
+			returnTo: `${referrer.pathname}${referrer.search}${referrer.hash}`,
+			corporationId: match[1],
+		}
+	} catch {
+		return null
+	}
+}

--- a/apps/ui/src/client/features/corporations/api.ts
+++ b/apps/ui/src/client/features/corporations/api.ts
@@ -67,6 +67,7 @@ export interface CorporationMembersQuery {
 	page?: number
 	limit?: number
 	search?: string
+	mainsOnly?: boolean
 	authFilter?: CorporationMembersAuthFilter
 	coverageFilter?: CorporationMembersCoverageFilter
 	activityFilter?: CorporationMembersActivityFilter
@@ -83,6 +84,7 @@ export function buildCorporationMembersQueryString(
 	if (options.includePagination !== false && query.page) params.set('page', String(query.page))
 	if (options.includePagination !== false && query.limit) params.set('limit', String(query.limit))
 	if (query.search) params.set('search', query.search)
+	if (query.mainsOnly) params.set('mainsOnly', 'true')
 	if (query.authFilter && query.authFilter !== 'all') params.set('authFilter', query.authFilter)
 	if (query.coverageFilter && query.coverageFilter !== 'all') {
 		params.set('coverageFilter', query.coverageFilter)
@@ -102,20 +104,6 @@ export function buildCorporationMembersExportUrl(
 ): string {
 	const queryString = buildCorporationMembersQueryString(query, { includePagination: false })
 	return `${API_BASE_URL}/corporations/${encodeURIComponent(corporationId)}/members/export${
-		queryString ? `?${queryString}` : ''
-	}`
-}
-
-export function buildCorporationUserSearchUrl(
-	corporationId: string,
-	query: { search?: string; limit?: number; offset?: number } = {}
-): string {
-	const params = new URLSearchParams()
-	if (query.search) params.set('search', query.search)
-	if (query.limit !== undefined) params.set('limit', String(query.limit))
-	if (query.offset !== undefined) params.set('offset', String(query.offset))
-	const queryString = params.toString()
-	return `${API_BASE_URL}/corporations/${encodeURIComponent(corporationId)}/members/user-search${
 		queryString ? `?${queryString}` : ''
 	}`
 }
@@ -150,56 +138,6 @@ export interface CorporationMembersResponse {
 			totalCharacters: number
 		}
 	}
-}
-
-export interface CorporationUserSearchCharacter {
-	characterId: string
-	characterName: string
-	characterOwnerHash: string
-	corporationId?: string | null
-	corporationName?: string | null
-	allianceId?: string | null
-	allianceName?: string | null
-	is_primary: boolean
-	hasValidToken: boolean
-	isBlacklisted: boolean
-}
-
-export interface CorporationUserSearchDetails {
-	characters: CorporationUserSearchCharacter[]
-}
-
-export interface CorporationUserSearchSummary {
-	id: string
-	mainCharacterId: string
-	mainCharacterName: string | null
-	characterCount: number
-	is_admin: boolean
-	discordUserId: string | null
-	discordUsername: string | null
-	matchedCharacterId: string | null
-	matchedCharacterName: string | null
-	matchedBy:
-		| 'main_character_name'
-		| 'character_name'
-		| 'character_id'
-		| 'user_id'
-		| 'discord_user_id'
-		| 'discord_username'
-		| 'legacy_auth_username'
-		| null
-	createdAt: string
-	updatedAt: string
-}
-
-export interface CorporationUserSearchResult {
-	users: Array<{
-		summary: CorporationUserSearchSummary
-		details: CorporationUserSearchDetails | null
-	}>
-	total: number
-	limit: number
-	offset: number
 }
 
 export interface CorporationMemberAccountResponse {
@@ -246,11 +184,19 @@ export interface CorporationAccessResult {
 		isMemberCorporation: boolean
 		isAltCorp: boolean
 		isSpecialPurpose: boolean
-		memberCount: number
-		linkedMemberCount: number
-		unlinkedMemberCount: number
-		validEsiKeyMemberCount: number
 	}>
+}
+
+export interface CorporationCoverageStats {
+	corporationId: string
+	memberCount: number
+	linkedMemberCount: number
+	unlinkedMemberCount: number
+	validEsiKeyMemberCount: number
+}
+
+export interface CorporationCoverageResult {
+	corporations: CorporationCoverageStats[]
 }
 
 export interface CorporationScopedAccessResult {
@@ -290,6 +236,11 @@ export const myCorporationsApi = {
 	 */
 	async checkAccess(): Promise<CorporationAccessResult> {
 		return apiClient.get('/users/corporation-access')
+	},
+
+	/** Get ESI coverage counts for corporations visible to the current user. */
+	async getCoverage(): Promise<CorporationCoverageResult> {
+		return apiClient.get('/users/corporation-coverage')
 	},
 
 	/**
@@ -341,23 +292,6 @@ export const myCorporationsApi = {
 		accountId: string
 	): Promise<CorporationMemberAccountResponse> {
 		return apiClient.get(`/corporations/${corporationId}/members/${accountId}`)
-	},
-
-	/**
-	 * Search users for the corp member page lookup dialog.
-	 * Returns matched users and all linked characters with no detail-page links.
-	 */
-	async searchCorporationUsers(
-		corporationId: string,
-		query: { search?: string; limit?: number; offset?: number } = {}
-	): Promise<CorporationUserSearchResult> {
-		const queryString = new URLSearchParams()
-		if (query.search) queryString.set('search', query.search)
-		if (query.limit !== undefined) queryString.set('limit', String(query.limit))
-		if (query.offset !== undefined) queryString.set('offset', String(query.offset))
-		return apiClient.get(
-			`/corporations/${corporationId}/members/user-search${queryString.toString() ? `?${queryString.toString()}` : ''}`
-		)
 	},
 
 	/**

--- a/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
+++ b/apps/ui/src/client/features/corporations/components/corporation-members-table.tsx
@@ -18,12 +18,15 @@ import {
 	User,
 } from 'lucide-react'
 import { useCallback, useState } from 'react'
+import { Link } from 'react-router'
 
 import { EsiStatusBadge, getEsiStatusBadgeState } from '@/components/esi-status-badge'
+import { MemberAvatar } from '@/components/member-avatar'
 import { TableRefreshFrame } from '@/components/table-refresh-frame'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select } from '@/components/ui/select'
@@ -37,7 +40,6 @@ import {
 } from '@/components/ui/table'
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { useMessage } from '@/hooks/useMessage'
-import { characterPortraitUrl } from '@/lib/eve-images'
 import { cn } from '@/lib/utils'
 
 import {
@@ -50,7 +52,7 @@ import {
 import { myCorporationsApi } from '../api'
 import { EmeritusConfirmationDialog } from './emeritus-confirmation-dialog'
 
-import type { SetStateAction } from 'react'
+import type { KeyboardEvent, MouseEvent, SetStateAction } from 'react'
 import type { HrRoleType } from '../../hr'
 import type {
 	CorporationMember,
@@ -174,6 +176,7 @@ export default function CorporationMembersTable({
 	const { showSuccess, showError } = useMessage()
 
 	const searchQuery = query.search ?? ''
+	const mainsOnly = query.mainsOnly ?? false
 	const authFilter = query.authFilter ?? 'all'
 	const activityFilter = query.activityFilter ?? 'all'
 	const roleFilter = query.roleFilter ?? 'all'
@@ -181,6 +184,37 @@ export default function CorporationMembersTable({
 	const sortOrder = query.sortOrder ?? 'asc'
 	const currentPage = pagination?.page ?? 1
 	const paginatedMembers = members
+
+	const getMemberHref = (member: CorporationMember): string =>
+		member.hasAuthAccount && member.authUserId
+			? `/corporations/${corporationId}/members/${member.authUserId}`
+			: `/character/${member.characterId}`
+
+	const handleMemberRowClick = (
+		event: MouseEvent<HTMLTableRowElement>,
+		member: CorporationMember
+	) => {
+		if ((event.target as HTMLElement).closest('a, button, input, [role="button"]')) return
+
+		const href = getMemberHref(member)
+		if (event.ctrlKey || event.metaKey || event.button === 1) {
+			event.preventDefault()
+			window.open(href, '_blank', 'noopener,noreferrer')
+			return
+		}
+
+		onMemberClick?.(member)
+	}
+
+	const handleMemberRowKeyDown = (
+		event: KeyboardEvent<HTMLTableRowElement>,
+		member: CorporationMember
+	) => {
+		if (event.key !== 'Enter' && event.key !== ' ') return
+		if ((event.target as HTMLElement).closest('button, input, [role="button"]')) return
+		event.preventDefault()
+		onMemberClick?.(member)
+	}
 
 	// HR dialog states
 	const [grantDialogMember, setGrantDialogMember] = useState<CorporationMember | null>(null)
@@ -449,6 +483,20 @@ export default function CorporationMembersTable({
 						]}
 						className="w-[140px]"
 					/>
+
+					<label className="flex cursor-pointer items-center gap-2 whitespace-nowrap text-sm">
+						<Checkbox
+							checked={mainsOnly}
+							onCheckedChange={(checked) =>
+								onQueryChange((prev) => ({
+									...prev,
+									page: 1,
+									mainsOnly: checked === true,
+								}))
+							}
+						/>
+						<span>Show mains only</span>
+					</label>
 				</div>
 			</Card>
 
@@ -476,25 +524,35 @@ export default function CorporationMembersTable({
 								<TableRow
 									key={member.characterId}
 									className={cn(
-										'hover:bg-muted/50 cursor-pointer',
+										'cursor-pointer hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
 										!member.hasAuthAccount && 'bg-yellow-500/5'
 									)}
-									onClick={() => onMemberClick?.(member)}
+									role="link"
+									tabIndex={0}
+									onClick={(event) => handleMemberRowClick(event, member)}
+									onAuxClick={(event) => handleMemberRowClick(event, member)}
+									onKeyDown={(event) => handleMemberRowKeyDown(event, member)}
 								>
 									<TableCell>
 										<div className="flex items-center gap-3">
-											<img
-												src={characterPortraitUrl(member.characterId, 64)}
-												alt={`${member.characterName}'s portrait`}
-												loading="lazy"
-												onError={(e) => {
-													;(e.currentTarget as HTMLImageElement).src =
-														'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"%3E%3Crect fill="%23404040" width="64" height="64"/%3E%3Ctext x="50%25" y="50%25" font-family="Arial" font-size="24" fill="%23bfbfbf" text-anchor="middle" dominant-baseline="middle"%3E?%3C/text%3E%3C/svg%3E'
-												}}
-												className="w-8 h-8 rounded-full border border-border"
+											<MemberAvatar
+												characterId={member.characterId}
+												characterName={member.characterName}
+												isBlacklisted={member.isBlacklisted}
+												size="sm"
+												className="rounded-full border border-border"
 											/>
 											<div>
-												<div className="font-medium">{member.characterName}</div>
+												<Link
+													to={getMemberHref(member)}
+													onClick={(event) => event.stopPropagation()}
+													className={cn(
+														'font-medium hover:underline',
+														member.isBlacklisted && 'text-red-500'
+													)}
+												>
+													{member.characterName}
+												</Link>
 												{member.locationSystem && (
 													<div className="text-xs text-muted-foreground">
 														{member.locationSystem}

--- a/apps/ui/src/client/features/corporations/components/corporation-user-search-dialog.tsx
+++ b/apps/ui/src/client/features/corporations/components/corporation-user-search-dialog.tsx
@@ -1,10 +1,5 @@
-import { Search, Users } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { Search } from 'lucide-react'
 
-import { CopyableMetaPill } from '@/components/copyable-meta-pill'
-import { CharacterIdentitySummary } from '@/features/applications/components/character-identity-summary'
-import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
-import { Badge } from '@/components/ui/badge'
 import {
 	Dialog,
 	DialogContent,
@@ -12,74 +7,20 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from '@/components/ui/dialog'
-import { Card, CardContent } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { LoadingSpinner } from '@/components/ui/loading'
-import { useDebounce } from '@/hooks/useDebounce'
-import { characterPortraitUrl } from '@/lib/eve-images'
-import { cn } from '@/lib/utils'
 
-import { useCorporationUserSearch } from '../hooks'
-
-import type { CorporationUserSearchResult } from '../api'
+import { HrUserSearchContent } from '../../applications/components/hr-user-search-content'
 
 interface CorporationUserSearchDialogProps {
-	corporationId: string
 	open: boolean
 	onOpenChange: (open: boolean) => void
 }
 
-function formatUserDisplayName(user: CorporationUserSearchResult['users'][number]): string {
-	const mainName = user.summary.mainCharacterName || user.summary.matchedCharacterName || 'Unknown Character'
-	const matchedName = user.summary.matchedCharacterName
-	const isAltMatch =
-		!!user.summary.matchedCharacterId &&
-		user.summary.matchedCharacterId !== user.summary.mainCharacterId &&
-		!!matchedName
-
-	return isAltMatch ? `${matchedName} (${mainName})` : mainName
-}
-
 export function CorporationUserSearchDialog({
-	corporationId,
 	open,
 	onOpenChange,
 }: CorporationUserSearchDialogProps) {
-	const [searchQuery, setSearchQuery] = useState('')
-	const [page, setPage] = useState(1)
-	const [pageSize, setPageSize] = useState(10)
-	const debouncedQuery = useDebounce(searchQuery.trim(), 400)
-
-	useEffect(() => {
-		setPage(1)
-	}, [debouncedQuery])
-
-	const limit = pageSize
-	const offset = useMemo(() => (page - 1) * pageSize, [page, pageSize])
-	const canSearch = open && debouncedQuery.length >= 2
-	const { data, isLoading, isFetching, error } = useCorporationUserSearch(
-		corporationId,
-		{
-			search: debouncedQuery,
-			limit,
-			offset,
-		},
-		{ enabled: canSearch }
-	)
-
-	const users = data?.users ?? []
-	const total = data?.total ?? 0
-	const totalPages = Math.ceil(total / pageSize)
-	const hasPagination = totalPages > 1
-	const isSearching = isLoading || isFetching
-
 	return (
-		<Dialog
-			open={open}
-			onOpenChange={(nextOpen) => {
-				onOpenChange(nextOpen)
-			}}
-		>
+		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="sm:max-w-5xl">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
@@ -92,200 +33,7 @@ export function CorporationUserSearchDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4">
-					<Card>
-						<CardContent className="pt-6">
-							<div className="space-y-2">
-								<div className="relative">
-									<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-									<Input
-										autoFocus
-										placeholder="Search character name, character ID, Discord username, or Discord ID"
-										value={searchQuery}
-										onChange={(event) => setSearchQuery(event.target.value)}
-										className="pl-9"
-									/>
-								</div>
-								<p className="text-xs text-muted-foreground">
-									Type at least 2 characters to start searching.
-								</p>
-							</div>
-						</CardContent>
-					</Card>
-
-					<Card>
-						<CardContent className="space-y-4 pt-6">
-							{error ? (
-								<p className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-									{error instanceof Error ? error.message : 'Failed to search users'}
-								</p>
-							) : null}
-
-							{!canSearch ? (
-								<p className="py-10 text-center text-sm text-muted-foreground">
-									Enter at least 2 characters to search the user directory.
-								</p>
-							) : isSearching ? (
-								<div className="flex justify-center py-10">
-									<LoadingSpinner size="md" />
-								</div>
-							) : users.length === 0 ? (
-								<p className="py-10 text-center text-sm text-muted-foreground">
-									No users matched that search.
-								</p>
-							) : (
-								<div className="space-y-4">
-									<UserSearchPaginationControls
-										totalCount={total}
-										page={page}
-										pageSize={pageSize}
-										onPageChange={setPage}
-										onPageSizeChange={(nextPageSize) => {
-											setPageSize(nextPageSize)
-											setPage(1)
-										}}
-										pageSizeOptions={[10, 25, 50]}
-										itemLabel="users"
-									/>
-
-									<div className="max-h-[55vh] space-y-3 overflow-y-auto pr-1">
-										{users.map((user) => {
-											const displayName = formatUserDisplayName(user)
-											const portraitId =
-												user.summary.matchedCharacterId || user.summary.mainCharacterId
-											const characters = [...(user.details?.characters ?? [])].sort((a, b) => {
-												if (a.is_primary !== b.is_primary) {
-													return a.is_primary ? -1 : 1
-												}
-												return a.characterName.localeCompare(b.characterName)
-											})
-
-											return (
-												<Card
-													key={user.summary.id}
-													className={cn(
-														'border-border/70',
-														user.summary.matchedCharacterId &&
-															user.summary.matchedCharacterId !== user.summary.mainCharacterId &&
-															'border-primary/30 bg-primary/5'
-													)}
-												>
-													<CardContent className="space-y-4 pt-6">
-														<div className="flex items-start gap-3">
-															<img
-																src={characterPortraitUrl(portraitId, 64)}
-																alt={displayName}
-																className="h-10 w-10 rounded-md"
-															/>
-															<div className="min-w-0 flex-1">
-																<div className="flex flex-wrap items-center gap-2">
-																	<p className="truncate text-base font-semibold">{displayName}</p>
-																	<span className="inline-flex items-center rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-																		<span className="text-white">
-																			{user.summary.characterCount} character
-																			{user.summary.characterCount !== 1 ? 's' : ''}
-																		</span>
-																	</span>
-																	{user.summary.is_admin && <Badge variant="default">Admin</Badge>}
-																	{user.summary.discordUserId && (
-																		<Badge variant="secondary">Discord linked</Badge>
-																	)}
-																</div>
-																<div className="mt-2 flex flex-wrap gap-2">
-																	<CopyableMetaPill
-																		label="User ID"
-																		value={user.summary.id}
-																	/>
-																	{user.summary.discordUsername ? (
-																		<CopyableMetaPill
-																			label="Discord username"
-																			value={user.summary.discordUsername}
-																		/>
-																	) : null}
-																	{user.summary.discordUserId ? (
-																		<CopyableMetaPill
-																			label="Discord ID"
-																			value={user.summary.discordUserId}
-																		/>
-																	) : null}
-																</div>
-															</div>
-														</div>
-
-														<div className="space-y-2">
-															<div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-																<Users className="h-3.5 w-3.5" />
-																Linked Characters
-															</div>
-															{characters.length > 0 ? (
-																<div className="space-y-2">
-																	{characters.map((character) => (
-																		<div
-																			key={character.characterId}
-																			className={cn(
-																				'rounded-lg border border-border/60 bg-background/80 px-3 py-2',
-																				user.summary.matchedCharacterId === character.characterId &&
-																					'border-primary/40 bg-primary/5'
-																			)}
-																		>
-																			<CharacterIdentitySummary
-																				characterId={character.characterId}
-																				characterName={character.characterName}
-																				hasAuthAccount
-																				hasValidToken={character.hasValidToken}
-																				corporationId={character.corporationId}
-																				corporationName={character.corporationName}
-																				allianceId={character.allianceId}
-																				allianceName={character.allianceName}
-																				portraitSize="sm"
-																				showMetrics={false}
-																				nameBadges={
-																					<>
-																						<Badge
-																							variant={character.is_primary ? 'default' : 'secondary'}
-																							className="px-1.5 py-0 text-[10px]"
-																						>
-																							{character.is_primary ? 'Main' : 'Alt'}
-																						</Badge>
-																					</>
-																				}
-																			/>
-																		</div>
-																	))}
-																</div>
-															) : (
-																<p className="text-sm text-muted-foreground">
-																	No linked characters were returned for this account.
-																</p>
-															)}
-														</div>
-													</CardContent>
-												</Card>
-											)
-										})}
-									</div>
-
-									{hasPagination && (
-										<div className="border-t border-border pt-4">
-											<UserSearchPaginationControls
-												totalCount={total}
-												page={page}
-												pageSize={pageSize}
-												onPageChange={setPage}
-												onPageSizeChange={(nextPageSize) => {
-													setPageSize(nextPageSize)
-													setPage(1)
-												}}
-												pageSizeOptions={[10, 25, 50]}
-												itemLabel="users"
-											/>
-										</div>
-									)}
-								</div>
-							)}
-						</CardContent>
-					</Card>
-				</div>
+				<HrUserSearchContent autoFocus enabled={open} />
 			</DialogContent>
 		</Dialog>
 	)

--- a/apps/ui/src/client/features/corporations/components/user-search-card.tsx
+++ b/apps/ui/src/client/features/corporations/components/user-search-card.tsx
@@ -1,0 +1,175 @@
+import { Users } from 'lucide-react'
+
+import { CopyableMetaPill } from '@/components/copyable-meta-pill'
+import { MemberAvatar } from '@/components/member-avatar'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { CharacterIdentitySummary } from '@/features/applications/components/character-identity-summary'
+import { cn } from '@/lib/utils'
+
+export interface UserSearchCardEntry {
+	summary: {
+		id: string
+		mainCharacterId: string
+		mainCharacterName: string | null
+		characterCount: number
+		is_admin: boolean
+		discordUserId: string | null
+		discordUsername: string | null
+		matchedCharacterId: string | null
+		matchedCharacterName: string | null
+		isBlacklisted: boolean
+	}
+	characters: Array<{
+		characterId: string
+		characterName: string
+		corporationId?: string | null
+		corporationName?: string | null
+		allianceId?: string | null
+		allianceName?: string | null
+		is_primary: boolean
+		hasValidToken: boolean
+		isBlacklisted: boolean
+	}>
+}
+
+export function formatUserDisplayName(user: UserSearchCardEntry): string {
+	const mainName =
+		user.summary.mainCharacterName || user.summary.matchedCharacterName || 'Unknown Character'
+	const matchedName = user.summary.matchedCharacterName
+	const isAltMatch =
+		!!user.summary.matchedCharacterId &&
+		user.summary.matchedCharacterId !== user.summary.mainCharacterId &&
+		!!matchedName
+
+	return isAltMatch ? `${matchedName} (${mainName})` : mainName
+}
+
+export function UserSearchCard({ user }: { user: UserSearchCardEntry }) {
+	const displayName = formatUserDisplayName(user)
+	const portraitId = user.summary.matchedCharacterId || user.summary.mainCharacterId
+	const characters = [...user.characters].sort((a, b) => {
+		if (a.is_primary !== b.is_primary) return a.is_primary ? -1 : 1
+		return a.characterName.localeCompare(b.characterName)
+	})
+	const mainCharacterIsBlacklisted =
+		user.characters.find((character) => character.characterId === user.summary.mainCharacterId)
+			?.isBlacklisted ||
+		user.summary.isBlacklisted ||
+		false
+	const displayedCharacterIsBlacklisted = user.summary.matchedCharacterId
+		? (user.characters.find(
+				(character) => character.characterId === user.summary.matchedCharacterId
+			)?.isBlacklisted ?? false)
+		: mainCharacterIsBlacklisted || false
+	const accountIsBlacklisted = user.summary.isBlacklisted ?? false
+
+	return (
+		<Card
+			className={cn(
+				'border-border/70',
+				user.summary.matchedCharacterId &&
+					user.summary.matchedCharacterId !== user.summary.mainCharacterId &&
+					'border-primary/30 bg-primary/5'
+			)}
+		>
+			<CardContent className="space-y-4 pt-6">
+				<div className="flex items-start gap-3">
+					<MemberAvatar
+						characterId={portraitId}
+						characterName={displayName}
+						isBlacklisted={displayedCharacterIsBlacklisted || accountIsBlacklisted}
+						size="auto"
+						className="h-10 w-10"
+					/>
+					<div className="min-w-0 flex-1">
+						<div className="flex flex-wrap items-center gap-2">
+							<p
+								className={cn(
+									'truncate text-base font-semibold',
+									(displayedCharacterIsBlacklisted || accountIsBlacklisted) && 'text-red-500'
+								)}
+							>
+								{displayName}
+							</p>
+							<span className="inline-flex items-center rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+								<span className="text-white">
+									{user.summary.characterCount} character
+									{user.summary.characterCount !== 1 ? 's' : ''}
+								</span>
+							</span>
+							{user.summary.is_admin && <Badge variant="default">Admin</Badge>}
+							{(mainCharacterIsBlacklisted || accountIsBlacklisted) && (
+								<Badge variant="destructive">Blocklisted</Badge>
+							)}
+							{user.summary.discordUserId && <Badge variant="success">Discord linked</Badge>}
+						</div>
+						<div className="mt-2 flex flex-wrap gap-2">
+							<CopyableMetaPill label="User ID" value={user.summary.id} />
+							{user.summary.discordUsername ? (
+								<CopyableMetaPill label="Discord username" value={user.summary.discordUsername} />
+							) : null}
+							{user.summary.discordUserId ? (
+								<CopyableMetaPill label="Discord ID" value={user.summary.discordUserId} />
+							) : null}
+						</div>
+					</div>
+				</div>
+
+				<div className="space-y-2">
+					<div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+						<Users className="h-3.5 w-3.5" />
+						Linked Characters
+					</div>
+					{characters.length > 0 ? (
+						<div className="space-y-2">
+							{characters.map((character) => (
+								<div
+									key={character.characterId}
+									className={cn(
+										'rounded-lg border border-border/60 bg-background/80 px-3 py-2',
+										user.summary.matchedCharacterId === character.characterId &&
+											'border-primary/40 bg-primary/5'
+									)}
+								>
+									<CharacterIdentitySummary
+										characterId={character.characterId}
+										characterName={character.characterName}
+										isBlacklisted={character.isBlacklisted}
+										hasAuthAccount
+										hasValidToken={character.hasValidToken}
+										corporationId={character.corporationId}
+										corporationName={character.corporationName}
+										allianceId={character.allianceId}
+										allianceName={character.allianceName}
+										portraitSize="sm"
+										showMetrics={false}
+										nameBadges={
+											<>
+												<Badge
+													variant={character.is_primary ? 'default' : 'secondary'}
+													className="px-1.5 py-0 text-[10px]"
+												>
+													{character.is_primary ? 'Main' : 'Alt'}
+												</Badge>
+												{character.isBlacklisted && (
+													<Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
+														Blocklisted
+													</Badge>
+												)}
+											</>
+										}
+									/>
+								</div>
+							))}
+						</div>
+					) : (
+						<p className="text-sm text-muted-foreground">
+							No linked characters were returned for this account.
+						</p>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/ui/src/client/features/corporations/hooks.ts
+++ b/apps/ui/src/client/features/corporations/hooks.ts
@@ -17,7 +17,6 @@ import type {
 	CorporationMembersQuery,
 	CorporationMembersResponse,
 	CorporationScopedAccessResult,
-	CorporationUserSearchResult,
 	MyCorporation,
 } from './api'
 
@@ -36,10 +35,9 @@ export const corporationKeys = {
 		[...corporationKeys.all, 'members', corpId, query] as const,
 	memberAccount: (corpId: string, accountId: string) =>
 		[...corporationKeys.all, 'member-account', corpId, accountId] as const,
-	userSearch: (corpId: string, query: { search?: string; limit?: number; offset?: number }) =>
-		[...corporationKeys.all, 'user-search', corpId, query] as const,
 	access: () => [...corporationKeys.all, 'access'] as const,
 	accessForCorporation: (corpId: string) => [...corporationKeys.all, 'access', corpId] as const,
+	coverage: () => [...corporationKeys.all, 'coverage'] as const,
 }
 
 // ============================================================================
@@ -105,6 +103,23 @@ export function useCorporationAccess() {
 }
 
 /**
+ * Hook to fetch ESI coverage statistics independently from corporation access.
+ * The backend shares the per-corporation cache across authorized users.
+ */
+export function useCorporationCoverage() {
+	const { user } = useAuth()
+	const userId = user?.id ?? null
+
+	return useQuery({
+		queryKey: [...corporationKeys.coverage(), userId],
+		queryFn: () => myCorporationsApi.getCoverage(),
+		staleTime: 10 * 60 * 1000,
+		gcTime: 30 * 60 * 1000,
+		enabled: userId !== null,
+	})
+}
+
+/**
  * Hook to fetch user's corporations with leadership roles
  */
 export function useMyCorporations() {
@@ -148,27 +163,6 @@ export function useCorporationMemberAccount(corporationId: string, accountId: st
 		staleTime: 1000 * 60,
 		gcTime: 1000 * 60 * 3,
 		enabled: Boolean(corporationId && accountId),
-	})
-}
-
-/**
- * Hook to search for users from the corporation member page lookup dialog.
- */
-export function useCorporationUserSearch(
-	corporationId: string,
-	query: { search?: string; limit?: number; offset?: number },
-	options?: { enabled?: boolean }
-) {
-	return useQuery<CorporationUserSearchResult>({
-		queryKey: corporationKeys.userSearch(corporationId, query),
-		queryFn: () => myCorporationsApi.searchCorporationUsers(corporationId, query),
-		placeholderData: (previousData) => previousData,
-		staleTime: 1000 * 30,
-		gcTime: 1000 * 60 * 3,
-		enabled: options?.enabled ?? !!corporationId,
-		meta: {
-			suppressErrorToast: true,
-		},
 	})
 }
 

--- a/apps/ui/src/client/features/corporations/index.ts
+++ b/apps/ui/src/client/features/corporations/index.ts
@@ -9,7 +9,13 @@
 export * from './hooks'
 
 // Re-export API types for use in other parts of the app
-export type { CorporationMember, MyCorporation, CorporationAccessResult } from './api'
+export type {
+	CorporationAccessResult,
+	CorporationCoverageResult,
+	CorporationCoverageStats,
+	CorporationMember,
+	MyCorporation,
+} from './api'
 
 // Re-export helper functions
 export {

--- a/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
+++ b/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
@@ -14,7 +14,7 @@ import {
 	Search,
 	Settings,
 } from 'lucide-react'
-import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router'
 
 import {
@@ -54,6 +54,81 @@ const CorporationMembersTable = lazy(() => import('../components/corporation-mem
 const MEMBERS_SEARCH_DEBOUNCE_MS = 400
 type MembersCoverageFilter = NonNullable<CorporationMembersQuery['coverageFilter']>
 
+const DEFAULT_MEMBERS_QUERY: CorporationMembersQuery = {
+	page: 1,
+	limit: 25,
+	search: '',
+	mainsOnly: false,
+	authFilter: 'all',
+	coverageFilter: 'all',
+	activityFilter: 'all',
+	roleFilter: 'all',
+	sortField: 'role',
+	sortOrder: 'asc',
+}
+
+function readMembersQuery(corporationId: string | undefined): CorporationMembersQuery {
+	if (!corporationId || typeof window === 'undefined') return DEFAULT_MEMBERS_QUERY
+
+	try {
+		const raw = window.sessionStorage.getItem(`corporation-members-query:${corporationId}`)
+		if (!raw) return DEFAULT_MEMBERS_QUERY
+		const saved = JSON.parse(raw) as Partial<CorporationMembersQuery>
+		const authFilter = [
+			'all',
+			'linked_valid',
+			'linked_invalid',
+			'linked_unknown',
+			'unlinked',
+		].includes(saved.authFilter ?? '')
+			? saved.authFilter
+			: 'all'
+		const coverageFilter = ['all', 'full', 'partial', 'none', 'unlinked'].includes(
+			saved.coverageFilter ?? ''
+		)
+			? saved.coverageFilter
+			: 'all'
+		const activityFilter = ['all', 'active', 'inactive', 'unknown'].includes(
+			saved.activityFilter ?? ''
+		)
+			? saved.activityFilter
+			: 'all'
+		const roleFilter = ['all', 'CEO', 'Director', 'Member'].includes(saved.roleFilter ?? '')
+			? saved.roleFilter
+			: 'all'
+		const sortField = [
+			'name',
+			'role',
+			'hrRole',
+			'auth',
+			'activity',
+			'lastLogin',
+			'joinDate',
+		].includes(saved.sortField ?? '')
+			? saved.sortField
+			: 'role'
+		const sortOrder = saved.sortOrder === 'desc' ? 'desc' : 'asc'
+		const limitValue = saved.limit ?? 25
+		const limit = [10, 25, 50, 100].includes(limitValue) ? limitValue : 25
+
+		return {
+			...DEFAULT_MEMBERS_QUERY,
+			page: 1,
+			limit,
+			search: typeof saved.search === 'string' ? saved.search : '',
+			mainsOnly: saved.mainsOnly === true,
+			authFilter,
+			coverageFilter,
+			activityFilter,
+			roleFilter,
+			sortField,
+			sortOrder,
+		}
+	} catch {
+		return DEFAULT_MEMBERS_QUERY
+	}
+}
+
 /**
  * Main Corporation Members Component
  */
@@ -77,17 +152,17 @@ export default function CorporationMembers() {
 	const [isRefreshing, setIsRefreshing] = useState(false)
 	const [isExporting, setIsExporting] = useState(false)
 	const [isUserSearchOpen, setIsUserSearchOpen] = useState(false)
-	const [membersQuery, setMembersQuery] = useState<CorporationMembersQuery>({
-		page: 1,
-		limit: 25,
-		search: '',
-		authFilter: 'all',
-		coverageFilter: 'all',
-		activityFilter: 'all',
-		roleFilter: 'all',
-		sortField: 'role',
-		sortOrder: 'asc',
-	})
+	const [membersQuery, setMembersQuery] = useState<CorporationMembersQuery>(() =>
+		readMembersQuery(corporationId)
+	)
+	useEffect(() => {
+		if (!corporationId || typeof window === 'undefined') return
+		const { page: _page, ...filters } = membersQuery
+		window.sessionStorage.setItem(
+			`corporation-members-query:${corporationId}`,
+			JSON.stringify(filters)
+		)
+	}, [corporationId, membersQuery])
 	const debouncedSearch = useDebounce(membersQuery.search ?? '', MEMBERS_SEARCH_DEBOUNCE_MS)
 	const effectiveMembersQuery = useMemo(
 		() => ({
@@ -607,12 +682,8 @@ export default function CorporationMembers() {
 				/>
 			</Suspense>
 
-			{canUseUserSearchTool && corporationId && (
-				<CorporationUserSearchDialog
-					corporationId={corporationId}
-					open={isUserSearchOpen}
-					onOpenChange={setIsUserSearchOpen}
-				/>
+			{canUseUserSearchTool && (
+				<CorporationUserSearchDialog open={isUserSearchOpen} onOpenChange={setIsUserSearchOpen} />
 			)}
 		</Container>
 	)

--- a/apps/ui/src/client/features/hr/api.ts
+++ b/apps/ui/src/client/features/hr/api.ts
@@ -72,6 +72,44 @@ export interface HrAccessibleCorporation {
 	isSpecialPurpose: boolean
 }
 
+export interface HrUserSearchCharacter {
+	characterId: string
+	characterName: string
+	corporationId: string | null
+	corporationName: string | null
+	allianceId: string | null
+	allianceName: string | null
+	is_primary: boolean
+	hasValidToken: boolean
+	isBlacklisted: boolean
+}
+
+export interface HrUserSearchSummary {
+	id: string
+	mainCharacterId: string
+	mainCharacterName: string | null
+	characterCount: number
+	is_admin: boolean
+	discordUserId: string | null
+	discordUsername: string | null
+	matchedCharacterId: string | null
+	matchedCharacterName: string | null
+	isBlacklisted: boolean
+	matchedBy: string | null
+	createdAt: string
+	updatedAt: string
+}
+
+export interface HrUserSearchResult {
+	users: Array<{
+		summary: HrUserSearchSummary
+		characters: HrUserSearchCharacter[]
+	}>
+	total: number
+	limit: number
+	offset: number
+}
+
 /**
  * HR Role capabilities for UI display
  */
@@ -95,6 +133,17 @@ export const HR_ROLE_NAMES: Record<HrRoleType, string> = {
  * HR API methods
  */
 export const hrApi = {
+	/** Search surface-level users within the authenticated user's HR scope. */
+	async searchUsers(query: { search?: string; limit?: number; offset?: number } = {}) {
+		const params = new URLSearchParams()
+		if (query.search) params.set('search', query.search)
+		if (query.limit !== undefined) params.set('limit', String(query.limit))
+		if (query.offset !== undefined) params.set('offset', String(query.offset))
+		return apiClient.get<HrUserSearchResult>(
+			`/hr/users/search${params.toString() ? `?${params.toString()}` : ''}`
+		)
+	},
+
 	/**
 	 * Grant an HR role to a user
 	 */

--- a/apps/ui/src/client/features/hr/hooks.ts
+++ b/apps/ui/src/client/features/hr/hooks.ts
@@ -8,6 +8,7 @@ import type {
 	CheckHrPermissionRequest,
 	GrantHrRoleRequest,
 	HrAccessibleCorporation,
+	HrUserSearchResult,
 	RevokeHrRoleRequest,
 } from './api'
 
@@ -20,6 +21,23 @@ export const hrKeys = {
 	roles: (corporationId: string) => [...hrKeys.all, 'roles', corporationId] as const,
 	permission: (corporationId: string) => [...hrKeys.all, 'permission', corporationId] as const,
 	corporations: () => [...hrKeys.all, 'corporations'] as const,
+	userSearch: (query: { search?: string; limit?: number; offset?: number }) =>
+		[...hrKeys.all, 'user-search', query] as const,
+}
+
+export function useHrUserSearch(
+	query: { search?: string; limit?: number; offset?: number },
+	options?: { enabled?: boolean }
+) {
+	return useQuery<HrUserSearchResult>({
+		queryKey: hrKeys.userSearch(query),
+		queryFn: () => hrApi.searchUsers(query),
+		placeholderData: (previousData) => previousData,
+		staleTime: 30 * 1000,
+		gcTime: 3 * 60 * 1000,
+		enabled: options?.enabled ?? true,
+		meta: { suppressErrorToast: true },
+	})
 }
 
 /**

--- a/apps/ui/src/client/hooks/useAuditorUsers.ts
+++ b/apps/ui/src/client/hooks/useAuditorUsers.ts
@@ -20,6 +20,8 @@ export interface AuditorUserSummary {
 	discordUsername: string | null
 	matchedCharacterId: string | null
 	matchedCharacterName: string | null
+	mainCharacterIsBlacklisted: boolean
+	matchedCharacterIsBlacklisted: boolean | null
 	createdAt: string
 	updatedAt: string
 }
@@ -35,6 +37,7 @@ export interface AuditorUserDetails {
 	id: string
 	mainCharacterId: string
 	is_admin: boolean
+	isBlacklisted: boolean
 	discordUserId: string | null
 	discord: {
 		userId: string
@@ -49,6 +52,7 @@ export interface AuditorUserDetails {
 		characterName: string
 		is_primary: boolean
 		hasValidToken: boolean
+		isBlacklisted: boolean
 	}>
 	groupMemberships: Array<{
 		groupId: string

--- a/apps/ui/src/client/routes/admin/user-detail.tsx
+++ b/apps/ui/src/client/routes/admin/user-detail.tsx
@@ -24,6 +24,7 @@ import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 
 import { IpHistoryCard } from '@/components/ip-history-card'
+import { MemberAvatar } from '@/components/member-avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -71,7 +72,6 @@ import { useCorporations } from '@/hooks/useCorporations'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { api } from '@/lib/api'
 import { formatDateTime, formatRelativeTime } from '@/lib/date-utils'
-import { characterPortraitUrl } from '@/lib/eve-images'
 import { cn } from '@/lib/utils'
 
 import type { BlacklistTargetType, DiscordRefreshOutput } from '@/lib/api'
@@ -576,9 +576,12 @@ export default function UserDetailPage() {
 				<CardContent className="pt-6">
 					<div className="flex items-start gap-6">
 						{primaryCharacter ? (
-							<img
-								src={characterPortraitUrl(primaryCharacter.characterId, 128)}
-								alt={primaryCharacterName || 'Unknown'}
+							<MemberAvatar
+								characterId={primaryCharacter.characterId}
+								characterName={primaryCharacterName}
+								isBlacklisted={Boolean(primaryCharacter.isBlacklisted)}
+								size="auto"
+								imageSize={128}
 								className="h-24 w-24 rounded-full"
 							/>
 						) : (
@@ -590,7 +593,14 @@ export default function UserDetailPage() {
 							<div className="flex items-start justify-between">
 								<div>
 									<div className="flex items-center justify-between gap-2">
-										<h2 className="text-2xl font-bold">{primaryCharacterName || 'Unknown'}</h2>
+										<h2
+											className={cn(
+												'text-2xl font-bold',
+												(activeBlacklist || primaryCharacter?.isBlacklisted) && 'text-red-500'
+											)}
+										>
+											{primaryCharacterName || 'Unknown'}
+										</h2>
 										{user.is_admin && (
 											<Badge variant="default">
 												<Shield className="h-3 w-3 mr-1" />
@@ -1139,13 +1149,19 @@ export default function UserDetailPage() {
 								>
 									<TableCell>
 										<div className="flex items-center gap-3">
-											<img
-												src={characterPortraitUrl(character.characterId, 64)}
-												alt={character.characterName}
+											<MemberAvatar
+												characterId={character.characterId}
+												characterName={character.characterName}
+												isBlacklisted={character.isBlacklisted}
+												size="auto"
 												className="h-10 w-10 rounded-full"
 											/>
 											<div>
-												<div className="font-medium">{character.characterName}</div>
+												<div
+													className={cn('font-medium', character.isBlacklisted && 'text-red-500')}
+												>
+													{character.characterName}
+												</div>
 												<div className="text-xs text-muted-foreground">{character.characterId}</div>
 												<div className="mt-1 flex gap-2">
 													{character.is_primary && <Badge variant="default">Primary</Badge>}

--- a/apps/ui/src/test/unit/features/applications/profile-navigation.unit.test.ts
+++ b/apps/ui/src/test/unit/features/applications/profile-navigation.unit.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getApplicationProfileNavigationFromReferrer } from '@/features/applications/utils/profile-navigation'
+
+describe('getApplicationProfileNavigationFromReferrer', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('derives application back context from a same-origin referrer', () => {
+		vi.stubGlobal('window', { location: { origin: 'https://pleaseignore.app' } })
+		vi.stubGlobal('document', {
+			referrer: 'https://pleaseignore.app/corporations/123/applications/456?tab=messages#notes',
+		} as Document)
+
+		expect(getApplicationProfileNavigationFromReferrer()).toEqual({
+			source: 'applications',
+			returnTo: '/corporations/123/applications/456?tab=messages#notes',
+			corporationId: '123',
+		})
+	})
+
+	it('ignores cross-origin referrers', () => {
+		vi.stubGlobal('window', { location: { origin: 'https://pleaseignore.app' } })
+		vi.stubGlobal('document', { referrer: 'https://example.com/corporations/123/applications/456' })
+
+		expect(getApplicationProfileNavigationFromReferrer()).toBeNull()
+	})
+
+	it('ignores referrers that are not application review pages', () => {
+		vi.stubGlobal('window', { location: { origin: 'https://pleaseignore.app' } })
+		vi.stubGlobal('document', { referrer: 'https://pleaseignore.app/hr/users' })
+
+		expect(getApplicationProfileNavigationFromReferrer()).toBeNull()
+	})
+})

--- a/apps/universe/src/durable-object.ts
+++ b/apps/universe/src/durable-object.ts
@@ -1,7 +1,7 @@
 import { DurableObject } from 'cloudflare:workers'
 import { alias } from 'drizzle-orm/pg-core'
 
-import { and, eq, gt, ilike, inArray, ne, sql } from '@repo/db-utils'
+import { and, asc, eq, gt, ilike, inArray, ne, sql } from '@repo/db-utils'
 import { getStub, LRUCache, withRpcResult } from '@repo/do-utils'
 import { buildPublicEsiUserKey, EsiRateLimitGuard, EsiRateLimitStore } from '@repo/esi-rate-limit'
 import { logger } from '@repo/hono-helpers'
@@ -88,6 +88,7 @@ import type { Env } from './context'
 let allSolarSystemNamesCache: Array<{ id: string; name: string }> | null = null
 let allSolarSystemNamesCacheExpiry = 0
 const UNIVERSE_BATCH_SIZE = 500
+const EVE_SHIP_CATEGORY_ID = '6'
 const STRUCTURE_FUEL_RULE_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
 type StructureFuelRuleCache = {
@@ -2493,8 +2494,7 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 	}
 
 	/**
-	 * Search for types by name (partial LIKE match)
-	 * Only returns published types. Results ordered by name.
+	 * Search for types by name (partial LIKE match).
 	 */
 	async searchTypes(query: string, limit: number = 20): Promise<InvType[]> {
 		if (!query || query.trim().length < 2) return []
@@ -2506,6 +2506,35 @@ export class UniverseDO extends DurableObject<Env, {}> implements Universe {
 			.limit(limit)
 
 		return results.map((r) => ({ ...r }))
+	}
+
+	/**
+	 * Search published ship types by name (partial LIKE match).
+	 * Category 6 is the SDE category for ships; joining through inventory groups
+	 * keeps modules, structures, rigs, and other published types out of this UI.
+	 */
+	async searchShipTypes(
+		query: string,
+		limit: number = 20
+	): Promise<Array<{ typeId: string; typeName: string }>> {
+		if (!query || query.trim().length < 2) return []
+
+		return this.db
+			.select({
+				typeId: invTypes.typeId,
+				typeName: invTypes.typeName,
+			})
+			.from(invTypes)
+			.innerJoin(invGroups, eq(invTypes.groupId, invGroups.groupId))
+			.where(
+				and(
+					ilike(invTypes.typeName, `%${query}%`),
+					eq(invTypes.published, true),
+					eq(invGroups.categoryId, EVE_SHIP_CATEGORY_ID)
+				)
+			)
+			.orderBy(asc(invTypes.typeName))
+			.limit(limit)
 	}
 
 	// ========================================================================

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -152,6 +152,7 @@ export interface UserDetails {
 	id: string
 	mainCharacterId: string
 	is_admin: boolean
+	isBlacklisted: boolean
 	discordUserId: string | null
 	discord: DiscordStatus | null
 	characters: CharacterSummary[]
@@ -471,18 +472,28 @@ function parseEsiScope(scope: (typeof THIRD_PARTY_APP_ESI_SCOPES)[number]): {
 }
 
 function describeEsiAction(action: string): string {
-	if (action.startsWith('read_')) return `Read ${action.slice('read_'.length).replaceAll('_', ' ')}.`
-	if (action.startsWith('write_')) return `Modify ${action.slice('write_'.length).replaceAll('_', ' ')}.`
-	if (action.startsWith('send_')) return `Send ${action.slice('send_'.length).replaceAll('_', ' ')}.`
-	if (action.startsWith('respond_')) return `Respond to ${action.slice('respond_'.length).replaceAll('_', ' ')}.`
-	if (action.startsWith('track_')) return `Track ${action.slice('track_'.length).replaceAll('_', ' ')}.`
-	if (action.startsWith('open_')) return `Open ${action.slice('open_'.length).replaceAll('_', ' ')} in the EVE client.`
-	if (action.startsWith('manage_')) return `Manage ${action.slice('manage_'.length).replaceAll('_', ' ')}.`
-	if (action.startsWith('organize_')) return `Organize ${action.slice('organize_'.length).replaceAll('_', ' ')}.`
+	if (action.startsWith('read_'))
+		return `Read ${action.slice('read_'.length).replaceAll('_', ' ')}.`
+	if (action.startsWith('write_'))
+		return `Modify ${action.slice('write_'.length).replaceAll('_', ' ')}.`
+	if (action.startsWith('send_'))
+		return `Send ${action.slice('send_'.length).replaceAll('_', ' ')}.`
+	if (action.startsWith('respond_'))
+		return `Respond to ${action.slice('respond_'.length).replaceAll('_', ' ')}.`
+	if (action.startsWith('track_'))
+		return `Track ${action.slice('track_'.length).replaceAll('_', ' ')}.`
+	if (action.startsWith('open_'))
+		return `Open ${action.slice('open_'.length).replaceAll('_', ' ')} in the EVE client.`
+	if (action.startsWith('manage_'))
+		return `Manage ${action.slice('manage_'.length).replaceAll('_', ' ')}.`
+	if (action.startsWith('organize_'))
+		return `Organize ${action.slice('organize_'.length).replaceAll('_', ' ')}.`
 	return titleCase(action)
 }
 
-function buildEsiScopeMetadata(scope: (typeof THIRD_PARTY_APP_ESI_SCOPES)[number]): ThirdPartyAppScopeMetadata {
+function buildEsiScopeMetadata(
+	scope: (typeof THIRD_PARTY_APP_ESI_SCOPES)[number]
+): ThirdPartyAppScopeMetadata {
 	const { domain, action } = parseEsiScope(scope)
 	const domainLabel = ESI_DOMAIN_LABELS[domain] ?? titleCase(domain)
 	const actionLabel = titleCase(action)
@@ -717,9 +728,7 @@ export function normalizeSidebarExternalLinkIconName(
 	return null
 }
 
-export function resolveSidebarExternalLinkIconName(
-	value: string
-): SidebarExternalLinkIconName {
+export function resolveSidebarExternalLinkIconName(value: string): SidebarExternalLinkIconName {
 	return normalizeSidebarExternalLinkIconName(value) ?? 'external-link'
 }
 
@@ -783,10 +792,7 @@ export interface SidebarExternalLinkUpdateInput {
 export interface ThirdPartyAppsAdminWorker {
 	listClients(options?: OAuthClientListOptions): Promise<OAuthClientListResult>
 	createClient(input: OAuthClientCreateInput): Promise<OAuthClientSummary>
-	updateClient(
-		clientId: string,
-		input: OAuthClientUpdateInput
-	): Promise<OAuthClientSummary | null>
+	updateClient(clientId: string, input: OAuthClientUpdateInput): Promise<OAuthClientSummary | null>
 	deleteClient(clientId: string): Promise<void>
 	regenerateClientSecret(clientId: string): Promise<OAuthClientSecretResult | null>
 	previewAuthorization(

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -479,6 +479,11 @@ export interface Discord {
 	getDiscordUserStatus(coreUserId: string): Promise<DiscordUserStatus | null>
 
 	/**
+	 * Get Discord statuses for multiple core users in one database query.
+	 */
+	getDiscordUserStatuses(coreUserIds: string[]): Promise<Record<string, DiscordUserStatus>>
+
+	/**
 	 * Update the last refreshed timestamp for a Discord user
 	 * @param coreUserId - Core user ID
 	 */

--- a/packages/esi/src/request.test.ts
+++ b/packages/esi/src/request.test.ts
@@ -46,6 +46,42 @@ describe('ESI request helpers', () => {
 		)
 	})
 
+	it('fetches and combines all X-Pages results', async () => {
+		const fetchSpy = vi.fn().mockImplementation((url: string) => {
+			const page = new URL(url).searchParams.get('page')
+			const rows = page === '1' ? [{ id: 1 }] : [{ id: 2 }]
+			return Promise.resolve(
+				new Response(JSON.stringify(rows), {
+					status: 200,
+					headers: {
+						'Content-Type': 'application/json',
+						'X-Pages': '2',
+					},
+				})
+			)
+		})
+		const client = new EsiRequestClient({
+			rateLimits: new EsiRateLimitStore(new MemoryKv() as never),
+			fetchImpl: fetchSpy,
+		})
+
+		const response = await client.requestPaginated<{ id: number }>({
+			path: '/characters/123/wallet/journal',
+			userKey: 'character:123',
+			cacheMode: 'no-store',
+			parse: async (res) => (await res.json()) as Array<{ id: number }>,
+			buildError: () => new Error('unexpected'),
+		})
+
+		expect(response.data).toEqual([{ id: 1 }, { id: 2 }])
+		expect(response.pages).toBe(2)
+		expect(fetchSpy).toHaveBeenCalledTimes(2)
+		expect(fetchSpy.mock.calls.map(([url]) => new URL(url).searchParams.get('page'))).toEqual([
+			'1',
+			'2',
+		])
+	})
+
 	it('returns cached responses without fetching when the cache is fresh', async () => {
 		const cache = {
 			getCachedResponse: vi.fn().mockResolvedValue({

--- a/packages/hr/src/index.ts
+++ b/packages/hr/src/index.ts
@@ -423,6 +423,12 @@ export interface ApplicationListResult {
 	}
 }
 
+export interface CorporationApplicationCounts {
+	corporationId: string
+	pending: number
+	underReview: number
+}
+
 /**
  * Filters for listing HR notes
  */
@@ -514,6 +520,15 @@ export interface Hr extends DurableObject {
 	): Promise<ApplicationListResult>
 
 	/**
+	 * Count open applications grouped by corporation without loading application rows.
+	 */
+	getApplicationCountsByCorporation(
+		corporationIds: string[],
+		userId: string,
+		access: HrAccessContext
+	): Promise<CorporationApplicationCounts[]>
+
+	/**
 	 * Get a single application with recommendations
 	 * @param applicationId - Application ID to retrieve
 	 * @param userId - ID of the requesting user
@@ -550,7 +565,12 @@ export interface Hr extends DurableObject {
 	 * @param characterId - Character ID of user withdrawing
 	 * @param characterName - Character name for activity log
 	 */
-	withdrawApplication(applicationId: string, userId: string, characterId: string, characterName: string): Promise<void>
+	withdrawApplication(
+		applicationId: string,
+		userId: string,
+		characterId: string,
+		characterName: string
+	): Promise<void>
 
 	/**
 	 * Add an alt character to a pending application (applicant only)

--- a/packages/universe/src/index.ts
+++ b/packages/universe/src/index.ts
@@ -233,6 +233,12 @@ export interface Universe {
 	 */
 	searchTypes(query: string, limit?: number): Promise<InvType[]>
 
+	/** Search published ship types by name for ship-picker UIs. */
+	searchShipTypes(
+		query: string,
+		limit?: number
+	): Promise<Array<{ typeId: string; typeName: string }>>
+
 	/**
 	 * Resolve multiple type details by their IDs
 	 * @param typeIds - Array of type IDs to resolve


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
This PR bundles a set of HR/user-search UX improvements with backend hardening: it extends the RPC-dispose fix from #624 to more Durable Object call sites, fixes the doctrine fitting ship picker returning non-ship results, and adds a global HR user-search directory with blacklist visibility and cross-tab profile navigation.

## Changes
- **RPC dispose pattern**: widened the `withRpcResult`/`disposeRpcResult` pattern (introduced in #624) to `groups-cache.ts`, `core-rpc.service.ts`, `routes/hr.ts`, `routes/doctrines.ts`, and `doctrines/durable-object.ts` so cross-DO RPC results are safely copied before disposal.
- **Doctrine icon search fix**: added a dedicated `UniverseDO.searchShipTypes()` (filtered to the Ships category, `published = true`) so the doctrine fitting ship picker no longer pulls in modules/rigs/structures from the generic type search.
- **Session middleware**: added `shouldBypassSessionMiddleware()` to skip session-resolution RPC calls for `/images*` requests.
- **HR user search**: new `UserSearchCard`/`HrUserSearchContent` components power a global HR directory search (name, character ID, Discord username/ID) with pagination and "Blocklisted" badges; `CorporationUserSearchDialog` was simplified to wrap the shared search content instead of duplicating it. Backed by a new `searchUsersForHrAccess()` RPC method.
- **Cross-tab profile navigation**: added `getApplicationProfileNavigationFromReferrer()` to recover application context (source, corp, return URL) via `document.referrer` when a profile page is opened in a new tab.
- **Application history panel**: switched to real `<Link>`s and now greys out/labels history entries the current user lacks HR access to.
- **Blacklist visibility**: added blacklist badges across the applications table, user search card, and contacts section (plus an `isNpcCharacterContact` helper); `getUserDetails()` gained an `includeUserBlacklist` option.
- **Resilience/performance**: `getUserProfile` no longer lets a failing preferences lookup block session auth; added batched `getDiscordUserStatuses()` to replace N+1 Discord status lookups; added `getApplicationCountsByCorporation` for a single grouped-count query; ESI wallet journal fetches now paginate via `fetchEsiPaginated`; `eve-token-store` refresh alarm/cooldown handling made more defensive.

## Testing
- Added/updated unit and route tests: `session-middleware.test.ts`, `profile-navigation.unit.test.ts`, `application.service.counts.test.ts`, expanded `hr.access-matrix.route.test.ts`, and updates to `corporations.access`, `corporations.detail`, `corporations.members.access`, and `users.corporation-access` route tests, plus a new pagination test in `packages/esi/src/request.test.ts`.
<!-- claude:end -->