### PR TITLE
fix fulcrum report url and breadcrumbs

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -223,6 +223,9 @@ const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY = 'shared:sovereignty-systems
 const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS = 2 * 60
 const ORBITAL_SKYHOOK_TYPE_ID = '81080'
 const STRUCTURE_ENRICHMENT_PRIORITY_LIMIT = 100
+// Keep asset upserts bounded while avoiding one database round trip per small slice.
+// Ten persisted fields per row keeps 500 rows well below PostgreSQL's parameter limit.
+const CORPORATION_ASSET_INSERT_BATCH_SIZE = 500
 const STRUCTURE_INVENTORY_ASSET_BATCH_SIZE = 250
 const STRUCTURE_SNAPSHOT_BATCH_SIZE = 10
 const STRUCTURE_CLEANUP_BATCH_SIZE = 250
@@ -2347,9 +2350,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		observedAt: Date
 	): Promise<void> {
 		const dedupedAssets = dedupeByItemId(assets, (asset) => String(asset.item_id))
-		const BATCH_SIZE = 25
-		for (let i = 0; i < dedupedAssets.length; i += BATCH_SIZE) {
-			const batch = dedupedAssets.slice(i, i + BATCH_SIZE)
+		for (let i = 0; i < dedupedAssets.length; i += CORPORATION_ASSET_INSERT_BATCH_SIZE) {
+			const batch = dedupedAssets.slice(i, i + CORPORATION_ASSET_INSERT_BATCH_SIZE)
 			const valuesToInsert = batch.map((asset) => ({
 				corporationId: String(corporationId),
 				itemId: asset.item_id,

--- a/apps/ui/src/client/App.tsx
+++ b/apps/ui/src/client/App.tsx
@@ -8,6 +8,8 @@ import { installTaxDemoWindow } from './dev/tax-demo-mode'
 import { useAuth } from './hooks/useAuth'
 import { useSessionSync } from './hooks/useSessionSync'
 import { useUserPermissions } from './hooks/useUserPermissions'
+import { logApiError } from './lib/api'
+import toast from './lib/toast'
 import AuthCallbackPage from './routes/auth-callback'
 import BroadcastDetailPage from './routes/broadcast-detail'
 import BroadcastsPage from './routes/broadcasts'
@@ -25,16 +27,14 @@ import InvitationsPage from './routes/invitations'
 import LandingPage from './routes/landing'
 import LegacyAuthCallbackPage from './routes/legacy-auth-callback'
 import MumblePage from './routes/mumble'
-import OAuthAuthorizePage from './routes/oauth-authorize'
 import MyGroupsPage from './routes/my-groups'
-import PasteViewPage from './routes/paste-view'
-import TempopGuestPage from './routes/tempop-guest'
+import OAuthAuthorizePage from './routes/oauth-authorize'
 import PasteEditPage from './routes/paste-edit'
+import PasteViewPage from './routes/paste-view'
 import PastesPage from './routes/pastes'
 import { adminRouteElements } from './routes/route-groups/admin-routes'
 import { taxRouteElements } from './routes/route-groups/tax-routes'
-import { logApiError } from './lib/api'
-import toast from './lib/toast'
+import TempopGuestPage from './routes/tempop-guest'
 
 const CorporationMembers = lazy(() => import('./features/corporations/routes/corporation-members'))
 const CorporationSettings = lazy(
@@ -89,9 +89,7 @@ const TrackingSessionDetail = lazy(
 	() => import('./features/fleet-tracking/routes/tracking-session-detail')
 )
 const SessionTimeline = lazy(() => import('./features/fleet-tracking/routes/session-timeline'))
-const MemberShipHistory = lazy(
-	() => import('./features/fleet-tracking/routes/member-ship-history')
-)
+const MemberShipHistory = lazy(() => import('./features/fleet-tracking/routes/member-ship-history'))
 const FleetStatsOverview = lazy(() => import('./features/fleet-tracking/routes/stats-overview'))
 const FleetCharacterStats = lazy(() => import('./features/fleet-tracking/routes/character-stats'))
 const FleetUserStats = lazy(() => import('./features/fleet-tracking/routes/user-stats'))
@@ -432,7 +430,7 @@ export default function App() {
 								}
 							/>
 							<Route
-								path="/fulcrum/reports/:reportId"
+								path="/corporations/:corporationId/members/:accountId/reports/:reportId"
 								element={
 									<Suspense fallback={<LoadingPage />}>
 										<FulcrumReport />
@@ -447,10 +445,7 @@ export default function App() {
 									</Suspense>
 								}
 							/>
-							<Route
-								path="/hr/users/:userId"
-								element={<HrUserProfileRoute />}
-							/>
+							<Route path="/hr/users/:userId" element={<HrUserProfileRoute />} />
 							<Route
 								path="/hr/users/:userId/reports/:reportId"
 								element={

--- a/apps/ui/src/client/features/applications/components/fulcrum-panel.tsx
+++ b/apps/ui/src/client/features/applications/components/fulcrum-panel.tsx
@@ -9,7 +9,7 @@
 import { formatDistanceToNow } from 'date-fns'
 import { AlertCircle, Clock, ExternalLink, FileText, Loader2, RefreshCw, Users } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { Link, useParams } from 'react-router'
+import { Link } from 'react-router'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -24,7 +24,6 @@ import {
 } from '@/components/ui/dialog'
 import { LoadingSpinner } from '@/components/ui/loading'
 import { Separator } from '@/components/ui/separator'
-import { CharacterIdentitySummary } from './character-identity-summary'
 
 import {
 	useFulcrumUserReports,
@@ -32,6 +31,7 @@ import {
 	useRequestFulcrumReport,
 	useRequestFulcrumReportBatch,
 } from '../hooks'
+import { CharacterIdentitySummary } from './character-identity-summary'
 
 import type { CharacterReportMetadata } from '../api'
 
@@ -68,7 +68,7 @@ function getReportStatusBadge(status: string) {
 function getLatestReport(reports: CharacterReportMetadata[]): CharacterReportMetadata | null {
 	if (reports.length === 0) return null
 	return reports.reduce((latest, r) =>
-		new Date(r.createdAt) > new Date(latest.createdAt) ? r : latest,
+		new Date(r.createdAt) > new Date(latest.createdAt) ? r : latest
 	)
 }
 
@@ -83,17 +83,8 @@ function canRequestNewReport(reports: CharacterReportMetadata[]): boolean {
 interface CharacterReportCardProps {
 	character: PanelCharacterRow
 	onRequest: () => void
-	getReportTarget: (reportId: string, characterName: string) => {
-		pathname: string
-		search: string
-		state: {
-			characterName: string
-			userId: string
-			corporationId: string
-			returnTo: string
-			backLabel: string
-			breadcrumbParentLabel: string
-		}
+	getReportTarget: (reportId: string) => {
+		to: string
 	}
 	isRequesting: boolean
 	requestingCharacterId: string | null
@@ -123,7 +114,10 @@ function CharacterReportCard({
 }: CharacterReportCardProps) {
 	const latestReport = getLatestReport(character.reports)
 	const isThisRequesting =
-		isRequesting && (requestingCharacterId === null || requestingCharacterId === character.characterId)
+		isRequesting &&
+		(requestingCharacterId === null || requestingCharacterId === character.characterId)
+	const reportTarget =
+		latestReport?.status === 'completed' ? getReportTarget(latestReport.id) : null
 
 	return (
 		<div className="card-gradient flex items-start gap-4 rounded-lg border border-border/50 bg-card p-4 shadow-elevated">
@@ -152,8 +146,7 @@ function CharacterReportCard({
 						{latestReport.status === 'completed' && latestReport.expiresAt && (
 							<div className="flex items-center gap-1 text-xs text-muted-foreground">
 								<Clock className="h-3 w-3" />
-								Expires{' '}
-								{formatDistanceToNow(new Date(latestReport.expiresAt), { addSuffix: true })}
+								Expires {formatDistanceToNow(new Date(latestReport.expiresAt), { addSuffix: true })}
 							</div>
 						)}
 
@@ -178,9 +171,9 @@ function CharacterReportCard({
 
 			{/* Actions */}
 			<div className="flex flex-col gap-2">
-				{latestReport?.status === 'completed' && (
+				{reportTarget && (
 					<Button asChild variant="ghost" size="sm">
-						<Link to={getReportTarget(latestReport.id, character.characterName)}>
+						<Link to={reportTarget.to}>
 							<ExternalLink className="mr-1.5 h-3.5 w-3.5" />
 							View
 						</Link>
@@ -216,7 +209,7 @@ function CharacterReportCard({
 interface FulcrumPanelProps {
 	userId: string
 	corporationId: string
-	applicationId?: string
+	applicationId: string
 	mainCharacterId?: string
 	altCharacterIds?: string[]
 	canRequestCharacterReport?: (character: PanelCharacterRow) => boolean
@@ -232,7 +225,6 @@ export function FulcrumPanel({
 	canRequestCharacterReport,
 	enabled = true,
 }: FulcrumPanelProps) {
-	const { corporationId: routeCorporationId } = useParams<{ corporationId: string }>()
 	const { data: reportCharacters = [], isLoading, error } = useFulcrumUserReports(userId, enabled)
 	const { data: hrCharacters = [] } = useHrUserCharacters(userId, {
 		enabled: !!userId && enabled,
@@ -271,7 +263,8 @@ export function FulcrumPanel({
 	const requestReportBatch = useRequestFulcrumReportBatch()
 	const [sendDmForScanRequests, setSendDmForScanRequests] = useState(getInitialSendDmPreference)
 	const [scanAllDialogOpen, setScanAllDialogOpen] = useState(false)
-	const [scanSingleDialogCharacter, setScanSingleDialogCharacter] = useState<PanelCharacterRow | null>(null)
+	const [scanSingleDialogCharacter, setScanSingleDialogCharacter] =
+		useState<PanelCharacterRow | null>(null)
 	const [isRequestingAll, setIsRequestingAll] = useState(false)
 
 	if (!enabled) {
@@ -295,36 +288,9 @@ export function FulcrumPanel({
 		})
 	}
 
-	const getReportTarget = (reportId: string, characterName: string) => {
-		const resolvedCorporationId = routeCorporationId ?? corporationId
-		const returnTo = applicationId
-			? `/corporations/${resolvedCorporationId}/applications/${applicationId}`
-			: `/corporations/${resolvedCorporationId}/members/${userId}`
-		const backLabel = applicationId ? 'Back to Application' : 'Back to User Profile'
-		const breadcrumbParentLabel = applicationId ? 'Application' : 'User Profile'
-		const search = new URLSearchParams({
-			characterName,
-			userId,
-			corporationId,
-			returnTo,
-			backLabel,
-			breadcrumbParentLabel,
-		}).toString()
-		return {
-			pathname: applicationId
-				? `/corporations/${resolvedCorporationId}/applications/${applicationId}/reports/${reportId}`
-				: `/fulcrum/reports/${reportId}`,
-			search: `?${search}`,
-			state: {
-				characterName,
-				userId,
-				corporationId,
-				returnTo,
-				backLabel,
-				breadcrumbParentLabel,
-			},
-		}
-	}
+	const getReportTarget = (reportId: string) => ({
+		to: `/corporations/${corporationId}/applications/${applicationId}/reports/${reportId}`,
+	})
 
 	if (isLoading) {
 		return (
@@ -353,12 +319,17 @@ export function FulcrumPanel({
 
 	const requestableCharacters = characters.filter(
 		(character) =>
-			canRequestNewReport(character.reports) &&
-			(canRequestCharacterReport?.(character) ?? true)
+			canRequestNewReport(character.reports) && (canRequestCharacterReport?.(character) ?? true)
 	)
 
 	const handleConfirmSingle = () => {
-		if (!scanSingleDialogCharacter || isRequestingAll || requestReport.isPending || requestReportBatch.isPending) return
+		if (
+			!scanSingleDialogCharacter ||
+			isRequestingAll ||
+			requestReport.isPending ||
+			requestReportBatch.isPending
+		)
+			return
 		persistSendDmPreference(sendDmForScanRequests)
 		const characterId = scanSingleDialogCharacter.characterId
 		setScanSingleDialogCharacter(null)
@@ -366,7 +337,13 @@ export function FulcrumPanel({
 	}
 
 	const handleConfirmRequestAll = async () => {
-		if (requestableCharacters.length === 0 || isRequestingAll || requestReport.isPending || requestReportBatch.isPending) return
+		if (
+			requestableCharacters.length === 0 ||
+			isRequestingAll ||
+			requestReport.isPending ||
+			requestReportBatch.isPending
+		)
+			return
 		persistSendDmPreference(sendDmForScanRequests)
 		setScanAllDialogOpen(false)
 		setIsRequestingAll(true)
@@ -409,7 +386,8 @@ export function FulcrumPanel({
 		setScanAllDialogOpen(true)
 	}
 
-	const isAnyRequestPending = requestReport.isPending || requestReportBatch.isPending || isRequestingAll
+	const isAnyRequestPending =
+		requestReport.isPending || requestReportBatch.isPending || isRequestingAll
 
 	// Split characters into application chars (main + alts) and other chars
 	const applicationCharacterIds = mainCharacterId
@@ -430,11 +408,11 @@ export function FulcrumPanel({
 				onRequest={() => handleOpenSingleDialog(character)}
 				getReportTarget={getReportTarget}
 				isRequesting={isAnyRequestPending}
-				canRequest={canRequestNewReport(character.reports) && (canRequestCharacterReport?.(character) ?? true)}
+				canRequest={
+					canRequestNewReport(character.reports) && (canRequestCharacterReport?.(character) ?? true)
+				}
 				requestingCharacterId={
-					requestReport.isPending
-						? (requestReport.variables?.characterId ?? null)
-						: null
+					requestReport.isPending ? (requestReport.variables?.characterId ?? null) : null
 				}
 			/>
 		))
@@ -466,9 +444,7 @@ export function FulcrumPanel({
 				</>
 			)}
 
-			{applicationCharacters.length > 0 && otherCharacters.length > 0 && (
-				<Separator />
-			)}
+			{applicationCharacters.length > 0 && otherCharacters.length > 0 && <Separator />}
 
 			{otherCharacters.length > 0 && (
 				<>
@@ -514,15 +490,16 @@ export function FulcrumPanel({
 				</DialogContent>
 			</Dialog>
 
-			<Dialog open={scanSingleDialogCharacter !== null} onOpenChange={(open) => !open && setScanSingleDialogCharacter(null)}>
+			<Dialog
+				open={scanSingleDialogCharacter !== null}
+				onOpenChange={(open) => !open && setScanSingleDialogCharacter(null)}
+			>
 				<DialogContent className="sm:max-w-[500px]">
 					<DialogHeader>
 						<DialogTitle>
 							Generate Report For {scanSingleDialogCharacter?.characterName ?? 'Character'}?
 						</DialogTitle>
-						<DialogDescription>
-							This will queue one character report.
-						</DialogDescription>
+						<DialogDescription>This will queue one character report.</DialogDescription>
 					</DialogHeader>
 					<div className="space-y-2">
 						<label

--- a/apps/ui/src/client/features/applications/routes/corporations.tsx
+++ b/apps/ui/src/client/features/applications/routes/corporations.tsx
@@ -86,6 +86,22 @@ function CorporationCoverageBars({ coverage }: { coverage: CorporationCoverageSt
 	)
 }
 
+function CorporationCoverageBarsSkeleton() {
+	return (
+		<div className="w-44 space-y-2" aria-label="Loading ESI coverage">
+			{Array.from({ length: 2 }, (_, index) => (
+				<div className="space-y-1" key={index}>
+					<div className="flex items-center justify-between gap-2">
+						<Skeleton className="h-3 w-28" />
+						<Skeleton className="h-3 w-10" />
+					</div>
+					<Skeleton className="h-1.5 w-full" />
+				</div>
+			))}
+		</div>
+	)
+}
+
 export default function CorporationsPage() {
 	const { user, isAuthenticated, isLoading: authLoading, permissions } = useAuth()
 	const isAuditor = useMemo(
@@ -101,7 +117,8 @@ export default function CorporationsPage() {
 		error,
 	} = useHrAccessibleCorporations()
 	const { data: corporationAccess } = useCorporationAccess()
-	const { data: corporationCoverage } = useCorporationCoverage()
+	const { data: corporationCoverage, isLoading: corporationCoverageLoading } =
+		useCorporationCoverage()
 	const { data: applicationCounts = [], isLoading: applicationCountsLoading } =
 		useCorporationApplicationCounts()
 	const availableCorporationTypes = useMemo(() => {
@@ -343,10 +360,15 @@ export default function CorporationsPage() {
 								</div>
 								<div className="justify-self-end self-end">
 									{coverageStats ||
+									corporationCoverageLoading ||
 									hasVisibleCounts ||
 									(canViewApplications && applicationCountsLoading) ? (
 										<div className="flex flex-col items-end gap-2">
-											{coverageStats && <CorporationCoverageBars coverage={coverageStats} />}
+											{coverageStats ? (
+												<CorporationCoverageBars coverage={coverageStats} />
+											) : corporationCoverageLoading ? (
+												<CorporationCoverageBarsSkeleton />
+											) : null}
 											<div className="flex flex-wrap items-center justify-end gap-2">
 												{canViewApplications && applicationCountsLoading && (
 													<Skeleton className="h-5 w-20" />

--- a/apps/ui/src/client/features/applications/routes/fulcrum-report.tsx
+++ b/apps/ui/src/client/features/applications/routes/fulcrum-report.tsx
@@ -6,7 +6,7 @@
  */
 
 import { ArrowLeft } from 'lucide-react'
-import { useLocation, useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 
 import {
 	Breadcrumb,
@@ -18,75 +18,88 @@ import {
 } from '@/components/ui/breadcrumb'
 import { Button } from '@/components/ui/button'
 import { Container } from '@/components/ui/container'
+import { useEntityNames } from '@/hooks/useEntityNames'
 import { usePageTitle } from '@/hooks/usePageTitle'
-import { useUserPermissions } from '@/hooks/useUserPermissions'
 
+import { useCorporationMemberAccount } from '../../corporations/hooks'
 import { FulcrumReportViewer } from '../components/fulcrum-report-viewer'
+import { useApplication, useHrUserCharacters, useReportSections } from '../hooks'
 
 export default function FulcrumReportPage() {
-	const { reportId, userId: routeUserId, corporationId: routeCorporationId, applicationId: routeApplicationId } = useParams<{
+	const {
+		reportId,
+		userId: routeUserId,
+		corporationId: routeCorporationId,
+		applicationId: routeApplicationId,
+		accountId: routeAccountId,
+	} = useParams<{
 		reportId: string
 		userId?: string
 		corporationId?: string
 		applicationId?: string
+		accountId?: string
 	}>()
-	const location = useLocation()
 	const navigate = useNavigate()
-	const { hasAnyPermission } = useUserPermissions()
-	const isAuditor = hasAnyPermission('urn:hr:auditor')
+	const userId = routeUserId
+	const corporationId = routeCorporationId
+	const applicationId = routeApplicationId
+	const accountId = routeAccountId
 
-	const state = location.state as
-		| {
-			characterName?: string
-			returnTo?: string
-			userId?: string
-			corporationId?: string
-			backLabel?: string
-			breadcrumbParentLabel?: string
-		}
-		| null
-	const query = new URLSearchParams(location.search)
-	const characterName = state?.characterName ?? query.get('characterName') ?? undefined
-	const returnTo = state?.returnTo ?? query.get('returnTo') ?? undefined
-	const userId = routeUserId ?? state?.userId ?? query.get('userId') ?? undefined
-	const corporationId = routeCorporationId ?? state?.corporationId ?? query.get('corporationId') ?? undefined
-	const applicationId = routeApplicationId ?? query.get('applicationId') ?? undefined
+	const reportSource =
+		applicationId && corporationId
+			? 'application'
+			: accountId && corporationId
+				? 'member'
+				: userId
+					? 'user'
+					: null
+	const { data: application } = useApplication(applicationId ?? '', {
+		enabled: reportSource === 'application',
+	})
+	const { data: memberAccount } = useCorporationMemberAccount(corporationId ?? '', accountId ?? '')
+	const { data: userCharacters = [] } = useHrUserCharacters(userId ?? '', {
+		enabled: reportSource === 'user',
+	})
+	const { data: manifest } = useReportSections(reportId ?? '', !!reportId)
+	const { data: characterNames = {} } = useEntityNames(
+		manifest?.characterId ? [manifest.characterId] : [],
+		{ enabled: !!manifest?.characterId }
+	)
 
-	const routeScopedBackPath = applicationId && corporationId
-		? `/corporations/${corporationId}/applications/${applicationId}`
-		: userId
-			? `/hr/users/${userId}`
-			: undefined
-
-	const roleBasedBackPath = isAuditor && userId
-		? `/hr/users/${userId}`
-		: corporationId && userId
-			? `/corporations/${corporationId}/members/${userId}`
-			: '/corporations'
-
-	const backPath = returnTo ?? routeScopedBackPath ?? roleBasedBackPath
-	const isUserProfileBackPath = backPath.includes('/members/')
-		|| backPath.includes('/hr/users/')
-		|| backPath.includes('/hr/auditor/users/')
-	const isApplicationBackPath = backPath.includes('/applications/')
-	const backLabel =
-		state?.backLabel
-		?? query.get('backLabel')
-		?? (isApplicationBackPath
-			? 'Back to Application'
-			: isUserProfileBackPath
-				? 'Back to User Profile'
-				: 'Back to Corporations')
-	const breadcrumbParentLabel =
-		state?.breadcrumbParentLabel
-		?? query.get('breadcrumbParentLabel')
-		?? (isApplicationBackPath ? 'Application' : isUserProfileBackPath ? 'User Profile' : 'Reports')
-
+	const characterName = manifest?.characterId ? characterNames[manifest.characterId] : undefined
+	const sourceUserName =
+		reportSource === 'application'
+			? application?.characterName
+			: reportSource === 'member'
+				? memberAccount?.account.mainName
+				: userCharacters[0]?.characterName
+	const displaySourceUserName = sourceUserName ?? characterName
+	const backPath =
+		reportSource === 'application'
+			? `/corporations/${corporationId}/applications/${applicationId}`
+			: reportSource === 'member'
+				? `/corporations/${corporationId}/members/${accountId}`
+				: reportSource === 'user'
+					? `/hr/users/${userId}`
+					: null
 	usePageTitle(characterName ? `Report - ${characterName}` : 'Character Report')
 
-	if (!reportId) {
+	if (!reportId || !backPath) {
 		return null
 	}
+
+	const backLabel =
+		reportSource === 'application'
+			? 'Back to Application'
+			: reportSource === 'member'
+				? 'Back to Member Profile'
+				: 'Back to User Profile'
+	const breadcrumbParentLabel =
+		reportSource === 'application'
+			? 'Application'
+			: reportSource === 'member'
+				? 'Members'
+				: 'User Profile'
 
 	return (
 		<Container>
@@ -95,13 +108,17 @@ export default function FulcrumReportPage() {
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem>
-							<BreadcrumbLink to={backPath}>
-								{breadcrumbParentLabel}
-							</BreadcrumbLink>
+							<BreadcrumbLink to={backPath}>{breadcrumbParentLabel}</BreadcrumbLink>
 						</BreadcrumbItem>
 						<BreadcrumbSeparator />
 						<BreadcrumbItem>
-							<BreadcrumbPage>{characterName ? `${characterName} Report` : 'Character Report'}</BreadcrumbPage>
+							<BreadcrumbPage>{displaySourceUserName ?? breadcrumbParentLabel}</BreadcrumbPage>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator />
+						<BreadcrumbItem>
+							<BreadcrumbPage>
+								{characterName ? `${characterName} Report` : 'Character Report'}
+							</BreadcrumbPage>
 						</BreadcrumbItem>
 					</BreadcrumbList>
 				</Breadcrumb>

--- a/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-auditor-user-profile.tsx
@@ -545,13 +545,6 @@ export default function HrAuditorUserProfilePage() {
 						}
 						getReportTarget={(character) => ({
 							to: `/hr/users/${userId}/reports/${character.latestReport!.id}`,
-							state: {
-								characterName: character.characterName,
-								userId: userId ?? undefined,
-								returnTo: `${location.pathname}${location.search}`,
-								backLabel: 'Back to User Profile',
-								breadcrumbParentLabel: 'User Profile',
-							},
 						})}
 						getDetailsTarget={(character) => ({
 							to: `/character/${character.characterId}`,

--- a/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-member-profile.tsx
@@ -611,19 +611,13 @@ export default function HrMemberProfile() {
 							(requestReport.variables as { characterId?: string } | undefined)?.characterId ===
 								characterId
 						}
-						onViewReport={(character) => {
-							if (character.latestReport?.status !== 'completed') return
-							void navigate(`/fulcrum/reports/${character.latestReport.id}`, {
-								state: {
-									characterName: character.characterName,
-									userId: accountId,
-									corporationId,
-									returnTo: `/corporations/${corporationId}/members/${accountId}`,
-									backLabel: 'Back to User Profile',
-									breadcrumbParentLabel: 'User Profile',
-								},
-							})
-						}}
+						getReportTarget={
+							corporationId && accountId
+								? (character) => ({
+										to: `/corporations/${corporationId}/members/${accountId}/reports/${character.latestReport!.id}`,
+									})
+								: undefined
+						}
 						onScan={(character) => {
 							if (!character.corporationId || !authUserId) return
 							requestReport.mutate({

--- a/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-user-profile.tsx
@@ -498,13 +498,6 @@ export default function HrUserProfilePage() {
 				}
 				getReportTarget={(character) => ({
 					to: `/hr/users/${userId}/reports/${character.latestReport!.id}`,
-					state: {
-						characterName: character.characterName,
-						userId: userId ?? undefined,
-						backTo: location.pathname + location.search,
-						backLabel: 'Back to User Details',
-						breadcrumbParentLabel: 'User Details',
-					},
 				})}
 				getDetailsTarget={(character) => ({
 					to: `/character/${character.characterId}`,


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes the Fulcrum report route and its breadcrumbs/back-navigation so they no longer depend on fragile query-string/router `state` and instead derive everything from route params and data hooks. Also bumps the corporation asset upsert batch size and adds a coverage-loading skeleton on the corporations page.

## Changes
- Replaced the standalone `/fulcrum/reports/:reportId` route with nested routes per context (`/corporations/:corporationId/members/:accountId/reports/:reportId`, plus the existing application/user routes), removing reliance on `location.state`/query params for character name, return path, and breadcrumb labels.
- Reworked `FulcrumReportPage` to resolve its "back" target, labels, and displayed character/user name from route params and the `useApplication`, `useCorporationMemberAccount`, `useHrUserCharacters`, `useReportSections`, and `useEntityNames` hooks, and to render an extra breadcrumb level for the source user/character.
- Simplified `FulcrumPanel`'s `getReportTarget` to return a plain `{ to }` link (no more manually-built search params/state), made `applicationId` required, and dropped its `useParams` usage.
- Updated `hr-user-profile.tsx`, `hr-auditor-user-profile.tsx`, and `hr-member-profile.tsx` to pass simple `{ to }` report targets instead of `state`-laden navigation, with `hr-member-profile.tsx` switching from an imperative `onViewReport` navigate call to a `getReportTarget` link builder.
- Increased `CORPORATION_ASSET_INSERT_BATCH_SIZE` for corporation asset upserts from 25 to 500 in `eve-corporation-data`'s durable object, reducing per-batch database round trips.
- Added a `CorporationCoverageBarsSkeleton` loading state to the corporations page shown while ESI coverage stats are loading.
- Minor import ordering/formatting cleanups in touched files.
<!-- claude:end -->
