### PR TITLE
fix pos upsert field order

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -4928,6 +4928,10 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 							structureId: corporationStructures.structureId,
 							corporationId: corporationStructures.corporationId,
 							lastAttemptedSyncAt: sql<Date>`${now}`.as('last_attempted_sync_at'),
+							// INSERT ... SELECT requires the complete sidecar column set in
+							// table order. These are populated after a successful POS fetch.
+							lastSyncedAt: sql<Date | null>`null`.as('last_synced_at'),
+							syncFailureReason: sql<string | null>`null`.as('sync_failure_reason'),
 						})
 						.from(corporationStructures)
 						.leftJoin(

--- a/apps/eve-corporation-data/src/test/unit/durable-object.assets.test.ts
+++ b/apps/eve-corporation-data/src/test/unit/durable-object.assets.test.ts
@@ -103,6 +103,13 @@ describe('EveCorporationDataDO asset refresh', () => {
 		).resolves.toEqual(['pos-1'])
 
 		expect(insertSelect).toHaveBeenCalledOnce()
+		expect(Object.keys(select.mock.calls[0]?.[0] ?? {})).toEqual([
+			'structureId',
+			'corporationId',
+			'lastAttemptedSyncAt',
+			'lastSyncedAt',
+			'syncFailureReason',
+		])
 		expect(onConflictDoUpdate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				target: expect.anything(),


### PR DESCRIPTION
<!-- claude:begin -->
## Summary

Fixes the INSERT SELECT used to claim POS structure sync attempts in EveCorporationDataDO.claimStructureSyncAttempts: the select projection was missing the lastSyncedAt and syncFailureReason columns required by corporationStructurePosDetails, since Drizzle insert-select requires the select column set/order to match the target table.

## Changes
- Add lastSyncedAt and syncFailureReason (both selected as null) to the select projection in the POS claim query, so the projected columns match the full sidecar column set in table order.
- Add a unit test assertion verifying the select call receives columns in the expected order: structureId, corporationId, lastAttemptedSyncAt, lastSyncedAt, syncFailureReason.

## Testing
- Added a unit test assertion in apps/eve-corporation-data/src/test/unit/durable-object.assets.test.ts checking the projected column order passed to select().
<!-- claude:end -->
