### PR TITLE
fix structure fetching with compat date

### DIFF
--- a/apps/esi/src/durable-object.ts
+++ b/apps/esi/src/durable-object.ts
@@ -224,6 +224,7 @@ import type { EsiDb } from './storage/state'
 const REVALIDATE_15_MIN = 900 // 15 minutes - for frequently-changing public info
 const REVALIDATE_5_MIN = 300 // 5 minutes - for security-relevant affiliation lookups
 const REVALIDATE_1_HOUR = 3600 // 1 hour - for less frequent updates
+const STRUCTURE_ENRICHMENT_COMPATIBILITY_DATE = '2026-05-19'
 
 /**
  * Durable Object responsible for authenticated ESI fetches on behalf of a character or corporation.
@@ -262,6 +263,8 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 			{
 				body: characterIds.map((id) => parseInt(id, 10)),
 				cacheMode,
+				compatibilityDate: options?.compatibilityDate,
+				includeVersionPath: options?.includeVersionPath,
 				maxRetries: options?.maxRetries,
 				timeoutMs: options?.timeoutMs,
 				maxLocalCacheTtl: cacheMode === 'no-store' ? undefined : REVALIDATE_5_MIN,
@@ -1059,7 +1062,10 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 		return toEsiResult(
 			await this.esiFetcher.fetchEsi<EsiSovereigntyHubListingResponse>(
 				`/corporations/${corporationId}/structures/sovereignty-hubs?page=${page}`,
-				{ cacheMode: 'no-store' }
+				{
+					cacheMode: 'no-store',
+					compatibilityDate: STRUCTURE_ENRICHMENT_COMPATIBILITY_DATE,
+				}
 			)
 		)
 	}
@@ -1072,7 +1078,10 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 		return (
 			await this.esiFetcher.fetchEsi<EsiSovereigntyHubDetail>(
 				`/corporations/${corporationId}/structures/sovereignty-hubs/${structureId}`,
-				{ cacheMode: 'no-store' }
+				{
+					cacheMode: 'no-store',
+					compatibilityDate: STRUCTURE_ENRICHMENT_COMPATIBILITY_DATE,
+				}
 			)
 		).data
 	}
@@ -1090,7 +1099,10 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 		return toEsiResult(
 			await this.esiFetcher.fetchEsi<EsiCorporationSkyhookListingResponse>(
 				`/corporations/${corporationId}/structures/skyhooks${query}`,
-				{ cacheMode: 'no-store' }
+				{
+					cacheMode: 'no-store',
+					compatibilityDate: STRUCTURE_ENRICHMENT_COMPATIBILITY_DATE,
+				}
 			)
 		)
 	}
@@ -1103,7 +1115,10 @@ export class EsiDO extends DurableObject<Env> implements Esi {
 		return (
 			await this.esiFetcher.fetchEsi<EsiCorporationSkyhookDetail>(
 				`/corporations/${corporationId}/structures/skyhooks/${structureId}`,
-				{ cacheMode: 'no-store' }
+				{
+					cacheMode: 'no-store',
+					compatibilityDate: STRUCTURE_ENRICHMENT_COMPATIBILITY_DATE,
+				}
 			)
 		).data
 	}

--- a/apps/esi/src/lib/esi-fetch.ts
+++ b/apps/esi/src/lib/esi-fetch.ts
@@ -45,6 +45,10 @@ import type { Env } from '../context'
  */
 export interface FetchEsiOptions<B = unknown> {
 	method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+	/** Override the ESI compatibility date for this request. */
+	compatibilityDate?: string
+	/** Include the ESI version path configured on the request client. */
+	includeVersionPath?: boolean
 	/** Request body for mutation requests. */
 	body?: B
 	/** Cache policy for this request. Stateful/auth-sensitive endpoints should use `no-store`. */
@@ -286,6 +290,8 @@ export class EsiFetcher {
 		return await this.requestClient.request<T>({
 			path,
 			userKey: context.userKey,
+			compatibilityDate: options?.compatibilityDate,
+			includeVersionPath: options?.includeVersionPath,
 			cacheScope,
 			cacheMode,
 			method,
@@ -385,6 +391,8 @@ export class EsiFetcher {
 		return await this.requestClient.requestPaginated<T>({
 			path,
 			userKey: context.userKey,
+			compatibilityDate: options?.compatibilityDate,
+			includeVersionPath: options?.includeVersionPath,
 			cacheScope,
 			cacheMode: options?.cacheMode ?? 'default',
 			method,

--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -3146,6 +3146,76 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 		return fuelBurnRateByStructure
 	}
 
+	/**
+	 * Move current structure projections before the new owner's normal enrichment
+	 * runs. Historical state and extraction rows intentionally keep their
+	 * original corporation so ownership changes do not rewrite history.
+	 */
+	private async transferCurrentStructureProjections(
+		corporationId: string,
+		structureIds: readonly string[]
+	): Promise<void> {
+		if (structureIds.length === 0) {
+			return
+		}
+
+		const db = this.getDb()
+		await db
+			.update(structureMoonDrills)
+			.set({ corporationId })
+			.where(
+				and(
+					inArray(structureMoonDrills.structureId, [...structureIds]),
+					ne(structureMoonDrills.corporationId, corporationId)
+				)
+			)
+		await db
+			.update(structureMoonGeographies)
+			.set({ corporationId })
+			.where(
+				and(
+					inArray(structureMoonGeographies.structureId, [...structureIds]),
+					ne(structureMoonGeographies.corporationId, corporationId)
+				)
+			)
+		await db
+			.update(structureSkyhooks)
+			.set({ corporationId })
+			.where(
+				and(
+					inArray(structureSkyhooks.structureId, [...structureIds]),
+					ne(structureSkyhooks.corporationId, corporationId)
+				)
+			)
+		await db
+			.update(structureSkyhookReagents)
+			.set({ corporationId })
+			.where(
+				and(
+					inArray(structureSkyhookReagents.structureId, [...structureIds]),
+					ne(structureSkyhookReagents.corporationId, corporationId)
+				)
+			)
+		await db
+			.update(structureSovereigntyHubs)
+			.set({ corporationId })
+			.where(
+				and(
+					inArray(structureSovereigntyHubs.structureId, [...structureIds]),
+					ne(structureSovereigntyHubs.corporationId, corporationId)
+				)
+			)
+		await db
+			.update(structureMiningExtractions)
+			.set({ corporationId })
+			.where(
+				and(
+					inArray(structureMiningExtractions.structureId, [...structureIds]),
+					ne(structureMiningExtractions.corporationId, corporationId)
+				)
+			)
+	}
+
 	private async getStructureServiceModuleTypeIds(
 		corporationId: string,
 		structureIds: readonly string[]
@@ -3258,29 +3328,85 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 			corporationId,
 			structures as EsiCorporationStructure[]
 		)
+		const ownershipConfirmedStructures = hydratedStructures.filter((structure) => {
+			const observedOwnerId = structure.structureInfo?.owner_id
+			if (!observedOwnerId || observedOwnerId === corporationId) {
+				return true
+			}
+
+			logger.info('[EveCorporationData] Ignoring stale structure listing after ownership change', {
+				corporationId,
+				structureId: structure.structureId,
+				observedOwnerId,
+			})
+			return false
+		})
 		const fuelBurnRateByStructure = await this.resolveStructureFuelBurnRates(
 			corporationId,
-			hydratedStructures
+			ownershipConfirmedStructures
 		)
-		const structureIds = hydratedStructures.map((structure) => structure.structureId)
+		const structureIds = [
+			...new Set(ownershipConfirmedStructures.map((structure) => structure.structureId)),
+		]
 		const existingStructureRows = await this.getDb().query.corporationStructures.findMany({
-			where: eq(corporationStructures.corporationId, corporationId),
+			where:
+				structureIds.length > 0
+					? or(
+							eq(corporationStructures.corporationId, corporationId),
+							inArray(corporationStructures.structureId, structureIds)
+						)
+					: eq(corporationStructures.corporationId, corporationId),
 			columns: {
 				structureId: true,
+				corporationId: true,
 				typeId: true,
 				updatedAt: true,
 			},
 		})
+		const transferredStructures = existingStructureRows.filter(
+			(row) => structureIds.includes(row.structureId) && row.corporationId !== corporationId
+		)
+
+		if (transferredStructures.length > 0) {
+			const transferredStructureIds = transferredStructures.map((row) => row.structureId)
+			await this.transferCurrentStructureProjections(corporationId, transferredStructureIds)
+			await this.getDb()
+				.delete(corporationStructureInventory)
+				.where(
+					and(
+						inArray(corporationStructureInventory.structureId, transferredStructureIds),
+						ne(corporationStructureInventory.corporationId, corporationId)
+					)
+				)
+			await this.getDb()
+				.delete(corporationAssets)
+				.where(
+					and(
+						inArray(corporationAssets.locationId, transferredStructureIds),
+						ne(corporationAssets.corporationId, corporationId)
+					)
+				)
+
+			logger.info('[EveCorporationData] Structure ownership transfer detected', {
+				corporationId,
+				transferredCount: transferredStructures.length,
+				transferredStructureIds,
+				previousCorporationIds: [...new Set(transferredStructures.map((row) => row.corporationId))],
+			})
+		}
+
 		const currentStructureIds = new Set(structureIds)
 		const departedStructureIds = filterPrunableStructureIds(
-			existingStructureRows.filter((row) => row.typeId !== ORBITAL_SKYHOOK_TYPE_ID),
+			existingStructureRows.filter(
+				(row) => row.corporationId === corporationId && row.typeId !== ORBITAL_SKYHOOK_TYPE_ID
+			),
 			currentStructureIds,
 			new Date()
 		)
 		const BATCH_SIZE = STRUCTURE_SNAPSHOT_BATCH_SIZE
 
-		for (let i = 0; i < hydratedStructures.length; i += BATCH_SIZE) {
-			const batch = hydratedStructures.slice(i, i + BATCH_SIZE)
+		for (let i = 0; i < ownershipConfirmedStructures.length; i += BATCH_SIZE) {
+			const batch = ownershipConfirmedStructures.slice(i, i + BATCH_SIZE)
 			const batchValues = batch.map((structure) => {
 				const fuelResult = fuelBurnRateByStructure.get(structure.structureId)
 				const hasUnresolvedFuelModules =
@@ -3303,6 +3429,7 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				.onConflictDoUpdate({
 					target: corporationStructures.structureId,
 					set: {
+						corporationId: sql`excluded.corporation_id`,
 						name: sql`excluded.name`,
 						typeId: sql`excluded.type_id`,
 						typeName: sql`excluded.type_name`,
@@ -3341,8 +3468,8 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 					)
 				)
 		})
-		await this.storeMoonGeographies(corporationId, hydratedStructures)
-		await this.storeMoonDrills(corporationId, hydratedStructures)
+		await this.storeMoonGeographies(corporationId, ownershipConfirmedStructures)
+		await this.storeMoonDrills(corporationId, ownershipConfirmedStructures)
 	}
 
 	private async storeMoonDrills(

--- a/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+	corporationAssets,
+	corporationStructureInventory,
 	corporationStructures,
 	structureMoonDrills,
 	structureMoonGeographies,
@@ -58,7 +60,7 @@ function makeDb() {
 	const insert = vi.fn(() => ({ values }))
 	const corporationStructuresFindMany = vi
 		.fn()
-		.mockResolvedValue([{ structureId: 'stale-structure' }])
+		.mockResolvedValue([{ structureId: 'stale-structure', corporationId: 'corp-1' }])
 	const structureSkyhooksFindMany = vi.fn().mockResolvedValue([{ structureId: 'stale-structure' }])
 	const structureMiningExtractionsFindMany = vi
 		.fn()
@@ -103,6 +105,7 @@ function makeDb() {
 		_returning: returning,
 		_set: set,
 		_values: values,
+		_onConflictDoUpdate: onConflictDoUpdate,
 		_execute: execute,
 	}
 }
@@ -154,6 +157,110 @@ describe('structure prune cleanup', () => {
 			db._values.mock.calls[0][0].map((row: { structureId: string }) => row.structureId)
 		).toEqual(['moon-1', 'moon-2'])
 		expect(db.delete).toHaveBeenCalledWith(structureMoonDrills)
+	})
+
+	it('moves transferred structures to the new corporation and clears old inventory projections', async () => {
+		const db = makeDb()
+		db.query.corporationStructures.findMany = vi
+			.fn()
+			.mockResolvedValueOnce([
+				{
+					structureId: 'transferred-structure',
+					corporationId: 'old-corp',
+				},
+			])
+			.mockResolvedValueOnce([])
+		db.query.structureMoonGeographies.findMany = vi.fn().mockResolvedValue([])
+		db.query.structureMoonDrills.findMany = vi.fn().mockResolvedValue([])
+		const instance = createDoInstance(db)
+
+		;(instance as any).hydrateStructureRows = vi.fn().mockResolvedValue([
+			{
+				corporationId: 'new-corp',
+				structureId: 'transferred-structure',
+				name: 'Transferred Structure',
+				typeId: '35832',
+				typeName: 'Astrahus',
+				systemId: '30000142',
+				systemName: 'Jita',
+				regionId: '10000002',
+				regionName: 'The Forge',
+				profileId: 'profile-1',
+				fuelExpires: null,
+				fuelAmount: null,
+				nextReinforceApply: null,
+				nextReinforceHour: null,
+				reinforceHour: null,
+				state: 'online',
+				stateTimerEnd: null,
+				stateTimerStart: null,
+				unanchorsAt: null,
+				lowPower: false,
+				syncStatus: 'ok',
+				syncFailureReason: null,
+				lastSyncedAt: new Date('2026-07-12T19:36:47.369Z'),
+				services: null,
+				fuelBurnRate: null,
+				structureInfo: null,
+				updatedAt: new Date('2026-07-12T19:36:47.369Z'),
+			},
+		])
+		;(instance as any).resolveStructureFuelBurnRates = vi.fn().mockResolvedValue(new Map())
+
+		await instance.storeStructures('new-corp', [
+			{
+				structure_id: 'transferred-structure',
+				type_id: '35832',
+				system_id: '30000142',
+				profile_id: 'profile-1',
+				state: 'online',
+			},
+		])
+
+		expect(db.delete).toHaveBeenCalledWith(corporationStructureInventory)
+		expect(db.delete).toHaveBeenCalledWith(corporationAssets)
+		expect(db._values).toHaveBeenCalledWith([
+			expect.objectContaining({
+				corporationId: 'new-corp',
+				structureId: 'transferred-structure',
+			}),
+		])
+		expect(db._onConflictDoUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				set: expect.objectContaining({ corporationId: expect.anything() }),
+			})
+		)
+	})
+
+	it('does not reattach a structure from a stale former-owner listing', async () => {
+		const db = makeDb()
+		db.query.corporationStructures.findMany = vi.fn().mockResolvedValue([])
+		db.query.structureMoonGeographies.findMany = vi.fn().mockResolvedValue([])
+		db.query.structureMoonDrills.findMany = vi.fn().mockResolvedValue([])
+		const instance = createDoInstance(db)
+
+		;(instance as any).hydrateStructureRows = vi.fn().mockResolvedValue([
+			{
+				corporationId: 'old-corp',
+				structureId: 'transferred-structure',
+				typeId: '35832',
+				typeName: 'Astrahus',
+				structureInfo: { owner_id: 'new-corp' },
+			},
+		])
+		;(instance as any).resolveStructureFuelBurnRates = vi.fn().mockResolvedValue(new Map())
+
+		await instance.storeStructures('old-corp', [
+			{
+				structure_id: 'transferred-structure',
+				type_id: '35832',
+				system_id: '30000142',
+				profile_id: 'profile-1',
+				state: 'online',
+			},
+		])
+
+		expect(db.insert).not.toHaveBeenCalled()
 	})
 
 	it('prunes stale skyhook and mining snapshots when structures disappear from a successful sync', async () => {

--- a/packages/esi/src/index.ts
+++ b/packages/esi/src/index.ts
@@ -100,6 +100,8 @@ export interface EsiRequestOptions {
 	cacheMode?: 'default' | 'no-store'
 	maxRetries?: number
 	timeoutMs?: number
+	compatibilityDate?: string
+	includeVersionPath?: boolean
 }
 
 /** Compact result for a domain-owned watermark traversal. */

--- a/packages/esi/src/request.test.ts
+++ b/packages/esi/src/request.test.ts
@@ -82,6 +82,59 @@ describe('ESI request helpers', () => {
 		])
 	})
 
+	it('allows request-level compatibility dates and version prefix control', async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		)
+		const client = new EsiRequestClient({
+			rateLimits: new EsiRateLimitStore(new MemoryKv() as never),
+			fetchImpl: fetchSpy,
+			baseUrl: 'https://esi.test/latest',
+		})
+
+		await client.request({
+			path: '/latest/corporations/123/structures/skyhooks',
+			userKey: 'corporation:123',
+			cacheMode: 'no-store',
+			compatibilityDate: '2026-05-19',
+			includeVersionPath: false,
+			parse: async (response) => response.json() as Promise<{ ok: boolean }>,
+			buildError: () => new Error('unexpected'),
+		})
+
+		const [url, requestInit] = fetchSpy.mock.calls[0] as [string, RequestInit]
+		expect(url).toBe('https://esi.test/corporations/123/structures/skyhooks')
+		expect(new Headers(requestInit.headers).get('X-Compatibility-Date')).toBe('2026-05-19')
+	})
+
+	it('keeps the configured version prefix by default and avoids duplicate prefixes', async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			})
+		)
+		const client = new EsiRequestClient({
+			rateLimits: new EsiRateLimitStore(new MemoryKv() as never),
+			fetchImpl: fetchSpy,
+			baseUrl: 'https://esi.test',
+			versionPath: '/latest',
+		})
+
+		await client.request({
+			path: '/latest/universe/types/34',
+			userKey: 'public',
+			cacheMode: 'no-store',
+			parse: async (response) => response.json() as Promise<{ ok: boolean }>,
+			buildError: () => new Error('unexpected'),
+		})
+
+		expect(fetchSpy.mock.calls[0]?.[0]).toBe('https://esi.test/latest/universe/types/34')
+	})
+
 	it('returns cached responses without fetching when the cache is fresh', async () => {
 		const cache = {
 			getCachedResponse: vi.fn().mockResolvedValue({

--- a/packages/esi/src/request.ts
+++ b/packages/esi/src/request.ts
@@ -119,6 +119,10 @@ export interface EsiRequestResponseContext {
 export interface EsiRequestOptions<T> {
 	path: string
 	userKey: string
+	/** Override the ESI compatibility date for this request. */
+	compatibilityDate?: string
+	/** Include the configured ESI version path, such as `/latest`. */
+	includeVersionPath?: boolean
 	cacheScope?: EsiCacheScopeContext
 	cacheMode?: 'default' | 'no-store'
 	method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
@@ -150,11 +154,16 @@ export interface EsiRequestClientOptions {
 	}
 	baseUrl?: string
 	compatibilityDate?: string
+	/** Version path used when `includeVersionPath` is enabled. */
+	versionPath?: string
+	/** Default for request-level `includeVersionPath` options. */
+	includeVersionPath?: boolean
 	maxRetries?: number
 	fetchImpl?: typeof fetch
 }
 
-const DEFAULT_BASE_URL = 'https://esi.evetech.net/latest'
+const DEFAULT_BASE_URL = 'https://esi.evetech.net'
+const DEFAULT_VERSION_PATH = '/latest'
 const DEFAULT_COMPATIBILITY_DATE = '2025-11-06'
 const DEFAULT_MAX_RETRIES = 5
 const DEFAULT_PUBLIC_SCOPE: EsiCacheScopeContext = {
@@ -274,26 +283,70 @@ function buildRequestInit(options: {
 	return requestInit
 }
 
+function normalizePath(path: string): string {
+	return `/${path.replace(/^\/+/, '')}`
+}
+
+function normalizeVersionPath(versionPath: string): string {
+	const normalized = normalizePath(versionPath).replace(/\/+$/, '')
+	if (normalized === '/') {
+		throw new TypeError('ESI version path cannot be empty')
+	}
+	return normalized
+}
+
+function stripPathPrefix(value: string, prefix: string): string {
+	if (value === prefix) return ''
+	if (value.startsWith(`${prefix}/`)) return value.slice(prefix.length)
+	return value
+}
+
+function stripVersionPathFromBaseUrl(baseUrl: string, versionPath: string): string {
+	const url = new URL(baseUrl)
+	const basePath = stripPathPrefix(url.pathname, versionPath)
+	url.pathname = basePath
+	url.search = ''
+	url.hash = ''
+	return url.toString().replace(/\/$/, '')
+}
+
 export class EsiRequestClient {
 	private readonly rateLimitGuard: EsiRateLimitGuard
 	private readonly baseUrl: string
 	private readonly compatibilityDate: string
+	private readonly versionPath: string
+	private readonly includeVersionPath: boolean
 	private readonly maxRetries: number
 	private readonly fetchImpl: typeof fetch
 
 	constructor(private readonly options: EsiRequestClientOptions) {
 		this.rateLimitGuard = new EsiRateLimitGuard(options.rateLimits)
-		this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL
+		this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '')
 		this.compatibilityDate = options.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE
+		this.versionPath = normalizeVersionPath(options.versionPath ?? DEFAULT_VERSION_PATH)
+		this.includeVersionPath = options.includeVersionPath ?? true
 		this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
 		this.fetchImpl = options.fetchImpl ?? fetch
+	}
+
+	private buildUrl(path: string, includeVersionPath: boolean): string {
+		const normalizedPath = normalizePath(path)
+		const baseUrl = stripVersionPathFromBaseUrl(this.baseUrl, this.versionPath)
+		const requestPath = stripPathPrefix(normalizedPath, this.versionPath)
+		const versionPrefix = includeVersionPath ? this.versionPath : ''
+		return `${baseUrl}${versionPrefix}${requestPath}`
 	}
 
 	private getCacheScope(scope?: EsiCacheScopeContext): EsiCacheScopeContext {
 		return scope ?? DEFAULT_PUBLIC_SCOPE
 	}
 
-	private async getCachePath(path: string, method: string, jsonBody?: unknown): Promise<string> {
+	private async getCachePath(
+		path: string,
+		method: string,
+		jsonBody?: unknown,
+		variant?: string
+	): Promise<string> {
 		let cachePath = removePageFromPath(path)
 
 		if (method === 'POST' && jsonBody !== undefined) {
@@ -302,7 +355,7 @@ export class EsiRequestClient {
 			cachePath = `${cachePath}:body:${bodyHash}`
 		}
 
-		return cachePath
+		return variant ? `${cachePath}:${variant}` : cachePath
 	}
 
 	private async readResponseErrorBody(response: Response): Promise<string> {
@@ -336,8 +389,14 @@ export class EsiRequestClient {
 		const cacheMode = options.cacheMode ?? 'default'
 		const method = options.method ?? (options.jsonBody !== undefined ? 'POST' : 'GET')
 		const persistGlobalCache = options.persistGlobalCache ?? true
+		const compatibilityDate = options.compatibilityDate ?? this.compatibilityDate
+		const includeVersionPath = options.includeVersionPath ?? this.includeVersionPath
+		const cacheVariant =
+			compatibilityDate === this.compatibilityDate && includeVersionPath === this.includeVersionPath
+				? undefined
+				: `compatibility:${compatibilityDate}:version:${includeVersionPath ? this.versionPath : 'none'}`
 		const cachePage = extractPageFromPath(options.path) ?? undefined
-		const cachePath = await this.getCachePath(options.path, method, options.jsonBody)
+		const cachePath = await this.getCachePath(options.path, method, options.jsonBody, cacheVariant)
 
 		const providedCached = options.cachedResponse ?? null
 		let cached: EsiResponse<T> | null = providedCached
@@ -403,14 +462,14 @@ export class EsiRequestClient {
 				contentType: options.contentType,
 				timeoutMs: options.timeoutMs,
 				cachedEtag,
-				compatibilityDate: this.compatibilityDate,
+				compatibilityDate,
 			})
 
 			try {
 				response = await this.rateLimitGuard.withResponseRateLimit(
 					options.path,
 					userKey,
-					async () => fetchImpl(`${this.baseUrl}${options.path}`, requestInit)
+					async () => fetchImpl(this.buildUrl(options.path, includeVersionPath), requestInit)
 				)
 			} catch (error) {
 				this.debug('ESI request blocked before fetch', {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Fixes structure-related ESI endpoints (sovereignty hubs, skyhooks) that broke because they need a newer ESI compatibility date and a different (non-`/latest`) versioned path than the rest of the client. Also hardens corporation structure syncing against stale/incorrect ownership data, since structure ownership transfers were causing structures to be duplicated or left attributed to the wrong corporation.

## Changes

- **ESI request client (`packages/esi`)**: split the base URL from the version path so requests can opt out of (or override) the default `/latest` prefix; added per-request `compatibilityDate` and `includeVersionPath` options that flow through `EsiRequestClient.request`/`requestPaginated`. Cache keys now include a variant suffix when a request uses non-default compatibility date/version settings, so overridden responses don't collide with default-cached ones.
- **`apps/esi`**: threaded the new `compatibilityDate`/`includeVersionPath` options through `EsiFetcher` and the ESI durable object; sovereignty-hub and skyhook structure endpoints now request with a fixed `STRUCTURE_ENRICHMENT_COMPATIBILITY_DATE` (`2026-05-19`).
- **`apps/eve-corporation-data`**: `storeStructures` now cross-checks structure `owner_id` from ESI and ignores stale listings from a former owner corporation. When a structure has genuinely changed ownership, it transfers the current projections (moon drills, moon geography, skyhooks, skyhook reagents, sovereignty hubs) to the new corporation, clears stale inventory/asset rows from the old owner, and updates `corporationStructures.corporationId` on conflict — while leaving historical state and extraction rows attributed to their original corporation.

## Testing

- Added unit tests in `apps/eve-corporation-data/src/test/unit/services/structure-prune-cleanup.test.ts` covering structure ownership transfer (projections moved, stale inventory/assets cleared) and rejection of stale former-owner listings.
- Added unit tests in `packages/esi/src/request.test.ts` covering request-level compatibility date/version-path overrides and default version-prefix behavior without duplication.
<!-- claude:end -->