### PR TITLE
make token endpoint return access tokens instead

### DIFF
--- a/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
+++ b/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
@@ -43,11 +43,11 @@ function makeDatabase() {
 	}
 }
 
-describe('member refresh token export route', () => {
+describe('member access token export route', () => {
 	let db: ReturnType<typeof makeDatabase>
 	let failCorporationData = false
 	const tokenStore = {
-		getRefreshTokensForIntegration: vi.fn(),
+		getAccessTokensForIntegration: vi.fn(),
 	}
 
 	beforeEach(() => {
@@ -119,8 +119,12 @@ describe('member refresh token export route', () => {
 			hasValidToken: true,
 		}))
 		db.query.userCharacters.findMany.mockResolvedValue(characters)
-		tokenStore.getRefreshTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
-			characterIds.map((characterId) => ({ characterId, refreshToken: `refresh-${characterId}` }))
+		tokenStore.getAccessTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
+			characterIds.map((characterId) => ({
+				characterId,
+				accessToken: `access-${characterId}`,
+				expiresAt: '2026-09-01T00:00:00.000Z',
+			}))
 		)
 
 		const response = await createApp().request(
@@ -141,9 +145,11 @@ describe('member refresh token export route', () => {
 			'director',
 			'director',
 		])
-		expect(body.corporations[0].tokens.every((token: any) => token.refreshToken)).toBe(true)
-		expect(tokenStore.getRefreshTokensForIntegration).toHaveBeenCalledTimes(2)
-		const firstLookup = tokenStore.getRefreshTokensForIntegration.mock.calls[0][0] as string[]
+		expect(body.corporations[0].tokens.every((token: any) => token.accessToken)).toBe(true)
+		expect(body.corporations[0].tokens.every((token: any) => token.expiresAt)).toBe(true)
+		expect(body.corporations[0].tokens.every((token: any) => !token.refreshToken)).toBe(true)
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledTimes(1)
+		const firstLookup = tokenStore.getAccessTokensForIntegration.mock.calls[0][0] as string[]
 		expect(firstLookup.slice(0, 2)).toEqual(['1010', '1011'])
 		expect(new Set(firstLookup)).toEqual(
 			new Set(characters.map((character) => character.characterId))
@@ -159,8 +165,12 @@ describe('member refresh token export route', () => {
 			{ characterId: '1001', characterName: 'Member 2', userId: 'user-2', hasValidToken: true },
 			{ characterId: '1002', characterName: 'Member 3', userId: 'user-3', hasValidToken: true },
 		])
-		tokenStore.getRefreshTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
-			characterIds.map((characterId) => ({ characterId, refreshToken: `refresh-${characterId}` }))
+		tokenStore.getAccessTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
+			characterIds.map((characterId) => ({
+				characterId,
+				accessToken: `access-${characterId}`,
+				expiresAt: '2026-09-01T00:00:00.000Z',
+			}))
 		)
 
 		type CryptoApi = {
@@ -217,8 +227,12 @@ describe('member refresh token export route', () => {
 				hasValidToken: false,
 			},
 		])
-		tokenStore.getRefreshTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
-			characterIds.map((characterId) => ({ characterId, refreshToken: `refresh-${characterId}` }))
+		tokenStore.getAccessTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
+			characterIds.map((characterId) => ({
+				characterId,
+				accessToken: `access-${characterId}`,
+				expiresAt: '2026-09-01T00:00:00.000Z',
+			}))
 		)
 
 		getStubMock.mockImplementation((binding: unknown) => {
@@ -247,7 +261,7 @@ describe('member refresh token export route', () => {
 
 		const body = (await response.json()) as any
 		expect(body.corporations[0].tokens).toMatchObject([{ characterId: '1000', role: 'member' }])
-		expect(tokenStore.getRefreshTokensForIntegration).toHaveBeenCalledWith(['1000'])
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledWith(['1000'])
 	})
 
 	it('deduplicates token rows and does not expose internal errors', async () => {
@@ -257,9 +271,9 @@ describe('member refresh token export route', () => {
 		db.query.userCharacters.findMany.mockResolvedValue([
 			{ characterId: '1000', characterName: 'Character', userId: 'user-1', hasValidToken: true },
 		])
-		tokenStore.getRefreshTokensForIntegration.mockResolvedValue([
-			{ characterId: '1000', refreshToken: 'refresh-first' },
-			{ characterId: '1000', refreshToken: 'refresh-second' },
+		tokenStore.getAccessTokensForIntegration.mockResolvedValue([
+			{ characterId: '1000', accessToken: 'access-first', expiresAt: '2026-09-01T00:00:00.000Z' },
+			{ characterId: '1000', accessToken: 'access-second', expiresAt: '2026-09-01T00:00:00.000Z' },
 		])
 
 		const response = await createApp().request(
@@ -273,9 +287,7 @@ describe('member refresh token export route', () => {
 
 		const body = (await response.json()) as any
 		expect(body.corporations[0].tokens).toHaveLength(1)
-		expect(['refresh-first', 'refresh-second']).toContain(
-			body.corporations[0].tokens[0].refreshToken
-		)
+		expect(['access-first', 'access-second']).toContain(body.corporations[0].tokens[0].accessToken)
 
 		failCorporationData = true
 		const failedResponse = await createApp().request(
@@ -287,9 +299,7 @@ describe('member refresh token export route', () => {
 			env
 		)
 		const failedBody = (await failedResponse.json()) as any
-		expect(failedBody.errors[0].error).toBe(
-			'Unable to retrieve refresh tokens for this corporation'
-		)
+		expect(failedBody.errors[0].error).toBe('Unable to retrieve access tokens for this corporation')
 		expect(JSON.stringify(failedBody)).not.toContain('SELECT refresh_token')
 	})
 

--- a/apps/core/src/routes/member-refresh-tokens.ts
+++ b/apps/core/src/routes/member-refresh-tokens.ts
@@ -8,7 +8,7 @@ import { createDb } from '../db'
 import { managedCorporations, userCharacters } from '../db/schema'
 
 import type { EveCorporationData } from '@repo/eve-corporation-data'
-import type { EveTokenStore } from '@repo/eve-token-store'
+import type { DecryptedAccessToken, EveTokenStore } from '@repo/eve-token-store'
 import type { App } from '../context'
 
 const MAX_TOKENS_PER_CORPORATION = 15
@@ -27,10 +27,9 @@ type Corporation = {
 	name: string
 }
 
-type CorporationResult = {
-	corporationId: string
-	corporationName: string
-	tokens: Array<Candidate & { refreshToken: string }>
+type CorporationCandidates = {
+	corporation: Corporation
+	candidates: Candidate[]
 }
 
 function getBearerToken(authorization: string | undefined): string | null {
@@ -75,7 +74,7 @@ function orderCandidates(
 	}
 
 	// Keep director priority deterministic, but rotate ordinary members so
-	// repeated daemon requests do not select the same ten characters forever.
+	// repeated daemon requests do not select the same fifteen characters forever.
 	directors.sort((a, b) => a.characterId.localeCompare(b.characterId))
 	for (let index = members.length - 1; index > 0; index -= 1) {
 		const random = new Uint32Array(1)
@@ -107,6 +106,28 @@ async function mapWithConcurrency<T, R>(
 
 	await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => runWorker()))
 	return results
+}
+
+async function getAccessTokensInBatches(
+	tokenStore: EveTokenStore,
+	characterIds: readonly string[]
+): Promise<Map<string, DecryptedAccessToken>> {
+	const uniqueCharacterIds = [...new Set(characterIds)]
+	const batches = Array.from(
+		{ length: Math.ceil(uniqueCharacterIds.length / TOKEN_BATCH_SIZE) },
+		(_, index) => uniqueCharacterIds.slice(index * TOKEN_BATCH_SIZE, (index + 1) * TOKEN_BATCH_SIZE)
+	)
+	const tokenBatches = await mapWithConcurrency(batches, CORPORATION_CONCURRENCY, (batch) =>
+		tokenStore.getAccessTokensForIntegration(batch)
+	)
+
+	const tokensByCharacterId = new Map<string, DecryptedAccessToken>()
+	for (const token of tokenBatches.flat()) {
+		if (!tokensByCharacterId.has(token.characterId)) {
+			tokensByCharacterId.set(token.characterId, token)
+		}
+	}
+	return tokensByCharacterId
 }
 
 const app = new Hono<App>()
@@ -142,13 +163,13 @@ app.get('/', async (c) => {
 	})
 
 	const tokenStore = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
-	const corporationResults = await mapWithConcurrency(
+	const corporationCandidates = await mapWithConcurrency(
 		corporations as Corporation[],
 		CORPORATION_CONCURRENCY,
 		async (
 			corporation
 		): Promise<
-			| { result: CorporationResult; error: null }
+			| { result: CorporationCandidates; error: null }
 			| { result: null; error: { corporationId: string; error: string } }
 		> => {
 			try {
@@ -181,52 +202,36 @@ app.get('/', async (c) => {
 					characters.filter((character) => character.hasValidToken === true),
 					directorIds
 				)
-				const tokensByCharacterId = new Map<string, string>()
+				const directorCandidates = candidates.filter((candidate) => candidate.role === 'director')
+				const memberCandidates = candidates.filter((candidate) => candidate.role === 'member')
+				const candidatesForTokenLookup = [
+					...directorCandidates,
+					...memberCandidates.slice(0, MAX_TOKENS_PER_CORPORATION),
+				]
+				const currentMemberCandidates: Candidate[] = []
 
-				for (
-					let offset = 0;
-					offset < candidates.length && tokensByCharacterId.size < MAX_TOKENS_PER_CORPORATION;
-					offset += TOKEN_BATCH_SIZE
-				) {
-					const batch = candidates.slice(offset, offset + TOKEN_BATCH_SIZE)
+				for (let offset = 0; offset < candidatesForTokenLookup.length; offset += TOKEN_BATCH_SIZE) {
+					const batch = candidatesForTokenLookup.slice(offset, offset + TOKEN_BATCH_SIZE)
 					const membershipByCharacterId = await corporationData.getCorporationIdsByCharacterIds(
 						batch.map((candidate) => candidate.characterId)
 					)
-					const currentMemberBatch = batch.filter(
-						(candidate) =>
-							membershipByCharacterId[candidate.characterId] === corporation.corporationId
+					currentMemberCandidates.push(
+						...batch.filter(
+							(candidate) =>
+								membershipByCharacterId[candidate.characterId] === corporation.corporationId
+						)
 					)
-					if (currentMemberBatch.length === 0) continue
-
-					const tokenRows = await tokenStore.getRefreshTokensForIntegration(
-						currentMemberBatch.map((candidate) => candidate.characterId)
-					)
-					const currentMemberIds = new Set(
-						currentMemberBatch.map((candidate) => candidate.characterId)
-					)
-					for (const token of tokenRows) {
-						if (currentMemberIds.has(token.characterId)) {
-							tokensByCharacterId.set(token.characterId, token.refreshToken)
-						}
-					}
 				}
 
 				return {
 					result: {
-						corporationId: corporation.corporationId,
-						corporationName: corporation.name,
-						tokens: candidates
-							.filter((candidate) => tokensByCharacterId.has(candidate.characterId))
-							.slice(0, MAX_TOKENS_PER_CORPORATION)
-							.map((candidate) => ({
-								...candidate,
-								refreshToken: tokensByCharacterId.get(candidate.characterId)!,
-							})),
+						corporation,
+						candidates: currentMemberCandidates,
 					},
 					error: null,
 				}
 			} catch (error) {
-				logger.error('[MemberRefreshTokenExport] Failed to load corporation tokens', {
+				logger.error('[MemberAccessTokenExport] Failed to load corporation candidates', {
 					corporationId: corporation.corporationId,
 					error: error instanceof Error ? error.message : String(error),
 				})
@@ -234,14 +239,38 @@ app.get('/', async (c) => {
 					result: null,
 					error: {
 						corporationId: corporation.corporationId,
-						error: 'Unable to retrieve refresh tokens for this corporation',
+						error: 'Unable to retrieve access tokens for this corporation',
 					},
 				}
 			}
 		}
 	)
-	const results = corporationResults.flatMap((entry) => (entry.result ? [entry.result] : []))
-	const errors = corporationResults.flatMap((entry) => (entry.error ? [entry.error] : []))
+	const tokenLookupCandidates = corporationCandidates.flatMap((entry) =>
+		entry.result ? entry.result.candidates.map((candidate) => candidate.characterId) : []
+	)
+	const tokensByCharacterId = await getAccessTokensInBatches(tokenStore, tokenLookupCandidates)
+	const results = corporationCandidates.flatMap((entry) => {
+		if (!entry.result) return []
+		const { corporation, candidates } = entry.result
+		return [
+			{
+				corporationId: corporation.corporationId,
+				corporationName: corporation.name,
+				tokens: candidates
+					.filter((candidate) => tokensByCharacterId.has(candidate.characterId))
+					.slice(0, MAX_TOKENS_PER_CORPORATION)
+					.map((candidate) => {
+						const token = tokensByCharacterId.get(candidate.characterId)!
+						return {
+							...candidate,
+							accessToken: token.accessToken,
+							expiresAt: token.expiresAt,
+						}
+					}),
+			},
+		]
+	})
+	const errors = corporationCandidates.flatMap((entry) => (entry.error ? [entry.error] : []))
 
 	return c.json(
 		{

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -30,7 +30,7 @@ import type {
 	AuthorizationUrlResponse,
 	CachedEveMetadata,
 	CallbackResult,
-	DecryptedRefreshToken,
+	DecryptedAccessToken,
 	EveMetadata,
 	EveTokenResponse,
 	EveTokenStore,
@@ -54,6 +54,7 @@ const METADATA_TTL_MS = 5 * 60 * 1000
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000
 const TOKEN_REFRESH_COOLDOWN_PREFIX = 'token:refresh:cooldown:'
 const TOKEN_REFRESH_TRANSIENT_COOLDOWN_MS = 5 * 60 * 1000
+const ACCESS_TOKEN_INTEGRATION_CONCURRENCY = 4
 
 async function parseJsonResponse<T>(response: Response, context: string): Promise<T> {
 	try {
@@ -67,6 +68,7 @@ type AccessTokenLookupResult =
 	| {
 			status: 'ok'
 			accessToken: string
+			expiresAt: Date
 	  }
 	| {
 			status:
@@ -354,7 +356,9 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 		}
 	}
 
-	private async getWarmAccessToken(characterId: string): Promise<string | null> {
+	private async getWarmAccessToken(
+		characterId: string
+	): Promise<{ accessToken: string; expiresAt: Date } | null> {
 		try {
 			const rows = [
 				...this.state.storage.sql.exec<{
@@ -372,7 +376,10 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 				return null
 			}
 
-			return await this.decrypt(cached.encrypted_access_token)
+			return {
+				accessToken: await this.decrypt(cached.encrypted_access_token),
+				expiresAt: new Date(cached.expires_at),
+			}
 		} catch (error) {
 			logger
 				.withTags({ operation: 'getWarmAccessToken', characterId })
@@ -926,53 +933,46 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	}
 
 	/**
-	 * Resolve a bounded batch of refresh tokens for a trusted internal
-	 * integration. The database stores encrypted values; plaintext never leaves
-	 * this method except through the explicitly authorized RPC caller.
+	 * Resolve a bounded batch of currently usable access tokens for a trusted
+	 * internal integration. This reuses the warm cache and demand-driven refresh
+	 * path so plaintext refresh tokens never leave the token-store domain.
 	 */
-	async getRefreshTokensForIntegration(characterIds: string[]): Promise<DecryptedRefreshToken[]> {
+	async getAccessTokensForIntegration(characterIds: string[]): Promise<DecryptedAccessToken[]> {
 		const uniqueCharacterIds = [...new Set(characterIds.map((characterId) => String(characterId)))]
 		if (uniqueCharacterIds.length === 0) return []
 		if (uniqueCharacterIds.length > 100) {
-			throw new Error('Refresh token lookup is limited to 100 characters per request')
+			throw new Error('Access token lookup is limited to 100 characters per request')
 		}
 
-		const rows = await this.db
-			.select({
-				characterId: eveCharacters.characterId,
-				refreshToken: eveTokens.refreshToken,
-			})
+		const eligibleRows = await this.db
+			.select({ characterId: eveCharacters.characterId })
 			.from(eveCharacters)
 			.innerJoin(eveTokens, eq(eveTokens.characterId, eveCharacters.id))
 			.where(
 				and(
 					inArray(eveCharacters.characterId, uniqueCharacterIds),
 					isNull(eveCharacters.deletedAt),
-					isNotNull(eveTokens.refreshToken),
 					isNull(eveTokens.invalidSince),
 					isNull(eveTokens.permanentInvalidAt)
 				)
 			)
-			.orderBy(desc(eveTokens.updatedAt), asc(eveTokens.id))
 
-		const resolvedByCharacterId = new Map<string, DecryptedRefreshToken>()
-		for (const row of rows) {
-			if (!row.refreshToken || resolvedByCharacterId.has(row.characterId)) continue
-			try {
-				resolvedByCharacterId.set(row.characterId, {
-					characterId: row.characterId,
-					refreshToken: await this.decrypt(row.refreshToken),
-				})
-			} catch (error) {
-				logger
-					.withTags({ operation: 'getRefreshTokensForIntegration', characterId: row.characterId })
-					.error('Failed to decrypt refresh token for internal integration', {
-						error: error instanceof Error ? error.message : String(error),
-					})
+		const eligibleCharacterIds = eligibleRows.map((row) => row.characterId)
+		const results = await mapWithConcurrency(
+			eligibleCharacterIds,
+			ACCESS_TOKEN_INTEGRATION_CONCURRENCY,
+			async (characterId) => {
+				const result = await this.getAccessTokenResult(characterId)
+				if (result.status !== 'ok') return null
+				return {
+					characterId,
+					accessToken: result.accessToken,
+					expiresAt: result.expiresAt.toISOString(),
+				}
 			}
-		}
+		)
 
-		return [...resolvedByCharacterId.values()]
+		return results.filter((result): result is DecryptedAccessToken => result !== null)
 	}
 
 	/**
@@ -1333,7 +1333,8 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			if (warmAccessToken) {
 				return {
 					status: 'ok',
-					accessToken: warmAccessToken,
+					accessToken: warmAccessToken.accessToken,
+					expiresAt: warmAccessToken.expiresAt,
 				}
 			}
 
@@ -1413,6 +1414,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 				return {
 					status: 'ok',
 					accessToken: decryptedToken,
+					expiresAt: updatedToken.expiresAt,
 				}
 			}
 
@@ -1421,6 +1423,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			return {
 				status: 'ok',
 				accessToken: decryptedToken,
+				expiresAt: tokenRecord.expiresAt,
 			}
 		} catch (error) {
 			logger
@@ -1960,4 +1963,24 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			.set({ lastDataSyncAt: new Date() })
 			.where(eq(eveCharacters.characterId, String(characterId)))
 	}
+}
+
+async function mapWithConcurrency<T, R>(
+	items: readonly T[],
+	concurrency: number,
+	mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+	const results = new Array<R>(items.length)
+	let nextIndex = 0
+
+	async function runWorker(): Promise<void> {
+		while (true) {
+			const index = nextIndex++
+			if (index >= items.length) return
+			results[index] = await mapper(items[index])
+		}
+	}
+
+	await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => runWorker()))
+	return results
 }

--- a/packages/eve-token-store/src/index.ts
+++ b/packages/eve-token-store/src/index.ts
@@ -245,12 +245,13 @@ export interface TokenInfo {
 }
 
 /**
- * A decrypted refresh token for a character selected by a trusted internal
+ * A decrypted access token for a character selected by a trusted internal
  * integration. This capability must not be exposed to browser-facing routes.
  */
-export interface DecryptedRefreshToken {
+export interface DecryptedAccessToken {
 	characterId: string
-	refreshToken: string
+	accessToken: string
+	expiresAt: string
 }
 
 /**
@@ -416,11 +417,11 @@ export interface EveTokenStore {
 	getTokenInfo(characterId: string): Promise<TokenInfo | null>
 
 	/**
-	 * Resolve stored refresh tokens for a trusted internal integration.
-	 * Token-store remains responsible for decryption; callers must authenticate
-	 * the downstream request before returning these values externally.
+	 * Resolve currently usable access tokens for a trusted internal integration.
+	 * Token-store owns warm-cache lookup, safety-margin refresh, and decryption;
+	 * callers must authenticate the downstream request before returning values.
 	 */
-	getRefreshTokensForIntegration(characterIds: string[]): Promise<DecryptedRefreshToken[]>
+	getAccessTokensForIntegration(characterIds: string[]): Promise<DecryptedAccessToken[]>
 
 	/**
 	 * Validate that a character token is present, refreshable/verifiable, and


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Changes the internal member token export endpoint to hand out short-lived EVE SSO access tokens instead of long-lived refresh tokens, so downstream integrations no longer receive plaintext refresh tokens from `eve-token-store`.

## Changes
- `EveTokenStore.getRefreshTokensForIntegration` is replaced with `getAccessTokensForIntegration`, which reuses the existing warm-cache/refresh (`getAccessTokenResult`) path internally so refresh tokens never leave the durable object; results now include an `expiresAt` timestamp.
- Renamed the `DecryptedRefreshToken` type to `DecryptedAccessToken` (`characterId`, `accessToken`, `expiresAt`) in `@repo/eve-token-store`.
- Added a `mapWithConcurrency` helper in the `eve-token-store` durable object to look up access tokens with bounded concurrency.
- Reworked `apps/core/src/routes/member-refresh-tokens.ts` to first select per-corporation candidate characters (directors + up to 15 members that are still current corp members), then batch-fetch access tokens for all corporations together via a new `getAccessTokensInBatches` helper, deduplicating by character ID across the whole request instead of per corporation.
- Updated error messages/log tags ("Unable to retrieve access tokens for this corporation", `MemberAccessTokenExport`) to reflect the access-token terminology.

## Testing
- Updated `apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts` to assert on `accessToken`/`expiresAt` fields, verify `refreshToken` is no longer present in responses, and check the new batched `getAccessTokensForIntegration` call pattern.
<!-- claude:end -->
