### PR TITLE
reduce sov workflow read amplification

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -216,9 +216,12 @@ const CHARACTER_WALLET_SCOPE = 'esi-wallet.read_character_wallet.v1'
 const CORPORATION_MEMBERSHIP_SCOPE = 'esi-corporations.read_corporation_membership.v1'
 const NPC_CORPORATION_ID_MIN = 1_000_000
 const NPC_CORPORATION_ID_MAX = 1_999_999
-const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY = 'shared:sovereignty-systems:observed-at'
-const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY = 'shared:sovereignty-systems:count'
+// Bump the metadata keys when the row-key layout changes so existing DOs lazily
+// rebuild the snapshot and remove rows written by the previous layout.
+const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY = 'shared:sovereignty-systems:v2:observed-at'
+const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY = 'shared:sovereignty-systems:v2:count'
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX = 'shared:sovereignty-systems:row:'
+const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_CORPORATION_ROW_PREFIX = `${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX}corporation:`
 const SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS = 60 * 60
 const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_KEY = 'shared:sovereignty-systems:refresh-lease'
 const SHARED_SOVEREIGNTY_SYSTEMS_REFRESH_LEASE_SECONDS = 2 * 60
@@ -425,6 +428,25 @@ type SharedSovereigntySystemsRefreshLease = {
 	token: string
 	expiresAtMs: number
 	acquiredAtMs: number
+}
+
+function getSharedSovereigntySystemCacheKey(system: EsiSovereigntySystem): string {
+	const corporationScope = system.corporation_id
+		? `${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_CORPORATION_ROW_PREFIX}${system.corporation_id}`
+		: `${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX}unscoped`
+
+	return `${corporationScope}:system:${system.system_id}`
+}
+
+function getSharedSovereigntyCorporationRowPrefix(corporationId: string): string {
+	return `${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_CORPORATION_ROW_PREFIX}${corporationId}:`
+}
+
+function getSharedSovereigntySystemCacheKeyForCorporation(
+	corporationId: string,
+	systemId: string
+): string {
+	return `${getSharedSovereigntyCorporationRowPrefix(corporationId)}system:${systemId}`
 }
 type SkyhookStorageRow = {
 	structureId: string
@@ -4049,10 +4071,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 	async storeSharedSovereigntySystems(systems: EsiSovereigntySystem[]): Promise<void> {
 		const observedAt = new Date().toISOString()
 		const rowEntries = Object.fromEntries(
-			systems.map((system) => [
-				`${SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX}${system.system_id}`,
-				system,
-			])
+			systems.map((system) => [getSharedSovereigntySystemCacheKey(system), system])
 		)
 
 		await this.state.storage.transaction(async (txn) => {
@@ -4115,10 +4134,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		const observedAtRaw = await this.state.storage.get<string>(
 			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
 		)
-		const cachedSystemCount = await this.state.storage.get<number>(
-			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_COUNT_KEY
-		)
-		if (!observedAtRaw || cachedSystemCount === undefined) {
+		if (!observedAtRaw) {
 			return null
 		}
 
@@ -4128,11 +4144,40 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		}
 
 		const rows = await this.state.storage.list<EsiSovereigntySystem>({
-			prefix: SHARED_SOVEREIGNTY_SYSTEMS_CACHE_ROW_PREFIX,
+			prefix: getSharedSovereigntyCorporationRowPrefix(corporationId),
 		})
-		if (rows.size !== cachedSystemCount) {
+		return [...rows.values()].filter(
+			(system) => system.claim_type === 'alliance' && system.corporation_id === corporationId
+		)
+	}
+
+	async getSharedSovereigntySystemsByIds(
+		corporationId: string,
+		systemIds: readonly string[],
+		maxAgeSeconds = SHARED_SOVEREIGNTY_SYSTEMS_CACHE_MAX_AGE_SECONDS
+	): Promise<EsiSovereigntySystem[] | null> {
+		const observedAtRaw = await this.state.storage.get<string>(
+			SHARED_SOVEREIGNTY_SYSTEMS_CACHE_META_KEY
+		)
+		if (!observedAtRaw) {
 			return null
 		}
+
+		const observedAt = parseDateOrNull(observedAtRaw)
+		if (!observedAt || Date.now() - observedAt.getTime() > maxAgeSeconds * 1000) {
+			return null
+		}
+
+		const uniqueSystemIds = [...new Set(systemIds.map((systemId) => String(systemId)))]
+		if (uniqueSystemIds.length === 0) {
+			return []
+		}
+
+		const rows = await this.state.storage.get<EsiSovereigntySystem>(
+			uniqueSystemIds.map((systemId) =>
+				getSharedSovereigntySystemCacheKeyForCorporation(corporationId, systemId)
+			)
+		)
 		return [...rows.values()].filter(
 			(system) => system.claim_type === 'alliance' && system.corporation_id === corporationId
 		)

--- a/apps/eve-corporation-data/src/test/unit/shared-sovereignty-storage.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/shared-sovereignty-storage.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { EveCorporationDataDO } from '../../durable-object'
+
+type StoredValue = unknown
+
+function createStorage() {
+	const values = new Map<string, StoredValue>()
+	const storage = {
+		get: vi.fn(async (keyOrKeys: string | string[]) => {
+			if (Array.isArray(keyOrKeys)) {
+				return new Map(
+					keyOrKeys.filter((key) => values.has(key)).map((key) => [key, values.get(key)])
+				)
+			}
+			return values.get(keyOrKeys)
+		}),
+		list: vi.fn(
+			async ({ prefix }: { prefix: string }) =>
+				new Map([...values].filter(([key]) => key.startsWith(prefix)))
+		),
+		put: vi.fn(async (keyOrEntries: string | Record<string, StoredValue>, value?: StoredValue) => {
+			if (typeof keyOrEntries === 'string') {
+				values.set(keyOrEntries, value)
+				return
+			}
+			for (const [key, entry] of Object.entries(keyOrEntries)) {
+				values.set(key, entry)
+			}
+		}),
+		delete: vi.fn(async (keyOrKeys: string | string[]) => {
+			for (const key of Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys]) {
+				values.delete(key)
+			}
+		}),
+		transaction: vi.fn(async (callback: (transaction: typeof storage) => Promise<void>) =>
+			callback(storage)
+		),
+	}
+
+	return { storage, values }
+}
+
+function createDoInstance(storage: ReturnType<typeof createStorage>['storage']) {
+	const instance = Object.create(EveCorporationDataDO.prototype) as EveCorporationDataDO
+	instance.state = { storage } as never
+	return instance
+}
+
+describe('shared sovereignty storage', () => {
+	it('reads only the requested corporation prefix while preserving full snapshots', async () => {
+		const { storage, values } = createStorage()
+		values.set('shared:sovereignty-systems:row:legacy-system', { system_id: 'legacy-system' })
+		const instance = createDoInstance(storage)
+		const systems = [
+			{
+				system_id: 'system-1',
+				claim_type: 'alliance' as const,
+				corporation_id: 'corp-1',
+			},
+			{
+				system_id: 'system-2',
+				claim_type: 'alliance' as const,
+				corporation_id: 'corp-2',
+			},
+			{
+				system_id: 'system-3',
+				claim_type: 'unclaimed' as const,
+				corporation_id: null,
+			},
+		]
+
+		await instance.storeSharedSovereigntySystems(systems)
+
+		const corporationSystems = await instance.getSharedSovereigntySystemsForCorporation('corp-1')
+		const targetedSystems = await instance.getSharedSovereigntySystemsByIds('corp-1', [
+			'system-1',
+			'missing-system',
+		])
+		const snapshot = await instance.getSharedSovereigntySystemsSnapshot()
+
+		expect(corporationSystems).toEqual([systems[0]])
+		expect(targetedSystems).toEqual([systems[0]])
+		expect(snapshot).toEqual(systems)
+		expect(values.has('shared:sovereignty-systems:row:legacy-system')).toBe(false)
+		expect(storage.list).toHaveBeenCalledWith({
+			prefix: 'shared:sovereignty-systems:row:corporation:corp-1:',
+		})
+	})
+})

--- a/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/workflows/structure-enrichment.test.ts
@@ -6,6 +6,7 @@ const SOVEREIGNTY_HUB_TYPE_ID = '32458'
 
 const mocks = vi.hoisted(() => {
 	const fetchSovereigntyHubsMock = vi.fn()
+	const readSharedSovereigntySystemsByIdsMock = vi.fn()
 	const readSharedSovereigntySystemsForCorporationMock = vi.fn()
 	const refreshSharedSovereigntySystemsMock = vi.fn()
 	const resolveSolarSystemsByIdsMock = vi.fn()
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => {
 
 	return {
 		fetchSovereigntyHubsMock,
+		readSharedSovereigntySystemsByIdsMock,
 		readSharedSovereigntySystemsForCorporationMock,
 		refreshSharedSovereigntySystemsMock,
 		resolveSolarSystemsByIdsMock,
@@ -59,6 +61,8 @@ vi.mock('../../../workflows/utils/services', () => ({
 }))
 
 vi.mock('../../../workflows/utils/sovereignty-systems-cache', () => ({
+	readSharedSovereigntySystemsByIds: (...args: unknown[]) =>
+		mocks.readSharedSovereigntySystemsByIdsMock(...args),
 	readSharedSovereigntySystemsForCorporation: (...args: unknown[]) =>
 		mocks.readSharedSovereigntySystemsForCorporationMock(...args),
 	refreshSharedSovereigntySystems: (...args: unknown[]) =>
@@ -87,12 +91,12 @@ describe('fetchSovereigntyEnrichment', () => {
 			},
 			pages: 1,
 		})
-		mocks.readSharedSovereigntySystemsForCorporationMock.mockResolvedValue([
+		mocks.readSharedSovereigntySystemsByIdsMock.mockResolvedValue([
 			{
 				system_id: '30000142',
 				claim_type: 'alliance',
 				alliance_id: '123456789',
-				corporation_id: '987654321',
+				corporation_id: 'corp-1',
 				claimed_since: '2026-07-12T19:36:46.834Z',
 				is_capital_system: false,
 				sovereignty_hub_structure_id: 'hub-1',
@@ -172,11 +176,13 @@ describe('fetchSovereigntyEnrichment', () => {
 				pruneCandidateIds: ['departed-hub'],
 			}
 		)
-		expect(mocks.readSharedSovereigntySystemsForCorporationMock).toHaveBeenCalledWith(
+		expect(mocks.readSharedSovereigntySystemsForCorporationMock).not.toHaveBeenCalled()
+		expect(mocks.readSharedSovereigntySystemsByIdsMock).toHaveBeenCalledWith(
 			{
 				UNIVERSE: {},
 			},
-			'corp-1'
+			'corp-1',
+			['30000142']
 		)
 		expect(mocks.getStubMock).toHaveBeenCalledWith({}, 'default')
 		expect(mocks.resolveSolarSystemsByIdsMock).toHaveBeenCalledWith(['30000142'])
@@ -197,6 +203,7 @@ describe('fetchSovereigntyEnrichment', () => {
 			syncPriorities: [],
 		})
 		mocks.readSharedSovereigntySystemsForCorporationMock.mockResolvedValue([])
+		mocks.readSharedSovereigntySystemsByIdsMock.mockReset()
 		mocks.fetchEsiMock.mockRejectedValue(
 			new Error(
 				'ESI request failed: 401 Unauthorized - {"error":"missing scope"} | metadata={"status":401,"path":"/corporations/123/structures/sovereignty-hubs/"}'
@@ -218,5 +225,62 @@ describe('fetchSovereigntyEnrichment', () => {
 			expect(error).toBeInstanceOf(Error)
 			expect((error as { target?: string }).target).toBe('sovereignty-hubs')
 		})
+	})
+
+	it('uses the corporation-scoped cache fallback when no live hubs are listed', async () => {
+		mocks.createTokenStoreMock.mockReturnValue({
+			fetchEsi: mocks.fetchEsiMock,
+		})
+		mocks.fetchEsiMock.mockResolvedValueOnce({
+			data: { sovereignty_hubs: [] },
+			pages: 1,
+		})
+		mocks.readSharedSovereigntySystemsForCorporationMock.mockResolvedValue([
+			{
+				system_id: '30000142',
+				claim_type: 'alliance',
+				alliance_id: '123456789',
+				corporation_id: 'corp-1',
+				claimed_since: null,
+				is_capital_system: false,
+				sovereignty_hub_structure_id: null,
+				vulnerability_window: null,
+				activity_defense_multiplier: '1.0000',
+				military_level: 1,
+				industrial_level: 1,
+				strategic_level: 1,
+				raw: { claim: {} },
+			},
+		])
+		mocks.getStructurePriorityQueueMock.mockResolvedValueOnce({
+			newStructureIds: [],
+			pruneCandidateIds: [],
+			syncPriorities: [],
+		})
+		mocks.fetchSovereigntyHubsMock.mockResolvedValueOnce({
+			sovereigntyHubs: [],
+			pruneCandidateIds: [],
+			failures: [],
+			failureCount: 0,
+			rateLimitFailureCount: 0,
+			nonRateLimitFailureCount: 0,
+		})
+
+		const result = await fetchSovereigntyEnrichment(
+			{
+				UNIVERSE: {} as never,
+			} as never,
+			'corp-1',
+			'character-1'
+		)
+
+		expect(mocks.readSharedSovereigntySystemsForCorporationMock).toHaveBeenCalledWith(
+			{
+				UNIVERSE: {},
+			},
+			'corp-1'
+		)
+		expect(mocks.readSharedSovereigntySystemsByIdsMock).not.toHaveBeenCalled()
+		expect(result?.sovereigntySystems).toHaveLength(1)
 	})
 })

--- a/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
+++ b/apps/eve-corporation-data/src/workflows/steps/structures/index.ts
@@ -5,6 +5,7 @@ import * as esiFetch from '../../../services/esi-fetch'
 import { buildPriorityQueuedEntries } from '../../../services/structure-priority'
 import { createTokenStore, getCorporationDataStub } from '../../utils/services'
 import {
+	readSharedSovereigntySystemsByIds,
 	readSharedSovereigntySystemsForCorporation,
 	refreshSharedSovereigntySystems,
 } from '../../utils/sovereignty-systems-cache'
@@ -149,20 +150,6 @@ export async function fetchSovereigntyEnrichment(
 	try {
 		const corpData = getCorporationDataStub(env, corporationId)
 		const tokenStore = createTokenStore(env)
-		let sovereigntySystems = await readSharedSovereigntySystemsForCorporation(env, corporationId)
-		if (!sovereigntySystems) {
-			logger.info(
-				'[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache',
-				{
-					corporationId,
-				}
-			)
-			await refreshSharedSovereigntySystems(env)
-			sovereigntySystems = await readSharedSovereigntySystemsForCorporation(env, corporationId)
-			if (!sovereigntySystems) {
-				throw new Error('Complete shared sovereignty snapshot was unavailable after refresh')
-			}
-		}
 		const sovereigntyHubListing = await fetchStructureListing(
 			(page) =>
 				fetchListingPage(
@@ -177,6 +164,29 @@ export async function fetchSovereigntyEnrichment(
 			(data) => data.sovereignty_hubs,
 			'sovereignty-hubs'
 		)
+		const liveSystemIds = [
+			...new Set(sovereigntyHubListing.map((hub) => String(hub.solar_system_id))),
+		]
+		let sovereigntySystems =
+			liveSystemIds.length > 0
+				? await readSharedSovereigntySystemsByIds(env, corporationId, liveSystemIds)
+				: await readSharedSovereigntySystemsForCorporation(env, corporationId)
+		if (!sovereigntySystems) {
+			logger.info(
+				'[StructuresStep] Shared sovereignty snapshot missing or stale; rewarming cache',
+				{
+					corporationId,
+				}
+			)
+			await refreshSharedSovereigntySystems(env)
+			sovereigntySystems =
+				liveSystemIds.length > 0
+					? await readSharedSovereigntySystemsByIds(env, corporationId, liveSystemIds)
+					: await readSharedSovereigntySystemsForCorporation(env, corporationId)
+			if (!sovereigntySystems) {
+				throw new Error('Complete shared sovereignty snapshot was unavailable after refresh')
+			}
+		}
 		const liveStructureIds = sovereigntyHubListing.map((hub) => String(hub.id))
 		const priorityQueue = await withRpcResult(
 			corpData.getStructurePriorityQueue(corporationId, 'sovereignty', liveStructureIds),

--- a/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
+++ b/apps/eve-corporation-data/src/workflows/utils/sovereignty-systems-cache.ts
@@ -33,6 +33,21 @@ export async function readSharedSovereigntySystemsForCorporation(
 }
 
 /**
+ * Read only the cached sovereignty systems referenced by a live hub listing.
+ */
+export async function readSharedSovereigntySystemsByIds(
+	env: Env,
+	corporationId: string,
+	systemIds: readonly string[]
+): Promise<EsiSovereigntySystem[] | null> {
+	const globalCorpData = getGlobalCorporationDataStub(env)
+	return await withRpcResult(
+		globalCorpData.getSharedSovereigntySystemsByIds(corporationId, systemIds),
+		(systems) => systems?.map((system) => ({ ...system })) ?? null
+	)
+}
+
+/**
  * Ensure the full sovereignty snapshot is available before structure fanout.
  */
 export async function ensureSharedSovereigntySystems(env: Env): Promise<void> {

--- a/packages/eve-corporation-data/src/index.ts
+++ b/packages/eve-corporation-data/src/index.ts
@@ -1428,6 +1428,17 @@ export interface EveCorporationData {
 	): Promise<EsiSovereigntySystem[] | null>
 
 	/**
+	 * Read fresh shared sovereignty systems for the requested corporation and system IDs.
+	 * This avoids scanning the corporation's complete cached sovereignty slice when only
+	 * the systems from a live hub listing are needed.
+	 */
+	getSharedSovereigntySystemsByIds(
+		corporationId: string,
+		systemIds: readonly string[],
+		maxAgeSeconds?: number
+	): Promise<EsiSovereigntySystem[] | null>
+
+	/**
 	 * Read the entire shared sovereignty system snapshot if it is still fresh.
 	 */
 	getSharedSovereigntySystemsSnapshot(


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Reduces read amplification in the sovereignty (SOV) workflow by letting structure enrichment fetch only the specific sovereignty systems referenced by a corporation's live hub listing, instead of always scanning/reading the corporation's entire cached sovereignty slice.

## Changes
- Row-keys for the shared sovereignty systems cache are now scoped by corporation (`shared:sovereignty-systems:row:corporation:<id>:system:<id>`) instead of a flat `row:<system_id>` prefix, via new `getSharedSovereigntySystemCacheKey`/`getSharedSovereigntyCorporationRowPrefix` helpers.
- Cache metadata keys (`observed-at`, `count`) are bumped to a `v2` namespace so existing Durable Objects lazily rebuild the snapshot and drop rows written under the old layout.
- `getSharedSovereigntySystemsForCorporation` now lists only the requesting corporation's row prefix instead of the whole cache, and no longer relies on a separate cached-count check.
- Adds `getSharedSovereigntySystemsByIds` (DO RPC) and `readSharedSovereigntySystemsByIds` (workflow util) to do targeted `storage.get` lookups for a specific corporation + set of system IDs.
- `fetchSovereigntyEnrichment` now reads only the sovereignty systems for the system IDs present in the live hub listing when hubs exist, falling back to the full per-corporation read when there are no live hubs; cache rewarming and the "still missing after refresh" error path are preserved for both cases.
- Updates the `EveCorporationData` RPC interface with the new `getSharedSovereigntySystemsByIds` method.

## Testing
- Added `apps/eve-corporation-data/src/test/unit/shared-sovereignty-storage.test.ts`, a new unit test verifying corporation-scoped storage/reads, that legacy unscoped rows are pruned, and that snapshot reads still return everything.
- Updated `structure-enrichment.test.ts` to cover both the new ID-scoped cache read path (when live hubs are present) and the fallback to the corporation-wide cache read (when no live hubs are listed).
<!-- claude:end -->