### PR TITLE
eve token store non ws

### DIFF
--- a/apps/eve-character-data/src/db/index.ts
+++ b/apps/eve-character-data/src/db/index.ts
@@ -1,17 +1,17 @@
-import { createDbClientWs } from '@repo/db-utils'
+import { createDbClient } from '@repo/db-utils'
 
 import * as schema from './schema'
 
-import type { DbClientWs } from '@repo/db-utils'
+import type { DbClient } from '@repo/db-utils'
 
 /**
  * Create a database client instance
  * @param databaseUrl - The Neon database connection URL
  * @returns A configured Drizzle database client
  */
-export function createDb(databaseUrl: string): DbClientWs<typeof schema> {
-	return createDbClientWs(databaseUrl, schema)
+export function createDb(databaseUrl: string): DbClient<typeof schema> {
+	return createDbClient(databaseUrl, schema)
 }
 
 export { schema }
-export type { DbClientWs as DbClient }
+export type { DbClient }

--- a/apps/eve-character-data/src/scripts/migrate.ts
+++ b/apps/eve-character-data/src/scripts/migrate.ts
@@ -2,7 +2,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { config } from 'dotenv'
 
-import { migrateWs } from '@repo/db-utils'
+import { migrate } from '@repo/db-utils'
 
 import drizzleConfig from '../../drizzle.config'
 import { createDb } from '../db'
@@ -33,7 +33,7 @@ async function main() {
 		migrationsFolder: drizzleConfig.out || './.migrations',
 	}
 
-	await migrateWs(db, migrationConfig)
+	await migrate(db, migrationConfig)
 
 	console.log('Migrations completed successfully!')
 	process.exit(0)

--- a/apps/eve-token-store/src/db/index.ts
+++ b/apps/eve-token-store/src/db/index.ts
@@ -21,10 +21,10 @@ export function createDb(
 	useWebSocket = true
 ): EveTokenStoreDbClient {
 	if (useWebSocket) {
-		return createDbClientWs(databaseUrl, schema, ctx)
+		return createDbClientWs(databaseUrl, schema)
 	}
 
-	return createDbClient(databaseUrl, schema, undefined, ctx)
+	return createDbClient(databaseUrl, schema)
 }
 
 export { schema }

--- a/apps/fleets/src/fleet-monitor.ts
+++ b/apps/fleets/src/fleet-monitor.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from 'cloudflare:workers'
 
-import { and, createDbClientWs, desc, eq, isNull, sql } from '@repo/db-utils'
+import { and, createDbClient, desc, eq, isNull, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import {
 	esiGetCharacterFleetInformationSchema,
@@ -80,7 +80,7 @@ async function resolveFleetBossAccessCharacterId(
 }
 
 async function syncFleetBossAccess(
-	db: ReturnType<typeof createDbClientWs<typeof schema>>,
+	db: ReturnType<typeof createDbClient<typeof schema>>,
 	args: {
 		fleetId: string
 		trackingSessionId: string
@@ -163,7 +163,7 @@ async function syncFleetBossAccess(
 export class FleetMonitorDO extends DurableObject {
 	private static readonly BASE_POLL_INTERVAL_MS = 10 * 1000
 	private static readonly MONITOR_STATE_TTL_MS = 24 * 60 * 60 * 1000
-	private db: ReturnType<typeof createDbClientWs<typeof schema>>
+	private db: ReturnType<typeof createDbClient<typeof schema>>
 	private finalizeSessionPromise: Promise<void> | null = null
 	// In-memory caches for ID to name mappings
 	private characterNameCache = new Map<string, string>()
@@ -180,7 +180,7 @@ export class FleetMonitorDO extends DurableObject {
 		public env: Env
 	) {
 		super(state, env)
-		this.db = createDbClientWs(this.env.DATABASE_URL, schema)
+		this.db = createDbClient(this.env.DATABASE_URL, schema)
 
 		// Initialize SQLite schema and run migrations
 		this.initializeSchema()


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Continues migrating workers off the WebSocket-based Neon database client (`createDbClientWs`/`migrateWs`) toward the plain HTTP client (`createDbClient`/`migrate`), reducing reliance on WebSocket connections for database access.

## Changes
- `apps/eve-character-data`: switch `createDb`/migration script from `createDbClientWs`/`migrateWs`/`DbClientWs` to `createDbClient`/`migrate`/`DbClient`.
- `apps/eve-token-store`: drop the unused `ctx` argument from both the WebSocket and non-WebSocket `createDb` branches.
- `apps/fleets` (`FleetMonitorDO`): replace `createDbClientWs` with `createDbClient` for the fleet monitor's database client, updating the associated type references.

## Testing
Not evident from the diff — no test changes included.
<!-- claude:end -->