### PR TITLE
Fix/bugbash

### DIFF
--- a/apps/core/src/context.ts
+++ b/apps/core/src/context.ts
@@ -14,6 +14,7 @@ import type { Skills } from '@repo/skills'
 import type { StructuresWorker } from '@repo/structures'
 import type { createDb } from './db'
 import type { CsvExportWorkflowParams } from './workflows/csv-export.workflow'
+import type { DirectorHealthRecheckWorkflowParams } from './workflows/director-health-recheck.workflow'
 import type { DiscordMemberAuditWorkflowParams } from './workflows/discord-member-audit.workflow'
 import type { ServiceAccessAuditWorkflowParams } from './workflows/service-access-audit.workflow'
 import type { UserDiscordRefreshWorkflowParams } from './workflows/user-discord-refresh.workflow'
@@ -76,6 +77,8 @@ export type Env = SharedHonoEnv & {
 	CORE: DurableObjectNamespace
 	/** User Refresh Workflow binding */
 	USER_REFRESH_WORKFLOW: Workflow<UserRefreshWorkflowParams>
+	/** Post-authentication director health verification workflow */
+	DIRECTOR_HEALTH_RECHECK_WORKFLOW: Workflow<DirectorHealthRecheckWorkflowParams>
 	/** User Discord Refresh Workflow binding */
 	USER_DISCORD_REFRESH_WORKFLOW: Workflow<UserDiscordRefreshWorkflowParams>
 	/** Discord Member Audit Workflow binding */

--- a/apps/core/src/durable-object.ts
+++ b/apps/core/src/durable-object.ts
@@ -1,9 +1,10 @@
 import { DurableObject } from 'cloudflare:workers'
 
-import { CORE_ROLES, SERVICE_CORE } from '@repo/core'
+import { CORE_ROLES, ROLE_CORE_ALLIANCE_MEMBER, SERVICE_CORE } from '@repo/core'
 import { and, asc, eq, inArray, isNull, lt, ne, or, sql } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { getPublicEsiInstance } from '@repo/esi'
+import { RoleAttachmentType } from '@repo/groups'
 import { logger } from '@repo/hono-helpers'
 
 import { createDb } from './db'
@@ -427,6 +428,20 @@ export class CoreDO extends DurableObject<Env> implements Core {
 	}
 
 	async isUserAllianceMember(userId: string): Promise<boolean> {
+		// Keep the capability tied to both persisted role assignment and current
+		// eligible affiliation. Membership flags alone do not grant the URN.
+		const groupsStub = getStub<Groups>(this.env.GROUPS, 'default')
+		const roleAttachments = await withRpcResult(
+			groupsStub.getRolesFor({
+				attachedToType: RoleAttachmentType.USER,
+				attachedToId: userId,
+			}),
+			(result) => result.map((attachment) => attachment.role.name)
+		)
+		if (!roleAttachments.includes(ROLE_CORE_ALLIANCE_MEMBER)) {
+			return false
+		}
+
 		const [match] = await this.getDb()
 			.select({ characterId: userCharacters.characterId })
 			.from(userCharacters)

--- a/apps/core/src/durable-object.ts
+++ b/apps/core/src/durable-object.ts
@@ -407,6 +407,46 @@ export class CoreDO extends DurableObject<Env> implements Core {
 			.then((corporation) => corporation !== undefined)
 	}
 
+	async getMemberCorporationIds(corporationIds: string[]): Promise<string[]> {
+		if (corporationIds.length === 0) {
+			return []
+		}
+
+		const corporations = await this.getDb()
+			.select({ corporationId: managedCorporations.corporationId })
+			.from(managedCorporations)
+			.where(
+				and(
+					inArray(managedCorporations.corporationId, corporationIds),
+					eq(managedCorporations.isActive, true),
+					eq(managedCorporations.isMemberCorporation, true)
+				)
+			)
+
+		return corporations.map((corporation) => corporation.corporationId)
+	}
+
+	async isUserAllianceMember(userId: string): Promise<boolean> {
+		const [match] = await this.getDb()
+			.select({ characterId: userCharacters.characterId })
+			.from(userCharacters)
+			.innerJoin(
+				managedCorporations,
+				eq(managedCorporations.corporationId, userCharacters.corporationId)
+			)
+			.where(
+				and(
+					eq(userCharacters.userId, userId),
+					eq(userCharacters.isDeleted, false),
+					eq(managedCorporations.isActive, true),
+					eq(managedCorporations.isMemberCorporation, true)
+				)
+			)
+			.limit(1)
+
+		return match !== undefined
+	}
+
 	async listUsersWithActiveCharactersPage(input: { limit: number; offset: number }): Promise<{
 		users: Array<{ userId: string; characterIds: string[] }>
 		totalCount: number

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -346,6 +346,14 @@ export class CoreWorker extends WorkerEntrypoint<Env> {
 		return this.getService().isMemberCorporation(corporationId)
 	}
 
+	async getMemberCorporationIds(corporationIds: string[]): Promise<string[]> {
+		return this.getService().getMemberCorporationIds(corporationIds)
+	}
+
+	async isUserAllianceMember(userId: string): Promise<boolean> {
+		return this.getService().isUserAllianceMember(userId)
+	}
+
 	/**
 	 * List a page of users that currently have at least one active linked character.
 	 */
@@ -1191,6 +1199,7 @@ export { TemporaryRoleAssignmentsDO as TemporaryRoleAssignments }
 
 // Export Workflow class
 export { UserRefreshWorkflow } from './workflows/user-refresh.workflow'
+export { DirectorHealthRecheckWorkflow } from './workflows/director-health-recheck.workflow'
 export { UserDiscordRefreshWorkflow } from './workflows/user-discord-refresh.workflow'
 export { DiscordMemberAuditWorkflow } from './workflows/discord-member-audit.workflow'
 export { UserMumbleRefreshWorkflow } from './workflows/user-mumble-refresh.workflow'

--- a/apps/core/src/lib/__tests__/workflow-triggers.test.ts
+++ b/apps/core/src/lib/__tests__/workflow-triggers.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
 	createDirectorHealthRecheckWorkflowId,
 	createDiscordRefreshWorkflowId,
+	createUserRefreshWorkflowId,
+	triggerUserRefreshWorkflow,
 } from '../workflow-triggers'
+
+const createWorkflowMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@repo/workflow-utils', () => ({
+	createWorkflow: createWorkflowMock,
+}))
 
 describe('Director health recheck workflow IDs', () => {
 	it('deduplicates the same character and corporation within a five-minute window', () => {
@@ -28,6 +36,80 @@ describe('Discord refresh workflow IDs', () => {
 
 		expect(workflowId).toMatch(
 			/^discord-refresh-user-manual-12345678123412341234123456789abc-[a-z0-9]+$/
+		)
+	})
+})
+
+describe('User refresh workflow IDs', () => {
+	it('deduplicates normal refreshes within the five-minute throttle window', () => {
+		const now = 1_699_999_801_000
+
+		expect(createUserRefreshWorkflowId('login', 'user-123', now)).toBe(
+			createUserRefreshWorkflowId('login', 'user-123', now + 4 * 60 * 1000)
+		)
+		expect(createUserRefreshWorkflowId('login', 'user-123', now)).not.toBe(
+			createUserRefreshWorkflowId('login', 'user-123', now + 5 * 60 * 1000)
+		)
+	})
+
+	it('allows explicit bypasses to create unique workflow IDs', () => {
+		const now = 1_699_999_801_000
+
+		expect(createUserRefreshWorkflowId('manual', 'user-123', now, false)).not.toBe(
+			createUserRefreshWorkflowId('manual', 'user-123', now + 1, false)
+		)
+	})
+})
+
+describe('User refresh workflow trigger', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	function makeDb(lastRefreshWorkflowAttempt: Date | null = null) {
+		const where = vi.fn().mockResolvedValue(undefined)
+		const set = vi.fn().mockReturnValue({ where })
+		return {
+			query: {
+				users: {
+					findFirst: vi.fn().mockResolvedValue({ lastRefreshWorkflowAttempt }),
+				},
+			},
+			update: vi.fn().mockReturnValue({ set }),
+		}
+	}
+
+	it('does not write the throttle watermark when workflow creation fails', async () => {
+		createWorkflowMock.mockRejectedValueOnce(new Error('workflows unavailable'))
+		const db = makeDb(null)
+
+		const result = await triggerUserRefreshWorkflow({
+			db: db as never,
+			env: { USER_REFRESH_WORKFLOW: {} } as never,
+			userId: 'user-1',
+			source: 'login',
+		})
+
+		expect(result).toMatchObject({ status: 'failed', triggered: false })
+		expect(db.update).not.toHaveBeenCalled()
+	})
+
+	it('writes the throttle watermark only after workflow creation succeeds', async () => {
+		createWorkflowMock.mockResolvedValueOnce({ id: 'workflow-1' })
+		const db = makeDb(null)
+
+		const result = await triggerUserRefreshWorkflow({
+			db: db as never,
+			env: { USER_REFRESH_WORKFLOW: {} } as never,
+			userId: 'user-1',
+			source: 'login',
+		})
+
+		expect(result).toMatchObject({ status: 'triggered', triggered: true })
+		expect(createWorkflowMock).toHaveBeenCalledOnce()
+		expect(db.update).toHaveBeenCalledOnce()
+		expect(createWorkflowMock.mock.invocationCallOrder[0]).toBeLessThan(
+			db.update.mock.invocationCallOrder[0]
 		)
 	})
 })

--- a/apps/core/src/lib/__tests__/workflow-triggers.test.ts
+++ b/apps/core/src/lib/__tests__/workflow-triggers.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest'
 
-import { createDiscordRefreshWorkflowId } from '../workflow-triggers'
+import {
+	createDirectorHealthRecheckWorkflowId,
+	createDiscordRefreshWorkflowId,
+} from '../workflow-triggers'
+
+describe('Director health recheck workflow IDs', () => {
+	it('deduplicates the same character and corporation within a five-minute window', () => {
+		const now = 1_699_999_801_000
+
+		expect(createDirectorHealthRecheckWorkflowId('123', '456', now)).toBe(
+			createDirectorHealthRecheckWorkflowId('123', '456', now + 4 * 60 * 1000)
+		)
+		expect(createDirectorHealthRecheckWorkflowId('123', '456', now)).not.toBe(
+			createDirectorHealthRecheckWorkflowId('123', '456', now + 5 * 60 * 1000)
+		)
+		expect(createDirectorHealthRecheckWorkflowId('123', '456', now)).not.toBe(
+			createDirectorHealthRecheckWorkflowId('123', '789', now)
+		)
+	})
+})
 
 describe('Discord refresh workflow IDs', () => {
 	it('contains the complete user identifier for exact ownership checks', () => {

--- a/apps/core/src/lib/workflow-triggers.ts
+++ b/apps/core/src/lib/workflow-triggers.ts
@@ -99,14 +99,19 @@ export interface TriggerUserRefreshResult {
 	error?: string
 }
 
-export function createUserRefreshWorkflowId(source: string, userId: string): string {
+export function createUserRefreshWorkflowId(
+	source: string,
+	userId: string,
+	now = Date.now(),
+	deduplicate = true
+): string {
 	const normalizedSource = source
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, '-')
 		.replace(/^-+|-+$/g, '')
 	const sourceToken = (normalizedSource || 'unknown').slice(0, 16)
 	const userToken = userId.replace(/-/g, '').slice(0, 12)
-	const timeToken = Date.now().toString(36)
+	const timeToken = deduplicate ? Math.floor(now / THROTTLE_MS).toString(36) : now.toString(36)
 	return `user-refresh-${sourceToken}-${userToken}-${timeToken}`
 }
 
@@ -314,22 +319,47 @@ export async function triggerUserRefreshWorkflow({
 			return { status: 'throttled', triggered: false }
 		}
 
-		await db
-			.update(users)
-			.set({ lastRefreshWorkflowAttempt: new Date() })
-			.where(eq(users.id, userId))
+		const now = Date.now()
+		const workflowId = createUserRefreshWorkflowId(source, userId, now, !bypassThrottle)
+		let instance: { id: string }
+		try {
+			instance = await createWorkflow(env.USER_REFRESH_WORKFLOW, {
+				id: workflowId,
+				params: {
+					userId,
+					source,
+					refreshMode,
+					suppressDiscordRefresh,
+					forceTokenValidation,
+					includeWalletJournal,
+				},
+			})
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error)
+			if (!/already exists|already been created|duplicate/i.test(errorMessage)) {
+				throw error
+			}
 
-		const instance = await createWorkflow(env.USER_REFRESH_WORKFLOW, {
-			id: createUserRefreshWorkflowId(source, userId),
-			params: {
+			// A normal trigger may race another request in the same throttle
+			// window. The deterministic workflow ID makes that race harmless.
+			await db
+				.update(users)
+				.set({ lastRefreshWorkflowAttempt: new Date(now) })
+				.where(eq(users.id, userId))
+			logger.info('[WorkflowTrigger] Deduplicated user refresh workflow', {
 				userId,
 				source,
-				refreshMode,
-				suppressDiscordRefresh,
-				forceTokenValidation,
-				includeWalletJournal,
-			},
-		})
+				workflowInstanceId: workflowId,
+			})
+			return { status: 'throttled', triggered: false }
+		}
+
+		// Commit the throttle watermark only after the workflow service accepts
+		// the instance. A failed enqueue must remain retryable.
+		await db
+			.update(users)
+			.set({ lastRefreshWorkflowAttempt: new Date(now) })
+			.where(eq(users.id, userId))
 
 		logger.info('[WorkflowTrigger] Triggered user refresh workflow', {
 			userId,

--- a/apps/core/src/lib/workflow-triggers.ts
+++ b/apps/core/src/lib/workflow-triggers.ts
@@ -7,10 +7,78 @@ import { isMumbleFeatureEnabled } from './mumble-feature'
 
 import type { Env } from '../context'
 import type { createDb } from '../db'
+import type { DirectorHealthRecheckWorkflowParams } from '../workflows/director-health-recheck.workflow'
 import type { UserDiscordRefreshWorkflowParams } from '../workflows/user-discord-refresh.workflow'
 import type { UserMumbleRefreshWorkflowParams } from '../workflows/user-mumble-refresh.workflow'
 
 const THROTTLE_MS = 5 * 60 * 1000 // 5 minutes
+const DIRECTOR_HEALTH_RECHECK_WINDOW_MS = 5 * 60 * 1000
+
+export function createDirectorHealthRecheckWorkflowId(
+	characterId: string,
+	corporationId: string,
+	now = Date.now()
+): string {
+	const windowToken = Math.floor(now / DIRECTOR_HEALTH_RECHECK_WINDOW_MS).toString(36)
+	return `director-health-recheck-${characterId}-${corporationId}-${windowToken}`
+}
+
+export interface TriggerDirectorHealthRecheckOptions {
+	env: Env
+	characterId: string
+	characterName: string
+	corporationId: string
+	source: string
+}
+
+/**
+ * Queue the post-authentication director verification outside the request.
+ * The caller resolves the character's current corporation before enqueueing, so
+ * the workflow does not fan out across unrelated corporation Durable Objects.
+ */
+export async function triggerDirectorHealthRecheckWorkflow({
+	env,
+	characterId,
+	characterName,
+	corporationId,
+	source,
+}: TriggerDirectorHealthRecheckOptions): Promise<void> {
+	try {
+		const params: DirectorHealthRecheckWorkflowParams = {
+			characterId,
+			characterName,
+			corporationId,
+			source,
+		}
+		const instance = await createWorkflow(env.DIRECTOR_HEALTH_RECHECK_WORKFLOW, {
+			id: createDirectorHealthRecheckWorkflowId(characterId, corporationId),
+			params,
+		})
+
+		logger.info('[WorkflowTrigger] Triggered director health recheck workflow', {
+			characterId,
+			characterName,
+			source,
+			workflowInstanceId: instance.id,
+		})
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error)
+		if (/already exists|already been created|duplicate/i.test(errorMessage)) {
+			logger.info('[WorkflowTrigger] Deduplicated director health recheck workflow', {
+				characterId,
+				corporationId,
+				source,
+			})
+			return
+		}
+		logger.error('[WorkflowTrigger] Failed to trigger director health recheck workflow', {
+			characterId,
+			characterName,
+			source,
+			error: errorMessage,
+		})
+	}
+}
 
 export interface TriggerUserRefreshOptions {
 	db: ReturnType<typeof createDb>
@@ -217,8 +285,8 @@ export async function triggerMumbleRefreshWorkflow({
 
 /**
  * Trigger user refresh workflow with throttling.
- * Returns immediately - does not block on workflow creation.
- * Logs errors but does not throw.
+ * Resolves after the workflow has been created (or the trigger has failed).
+ * Logs errors but does not throw, so callers can safely await the short enqueue operation.
  */
 export async function triggerUserRefreshWorkflow({
 	db,

--- a/apps/core/src/middleware/session.ts
+++ b/apps/core/src/middleware/session.ts
@@ -77,17 +77,29 @@ export const sessionMiddleware = (): MiddlewareHandler<App> => {
 			const isAdminRoute = c.req.path.startsWith('/api/admin/')
 
 			// Execute independent operations in parallel for better performance
-			const [userProfile, isBlacklisted, roleAttachments, isAllianceMember] = await Promise.all([
-				userService.getUserProfile(userId),
-				getStub<Hr>(c.env.HR, 'default').isUserBlacklisted(userId),
-				isAdminRoute
-					? Promise.resolve([])
-					: getCachedUserRoles(c.env, userId).catch((error) => {
-							logger.error('Error fetching user roles:', error)
-							return []
-						}),
-				isAdminRoute ? Promise.resolve(false) : hasCurrentAllianceMembership(c.env, userId),
-			])
+			const [userProfile, isBlacklisted, roleAttachments, isCurrentAllianceMember] =
+				await Promise.all([
+					userService.getUserProfile(userId),
+					getStub<Hr>(c.env.HR, 'default').isUserBlacklisted(userId),
+					isAdminRoute
+						? Promise.resolve([])
+						: getCachedUserRoles(c.env, userId).catch((error) => {
+								logger.error('Error fetching user roles:', error)
+								return []
+							}),
+					isAdminRoute
+						? Promise.resolve(false)
+						: hasCurrentAllianceMembership(c.env, userId).catch((error) => {
+								// A membership lookup failure must not erase an otherwise valid
+								// authenticated session. Protected routes fail closed when this is
+								// false, while personal routes remain available.
+								logger.warn('Failed to resolve current alliance membership', {
+									userId,
+									error: error instanceof Error ? error.message : String(error),
+								})
+								return false
+							}),
+				])
 
 			// SECURITY: Check blacklist first (fail fast)
 			if (isBlacklisted) {
@@ -98,17 +110,7 @@ export const sessionMiddleware = (): MiddlewareHandler<App> => {
 			}
 
 			// Extract role names (URNs) from attachments
-			const userRoles = roleAttachments
-				.filter(
-					(attachment) => attachment.role.name !== ROLE_CORE_ALLIANCE_MEMBER || isAllianceMember
-				)
-				.map((attachment) => attachment.role.name)
-			if (
-				(userProfile.is_admin || isAllianceMember) &&
-				!userRoles.includes(ROLE_CORE_ALLIANCE_MEMBER)
-			) {
-				userRoles.push(ROLE_CORE_ALLIANCE_MEMBER)
-			}
+			const userRoles = resolveSessionRoles(roleAttachments, isCurrentAllianceMember)
 
 			// Build session user object (Discord status can be loaded on-demand via getDiscordStatus())
 			const sessionUser: SessionUser = {
@@ -171,6 +173,28 @@ export type RoleRequirement =
 	| string[] // Multiple roles with OR logic (user must have at least one)
 	| { all: string[] } // Multiple roles with AND logic (user must have all)
 	| { any: string[] } // Multiple roles with OR logic (explicit)
+
+type SessionRoleAttachment = {
+	role: {
+		name: string
+	}
+}
+
+/**
+ * Keep the alliance capability tied to both sources of truth: the current
+ * corporation eligibility check and an actual alliance-member role attachment.
+ * Membership alone must not synthesize a permission that was never granted.
+ */
+export function resolveSessionRoles(
+	roleAttachments: SessionRoleAttachment[],
+	isCurrentAllianceMember: boolean
+): string[] {
+	return roleAttachments
+		.filter(
+			(attachment) => attachment.role.name !== ROLE_CORE_ALLIANCE_MEMBER || isCurrentAllianceMember
+		)
+		.map((attachment) => attachment.role.name)
+}
 
 const allianceMembershipCache = new TimeCache<boolean>(15 * 1000)
 

--- a/apps/core/src/middleware/session.ts
+++ b/apps/core/src/middleware/session.ts
@@ -2,7 +2,7 @@ import { getCookie } from 'hono/cookie'
 
 import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { getStub } from '@repo/do-utils'
-import { logger } from '@repo/hono-helpers'
+import { logger, TimeCache } from '@repo/hono-helpers'
 
 import { createDb } from '../db'
 import { waitUntilWithTelemetry } from '../lib/background-task'
@@ -13,6 +13,7 @@ import { SessionService } from '../services/session.service'
 import { UserService } from '../services/user.service'
 
 import type { MiddlewareHandler } from 'hono'
+import type { Core } from '@repo/core'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { Hr } from '@repo/hr'
 import type { App, SessionUser } from '../context'
@@ -76,7 +77,7 @@ export const sessionMiddleware = (): MiddlewareHandler<App> => {
 			const isAdminRoute = c.req.path.startsWith('/api/admin/')
 
 			// Execute independent operations in parallel for better performance
-			const [userProfile, isBlacklisted, roleAttachments] = await Promise.all([
+			const [userProfile, isBlacklisted, roleAttachments, isAllianceMember] = await Promise.all([
 				userService.getUserProfile(userId),
 				getStub<Hr>(c.env.HR, 'default').isUserBlacklisted(userId),
 				isAdminRoute
@@ -85,6 +86,7 @@ export const sessionMiddleware = (): MiddlewareHandler<App> => {
 							logger.error('Error fetching user roles:', error)
 							return []
 						}),
+				isAdminRoute ? Promise.resolve(false) : hasCurrentAllianceMembership(c.env, userId),
 			])
 
 			// SECURITY: Check blacklist first (fail fast)
@@ -96,7 +98,17 @@ export const sessionMiddleware = (): MiddlewareHandler<App> => {
 			}
 
 			// Extract role names (URNs) from attachments
-			const userRoles = roleAttachments.map((attachment) => attachment.role.name)
+			const userRoles = roleAttachments
+				.filter(
+					(attachment) => attachment.role.name !== ROLE_CORE_ALLIANCE_MEMBER || isAllianceMember
+				)
+				.map((attachment) => attachment.role.name)
+			if (
+				(userProfile.is_admin || isAllianceMember) &&
+				!userRoles.includes(ROLE_CORE_ALLIANCE_MEMBER)
+			) {
+				userRoles.push(ROLE_CORE_ALLIANCE_MEMBER)
+			}
 
 			// Build session user object (Discord status can be loaded on-demand via getDiscordStatus())
 			const sessionUser: SessionUser = {
@@ -160,6 +172,18 @@ export type RoleRequirement =
 	| { all: string[] } // Multiple roles with AND logic (user must have all)
 	| { any: string[] } // Multiple roles with OR logic (explicit)
 
+const allianceMembershipCache = new TimeCache<boolean>(15 * 1000)
+
+async function hasCurrentAllianceMembership(
+	env: App['Bindings'],
+	userId: string
+): Promise<boolean> {
+	return allianceMembershipCache.getOrSet(`alliance-member:${userId}`, async () => {
+		const core = getStub<Core>(env.CORE, 'default')
+		return core.isUserAllianceMember(userId)
+	})
+}
+
 /**
  * Require authentication middleware with optional role-based access control
  *
@@ -191,6 +215,13 @@ export const requireAuth = (requiredRoles?: RoleRequirement): MiddlewareHandler<
 		// Check authentication
 		if (!user) {
 			return c.json({ error: 'Unauthorized' }, 401)
+		}
+
+		// Site administrators are the platform-wide authority. Preserve the
+		// existing role-based route declarations while allowing them to pass
+		// capability guards without requiring derived membership attachments.
+		if (user.is_admin) {
+			return next()
 		}
 
 		// If no role requirements, just check authentication
@@ -268,6 +299,13 @@ export const requireAllianceMember = (): MiddlewareHandler<App> => {
 		if (!user) {
 			return c.json({ error: 'Unauthorized' }, 401)
 		}
+		if (user.is_admin) {
+			return next()
+		}
+		// sessionMiddleware derives this role from the current corporation
+		// affiliation. Keeping the route check role-based avoids an additional
+		// Core RPC on every protected request while preserving that source-of-truth
+		// validation at session construction time.
 		if (!user.roles.includes(ROLE_CORE_ALLIANCE_MEMBER)) {
 			return c.json({ error: 'Forbidden' }, 403)
 		}

--- a/apps/core/src/routes/__tests__/auth.session.test.ts
+++ b/apps/core/src/routes/__tests__/auth.session.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+
+import { resolveSessionRoles } from '../../middleware/session'
 import { buildAuthSessionResponse, shouldUseSecureSessionCookie } from '../auth'
 
 describe('/auth/session response shaping', () => {
+	it('requires an explicit alliance role attachment in addition to current membership', () => {
+		const attachment = (name: string) => ({ role: { name } })
+
+		expect(resolveSessionRoles([attachment('urn:service:other:role')], true)).toEqual([
+			'urn:service:other:role',
+		])
+		expect(resolveSessionRoles([attachment(ROLE_CORE_ALLIANCE_MEMBER)], false)).toEqual([])
+		expect(resolveSessionRoles([attachment(ROLE_CORE_ALLIANCE_MEMBER)], true)).toEqual([
+			ROLE_CORE_ALLIANCE_MEMBER,
+		])
+	})
+
 	it('preserves resolved structure permissions in the session payload', () => {
 		const response = buildAuthSessionResponse(
 			{

--- a/apps/core/src/routes/__tests__/corporation-tax.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporation-tax.route.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { getStub } from '@repo/do-utils'
 
 import { getCachedCharacterPermissions, getCachedUserPermissions } from '../../lib/groups-cache'
@@ -69,7 +70,7 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 			},
 		],
 		is_admin: false,
-		roles: [],
+		roles: [ROLE_CORE_ALLIANCE_MEMBER],
 		discordUserId: null,
 		...overrides,
 	}

--- a/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
+++ b/apps/core/src/routes/__tests__/fleets.tracking.route.test.ts
@@ -21,6 +21,11 @@ vi.mock('../../middleware/session', () => ({
 		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
 			await next()
 		},
+	requireAllianceMember:
+		() =>
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 }))
 
 vi.mock('../../lib/groups-cache', () => ({

--- a/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/fulcrum.access.route.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { getStub } from '@repo/do-utils'
 
 import { getCachedUserPermissions } from '../../lib/groups-cache'
@@ -49,7 +50,7 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 			},
 		],
 		is_admin: false,
-		roles: [],
+		roles: [ROLE_CORE_ALLIANCE_MEMBER],
 		discordUserId: null,
 		...overrides,
 	}

--- a/apps/core/src/routes/__tests__/groups.discord-role.route.test.ts
+++ b/apps/core/src/routes/__tests__/groups.discord-role.route.test.ts
@@ -12,20 +12,25 @@ vi.mock('@repo/do-utils', () => ({
 }))
 
 vi.mock('../../middleware/session', () => ({
+	requireAllianceMember:
+		() =>
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 	requireAuth:
 		() =>
-			async (_c: unknown, next: () => Promise<void>): Promise<void> => {
-				await next()
-			},
+		async (_c: unknown, next: () => Promise<void>): Promise<void> => {
+			await next()
+		},
 	requireAdmin:
 		() =>
-			async (c: any, next: () => Promise<void>): Promise<Response | void> => {
-				const user = c.get('user')
-				if (!user?.is_admin) {
-					return c.json({ error: 'Forbidden' }, 403)
-				}
-				await next()
-			},
+		async (c: any, next: () => Promise<void>): Promise<Response | void> => {
+			const user = c.get('user')
+			if (!user?.is_admin) {
+				return c.json({ error: 'Forbidden' }, 403)
+			}
+			await next()
+		},
 }))
 
 const getStubMock = vi.mocked(getStub)

--- a/apps/core/src/routes/__tests__/hr.access-matrix.route.test.ts
+++ b/apps/core/src/routes/__tests__/hr.access-matrix.route.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { getStub } from '@repo/do-utils'
 import { getPublicEsiInstance } from '@repo/esi'
 
@@ -52,7 +53,7 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 			},
 		],
 		is_admin: false,
-		roles: [],
+		roles: [ROLE_CORE_ALLIANCE_MEMBER],
 		discordUserId: null,
 		...overrides,
 	}
@@ -1319,6 +1320,15 @@ describe('hr route access matrix', () => {
 				},
 			],
 		})
+	})
+
+	it('denies HR directory access to an HR user without alliance membership', async () => {
+		hrStub.getUserHrCorporations.mockResolvedValue(['1001'])
+		const app = createApp({ user: makeUser({ roles: [] }), db: dbStub })
+		const res = await app.request('/api/hr/users/search?search=pilot', {}, env)
+
+		expect(res.status).toBe(403)
+		expect(searchUsersForHrAccessMock).not.toHaveBeenCalled()
 	})
 
 	it('allows /audit/users for auditor', async () => {

--- a/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
+++ b/apps/core/src/routes/__tests__/prediction-markets.member.route.test.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+
 import predictionMarketsRoutes from '../prediction-markets'
 
 import type { SessionUser } from '../../context'
@@ -13,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 // requireAuth → pass-through; the test injects the session user directly.
 vi.mock('../../middleware/session', () => ({
 	requireAuth: () => async (_c: unknown, next: () => Promise<void>) => next(),
+	requireAllianceMember: () => async (_c: unknown, next: () => Promise<void>) => next(),
 }))
 vi.mock('../../lib/market-permissions', () => ({
 	hasMarketPermission: mocks.hasMarketPermission,
@@ -30,7 +33,7 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 		sessionId: 'session-1',
 		characters: [],
 		is_admin: false,
-		roles: [],
+		roles: [ROLE_CORE_ALLIANCE_MEMBER],
 		discordUserId: null,
 		...overrides,
 	}

--- a/apps/core/src/routes/__tests__/structures.route.test.ts
+++ b/apps/core/src/routes/__tests__/structures.route.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { DEFAULT_WORKFLOW_RETENTION } from '@repo/workflow-utils'
 
 import { getCachedUserPermissions } from '../../lib/groups-cache'
@@ -40,7 +41,7 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 		sessionId: 'session-1',
 		characters: [],
 		is_admin: false,
-		roles: ['urn:structures:all:viewer'],
+		roles: ['urn:structures:all:viewer', ROLE_CORE_ALLIANCE_MEMBER],
 		discordUserId: null,
 		...overrides,
 	}

--- a/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
+++ b/apps/core/src/routes/__tests__/users.corporation-access.route.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { getStub } from '@repo/do-utils'
 
 import { hasHrAuditorPermission } from '../../lib/hr-access'
@@ -48,7 +49,7 @@ function makeUser(overrides: Partial<SessionUser> = {}): SessionUser {
 		sessionId: 'session-1',
 		characters: [],
 		is_admin: false,
-		roles: [],
+		roles: [ROLE_CORE_ALLIANCE_MEMBER],
 		discordUserId: null,
 		...overrides,
 	}
@@ -251,6 +252,15 @@ describe('users corporation access', () => {
 		expect(hrStub.getUserRoles).toHaveBeenCalledWith('user-1')
 		expect(corpStub.getMembers).not.toHaveBeenCalled()
 		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('denies corporation access endpoints without the alliance-member role', async () => {
+		const app = createApp({ user: makeUser({ roles: [] }), db: dbStub })
+
+		const response = await app.request('/api/users/corporation-access', {}, env)
+
+		expect(response.status).toBe(403)
+		expect(dbStub.query.managedCorporations.findMany).not.toHaveBeenCalled()
 	})
 
 	it('disposes RPC results for the full corporation access response', async () => {

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -2,31 +2,26 @@ import { Hono } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 
 import { eq } from '@repo/db-utils'
-import { getStub } from '@repo/do-utils'
+import { getStub, withRpcResult } from '@repo/do-utils'
 import { assertEveCharacterId } from '@repo/eve-types'
 import { captureException, logger, toErrorMessage } from '@repo/hono-helpers'
-import { createWorkflow } from '@repo/workflow-utils'
 
 import { createDb } from '../db'
-import {
-	managedCorporations,
-	mumbleTempops,
-	oauthStates,
-	userCharacters,
-	users,
-} from '../db/schema'
+import { mumbleTempops, oauthStates, userCharacters, users } from '../db/schema'
 import { waitUntilWithTelemetry } from '../lib/background-task'
 import { getDiscordStatus } from '../lib/discord-helpers'
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import { extractClientIp, recordUserIpAddress } from '../lib/ip-tracking'
-import { createUserRefreshWorkflowId } from '../lib/workflow-triggers'
+import {
+	triggerDirectorHealthRecheckWorkflow,
+	triggerUserRefreshWorkflow,
+} from '../lib/workflow-triggers'
 import { requireAuth } from '../middleware/session'
 import { ActivityService } from '../services/activity.service'
 import { AuthService } from '../services/auth.service'
 import { hydrateCharacterAffiliation } from '../services/character-affiliation-hydration.service'
 import { reconcileUserCoreMembershipRoles } from '../services/core-role-reconciliation.service'
 import { autoRegisterDirectorCorporation } from '../services/corporation-auto-register.service'
-import { recheckDirectorHealthAfterTokenReauth } from '../services/director-health-recheck.service'
 import { storeCredentialHandoff } from '../services/mumble-tempop.service'
 import { provisionTempopGuest } from '../services/mumble.service'
 import { SessionService } from '../services/session.service'
@@ -40,10 +35,6 @@ import type { BlacklistEntry, Hr } from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
 import type { App } from '../context'
 import type { ClaimMainOAuthMetadata, OAuthStateMetadata, TempopOAuthMetadata } from '../db/schema'
-import type {
-	DirectorHealthRecheckStub,
-	ManagedCorporationSummary,
-} from '../services/director-health-recheck.service'
 
 /**
  * Authentication routes
@@ -278,87 +269,50 @@ async function hydrateAndReconcileUserRoles(
 	}
 }
 
-async function scheduleDirectorHealthRecheckAfterTokenReauth(
+async function triggerDirectorHealthRecheckAfterTokenReauth(
 	c: Context<App>,
 	db: ReturnType<typeof createDb>,
 	characterId: string,
 	characterName: string
 ): Promise<void> {
+	let corporationId: string | null = null
 	try {
-		const corporations: ManagedCorporationSummary[] = await db.query.managedCorporations.findMany({
-			where: eq(managedCorporations.isActive, true),
-			columns: {
-				corporationId: true,
-				name: true,
-			},
-		})
-
-		if (corporations.length === 0) {
-			return
-		}
-		const result = await recheckDirectorHealthAfterTokenReauth({
-			characterId,
-			characterName,
-			corporations,
-			getCorporationStub: (corporationId): DirectorHealthRecheckStub =>
-				getStub<DirectorHealthRecheckStub>(c.env.EVE_CORPORATION_DATA, corporationId),
-			updateManagedCorporationHealth: async ({ corporationId, healthyDirectorCount }) => {
-				await db
-					.update(managedCorporations)
-					.set({
-						healthyDirectorCount,
-						isVerified: healthyDirectorCount > 0,
-						lastVerified: new Date(),
-						updatedAt: new Date(),
-					})
-					.where(eq(managedCorporations.corporationId, corporationId))
-			},
-		})
-
-		if (result.matchedCorporations.length === 0) {
-			return
-		}
-
-		if (result.matchedCorporations.length > 1) {
-			logger.warn('[Auth] Character is configured as director in multiple corporations', {
-				characterId,
-				characterName,
-				corporationIds: result.matchedCorporations,
-			})
-		}
-
-		for (const corporationId of result.verifiedCorporations) {
-			logger.log('[Auth] Director recovered after token reauth', {
-				characterId,
-				characterName,
-				corporationId,
-			})
-		}
+		const characterData = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
+		const publicRefresh = await withRpcResult(
+			characterData.refreshPublicCharacterData(characterId, true),
+			(result) => ({ ...result })
+		)
+		corporationId = publicRefresh.currentCorporationId ?? null
 	} catch (error) {
-		logger.error('[Auth] Failed to schedule director health recheck after token reauth', {
+		logger.warn('[Auth] Failed to refresh character affiliation for director health recheck', {
 			characterId,
-			characterName,
 			error: toErrorMessage(error),
 		})
 	}
-}
 
-function triggerDirectorHealthRecheckAfterTokenReauth(
-	c: Context<App>,
-	db: ReturnType<typeof createDb>,
-	characterId: string,
-	characterName: string
-): void {
-	waitUntilWithTelemetry(
-		c.executionCtx,
-		'auth.director-health-recheck',
-		() => scheduleDirectorHealthRecheckAfterTokenReauth(c, db, characterId, characterName),
-		{
+	if (!corporationId) {
+		const storedCharacter = await db.query.userCharacters?.findFirst?.({
+			where: eq(userCharacters.characterId, characterId),
+			columns: { corporationId: true },
+		})
+		corporationId = storedCharacter?.corporationId ?? null
+	}
+
+	if (!corporationId || corporationId === '1000001') {
+		logger.info('[Auth] Skipping director health recheck without a valid corporation affiliation', {
 			characterId,
-			characterName,
-			source: 'oauth-callback',
-		}
-	)
+			corporationId,
+		})
+		return
+	}
+
+	await triggerDirectorHealthRecheckWorkflow({
+		env: c.env,
+		characterId,
+		characterName,
+		corporationId,
+		source: 'oauth-callback',
+	})
 }
 
 function triggerLegacyMigrationRecheck(c: Context<App>, userId: string): void {
@@ -746,12 +700,20 @@ auth.get('/callback', async (c) => {
 					.update(userCharacters)
 					.set({ hasValidToken: true, updatedAt: new Date() })
 					.where(eq(userCharacters.characterId, characterId))
-				triggerDirectorHealthRecheckAfterTokenReauth(
+				await triggerDirectorHealthRecheckAfterTokenReauth(
 					c,
 					db,
 					characterId,
 					characterInfo.characterName
 				)
+				await triggerUserRefreshWorkflow({
+					db,
+					env: c.env,
+					userId: stateUserId,
+					source: 'character-token-updated',
+					bypassThrottle: true,
+					refreshMode: 'event',
+				})
 
 				// Character already linked to this user - token has been updated, just return success
 				return c.json({
@@ -813,39 +775,24 @@ auth.get('/callback', async (c) => {
 			.update(userCharacters)
 			.set({ hasValidToken: true })
 			.where(eq(userCharacters.characterId, characterId))
-		triggerDirectorHealthRecheckAfterTokenReauth(c, db, characterId, characterInfo.characterName)
+		await triggerDirectorHealthRecheckAfterTokenReauth(
+			c,
+			db,
+			characterId,
+			characterInfo.characterName
+		)
 
 		await activityService.logCharacterLinked(stateUserId, characterId, getRequestMetadata(c))
 		triggerLegacyMigrationRecheck(c, stateUserId)
 
-		// Fetch character data in background (non-blocking)
-		const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
-		waitUntilWithTelemetry(
-			c.executionCtx,
-			'auth.link-character.refresh',
-			async () => {
-				// Fetch public character data
-				await eveCharacterDataStub.fetchCharacterData(String(characterId), false)
-
-				// Fetch authenticated data (skills, attributes, etc.)
-				await eveCharacterDataStub.fetchAuthenticatedData(String(characterId), false)
-
-				await db
-					.update(users)
-					.set({ lastRefreshWorkflowAttempt: new Date() })
-					.where(eq(users.id, stateUserId))
-
-				await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
-					id: createUserRefreshWorkflowId('link', stateUserId),
-					params: { userId: stateUserId, refreshMode: 'event' },
-				})
-			},
-			{
-				userId: stateUserId,
-				characterId: String(characterId),
-				source: 'link-character',
-			}
-		)
+		await triggerUserRefreshWorkflow({
+			db,
+			env: c.env,
+			userId: stateUserId,
+			source: 'link-character',
+			bypassThrottle: true,
+			refreshMode: 'event',
+		})
 
 		// Auto-register corporation if character is a director
 		let autoRegResult
@@ -978,51 +925,22 @@ auth.get('/callback', async (c) => {
 			.update(userCharacters)
 			.set({ hasValidToken: true })
 			.where(eq(userCharacters.characterId, characterId))
-		triggerDirectorHealthRecheckAfterTokenReauth(c, db, characterId, characterInfo.characterName)
+		await triggerDirectorHealthRecheckAfterTokenReauth(
+			c,
+			db,
+			characterId,
+			characterInfo.characterName
+		)
 
 		await activityService.logLogin(user.id, characterId, getRequestMetadata(c))
 
-		// Fetch character data in background (non-blocking)
-		const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
-		waitUntilWithTelemetry(
-			c.executionCtx,
-			'auth.login.refresh',
-			async () => {
-				// Fetch public character data
-				await eveCharacterDataStub.fetchCharacterData(String(characterId), false)
-
-				// Fetch authenticated data (skills, attributes, etc.)
-				await eveCharacterDataStub.fetchAuthenticatedData(String(characterId), false)
-
-				// Trigger user refresh workflow (throttled to every 5 minutes)
-				const THROTTLE_MS = 5 * 60 * 1000 // 5 minutes
-				const userRecord = await db.query.users.findFirst({
-					where: eq(users.id, user.id),
-					columns: { lastRefreshWorkflowAttempt: true },
-				})
-
-				const shouldTrigger =
-					!userRecord?.lastRefreshWorkflowAttempt ||
-					Date.now() - userRecord.lastRefreshWorkflowAttempt.getTime() > THROTTLE_MS
-
-				if (shouldTrigger) {
-					await db
-						.update(users)
-						.set({ lastRefreshWorkflowAttempt: new Date() })
-						.where(eq(users.id, user.id))
-
-					await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
-						id: createUserRefreshWorkflowId('login', user.id),
-						params: { userId: user.id, refreshMode: 'event' },
-					})
-				}
-			},
-			{
-				userId: user.id,
-				characterId: String(characterId),
-				source: 'login',
-			}
-		)
+		await triggerUserRefreshWorkflow({
+			db,
+			env: c.env,
+			userId: user.id,
+			source: 'login',
+			refreshMode: 'event',
+		})
 
 		// Auto-register corporation if character is a director
 		let autoRegResult
@@ -1227,6 +1145,12 @@ auth.post('/claim-main', async (c) => {
 		.update(userCharacters)
 		.set({ hasValidToken: true })
 		.where(eq(userCharacters.characterId, tokenInfo.characterId))
+	await triggerDirectorHealthRecheckAfterTokenReauth(
+		c,
+		db,
+		tokenInfo.characterId,
+		tokenInfo.characterName
+	)
 
 	// Create session
 	const session = await authService.createSession({
@@ -1240,35 +1164,14 @@ auth.post('/claim-main', async (c) => {
 	await activityService.logLogin(user.id, tokenInfo.characterId, getRequestMetadata(c))
 	triggerLegacyMigrationRecheck(c, user.id)
 
-	// Fetch character data in background (non-blocking)
-	const eveCharacterDataStub = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
-	waitUntilWithTelemetry(
-		c.executionCtx,
-		'auth.claim-main.refresh',
-		async () => {
-			// Fetch public character data
-			await eveCharacterDataStub.fetchCharacterData(String(tokenInfo.characterId), false)
-
-			// Fetch authenticated data (skills, attributes, etc.)
-			await eveCharacterDataStub.fetchAuthenticatedData(String(tokenInfo.characterId), false)
-
-			// Trigger user refresh workflow for new user
-			await db
-				.update(users)
-				.set({ lastRefreshWorkflowAttempt: new Date() })
-				.where(eq(users.id, user.id))
-
-			await createWorkflow(c.env.USER_REFRESH_WORKFLOW, {
-				id: createUserRefreshWorkflowId('login', user.id),
-				params: { userId: user.id, refreshMode: 'event' },
-			})
-		},
-		{
-			userId: user.id,
-			characterId: tokenInfo.characterId,
-			source: 'claim-main',
-		}
-	)
+	await triggerUserRefreshWorkflow({
+		db,
+		env: c.env,
+		userId: user.id,
+		source: 'claim-main',
+		bypassThrottle: true,
+		refreshMode: 'event',
+	})
 
 	// Auto-register corporation if character is a director
 	let autoRegResult

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -283,11 +283,21 @@ async function triggerDirectorHealthRecheckAfterTokenReauth(
 	// the bounded user-refresh workflow performs the next public refresh.
 	let corporationId = hydratedCorporationId ?? null
 	if (!corporationId) {
-		const storedCharacter = await db.query.userCharacters?.findFirst?.({
-			where: eq(userCharacters.characterId, characterId),
-			columns: { corporationId: true },
-		})
-		corporationId = storedCharacter?.corporationId ?? null
+		try {
+			const storedCharacter = await db.query.userCharacters?.findFirst?.({
+				where: eq(userCharacters.characterId, characterId),
+				columns: { corporationId: true },
+			})
+			corporationId = storedCharacter?.corporationId ?? null
+		} catch (error) {
+			// Director verification is ancillary to authentication. A transient
+			// database failure must not turn a successful SSO exchange into a
+			// failed login; the next bounded refresh/recheck can try again.
+			logger.warn('[Auth] Failed to load stored affiliation for director health recheck', {
+				characterId,
+				error: toErrorMessage(error),
+			})
+		}
 	}
 
 	if (!corporationId || corporationId === '1000001') {

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 
 import { eq } from '@repo/db-utils'
-import { getStub, withRpcResult } from '@repo/do-utils'
+import { getStub } from '@repo/do-utils'
 import { assertEveCharacterId } from '@repo/eve-types'
 import { captureException, logger, toErrorMessage } from '@repo/hono-helpers'
 
@@ -29,7 +29,6 @@ import { CharacterAlreadyClaimedError, UserService } from '../services/user.serv
 
 import type { Context } from 'hono'
 import type { RequestMetadata, UserProfileDTO } from '@repo/core'
-import type { EveCharacterData } from '@repo/eve-character-data'
 import type { EveTokenStore } from '@repo/eve-token-store'
 import type { BlacklistEntry, Hr } from '@repo/hr'
 import type { Legacy } from '@repo/legacy'
@@ -233,9 +232,10 @@ async function hydrateAndReconcileUserRoles(
 	db: ReturnType<typeof createDb>,
 	userId: string,
 	characterId: string
-): Promise<void> {
+): Promise<Awaited<ReturnType<typeof hydrateCharacterAffiliation>> | null> {
+	let affiliation: Awaited<ReturnType<typeof hydrateCharacterAffiliation>> | null = null
 	try {
-		await hydrateCharacterAffiliation({
+		affiliation = await hydrateCharacterAffiliation({
 			db,
 			env: c.env,
 			characterId,
@@ -243,7 +243,7 @@ async function hydrateAndReconcileUserRoles(
 			executionCtx: c.executionCtx,
 		})
 	} catch (error) {
-		logger.error('[Auth] Failed to hydrate character affiliation at link-time', {
+		logger.error('[Auth] Failed to hydrate character affiliation during auth flow', {
 			userId,
 			characterId,
 			error: toErrorMessage(error),
@@ -267,29 +267,21 @@ async function hydrateAndReconcileUserRoles(
 			error: toErrorMessage(error),
 		})
 	}
+
+	return affiliation
 }
 
 async function triggerDirectorHealthRecheckAfterTokenReauth(
 	c: Context<App>,
 	db: ReturnType<typeof createDb>,
 	characterId: string,
-	characterName: string
+	characterName: string,
+	hydratedCorporationId?: string | null
 ): Promise<void> {
-	let corporationId: string | null = null
-	try {
-		const characterData = getStub<EveCharacterData>(c.env.EVE_CHARACTER_DATA, 'default')
-		const publicRefresh = await withRpcResult(
-			characterData.refreshPublicCharacterData(characterId, true),
-			(result) => ({ ...result })
-		)
-		corporationId = publicRefresh.currentCorporationId ?? null
-	} catch (error) {
-		logger.warn('[Auth] Failed to refresh character affiliation for director health recheck', {
-			characterId,
-			error: toErrorMessage(error),
-		})
-	}
-
+	// Initial link/claim flows pass the affiliation returned by their required
+	// public hydration. Existing login flows use the persisted affiliation while
+	// the bounded user-refresh workflow performs the next public refresh.
+	let corporationId = hydratedCorporationId ?? null
 	if (!corporationId) {
 		const storedCharacter = await db.query.userCharacters?.findFirst?.({
 			where: eq(userCharacters.characterId, characterId),
@@ -694,7 +686,7 @@ auth.get('/callback', async (c) => {
 		const existingUser = await userService.getUserByCharacterId(characterId)
 		if (existingUser) {
 			if (existingUser.id === stateUserId) {
-				await hydrateAndReconcileUserRoles(c, db, stateUserId, characterId)
+				const affiliation = await hydrateAndReconcileUserRoles(c, db, stateUserId, characterId)
 				const existingCharacter = user.characters.find((char) => char.characterId === characterId)
 				await db
 					.update(userCharacters)
@@ -704,7 +696,8 @@ auth.get('/callback', async (c) => {
 					c,
 					db,
 					characterId,
-					characterInfo.characterName
+					characterInfo.characterName,
+					affiliation?.corporationId
 				)
 				await triggerUserRefreshWorkflow({
 					db,
@@ -768,7 +761,7 @@ auth.get('/callback', async (c) => {
 			characterId: characterInfo.characterId,
 			characterName: characterInfo.characterName,
 		})
-		await hydrateAndReconcileUserRoles(c, db, stateUserId, characterId)
+		const affiliation = await hydrateAndReconcileUserRoles(c, db, stateUserId, characterId)
 
 		// Update token validity cache (token was just received from SSO)
 		await db
@@ -779,7 +772,8 @@ auth.get('/callback', async (c) => {
 			c,
 			db,
 			characterId,
-			characterInfo.characterName
+			characterInfo.characterName,
+			affiliation?.corporationId
 		)
 
 		await activityService.logCharacterLinked(stateUserId, characterId, getRequestMetadata(c))
@@ -1138,7 +1132,7 @@ auth.post('/claim-main', async (c) => {
 		throw error
 	}
 
-	await hydrateAndReconcileUserRoles(c, db, user.id, tokenInfo.characterId)
+	const affiliation = await hydrateAndReconcileUserRoles(c, db, user.id, tokenInfo.characterId)
 
 	// Update token validity cache (token was just received from SSO)
 	await db
@@ -1149,7 +1143,8 @@ auth.post('/claim-main', async (c) => {
 		c,
 		db,
 		tokenInfo.characterId,
-		tokenInfo.characterName
+		tokenInfo.characterName,
+		affiliation?.corporationId
 	)
 
 	// Create session

--- a/apps/core/src/routes/broadcasts.ts
+++ b/apps/core/src/routes/broadcasts.ts
@@ -1,14 +1,13 @@
 import { Hono } from 'hono'
 
 import { getBroadcastSystemTemplateToken } from '@repo/broadcasts'
-import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { and, eq } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 
 import { createDb, schema } from '../db'
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import { validatePagination } from '../lib/validation'
-import { requireAuth } from '../middleware/session'
+import { requireAllianceMember } from '../middleware/session'
 import {
 	buildBroadcastPermissionContext,
 	canAccessBroadcastPermissionId,
@@ -538,7 +537,7 @@ async function getUserBroadcastPermissionContext(
 const broadcasts = new Hono<App>()
 
 // Apply authentication middleware to all routes
-broadcasts.use('*', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }))
+broadcasts.use('*', requireAllianceMember())
 
 // =============================================================================
 // BROADCAST TARGETS

--- a/apps/core/src/routes/corporation-tax/index.ts
+++ b/apps/core/src/routes/corporation-tax/index.ts
@@ -6,7 +6,7 @@ import { getStub } from '@repo/do-utils'
 import { logger, TimeCache } from '@repo/hono-helpers'
 
 import { discordServers, managedCorporations, userCharacters } from '../../db/schema'
-import { requireAuth } from '../../middleware/session'
+import { requireAllianceMember, requireAuth } from '../../middleware/session'
 import {
 	canAuditTaxFeature,
 	canManageTaxFeature,
@@ -135,6 +135,7 @@ app.use('*', async (c, next) => {
 	}
 	await next()
 })
+app.use('*', requireAllianceMember())
 
 async function validateBillingPayeeSelection(
 	db: App['Variables']['db'],

--- a/apps/core/src/routes/fleets.ts
+++ b/apps/core/src/routes/fleets.ts
@@ -17,7 +17,7 @@ import {
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import { validatePagination } from '../lib/validation'
 import { normalizeWorkflowStatus } from '../lib/workflow-status'
-import { requireAuth } from '../middleware/session'
+import { requireAllianceMember, requireAuth } from '../middleware/session'
 import { hasCorporationSelfServiceAccess } from '../middleware/tax-permissions'
 
 import type { Context } from 'hono'
@@ -38,7 +38,7 @@ import type { App } from '../context'
 const app = new Hono<App>()
 
 // All fleet endpoints require authentication
-app.use('*', requireAuth())
+app.use('*', requireAuth(), requireAllianceMember())
 
 /**
  * GET /fleets/character/:characterId

--- a/apps/core/src/routes/freight.ts
+++ b/apps/core/src/routes/freight.ts
@@ -1,7 +1,8 @@
 /**
  * Freight routes - Administrative operations for managing freight routes
  *
- * All endpoints require authentication and admin privileges.
+ * All endpoints require alliance membership; management operations additionally
+ * require the freight manager permission or site-admin access.
  * These endpoints call the Freight Durable Object via RPC.
  */
 
@@ -55,6 +56,8 @@ async function isFreightManager(
 }
 
 const app = new Hono<App>()
+
+app.use('*', requireAuth(), requireAllianceMember())
 
 /**
  * GET /freight/routes/active

--- a/apps/core/src/routes/fulcrum.ts
+++ b/apps/core/src/routes/fulcrum.ts
@@ -9,7 +9,7 @@ import { managedCorporations, userCharacters, users } from '../db/schema'
 import { waitUntilWithTelemetry } from '../lib/background-task'
 import { getCachedUserPermissions } from '../lib/groups-cache'
 import { queueImmunitasAccessAlertForUser } from '../lib/immunitas-alerts'
-import { requireAuth } from '../middleware/session'
+import { requireAllianceMember, requireAuth } from '../middleware/session'
 
 import type { Context } from 'hono'
 import type { Core } from '@repo/core'
@@ -20,6 +20,7 @@ import type { Hr } from '@repo/hr'
 import type { App, SessionUser } from '../context'
 
 const app = new Hono<App>()
+app.use('*', requireAuth(), requireAllianceMember())
 const MS_PER_DAY = 86_400_000
 
 // ============================================================================

--- a/apps/core/src/routes/groups.ts
+++ b/apps/core/src/routes/groups.ts
@@ -14,7 +14,7 @@ import {
 	triggerDiscordRefreshWorkflow,
 	triggerMumbleRefreshWorkflow,
 } from '../lib/workflow-triggers'
-import { requireAdmin, requireAuth } from '../middleware/session'
+import { requireAdmin, requireAllianceMember, requireAuth } from '../middleware/session'
 import {
 	dispatchGroupApplicationSubmittedAlert,
 	dispatchGroupInvitationAlert,
@@ -31,7 +31,7 @@ import type { App } from '../context'
  * Session middleware loads user into context.
  */
 const groups = new Hono<App>()
-groups.use('*', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }))
+groups.use('*', requireAllianceMember())
 
 function parseDiscordRoleMembershipType(value: unknown): 'member' | 'owner_admin' | null {
 	if (value === undefined) {

--- a/apps/core/src/routes/hr.ts
+++ b/apps/core/src/routes/hr.ts
@@ -17,7 +17,7 @@ import {
 import { getIpHashMatches, getUserIpHistory } from '../lib/ip-history'
 import { getUserCorporationAffiliationIds } from '../lib/user-corporation-affiliations'
 import { validatePagination } from '../lib/validation'
-import { requireAdmin, requireAuth } from '../middleware/session'
+import { requireAdmin, requireAllianceMember, requireAuth } from '../middleware/session'
 import { CoreRpcService } from '../services/core-rpc.service'
 import { dispatchCorporationAlert } from '../services/corporation-alerts.service'
 
@@ -39,6 +39,30 @@ import type { Legacy } from '@repo/legacy'
 import type { App } from '../context'
 
 const app = new Hono<App>()
+
+// Internal HR directory and audit surfaces require the alliance capability in
+// addition to their narrower HR permissions. Applicant-facing routes remain
+// authenticated-only so users can still manage their own applications.
+app.use('/corporations', requireAllianceMember())
+app.use('/corporations/*', requireAllianceMember())
+app.use('/users', requireAllianceMember())
+app.use('/users/*', requireAllianceMember())
+app.use('/audit', requireAllianceMember())
+app.use('/audit/*', requireAllianceMember())
+app.use('/legacy', requireAllianceMember())
+app.use('/legacy/*', requireAllianceMember())
+app.use('/recommendations', requireAllianceMember())
+app.use('/recommendations/*', requireAllianceMember())
+app.use('/templates', requireAllianceMember())
+app.use('/templates/*', requireAllianceMember())
+app.use('/notes', requireAllianceMember())
+app.use('/notes/*', requireAllianceMember())
+app.use('/roles', requireAllianceMember())
+app.use('/roles/*', requireAllianceMember())
+app.use('/:corporationId/templates', requireAllianceMember())
+app.use('/:corporationId/templates/*', requireAllianceMember())
+app.use('/:corporationId/roles', requireAllianceMember())
+app.use('/:corporationId/roles/*', requireAllianceMember())
 
 const updateApplicationSchema = z.object({
 	status: z.enum(APPLICATION_STATUSES),

--- a/apps/core/src/routes/inventory.ts
+++ b/apps/core/src/routes/inventory.ts
@@ -9,7 +9,7 @@ import { Hono } from 'hono'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
-import { requireAuth } from '../middleware/session'
+import { requireAllianceMember } from '../middleware/session'
 
 import type { InventoryParseResult } from '@repo/eve-types'
 import type { Universe } from '@repo/universe'
@@ -18,7 +18,7 @@ import type { App } from '../context'
 const app = new Hono<App>()
 
 // Require authentication for all inventory routes
-app.use('*', requireAuth())
+app.use('*', requireAllianceMember())
 
 /**
  * POST /inventory/parse

--- a/apps/core/src/routes/prediction-markets.ts
+++ b/apps/core/src/routes/prediction-markets.ts
@@ -13,7 +13,7 @@ import { Hono } from 'hono'
 import { logger } from '@repo/hono-helpers'
 
 import { hasMarketPermission } from '../lib/market-permissions'
-import { requireAuth } from '../middleware/session'
+import { requireAllianceMember } from '../middleware/session'
 import {
 	createAndPublishMarket,
 	createMarketCreatorSchema,
@@ -26,7 +26,7 @@ import type { App } from '../context'
 const app = new Hono<App>()
 
 // A valid session is required for every member endpoint (the per-tier gate is per-route below).
-app.use('*', requireAuth())
+app.use('*', requireAllianceMember())
 
 // POST /markets — a member with urn:markets:creator (or manager/admin) creates a market. `createdBy`
 // comes from the session, never the client. The creator may bet on their own market but can't resolve

--- a/apps/core/src/routes/structures.ts
+++ b/apps/core/src/routes/structures.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { getStub } from '@repo/do-utils'
 import { hasAllStructureManagerPermission, hasAnyStructurePermission } from '@repo/groups'
 import {
@@ -118,6 +119,7 @@ async function getStructureActor(c: Context<App>) {
 	return {
 		id: user.id,
 		is_admin: user.is_admin,
+		isAllianceMember: user.is_admin || user.roles.includes(ROLE_CORE_ALLIANCE_MEMBER),
 		roles: permissions.map((permission) => permission.urn),
 		implicitSensitiveCorporationIds,
 	}
@@ -125,9 +127,10 @@ async function getStructureActor(c: Context<App>) {
 
 function hasStructureApiAccess(actor: Awaited<ReturnType<typeof getStructureActor>>): boolean {
 	return (
-		actor.is_admin ||
-		hasAnyStructurePermission(actor.roles.map((urn) => ({ urn }))) ||
-		(actor.implicitSensitiveCorporationIds?.length ?? 0) > 0
+		actor.isAllianceMember &&
+		(actor.is_admin ||
+			hasAnyStructurePermission(actor.roles.map((urn) => ({ urn }))) ||
+			(actor.implicitSensitiveCorporationIds?.length ?? 0) > 0)
 	)
 }
 

--- a/apps/core/src/routes/users.ts
+++ b/apps/core/src/routes/users.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { and, eq, inArray, or } from '@repo/db-utils'
 import { getStub, withRpcResult } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
@@ -397,122 +398,129 @@ users.post('/me/characters/:characterId/set-primary', async (c) => {
  * Quick check if user has any CEO/director access (for UI navigation).
  * This is a lighter-weight version that just returns true/false.
  */
-users.get('/has-corporation-access', async (c) => {
-	const user = c.get('user')!
-	const db = c.get('db') || createDb(c.env.DATABASE_URL)
+users.get(
+	'/has-corporation-access',
+	requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }),
+	async (c) => {
+		const user = c.get('user')!
+		const db = c.get('db') || createDb(c.env.DATABASE_URL)
 
-	try {
-		// Site admins have access to all corporations
-		if (user.is_admin) {
-			return c.json({ hasAccess: true })
-		}
-
-		// Get all user's characters
-		const characters = await db.query.userCharacters.findMany({
-			where: eq(userCharacters.userId, user.id),
-			columns: {
-				characterId: true,
-				characterName: true,
-				corporationId: true,
-				hasValidToken: true,
-				status: true,
-			},
-		})
-
-		if (!characters.length) {
-			return c.json({ hasAccess: false })
-		}
-
-		// Get all active managed corporations that can be led by the current user.
-		const managedCorps = filterManagedNonNpcCorps(
-			await db.query.managedCorporations.findMany({
-				where: and(
-					eq(managedCorporations.isActive, true),
-					or(
-						eq(managedCorporations.isMemberCorporation, true),
-						eq(managedCorporations.isAltCorp, true),
-						eq(managedCorporations.isSpecialPurpose, true)
-					)
-				),
-			})
-		)
-
-		if (!managedCorps.length) {
-			return c.json({ hasAccess: false })
-		}
-
-		// Fetch corporation IDs for ALL characters (not just first 10)
-		// This ensures we check all managed corporations the user has characters in
-		const charCorpPromises = characters.map(async (character) => {
-			const charStub = getStub<Rpc.Provider<EveCharacterData>>(c.env.EVE_CHARACTER_DATA, 'default')
-			try {
-				return withRpcResult(charStub.getCharacterInfo(character.characterId), (result) =>
-					result ? String(result.corporationId) : null
-				)
-			} catch {
-				return null
-			}
-		})
-
-		const characterCorpIds = await Promise.all(charCorpPromises)
-		const uniqueCorpIds = new Set(characterCorpIds.filter((id) => id !== null))
-
-		// Check if any of these corps are managed and user has a role
-		for (const corpId of uniqueCorpIds) {
-			const managedCorp = managedCorps.find((c) => c.corporationId === corpId)
-			if (managedCorp) {
-				// Found a managed corp - quick check for any role
-				const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
-					c.env.EVE_CORPORATION_DATA,
-					corpId
-				)
-				try {
-					const [corpInfo, directors] = await Promise.all([
-						withRpcResult(corpStub.getCorporationInfo(corpId), (result) =>
-							result ? { ceoId: result.ceoId } : null
-						),
-						withRpcResult(corpStub.getDirectors(corpId), (result) =>
-							result.map((director) => ({ characterId: director.characterId }))
-						),
-					])
-
-					// Check if any character is CEO or director
-					for (const char of characters) {
-						const isCeo = corpInfo && String(corpInfo.ceoId) === char.characterId
-						const matchedDirector = directors.find((d) => d.characterId === char.characterId)
-
-						if (isCeo) {
-							return c.json({ hasAccess: true })
-						}
-						if (matchedDirector) {
-							return c.json({ hasAccess: true })
-						}
-					}
-				} catch {
-					continue
-				}
-			}
-		}
-
-		// Also check if user has any HR roles
-		const hrStub = getStub<Rpc.Provider<Hr>>(c.env.HR, 'default')
 		try {
-			const hrCorpIds = await withRpcResult(hrStub.getUserHrCorporations(user.id), (result) => [
-				...result,
-			])
-			if (hrCorpIds.length > 0) {
+			// Site admins have access to all corporations
+			if (user.is_admin) {
 				return c.json({ hasAccess: true })
 			}
-		} catch {
-			// Ignore HR check failures
-		}
 
-		return c.json({ hasAccess: false })
-	} catch (error) {
-		logger.error('Error checking corporation access:', error)
-		return c.json({ hasAccess: false })
+			// Get all user's characters
+			const characters = await db.query.userCharacters.findMany({
+				where: eq(userCharacters.userId, user.id),
+				columns: {
+					characterId: true,
+					characterName: true,
+					corporationId: true,
+					hasValidToken: true,
+					status: true,
+				},
+			})
+
+			if (!characters.length) {
+				return c.json({ hasAccess: false })
+			}
+
+			// Get all active managed corporations that can be led by the current user.
+			const managedCorps = filterManagedNonNpcCorps(
+				await db.query.managedCorporations.findMany({
+					where: and(
+						eq(managedCorporations.isActive, true),
+						or(
+							eq(managedCorporations.isMemberCorporation, true),
+							eq(managedCorporations.isAltCorp, true),
+							eq(managedCorporations.isSpecialPurpose, true)
+						)
+					),
+				})
+			)
+
+			if (!managedCorps.length) {
+				return c.json({ hasAccess: false })
+			}
+
+			// Fetch corporation IDs for ALL characters (not just first 10)
+			// This ensures we check all managed corporations the user has characters in
+			const charCorpPromises = characters.map(async (character) => {
+				const charStub = getStub<Rpc.Provider<EveCharacterData>>(
+					c.env.EVE_CHARACTER_DATA,
+					'default'
+				)
+				try {
+					return withRpcResult(charStub.getCharacterInfo(character.characterId), (result) =>
+						result ? String(result.corporationId) : null
+					)
+				} catch {
+					return null
+				}
+			})
+
+			const characterCorpIds = await Promise.all(charCorpPromises)
+			const uniqueCorpIds = new Set(characterCorpIds.filter((id) => id !== null))
+
+			// Check if any of these corps are managed and user has a role
+			for (const corpId of uniqueCorpIds) {
+				const managedCorp = managedCorps.find((c) => c.corporationId === corpId)
+				if (managedCorp) {
+					// Found a managed corp - quick check for any role
+					const corpStub = getStub<Rpc.Provider<EveCorporationData>>(
+						c.env.EVE_CORPORATION_DATA,
+						corpId
+					)
+					try {
+						const [corpInfo, directors] = await Promise.all([
+							withRpcResult(corpStub.getCorporationInfo(corpId), (result) =>
+								result ? { ceoId: result.ceoId } : null
+							),
+							withRpcResult(corpStub.getDirectors(corpId), (result) =>
+								result.map((director) => ({ characterId: director.characterId }))
+							),
+						])
+
+						// Check if any character is CEO or director
+						for (const char of characters) {
+							const isCeo = corpInfo && String(corpInfo.ceoId) === char.characterId
+							const matchedDirector = directors.find((d) => d.characterId === char.characterId)
+
+							if (isCeo) {
+								return c.json({ hasAccess: true })
+							}
+							if (matchedDirector) {
+								return c.json({ hasAccess: true })
+							}
+						}
+					} catch {
+						continue
+					}
+				}
+			}
+
+			// Also check if user has any HR roles
+			const hrStub = getStub<Rpc.Provider<Hr>>(c.env.HR, 'default')
+			try {
+				const hrCorpIds = await withRpcResult(hrStub.getUserHrCorporations(user.id), (result) => [
+					...result,
+				])
+				if (hrCorpIds.length > 0) {
+					return c.json({ hasAccess: true })
+				}
+			} catch {
+				// Ignore HR check failures
+			}
+
+			return c.json({ hasAccess: false })
+		} catch (error) {
+			logger.error('Error checking corporation access:', error)
+			return c.json({ hasAccess: false })
+		}
 	}
-})
+)
 
 /**
  * GET /users/corporation-access
@@ -521,7 +529,7 @@ users.get('/has-corporation-access', async (c) => {
  * Returns list of corporations where user has leadership roles.
  * This is the full check that returns all accessible corporations.
  */
-users.get('/corporation-access', async (c) => {
+users.get('/corporation-access', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), async (c) => {
 	const user = c.get('user')!
 	const db = c.get('db') || createDb(c.env.DATABASE_URL)
 
@@ -852,7 +860,7 @@ users.get('/corporation-access', async (c) => {
  * Access is resolved independently from the statistics, while each
  * corporation's counts are cached for reuse by other authorized users.
  */
-users.get('/corporation-coverage', async (c) => {
+users.get('/corporation-coverage', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), async (c) => {
 	const user = c.get('user')!
 	const db = c.get('db') || createDb(c.env.DATABASE_URL)
 
@@ -992,7 +1000,7 @@ users.get('/corporation-coverage', async (c) => {
  * Optimized to eliminate N+1 queries and parallelize all I/O operations.
  * Cached for 5 minutes to improve performance.
  */
-users.get('/my-corporations', async (c) => {
+users.get('/my-corporations', requireAuth({ any: [ROLE_CORE_ALLIANCE_MEMBER] }), async (c) => {
 	const user = c.get('user')!
 	const db = c.get('db') || createDb(c.env.DATABASE_URL)
 

--- a/apps/core/src/services/__tests__/core-role-reconciliation.service.test.ts
+++ b/apps/core/src/services/__tests__/core-role-reconciliation.service.test.ts
@@ -11,6 +11,8 @@ const hoisted = vi.hoisted(() => {
 		groupsBinding: {} as DurableObjectNamespace,
 		mocks: {
 			getUserCharacters: vi.fn(),
+			isMemberCorporation: vi.fn(),
+			getMemberCorporationIds: vi.fn(),
 			batchCreateRoles: vi.fn(),
 			replaceCoreMembershipRolesForUser: vi.fn(),
 			clearUserRolesCache: vi.fn(),
@@ -23,6 +25,8 @@ vi.mock('@repo/do-utils', () => ({
 		if (binding === hoisted.coreBinding) {
 			return {
 				getUserCharacters: hoisted.mocks.getUserCharacters,
+				isMemberCorporation: hoisted.mocks.isMemberCorporation,
+				getMemberCorporationIds: hoisted.mocks.getMemberCorporationIds,
 			}
 		}
 		return {
@@ -39,6 +43,10 @@ vi.mock('../../lib/groups-cache', () => ({
 describe('reconcileUserCoreMembershipRoles', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		hoisted.mocks.isMemberCorporation.mockResolvedValue(true)
+		hoisted.mocks.getMemberCorporationIds.mockImplementation(
+			async (corporationIds: string[]) => corporationIds
+		)
 	})
 
 	it('deduplicates desired role targets and clears role cache', async () => {
@@ -129,6 +137,45 @@ describe('reconcileUserCoreMembershipRoles', () => {
 		expect(hoisted.mocks.replaceCoreMembershipRolesForUser).toHaveBeenCalledWith({
 			userId: 'user-2',
 			roles: [],
+		})
+	})
+
+	it('does not grant alliance membership for an alliance character in a non-member corporation', async () => {
+		hoisted.mocks.getUserCharacters.mockResolvedValue([
+			{
+				characterId: '1',
+				characterName: 'A',
+				isDeleted: false,
+				corporationId: '999',
+				allianceId: '200',
+			},
+		])
+		hoisted.mocks.getMemberCorporationIds.mockResolvedValue([])
+		hoisted.mocks.batchCreateRoles.mockResolvedValue([])
+		hoisted.mocks.replaceCoreMembershipRolesForUser.mockResolvedValue({
+			roleAttachments: [],
+			desiredCount: 1,
+			attachedCount: 1,
+			detachedCount: 0,
+		})
+
+		await reconcileUserCoreMembershipRoles(
+			{
+				CORE: hoisted.coreBinding,
+				GROUPS: hoisted.groupsBinding,
+			},
+			'user-3'
+		)
+
+		expect(hoisted.mocks.replaceCoreMembershipRolesForUser).toHaveBeenCalledWith({
+			userId: 'user-3',
+			roles: [
+				{
+					roleName: ROLE_CORE_CORP_MEMBER,
+					resourceId: '999',
+					resourceType: ResourceType.CORPORATION,
+				},
+			],
 		})
 	})
 })

--- a/apps/core/src/services/__tests__/core-rpc.alliance-membership.test.ts
+++ b/apps/core/src/services/__tests__/core-rpc.alliance-membership.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+import { RoleAttachmentType } from '@repo/groups'
+
+import { CoreRpcService } from '../core-rpc.service'
+
+const getStubMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@repo/do-utils', () => ({
+	getStub: getStubMock,
+	withRpcResult: async <T, R>(result: Promise<T>, consume: (value: T) => R) =>
+		consume(await result),
+}))
+
+describe('CoreRpcService.isUserAllianceMember', () => {
+	let groupsStub: { getRolesFor: ReturnType<typeof vi.fn> }
+	let db: {
+		select: ReturnType<typeof vi.fn>
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		groupsStub = { getRolesFor: vi.fn() }
+		db = { select: vi.fn() }
+		getStubMock.mockReturnValue(groupsStub)
+	})
+
+	it('requires the persisted alliance-member role before querying affiliation', async () => {
+		groupsStub.getRolesFor.mockResolvedValue([])
+		const service = new CoreRpcService(db as never, { GROUPS: {} } as never)
+
+		expect(await service.isUserAllianceMember('user-1')).toBe(false)
+		expect(groupsStub.getRolesFor).toHaveBeenCalledWith({
+			attachedToType: RoleAttachmentType.USER,
+			attachedToId: 'user-1',
+		})
+		expect(db.select).not.toHaveBeenCalled()
+	})
+
+	it('requires both the role and an active eligible corporation affiliation', async () => {
+		groupsStub.getRolesFor.mockResolvedValue([{ role: { name: ROLE_CORE_ALLIANCE_MEMBER } }])
+		const limit = vi.fn().mockResolvedValue([{ characterId: '9001' }])
+		const where = vi.fn().mockReturnValue({ limit })
+		const innerJoin = vi.fn().mockReturnValue({ where })
+		const from = vi.fn().mockReturnValue({ innerJoin })
+		db.select.mockReturnValue({ from })
+		const service = new CoreRpcService(db as never, { GROUPS: {} } as never)
+
+		expect(await service.isUserAllianceMember('user-1')).toBe(true)
+		expect(limit).toHaveBeenCalledWith(1)
+	})
+
+	it('returns false when the role exists but no eligible affiliation exists', async () => {
+		groupsStub.getRolesFor.mockResolvedValue([{ role: { name: ROLE_CORE_ALLIANCE_MEMBER } }])
+		const limit = vi.fn().mockResolvedValue([])
+		const where = vi.fn().mockReturnValue({ limit })
+		const innerJoin = vi.fn().mockReturnValue({ where })
+		const from = vi.fn().mockReturnValue({ innerJoin })
+		db.select.mockReturnValue({ from })
+		const service = new CoreRpcService(db as never, { GROUPS: {} } as never)
+
+		expect(await service.isUserAllianceMember('user-1')).toBe(false)
+	})
+})

--- a/apps/core/src/services/core-role-reconciliation.service.ts
+++ b/apps/core/src/services/core-role-reconciliation.service.ts
@@ -42,6 +42,14 @@ export async function reconcileUserCoreMembershipRoles(
 	})
 
 	const characters = await coreStub.getUserCharacters(userId)
+	const corporationIds = [
+		...new Set(
+			characters
+				.map((character) => character.corporationId)
+				.filter((corporationId): corporationId is string => Boolean(corporationId))
+		),
+	]
+	const memberCorporationIds = new Set(await coreStub.getMemberCorporationIds(corporationIds))
 
 	const seen = new Set<string>()
 	const roleTargets: Array<{
@@ -62,7 +70,11 @@ export async function reconcileUserCoreMembershipRoles(
 				})
 			}
 		}
-		if (character.allianceId) {
+		if (
+			character.allianceId &&
+			character.corporationId &&
+			memberCorporationIds.has(character.corporationId)
+		) {
 			const key = `${ROLE_CORE_ALLIANCE_MEMBER}|${character.allianceId}|${ResourceType.ALLIANCE}`
 			if (!seen.has(key)) {
 				seen.add(key)

--- a/apps/core/src/services/core-rpc.service.ts
+++ b/apps/core/src/services/core-rpc.service.ts
@@ -970,6 +970,47 @@ export class CoreRpcService {
 		return corporation !== undefined
 	}
 
+	async getMemberCorporationIds(corporationIds: string[]): Promise<string[]> {
+		if (corporationIds.length === 0) {
+			return []
+		}
+
+		const corporations = await this.db
+			.select({ corporationId: managedCorporations.corporationId })
+			.from(managedCorporations)
+			.where(
+				and(
+					inArray(managedCorporations.corporationId, corporationIds),
+					eq(managedCorporations.isActive, true),
+					eq(managedCorporations.isMemberCorporation, true)
+				)
+			)
+
+		return corporations.map((corporation) => corporation.corporationId)
+	}
+
+	/** Whether a user currently has an active linked character in a member corporation. */
+	async isUserAllianceMember(userId: string): Promise<boolean> {
+		const [match] = await this.db
+			.select({ characterId: userCharacters.characterId })
+			.from(userCharacters)
+			.innerJoin(
+				managedCorporations,
+				eq(managedCorporations.corporationId, userCharacters.corporationId)
+			)
+			.where(
+				and(
+					eq(userCharacters.userId, userId),
+					eq(userCharacters.isDeleted, false),
+					eq(managedCorporations.isActive, true),
+					eq(managedCorporations.isMemberCorporation, true)
+				)
+			)
+			.limit(1)
+
+		return match !== undefined
+	}
+
 	async listUsersWithActiveCharactersPage(input: { limit: number; offset: number }): Promise<{
 		users: Array<{ userId: string; characterIds: string[] }>
 		totalCount: number

--- a/apps/core/src/services/core-rpc.service.ts
+++ b/apps/core/src/services/core-rpc.service.ts
@@ -1,5 +1,7 @@
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
 import { and, asc, desc, eq, gt, ilike, inArray, or, sql } from '@repo/db-utils'
 import { getStub, withRpcResult } from '@repo/do-utils'
+import { RoleAttachmentType } from '@repo/groups'
 import { logger } from '@repo/hono-helpers'
 
 import { discordServers, managedCorporations, userCharacters, users } from '../db/schema'
@@ -991,6 +993,20 @@ export class CoreRpcService {
 
 	/** Whether a user currently has an active linked character in a member corporation. */
 	async isUserAllianceMember(userId: string): Promise<boolean> {
+		// Corporation eligibility and the alliance-member URN are separate
+		// sources of truth. A corporation flag must never synthesize the role.
+		const groupsStub = getStub<Groups>(this.env.GROUPS, 'default')
+		const roleAttachments = await withRpcResult(
+			groupsStub.getRolesFor({
+				attachedToType: RoleAttachmentType.USER,
+				attachedToId: userId,
+			}),
+			(result) => result.map((attachment) => ({ roleName: attachment.role.name }))
+		)
+		if (!roleAttachments.some((attachment) => attachment.roleName === ROLE_CORE_ALLIANCE_MEMBER)) {
+			return false
+		}
+
 		const [match] = await this.db
 			.select({ characterId: userCharacters.characterId })
 			.from(userCharacters)

--- a/apps/core/src/services/director-health-recheck.service.ts
+++ b/apps/core/src/services/director-health-recheck.service.ts
@@ -1,3 +1,5 @@
+import { withRpcResult } from '@repo/do-utils'
+
 import type { EveCorporationData } from '@repo/eve-corporation-data'
 
 export type ManagedCorporationSummary = {
@@ -32,6 +34,52 @@ export interface DirectorHealthRecheckResult {
 	verifiedCorporations: string[]
 }
 
+export interface DirectorHealthRecheckCorporationDeps {
+	characterId: string
+	corporationId: string
+	getCorporationStub: (corporationId: string) => DirectorHealthRecheckStub
+	updateManagedCorporationHealth: (params: {
+		corporationId: string
+		healthyDirectorCount: number
+	}) => Promise<void>
+}
+
+export interface DirectorHealthRecheckCorporationResult {
+	matched: boolean
+	verified: boolean
+	healthyDirectorCount?: number
+}
+
+export async function recheckDirectorHealthForCorporation(
+	deps: DirectorHealthRecheckCorporationDeps
+): Promise<DirectorHealthRecheckCorporationResult> {
+	const corpStub = deps.getCorporationStub(deps.corporationId)
+	const directors = await withRpcResult(corpStub.getDirectors(deps.corporationId), (result) => [
+		...result,
+	])
+	const director = directors.find((entry) => entry.characterId === deps.characterId)
+	if (!director) {
+		return { matched: false, verified: false }
+	}
+
+	const verified = await corpStub.verifyDirectorHealth(deps.corporationId, director.directorId)
+	if (!verified) {
+		return { matched: true, verified: false }
+	}
+
+	const refreshedDirectors = await withRpcResult(
+		corpStub.getDirectors(deps.corporationId),
+		(result) => [...result]
+	)
+	const healthyDirectorCount = refreshedDirectors.filter((entry) => entry.isHealthy).length
+	await deps.updateManagedCorporationHealth({
+		corporationId: deps.corporationId,
+		healthyDirectorCount,
+	})
+
+	return { matched: true, verified: true, healthyDirectorCount }
+}
+
 export async function recheckDirectorHealthAfterTokenReauth(
 	deps: DirectorHealthRecheckDeps
 ): Promise<DirectorHealthRecheckResult> {
@@ -39,30 +87,14 @@ export async function recheckDirectorHealthAfterTokenReauth(
 	const verifiedCorporations: string[] = []
 
 	for (const corporation of deps.corporations) {
-		const corpStub = deps.getCorporationStub(corporation.corporationId)
-		const directors = await corpStub.getDirectors(corporation.corporationId)
-		const director = directors.find((entry) => entry.characterId === deps.characterId)
-		if (!director) {
-			continue
-		}
-
-		matchedCorporations.push(corporation.corporationId)
-
-		const verified = await corpStub.verifyDirectorHealth(
-			corporation.corporationId,
-			director.directorId
-		)
-		if (!verified) {
-			continue
-		}
-
-		const refreshedDirectors = await corpStub.getDirectors(corporation.corporationId)
-		const healthyDirectorCount = refreshedDirectors.filter((entry) => entry.isHealthy).length
-		await deps.updateManagedCorporationHealth({
+		const result = await recheckDirectorHealthForCorporation({
+			characterId: deps.characterId,
 			corporationId: corporation.corporationId,
-			healthyDirectorCount,
+			getCorporationStub: deps.getCorporationStub,
+			updateManagedCorporationHealth: deps.updateManagedCorporationHealth,
 		})
-		verifiedCorporations.push(corporation.corporationId)
+		if (result.matched) matchedCorporations.push(corporation.corporationId)
+		if (result.verified) verifiedCorporations.push(corporation.corporationId)
 	}
 
 	return {

--- a/apps/core/src/workflows/director-health-recheck.workflow.ts
+++ b/apps/core/src/workflows/director-health-recheck.workflow.ts
@@ -1,0 +1,131 @@
+import { WorkflowEntrypoint } from 'cloudflare:workers'
+
+import { and, eq } from '@repo/db-utils'
+import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
+
+import { createDb } from '../db'
+import { managedCorporations } from '../db/schema'
+import { recheckDirectorHealthForCorporation } from '../services/director-health-recheck.service'
+
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers'
+import type { EveCorporationData } from '@repo/eve-corporation-data'
+import type { Env } from '../context'
+
+export interface DirectorHealthRecheckWorkflowParams {
+	characterId: string
+	characterName: string
+	corporationId: string
+	source: string
+}
+
+interface ManagedCorporationSummary {
+	corporationId: string
+	name: string
+}
+
+interface CorporationRecheckResult {
+	corporationId: string
+	matched: boolean
+	verified: boolean
+	healthyDirectorCount?: number
+	error?: string
+}
+
+const CORPORATION_STEP_OPTIONS = {
+	retries: { limit: 2, delay: '3 seconds' as const, backoff: 'exponential' as const },
+	timeout: '1 minute' as const,
+}
+
+export class DirectorHealthRecheckWorkflow extends WorkflowEntrypoint<
+	Env,
+	DirectorHealthRecheckWorkflowParams
+> {
+	private async recheckCorporation(
+		step: WorkflowStep,
+		corporation: ManagedCorporationSummary,
+		characterId: string
+	): Promise<CorporationRecheckResult> {
+		return step.do(`recheck-${corporation.corporationId}`, CORPORATION_STEP_OPTIONS, async () => {
+			const result = await recheckDirectorHealthForCorporation({
+				characterId,
+				corporationId: corporation.corporationId,
+				getCorporationStub: (corporationId) =>
+					getStub<EveCorporationData>(this.env.EVE_CORPORATION_DATA, corporationId),
+				updateManagedCorporationHealth: async ({ corporationId, healthyDirectorCount }) => {
+					const db = createDb(this.env.DATABASE_URL)
+					await db
+						.update(managedCorporations)
+						.set({
+							healthyDirectorCount,
+							isVerified: healthyDirectorCount > 0,
+							lastVerified: new Date(),
+							updatedAt: new Date(),
+						})
+						.where(eq(managedCorporations.corporationId, corporationId))
+				},
+			})
+			return {
+				corporationId: corporation.corporationId,
+				...result,
+			}
+		})
+	}
+
+	async run(
+		event: WorkflowEvent<DirectorHealthRecheckWorkflowParams>,
+		step: WorkflowStep
+	): Promise<{ status: 'completed'; characterId: string; results: CorporationRecheckResult[] }> {
+		const { characterId, characterName, corporationId, source } = event.payload
+		const workflowInstanceId = event.instanceId
+		const corporations = await step.do('load-active-corporation', async () =>
+			createDb(this.env.DATABASE_URL).query.managedCorporations.findMany({
+				where: and(
+					eq(managedCorporations.corporationId, corporationId),
+					eq(managedCorporations.isActive, true)
+				),
+				columns: { corporationId: true, name: true },
+			})
+		)
+
+		logger.info('[DirectorHealthRecheckWorkflow] Starting', {
+			workflowInstanceId,
+			characterId,
+			corporationId,
+			characterName,
+			source,
+			corporationCount: corporations.length,
+		})
+
+		const results: CorporationRecheckResult[] = []
+		for (const corporation of corporations) {
+			try {
+				results.push(await this.recheckCorporation(step, corporation, characterId))
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				logger.error('[DirectorHealthRecheckWorkflow] Corporation recheck failed', {
+					workflowInstanceId,
+					characterId,
+					corporationId: corporation.corporationId,
+					error: message,
+				})
+				results.push({
+					corporationId: corporation.corporationId,
+					matched: false,
+					verified: false,
+					error: message,
+				})
+			}
+		}
+
+		logger.info('[DirectorHealthRecheckWorkflow] Completed', {
+			workflowInstanceId,
+			characterId,
+			matchedCorporationCount: results.filter((result) => result.matched).length,
+			verifiedCorporationCount: results.filter((result) => result.verified).length,
+			failedCorporationCount: results.filter((result) => result.error).length,
+		})
+
+		return { status: 'completed', characterId, results }
+	}
+}

--- a/apps/core/src/workflows/director-health-recheck.workflow.ts
+++ b/apps/core/src/workflows/director-health-recheck.workflow.ts
@@ -75,7 +75,11 @@ export class DirectorHealthRecheckWorkflow extends WorkflowEntrypoint<
 	async run(
 		event: WorkflowEvent<DirectorHealthRecheckWorkflowParams>,
 		step: WorkflowStep
-	): Promise<{ status: 'completed'; characterId: string; results: CorporationRecheckResult[] }> {
+	): Promise<{
+		status: 'completed' | 'completed_with_failures'
+		characterId: string
+		results: CorporationRecheckResult[]
+	}> {
 		const { characterId, characterName, corporationId, source } = event.payload
 		const workflowInstanceId = event.instanceId
 		const corporations = await step.do('load-active-corporation', async () =>
@@ -126,6 +130,10 @@ export class DirectorHealthRecheckWorkflow extends WorkflowEntrypoint<
 			failedCorporationCount: results.filter((result) => result.error).length,
 		})
 
-		return { status: 'completed', characterId, results }
+		return {
+			status: results.some((result) => result.error) ? 'completed_with_failures' : 'completed',
+			characterId,
+			results,
+		}
 	}
 }

--- a/apps/core/wrangler.jsonc
+++ b/apps/core/wrangler.jsonc
@@ -263,6 +263,11 @@
 			"class_name": "UserRefreshWorkflow"
 		},
 		{
+			"name": "director-health-recheck-workflow",
+			"binding": "DIRECTOR_HEALTH_RECHECK_WORKFLOW",
+			"class_name": "DirectorHealthRecheckWorkflow"
+		},
+		{
 			"name": "user-discord-refresh-workflow",
 			"binding": "USER_DISCORD_REFRESH_WORKFLOW",
 			"class_name": "UserDiscordRefreshWorkflow"

--- a/apps/esi/src/durable-object-id-resolver.test.ts
+++ b/apps/esi/src/durable-object-id-resolver.test.ts
@@ -176,4 +176,31 @@ describe('EsiTypeResolverDO local-first resolution', () => {
 		expect(fetchSpy).toHaveBeenCalledTimes(1)
 		expect(universeStub.resolveRegionsByIds).toHaveBeenCalledWith(['10000002'])
 	})
+
+	it('does not make nested ESI calls for uncached structure IDs', async () => {
+		const { resolver, env } = await createResolver()
+		const structureId = '1055230334468'
+		const universeStub = {
+			resolveTypeNamesByIds: vi.fn().mockResolvedValue({}),
+			resolveRegionsByIds: vi.fn().mockResolvedValue({}),
+			resolveSolarSystemsByIds: vi.fn().mockResolvedValue({}),
+			resolveNpcStationsByIds: vi.fn().mockResolvedValue({}),
+			resolveStargatesByIds: vi.fn().mockResolvedValue({}),
+			resolvePlanetsByIds: vi.fn().mockResolvedValue({}),
+			resolveStaticMoonsByIds: vi.fn().mockResolvedValue({}),
+		}
+
+		const mockedGetStub = vi.mocked(getStub)
+		mockedGetStub.mockImplementation((binding) => {
+			if (binding === env.UNIVERSE) return universeStub as never
+			if (binding === env.ESI) {
+				throw new Error('Structure resolution must not call the ESI namespace')
+			}
+			throw new Error('Unexpected binding in test')
+		})
+
+		await expect(resolver.resolveIds([structureId])).resolves.toEqual({
+			[structureId]: 'Structure (Unknown or no access)',
+		})
+	})
 })

--- a/apps/esi/src/durable-object-id-resolver.ts
+++ b/apps/esi/src/durable-object-id-resolver.ts
@@ -3,7 +3,6 @@ import { DurableObject } from 'cloudflare:workers'
 import { getStub } from '@repo/do-utils'
 import {
 	EsiRequestClient,
-	getEsiInstanceForCharacter,
 	getIdClassification,
 	isStructureId,
 	normalizeEntityType,
@@ -647,26 +646,21 @@ export class EsiTypeResolverDO extends DurableObject<Env> implements EsiTypeReso
 	}
 
 	/**
-	 * Resolves structure IDs to names via authenticated ESI calls or cache
-	 * If character ID is provided, attempts authenticated fetch
-	 * Falls back to cache, then to default message if unavailable
+	 * Resolves structure IDs from the shared entity cache.
+	 *
+	 * Authenticated structure hydration belongs to the caller's domain workflow.
+	 * Keeping it out of this generic resolver avoids a nested resolver -> ESI DO
+	 * -> token-store DO chain, while still allowing dedicated structure workflows
+	 * to use their authenticated ESI client directly.
 	 * @param structureIds - Array of structure IDs to resolve
-	 * @param withCharacterId - Optional character ID for authenticated structure lookups
 	 * @returns Map of structure ID to display name
 	 */
-	private async resolveStructureNames(
-		structureIds: string[],
-		withCharacterId?: string
-	): Promise<Record<string, string>> {
+	private async resolveStructureNames(structureIds: string[]): Promise<Record<string, string>> {
 		if (structureIds.length === 0) {
 			return {}
 		}
 
 		const result: Record<string, string> = {}
-
-		const esiStub = withCharacterId
-			? getEsiInstanceForCharacter(this.env.ESI, withCharacterId)
-			: null
 
 		await forEachWithConcurrency(
 			structureIds,
@@ -679,31 +673,7 @@ export class EsiTypeResolverDO extends DurableObject<Env> implements EsiTypeReso
 					return
 				}
 
-				// If character ID is provided, try authenticated fetch
-				if (withCharacterId && esiStub) {
-					try {
-						const structureInfo = await esiStub.fetchStructureInfo(withCharacterId, structureId)
-						if (structureInfo) {
-							const structureName = structureInfo.name
-							result[structureId] = structureName
-							// Cache the result
-							const cacheKey = this.getEntityCacheKey(structureId)
-							await this.setLocalEntityName(cacheKey, structureName)
-							await this.setGlobalEntityName(cacheKey, structureName)
-							return
-						}
-					} catch (error) {
-						logger
-							.withTags({
-								structureId,
-								characterId: withCharacterId,
-								error: error instanceof Error ? error.message : String(error),
-							})
-							.warn('Failed to fetch structure info')
-					}
-				}
-
-				// If not cached and no character or fetch failed, return default message
+				// Private structure names are hydrated by dedicated domain workflows.
 				result[structureId] = 'Structure (Unknown or no access)'
 			}
 		)
@@ -936,7 +906,7 @@ export class EsiTypeResolverDO extends DurableObject<Env> implements EsiTypeReso
 		}
 	}
 
-	async resolveIds(ids: string[], withCharacterId?: string): Promise<Record<string, string>> {
+	async resolveIds(ids: string[]): Promise<Record<string, string>> {
 		if (ids.length === 0) {
 			return {}
 		}
@@ -1051,10 +1021,7 @@ export class EsiTypeResolverDO extends DurableObject<Env> implements EsiTypeReso
 		Object.assign(result, fetched)
 
 		// Resolve structure names
-		const structureNames = await this.resolveStructureNames(
-			Array.from(structureIds),
-			withCharacterId
-		)
+		const structureNames = await this.resolveStructureNames(Array.from(structureIds))
 		Object.assign(result, structureNames)
 
 		return result

--- a/apps/fulcrum/src/workflows/character-report.workflow.ts
+++ b/apps/fulcrum/src/workflows/character-report.workflow.ts
@@ -488,7 +488,9 @@ export class CharacterReportWorkflow extends WorkflowEntrypoint<Env, WorkflowPar
 						fetchNotificationsResult,
 						workflowInstanceId,
 						characterId,
-						characterAffiliationCoordinator
+						characterAffiliationCoordinator,
+						undefined,
+						structureResolutionCoordinator
 					)
 			)
 

--- a/apps/fulcrum/src/workflows/processors/helpers/assets.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/assets.ts
@@ -129,7 +129,7 @@ export async function enrichAssets(
 	})
 
 	const typeResolver = getStub<EsiTypeResolver>(env.ESI_TYPE_RESOLVER, 'global')
-	const nameMap = await typeResolver.resolveIds(allIdsToResolve, characterId)
+	const nameMap = await typeResolver.resolveIds(allIdsToResolve)
 
 	// Fetch type metadata (market group and category) for all unique type IDs
 	const typeMetadataMap: Record<

--- a/apps/fulcrum/src/workflows/processors/helpers/notifications.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/notifications.ts
@@ -7,6 +7,7 @@ import type {
     CharacterAffiliationDisplayCandidate,
 } from './character-affiliation'
 import type { EntityLinkCoordinator } from './entity-links'
+import type { StructureResolutionCoordinator } from './structure-resolution'
 import type { CoreBinding } from '../../../types/core-binding'
 import { logger } from '@repo/hono-helpers'
 
@@ -159,6 +160,7 @@ export async function enrichNotifications(
     characterId?: string,
     affiliationCoordinator?: CharacterAffiliationCoordinator,
     entityLinkCoordinator?: EntityLinkCoordinator,
+    structureResolutionCoordinator?: StructureResolutionCoordinator,
 ): Promise<EnrichedNotificationData> {
     if (notifications.length === 0) {
         return { notifications: [], types: [] }
@@ -181,15 +183,42 @@ export async function enrichNotifications(
         idsToResolve.add(id)
     }
 
+    const structureIds = parsed
+        .flatMap((notification) =>
+            Object.entries(notification.parsedText ?? {})
+                .filter(([key, value]) => key.toLowerCase().includes('structureid') && isPlausibleId(value))
+                .map(([, value]) => value)
+        )
+        .filter((id, index, values) => values.indexOf(id) === index)
+
     // Batch-resolve all IDs in one call
     let nameMap: Record<string, string> = {}
     if (idsToResolve.size > 0) {
         try {
             const typeResolver = getStub<EsiTypeResolver>(env.ESI_TYPE_RESOLVER, 'global')
-            nameMap = await typeResolver.resolveIds(Array.from(idsToResolve), characterId)
+            nameMap = await typeResolver.resolveIds(Array.from(idsToResolve))
         } catch (error) {
             logger.error('Failed to resolve IDs for notifications:', error)
         }
+    }
+
+    if (structureResolutionCoordinator && characterId && structureIds.length > 0) {
+        const knownStructureNames = Object.fromEntries(
+            structureIds
+                .filter((structureId) => {
+                    const name = nameMap[structureId]
+                    return Boolean(name && name !== 'Structure (Unknown or no access)')
+                })
+                .map((structureId) => [structureId, nameMap[structureId]])
+        )
+        const structureNames = await structureResolutionCoordinator.resolveStructureNames(
+            { ESI: env.ESI },
+            characterId,
+            structureIds,
+            'enrichNotifications',
+            knownStructureNames,
+        )
+        Object.assign(nameMap, structureNames)
     }
 
     const senderDisplayNameMap =

--- a/apps/fulcrum/src/workflows/processors/helpers/orders.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/orders.ts
@@ -65,7 +65,7 @@ export async function enrichMarketOrders(
 	})
 
 	const typeResolver = getStub<EsiTypeResolver>(env.ESI_TYPE_RESOLVER, 'global')
-	const nameMap = await typeResolver.resolveIds(idsToResolve, characterId)
+	const nameMap = await typeResolver.resolveIds(idsToResolve)
 
 	const typeMetadataMap: Record<
 		string,

--- a/apps/fulcrum/src/workflows/processors/helpers/ships.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/ships.ts
@@ -116,7 +116,7 @@ export async function findFittedShips(
 		}
 	}
 
-	const locationNameMap = await typeResolver.resolveIds([...stationLocationIds], characterId)
+	const locationNameMap = await typeResolver.resolveIds([...stationLocationIds])
 	const structureNameMap =
 		structureLocationIds.size > 0
 			? await (
@@ -275,7 +275,7 @@ export async function findShipItems(
 			? []
 			: [resolvedLocation?.locationId ?? ship.location_id]
 	const idsToResolve = Array.from(new Set([...allTypeIds, ...locationIds]))
-	const nameMap = await stub.resolveIds(idsToResolve, characterId)
+	const nameMap = await stub.resolveIds(idsToResolve)
 	// Ensure shipName is always a string - fallback to typeId if resolution failed
 	const shipName = nameMap[ship.type_id] || ship.type_id
 	const locationId = resolvedLocation?.locationId ?? ship.location_id

--- a/apps/fulcrum/src/workflows/steps/notifications/process-notifications.ts
+++ b/apps/fulcrum/src/workflows/steps/notifications/process-notifications.ts
@@ -2,6 +2,7 @@ import { retrieveData, storeOrReturn, type StepResult } from '../../utils/storag
 import { enrichNotifications } from '../../processors/helpers/notifications'
 import type { CharacterAffiliationCoordinator } from '../../processors/helpers/character-affiliation'
 import type { EntityLinkCoordinator } from '../../processors/helpers/entity-links'
+import type { StructureResolutionCoordinator } from '../../processors/helpers/structure-resolution'
 import type { CoreBinding } from '../../../types/core-binding'
 import type { NotificationFetchResult } from './fetch-notifications'
 import { logger } from '@repo/hono-helpers'
@@ -21,6 +22,7 @@ export async function processNotifications(
     characterId: string,
     affiliationCoordinator?: CharacterAffiliationCoordinator,
     entityLinkCoordinator?: EntityLinkCoordinator,
+    structureResolutionCoordinator?: StructureResolutionCoordinator,
 ): Promise<StepResult> {
     try {
         if (!fetchResult.success) {
@@ -53,6 +55,7 @@ export async function processNotifications(
             characterId,
             affiliationCoordinator,
             entityLinkCoordinator,
+            structureResolutionCoordinator,
         )
 
         logger.log('[processNotifications] Enrichment complete', {

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -76,13 +76,15 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 	const logout = useLogout()
 	const { data: corporationAccess } = useHasCorporationAccess()
 	const { data: leadershipCorporationAccess } = useCorporationAccess()
-	const { data: hrCorporations } = useHrAccessibleCorporations()
 	const { permissions, hasAnyPermission } = useUserPermissions()
-	const { data: structureAccess } = useStructureAccess({ enabled: Boolean(user) })
-	const moonScanPermissions = useMoonScanPermissions()
 	const isSiteAdmin = user?.is_admin === true
 	const isAllianceMember = user?.roles?.includes(ROLE_CORE_ALLIANCE_MEMBER) ?? false
 	const canSeeAllianceMemberNav = isSiteAdmin || isAllianceMember
+	const { data: hrCorporations } = useHrAccessibleCorporations({
+		enabled: canSeeAllianceMemberNav,
+	})
+	const { data: structureAccess } = useStructureAccess({ enabled: Boolean(user) })
+	const moonScanPermissions = useMoonScanPermissions()
 	const { data: invitations } = usePendingInvitations({ enabled: canSeeAllianceMemberNav })
 	const { isEnabled: isMumbleFeatureEnabled } = useMumbleFeatureEnabled()
 	const canViewStructures =
@@ -275,7 +277,7 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 			!(corporationAccess?.hasAccess ?? false) && ((hrCorporations?.length ?? 0) > 0 || isAuditor)
 		const isOnCorpHrRoute = /^\/corporations\/[^/]+\/hr/.test(location.pathname)
 
-		if (hasCorporationModuleAccess) {
+		if (canSeeAllianceMemberNav && hasCorporationModuleAccess) {
 			hrItems.push({
 				label: 'Corporations',
 				href: '/corporations',
@@ -289,14 +291,14 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 
 		const canUseCorporationUserSearch =
 			isAuditor || isSiteAdmin || (hrCorporations?.length ?? 0) > 0
-		if (canUseCorporationUserSearch) {
+		if (canSeeAllianceMemberNav && canUseCorporationUserSearch) {
 			hrItems.push({
 				label: 'User Search',
 				href: '/hr/users',
 			})
 		}
 
-		if (canSeeLegacyApplications) {
+		if (canSeeAllianceMemberNav && canSeeLegacyApplications) {
 			hrItems.push({
 				label: 'Legacy Applications',
 				href: '/hr/legacy-history',
@@ -311,7 +313,7 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 		})
 	}
 
-	if (canSeeFleetTrackingList || canSeeFleetTrackingStats) {
+	if (canSeeAllianceMemberNav && (canSeeFleetTrackingList || canSeeFleetTrackingStats)) {
 		const fleetTrackingItems: SidebarNavItem[] = []
 		if (canSeeFleetTrackingList) {
 			fleetTrackingItems.push({ label: 'Fleets', href: '/fleet-tracking' })

--- a/apps/ui/src/client/components/sidebar-nav.tsx
+++ b/apps/ui/src/client/components/sidebar-nav.tsx
@@ -483,21 +483,26 @@ export function SidebarNav({ onNavigate, isSidebarOpen = true, onToggleSidebar }
 		}
 
 		const canReadTaxFeature =
-			isSiteAdmin ||
-			permissions.some(
-				(permission) => extractCorporationIdFromTaxViewerScopedUrn(permission.urn) !== null
-			) ||
-			hasAnyPermission('urn:tax:auditor', 'urn:tax:admin') ||
-			!!corporationAccess?.hasAccess
+			canSeeAllianceMemberNav &&
+			(isSiteAdmin ||
+				permissions.some(
+					(permission) => extractCorporationIdFromTaxViewerScopedUrn(permission.urn) !== null
+				) ||
+				hasAnyPermission('urn:tax:auditor', 'urn:tax:admin') ||
+				!!corporationAccess?.hasAccess)
 		const canReadScopedTaxReports =
-			permissions.some(
+			canSeeAllianceMemberNav &&
+			(permissions.some(
 				(permission) => extractCorporationIdFromTaxViewerScopedUrn(permission.urn) !== null
 			) ||
-			(leadershipCorporationAccess?.corporations ?? []).some(
-				(corporation) => corporation.userRole === 'CEO' || corporation.userRole === 'Director'
-			)
-		const canAuditTaxFeature = isSiteAdmin || hasAnyPermission('urn:tax:auditor', 'urn:tax:admin')
-		const canManageTaxFeature = isSiteAdmin || hasAnyPermission('urn:tax:admin')
+				(leadershipCorporationAccess?.corporations ?? []).some(
+					(corporation) => corporation.userRole === 'CEO' || corporation.userRole === 'Director'
+				))
+		const canAuditTaxFeature =
+			canSeeAllianceMemberNav &&
+			(isSiteAdmin || hasAnyPermission('urn:tax:auditor', 'urn:tax:admin'))
+		const canManageTaxFeature =
+			canSeeAllianceMemberNav && (isSiteAdmin || hasAnyPermission('urn:tax:admin'))
 		const { data: openTaxAlerts = [] } = useTaxAlerts({
 			status: 'open',
 			limit: 200,

--- a/apps/ui/src/client/features/applications/routes/hr-auditor-users.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-auditor-users.tsx
@@ -2,6 +2,8 @@ import { Search, Users } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Navigate } from 'react-router'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Container } from '@/components/ui/container'
 import { Input } from '@/components/ui/input'
@@ -9,17 +11,26 @@ import { LoadingSpinner } from '@/components/ui/loading'
 import { PageHeader } from '@/components/ui/page-header'
 import { UserSearchPaginationControls } from '@/components/user-search-pagination-controls'
 import { UserSearchResultsTable } from '@/components/user-search-results-table'
+import { useHrAccessibleCorporations } from '@/features/hr'
 import { useAuth } from '@/hooks/useAuth'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useUserPermissions } from '@/hooks/useUserPermissions'
 
 import { useAuditorUsers } from '../../../hooks/useAuditorUsers'
+import { AccessDeniedCard } from '../components/access-denied-card'
 import { HrUserSearchContent } from '../components/hr-user-search-content'
 
 export default function HrAuditorUsersPage() {
 	const { user, isAuthenticated, isLoading: authLoading } = useAuth()
 	const { hasAnyPermission } = useUserPermissions()
 	const isAuditor = hasAnyPermission('urn:hr:auditor')
+	const isSiteAdmin = user?.is_admin === true
+	const isAllianceMember = user?.roles?.includes(ROLE_CORE_ALLIANCE_MEMBER) === true
+	const isGlobalHrSearchUser = isSiteAdmin || isAuditor
+	const { data: hrCorporations = [], isLoading: hrCorporationsLoading } =
+		useHrAccessibleCorporations({
+			enabled: isAllianceMember && !isGlobalHrSearchUser,
+		})
 
 	usePageTitle('User Search')
 
@@ -37,7 +48,43 @@ export default function HrAuditorUsersPage() {
 		)
 	}
 
-	return isAuditor || user?.is_admin ? <HrAuditorUsersAdminPage /> : <HrScopedUsersPage />
+	if (!isAllianceMember && !isSiteAdmin) {
+		return (
+			<Container>
+				<AccessDeniedCard
+					title="Alliance Membership Required"
+					message="User Search is available only to members of an active alliance corporation."
+					backHref="/dashboard"
+					backLabel="Back to Dashboard"
+				/>
+			</Container>
+		)
+	}
+
+	if (!isGlobalHrSearchUser && hrCorporationsLoading) {
+		return (
+			<Container>
+				<div className="flex min-h-[320px] items-center justify-center">
+					<LoadingSpinner size="lg" />
+				</div>
+			</Container>
+		)
+	}
+
+	if (!isGlobalHrSearchUser && hrCorporations.length === 0) {
+		return (
+			<Container>
+				<AccessDeniedCard
+					title="HR Access Required"
+					message="User Search requires an active HR role for at least one accessible corporation."
+					backHref="/dashboard"
+					backLabel="Back to Dashboard"
+				/>
+			</Container>
+		)
+	}
+
+	return isGlobalHrSearchUser ? <HrAuditorUsersAdminPage /> : <HrScopedUsersPage />
 }
 
 function HrAuditorUsersAdminPage() {

--- a/apps/ui/src/client/features/corporations/hooks.ts
+++ b/apps/ui/src/client/features/corporations/hooks.ts
@@ -7,6 +7,8 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo } from 'react'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+
 import { useAuth } from '@/hooks/useAuth'
 
 import { myCorporationsApi } from './api'
@@ -40,6 +42,12 @@ export const corporationKeys = {
 	coverage: () => [...corporationKeys.all, 'coverage'] as const,
 }
 
+function canUseCorporationAccess(
+	user: { is_admin?: boolean; roles?: string[] } | null | undefined
+) {
+	return user?.is_admin === true || user?.roles?.includes(ROLE_CORE_ALLIANCE_MEMBER) === true
+}
+
 // ============================================================================
 // Hooks
 // ============================================================================
@@ -51,13 +59,16 @@ export const corporationKeys = {
 export function useHasCorporationAccess() {
 	const { user } = useAuth()
 	const userId = user?.id ?? null
+	const hasCorporationAccessCapability = canUseCorporationAccess(user)
 
 	return useQuery({
-		queryKey: ['my-corporations', 'has-access', userId],
+		queryKey: ['my-corporations', 'has-access', userId, hasCorporationAccessCapability],
 		queryFn: () => myCorporationsApi.hasAccess(),
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		gcTime: 1000 * 60 * 10, // 10 minutes
-		enabled: userId !== null,
+		// The API is alliance-member scoped. Do not probe it for authenticated
+		// sessions that cannot use the surrounding corporation features.
+		enabled: userId !== null && hasCorporationAccessCapability,
 	})
 }
 
@@ -92,13 +103,14 @@ export function formatCorporationRoleLabel(
 export function useCorporationAccess() {
 	const { user } = useAuth()
 	const userId = user?.id ?? null
+	const hasCorporationAccessCapability = canUseCorporationAccess(user)
 
 	return useQuery<CorporationAccessResult>({
-		queryKey: [...corporationKeys.access(), userId],
+		queryKey: [...corporationKeys.access(), userId, hasCorporationAccessCapability],
 		queryFn: () => myCorporationsApi.checkAccess(),
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		gcTime: 1000 * 60 * 10, // 10 minutes (formerly cacheTime)
-		enabled: userId !== null,
+		enabled: userId !== null && hasCorporationAccessCapability,
 	})
 }
 
@@ -109,13 +121,14 @@ export function useCorporationAccess() {
 export function useCorporationCoverage() {
 	const { user } = useAuth()
 	const userId = user?.id ?? null
+	const hasCorporationAccessCapability = canUseCorporationAccess(user)
 
 	return useQuery({
-		queryKey: [...corporationKeys.coverage(), userId],
+		queryKey: [...corporationKeys.coverage(), userId, hasCorporationAccessCapability],
 		queryFn: () => myCorporationsApi.getCoverage(),
 		staleTime: 10 * 60 * 1000,
 		gcTime: 30 * 60 * 1000,
-		enabled: userId !== null,
+		enabled: userId !== null && hasCorporationAccessCapability,
 	})
 }
 
@@ -125,13 +138,14 @@ export function useCorporationCoverage() {
 export function useMyCorporations() {
 	const { user } = useAuth()
 	const userId = user?.id ?? null
+	const hasCorporationAccessCapability = canUseCorporationAccess(user)
 
 	return useQuery<MyCorporation[]>({
-		queryKey: [...corporationKeys.list(), userId],
+		queryKey: [...corporationKeys.list(), userId, hasCorporationAccessCapability],
 		queryFn: () => myCorporationsApi.getMyCorporations(),
 		staleTime: 1000 * 60 * 2, // 2 minutes
 		gcTime: 1000 * 60 * 5, // 5 minutes
-		enabled: userId !== null,
+		enabled: userId !== null && hasCorporationAccessCapability,
 	})
 }
 

--- a/apps/ui/src/client/features/hr/hooks.ts
+++ b/apps/ui/src/client/features/hr/hooks.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
+import { ROLE_CORE_ALLIANCE_MEMBER } from '@repo/core'
+
 import { useAuth } from '@/hooks/useAuth'
 
 import { hrApi } from './api'
@@ -82,12 +84,16 @@ export function useHrPermissionCheck(request: CheckHrPermissionRequest | null) {
 export function useHrAccessibleCorporations(options?: { enabled?: boolean }) {
 	const { user } = useAuth()
 	const userId = user?.id ?? null
+	const canUseMemberHrSurface =
+		user?.is_admin === true || user?.roles?.includes(ROLE_CORE_ALLIANCE_MEMBER) === true
 
 	return useQuery<HrAccessibleCorporation[]>({
 		queryKey: [...hrKeys.corporations(), userId],
 		queryFn: () => hrApi.listAccessibleCorporations(),
 		staleTime: 5 * 60 * 1000,
-		enabled: (options?.enabled ?? true) && userId !== null,
+		// /hr/corporations is alliance-member gated. Do not issue a request for
+		// sessions that cannot access the internal HR surface.
+		enabled: (options?.enabled ?? true) && userId !== null && canUseMemberHrSurface,
 	})
 }
 

--- a/apps/ui/src/client/features/skill-plans/routes/skill-plan-create.tsx
+++ b/apps/ui/src/client/features/skill-plans/routes/skill-plan-create.tsx
@@ -1,5 +1,7 @@
-import { Navigate, useNavigate } from 'react-router'
+import { ArrowLeft } from 'lucide-react'
+import { Link, Navigate, useNavigate } from 'react-router'
 
+import { Button } from '../../../components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '../../../components/ui/card'
 import { Container } from '../../../components/ui/container'
 import { LoadingPage } from '../../../components/ui/loading'
@@ -55,6 +57,14 @@ export default function SkillPlanCreate() {
 			<PageHeader
 				title="Create Skill Plan"
 				description="Create a new skill training plan for EVE Online"
+				action={
+					<Button variant="ghost" size="sm" asChild>
+						<Link to="/skill-plans">
+							<ArrowLeft className="h-4 w-4" />
+							Back to Plans
+						</Link>
+					</Button>
+				}
 			/>
 
 			<Section>

--- a/apps/ui/src/client/features/skill-plans/routes/skill-plan-detail.tsx
+++ b/apps/ui/src/client/features/skill-plans/routes/skill-plan-detail.tsx
@@ -99,16 +99,18 @@ export default function SkillPlanDetail() {
 
 	return (
 		<Container>
-			<div className="mb-4">
-				<Button variant="ghost" size="sm" asChild>
-					<Link to="/skill-plans">
-						<ArrowLeft className="h-4 w-4" />
-						Back to Plans
-					</Link>
-				</Button>
-			</div>
-
-			<PageHeader title={plan.name} description={plan.description} />
+			<PageHeader
+				title={plan.name}
+				description={plan.description}
+				action={
+					<Button variant="ghost" size="sm" asChild>
+						<Link to="/skill-plans">
+							<ArrowLeft className="h-4 w-4" />
+							Back to Plans
+						</Link>
+					</Button>
+				}
+			/>
 
 			<Section>
 				{/* Action buttons */}

--- a/apps/ui/src/client/features/skill-plans/routes/skill-plan-edit.tsx
+++ b/apps/ui/src/client/features/skill-plans/routes/skill-plan-edit.tsx
@@ -160,19 +160,17 @@ export default function SkillPlanEdit() {
 			<PageHeader
 				title={`Edit: ${plan.name}`}
 				description="Modify plan details and manage skills"
-			/>
-
-			<Section>
-				{/* Navigation buttons */}
-				<div className="flex justify-between items-center mb-6">
-					<Button variant="ghost" asChild>
+				action={
+					<Button variant="ghost" size="sm" asChild>
 						<Link to={`/skill-plans/${id}`}>
 							<ArrowLeft className="h-4 w-4" />
 							Back to Plan
 						</Link>
 					</Button>
-				</div>
+				}
+			/>
 
+			<Section>
 				{/* Tabs for different sections */}
 				<Tabs value={activeTab} onValueChange={setActiveTab}>
 					<TabsList>

--- a/apps/ui/src/client/features/skill-plans/routes/skill-plan-progress.tsx
+++ b/apps/ui/src/client/features/skill-plans/routes/skill-plan-progress.tsx
@@ -30,16 +30,17 @@ export default function SkillPlanProgress() {
 
 	return (
 		<Container>
-			<div className="mb-4">
-				<Button variant="ghost" size="sm" asChild>
-					<Link to={`/skill-plans/${id}`}>
-						<ArrowLeft className="h-4 w-4" />
-						Back to Plan
-					</Link>
-				</Button>
-			</div>
-
-			<PageHeader title={`Progress Check: ${plan.name}`} />
+			<PageHeader
+				title={`Progress Check: ${plan.name}`}
+				action={
+					<Button variant="ghost" size="sm" asChild>
+						<Link to={`/skill-plans/${id}`}>
+							<ArrowLeft className="h-4 w-4" />
+							Back to Plan
+						</Link>
+					</Button>
+				}
+			/>
 
 			<Section className="mt-8">
 				<ProgressChecker planId={id} planName={plan.name} initialCharacterId={characterId} />

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,8 @@
 export interface Core {
 	getCharacterOwner(characterId: string): Promise<{ userId: string; isPrimary: boolean } | null>
 	isMemberCorporation(corporationId: string): Promise<boolean>
+	getMemberCorporationIds(corporationIds: string[]): Promise<string[]>
+	isUserAllianceMember(userId: string): Promise<boolean>
 	getUserCharacterIds(userId: string): Promise<string[]>
 	listUsersWithActiveCharactersPage(input: { limit: number; offset: number }): Promise<{
 		users: Array<{

--- a/packages/esi/src/index.ts
+++ b/packages/esi/src/index.ts
@@ -408,7 +408,7 @@ export interface EsiTypeResolver {
 	 * // Returns: { '30000142': 'Jita', '1354830081': 'Goonswarm Federation' }
 	 * ```
 	 */
-	resolveIds(ids: string[], withCharacterId?: string): Promise<Record<string, string>>
+	resolveIds(ids: string[]): Promise<Record<string, string>>
 }
 
 /**


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Bug-bash roundup that closes an alliance-member authorization gap (membership is now re-verified against active member corporations instead of trusted from a stale role attachment), turns the fire-and-forget director health recheck into a proper Cloudflare Workflow, consolidates duplicated user-refresh triggering logic, and removes an authenticated ESI structure-lookup path that caused nested Durable Object calls.

## Changes
- **Alliance membership authorization**: add `Core.getMemberCorporationIds` / `Core.isUserAllianceMember` RPCs (`apps/core/src/durable-object.ts`, `apps/core/src/services/core-rpc.service.ts`, `packages/core/src/index.ts`); `reconcileUserCoreMembershipRoles` now only grants the alliance-member role when the character's corporation is an active *member* corporation, not any alliance corp.
- **Session middleware** (`apps/core/src/middleware/session.ts`): new `resolveSessionRoles` strips the alliance-member role attachment unless a live, short-TTL-cached (`TimeCache`, 15s) membership check confirms it; `requireAuth`/`requireAllianceMember` short-circuit for site admins.
- **New `requireAllianceMember()` guard** applied in place of bare `requireAuth()` across broadcasts, corporation-tax, fleets, freight, fulcrum, groups, hr (directory/audit/roles/templates/notes surfaces), inventory, prediction-markets, and the structures API access check, wherever alliance membership was implicitly assumed.
- **Director health recheck** rewritten as `DirectorHealthRecheckWorkflow` (`apps/core/src/workflows/director-health-recheck.workflow.ts`), queued via `triggerDirectorHealthRecheckWorkflow` and deduplicated with a 5-minute time-windowed workflow ID, replacing an inline `waitUntilWithTelemetry` scan over every active managed corporation; shared per-corporation logic extracted into `recheckDirectorHealthForCorporation`.
- **User refresh triggering** consolidated into `triggerUserRefreshWorkflow`, replacing duplicated inline background-fetch/workflow-creation blocks in the OAuth callback and claim-main routes.
- **ESI type resolver** (`apps/esi/src/durable-object-id-resolver.ts`): dropped the `withCharacterId` authenticated structure-lookup path from `resolveIds` (removed the resolver → ESI DO → token-store DO chain); authenticated structure name hydration now goes through a dedicated `StructureResolutionCoordinator` used by the Fulcrum notification enrichment pipeline.
- **UI**: sidebar nav and HR user search now gate corporation/HR-related sections behind alliance membership (`canSeeAllianceMemberNav`), and `useHrAccessibleCorporations` skips its query for non-member sessions; unrelated minor cleanup moving skill-plan page "back" buttons into `PageHeader`'s `action` slot.

## Testing
- Added/updated unit tests for `resolveSessionRoles`, `createDirectorHealthRecheckWorkflowId` dedup windowing, and `reconcileUserCoreMembershipRoles` (denies the alliance role for a character in a non-member corporation).
- Updated route access-matrix tests (`corporation-tax`, `fulcrum.access`, `hr.access-matrix`, `prediction-markets.member`, `structures`, `groups.discord-role`, `fleets.tracking`) to account for the new `requireAllianceMember` gate.
- Added a regression test for the ESI structure resolver confirming it no longer calls the ESI namespace for uncached structure IDs.
<!-- claude:end -->