### PR TITLE
fix intended skill plans permissions visibility

### DIFF
--- a/apps/core/src/lib/__tests__/skill-plan-auth.test.ts
+++ b/apps/core/src/lib/__tests__/skill-plan-auth.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { canModifyPlan, canViewPlan } from '../skill-plan-auth'
+
+const { getCachedUserMemberships, getCachedUserPermissions } = vi.hoisted(() => ({
+	getCachedUserMemberships: vi.fn(),
+	getCachedUserPermissions: vi.fn(),
+}))
+
+vi.mock('../groups-cache', () => ({
+	getCachedUserMemberships,
+	getCachedUserPermissions,
+}))
+
+const env = { GROUPS: {} as DurableObjectNamespace }
+const draftPlan = {
+	maintainerId: 'maintainer-1',
+	isPublished: false,
+}
+
+describe('skill plan visibility authorization', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		getCachedUserPermissions.mockResolvedValue([])
+		getCachedUserMemberships.mockResolvedValue([])
+	})
+
+	it('allows site admins to view unpublished plans', async () => {
+		await expect(canViewPlan(draftPlan, 'admin-1', env, true)).resolves.toBe(true)
+	})
+
+	it('allows manage-all users to view unpublished plans', async () => {
+		getCachedUserPermissions.mockResolvedValue([{ urn: 'urn:skill-plans:manage-all' }])
+
+		await expect(canViewPlan(draftPlan, 'manager-1', env)).resolves.toBe(true)
+	})
+
+	it('does not expose unrelated unpublished plans', async () => {
+		await expect(canViewPlan(draftPlan, 'other-user', env)).resolves.toBe(false)
+	})
+
+	it('allows the maintainer to view and modify an unpublished plan', async () => {
+		await expect(canViewPlan(draftPlan, 'maintainer-1', env)).resolves.toBe(true)
+		await expect(canModifyPlan(draftPlan, 'maintainer-1', env)).resolves.toBe(true)
+	})
+})

--- a/apps/core/src/lib/skill-plan-auth.ts
+++ b/apps/core/src/lib/skill-plan-auth.ts
@@ -32,8 +32,13 @@ async function hasSkillPlanPermission(
 export async function canModifyPlan(
 	plan: PlanForAuth,
 	userId: string,
-	env: GroupsEnv
+	env: GroupsEnv,
+	isSiteAdmin = false
 ): Promise<boolean> {
+	if (isSiteAdmin) {
+		return true
+	}
+
 	// Global override: users with manage-all can modify any plan.
 	if (await hasSkillPlanPermission(env, userId, 'urn:skill-plans:manage-all')) {
 		return true
@@ -61,10 +66,11 @@ export async function canModifyPlan(
 export async function canDeletePlan(
 	plan: PlanForAuth,
 	userId: string,
-	env: GroupsEnv
+	env: GroupsEnv,
+	isSiteAdmin = false
 ): Promise<boolean> {
 	// Maintainers and users with manage-all can delete.
-	return canModifyPlan(plan, userId, env)
+	return canModifyPlan(plan, userId, env, isSiteAdmin)
 }
 
 /**
@@ -75,8 +81,18 @@ export async function canDeletePlan(
 export async function canViewPlan(
 	plan: PlanForAuth,
 	userId: string,
-	env: GroupsEnv
+	env: GroupsEnv,
+	isSiteAdmin = false
 ): Promise<boolean> {
+	if (isSiteAdmin) {
+		return true
+	}
+
+	// The global management permission includes unpublished-plan visibility.
+	if (await hasSkillPlanPermission(env, userId, 'urn:skill-plans:manage-all')) {
+		return true
+	}
+
 	// Published plans are visible to all alliance members
 	if (plan.isPublished) {
 		return true

--- a/apps/core/src/routes/skill-plans.ts
+++ b/apps/core/src/routes/skill-plans.ts
@@ -238,40 +238,51 @@ const skillPlansRoutes = new Hono<App>()
 
 		try {
 			if (myPlans && user.mainCharacterId) {
-				// Get plans maintained by the user
-				const result = await skillsStub.listPlansByOwner(user.mainCharacterId, { limit, offset })
-				return c.json(result)
-			} else {
-				// Get published plans, optionally filtered by category
-				const result = await skillsStub.listPublishedPlans(categoryId, { limit, offset })
-				const db = createDb(c.env.DATABASE_URL)
-
-				// Add permission flags and maintainer name for each plan
-				const plansWithPermissions = await Promise.all(
-					result.items.map(async (plan) => {
-						const canModify = await canModifyPlan(plan, user.id, c.env)
-						const canDelete = await canDeletePlan(plan, user.id, c.env)
-						const maintainerType = plan.maintainerId?.startsWith('group:')
-							? ('group' as const)
-							: ('user' as const)
-						const maintainerName = plan.maintainerId
-							? await resolveMaintainerName(plan.maintainerId, user.id, c.env, db)
-							: 'System'
-						return {
-							...plan,
-							canModify,
-							canDelete,
-							maintainerType,
-							maintainerName,
-						}
-					})
-				)
-
-				return c.json({
-					...result,
-					items: plansWithPermissions,
-				})
+				return c.json(await skillsStub.listPlansByOwner(user.mainCharacterId, { limit, offset }))
 			}
+
+			const canManageAll = await hasSkillPlanPermission(c.env, user, 'urn:skill-plans:manage-all')
+			const memberships = canManageAll ? [] : await getCachedUserMemberships(c.env, user.id)
+			const maintainerIds = [
+				user.id,
+				...memberships.map((membership) => `group:${membership.groupId}`),
+			]
+
+			// The Skills DO applies the visibility predicate before pagination. This
+			// prevents manageable drafts from being lost behind a published-only page.
+			const result = await skillsStub.listVisiblePlans({
+				categoryId,
+				limit,
+				offset,
+				includeAll: canManageAll,
+				maintainerIds,
+			})
+			const db = createDb(c.env.DATABASE_URL)
+
+			const plansWithPermissions = await Promise.all(
+				result.items.map(async (plan) => {
+					const canModify = await canModifyPlan(plan, user.id, c.env, user.is_admin)
+					const canDelete = await canDeletePlan(plan, user.id, c.env, user.is_admin)
+					const maintainerType = plan.maintainerId?.startsWith('group:')
+						? ('group' as const)
+						: ('user' as const)
+					const maintainerName = plan.maintainerId
+						? await resolveMaintainerName(plan.maintainerId, user.id, c.env, db)
+						: 'System'
+					return {
+						...plan,
+						canModify,
+						canDelete,
+						maintainerType,
+						maintainerName,
+					}
+				})
+			)
+
+			return c.json({
+				...result,
+				items: plansWithPermissions,
+			})
 		} catch (error) {
 			logger.error('Failed to list skill plans:', error)
 			return c.json({ error: 'Failed to list skill plans' }, 500)
@@ -332,10 +343,11 @@ const skillPlansRoutes = new Hono<App>()
 					const maintainerName = plan.maintainerId
 						? await resolveMaintainerName(plan.maintainerId, user.id, c.env, db)
 						: 'System'
+					const canModify = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 					return {
 						...plan,
-						canModify: true, // User can modify plans they maintain
-						canDelete: true, // User can delete plans they maintain
+						canModify,
+						canDelete: await canDeletePlan(plan, user.id, c.env, user.is_admin),
 						maintainerType,
 						maintainerName,
 					}
@@ -372,7 +384,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check view permission (same as viewing the plan)
-		const allowed = await canViewPlan(plan, user.id, c.env)
+		const allowed = await canViewPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -422,7 +434,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check if user can view the plan (if private)
-		const canView = await canViewPlan(plan, user.id, c.env)
+		const canView = await canViewPlan(plan, user.id, c.env, user.is_admin)
 		if (!canView) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -524,7 +536,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check if user can view the plan (if private)
-		const canView = await canViewPlan(plan, user.id, c.env)
+		const canView = await canViewPlan(plan, user.id, c.env, user.is_admin)
 		if (!canView) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -621,14 +633,14 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check view permission
-		const allowed = await canViewPlan(plan, user.id, c.env)
+		const allowed = await canViewPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
 
 		// Add permission flags for the UI
-		const canModify = await canModifyPlan(plan, user.id, c.env)
-		const canDelete = await canDeletePlan(plan, user.id, c.env)
+		const canModify = await canModifyPlan(plan, user.id, c.env, user.is_admin)
+		const canDelete = await canDeletePlan(plan, user.id, c.env, user.is_admin)
 
 		// Add maintainer name for display
 		const db = createDb(c.env.DATABASE_URL)
@@ -723,7 +735,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check modification permission
-		const allowed = await canModifyPlan(plan, user.id, c.env)
+		const allowed = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -780,7 +792,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check deletion permission
-		const allowed = await canDeletePlan(plan, user.id, c.env)
+		const allowed = await canDeletePlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -819,7 +831,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check modification permission
-		const allowed = await canModifyPlan(plan, user.id, c.env)
+		const allowed = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -896,7 +908,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check modification permission
-		const allowed = await canModifyPlan(plan, user.id, c.env)
+		const allowed = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -1013,7 +1025,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check modification permission
-		const allowed = await canModifyPlan(plan, user.id, c.env)
+		const allowed = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -1091,7 +1103,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check modification permission
-		const allowed = await canModifyPlan(plan, user.id, c.env)
+		const allowed = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -1134,7 +1146,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check modification permission
-		const allowed = await canModifyPlan(plan, user.id, c.env)
+		const allowed = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -1175,7 +1187,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check modification permission
-		const allowed = await canModifyPlan(plan, user.id, c.env)
+		const allowed = await canModifyPlan(plan, user.id, c.env, user.is_admin)
 		if (!allowed) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}
@@ -1241,7 +1253,7 @@ const skillPlansRoutes = new Hono<App>()
 		}
 
 		// Check if user can view the plan (if private)
-		const canView = await canViewPlan(plan, user.id, c.env)
+		const canView = await canViewPlan(plan, user.id, c.env, user.is_admin)
 		if (!canView) {
 			return c.json({ error: 'Permission denied' }, 403)
 		}

--- a/apps/skills/src/durable-object.ts
+++ b/apps/skills/src/durable-object.ts
@@ -28,6 +28,7 @@ import type {
 	SkillPlan,
 	SkillPlanCategory,
 	SkillPlanSummary,
+	SkillPlanVisibilityOptions,
 	Skills,
 } from '@repo/skills'
 import type { Env } from './context'
@@ -623,38 +624,51 @@ export class SkillsDO extends DurableObject<Env, {}> implements Skills {
 		return result.length > 0
 	}
 
-	/**
-	 * List published skill plans
-	 * @param categoryId - Optional category ID to filter by
-	 * @param options - Pagination options (limit and offset)
-	 * @returns Paginated list of published skill plans
-	 */
+	/** List published plans for callers that do not need private visibility. */
 	async listPublishedPlans(
 		categoryId?: string,
 		options?: PaginationOptions
 	): Promise<PaginatedResult<SkillPlanSummary>> {
+		return this.listVisiblePlans({ ...options, categoryId })
+	}
+
+	/**
+	 * List plans using the visibility boundary supplied by the API layer.
+	 * The DO does not resolve users or group memberships; it only applies the
+	 * resulting maintainer IDs and the site-admin all-plans flag to SQL.
+	 */
+	async listVisiblePlans(
+		options?: SkillPlanVisibilityOptions
+	): Promise<PaginatedResult<SkillPlanSummary>> {
 		const limit = options?.limit ?? 50
 		const offset = options?.offset ?? 0
-
-		// Get total count first
-		const countQuery = sql`
-			SELECT COUNT(DISTINCT sp.id)::int as total
-			FROM ${skillPlans} sp
-			WHERE sp.is_published = true
-			${
-				categoryId
-					? sql`AND EXISTS (
+		const categoryId = options?.categoryId
+		const maintainerIds = options?.maintainerIds ?? []
+		const maintainerCondition =
+			maintainerIds.length > 0
+				? sql` OR sp.maintainer_id IN (${sql.join(
+						maintainerIds.map((id) => sql`${id}`),
+						sql`, `
+					)})`
+				: sql``
+		const visibilityCondition = options?.includeAll
+			? sql``
+			: sql`AND (sp.is_published = true ${maintainerCondition})`
+		const categoryCondition = categoryId
+			? sql`AND EXISTS (
 				SELECT 1 FROM ${skillPlanCategoryMappings} cm2
 				WHERE cm2.plan_id = sp.id AND cm2.category_id = ${categoryId}
 			)`
-					: sql``
-			}
+			: sql``
+
+		const countQuery = sql`
+			SELECT COUNT(DISTINCT sp.id)::int as total
+			FROM ${skillPlans} sp
+			WHERE true ${visibilityCondition} ${categoryCondition}
 		`
 		const countResult = await this.db.execute(countQuery)
 		const total = (countResult.rows[0] as any)?.total || 0
 
-		// Build the SQL query with aggregation to avoid N+1 queries
-		// This query performs LEFT JOINs and aggregates data in a single database roundtrip
 		const query = sql`
 			SELECT
 				sp.id,
@@ -682,15 +696,7 @@ export class SkillsDO extends DurableObject<Env, {}> implements Skills {
 			LEFT JOIN ${skillPlanSkills} sps ON sp.id = sps.plan_id
 			LEFT JOIN ${skillPlanCategoryMappings} cm ON sp.id = cm.plan_id
 			LEFT JOIN ${skillPlanCategories} c ON cm.category_id = c.id
-			WHERE sp.is_published = true
-			${
-				categoryId
-					? sql`AND EXISTS (
-				SELECT 1 FROM ${skillPlanCategoryMappings} cm2
-				WHERE cm2.plan_id = sp.id AND cm2.category_id = ${categoryId}
-			)`
-					: sql``
-			}
+			WHERE true ${visibilityCondition} ${categoryCondition}
 			GROUP BY sp.id
 			ORDER BY sp.updated_at DESC
 			LIMIT ${limit}

--- a/apps/ui/src/client/features/skill-plans/routes/categories-management.tsx
+++ b/apps/ui/src/client/features/skill-plans/routes/categories-management.tsx
@@ -1,6 +1,6 @@
-import { Edit2, Plus, Settings, Trash2 } from 'lucide-react'
+import { ArrowLeft, Edit2, Plus, Settings, Trash2 } from 'lucide-react'
 import { useState } from 'react'
-import { Navigate } from 'react-router'
+import { Link, Navigate } from 'react-router'
 
 import { Badge } from '../../../components/ui/badge'
 import { Button } from '../../../components/ui/button'
@@ -118,6 +118,14 @@ export default function CategoriesManagement() {
 			<PageHeader
 				title="Manage Categories"
 				description="Create and manage categories for organizing skill plans"
+				action={
+					<Button variant="ghost" size="sm" asChild>
+						<Link to="/skill-plans">
+							<ArrowLeft className="h-4 w-4" />
+							Back to Plans
+						</Link>
+					</Button>
+				}
 			/>
 
 			<Section>

--- a/apps/ui/src/client/features/skill-plans/routes/skill-plans-list.tsx
+++ b/apps/ui/src/client/features/skill-plans/routes/skill-plans-list.tsx
@@ -1,6 +1,6 @@
 import { useQueries } from '@tanstack/react-query'
 import { Plus, Search, Settings } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router'
 
 import { Button } from '../../../components/ui/button'
@@ -48,22 +48,12 @@ export default function SkillPlansList() {
 	const canEditSkillPlans =
 		!!user && (canCreatePlans || canManageCategories || hasPermission('urn:skill-plans:manage-all'))
 	const [filters, setFilters] = useState<SkillPlansFilter>({
-		published: true, // Default to published plans
+		published: undefined, // The backend limits this to statuses the user may see.
 		search: '',
 		categoryId: undefined,
 		maintainer: 'all',
 	})
 	const [selectedCharacterId, setSelectedCharacterId] = useState<string>('all')
-
-	useEffect(() => {
-		if (!canEditSkillPlans) {
-			setFilters((prev) => ({
-				...prev,
-				published: true,
-				myPlansOnly: false,
-			}))
-		}
-	}, [canEditSkillPlans])
 
 	const { data: plansResponse, isLoading: plansLoading } = useSkillPlans({
 		categoryId: filters.categoryId,
@@ -112,7 +102,9 @@ export default function SkillPlansList() {
 	// Filter plans client-side because backend list endpoint only supports category filtering
 	const filteredPlans = useMemo(() => {
 		return mergedPlans.filter((plan) => {
-			if (!canEditSkillPlans && !plan.isPublished) {
+			// Draft visibility is decided by the backend. Keep only a defensive
+			// client-side guard for responses that do not grant modification access.
+			if (!plan.isPublished && !plan.canModify) {
 				return false
 			}
 
@@ -157,7 +149,6 @@ export default function SkillPlansList() {
 			return `${type}:${plan.maintainerId}` === filters.maintainer
 		})
 	}, [
-		canEditSkillPlans,
 		filters.categoryId,
 		filters.maintainer,
 		filters.myPlansOnly,
@@ -168,6 +159,8 @@ export default function SkillPlansList() {
 	])
 
 	const totalPlans = mergedPlans.length
+	const showPublicationState =
+		canEditSkillPlans || mergedPlans.some((plan) => plan.canModify && !plan.isPublished)
 
 	// Group filtered plans by category
 	const groupedPlans = useMemo(() => {
@@ -469,7 +462,7 @@ export default function SkillPlansList() {
 													characterReadiness={readinessByPlanId.get(plan.id)}
 													hasNoSkills={readinessByPlanId.get(plan.id)?.hasNoSkills || false}
 													isReadinessLoading={readinessLoadingByPlanId.get(plan.id) || false}
-													showPublicationState={canEditSkillPlans}
+													showPublicationState={showPublicationState}
 													readinessIndicator={readinessIndicatorByPlanId.get(plan.id)}
 												/>
 											))}

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -19,6 +19,7 @@ import type {
 	SkillPlan,
 	SkillPlanCategory,
 	SkillPlanSummary,
+	SkillPlanVisibilityOptions,
 } from './types'
 
 export type {
@@ -36,6 +37,7 @@ export type {
 	SkillPlanCategory,
 	SkillPlanSkill,
 	SkillPlanSummary,
+	SkillPlanVisibilityOptions,
 } from './types'
 
 /**
@@ -144,6 +146,13 @@ export interface Skills extends DurableObject {
 		categoryId?: string,
 		options?: PaginationOptions
 	): Promise<PaginatedResult<SkillPlanSummary>>
+
+	/**
+	 * List plans visible to a caller. Published plans are always included;
+	 * unpublished plans are included only when maintained by one of the supplied
+	 * identifiers, unless includeAll is explicitly enabled for site admins.
+	 */
+	listVisiblePlans(options?: SkillPlanVisibilityOptions): Promise<PaginatedResult<SkillPlanSummary>>
 
 	/**
 	 * List skill plans by owner

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -8,6 +8,14 @@ export interface PaginationOptions {
 	offset?: number
 }
 
+export interface SkillPlanVisibilityOptions extends PaginationOptions {
+	categoryId?: string
+	/** Include every plan. This is reserved for site-admin callers. */
+	includeAll?: boolean
+	/** Include unpublished plans maintained by any of these identifiers. */
+	maintainerIds?: string[]
+}
+
 /**
  * Paginated result wrapper
  */


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes skill plan visibility so unpublished/draft plans are shown only to callers authorized to see them (maintainers, group-maintainer members, `manage-all` permission holders, and site admins), instead of being restricted to "published only" or, in the list endpoint, silently dropped once pagination was applied at the app layer.

## Changes
- `canModifyPlan`, `canDeletePlan`, and `canViewPlan` (`apps/core/src/lib/skill-plan-auth.ts`) now accept an `isSiteAdmin` flag that short-circuits to `true`, and `canViewPlan` also grants access to `urn:skill-plans:manage-all` holders for unpublished plans.
- All skill-plan route handlers (`apps/core/src/routes/skill-plans.ts`) now pass `user.is_admin` into these auth checks, and the modify/delete flags on the maintainer's own plans list are now computed via the real auth checks instead of being hardcoded to `true`.
- The list endpoint now resolves the caller's group memberships and delegates visibility filtering (published plans + plans maintained by the user or their groups, or everything for `manage-all`/admins) to a new `listVisiblePlans` DO method, applying the predicate before pagination so manageable drafts aren't lost off the page.
- `SkillsDO.listPublishedPlans` (`apps/skills/src/durable-object.ts`) is now a thin wrapper around the new `listVisiblePlans`, which builds the visibility/category SQL conditions dynamically based on `includeAll` and `maintainerIds`.
- Added `SkillPlanVisibilityOptions` type and a `listVisiblePlans` method to the `Skills` DO interface (`packages/skills/src/types.ts`, `packages/skills/src/index.ts`).
- Updated the skill plans list UI (`apps/ui/src/client/features/skill-plans/routes/skill-plans-list.tsx`) to stop forcing `published: true` for non-editors and instead trust backend-provided `canModify` flags for draft visibility and publication-state display; added a "Back to Plans" link on the categories management page.

## Testing
- Added `apps/core/src/lib/__tests__/skill-plan-auth.test.ts` covering `canViewPlan`/`canModifyPlan` for site admins, `manage-all` users, unrelated users, and maintainers of unpublished plans.
<!-- claude:end -->