### PR TITLE
make eve-token-store not websocket

### DIFF
--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -143,7 +143,11 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		super(state, env)
 		// Local Vite dev is the only environment exhibiting the CONNECT failure
 		// on this path, so use Neon HTTP there and keep WebSockets elsewhere.
-		const useWebSocket = env.ENVIRONMENT !== 'development'
+
+		// turning off to see if this is the cause of our duration issues
+		// const useWebSocket = env.ENVIRONMENT !== 'development'
+		const useWebSocket = false
+
 		this.db = createDb(env, env.DATABASE_URL, useWebSocket)
 		this.esiRateLimits = new EsiRateLimitStore(env.ESI_RATE_LIMITS)
 		this.esiRequestClient = new EsiRequestClient({


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Disables WebSocket-based Neon connections for the `eve-token-store` Durable Object, forcing it to always use Neon HTTP, as an experiment to see whether this is contributing to elevated request durations.

## Changes
- In `apps/eve-token-store/src/durable-object.ts`, hardcode `useWebSocket = false` instead of `env.ENVIRONMENT !== 'development'`, temporarily disabling WebSocket connections in all environments (the previous logic is left commented out for easy revert).

## Testing
No tests included; this is a temporary diagnostic change to be evaluated by observing production request durations.
<!-- claude:end -->