### PR TITLE
fix SRP filter UI stuck state

### DIFF
--- a/apps/ui/src/client/features/srp/routes/review.tsx
+++ b/apps/ui/src/client/features/srp/routes/review.tsx
@@ -30,6 +30,7 @@ import { typeIconUrl } from '@/lib/eve-images'
 import { CharacterRoleBadge } from '../components/CharacterRoleBadge'
 import { RequestStatusBadge } from '../components/RequestStatusBadge'
 import {
+	clearReviewQueueFilters,
 	setReviewQueueActiveTab,
 	setReviewQueuePage,
 	setReviewQueuePageSize,
@@ -109,7 +110,7 @@ export default function ReviewQueue() {
 
 			<Card className="mt-section">
 				<CardContent className="space-y-4 p-4">
-					<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+					<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
 						<Select
 							options={[]}
 							value={filters.characterName ?? ''}
@@ -195,6 +196,23 @@ export default function ReviewQueue() {
 							placeholder="Loss date range"
 							className="[&_.themed-date-picker__input]:h-10"
 						/>
+						<div className="flex items-end justify-end">
+							<Button
+								type="button"
+								variant="secondary"
+								size="sm"
+								onClick={clearReviewQueueFilters}
+								disabled={
+									!filters.characterName &&
+									!filters.shipTypeName &&
+									!filters.solarSystemName &&
+									!filters.dateFrom &&
+									!filters.dateTo
+								}
+							>
+								Clear Filters
+							</Button>
+						</div>
 					</div>
 
 					<Tabs value={activeTab} onValueChange={handleTabChange}>

--- a/apps/ui/src/client/features/srp/state/review-queue-snapshot-store.ts
+++ b/apps/ui/src/client/features/srp/state/review-queue-snapshot-store.ts
@@ -1,7 +1,7 @@
 import { createStore } from '@tanstack/store'
 import { useSyncExternalStore } from 'react'
 
-import type { RequestStatus, RequestListResponse, SRPRequestResponse } from '../types'
+import type { RequestListResponse, RequestStatus, SRPRequestResponse } from '../types'
 
 export type ReviewQueueParams = {
 	limit?: number
@@ -194,7 +194,8 @@ function readStateFromStorage(): ReviewQueueStoreState {
 						...parsed.ui,
 						filters: normalizeParams(parsed.ui?.filters ?? {}),
 						sortDirection:
-							parsed.ui?.sortDirection ?? getDefaultSortDirectionForStatus(parsed.ui?.activeTab ?? 'pending'),
+							parsed.ui?.sortDirection ??
+							getDefaultSortDirectionForStatus(parsed.ui?.activeTab ?? 'pending'),
 					},
 					snapshots,
 					entities: parsed.entities ?? {},
@@ -237,9 +238,7 @@ reviewQueueStore.subscribe(() => {
 	emitChange()
 })
 
-function updateState(
-	updater: (previous: ReviewQueueStoreState) => ReviewQueueStoreState
-): void {
+function updateState(updater: (previous: ReviewQueueStoreState) => ReviewQueueStoreState): void {
 	reviewQueueStore.setState((previous) => {
 		const next = updater(previous)
 		if (next === previous) return previous
@@ -280,6 +279,7 @@ export function setReviewQueueActiveTab(nextTab: RequestStatus): void {
 		ui: {
 			...previous.ui,
 			activeTab: nextTab,
+			filters: {},
 			page: 1,
 			sortDirection: getDefaultSortDirectionForStatus(nextTab),
 		},
@@ -291,7 +291,9 @@ export function updateReviewQueueFilters(
 ): void {
 	updateState((previous) => {
 		const nextFilters =
-			typeof patch === 'function' ? patch(previous.ui.filters) : { ...previous.ui.filters, ...patch }
+			typeof patch === 'function'
+				? patch(previous.ui.filters)
+				: { ...previous.ui.filters, ...patch }
 		return {
 			...previous,
 			ui: {
@@ -301,6 +303,17 @@ export function updateReviewQueueFilters(
 			},
 		}
 	})
+}
+
+export function clearReviewQueueFilters(): void {
+	updateState((previous) => ({
+		...previous,
+		ui: {
+			...previous.ui,
+			filters: {},
+			page: 1,
+		},
+	}))
 }
 
 export function setReviewQueuePage(page: number): void {
@@ -410,10 +423,7 @@ export function clearReviewQueueSnapshots(): void {
 	}))
 }
 
-function matchesSnapshotFilters(
-	request: SRPRequestResponse,
-	params: ReviewQueueParams
-): boolean {
+function matchesSnapshotFilters(request: SRPRequestResponse, params: ReviewQueueParams): boolean {
 	if (params.characterName && request.characterName !== params.characterName) return false
 	if (params.shipTypeName && request.shipTypeName !== params.shipTypeName) return false
 	if (params.solarSystemName && request.solarSystemName !== params.solarSystemName) return false
@@ -442,7 +452,8 @@ export function upsertRequestAcrossReviewQueueSnapshots(request: SRPRequestRespo
 		for (const [key, entry] of Object.entries(previous.snapshots)) {
 			const currentRequests = Array.isArray(entry.data.requests) ? entry.data.requests : []
 			let nextRequests = currentRequests
-			let nextTotal = typeof entry.data.total === 'number' ? entry.data.total : currentRequests.length
+			let nextTotal =
+				typeof entry.data.total === 'number' ? entry.data.total : currentRequests.length
 
 			const idx = currentRequests.findIndex((row) => row.id === request.id)
 			const shouldInclude =
@@ -476,7 +487,10 @@ export function upsertRequestAcrossReviewQueueSnapshots(request: SRPRequestRespo
 					requests: nextRequests,
 					total: nextTotal,
 				},
-				updatedAt: nextRequests === entry.data.requests && nextTotal === entry.data.total ? entry.updatedAt : Date.now(),
+				updatedAt:
+					nextRequests === entry.data.requests && nextTotal === entry.data.total
+						? entry.updatedAt
+						: Date.now(),
 			}
 		}
 
@@ -567,7 +581,8 @@ export function transitionRequestStatusAcrossReviewQueueSnapshots(
 				data: {
 					...entry.data,
 					requests: limit ? nextRequests.slice(0, limit) : nextRequests,
-					total: (typeof entry.data.total === 'number' ? entry.data.total : currentRequests.length) + 1,
+					total:
+						(typeof entry.data.total === 'number' ? entry.data.total : currentRequests.length) + 1,
 				},
 				updatedAt: Date.now(),
 			}

--- a/apps/ui/src/test/unit/features/srp/review-queue-snapshot-store.unit.test.ts
+++ b/apps/ui/src/test/unit/features/srp/review-queue-snapshot-store.unit.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
 	__resetReviewQueueSnapshotStoreForTests,
+	clearReviewQueueFilters,
 	getReviewQueueUiState,
 	restoreReviewQueueStateFromRollback,
 	setReviewQueueActiveTab,
@@ -9,8 +10,8 @@ import {
 	setReviewQueuePageSize,
 	setReviewQueueSnapshot,
 	snapshotReviewQueueStateForRollback,
-	transitionRequestStatusAcrossReviewQueueSnapshots,
 	toggleReviewQueueSort,
+	transitionRequestStatusAcrossReviewQueueSnapshots,
 	updateReviewQueueFilters,
 } from '@/features/srp/state/review-queue-snapshot-store'
 
@@ -46,10 +47,12 @@ describe('srp review queue snapshot store', () => {
 
 	it('tracks active tab, resets page, and uses the tab default sort direction', () => {
 		setReviewQueuePage(4)
+		updateReviewQueueFilters({ characterName: 'Alpha' })
 		setReviewQueueActiveTab('approved')
 		const state = getReviewQueueUiState()
 		expect(state.activeTab).toBe('approved')
 		expect(state.page).toBe(1)
+		expect(state.filters).toEqual({})
 		expect(state.sortDirection).toBe('desc')
 	})
 
@@ -58,6 +61,15 @@ describe('srp review queue snapshot store', () => {
 		updateReviewQueueFilters({ characterName: 'Alpha' })
 		expect(getReviewQueueUiState().page).toBe(1)
 		expect(getReviewQueueUiState().filters.characterName).toBe('Alpha')
+	})
+
+	it('clears filters and resets the page', () => {
+		setReviewQueuePage(3)
+		updateReviewQueueFilters({ characterName: 'Alpha', dateFrom: '2026-01-01' })
+		clearReviewQueueFilters()
+		const state = getReviewQueueUiState()
+		expect(state.filters).toEqual({})
+		expect(state.page).toBe(1)
 	})
 
 	it('keeps page size changes and resets page', () => {
@@ -81,9 +93,12 @@ describe('srp review queue snapshot store', () => {
 		)
 		transitionRequestStatusAcrossReviewQueueSnapshots('111', 'approved')
 		const state = snapshotReviewQueueStateForRollback()
-		expect(Object.values(state.snapshots).find((entry) => entry.status === 'pending')?.data.requests).toHaveLength(0)
 		expect(
-			Object.values(state.snapshots).find((entry) => entry.status === 'approved')?.data.requests[0]?.requestStatus
+			Object.values(state.snapshots).find((entry) => entry.status === 'pending')?.data.requests
+		).toHaveLength(0)
+		expect(
+			Object.values(state.snapshots).find((entry) => entry.status === 'approved')?.data.requests[0]
+				?.requestStatus
 		).toBe('approved')
 		expect(state.entities['111']?.requestStatus).toBe('approved')
 	})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes a stuck-state bug in the SRP review queue where filters carried over between tabs, leaving the UI showing stale/empty results after switching tabs. Also adds a way to manually clear all active filters.

## Changes
- `setReviewQueueActiveTab` now resets `filters` to `{}` whenever the active tab changes, in addition to resetting the page.
- Added `clearReviewQueueFilters` action to reset filters and page independently of tab changes.
- Added a "Clear Filters" button to the review queue filter bar, disabled when no filters are active; adjusted the filter grid layout to fit the new button column.
- Minor formatting-only cleanup (Prettier) across `review-queue-snapshot-store.ts` and its unit tests; no behavioral changes from these.

## Testing
- Added/updated unit tests in `review-queue-snapshot-store.unit.test.ts` covering: filters reset when the active tab changes, and `clearReviewQueueFilters` resets filters and page.
<!-- claude:end -->