### PR TITLE
estimate sov reagent bay since it doesn't update unless touched

### DIFF
--- a/apps/eve-corporation-data/src/durable-object.ts
+++ b/apps/eve-corporation-data/src/durable-object.ts
@@ -30,7 +30,6 @@ import {
 	SKYHOOK_MAGMATIC_GAS_TYPE_NAME,
 	SKYHOOK_SUPERIONIC_ICE_TYPE_ID,
 	SKYHOOK_SUPERIONIC_ICE_TYPE_NAME,
-	summarizeSovereigntyReagentBay,
 } from '@repo/structures'
 import { normalizeUniverseServiceName } from '@repo/universe'
 import { parseDateOrNull } from '@repo/worker-utils'
@@ -4655,7 +4654,6 @@ export class EveCorporationDataDO extends DurableObject<Env> implements EveCorpo
 				reagentBayLastUpdated: parseDateOrNull(hub.reagent_bay.last_updated) ?? null,
 				reagentBay: {
 					lastUpdated: hub.reagent_bay.last_updated,
-					summary: summarizeSovereigntyReagentBay(reagents),
 					reagents,
 				},
 				resources: hub.resources,

--- a/apps/structures/src/services/structures.service.ts
+++ b/apps/structures/src/services/structures.service.ts
@@ -32,6 +32,7 @@ import {
 } from '@repo/moon-scan'
 import {
 	FUEL_BLOCK_TYPE_IDS,
+	getEstimatedSovereigntyReagent,
 	getSkyhookFullness,
 	getSkyhookReagentEntriesFromStorageState,
 	getSkyhookReagentSummaryFromStorageState,
@@ -39,6 +40,7 @@ import {
 	getSovereigntyReagentBayReagents,
 	getSovereigntyReagentBaySummary,
 	getStructureTabForTypeId,
+	isSovereigntyReagentBaySnapshot,
 	METENOX_MOON_DRILL_TYPE_NAME,
 	MINING_CITADEL_TYPE_NAMES,
 	MOON_DRILL_STRUCTURE_TYPE_IDS,
@@ -903,8 +905,15 @@ function buildHiddenVisibilityWhere(
 function summarizeStructureSovereigntyHub(
 	hub: typeof structureSovereigntyHubs.$inferSelect
 ): StructureSovereigntyHubSummary {
-	const reagentBaySummary = getSovereigntyReagentBaySummary(hub.reagentBay)
-	const reagents = getSovereigntyReagentBayReagents(hub.reagentBay)
+	const referenceTimeMs = Date.now()
+	const reagentBaySummary = getSovereigntyReagentBaySummary(hub.reagentBay, referenceTimeMs)
+	const rawReagents = getSovereigntyReagentBayReagents(hub.reagentBay)
+	const lastUpdated = isSovereigntyReagentBaySnapshot(hub.reagentBay)
+		? hub.reagentBay.lastUpdated
+		: (hub.reagentBayLastUpdated?.toISOString() ?? null)
+	const reagents = rawReagents.map((reagent) =>
+		getEstimatedSovereigntyReagent(reagent, lastUpdated, referenceTimeMs)
+	)
 
 	return {
 		controllerAllianceId: hub.controllerAllianceId ?? null,
@@ -919,7 +928,10 @@ function summarizeStructureSovereigntyHub(
 		superionicIceQuantity: reagentBaySummary?.superionicIceQuantity ?? 0,
 		superionicIceBurningPerHour: reagentBaySummary?.superionicIceBurningPerHour ?? 0,
 		superionicIceEstimatedDepletionAt: reagentBaySummary?.superionicIceEstimatedDepletionAt ?? null,
-		reagentBay: hub.reagentBay,
+		reagentBay: {
+			lastUpdated: lastUpdated ?? '',
+			reagents,
+		},
 		resources: hub.resources,
 		upgrades: hub.upgrades,
 		workforceTransport:
@@ -3053,25 +3065,53 @@ function buildSovereigntyReagentMetricSql(
 	const summaryValue = sql<
 		string | null
 	>`nullif(${source.reagentBay} -> 'summary' ->> ${summaryField}, '')`
+	const reagentArray = sql`
+		case
+			when jsonb_typeof(${source.reagentBay}) = 'object'
+				and jsonb_typeof(${source.reagentBay} -> 'reagents') = 'array'
+				then ${source.reagentBay} -> 'reagents'
+			when jsonb_typeof(${source.reagentBay}) = 'array' then ${source.reagentBay}
+			else '[]'::jsonb
+		end
+	`
+	const snapshotLastUpdated = sql`
+		nullif(${source.reagentBay} ->> 'lastUpdated', '')::timestamptz
+	`
 	const arrayValue = sql<number>`
 		(
-			select coalesce(sum((reagent ->> ${reagentField})::numeric), 0)
-			from jsonb_array_elements(
+			select coalesce(sum(
 				case
-					when jsonb_typeof(${source.reagentBay}) = 'object'
-						and jsonb_typeof(${source.reagentBay} -> 'reagents') = 'array'
-						then ${source.reagentBay} -> 'reagents'
-					when jsonb_typeof(${source.reagentBay}) = 'array' then ${source.reagentBay}
-					else '[]'::jsonb
+					when ${reagentField === 'amount' ? sql`jsonb_typeof(${source.reagentBay}) = 'object' and ${snapshotLastUpdated} is not null and nullif(reagent ->> 'amount', '')::numeric is not null and nullif(reagent ->> 'burningPerHour', '')::numeric > 0` : sql`false`}
+						then floor(
+							greatest(
+								((reagent ->> 'amount')::numeric)
+								- greatest(extract(epoch from (now() - ${snapshotLastUpdated})) / 3600, 0)
+									* ((reagent ->> 'burningPerHour')::numeric),
+								0
+							)
+						)
+					when ${reagentField === 'amount' ? sql`true` : sql`false`}
+						then floor((reagent ->> 'amount')::numeric)
+					else (reagent ->> 'burningPerHour')::numeric
 				end
-			) as reagent
+			), 0)
+			from jsonb_array_elements(${reagentArray}) as reagent
 			where reagent ->> 'typeId' = ${typeId}
 		)
 	`
 
-	return sql<number>`
-		coalesce(nullif(((${summaryValue})::numeric), 'NaN'::numeric), ${arrayValue})
+	const hasReagentArray = sql`
+		jsonb_typeof(${source.reagentBay}) = 'array'
+		or (
+			jsonb_typeof(${source.reagentBay}) = 'object'
+			and jsonb_typeof(${source.reagentBay} -> 'reagents') = 'array'
+		)
 	`
+
+	return sql<number>`coalesce(
+		case when ${hasReagentArray} then ${arrayValue} else nullif(((${summaryValue})::numeric), 'NaN'::numeric) end,
+		0
+	)`
 }
 
 function buildSovereigntySummaryDateSql(source: any, field: string) {

--- a/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
+++ b/apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+	estimateSovereigntyReagentAmount,
+	getEstimatedSovereigntyReagent,
+	getSovereigntyReagentBaySummary,
+} from '@repo/structures'
+
+import {
 	buildSovereigntyWhere,
 	computeStructureAccess,
 	getStructureDetail,
@@ -545,6 +551,60 @@ function makeDb() {
 }
 
 describe('sovereignty hub model', () => {
+	it('projects reagent amounts from the ESI baseline at query time', () => {
+		const referenceTimeMs = Date.parse('2026-09-02T12:00:00.000Z')
+		const reagent = {
+			typeId: '81143',
+			amount: 100,
+			burningPerHour: 10,
+			lastCycle: '2026-09-02T08:00:00.000Z',
+		}
+		const lastUpdated = '2026-09-02T06:00:00.000Z'
+
+		expect(estimateSovereigntyReagentAmount(reagent, lastUpdated, referenceTimeMs)).toBe(40)
+		expect(getEstimatedSovereigntyReagent(reagent, lastUpdated, referenceTimeMs)).toMatchObject({
+			estimatedAmount: 40,
+			estimatedDepletionAt: '2026-09-02T16:00:00.000Z',
+		})
+
+		const summary = getSovereigntyReagentBaySummary(
+			{
+				lastUpdated,
+				summary: {
+					reagentCount: 1,
+					magmaticGasQuantity: 100,
+					magmaticGasBurningPerHour: 10,
+					magmaticGasEstimatedDepletionAt: '2026-09-02T22:00:00.000Z',
+					superionicIceQuantity: 0,
+					superionicIceBurningPerHour: 0,
+					superionicIceEstimatedDepletionAt: null,
+				},
+				reagents: [reagent],
+			},
+			referenceTimeMs
+		)
+		expect(summary?.magmaticGasQuantity).toBe(40)
+		expect(summary?.magmaticGasEstimatedDepletionAt).toBe('2026-09-02T16:00:00.000Z')
+
+		expect(
+			estimateSovereigntyReagentAmount(reagent, '2026-09-02T13:00:00.000Z', referenceTimeMs)
+		).toBe(100)
+		expect(
+			estimateSovereigntyReagentAmount(
+				{ ...reagent, amount: 100.5 },
+				'2026-09-02T06:00:00.000Z',
+				referenceTimeMs
+			)
+		).toBe(40)
+		expect(
+			estimateSovereigntyReagentAmount(
+				{ ...reagent, amount: 100.5, burningPerHour: 0 },
+				lastUpdated,
+				referenceTimeMs
+			)
+		).toBe(100)
+	})
+
 	it('scopes sovereignty queries to the corporations allowed for the sovereignty tab', () => {
 		const access = computeStructureAccess(['urn:structures:corp-1:sensitive'], false)
 		const condition = buildSovereigntyWhere(access, {}) as { queryChunks?: unknown[] }

--- a/apps/ui/src/client/routes/structures-detail.tsx
+++ b/apps/ui/src/client/routes/structures-detail.tsx
@@ -130,9 +130,13 @@ type AssetSyncStatus = 'ok' | 'warning' | 'error' | 'disabled'
 
 function assetSyncStatus(enabled: boolean, lastAssetSnapshotAt: string | null): AssetSyncStatus {
 	if (!enabled) return 'disabled'
-	if (!lastAssetSnapshotAt) return 'error'
+	return snapshotSyncStatus(lastAssetSnapshotAt)
+}
 
-	const parsed = new Date(lastAssetSnapshotAt)
+function snapshotSyncStatus(lastSnapshotAt: string | null): Exclude<AssetSyncStatus, 'disabled'> {
+	if (!lastSnapshotAt) return 'error'
+
+	const parsed = new Date(lastSnapshotAt)
 	if (Number.isNaN(parsed.getTime())) return 'error'
 
 	const ageMs = Math.max(0, Date.now() - parsed.getTime())
@@ -143,13 +147,17 @@ function assetSyncStatus(enabled: boolean, lastAssetSnapshotAt: string | null): 
 
 function assetSyncStatusDescription(enabled: boolean, lastAssetSnapshotAt: string | null): string {
 	if (!enabled) return 'Asset sync is disabled for this corporation.'
-	if (!lastAssetSnapshotAt) {
-		return 'Asset sync is enabled, but no successful inventory snapshot has been recorded.'
+	return snapshotSyncStatusDescription('asset', lastAssetSnapshotAt)
+}
+
+function snapshotSyncStatusDescription(label: string, lastSnapshotAt: string | null): string {
+	if (!lastSnapshotAt) {
+		return `No ${label} snapshot timestamp has been recorded.`
 	}
 
-	const parsed = new Date(lastAssetSnapshotAt)
+	const parsed = new Date(lastSnapshotAt)
 	if (Number.isNaN(parsed.getTime())) {
-		return 'The last asset snapshot timestamp was invalid, so the inventory snapshot cannot be trusted.'
+		return `The last ${label} snapshot timestamp was invalid, so the snapshot cannot be trusted.`
 	}
 
 	const ageMs = Math.max(0, Date.now() - parsed.getTime())
@@ -158,9 +166,9 @@ function assetSyncStatusDescription(enabled: boolean, lastAssetSnapshotAt: strin
 			? 'This snapshot is more than 24 hours old and should be treated as stale.'
 			: ageMs >= STRUCTURE_SYNC_WARNING_STALE_MS
 				? 'This snapshot is more than 12 hours old and may be stale.'
-				: 'The stored inventory snapshot is current.'
+				: `The stored ${label} snapshot is current.`
 
-	return `Last successful asset snapshot at ${formatDateTimeLong(lastAssetSnapshotAt)}. ${stalenessNote}`
+	return `Last ${label} snapshot at ${formatDateTimeLong(lastSnapshotAt)}. ${stalenessNote}`
 }
 
 function serviceBadgeVariant(state: string): BadgeVariant {
@@ -219,6 +227,11 @@ function formatEveTimeLabel(value: string | null | undefined): string {
 function formatNullableNumber(value: number | null | undefined): string {
 	if (value === null || value === undefined) return '-'
 	return value.toLocaleString()
+}
+
+function formatApproximateNumber(value: number | null | undefined): string {
+	if (value === null || value === undefined) return '-'
+	return `~${value.toLocaleString()}`
 }
 
 function formatEstimatedRemaining(
@@ -1017,6 +1030,13 @@ export default function StructuresDetailPage() {
 		structure.includeInStructureAssetSync,
 		structure.assetsLastSync
 	)
+	const reagentBaySyncStatus = snapshotSyncStatus(
+		structure.sovereignty?.hub?.reagentBayLastUpdated ?? null
+	)
+	const reagentBaySyncDescription = `${snapshotSyncStatusDescription(
+		'reagent-bay',
+		structure.sovereignty?.hub?.reagentBayLastUpdated ?? null
+	)} Reagent quantities and remaining times are approximations calculated from that ESI baseline and its reported burn rate.`
 
 	const handleSave = async () => {
 		await updateMutation.mutateAsync({
@@ -1393,6 +1413,18 @@ export default function StructuresDetailPage() {
 													/>
 												</>
 											)}
+											{hasSovereigntySummary && structure.sovereignty?.hub && (
+												<>
+													<span aria-hidden className="text-sm text-muted-foreground">
+														-
+													</span>
+													<StructureSyncStatusBadge
+														label="Reagent Bay"
+														status={reagentBaySyncStatus}
+														description={reagentBaySyncDescription}
+													/>
+												</>
+											)}
 										</div>
 										<div className="mt-2 text-sm text-muted-foreground">{syncDescription}</div>
 									</div>
@@ -1580,7 +1612,7 @@ export default function StructuresDetailPage() {
 												<TableHeader>
 													<TableRow>
 														<TableHead>Reagent</TableHead>
-														<TableHead>Amount</TableHead>
+														<TableHead>Est. Amount</TableHead>
 														<TableHead>Burn / Hr</TableHead>
 														<TableHead>Est. Remaining</TableHead>
 														<TableHead>Last Cycle</TableHead>
@@ -1597,10 +1629,24 @@ export default function StructuresDetailPage() {
 																	</span>
 																</div>
 															</TableCell>
-															<TableCell>{formatNullableNumber(reagent.amount)}</TableCell>
+															<TableCell>
+																{formatApproximateNumber(reagent.estimatedAmount ?? reagent.amount)}
+															</TableCell>
 															<TableCell>{formatNullableNumber(reagent.burningPerHour)}</TableCell>
 															<TableCell>
-																{formatEstimatedRemaining(reagent.amount, reagent.burningPerHour)}
+																{reagent.estimatedDepletionAt ? (
+																	<DurationDisplay
+																		endDate={reagent.estimatedDepletionAt}
+																		maxUnits={3}
+																		durationStyle="compact"
+																		format="compact"
+																	/>
+																) : (
+																	formatEstimatedRemaining(
+																		reagent.estimatedAmount ?? reagent.amount,
+																		reagent.burningPerHour
+																	)
+																)}
 															</TableCell>
 															<TableCell>{formatNullableDateTime(reagent.lastCycle)}</TableCell>
 														</TableRow>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"check:deps": "runx check --deps",
 		"check:format": "runx check --format",
 		"check:lint:all": "run-eslint",
+		"diagnose:character-notifications": "node scripts/diagnose-character-notifications.mjs",
 		"diagnose:corporation-mining-extractions": "node scripts/diagnose-corporation-mining-extractions.mjs",
 		"diagnose:sovereignty-alliance": "node scripts/diagnose-sovereignty-alliance.mjs",
 		"test": "vitest",

--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -318,6 +318,8 @@ export interface StructureSovereigntyReagent {
 	amount: number
 	burningPerHour: number
 	lastCycle: string
+	estimatedAmount?: number
+	estimatedDepletionAt?: string | null
 }
 
 export interface StructureSovereigntyTransportEntry {

--- a/packages/structures/src/sovereignty-metrics.ts
+++ b/packages/structures/src/sovereignty-metrics.ts
@@ -11,6 +11,9 @@ export interface SovereigntyReagentEntry {
 	amount: number
 	burningPerHour: number
 	lastCycle: string
+	/** Query-time projection; omitted from the persisted ESI snapshot. */
+	estimatedAmount?: number
+	estimatedDepletionAt?: string | null
 }
 
 export interface SovereigntyReagentSummary {
@@ -29,24 +32,81 @@ export interface SovereigntyReagentBaySnapshot {
 	reagents: SovereigntyReagentEntry[]
 }
 
-export type SovereigntyReagentBaySnapshotValue = SovereigntyReagentEntry[] | SovereigntyReagentBaySnapshot
+export type SovereigntyReagentBaySnapshotValue =
+	| SovereigntyReagentEntry[]
+	| SovereigntyReagentBaySnapshot
+
+function parseTimestampMs(value: string | null | undefined): number | null {
+	if (!value) {
+		return null
+	}
+
+	const timestampMs = Date.parse(value)
+	return Number.isFinite(timestampMs) ? timestampMs : null
+}
 
 function estimateReagentDepletionAt(
 	quantity: number,
 	burningPerHour: number,
 	referenceTimeMs: number
 ): string | null {
-	if (!Number.isFinite(quantity) || !Number.isFinite(burningPerHour) || burningPerHour <= 0) {
+	if (
+		quantity <= 0 ||
+		!Number.isFinite(quantity) ||
+		!Number.isFinite(burningPerHour) ||
+		burningPerHour <= 0
+	) {
 		return null
 	}
 
 	return new Date(referenceTimeMs + (quantity / burningPerHour) * 60 * 60 * 1000).toISOString()
 }
 
+/**
+ * ESI's reagent amount is a point-in-time baseline, not a live counter.
+ * Project it forward using the reported burn rate while never allowing a
+ * future or malformed timestamp to increase the reported amount.
+ */
+export function estimateSovereigntyReagentAmount(
+	reagent: Pick<SovereigntyReagentEntry, 'amount' | 'burningPerHour'>,
+	lastUpdated: string | null | undefined,
+	referenceTimeMs = Date.now()
+): number {
+	const amount = Number.isFinite(reagent.amount) ? Math.floor(Math.max(0, reagent.amount)) : 0
+	const burningPerHour = reagent.burningPerHour
+	const snapshotTimeMs = parseTimestampMs(lastUpdated)
+
+	if (snapshotTimeMs === null || !Number.isFinite(burningPerHour) || burningPerHour <= 0) {
+		return amount
+	}
+
+	const elapsedHours = Math.max(0, referenceTimeMs - snapshotTimeMs) / (60 * 60 * 1000)
+	return Math.floor(Math.max(0, amount - elapsedHours * burningPerHour))
+}
+
+export function getEstimatedSovereigntyReagent(
+	reagent: SovereigntyReagentEntry,
+	lastUpdated: string | null | undefined,
+	referenceTimeMs = Date.now()
+): SovereigntyReagentEntry {
+	const estimatedAmount = estimateSovereigntyReagentAmount(reagent, lastUpdated, referenceTimeMs)
+
+	return {
+		...reagent,
+		estimatedAmount,
+		estimatedDepletionAt: estimateReagentDepletionAt(
+			estimatedAmount,
+			reagent.burningPerHour,
+			referenceTimeMs
+		),
+	}
+}
+
 export function summarizeSovereigntyReagentStats(
 	reagents: readonly SovereigntyReagentEntry[],
 	match: { typeId: string; typeName: string },
-	referenceTimeMs: number
+	referenceTimeMs: number,
+	lastUpdated?: string | null
 ): {
 	quantity: number
 	burningPerHour: number
@@ -62,7 +122,11 @@ export function summarizeSovereigntyReagentStats(
 				return accumulator
 			}
 
-			accumulator.quantity += reagent.amount
+			accumulator.quantity += estimateSovereigntyReagentAmount(
+				reagent,
+				lastUpdated,
+				referenceTimeMs
+			)
 			accumulator.burningPerHour += reagent.burningPerHour
 			return accumulator
 		},
@@ -81,7 +145,8 @@ export function summarizeSovereigntyReagentStats(
 
 export function summarizeSovereigntyReagentBay(
 	reagents: readonly SovereigntyReagentEntry[],
-	referenceTimeMs = Date.now()
+	referenceTimeMs = Date.now(),
+	lastUpdated?: string | null
 ): SovereigntyReagentSummary {
 	const magmaticGasStats = summarizeSovereigntyReagentStats(
 		reagents,
@@ -89,7 +154,8 @@ export function summarizeSovereigntyReagentBay(
 			typeId: SKYHOOK_MAGMATIC_GAS_TYPE_ID,
 			typeName: SKYHOOK_MAGMATIC_GAS_TYPE_NAME,
 		},
-		referenceTimeMs
+		referenceTimeMs,
+		lastUpdated
 	)
 	const superionicIceStats = summarizeSovereigntyReagentStats(
 		reagents,
@@ -97,7 +163,8 @@ export function summarizeSovereigntyReagentBay(
 			typeId: SKYHOOK_SUPERIONIC_ICE_TYPE_ID,
 			typeName: SKYHOOK_SUPERIONIC_ICE_TYPE_NAME,
 		},
-		referenceTimeMs
+		referenceTimeMs,
+		lastUpdated
 	)
 
 	return {
@@ -124,11 +191,14 @@ export function getSovereigntyReagentBayReagents(
 }
 
 export function getSovereigntyReagentBaySummary(
-	value: SovereigntyReagentBaySnapshotValue
+	value: SovereigntyReagentBaySnapshotValue,
+	referenceTimeMs = Date.now()
 ): SovereigntyReagentSummary | null {
 	if (Array.isArray(value)) {
-		return summarizeSovereigntyReagentBay(value)
+		return summarizeSovereigntyReagentBay(value, referenceTimeMs)
 	}
 
-	return value.summary ?? summarizeSovereigntyReagentBay(value.reagents)
+	// Do not reuse the persisted summary: it was calculated when the snapshot
+	// was ingested and cannot account for elapsed reagent burn.
+	return summarizeSovereigntyReagentBay(value.reagents, referenceTimeMs, value.lastUpdated)
 }

--- a/scripts/diagnose-character-notifications.mjs
+++ b/scripts/diagnose-character-notifications.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ESI_BASE_URL = 'https://esi.evetech.net'
+const EVE_OAUTH_METADATA_URL = 'https://login.eveonline.com/.well-known/oauth-authorization-server'
+const EVE_SSO_VERIFY_URL = 'https://login.eveonline.com/oauth/verify'
+const DEFAULT_COMPATIBILITY_DATE = '2026-05-19'
+const USER_AGENT = 'pleaseignore.app character notifications diagnostic/1.0'
+const ESI_HOSTNAME = new URL(ESI_BASE_URL).hostname
+const EVE_SSO_HOSTNAME = new URL(EVE_OAUTH_METADATA_URL).hostname
+
+function parseEnvValue(rawValue) {
+	let value = ''
+	let quote = null
+
+	for (let index = 0; index < rawValue.length; index += 1) {
+		const character = rawValue[index]
+		if (quote) {
+			if (character === quote) quote = null
+			else value += character
+			continue
+		}
+
+		if (character === '"' || character === "'") quote = character
+		else if (character === '#' && (index === 0 || /\s/.test(rawValue[index - 1]))) break
+		else value += character
+	}
+
+	return value.trim()
+}
+
+function loadEnvFile() {
+	const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+	const envPath = resolve(rootDir, '.env')
+
+	try {
+		for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+			const trimmed = line.trim()
+			if (!trimmed || trimmed.startsWith('#')) continue
+
+			const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/)
+			if (!match) continue
+
+			const [, key, rawValue] = match
+			if (!process.env[key]) process.env[key] = parseEnvValue(rawValue)
+		}
+	} catch (error) {
+		if (error?.code !== 'ENOENT') throw error
+	}
+}
+
+function getRequiredEnv(name) {
+	const value = process.env[name]?.trim()
+	if (!value) throw new Error(`Missing ${name} in .env or the process environment`)
+	return value
+}
+
+function validateCharacterId(value) {
+	if (!/^\d+$/.test(value) || value === '0') {
+		throw new Error(`Invalid character ID: ${value}`)
+	}
+	return value
+}
+
+function validateOfficialHttpsUrl(value, hostname, label, preservePath = false) {
+	let url
+	try {
+		url = new URL(value)
+	} catch {
+		throw new Error(`Invalid ${label}: ${value}`)
+	}
+
+	if (
+		url.protocol !== 'https:' ||
+		url.hostname !== hostname ||
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash
+	) {
+		throw new Error(`${label} must be an HTTPS URL on ${hostname}`)
+	}
+
+	return preservePath ? url.href : url.origin
+}
+
+function parseArgs(args) {
+	const parsedArgs = args[0] === '--' ? args.slice(1) : args
+	let characterId = process.env.DIAGNOSTIC_CHARACTER_ID?.trim()
+	let baseUrl = ESI_BASE_URL
+	let compatibilityDate = DEFAULT_COMPATIBILITY_DATE
+
+	for (let index = 0; index < parsedArgs.length; index += 1) {
+		const argument = parsedArgs[index]
+		if (argument === '--character-id' || argument === '--character') {
+			characterId = parsedArgs[++index]
+		} else if (argument === '--base-url') {
+			baseUrl = parsedArgs[++index] ?? baseUrl
+		} else if (argument === '--compatibility-date') {
+			compatibilityDate = parsedArgs[++index] ?? compatibilityDate
+		} else if (argument === '--help' || argument === '-h') {
+			console.log(`Usage: node scripts/diagnose-character-notifications.mjs [options]
+
+Required environment variables:
+  DIAGNOSTIC_EVE_SSO_CLIENT_ID
+  DIAGNOSTIC_EVE_SSO_CLIENT_SECRET
+  DIAGNOSTIC_EVE_SSO_REFRESH_TOKEN
+
+Character selection:
+  DIAGNOSTIC_CHARACTER_ID       Optional character ID (or pass --character-id)
+                                Omit to resolve it from the diagnostic token
+
+Options:
+  --character-id <id>            Character ID to inspect
+  --base-url <url>               ESI base URL (default: ${ESI_BASE_URL})
+  --compatibility-date <date>    X-Compatibility-Date override (default: ${DEFAULT_COMPATIBILITY_DATE})
+  --help                         Show this help text`)
+			process.exit(0)
+		} else {
+			throw new Error(`Unknown argument: ${argument}`)
+		}
+	}
+
+	return {
+		characterId: characterId ? validateCharacterId(characterId) : null,
+		baseUrl: validateOfficialHttpsUrl(baseUrl, ESI_HOSTNAME, 'ESI base URL'),
+		compatibilityDate,
+	}
+}
+
+function isRecord(value) {
+	return typeof value === 'object' && value !== null
+}
+
+async function readResponse(response, label) {
+	const bodyText = await response.text()
+	let payload
+
+	try {
+		payload = JSON.parse(bodyText)
+	} catch {
+		payload = bodyText
+	}
+
+	if (!response.ok) {
+		const detail = typeof payload === 'string' ? payload.slice(0, 1000) : JSON.stringify(payload)
+		throw new Error(`${label} failed: ${response.status} ${response.statusText} - ${detail}`)
+	}
+
+	return { payload, response }
+}
+
+async function refreshAccessToken() {
+	const metadataResponse = await fetch(EVE_OAUTH_METADATA_URL, {
+		headers: {
+			Accept: 'application/json',
+			'User-Agent': USER_AGENT,
+		},
+	})
+	const { payload: metadata } = await readResponse(
+		metadataResponse,
+		'GET /.well-known/oauth-authorization-server'
+	)
+
+	if (!isRecord(metadata) || typeof metadata.token_endpoint !== 'string') {
+		throw new Error('OAuth metadata did not include a token endpoint')
+	}
+	const tokenEndpoint = validateOfficialHttpsUrl(
+		metadata.token_endpoint,
+		EVE_SSO_HOSTNAME,
+		'OAuth token endpoint',
+		true
+	)
+
+	const clientId = getRequiredEnv('DIAGNOSTIC_EVE_SSO_CLIENT_ID')
+	const clientSecret = getRequiredEnv('DIAGNOSTIC_EVE_SSO_CLIENT_SECRET')
+	const refreshToken = getRequiredEnv('DIAGNOSTIC_EVE_SSO_REFRESH_TOKEN')
+	const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+	const response = await fetch(tokenEndpoint, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			Authorization: `Basic ${credentials}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'User-Agent': USER_AGENT,
+		},
+		body: new URLSearchParams({
+			grant_type: 'refresh_token',
+			refresh_token: refreshToken,
+		}),
+	})
+	const { payload } = await readResponse(response, 'Refresh token exchange')
+
+	if (!isRecord(payload) || typeof payload.access_token !== 'string') {
+		throw new Error('Refresh token exchange did not return an access token')
+	}
+
+	return payload.access_token
+}
+
+async function resolveCharacterId(accessToken) {
+	const response = await fetch(EVE_SSO_VERIFY_URL, {
+		headers: {
+			Accept: 'application/json',
+			Authorization: `Bearer ${accessToken}`,
+			'User-Agent': USER_AGENT,
+		},
+	})
+	const { payload } = await readResponse(response, 'EVE SSO token verification')
+	const characterId = isRecord(payload) ? (payload.CharacterID ?? payload.character_id) : null
+
+	if (typeof characterId !== 'number' && typeof characterId !== 'string') {
+		throw new Error('EVE SSO token verification did not return a character ID')
+	}
+
+	return validateCharacterId(String(characterId))
+}
+
+async function fetchNotifications(config, accessToken) {
+	const response = await fetch(`${config.baseUrl}/characters/${config.characterId}/notifications`, {
+		headers: {
+			Accept: 'application/json',
+			Authorization: `Bearer ${accessToken}`,
+			'User-Agent': USER_AGENT,
+			'X-Compatibility-Date': config.compatibilityDate,
+		},
+	})
+
+	const result = await readResponse(response, `GET /characters/${config.characterId}/notifications`)
+
+	return {
+		status: response.status,
+		responseHeaders: {
+			cacheControl: response.headers.get('Cache-Control'),
+			contentType: response.headers.get('Content-Type'),
+			etag: response.headers.get('ETag'),
+			lastModified: response.headers.get('Last-Modified'),
+			xCompatibilityDate: response.headers.get('X-Compatibility-Date'),
+		},
+		payload: result.payload,
+	}
+}
+
+async function main() {
+	loadEnvFile()
+	const config = parseArgs(process.argv.slice(2))
+	const accessToken = await refreshAccessToken()
+	const characterId = config.characterId ?? (await resolveCharacterId(accessToken))
+	const result = await fetchNotifications({ ...config, characterId }, accessToken)
+
+	process.stdout.write(
+		`${JSON.stringify(
+			{
+				character_id: characterId,
+				endpoint: `/characters/${characterId}/notifications`,
+				compatibility_date: config.compatibilityDate,
+				...result,
+			},
+			null,
+			2
+		)}\n`
+	)
+}
+
+main().catch((error) => {
+	console.error(
+		'[character-notifications-diagnostic]',
+		error instanceof Error ? error.message : String(error)
+	)
+	process.exitCode = 1
+})


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
The sovereignty reagent bay snapshot from ESI is a point-in-time baseline that only updates when touched, so quantities shown in the UI and used in queries were becoming stale between syncs. This PR projects reagent amounts forward from the last known snapshot using the reported burn rate, computed at query/render time instead of relying on a persisted summary.

## Changes
- Add `estimateSovereigntyReagentAmount` / `getEstimatedSovereigntyReagent` in `packages/structures/src/sovereignty-metrics.ts` to project a reagent's remaining amount (and estimated depletion time) forward from `lastUpdated` using its burn rate, clamped so it never increases or goes negative.
- Change `summarizeSovereigntyReagentStats` / `summarizeSovereigntyReagentBay` / `getSovereigntyReagentBaySummary` to always recompute the summary from raw reagents plus `lastUpdated` at call time, rather than reusing the persisted `summary` field, which reflected values only from the last ingest.
- Update `summarizeStructureSovereigntyHub` (`apps/structures/src/services/structures.service.ts`) to build `reagentBay` with per-reagent `estimatedAmount`/`estimatedDepletionAt` and to resolve `lastUpdated` from either the snapshot object or the `reagentBayLastUpdated` column.
- Rework `buildSovereigntyReagentMetricSql` to derive reagent totals in SQL by projecting `amount` forward from the snapshot's `lastUpdated` and `burningPerHour`, instead of trusting the persisted `summary` JSON.
- Remove the now-unused `summarizeSovereigntyReagentBay` call/import from `apps/eve-corporation-data/src/durable-object.ts` (the persisted `summary` field is no longer written there).
- Update the structures detail UI (`apps/ui/src/client/routes/structures-detail.tsx`) to show "Est. Amount" (approximated, prefixed with `~`) and an estimated depletion duration, and add a "Reagent Bay" sync status badge explaining that quantities are approximations from the last ESI baseline. Also generalize the asset sync status helpers to a shared `snapshotSyncStatus`/`snapshotSyncStatusDescription` used by both asset and reagent bay sync indicators.
- Add `estimatedAmount?`/`estimatedDepletionAt?` fields to `StructureSovereigntyReagent`/`SovereigntyReagentEntry` types.
- Add a new `scripts/diagnose-character-notifications.mjs` diagnostic script (with a `diagnose:character-notifications` package.json script) for inspecting the `/characters/{id}/notifications` ESI endpoint, following the pattern of the existing diagnostic scripts.

## Testing
- Added a unit test in `apps/structures/src/test/unit/services/sovereignty-hub-model.test.ts` covering `estimateSovereigntyReagentAmount`, `getEstimatedSovereigntyReagent`, and `getSovereigntyReagentBaySummary` projecting reagent quantities forward in time from a fixed reference timestamp.
<!-- claude:end -->
