### PR TITLE
fix character data sharding

### DIFF
--- a/apps/core/src/lib/character-access.ts
+++ b/apps/core/src/lib/character-access.ts
@@ -181,14 +181,13 @@ export async function resolveCharacterAccessContext(
 				targetOwner ? await resolveSharedCorporationCandidates(c, user, targetOwner) : []
 
 			if (candidateCorporations.length > 0) {
+				// One shared stub for every character: EveCharacterData is Postgres-backed and
+				// takes the character ID per call, so keying by character only multiplies objects.
+				const userCharStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 				const viewerCharacterResults = await Promise.all(
 					user.characters.map(async (userChar) => {
 						try {
-							const userCharStub = getStub<EveCharacterData>(
-								c.env.EVE_CHARACTER_DATA,
-								userChar.characterId
-							)
-							const userCharInstance = await userCharStub.getInstance(userChar.characterId)
+							using userCharInstance = await userCharStub.getInstance(userChar.characterId)
 							const userCharInfo = await userCharInstance.getCharacterInfo()
 							return {
 								characterId: userChar.characterId,

--- a/apps/core/src/middleware/tax-permissions.ts
+++ b/apps/core/src/middleware/tax-permissions.ts
@@ -81,7 +81,7 @@ export async function hasCorporationSelfServiceAccess(
 		const directorIds = new Set(directors.map((director) => director.characterId))
 		for (const characterId of characterIds) {
 			try {
-				const characterStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
+				const characterStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 				const characterInfo = await characterStub.getCharacterInfo(characterId)
 				if (!characterInfo || String(characterInfo.corporationId) !== corporationId) {
 					continue
@@ -158,7 +158,7 @@ export async function hasCorporationMembershipAccess(
 
 		for (const characterId of characterIds) {
 			try {
-				const characterStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
+				const characterStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 				const characterInfo = await characterStub.getCharacterInfo(characterId)
 				if (characterInfo && String(characterInfo.corporationId) === corporationId) {
 					return true

--- a/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
+++ b/apps/core/src/routes/__tests__/characters.hr-auditor.route.test.ts
@@ -35,6 +35,8 @@ const hoisted = vi.hoisted(() => ({
 		getSensitiveData: vi.fn(),
 		fetchCharacterData: vi.fn(),
 		refreshPublicCharacterData: vi.fn(),
+		// Real RpcTarget stubs are disposable; routes declare them with `using`.
+		[Symbol.dispose]: vi.fn(),
 	},
 	skills: {
 		getAllSkills: vi.fn(),

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -819,10 +819,7 @@ auth.get('/callback', async (c) => {
 		triggerLegacyMigrationRecheck(c, stateUserId)
 
 		// Fetch character data in background (non-blocking)
-		const eveCharacterDataStub = getStub<EveCharacterData>(
-			c.env.EVE_CHARACTER_DATA,
-			typeof characterId === 'string' ? characterId : String(characterId)
-		)
+		const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 		waitUntilWithTelemetry(
 			c.executionCtx,
 			'auth.link-character.refresh',
@@ -985,10 +982,7 @@ auth.get('/callback', async (c) => {
 		await activityService.logLogin(user.id, characterId, getRequestMetadata(c))
 
 		// Fetch character data in background (non-blocking)
-		const eveCharacterDataStub = getStub<EveCharacterData>(
-			c.env.EVE_CHARACTER_DATA,
-			typeof characterId === 'string' ? characterId : String(characterId)
-		)
+		const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 		waitUntilWithTelemetry(
 			c.executionCtx,
 			'auth.login.refresh',
@@ -1245,10 +1239,7 @@ auth.post('/claim-main', async (c) => {
 	triggerLegacyMigrationRecheck(c, user.id)
 
 	// Fetch character data in background (non-blocking)
-	const eveCharacterDataStub = getStub<EveCharacterData>(
-		c.env.EVE_CHARACTER_DATA,
-		typeof characterId === 'string' ? characterId : String(characterId)
-	)
+	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 	waitUntilWithTelemetry(
 		c.executionCtx,
 		'auth.claim-main.refresh',

--- a/apps/core/src/routes/characters.ts
+++ b/apps/core/src/routes/characters.ts
@@ -318,8 +318,8 @@ app.get('/:characterId/private', requireAuth(), async (c) => {
 	}
 
 	const access = accessOrResponse
-	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
-	const eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
+	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
+	using eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
 	const eveTokenStore = c.get('eveTokenStore')
 
 	if (!eveTokenStore) {
@@ -514,8 +514,8 @@ app.get('/:characterId/skills', requireAuth(), async (c) => {
 		return c.json({ error: 'You do not have permission to view this character' }, 403)
 	}
 
-	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
-	const eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
+	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
+	using eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
 
 	try {
 		let info = await eveCharacterData.getCharacterInfo()
@@ -551,8 +551,8 @@ app.get('/:characterId/skills', requireAuth(), async (c) => {
 app.get('/:characterId', requireAuth(), async (c) => {
 	const characterIdStr = c.req.param('characterId')
 	const characterId = createEveCharacterId(characterIdStr)
-	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
-	const eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
+	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
+	using eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
 
 	try {
 		const [initialInfo, initialCorporationHistory, attributes, lastUpdated] = await Promise.all([
@@ -699,8 +699,8 @@ app.post('/:characterId/refresh', requireAuth(), async (c) => {
 	}
 
 	// Get EVE Character Data DO stub
-	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
-	const eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
+	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
+	using eveCharacterData = await eveCharacterDataStub.getInstance(characterId)
 
 	// Get EVE Token Store DO stub for authenticated data
 	const eveTokenStoreStub = c.get('eveTokenStore')

--- a/apps/core/src/routes/corporation-tax/index.ts
+++ b/apps/core/src/routes/corporation-tax/index.ts
@@ -248,7 +248,7 @@ async function getMemberCharacterIdsInCorporation(
 		const memberships = await Promise.all(
 			characterIds.map(async (characterId) => {
 				try {
-					const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
+					const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 					const characterInfo = await characterStub.getCharacterInfo(characterId)
 					if (!characterInfo || String(characterInfo.corporationId) !== corporationId) {
 						return null

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -1134,10 +1134,10 @@ async function checkCorporationAccess(
 	// This keeps correctness while minimizing slow EVE_CHARACTER_DATA round-trips.
 	const unresolvedAffiliationCharacters = userChars.filter((character) => !character.corporationId)
 
+	const charStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 	for (const character of unresolvedAffiliationCharacters) {
 		try {
 			// Check if character is in this corporation
-			const charStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, character.characterId)
 			const charData = await withRpcResult(
 				charStub.getCharacterInfo(character.characterId),
 				(result) => (result ? { corporationId: result.corporationId } : null)

--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -98,7 +98,7 @@ async function getCharacterCorporationId(
 	c: Context<App>,
 	characterId: string
 ): Promise<string | null> {
-	const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
+	const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 	return withRpcResult(characterStub.getInstance(characterId), (characterInstance) =>
 		withRpcResult(characterInstance.getCharacterInfo(), (characterInfo) =>
 			characterInfo?.corporationId ? String(characterInfo.corporationId) : null
@@ -379,7 +379,7 @@ async function isMemberCorpCeo(c: Context<App>, characterId: string): Promise<bo
 		throw new Error('Database not available')
 	}
 
-	const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, characterId)
+	const characterStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
 	const characterInfo = await withRpcResult(
 		characterStub.getInstance(characterId),
 		(characterInstance) =>

--- a/apps/core/src/services/character-affiliation-hydration.service.ts
+++ b/apps/core/src/services/character-affiliation-hydration.service.ts
@@ -41,7 +41,7 @@ export async function hydrateCharacterAffiliation(
 	params: CharacterAffiliationHydrationParams
 ): Promise<HydratedCharacterAffiliation> {
 	const { db, env, characterId, executionCtx } = params
-	const eveCharacterData = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
+	const eveCharacterData = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 
 	const publicRefreshResult = await eveCharacterData.refreshPublicCharacterData(characterId, false)
 

--- a/apps/core/src/services/corporation-auto-register.service.ts
+++ b/apps/core/src/services/corporation-auto-register.service.ts
@@ -319,7 +319,7 @@ export async function checkAndUpdateDirectorStatus(
 ): Promise<{ updated: boolean; reason?: string }> {
 	try {
 		// Get the character data stub
-		const characterDataStub = getStub<EveCharacterData>(eveCharacterDataNamespace, characterId)
+		const characterDataStub = getStub<EveCharacterData>(eveCharacterDataNamespace, 'default')
 
 		// Fetch corporation roles
 		const roles = await characterDataStub.fetchCorporationRoles(characterId, false)

--- a/apps/core/src/services/dkp.service.ts
+++ b/apps/core/src/services/dkp.service.ts
@@ -77,10 +77,7 @@ export class DkpService {
 		// Strategy 1: Try eve-character-data Durable Object (most reliable, ESI-backed)
 		if (this.eveCharacterDataNamespace) {
 			try {
-				const charStub = getStub<EveCharacterData>(
-					this.eveCharacterDataNamespace,
-					params.characterId
-				)
+				const charStub = getStub<EveCharacterData>(this.eveCharacterDataNamespace, 'default')
 				const characterInfo = await charStub.getCharacterInfo(params.characterId)
 
 				if (characterInfo) {
@@ -228,8 +225,9 @@ export class DkpService {
 		// Get unique names
 		const uniqueNames = [...new Set(names)]
 
-		// Get eve-character-data stub (use any character ID as the DO is stateless for search)
-		const charDataStub = getStub<EveCharacterData>(this.eveCharacterDataNamespace, '0')
+		// Get eve-character-data stub. The DO keeps all state in Postgres and takes the
+		// character ID per call, so every caller shares the one 'default' instance.
+		const charDataStub = getStub<EveCharacterData>(this.eveCharacterDataNamespace, 'default')
 
 		// Resolve each name
 		for (const name of uniqueNames) {

--- a/apps/core/src/services/mumble.service.ts
+++ b/apps/core/src/services/mumble.service.ts
@@ -650,7 +650,7 @@ export async function provisionTempopGuest(
 	}
 
 	// Fetch identity + affiliation (no persistence to core tables).
-	const characterStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
+	const characterStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 	const publicData = await characterStub.refreshPublicCharacterData(characterId, false)
 	const characterName = publicData.characterName ?? `Pilot ${characterId}`
 	const corporationId = publicData.currentCorporationId ?? null

--- a/apps/core/src/workflows/steps/update-character/try-character-authenticated-fetch.ts
+++ b/apps/core/src/workflows/steps/update-character/try-character-authenticated-fetch.ts
@@ -63,7 +63,7 @@ export async function tryCharacterAuthenticatedFetch(
 }> {
 	const logger = getWorkflowLogger(ctx, 'validate-character-token')
 	const eveTokenStore = getStub<EveTokenStore>(ctx.env.EVE_TOKEN_STORE, 'default')
-	const eveCharacterData = getStub<EveCharacterData>(ctx.env.EVE_CHARACTER_DATA, characterId)
+	const eveCharacterData = getStub<EveCharacterData>(ctx.env.EVE_CHARACTER_DATA, 'default')
 
 	const existingCharacter = await ctx.db.query.userCharacters.findFirst({
 		where: eq(userCharacters.characterId, characterId),

--- a/apps/core/src/workflows/steps/update-character/update-character-public.ts
+++ b/apps/core/src/workflows/steps/update-character/update-character-public.ts
@@ -40,7 +40,7 @@ export async function updateCharacterPublicInfo(
 	affiliationChanged: boolean
 }> {
 	const logger = getWorkflowLogger(ctx, 'update-character-public-info')
-	const eveCharDataStub = getStub<EveCharacterData>(ctx.env.EVE_CHARACTER_DATA, characterId)
+	const eveCharDataStub = getStub<EveCharacterData>(ctx.env.EVE_CHARACTER_DATA, 'default')
 
 	const publicRefreshResult = await eveCharDataStub.refreshPublicCharacterData(characterId, false)
 

--- a/apps/eve-character-data/src/workflows/helpers/refresh-authenticated-data.ts
+++ b/apps/eve-character-data/src/workflows/helpers/refresh-authenticated-data.ts
@@ -34,7 +34,7 @@ export async function refreshAuthenticatedData(
 	const normalizedCharacterId = String(characterId)
 
 	// Create fresh stubs for this operation
-	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, normalizedCharacterId)
+	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 	const tokenStoreStub = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
 
 	try {

--- a/apps/eve-character-data/src/workflows/helpers/refresh-market-data.ts
+++ b/apps/eve-character-data/src/workflows/helpers/refresh-market-data.ts
@@ -22,9 +22,9 @@ export async function refreshMarketData(
 	characterId: string
 ): Promise<RefreshMarketDataResult> {
 	// Create fresh stubs for this operation
-	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
+	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 	const tokenStoreStub = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
-	const characterData = await characterDataStub.getInstance(characterId)
+	using characterData = await characterDataStub.getInstance(characterId)
 
 	try {
 		// Check if token exists and is valid

--- a/apps/eve-character-data/src/workflows/helpers/refresh-public-info.ts
+++ b/apps/eve-character-data/src/workflows/helpers/refresh-public-info.ts
@@ -44,7 +44,7 @@ export async function refreshPublicInfo(
 	const normalizedCharacterId = String(characterId)
 
 	// Create fresh stubs for this operation
-	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, normalizedCharacterId)
+	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 
 	logger.info('[refreshPublicInfo] Starting public info refresh', {
 		characterId: normalizedCharacterId,

--- a/apps/eve-character-data/src/workflows/helpers/refresh-wallet-journal.ts
+++ b/apps/eve-character-data/src/workflows/helpers/refresh-wallet-journal.ts
@@ -21,9 +21,9 @@ export async function refreshWalletJournal(
 	characterId: string
 ): Promise<RefreshWalletJournalResult> {
 	// Create fresh stubs for this operation
-	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, characterId)
+	const characterDataStub = getStub<EveCharacterData>(env.EVE_CHARACTER_DATA, 'default')
 	const tokenStoreStub = getStub<EveTokenStore>(env.EVE_TOKEN_STORE, 'default')
-	const characterData = await characterDataStub.getInstance(characterId)
+	using characterData = await characterDataStub.getInstance(characterId)
 
 	try {
 		// Check if token exists and is valid

--- a/apps/eve-character-data/src/workflows/sync-workflow.ts
+++ b/apps/eve-character-data/src/workflows/sync-workflow.ts
@@ -255,7 +255,7 @@ export class EveCharacterSyncWorkflow extends WorkflowEntrypoint<Env, EveCharact
 									async () => {
 										const characterDataStub = getStub<EveCharacterData>(
 											this.env.EVE_CHARACTER_DATA,
-											characterId
+											'default'
 										)
 										logger.debug('[Step] Fetching corporation history', {
 											characterId,

--- a/apps/fleets/src/durable-object.ts
+++ b/apps/fleets/src/durable-object.ts
@@ -426,10 +426,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 		}
 
 		// Get fleet boss name
-		const characterStub = getStub<EveCharacterData>(
-			this.env.EVE_CHARACTER_DATA,
-			invitation.fleetBossId
-		)
+		const characterStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, 'default')
 		const characterInfo = await characterStub.getCharacterInfo(invitation.fleetBossId)
 
 		return {
@@ -494,7 +491,7 @@ export class FleetsDO extends DurableObject implements Fleets {
 			members = undefined
 		}
 
-		const characterStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, characterId)
+		const characterStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, 'default')
 		const characterInfo = await characterStub.getCharacterInfo(characterId)
 
 		// Resolve ship type IDs, character IDs, system IDs, and station IDs to names if members are available

--- a/apps/fleets/src/fleet-monitor.ts
+++ b/apps/fleets/src/fleet-monitor.ts
@@ -876,7 +876,7 @@ export class FleetMonitorDO extends DurableObject {
 			// Resolve the live fleet boss name independently of the ESI source so
 			// the display and access paths stay aligned even across leadership
 			// handoffs.
-			const characterStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, liveFleetBossId)
+			const characterStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, 'default')
 			const characterInfo = await characterStub.getCharacterInfo(liveFleetBossId)
 
 			// Resolve ship type IDs, character IDs, system IDs, and station IDs to names if members are available
@@ -1509,10 +1509,12 @@ export class FleetMonitorDO extends DurableObject {
 		}
 
 		if (uncachedIds.length > 0) {
+			// One shared stub: EveCharacterData keeps all state in Postgres and takes the
+			// character ID per call, so a stub per ID would only multiply Durable Objects.
+			const stub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, 'default')
 			// Issue all character-info lookups in parallel; tolerate per-character failures.
 			const results = await Promise.allSettled(
 				uncachedIds.map(async (id) => {
-					const stub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, id)
 					const info = await stub.getCharacterInfo(id)
 					return { id, corporationId: info?.corporationId ?? null }
 				})

--- a/apps/groups/src/durable-object.ts
+++ b/apps/groups/src/durable-object.ts
@@ -3054,7 +3054,7 @@ export class GroupsDO extends DurableObject<Env> implements Groups {
 		logger.log('[getCharacterPermissions] Fetching permissions for character', { characterId })
 
 		// Resolve character's corporation via EveCharacterData DO
-		const charStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, characterId)
+		const charStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, 'default')
 		const charInfo = await charStub.getCharacterInfo(characterId)
 
 		if (!charInfo || !charInfo.corporationId) {

--- a/apps/srp/src/durable-object.ts
+++ b/apps/srp/src/durable-object.ts
@@ -358,7 +358,7 @@ export class SrpDO extends DurableObject<Env> implements Srp {
 	}
 
 	private async getCharacterDataInstance(characterId: string) {
-		const charStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, characterId)
+		const charStub = getStub<EveCharacterData>(this.env.EVE_CHARACTER_DATA, 'default')
 		return await charStub.getInstance(characterId)
 	}
 


### PR DESCRIPTION
<!-- claude:begin -->
**Summary**

EveCharacterData is a Postgres-backed Durable Object that takes the character ID as a parameter on every RPC call, so it does not need to be sharded per character. This PR stops keying getStub calls for EveCharacterData by characterId (and, in one case, the wrong hardcoded value 0) and instead uses the shared default instance everywhere, matching the pattern already used for EveTokenStore.

**Changes**

- Replace getStub calls to EveCharacterData keyed by characterId with a shared default instance across apps/core, apps/eve-character-data, apps/fleets, apps/groups, and apps/srp (routes, middleware, services, workflows, and durable objects).
- Hoist stub creation out of per-character loops and Promise.all blocks in character-access.ts, corporations/index.ts, and fleet-monitor.ts so a single shared stub is reused instead of one per character.
- Add using when acquiring RpcTarget instances via getInstance() (e.g. characters.ts, refresh-market-data.ts, refresh-wallet-journal.ts, character-access.ts) so they are properly disposed, per the getStub RpcTarget disposal pattern in the do-utils package.
- Update the hr-auditor route test mock to include a Symbol.dispose stub matching the new using usage.

**Testing**

No explicit test run mentioned in the commit; the only test change is the added Symbol.dispose mock in characters.hr-auditor.route.test.ts to keep the existing test suite passing with the new using disposal pattern.
<!-- claude:end -->