### PR TITLE
fix lingering post-refactor errors

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -76,7 +76,6 @@ import usersRoutes from './routes/users'
 import { CoreRpcService } from './services/core-rpc.service'
 import {
 	buildDiscordInteractionRouting,
-	ensureDiscordCommandRegistryLoaded,
 	executeDiscordSlashCommand,
 } from './services/discord-commands.service'
 import {
@@ -316,13 +315,6 @@ export class CoreWorker extends WorkerEntrypoint<Env> {
 
 	constructor(ctx: ExecutionContext, env: Env) {
 		super(ctx, env)
-		const db = createDb(env.DATABASE_URL)
-		waitUntilWithTelemetry(
-			ctx,
-			'core.command-registry-warm',
-			() => ensureDiscordCommandRegistryLoaded(db, env),
-			{}
-		)
 	}
 
 	/**

--- a/apps/core/src/lib/__tests__/background-task.test.ts
+++ b/apps/core/src/lib/__tests__/background-task.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { waitUntilWithTelemetry } from '../background-task'
+
+describe('waitUntilWithTelemetry', () => {
+	it('registers the background promise before starting the task', async () => {
+		const events: string[] = []
+		let registeredPromise: Promise<unknown> | undefined
+		const executionCtx = {
+			waitUntil: vi.fn((promise: Promise<unknown>) => {
+				events.push('registered')
+				registeredPromise = promise
+			}),
+		}
+
+		waitUntilWithTelemetry(executionCtx, 'test.task', async () => {
+			events.push('started')
+		})
+
+		expect(events).toEqual(['registered'])
+		if (!registeredPromise) {
+			throw new Error('waitUntil did not receive a promise')
+		}
+		await registeredPromise
+		expect(events).toEqual(['registered', 'started'])
+	})
+})

--- a/apps/core/src/lib/background-task.ts
+++ b/apps/core/src/lib/background-task.ts
@@ -44,37 +44,39 @@ export function waitUntilWithTelemetry(
 		})
 	}, warnAfterMs)
 
-	executionCtx.waitUntil(
-		(async () => {
-			if (verbose) {
-				logger.debug('[BackgroundTask] started', {
-					label,
-					...metadata,
-				})
-			}
+	// Register the promise before invoking the task. This matters for RPC and request
+	// contexts: the platform must know about the work before any task-side I/O starts.
+	const backgroundPromise = Promise.resolve().then(async () => {
+		if (verbose) {
+			logger.debug('[BackgroundTask] started', {
+				label,
+				...metadata,
+			})
+		}
 
-			try {
-				await task()
-				settled = true
-				if (verbose) {
-					logger.debug('[BackgroundTask] completed', {
-						label,
-						durationMs: Date.now() - startedAt,
-						...metadata,
-					})
-				}
-			} catch (error) {
-				settled = true
-				logger.error('[BackgroundTask] failed', {
+		try {
+			await task()
+			settled = true
+			if (verbose) {
+				logger.debug('[BackgroundTask] completed', {
 					label,
 					durationMs: Date.now() - startedAt,
-					error: error instanceof Error ? error.message : String(error),
 					...metadata,
 				})
-				throw error
-			} finally {
-				clearTimeout(warningTimer)
 			}
-		})()
-	)
+		} catch (error) {
+			settled = true
+			logger.error('[BackgroundTask] failed', {
+				label,
+				durationMs: Date.now() - startedAt,
+				error: error instanceof Error ? error.message : String(error),
+				...metadata,
+			})
+			throw error
+		} finally {
+			clearTimeout(warningTimer)
+		}
+	})
+
+	executionCtx.waitUntil(backgroundPromise)
 }

--- a/apps/core/src/routes/characters.ts
+++ b/apps/core/src/routes/characters.ts
@@ -342,7 +342,7 @@ app.get('/:characterId/private', requireAuth(), async (c) => {
 					source: 'characters.private',
 				})
 			if (executionCtx) {
-				await waitUntilWithTelemetry(executionCtx, 'characters.immunitas-profile-alert', queueAlert)
+				waitUntilWithTelemetry(executionCtx, 'characters.immunitas-profile-alert', queueAlert)
 			} else {
 				await queueAlert()
 			}

--- a/apps/fulcrum/src/queue.ts
+++ b/apps/fulcrum/src/queue.ts
@@ -3,13 +3,15 @@
  * Handles asynchronous report creation via CHARACTER_REPORTS_QUEUE
  */
 
-import { logger, withWorkerLogContext } from '@repo/hono-helpers'
 import { DEFAULT_RETENTION_DAYS, RETENTION_POLICIES } from '@repo/fulcrum'
+import { logger, withWorkerLogContext } from '@repo/hono-helpers'
 import { createWorkflow } from '@repo/workflow-utils'
+
 import { createDb } from './db'
 import * as queries from './db/queries'
 import { sendReportFailedDM } from './lib/discord-webhook'
 import { resolveReportMetadata } from './lib/report-metadata'
+
 import type { Env } from './context'
 import type { WorkflowParams } from './workflows/character-report.workflow.js'
 
@@ -35,7 +37,7 @@ export interface CharacterReportQueueMessage {
 export async function handleCharacterReportsQueue(
 	batch: MessageBatch<CharacterReportQueueMessage>,
 	env: Env,
-	_ctx: ExecutionContext,
+	_ctx: ExecutionContext
 ): Promise<void> {
 	await withWorkerLogContext('fulcrum-queue', env, async () => {
 		const db = createDb(env.DATABASE_URL)
@@ -53,8 +55,7 @@ export async function handleCharacterReportsQueue(
 					targetUserId,
 					expiresAt,
 					sendDm = true,
-				} =
-					message.body
+				} = message.body
 
 				queueLogger.info('Processing report request', {
 					reportId,
@@ -63,7 +64,9 @@ export async function handleCharacterReportsQueue(
 				})
 
 				// Compute retention from server-side policy
-				const retentionDays = RETENTION_POLICIES[requestSource as keyof typeof RETENTION_POLICIES] ?? DEFAULT_RETENTION_DAYS
+				const retentionDays =
+					RETENTION_POLICIES[requestSource as keyof typeof RETENTION_POLICIES] ??
+					DEFAULT_RETENTION_DAYS
 
 				// Create database record
 				await queries.createCharacterReport(db, {
@@ -111,8 +114,7 @@ export async function handleCharacterReportsQueue(
 				})
 
 				// Update database to mark report as failed
-				const { reportId, characterId, requestorUserId, requestorCorporationId } =
-					message.body
+				const { reportId, characterId, requestorUserId, requestorCorporationId } = message.body
 
 				try {
 					await queries.updateReportStatus(db, reportId, 'failed', {
@@ -141,8 +143,7 @@ export async function handleCharacterReportsQueue(
 						} catch (dmError) {
 							queueLogger.error('Failed to send report failed DM', {
 								reportId,
-								error:
-									dmError instanceof Error ? dmError.message : String(dmError),
+								error: dmError instanceof Error ? dmError.message : String(dmError),
 							})
 						}
 					}

--- a/apps/fulcrum/src/test/unit/structure-resolution.test.ts
+++ b/apps/fulcrum/src/test/unit/structure-resolution.test.ts
@@ -48,4 +48,19 @@ describe('structure resolution', () => {
 		expect(second).toEqual({})
 		expect(fetchStructureInfo).toHaveBeenCalledTimes(1)
 	})
+
+	it('uses stored corporation names before attempting authenticated ESI lookup', async () => {
+		const state = new StructureResolutionCoordinator()
+
+		const result = await state.resolveStructureNames(
+			{ ESI: {} as DurableObjectNamespace },
+			'93665130',
+			['1055096892244'],
+			'test-structure-resolution',
+			{ '1055096892244': 'Private Structure' }
+		)
+
+		expect(result).toEqual({ '1055096892244': 'Private Structure' })
+		expect(fetchStructureInfo).not.toHaveBeenCalled()
+	})
 })

--- a/apps/fulcrum/src/workflows/bulk-character-report.runner.ts
+++ b/apps/fulcrum/src/workflows/bulk-character-report.runner.ts
@@ -4,10 +4,7 @@ import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from '../db'
 import * as queries from '../db/queries'
-import {
-	sendBatchReportFinishedDM,
-	sendBatchReportStartedDM,
-} from '../lib/discord-webhook'
+import { sendBatchReportFinishedDM, sendBatchReportStartedDM } from '../lib/discord-webhook'
 import { resolveBatchReportMetadata } from '../lib/report-metadata'
 
 import type { ReportRequestSource } from '@repo/fulcrum'
@@ -65,7 +62,7 @@ export async function runBulkCharacterReportWorkflow(
 	env: RunnerEnv,
 	stepDo: StepDo,
 	batchId: string,
-	payload: BulkCharacterReportWorkflowParams,
+	payload: BulkCharacterReportWorkflowParams
 ) {
 	return await withWorkerLogContext('bulk-character-report-workflow', env, async () => {
 		const {
@@ -91,7 +88,7 @@ export async function runBulkCharacterReportWorkflow(
 					env as any,
 					requestorUserId,
 					requestorCorporationId,
-					targetUserId,
+					targetUserId
 				)
 				if (!metadata) return
 				await sendBatchReportStartedDM(env as any, requestorUserId, {
@@ -113,7 +110,10 @@ export async function runBulkCharacterReportWorkflow(
 			const refs = await Promise.all(
 				dedupedCharacterIds.map(async (characterId): Promise<ChildReportRef> => {
 					try {
-						const existingInProgress = await queries.getInProgressReportForCharacter(db, characterId)
+						const existingInProgress = await queries.getInProgressReportForCharacter(
+							db,
+							characterId
+						)
 						if (existingInProgress) {
 							return {
 								characterId,
@@ -155,9 +155,10 @@ export async function runBulkCharacterReportWorkflow(
 								workflowInstanceId: childWorkflowInstance.id,
 							}
 						} catch (workflowStartError) {
-							const message = workflowStartError instanceof Error
-								? workflowStartError.message
-								: String(workflowStartError)
+							const message =
+								workflowStartError instanceof Error
+									? workflowStartError.message
+									: String(workflowStartError)
 							await queries.updateReportStatus(db, reportId, 'failed', {
 								errorMessage: `Failed to start child workflow: ${message}`.slice(0, 500),
 							})
@@ -198,16 +199,14 @@ export async function runBulkCharacterReportWorkflow(
 							workflowInstanceId: null,
 						}
 					}
-				}),
+				})
 			)
 
 			return refs
 		})
 
 		await stepDo('wait-for-child-workflows', STEP, async () => {
-			const pending = new Map<string, ChildReportRef>(
-				childRefs.map((ref) => [ref.reportId, ref]),
-			)
+			const pending = new Map<string, ChildReportRef>(childRefs.map((ref) => [ref.reportId, ref]))
 			let guard = 0
 
 			while (pending.size > 0 && guard < 720) {
@@ -243,7 +242,7 @@ export async function runBulkCharacterReportWorkflow(
 								error: error instanceof Error ? error.message : String(error),
 							})
 						}
-					}),
+					})
 				)
 
 				if (pending.size > 0) {
@@ -285,7 +284,7 @@ export async function runBulkCharacterReportWorkflow(
 					env as any,
 					requestorUserId,
 					requestorCorporationId,
-					targetUserId,
+					targetUserId
 				)
 				if (!metadata) return
 				await sendBatchReportFinishedDM(
@@ -299,7 +298,7 @@ export async function runBulkCharacterReportWorkflow(
 						targetMainCharacterId: metadata.targetMainCharacterId,
 						targetMainCharacterName: metadata.targetMainCharacterName,
 					},
-					finalSummary,
+					finalSummary
 				)
 			})
 		}

--- a/apps/fulcrum/src/workflows/processors/helpers/structure-resolution.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/structure-resolution.ts
@@ -27,7 +27,8 @@ export class StructureResolutionCoordinator {
 		},
 		characterId: string,
 		structureIds: Iterable<string>,
-		label: string
+		label: string,
+		knownStructureNames: Readonly<Record<string, string>> = {}
 	): Promise<Record<string, string>> {
 		const resolved: Record<string, string> = {}
 		const esiStub = getEsiInstanceForCharacter(env.ESI, characterId)
@@ -39,6 +40,13 @@ export class StructureResolutionCoordinator {
 			processed += 1
 
 			if (this.deniedStructureIds.has(structureId)) {
+				continue
+			}
+
+			const knownName = knownStructureNames[structureId]
+			if (knownName) {
+				this.resolvedStructureNames.set(structureId, knownName)
+				resolved[structureId] = knownName
 				continue
 			}
 

--- a/apps/fulcrum/src/workflows/processors/helpers/wallet-journal.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/wallet-journal.ts
@@ -43,6 +43,15 @@ export interface ProcessedWalletJournalEntry extends CharacterWalletJournalEntry
 
 export type ProcessedWalletJournalEntries = ProcessedWalletJournalEntry[]
 
+export interface WalletJournalEnrichmentOptions {
+	/**
+	 * Structure names are presentation-only. Keep this disabled unless a caller
+	 * explicitly needs them; party/context IDs remain available in the raw row.
+	 */
+	resolveStructureNames?: boolean
+	knownStructureNames?: Readonly<Record<string, string>>
+}
+
 export async function enrichWalletJournalEntries(
 	env: {
 		ESI_TYPE_RESOLVER: DurableObjectNamespace
@@ -52,6 +61,7 @@ export async function enrichWalletJournalEntries(
 	},
 	entries: CharacterWalletJournalEntry[],
 	characterId: string,
+	options: WalletJournalEnrichmentOptions = {},
 	structureResolutionCoordinator?: StructureResolutionCoordinator,
 	affiliationCoordinator?: CharacterAffiliationCoordinator,
 	entityLinkCoordinator?: EntityLinkCoordinator
@@ -81,7 +91,10 @@ export async function enrichWalletJournalEntries(
 
 		const contextId = normalizeIdToString(entry.context_id)
 		if (contextId) {
-			if (entry.context_id_type === 'structure_id' || isStructureId(contextId)) {
+			if (
+				options.resolveStructureNames &&
+				(entry.context_id_type === 'structure_id' || isStructureId(contextId))
+			) {
 				structureIds.add(contextId)
 			} else if (RESOLVABLE_CONTEXT_TYPES.has(entry.context_id_type ?? '')) {
 				idsToResolve.add(contextId)
@@ -104,14 +117,15 @@ export async function enrichWalletJournalEntries(
 	}
 
 	const structureNameMap =
-		structureIds.size > 0
+		options.resolveStructureNames && structureIds.size > 0
 			? await (
 					structureResolutionCoordinator ?? new StructureResolutionCoordinator()
 				).resolveStructureNames(
 					{ ESI: env.ESI },
 					characterId,
 					structureIds,
-					'enrichWalletJournalEntries'
+					'enrichWalletJournalEntries',
+					options.knownStructureNames
 				)
 			: {}
 
@@ -177,7 +191,7 @@ export async function enrichWalletJournalEntries(
 				)
 			: {}
 
-	if (structureIds.size > 0) {
+	if (options.resolveStructureNames && structureIds.size > 0) {
 		logger.log('[enrichWalletJournalEntries] Structure resolution complete', {
 			requested: structureIds.size,
 			resolved: Object.keys(structureNameMap).length,

--- a/apps/fulcrum/src/workflows/steps/wallet-journal/process-wallet-journal.ts
+++ b/apps/fulcrum/src/workflows/steps/wallet-journal/process-wallet-journal.ts
@@ -1,11 +1,14 @@
+import { logger } from '@repo/hono-helpers'
+
+import { enrichWalletJournalEntries } from '../../processors/helpers/wallet-journal'
+import { retrieveData, storeOrReturn } from '../../utils/storage'
+
 import type { CharacterWalletJournalEntry } from '@repo/esi'
+import type { CoreBinding } from '../../../types/core-binding'
 import type { CharacterAffiliationCoordinator } from '../../processors/helpers/character-affiliation'
 import type { EntityLinkCoordinator } from '../../processors/helpers/entity-links'
 import type { StructureResolutionCoordinator } from '../../processors/helpers/structure-resolution'
-import type { CoreBinding } from '../../../types/core-binding'
-import { retrieveData, storeOrReturn, type StepResult } from '../../utils/storage'
-import { enrichWalletJournalEntries } from '../../processors/helpers/wallet-journal'
-import { logger } from '@repo/hono-helpers'
+import type { StepResult } from '../../utils/storage'
 
 export async function processWalletJournal(
 	env: {
@@ -22,7 +25,7 @@ export async function processWalletJournal(
 	characterId: string,
 	structureResolutionCoordinator?: StructureResolutionCoordinator,
 	affiliationCoordinator?: CharacterAffiliationCoordinator,
-	entityLinkCoordinator?: EntityLinkCoordinator,
+	entityLinkCoordinator?: EntityLinkCoordinator
 ): Promise<StepResult> {
 	try {
 		if (!fetchResult.success) {
@@ -66,9 +69,10 @@ export async function processWalletJournal(
 			env,
 			entries,
 			characterId,
+			{ resolveStructureNames: false },
 			structureResolutionCoordinator,
 			affiliationCoordinator,
-			entityLinkCoordinator,
+			entityLinkCoordinator
 		)
 
 		logger.log('[processWalletJournal] Enrichment complete', {
@@ -89,7 +93,7 @@ export async function processWalletJournal(
 			bucketName,
 			workflowInstanceId,
 			'process-wallet-journal',
-			enrichedData,
+			enrichedData
 		)
 	} catch (error) {
 		return {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Follow-up fixes for lingering issues from the recent token-store/ESI sharding refactor (#634): removes a stale Discord command-registry warm-up call, fixes an ordering bug in the background-task helper, and makes wallet-journal structure-name resolution opt-in with support for pre-known names.

## Changes
- `apps/core/src/index.ts`: removed the leftover `ensureDiscordCommandRegistryLoaded` warm-up call (and its import) from the `CoreWorker` constructor.
- `apps/core/src/lib/background-task.ts`: `waitUntilWithTelemetry` now registers the background promise with `executionCtx.waitUntil()` *before* the task starts running, instead of after, so the platform is guaranteed to know about the work before any task-side I/O begins; added a unit test asserting this ordering.
- `apps/core/src/routes/characters.ts`: updated the caller to stop `await`ing `waitUntilWithTelemetry` now that it's fire-and-forget.
- `apps/fulcrum/src/workflows/processors/helpers/structure-resolution.ts`: `resolveStructureNames` accepts an optional `knownStructureNames` map so already-known/stored structure names are used before falling back to an authenticated ESI lookup; added test coverage.
- `apps/fulcrum/src/workflows/processors/helpers/wallet-journal.ts`: `enrichWalletJournalEntries` now takes a `WalletJournalEnrichmentOptions` object with a `resolveStructureNames` flag (default off, since structure names are presentation-only) and `knownStructureNames`.
- `apps/fulcrum/src/workflows/steps/wallet-journal/process-wallet-journal.ts`: explicitly disables structure name resolution when enriching wallet journal entries.
- Formatting/import-order cleanup in `apps/fulcrum/src/queue.ts` and `bulk-character-report.runner.ts` (no behavior change).

## Testing
- Added a unit test for `waitUntilWithTelemetry` verifying the background promise is registered with `waitUntil` before the task body runs.
- Added a unit test for `resolveStructureNames` verifying stored/known structure names are used without calling `fetchStructureInfo`.
<!-- claude:end -->