### PR TITLE
add sp and wallet to fulcfrum and stop resolving structures on notifications

### DIFF
--- a/apps/fulcrum/src/test/unit/fetch-skills.test.ts
+++ b/apps/fulcrum/src/test/unit/fetch-skills.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchSkillsFromEsi } from '../../workflows/steps/skills/fetch-skills'
+
+import type { Esi } from '@repo/esi'
+
+describe('fetchSkillsFromEsi', () => {
+	it('returns wallet balance alongside the skills snapshot', async () => {
+		const esi = {
+			fetchCharacterSkills: vi.fn().mockResolvedValue({ skills: [], total_sp: 12_345 }),
+			fetchCharacterSkillQueue: vi.fn().mockResolvedValue([]),
+			fetchCharacterWalletBalance: vi.fn().mockResolvedValue(987_654.32),
+		} as unknown as Esi
+
+		await expect(fetchSkillsFromEsi(esi, '123')).resolves.toEqual({
+			skills: { skills: [], total_sp: 12_345 },
+			skillQueue: [],
+			walletBalance: 987_654.32,
+		})
+	})
+
+	it('keeps the skills snapshot when wallet access is unavailable', async () => {
+		const esi = {
+			fetchCharacterSkills: vi.fn().mockResolvedValue({ skills: [], total_sp: 12_345 }),
+			fetchCharacterSkillQueue: vi.fn().mockResolvedValue([]),
+			fetchCharacterWalletBalance: vi.fn().mockRejectedValue(new Error('missing wallet scope')),
+		} as unknown as Esi
+
+		await expect(fetchSkillsFromEsi(esi, '123')).resolves.toMatchObject({
+			skills: { total_sp: 12_345 },
+			skillQueue: [],
+			walletBalance: null,
+		})
+	})
+})

--- a/apps/fulcrum/src/workflows/character-report.workflow.ts
+++ b/apps/fulcrum/src/workflows/character-report.workflow.ts
@@ -34,7 +34,11 @@ import { processFittedShips } from './steps/fitted-ships'
 import { fetchMails, processMails } from './steps/mails'
 import { fetchNotifications, processNotifications } from './steps/notifications'
 import { fetchOrders, processOrders } from './steps/orders'
-import { fetchPublicInfo, processPublicInfo } from './steps/public-info'
+import {
+	addAccountSummaryToPublicInfo,
+	fetchPublicInfo,
+	processPublicInfo,
+} from './steps/public-info'
 import { fetchSkills, processSkills } from './steps/skills'
 import { fetchWalletJournal, processWalletJournal } from './steps/wallet-journal'
 import { fetchWalletTransactions, processWalletTransactions } from './steps/wallet-transactions'
@@ -189,7 +193,7 @@ export class CharacterReportWorkflow extends WorkflowEntrypoint<Env, WorkflowPar
 			)
 
 			// Step 3: Process public info
-			const processResult = await doStep('process-public-info', STEP, () =>
+			let processResult = await doStep('process-public-info', STEP, () =>
 				processPublicInfo(
 					this.env,
 					getBucket,
@@ -439,6 +443,19 @@ export class CharacterReportWorkflow extends WorkflowEntrypoint<Env, WorkflowPar
 				)
 			)
 
+			// Keep authenticated metrics in the same persisted section as the
+			// public character details shown on the overview tab.
+			processResult = await doStep('process-public-info-account-summary', STEP, () =>
+				addAccountSummaryToPublicInfo(
+					getBucket,
+					this.env.CHARACTER_REPORTS,
+					'CHARACTER_REPORTS',
+					processResult,
+					fetchSkillsResult,
+					workflowInstanceId
+				)
+			)
+
 			// Step 22: Fetch contracts from ESI
 			const fetchContractsResult = await doStep('fetch-contracts-data', ESI_STEP, () =>
 				fetchContracts(
@@ -489,8 +506,7 @@ export class CharacterReportWorkflow extends WorkflowEntrypoint<Env, WorkflowPar
 						workflowInstanceId,
 						characterId,
 						characterAffiliationCoordinator,
-						undefined,
-						structureResolutionCoordinator
+						undefined
 					)
 			)
 

--- a/apps/fulcrum/src/workflows/processors/helpers/notifications.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/notifications.ts
@@ -1,29 +1,28 @@
 import { getStub } from '@repo/do-utils'
-import { normalizeIdToString } from '@repo/eve-types'
-
-import type { EsiTypeResolver, CharacterNotification } from '@repo/esi'
-import type {
-    CharacterAffiliationCoordinator,
-    CharacterAffiliationDisplayCandidate,
-} from './character-affiliation'
-import type { EntityLinkCoordinator } from './entity-links'
-import type { StructureResolutionCoordinator } from './structure-resolution'
-import type { CoreBinding } from '../../../types/core-binding'
+import { isStructureId, normalizeIdToString } from '@repo/eve-types'
 import { logger } from '@repo/hono-helpers'
 
+import type { CharacterNotification, EsiTypeResolver } from '@repo/esi'
+import type { CoreBinding } from '../../../types/core-binding'
+import type {
+	CharacterAffiliationCoordinator,
+	CharacterAffiliationDisplayCandidate,
+} from './character-affiliation'
+import type { EntityLinkCoordinator } from './entity-links'
+
 export interface ProcessedNotification extends CharacterNotification {
-    senderName?: string
-    senderDisplayName?: string
-    senderDisplayHref?: string
-    /** Parsed text content as key-value pairs (IDs resolved to names where possible) */
-    parsedText?: Record<string, string>
-    processedAt: string
+	senderName?: string
+	senderDisplayName?: string
+	senderDisplayHref?: string
+	/** Parsed text content as key-value pairs (IDs resolved to names where possible) */
+	parsedText?: Record<string, string>
+	processedAt: string
 }
 
 export interface EnrichedNotificationData {
-    notifications: ProcessedNotification[]
-    /** Distinct notification types present */
-    types: string[]
+	notifications: ProcessedNotification[]
+	/** Distinct notification types present */
+	types: string[]
 }
 
 /**
@@ -36,60 +35,82 @@ export interface EnrichedNotificationData {
  *   corpStationID: *id001
  */
 function parseNotificationText(text?: string): Record<string, string> | undefined {
-    if (!text) return undefined
-    const result: Record<string, string> = {}
-    const anchors: Record<string, string> = {}
-    const lines = text.split('\n')
-    for (const line of lines) {
-        const trimmed = line.trim()
-        if (!trimmed) continue
-        const colonIdx = trimmed.indexOf(':')
-        if (colonIdx > 0) {
-            const key = trimmed.slice(0, colonIdx).trim()
-            let value = trimmed.slice(colonIdx + 1).trim()
+	if (!text) return undefined
+	const result: Record<string, string> = {}
+	const anchors: Record<string, string> = {}
+	const lines = text.split('\n')
+	for (const line of lines) {
+		const trimmed = line.trim()
+		if (!trimmed) continue
+		const colonIdx = trimmed.indexOf(':')
+		if (colonIdx > 0) {
+			const key = trimmed.slice(0, colonIdx).trim()
+			let value = trimmed.slice(colonIdx + 1).trim()
 
-            // Handle YAML anchor: "&id001 1051346234914" → store anchor and extract value
-            const anchorMatch = value.match(/^&(\S+)\s+(.+)$/)
-            if (anchorMatch) {
-                anchors[anchorMatch[1]] = anchorMatch[2]
-                value = anchorMatch[2]
-            }
+			// Handle YAML anchor: "&id001 1051346234914" → store anchor and extract value
+			const anchorMatch = value.match(/^&(\S+)\s+(.+)$/)
+			if (anchorMatch) {
+				anchors[anchorMatch[1]] = anchorMatch[2]
+				value = anchorMatch[2]
+			}
 
-            // Handle YAML reference: "*id001" → resolve to anchor value
-            const refMatch = value.match(/^\*(\S+)$/)
-            if (refMatch && anchors[refMatch[1]]) {
-                value = anchors[refMatch[1]]
-            }
+			// Handle YAML reference: "*id001" → resolve to anchor value
+			const refMatch = value.match(/^\*(\S+)$/)
+			if (refMatch && anchors[refMatch[1]]) {
+				value = anchors[refMatch[1]]
+			}
 
-            if (key) result[key] = value
-        } else {
-            // Line without colon — store as-is
-            result[trimmed] = ''
-        }
-    }
-    return Object.keys(result).length > 0 ? result : undefined
+			if (key) result[key] = value
+		} else {
+			// Line without colon — store as-is
+			result[trimmed] = ''
+		}
+	}
+	return Object.keys(result).length > 0 ? result : undefined
 }
 
 // Keys whose values are known to be EVE entity/type IDs worth resolving.
 // Matched case-insensitively against parsedText keys.
 const ID_KEY_SUFFIXES = [
-    'corpid', 'corporationid', 'allianceid', 'charid', 'characterid',
-    'typeid', 'solarsystemid', 'systemid', 'stationid', 'structureid',
-    'factionid', 'aggressorid', 'declaredbyid', 'againstid', 'defenderid',
-    'attackerid', 'senderid', 'ownerid', 'victimid', 'locationid',
-    'shiptypeid', 'destroyerid', 'podkillerid', 'clonestationid',
-    'ceoid', 'quitterid', 'opponentid', 'allyid', 'mercid',
-    'offeredid', 'entityid', 'constellationid', 'planetid',
-    'invokingcharid',
+	'corpid',
+	'corporationid',
+	'allianceid',
+	'charid',
+	'characterid',
+	'typeid',
+	'solarsystemid',
+	'systemid',
+	'stationid',
+	'structureid',
+	'factionid',
+	'aggressorid',
+	'declaredbyid',
+	'againstid',
+	'defenderid',
+	'attackerid',
+	'senderid',
+	'ownerid',
+	'victimid',
+	'locationid',
+	'shiptypeid',
+	'destroyerid',
+	'podkillerid',
+	'clonestationid',
+	'ceoid',
+	'quitterid',
+	'opponentid',
+	'allyid',
+	'mercid',
+	'offeredid',
+	'entityid',
+	'constellationid',
+	'planetid',
+	'invokingcharid',
 ]
 
 // Keys that end in "ID" but do NOT represent resolvable EVE entities.
 // These would poison /universe/names/ batches causing entire batches to fail.
-const NON_ENTITY_ID_KEYS = new Set([
-    'killmailid',
-    'warnegotiationid',
-    'itemid',
-])
+const NON_ENTITY_ID_KEYS = new Set(['killmailid', 'warnegotiationid', 'itemid'])
 
 /**
  * Check if a parsedText key looks like it contains an entity ID.
@@ -97,9 +118,9 @@ const NON_ENTITY_ID_KEYS = new Set([
  * excluding known non-entity keys.
  */
 function isIdKey(key: string): boolean {
-    const lower = key.toLowerCase()
-    if (NON_ENTITY_ID_KEYS.has(lower)) return false
-    return ID_KEY_SUFFIXES.some((suffix) => lower === suffix || lower.endsWith(suffix))
+	const lower = key.toLowerCase()
+	if (NON_ENTITY_ID_KEYS.has(lower)) return false
+	return ID_KEY_SUFFIXES.some((suffix) => lower === suffix || lower.endsWith(suffix))
 }
 
 /**
@@ -108,179 +129,154 @@ function isIdKey(key: string): boolean {
  * Allows up to 13 digits to cover structure IDs (1T–2T range).
  */
 function isPlausibleId(value: string): boolean {
-    if (!value || value.length > 13) return false
-    const num = Number(value)
-    return Number.isInteger(num) && num > 0 && num < 2_000_000_000_000
+	if (!value || value.length > 13) return false
+	const num = Number(value)
+	return Number.isInteger(num) && num > 0 && num < 2_000_000_000_000
 }
 
 /**
  * Collect all entity IDs from parsedText that need resolution.
  */
 function collectParsedTextIds(
-    notifications: Array<{ parsedText?: Record<string, string> }>,
+	notifications: Array<{ parsedText?: Record<string, string> }>
 ): Set<string> {
-    const ids = new Set<string>()
-    for (const n of notifications) {
-        if (!n.parsedText) continue
-        for (const [key, value] of Object.entries(n.parsedText)) {
-            if (isIdKey(key) && isPlausibleId(value)) {
-                ids.add(value)
-            }
-        }
-    }
-    return ids
+	const ids = new Set<string>()
+	for (const n of notifications) {
+		if (!n.parsedText) continue
+		for (const [key, value] of Object.entries(n.parsedText)) {
+			if (isIdKey(key) && isPlausibleId(value)) {
+				ids.add(value)
+			}
+		}
+	}
+	return ids
 }
 
 /**
  * Replace raw IDs in parsedText with resolved names.
  */
 function annotateParsedText(
-    parsedText: Record<string, string>,
-    nameMap: Record<string, string>,
+	parsedText: Record<string, string>,
+	nameMap: Record<string, string>
 ): Record<string, string> {
-    const result: Record<string, string> = {}
-    for (const [key, value] of Object.entries(parsedText)) {
-        if (isIdKey(key) && isPlausibleId(value) && nameMap[value]) {
-            result[key] = `${nameMap[value]} (${value})`
-        } else {
-            result[key] = value
-        }
-    }
-    return result
+	const result: Record<string, string> = {}
+	for (const [key, value] of Object.entries(parsedText)) {
+		if (isIdKey(key) && isPlausibleId(value) && nameMap[value]) {
+			result[key] = `${nameMap[value]} (${value})`
+		} else {
+			result[key] = value
+		}
+	}
+	return result
 }
 
 export async function enrichNotifications(
-    env: {
-        ESI_TYPE_RESOLVER: DurableObjectNamespace
-        ESI: DurableObjectNamespace
-        EVE_TOKEN_STORE: DurableObjectNamespace
-        CORE: CoreBinding
-    },
-    notifications: CharacterNotification[],
-    characterId?: string,
-    affiliationCoordinator?: CharacterAffiliationCoordinator,
-    entityLinkCoordinator?: EntityLinkCoordinator,
-    structureResolutionCoordinator?: StructureResolutionCoordinator,
+	env: {
+		ESI_TYPE_RESOLVER: DurableObjectNamespace
+		ESI: DurableObjectNamespace
+		EVE_TOKEN_STORE: DurableObjectNamespace
+		CORE: CoreBinding
+	},
+	notifications: CharacterNotification[],
+	characterId?: string,
+	affiliationCoordinator?: CharacterAffiliationCoordinator,
+	entityLinkCoordinator?: EntityLinkCoordinator
 ): Promise<EnrichedNotificationData> {
-    if (notifications.length === 0) {
-        return { notifications: [], types: [] }
-    }
+	if (notifications.length === 0) {
+		return { notifications: [], types: [] }
+	}
 
-    // First pass: parse all notification text
-    const parsed = notifications.map((n) => ({
-        ...n,
-        parsedText: parseNotificationText(n.text),
-    }))
+	// First pass: parse all notification text
+	const parsed = notifications.map((n) => ({
+		...n,
+		parsedText: parseNotificationText(n.text),
+	}))
 
-    // Collect all IDs to resolve: sender IDs + IDs from parsedText
-    const idsToResolve = new Set<string>()
-    for (const n of parsed) {
-        const senderId = normalizeIdToString(n.sender_id)
-        if (senderId) idsToResolve.add(senderId)
-    }
-    const parsedTextIds = collectParsedTextIds(parsed)
-    for (const id of parsedTextIds) {
-        idsToResolve.add(id)
-    }
+	// Collect all IDs to resolve: sender IDs + IDs from parsedText
+	const idsToResolve = new Set<string>()
+	for (const n of parsed) {
+		const senderId = normalizeIdToString(n.sender_id)
+		if (senderId) idsToResolve.add(senderId)
+	}
+	// Structure IDs in notification text are intentionally left raw. Resolving
+	// them requires authenticated per-structure requests and commonly returns
+	// 403 for structures the character cannot access.
+	const parsedTextIds = Array.from(collectParsedTextIds(parsed)).filter((id) => !isStructureId(id))
+	for (const id of parsedTextIds) {
+		idsToResolve.add(id)
+	}
 
-    const structureIds = parsed
-        .flatMap((notification) =>
-            Object.entries(notification.parsedText ?? {})
-                .filter(([key, value]) => key.toLowerCase().includes('structureid') && isPlausibleId(value))
-                .map(([, value]) => value)
-        )
-        .filter((id, index, values) => values.indexOf(id) === index)
+	// Batch-resolve all IDs in one call
+	let nameMap: Record<string, string> = {}
+	if (idsToResolve.size > 0) {
+		try {
+			const typeResolver = getStub<EsiTypeResolver>(env.ESI_TYPE_RESOLVER, 'global')
+			nameMap = await typeResolver.resolveIds(Array.from(idsToResolve))
+		} catch (error) {
+			logger.error('Failed to resolve IDs for notifications:', error)
+		}
+	}
 
-    // Batch-resolve all IDs in one call
-    let nameMap: Record<string, string> = {}
-    if (idsToResolve.size > 0) {
-        try {
-            const typeResolver = getStub<EsiTypeResolver>(env.ESI_TYPE_RESOLVER, 'global')
-            nameMap = await typeResolver.resolveIds(Array.from(idsToResolve))
-        } catch (error) {
-            logger.error('Failed to resolve IDs for notifications:', error)
-        }
-    }
+	const senderDisplayNameMap =
+		affiliationCoordinator && notifications.length > 0
+			? await affiliationCoordinator.resolveDisplayNames(
+					{ ESI: env.ESI },
+					characterId ?? 'default',
+					(() => {
+						const candidates: CharacterAffiliationDisplayCandidate[] = []
+						for (const notification of parsed) {
+							if (notification.sender_type !== 'character') continue
+							const senderId = normalizeIdToString(notification.sender_id)
+							if (senderId && nameMap[senderId]) {
+								candidates.push({
+									characterId: senderId,
+									characterName: nameMap[senderId],
+									forceCharacter: true,
+								})
+							}
+						}
+						return candidates
+					})(),
+					'enrichNotifications'
+				)
+			: {}
 
-    if (structureResolutionCoordinator && characterId && structureIds.length > 0) {
-        const knownStructureNames = Object.fromEntries(
-            structureIds
-                .filter((structureId) => {
-                    const name = nameMap[structureId]
-                    return Boolean(name && name !== 'Structure (Unknown or no access)')
-                })
-                .map((structureId) => [structureId, nameMap[structureId]])
-        )
-        const structureNames = await structureResolutionCoordinator.resolveStructureNames(
-            { ESI: env.ESI },
-            characterId,
-            structureIds,
-            'enrichNotifications',
-            knownStructureNames,
-        )
-        Object.assign(nameMap, structureNames)
-    }
+	const displayHrefMap =
+		entityLinkCoordinator && notifications.length > 0
+			? await entityLinkCoordinator.resolveDisplayHrefs(
+					env.CORE,
+					notifications.map((notification) => ({
+						entityId: String(notification.sender_id ?? ''),
+						entityType: notification.sender_type ?? null,
+					})),
+					'enrichNotifications'
+				)
+			: {}
 
-    const senderDisplayNameMap =
-        affiliationCoordinator && notifications.length > 0
-            ? await affiliationCoordinator.resolveDisplayNames(
-                    { ESI: env.ESI },
-                    characterId ?? 'default',
-                    (() => {
-                        const candidates: CharacterAffiliationDisplayCandidate[] = []
-                        for (const notification of parsed) {
-                            if (notification.sender_type !== 'character') continue
-                            const senderId = normalizeIdToString(notification.sender_id)
-                            if (senderId && nameMap[senderId]) {
-                                candidates.push({
-                                    characterId: senderId,
-                                    characterName: nameMap[senderId],
-                                    forceCharacter: true,
-                                })
-                            }
-                        }
-                        return candidates
-                    })(),
-                    'enrichNotifications',
-                )
-            : {}
+	// Second pass: build processed notifications with resolved names
+	const processed: ProcessedNotification[] = parsed.map((n) => {
+		const senderId = normalizeIdToString(n.sender_id)
+		return {
+			...n,
+			senderName: senderId ? nameMap[senderId] : undefined,
+			senderDisplayName: senderId
+				? (senderDisplayNameMap[senderId] ?? nameMap[senderId])
+				: undefined,
+			senderDisplayHref: senderId ? displayHrefMap[senderId] : undefined,
+			parsedText: n.parsedText ? annotateParsedText(n.parsedText, nameMap) : undefined,
+			processedAt: new Date().toISOString(),
+		}
+	})
 
-    const displayHrefMap =
-        entityLinkCoordinator && notifications.length > 0
-            ? await entityLinkCoordinator.resolveDisplayHrefs(
-                    env.CORE,
-                    notifications.map((notification) => ({
-                        entityId: String(notification.sender_id ?? ''),
-                        entityType: notification.sender_type ?? null,
-                    })),
-                    'enrichNotifications',
-                )
-            : {}
+	// Sort newest first
+	processed.sort((a, b) => {
+		const timeA = a.timestamp ? new Date(a.timestamp).getTime() : 0
+		const timeB = b.timestamp ? new Date(b.timestamp).getTime() : 0
+		return timeB - timeA
+	})
 
-    // Second pass: build processed notifications with resolved names
-    const processed: ProcessedNotification[] = parsed.map((n) => {
-        const senderId = normalizeIdToString(n.sender_id)
-        return {
-            ...n,
-            senderName: senderId ? nameMap[senderId] : undefined,
-            senderDisplayName: senderId ? senderDisplayNameMap[senderId] ?? nameMap[senderId] : undefined,
-            senderDisplayHref: senderId ? displayHrefMap[senderId] : undefined,
-            parsedText: n.parsedText
-                ? annotateParsedText(n.parsedText, nameMap)
-                : undefined,
-            processedAt: new Date().toISOString(),
-        }
-    })
+	// Collect distinct types
+	const types = [...new Set(processed.map((n) => n.type))].sort()
 
-    // Sort newest first
-    processed.sort((a, b) => {
-        const timeA = a.timestamp ? new Date(a.timestamp).getTime() : 0
-        const timeB = b.timestamp ? new Date(b.timestamp).getTime() : 0
-        return timeB - timeA
-    })
-
-    // Collect distinct types
-    const types = [...new Set(processed.map((n) => n.type))].sort()
-
-    return { notifications: processed, types }
+	return { notifications: processed, types }
 }

--- a/apps/fulcrum/src/workflows/processors/helpers/public-info.ts
+++ b/apps/fulcrum/src/workflows/processors/helpers/public-info.ts
@@ -1,10 +1,11 @@
 import { getStub } from '@repo/do-utils'
+import { logger } from '@repo/hono-helpers'
+
 import { stripHtmlToPlainText } from './html-stripper'
-import type { EntityLinkCoordinator } from './entity-links'
 
 import type { CharacterPublicInfo, EsiTypeResolver } from '@repo/esi'
 import type { CoreBinding } from '../../../types/core-binding'
-import { logger } from '@repo/hono-helpers'
+import type { EntityLinkCoordinator } from './entity-links'
 
 /**
  * Data enrichment functions for public character information
@@ -35,6 +36,8 @@ export interface ProcessedPublicInfo {
 	factionName?: string
 	description?: string
 	title?: string
+	totalSp?: number
+	walletBalance?: number | null
 	processedAt: string
 }
 
@@ -50,7 +53,7 @@ export async function enrichPublicInfo(
 	env: { ESI_TYPE_RESOLVER: DurableObjectNamespace; CORE: CoreBinding },
 	data: CharacterPublicInfo,
 	characterId: string,
-	entityLinkCoordinator?: EntityLinkCoordinator,
+	entityLinkCoordinator?: EntityLinkCoordinator
 ): Promise<ProcessedPublicInfo> {
 	// Collect all IDs that need resolution
 	const idsToResolve: string[] = [data.corporation_id]
@@ -86,7 +89,7 @@ export async function enrichPublicInfo(
 						{ entityId: data.corporation_id, entityType: 'corporation' },
 						...(data.alliance_id ? [{ entityId: data.alliance_id, entityType: 'alliance' }] : []),
 					],
-					'enrichPublicInfo',
+					'enrichPublicInfo'
 				)
 			: {}
 

--- a/apps/fulcrum/src/workflows/steps/notifications/process-notifications.ts
+++ b/apps/fulcrum/src/workflows/steps/notifications/process-notifications.ts
@@ -1,80 +1,80 @@
-import { retrieveData, storeOrReturn, type StepResult } from '../../utils/storage'
-import { enrichNotifications } from '../../processors/helpers/notifications'
-import type { CharacterAffiliationCoordinator } from '../../processors/helpers/character-affiliation'
-import type { EntityLinkCoordinator } from '../../processors/helpers/entity-links'
-import type { StructureResolutionCoordinator } from '../../processors/helpers/structure-resolution'
-import type { CoreBinding } from '../../../types/core-binding'
-import type { NotificationFetchResult } from './fetch-notifications'
 import { logger } from '@repo/hono-helpers'
 
+import { enrichNotifications } from '../../processors/helpers/notifications'
+import { retrieveData, storeOrReturn } from '../../utils/storage'
+
+import type { CoreBinding } from '../../../types/core-binding'
+import type { CharacterAffiliationCoordinator } from '../../processors/helpers/character-affiliation'
+import type { EntityLinkCoordinator } from '../../processors/helpers/entity-links'
+import type { StepResult } from '../../utils/storage'
+import type { NotificationFetchResult } from './fetch-notifications'
+
 export async function processNotifications(
-    env: {
-        ESI_TYPE_RESOLVER: DurableObjectNamespace
-        ESI: DurableObjectNamespace
-        EVE_TOKEN_STORE: DurableObjectNamespace
-        CORE: CoreBinding
-    },
-    getBucket: (name: string) => R2Bucket,
-    bucket: R2Bucket,
-    bucketName: string,
-    fetchResult: StepResult,
-    workflowInstanceId: string,
-    characterId: string,
-    affiliationCoordinator?: CharacterAffiliationCoordinator,
-    entityLinkCoordinator?: EntityLinkCoordinator,
-    structureResolutionCoordinator?: StructureResolutionCoordinator,
+	env: {
+		ESI_TYPE_RESOLVER: DurableObjectNamespace
+		ESI: DurableObjectNamespace
+		EVE_TOKEN_STORE: DurableObjectNamespace
+		CORE: CoreBinding
+	},
+	getBucket: (name: string) => R2Bucket,
+	bucket: R2Bucket,
+	bucketName: string,
+	fetchResult: StepResult,
+	workflowInstanceId: string,
+	characterId: string,
+	affiliationCoordinator?: CharacterAffiliationCoordinator,
+	entityLinkCoordinator?: EntityLinkCoordinator
 ): Promise<StepResult> {
-    try {
-        if (!fetchResult.success) {
-            return {
-                source: 'none',
-                success: false,
-                error: 'Fetch failed: ' + (fetchResult as any).error,
-            }
-        }
+	try {
+		if (!fetchResult.success) {
+			return {
+				source: 'none',
+				success: false,
+				error: 'Fetch failed: ' + (fetchResult as any).error,
+			}
+		}
 
-        const data = await retrieveData(getBucket, fetchResult)
-        if (!data) {
-            return {
-                source: 'none',
-                success: false,
-                error: 'No data retrieved from fetch step',
-            }
-        }
+		const data = await retrieveData(getBucket, fetchResult)
+		if (!data) {
+			return {
+				source: 'none',
+				success: false,
+				error: 'No data retrieved from fetch step',
+			}
+		}
 
-        const fetchData = data as NotificationFetchResult
-        const { notifications } = fetchData
+		const fetchData = data as NotificationFetchResult
+		const { notifications } = fetchData
 
-        logger.log('[processNotifications] Starting enrichment', {
-            count: notifications.length,
-        })
+		logger.log('[processNotifications] Starting enrichment', {
+			count: notifications.length,
+		})
 
-        const enrichedData = await enrichNotifications(
-            env,
-            notifications,
-            characterId,
-            affiliationCoordinator,
-            entityLinkCoordinator,
-            structureResolutionCoordinator,
-        )
+		const enrichedData = await enrichNotifications(
+			env,
+			notifications,
+			characterId,
+			affiliationCoordinator,
+			entityLinkCoordinator
+		)
 
-        logger.log('[processNotifications] Enrichment complete', {
-            count: enrichedData.notifications.length,
-            types: enrichedData.types.length,
-        })
+		logger.log('[processNotifications] Enrichment complete', {
+			count: enrichedData.notifications.length,
+			types: enrichedData.types.length,
+		})
 
-        return await storeOrReturn(
-            bucket,
-            bucketName,
-            workflowInstanceId,
-            'process-notifications',
-            enrichedData,
-        )
-    } catch (error) {
-        return {
-            source: 'none',
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-        }
-    }
+		return await storeOrReturn(
+			bucket,
+			bucketName,
+			workflowInstanceId,
+			'process-notifications',
+			enrichedData
+		)
+	} catch (error) {
+		return {
+			source: 'none',
+			success: false,
+			error: error instanceof Error ? error.message : String(error),
+		}
+	}
 }

--- a/apps/fulcrum/src/workflows/steps/public-info/process-public-info.ts
+++ b/apps/fulcrum/src/workflows/steps/public-info/process-public-info.ts
@@ -3,11 +3,18 @@
  * Resolves IDs to human-readable names using ESI Type Resolver
  */
 
-import type { CharacterPublicInfo } from '@repo/esi'
-import { retrieveData, storeOrReturn, type StepResult } from '../../utils/storage'
 import { enrichPublicInfo } from '../../processors/helpers/public-info'
-import type { EntityLinkCoordinator } from '../../processors/helpers/entity-links'
+import { retrieveData, storeOrReturn } from '../../utils/storage'
+
+import type { CharacterPublicInfo } from '@repo/esi'
 import type { CoreBinding } from '../../../types/core-binding'
+import type { EntityLinkCoordinator } from '../../processors/helpers/entity-links'
+import type { StepResult } from '../../utils/storage'
+
+interface FetchedAccountData {
+	skills?: { total_sp?: number }
+	walletBalance?: number | null
+}
 
 /**
  * Process public character info by enriching with resolved names
@@ -29,7 +36,7 @@ export async function processPublicInfo(
 	fetchResult: StepResult,
 	workflowInstanceId: string,
 	characterId: string,
-	entityLinkCoordinator?: EntityLinkCoordinator,
+	entityLinkCoordinator?: EntityLinkCoordinator
 ): Promise<StepResult> {
 	try {
 		// Check if fetch was successful
@@ -70,7 +77,7 @@ export async function processPublicInfo(
 			bucketName,
 			workflowInstanceId,
 			'process-public-info',
-			enrichedData,
+			enrichedData
 		)
 	} catch (error) {
 		return {
@@ -78,5 +85,45 @@ export async function processPublicInfo(
 			success: false,
 			error: error instanceof Error ? error.message : String(error),
 		}
+	}
+}
+
+/**
+ * Add authenticated metrics collected by the skills step to the persisted
+ * public-info section used by the report overview.
+ */
+export async function addAccountSummaryToPublicInfo(
+	getBucket: (name: string) => R2Bucket,
+	bucket: R2Bucket,
+	bucketName: string,
+	publicInfoResult: StepResult,
+	accountDataResult: StepResult,
+	workflowInstanceId: string
+): Promise<StepResult> {
+	try {
+		if (!publicInfoResult.success || !accountDataResult.success) return publicInfoResult
+
+		const publicInfo = await retrieveData<Record<string, unknown>>(getBucket, publicInfoResult)
+		const accountData = await retrieveData<FetchedAccountData>(getBucket, accountDataResult)
+		if (!publicInfo || !accountData) return publicInfoResult
+
+		const totalSp = accountData.skills?.total_sp
+		const walletBalance = accountData.walletBalance
+		if (totalSp === undefined && walletBalance === undefined) return publicInfoResult
+
+		return await storeOrReturn(
+			bucket,
+			bucketName,
+			workflowInstanceId,
+			'process-public-info-account-summary',
+			{
+				...publicInfo,
+				...(totalSp !== undefined ? { totalSp } : {}),
+				...(walletBalance !== undefined ? { walletBalance } : {}),
+			}
+		)
+	} catch {
+		// The base public-info section remains valid if optional metrics cannot be merged.
+		return publicInfoResult
 	}
 }

--- a/apps/fulcrum/src/workflows/steps/skills/fetch-skills.ts
+++ b/apps/fulcrum/src/workflows/steps/skills/fetch-skills.ts
@@ -14,11 +14,21 @@ import type { StepResult } from '../../utils/storage'
  * Separated for testability
  */
 export async function fetchSkillsFromEsi(esiStub: Esi, characterId: string) {
-	const [skills, skillQueue] = await Promise.all([
+	const [skillsResult, skillQueueResult, walletBalanceResult] = await Promise.allSettled([
 		esiStub.fetchCharacterSkills(characterId, { cacheMode: 'no-store' }),
 		esiStub.fetchCharacterSkillQueue(characterId, { cacheMode: 'no-store' }),
+		esiStub.fetchCharacterWalletBalance(characterId),
 	])
-	return { skills, skillQueue }
+
+	if (skillsResult.status === 'rejected') throw skillsResult.reason
+	if (skillQueueResult.status === 'rejected') throw skillQueueResult.reason
+
+	return {
+		skills: skillsResult.value,
+		skillQueue: skillQueueResult.value,
+		// Wallet access is optional. A missing wallet scope must not discard skills.
+		walletBalance: walletBalanceResult.status === 'fulfilled' ? walletBalanceResult.value : null,
+	}
 }
 
 /**

--- a/apps/ui/src/client/features/applications/components/report-sections/public-info-section.tsx
+++ b/apps/ui/src/client/features/applications/components/report-sections/public-info-section.tsx
@@ -4,9 +4,13 @@
 
 import { ExternalLink } from 'lucide-react'
 
+import { formatSkillPoints } from '@repo/eve-types'
+
 import { MemberAvatar } from '@/components/member-avatar'
 import { Card, CardContent } from '@/components/ui/card'
 import { allianceLogoUrl, corporationLogoUrl } from '@/lib/eve-images'
+import { formatISKShort } from '@/lib/format-utils'
+
 import { EntityNameLink } from './entity-name-link'
 
 interface ProcessedPublicInfo {
@@ -30,6 +34,8 @@ interface ProcessedPublicInfo {
 	factionName?: string
 	description?: string
 	title?: string
+	totalSp?: number
+	walletBalance?: number | null
 	processedAt: string
 }
 
@@ -51,14 +57,23 @@ function SimpleInfoRow({ label, value }: { label: string; value?: string | null 
 	)
 }
 
+function NumericInfoRow({
+	label,
+	value,
+	format,
+}: {
+	label: string
+	value?: number | null
+	format: (value: number) => string
+}) {
+	if (value == null) return null
+	return <SimpleInfoRow label={label} value={format(value)} />
+}
+
 export function PublicInfoHeader({ data }: { data: ProcessedPublicInfo }) {
 	return (
 		<div className="flex items-center gap-4">
-			<MemberAvatar
-				characterId={data.characterId}
-				characterName={data.characterName}
-				size="lg"
-			/>
+			<MemberAvatar characterId={data.characterId} characterName={data.characterName} size="lg" />
 			<div>
 				<h3 className="text-xl font-bold text-foreground">
 					<EntityNameLink entityId={data.characterId} href={data.characterDisplayHref}>
@@ -78,6 +93,16 @@ export function PublicInfoCard({ data }: { data: ProcessedPublicInfo }) {
 		<Card variant="flat">
 			<CardContent className="pt-4">
 				<div className="divide-y divide-border">
+					<NumericInfoRow
+						label="Skill Points"
+						value={data.totalSp}
+						format={(value) => formatSkillPoints(value)}
+					/>
+					<NumericInfoRow
+						label="Wallet Balance"
+						value={data.walletBalance}
+						format={(value) => formatISKShort(value)}
+					/>
 					<SimpleInfoRow label="Birthday" value={new Date(data.birthday).toLocaleDateString()} />
 					<SimpleInfoRow label="Race" value={data.raceName} />
 					<SimpleInfoRow label="Bloodline" value={data.bloodlineName} />
@@ -98,15 +123,9 @@ export function PublicInfoCard({ data }: { data: ProcessedPublicInfo }) {
 					)}
 					{data.allianceId && (
 						<InfoRow label="Alliance">
-							<img
-								src={allianceLogoUrl(data.allianceId, 32)}
-								alt=""
-								className="h-5 w-5 rounded"
-							/>
+							<img src={allianceLogoUrl(data.allianceId, 32)} alt="" className="h-5 w-5 rounded" />
 							<EntityNameLink entityId={data.allianceId} href={data.allianceDisplayHref}>
-								<span className="text-sm font-medium text-foreground">
-									{data.allianceName}
-								</span>
+								<span className="text-sm font-medium text-foreground">{data.allianceName}</span>
 							</EntityNameLink>
 						</InfoRow>
 					)}


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a character's total skill points and wallet balance to the Fulcrum character report overview, and stops resolving structure IDs found in notification text (which was unreliable and could poison ID-resolution batches).

## Changes
- `fetch-skills.ts`: fetches wallet balance alongside skills/skill queue via `Promise.allSettled`; a missing wallet scope no longer discards the skills result (`walletBalance` falls back to `null`).
- `process-public-info.ts`: adds `addAccountSummaryToPublicInfo` to merge `totalSp`/`walletBalance` from the skills step into the persisted public-info section.
- `character-report.workflow.ts`: runs the new merge step after skills are fetched, and stops passing `structureResolutionCoordinator` into notification processing.
- `notifications.ts` (helpers): drops the `structureResolutionCoordinator` parameter and structure-resolution logic entirely; structure IDs in parsed notification text are now filtered out via `isStructureId` and left unresolved instead of being looked up.
- `process-notifications.ts`: updated call site to match the removed `structureResolutionCoordinator` parameter.
- `public-info-section.tsx` (UI): renders new "Skill Points" and "Wallet Balance" rows via a `NumericInfoRow` helper, using `formatSkillPoints` and `formatISKShort`.
- Reformatted touched files from spaces to tabs and reordered imports per project conventions.

## Testing
- Added `fetch-skills.test.ts` covering `fetchSkillsFromEsi`: verifies wallet balance is included when available, and that skills/skill queue are still returned (with `walletBalance: null`) when the wallet call rejects.
<!-- claude:end -->