### PR TITLE
reduce wallet journal paging with watermark checks

### DIFF
--- a/apps/eve-character-data/src/durable-object.ts
+++ b/apps/eve-character-data/src/durable-object.ts
@@ -1248,11 +1248,31 @@ export class EveCharacterDataDO extends DurableObject<Env> implements EveCharact
 		_forceRefresh = false
 	): Promise<void> {
 		const tokenStoreStub = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
-		const response = await tokenStoreStub.fetchEsiAllPages<RawCharacterWalletJournalEntry>(
-			`/characters/${String(characterId)}/wallet/journal`,
-			String(characterId),
-			{ cacheMode: 'no-store' }
-		)
+		const [watermark] = await this.db
+			.select({
+				maxJournalId: sql<string | null>`max(${characterWalletJournal.journalId}::numeric)::text`,
+				maxJournalDate: sql<Date | string | null>`max(${characterWalletJournal.date})`,
+			})
+			.from(characterWalletJournal)
+			.where(eq(characterWalletJournal.characterId, characterId))
+		const storedMaxJournalId = watermark?.maxJournalId ?? null
+		const storedMaxJournalDate = parseDateOrNull(watermark?.maxJournalDate)
+		const journalPath = `/characters/${String(characterId)}/wallet/journal`
+		const response = storedMaxJournalId
+			? await tokenStoreStub.fetchEsiPagesUntilWatermark<RawCharacterWalletJournalEntry>(
+					journalPath,
+					String(characterId),
+					{
+						maxId: storedMaxJournalId,
+						maxDate: storedMaxJournalDate,
+					},
+					{ cacheMode: 'no-store' }
+				)
+			: await tokenStoreStub.fetchEsiAllPages<RawCharacterWalletJournalEntry>(
+					journalPath,
+					String(characterId),
+					{ cacheMode: 'no-store' }
+				)
 
 		let entries: EsiWalletJournalEntry[]
 		try {
@@ -1278,16 +1298,6 @@ export class EveCharacterDataDO extends DurableObject<Env> implements EveCharact
 		} finally {
 			disposeRpcResult(response)
 		}
-
-		const [watermark] = await this.db
-			.select({
-				maxJournalId: sql<string | null>`max(${characterWalletJournal.journalId}::numeric)::text`,
-				maxJournalDate: sql<Date | string | null>`max(${characterWalletJournal.date})`,
-			})
-			.from(characterWalletJournal)
-			.where(eq(characterWalletJournal.characterId, characterId))
-		const storedMaxJournalId = watermark?.maxJournalId ?? null
-		const storedMaxJournalDate = parseDateOrNull(watermark?.maxJournalDate)
 
 		const candidateEntries = entries.filter((entry) => {
 			if (storedMaxJournalId === null) {

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -128,6 +128,7 @@ import type {
 	StructureInventorySyncResult,
 	StructureSyncFailureTarget,
 	StructureSyncPriorityTarget,
+	WalletJournalWatermark,
 	WalletJournalWindowFilters,
 	WalletTransactionWatermark,
 	WalletTransactionWindowFilters,
@@ -2042,27 +2043,37 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async storeWalletJournal(
 		corporationId: string,
 		division: number,
-		entries: any[]
+		entries: any[],
+		providedWatermark?: WalletJournalWatermark
 	): Promise<{ persistedNewRows: number }> {
 		if (entries.length === 0) {
 			return { persistedNewRows: 0 }
 		}
 
 		const db = this.getDb()
-		const [watermark] = await db
-			.select({
-				maxJournalId: sql<string | null>`max(${corporationWalletJournal.journalId}::numeric)::text`,
-				maxJournalDate: sql<Date | string | null>`max(${corporationWalletJournal.date})`,
-			})
-			.from(corporationWalletJournal)
-			.where(
-				and(
-					eq(corporationWalletJournal.corporationId, String(corporationId)),
-					eq(corporationWalletJournal.division, division)
+		let watermark = providedWatermark
+		if (!watermark) {
+			const [storedWatermark] = await db
+				.select({
+					maxJournalId: sql<
+						string | null
+					>`max(${corporationWalletJournal.journalId}::numeric)::text`,
+					maxJournalDate: sql<Date | string | null>`max(${corporationWalletJournal.date})`,
+				})
+				.from(corporationWalletJournal)
+				.where(
+					and(
+						eq(corporationWalletJournal.corporationId, String(corporationId)),
+						eq(corporationWalletJournal.division, division)
+					)
 				)
-			)
-		const storedMaxJournalId = watermark?.maxJournalId ?? null
-		const storedMaxJournalDate = parseDateOrNull(watermark?.maxJournalDate)
+			watermark = {
+				maxJournalId: storedWatermark?.maxJournalId ?? null,
+				maxJournalDate: parseDateOrNull(storedWatermark?.maxJournalDate),
+			}
+		}
+		const storedMaxJournalId = watermark.maxJournalId
+		const storedMaxJournalDate = watermark.maxJournalDate
 		const fetchedMaxJournalId = entries.reduce<string | null>((max, entry) => {
 			const journalId = String(entry.id)
 			if (max === null || compareNumericStrings(journalId, max) > 0) {
@@ -2164,6 +2175,28 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		return { persistedNewRows }
+	}
+
+	async getWalletJournalWatermarks(
+		corporationId: string
+	): Promise<Array<{ division: number; watermark: WalletJournalWatermark }>> {
+		const rows = await this.getDb()
+			.select({
+				division: corporationWalletJournal.division,
+				maxJournalId: sql<string | null>`max(${corporationWalletJournal.journalId}::numeric)::text`,
+				maxJournalDate: sql<Date | string | null>`max(${corporationWalletJournal.date})`,
+			})
+			.from(corporationWalletJournal)
+			.where(eq(corporationWalletJournal.corporationId, String(corporationId)))
+			.groupBy(corporationWalletJournal.division)
+
+		return rows.map((row) => ({
+			division: row.division,
+			watermark: {
+				maxJournalId: row.maxJournalId,
+				maxJournalDate: parseDateOrNull(row.maxJournalDate),
+			},
+		}))
 	}
 
 	/**
@@ -5633,11 +5666,15 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		await this.requireCorpRole(corporationId, characterId, ['Accountant', 'Junior_Accountant'])
 
 		const tokenStore = getStub<EveTokenStore>(this.env.EVE_TOKEN_STORE, 'default')
+		const watermark = (await this.getWalletJournalWatermarks(corporationId)).find(
+			(entry) => entry.division === division
+		)?.watermark
 		const entries = await esiFetch.fetchWalletJournal(
 			tokenStore,
 			corporationId,
 			division,
-			characterId
+			characterId,
+			watermark
 		)
 
 		logger
@@ -5662,8 +5699,9 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 
 		let persistedNewRows = 0
 		try {
-			persistedNewRows = (await this.storeWalletJournal(corporationId, division, entries))
-				.persistedNewRows
+			persistedNewRows = (
+				await this.storeWalletJournal(corporationId, division, entries, watermark)
+			).persistedNewRows
 		} catch (error) {
 			logger
 				.withTags({

--- a/apps/eve-corporation-data/src/services/esi-fetch.ts
+++ b/apps/eve-corporation-data/src/services/esi-fetch.ts
@@ -47,6 +47,7 @@ import type {
 	EsiCorporationWalletTransaction,
 	EsiSovereigntyHub,
 	EsiSovereigntySystem,
+	WalletJournalWatermark,
 	WalletTransactionWatermark,
 } from '@repo/eve-corporation-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
@@ -188,7 +189,8 @@ export async function fetchWalletJournal(
 	tokenStore: EveTokenStore,
 	corporationId: string,
 	division: number,
-	characterId: string
+	characterId: string,
+	watermark?: WalletJournalWatermark
 ): Promise<EsiCorporationWalletJournalEntry[]> {
 	type RawJournalEntry = {
 		id: number
@@ -206,14 +208,22 @@ export async function fetchWalletJournal(
 		tax_receiver_id?: number
 	}
 
-	return withRpcResult(
-		tokenStore.fetchEsiAllPages<RawJournalEntry>(
-			`/corporations/${corporationId}/wallets/${division}/journal`,
-			characterId,
-			{ cacheMode: 'no-store' }
-		),
-		(result) => transformWalletJournal(result.data)
-	)
+	const basePath = `/corporations/${corporationId}/wallets/${division}/journal`
+	const response = watermark?.maxJournalId
+		? tokenStore.fetchEsiPagesUntilWatermark<RawJournalEntry>(
+				basePath,
+				characterId,
+				{
+					maxId: watermark.maxJournalId,
+					maxDate: watermark.maxJournalDate,
+				},
+				{ cacheMode: 'no-store' }
+			)
+		: tokenStore.fetchEsiAllPages<RawJournalEntry>(basePath, characterId, {
+				cacheMode: 'no-store',
+			})
+
+	return withRpcResult(response, (result) => transformWalletJournal(result.data))
 }
 
 /**

--- a/apps/eve-corporation-data/src/test/unit/services/esi-fetch.wallet-journal.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/esi-fetch.wallet-journal.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchWalletJournal } from '../../../services/esi-fetch'
+
+const rawJournalEntry = (id: number) => ({
+	id,
+	amount: 100,
+	balance: 200,
+	date: '2026-08-06T00:00:00Z',
+	description: 'Test journal entry',
+	ref_type: 'bounty_prizes',
+})
+
+describe('wallet journal ESI pagination', () => {
+	it('uses bounded pagination when a journal watermark exists', async () => {
+		const fetchEsiPagesUntilWatermark = vi.fn().mockResolvedValue({
+			data: [rawJournalEntry(101), rawJournalEntry(100)],
+			pages: 5,
+			pagesFetched: 2,
+			stoppedAtWatermark: true,
+		})
+		const fetchEsiAllPages = vi.fn()
+		const tokenStore = { fetchEsiPagesUntilWatermark, fetchEsiAllPages }
+
+		const result = await fetchWalletJournal(tokenStore as never, '123', 1, '456', {
+			maxJournalId: '100',
+			maxJournalDate: new Date('2026-08-05T00:00:00Z'),
+		})
+
+		expect(fetchEsiPagesUntilWatermark).toHaveBeenCalledWith(
+			'/corporations/123/wallets/1/journal',
+			'456',
+			{
+				maxId: '100',
+				maxDate: new Date('2026-08-05T00:00:00Z'),
+			},
+			{ cacheMode: 'no-store' }
+		)
+		expect(fetchEsiAllPages).not.toHaveBeenCalled()
+		expect(result.map((entry) => entry.id)).toEqual(['101', '100'])
+	})
+
+	it('uses full pagination when no journal watermark exists', async () => {
+		const fetchEsiPagesUntilWatermark = vi.fn()
+		const fetchEsiAllPages = vi.fn().mockResolvedValue({
+			data: [rawJournalEntry(100)],
+			pages: 1,
+		})
+		const tokenStore = { fetchEsiPagesUntilWatermark, fetchEsiAllPages }
+
+		const result = await fetchWalletJournal(tokenStore as never, '123', 1, '456')
+
+		expect(fetchEsiAllPages).toHaveBeenCalledWith('/corporations/123/wallets/1/journal', '456', {
+			cacheMode: 'no-store',
+		})
+		expect(fetchEsiPagesUntilWatermark).not.toHaveBeenCalled()
+		expect(result.map((entry) => entry.id)).toEqual(['100'])
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/services/wallet-journal-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/wallet-journal-storage.test.ts
@@ -109,6 +109,20 @@ describe('wallet journal storage', () => {
 		expect(insert).not.toHaveBeenCalled()
 	})
 
+	it('uses a supplied watermark without re-reading it from the database', async () => {
+		const { db, insert, select, values } = createDb('2', '2026-08-05T00:00:00Z', ['3'])
+		const instance = createDoInstance(db)
+
+		await instance.storeWalletJournal('123', 1, [journalEntry('3')], {
+			maxJournalId: '2',
+			maxJournalDate: new Date('2026-08-05T00:00:00Z'),
+		})
+
+		expect(select).not.toHaveBeenCalled()
+		expect(insert).toHaveBeenCalledOnce()
+		expect(values).toHaveBeenCalledOnce()
+	})
+
 	it('accepts late higher IDs and wrapped lower IDs', async () => {
 		const { db, values } = createDb('500', '2026-08-05T00:00:00Z', ['501', '400', '402'])
 		const instance = createDoInstance(db)

--- a/apps/eve-corporation-data/src/workflows/steps/wallet-journal/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/wallet-journal/index.ts
@@ -37,6 +37,17 @@ export async function syncWalletJournal(
 ): Promise<WalletJournalSyncResult> {
 	const tokenStore = createTokenStore(env)
 	const corpData = getCorporationDataStub(env, corporationId)
+	const watermarks = await withRpcResult(
+		corpData.getWalletJournalWatermarks(corporationId),
+		(watermarks) =>
+			watermarks.map(({ division, watermark }) => ({
+				division,
+				watermark: watermark ? { ...watermark } : undefined,
+			}))
+	)
+	const watermarkByDivision = new Map(
+		watermarks.map(({ division, watermark }) => [division, watermark])
+	)
 
 	const results = await Promise.allSettled(
 		WALLET_DIVISIONS.map(async (division, index) => {
@@ -49,10 +60,16 @@ export async function syncWalletJournal(
 				tokenStore,
 				corporationId,
 				division,
-				directorCharacterId
+				directorCharacterId,
+				watermarkByDivision.get(division)
 			)
 			const storeResult = await withRpcResult(
-				corpData.storeWalletJournal(corporationId, division, entries),
+				corpData.storeWalletJournal(
+					corporationId,
+					division,
+					entries,
+					watermarkByDivision.get(division)
+				),
 				(result) => ({ persistedNewRows: result.persistedNewRows })
 			)
 			const maxJournalId =

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -13,7 +13,7 @@ import {
 	hasAllScopes,
 } from '@repo/eve-token-store'
 import { logger, toErrorLogDetails } from '@repo/hono-helpers'
-import { parseJsonResponse } from '@repo/worker-utils'
+import { parseDateOrNull, parseJsonResponse } from '@repo/worker-utils'
 
 import { createDb } from './db'
 import { eveCharacters, eveTokens } from './db/schema'
@@ -2116,6 +2116,93 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		return {
 			data: allData,
 			pages: totalPages,
+		}
+	}
+
+	async fetchEsiPagesUntilWatermark<T extends { id: string | number; date?: string | Date }>(
+		basePath: string,
+		characterId: string,
+		watermark?: { maxId: string | null; maxDate: Date | string | null },
+		options?: { cacheMode?: 'default' | 'no-store' }
+	): Promise<{
+		data: T[]
+		pages: number
+		pagesFetched: number
+		stoppedAtWatermark: boolean
+	}> {
+		if (!watermark?.maxId) {
+			const result = await this.fetchEsiAllPages<T>(basePath, characterId, options)
+			return {
+				...result,
+				pagesFetched: result.pages,
+				stoppedAtWatermark: false,
+			}
+		}
+
+		const cleanPath = basePath.replace(/[?&]page=\d+/, '')
+		const separator = cleanPath.includes('?') ? '&' : '?'
+		const totalPagesResponse = await this.fetchEsi<T[]>(
+			`${cleanPath}${separator}page=1`,
+			characterId,
+			options
+		)
+		const totalPages = totalPagesResponse.pages ?? 1
+		const entries = [...totalPagesResponse.data]
+		let pagesFetched = 1
+		let stoppedAtWatermark = false
+		let watermarkSeen = false
+		const maxDate = parseDateOrNull(watermark.maxDate)
+
+		const compareNumericIds = (left: string, right: string): number => {
+			try {
+				const leftValue = BigInt(left)
+				const rightValue = BigInt(right)
+				return leftValue === rightValue ? 0 : leftValue > rightValue ? 1 : -1
+			} catch {
+				return left.localeCompare(right, 'en')
+			}
+		}
+
+		const hasRowsAtOrBeyondWatermark = (pageEntries: T[]): boolean =>
+			pageEntries.some((entry) => {
+				const entryId = String(entry.id)
+				if (entryId === watermark.maxId) return false
+				if (compareNumericIds(entryId, watermark.maxId!) > 0) return true
+				const entryDate = parseDateOrNull(entry.date)
+				return maxDate !== null && entryDate !== null && entryDate >= maxDate
+			})
+
+		const inspectPage = (pageEntries: T[]): boolean => {
+			if (pageEntries.some((entry) => String(entry.id) === watermark.maxId)) {
+				watermarkSeen = true
+			}
+			return watermarkSeen && !hasRowsAtOrBeyondWatermark(pageEntries)
+		}
+
+		if (inspectPage(totalPagesResponse.data)) {
+			stoppedAtWatermark = true
+		} else {
+			for (let page = 2; page <= totalPages; page += 1) {
+				const response = await this.fetchEsi<T[]>(
+					`${cleanPath}${separator}page=${page}`,
+					characterId,
+					options
+				)
+				pagesFetched += 1
+				entries.push(...response.data)
+
+				if (inspectPage(response.data)) {
+					stoppedAtWatermark = true
+					break
+				}
+			}
+		}
+
+		return {
+			data: entries,
+			pages: totalPages,
+			pagesFetched,
+			stoppedAtWatermark,
 		}
 	}
 

--- a/apps/ui/src/client/components/tax-reports/report-sections.tsx
+++ b/apps/ui/src/client/components/tax-reports/report-sections.tsx
@@ -88,6 +88,7 @@ export function TopIncomeSourcesReportSection(props: {
 	const {
 		data = [],
 		isLoading,
+		isFetching,
 		error,
 	} = useTaxTopIncomeSourcesMonthlyReport({
 		...props.filters,
@@ -184,9 +185,9 @@ export function TopIncomeSourcesReportSection(props: {
 				</div>
 			</div>
 
-			{isLoading ? (
+			{isLoading && data.length === 0 ? (
 				<div className="py-8 text-sm text-muted-foreground">Loading income sources...</div>
-			) : error ? (
+			) : error && data.length === 0 ? (
 				<div className="py-8 text-sm text-destructive">
 					{error instanceof Error ? error.message : 'Failed to load income sources report'}
 				</div>
@@ -195,6 +196,7 @@ export function TopIncomeSourcesReportSection(props: {
 					rows={data}
 					incomeMode={props.controls.incomeMode}
 					walletSource={props.controls.walletSource}
+					loading={isFetching}
 				/>
 			)}
 		</div>

--- a/apps/ui/src/client/components/tax-reports/top-income-sources-monthly-chart.tsx
+++ b/apps/ui/src/client/components/tax-reports/top-income-sources-monthly-chart.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import { formatTaxIskCompact, formatTaxRefTypeLabel, getTaxRefTypeColor } from '@/lib/tax-display'
@@ -78,10 +79,12 @@ export function TopIncomeSourcesMonthlyChart({
 	rows,
 	incomeMode,
 	walletSource,
+	loading = false,
 }: {
 	rows: TaxTopIncomeSourceMonthlyRow[]
 	incomeMode: 'total' | 'assessed'
 	walletSource: 'corporation' | 'character'
+	loading?: boolean
 }) {
 	const [hoveredSegment, setHoveredSegment] = useState<{
 		key: string
@@ -129,7 +132,12 @@ export function TopIncomeSourcesMonthlyChart({
 	}, [rows])
 
 	if (chartData.months.length === 0 || chartData.refTypes.length === 0) {
-		return <div className="py-8 text-sm text-muted-foreground">No income sources found.</div>
+		return (
+			<div className="relative rounded border bg-muted/20 p-3" aria-busy={loading}>
+				<div className="py-8 text-sm text-muted-foreground">No income sources found.</div>
+				{loading ? <ChartLoadingOverlay /> : null}
+			</div>
+		)
 	}
 
 	const chartWidth =
@@ -151,7 +159,7 @@ export function TopIncomeSourcesMonthlyChart({
 
 	return (
 		<div className="space-y-4">
-			<div className="rounded border bg-muted/20 p-3">
+			<div className="relative rounded border bg-muted/20 p-3" aria-busy={loading}>
 				<div className="overflow-x-auto">
 					<svg
 						viewBox={`0 0 ${chartWidth} ${MONTHLY_INCOME_CHART_HEIGHT}`}
@@ -407,7 +415,16 @@ export function TopIncomeSourcesMonthlyChart({
 						</div>
 					))}
 				</div>
+				{loading ? <ChartLoadingOverlay /> : null}
 			</div>
+		</div>
+	)
+}
+
+function ChartLoadingOverlay() {
+	return (
+		<div className="absolute inset-0 z-10 flex items-center justify-center rounded bg-background/60 backdrop-blur-[1px]">
+			<Loader2 aria-label="Loading" className="h-6 w-6 animate-spin text-primary" />
 		</div>
 	)
 }

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -432,6 +432,11 @@ export interface WalletJournalStoreResult {
 	persistedNewRows: number
 }
 
+export interface WalletJournalWatermark {
+	maxJournalId: string | null
+	maxJournalDate: Date | null
+}
+
 export interface WalletTransactionsStoreResult {
 	persistedNewRows: number
 }
@@ -1309,8 +1314,14 @@ export interface EveCorporationData {
 	storeWalletJournal(
 		corporationId: string,
 		division: number,
-		entries: any[]
+		entries: any[],
+		watermark?: WalletJournalWatermark
 	): Promise<WalletJournalStoreResult>
+
+	/** Read compact journal watermarks for all wallet divisions. */
+	getWalletJournalWatermarks(
+		corporationId: string
+	): Promise<Array<{ division: number; watermark: WalletJournalWatermark }>>
 
 	/**
 	 * Store wallet transactions (workflow-friendly)

--- a/packages/eve-token-store/src/index.ts
+++ b/packages/eve-token-store/src/index.ts
@@ -692,6 +692,23 @@ export interface EveTokenStore {
 	}>
 
 	/**
+	 * Fetch paginated ESI rows from newest to oldest until a journal-style
+	 * watermark has been reached. Without a watermark this falls back to the
+	 * regular full-pagination behavior.
+	 */
+	fetchEsiPagesUntilWatermark<T extends { id: string | number; date?: string | Date }>(
+		basePath: string,
+		characterId: string,
+		watermark?: { maxId: string | null; maxDate: Date | string | null },
+		options?: { cacheMode?: 'default' | 'no-store' }
+	): Promise<{
+		data: T[]
+		pages: number
+		pagesFetched: number
+		stoppedAtWatermark: boolean
+	}>
+
+	/**
 	 * Fetch all pages from a paginated public ESI endpoint (unauthenticated)
 	 * Automatically fetches all pages in parallel and returns combined results
 	 *


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Reduces ESI wallet journal sync cost by using stored watermarks (max journal ID/date) to stop paginating once previously-synced entries are reached, instead of always fetching every page. Also tweaks the tax report income-sources chart to avoid flashing a loading/error/empty state during background refetches.

## Changes
- **`eve-token-store`**: Add `fetchEsiPagesUntilWatermark`, which fetches ESI pages newest-first and stops once it encounters the stored watermark (falls back to `fetchEsiAllPages` when no watermark is provided).
- **`eve-character-data`**: Read the wallet journal watermark before fetching (instead of after) and use `fetchEsiPagesUntilWatermark` when a watermark exists, so only new pages are pulled.
- **`eve-corporation-data`**:
  - Add `getWalletJournalWatermarks` to fetch per-division watermarks in one query.
  - `storeWalletJournal` accepts an optional pre-computed watermark to avoid re-querying the DB when the caller already has it.
  - `fetchWalletJournal` uses the watermark to call `fetchEsiPagesUntilWatermark` instead of full pagination.
  - The manual wallet journal sync route and the `syncWalletJournal` workflow step now fetch watermarks for all divisions up front and reuse them across both the fetch and store calls.
- **`apps/ui`**: `TopIncomeSourcesReportSection`/`TopIncomeSourcesMonthlyChart` track `isFetching` separately from `isLoading` and show a loading overlay on top of existing data instead of replacing it with a loading/error message during refetches.

## Testing
- Added unit tests for `fetchWalletJournal` covering both the watermark-bounded and full-pagination paths (`esi-fetch.wallet-journal.test.ts`).
- Added a unit test verifying `storeWalletJournal` uses a supplied watermark without re-querying the database (`wallet-journal-storage.test.ts`).
<!-- claude:end -->