### PR TITLE
fix HR admin role access when granted to a director

### DIFF
--- a/apps/core/src/routes/__tests__/corporations.access.route.test.ts
+++ b/apps/core/src/routes/__tests__/corporations.access.route.test.ts
@@ -89,6 +89,7 @@ describe('corporations access route', () => {
 	}
 	let hrStub: {
 		checkPermission: ReturnType<typeof vi.fn>
+		getUserRoles: ReturnType<typeof vi.fn>
 	}
 	let corpStub: {
 		getCorporationInfo: ReturnType<typeof vi.fn>
@@ -126,6 +127,7 @@ describe('corporations access route', () => {
 		}
 		hrStub = {
 			checkPermission: vi.fn().mockResolvedValue(false),
+			getUserRoles: vi.fn().mockResolvedValue([]),
 		}
 		corpStub = {
 			getCorporationInfo: vi.fn().mockResolvedValue({ ceoId: '1001' } as any),
@@ -149,6 +151,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: true,
 			userRole: 'CEO',
+			hrRole: null,
 			corporation: {
 				corporationId: '1001',
 				name: 'Alpha Corp',
@@ -169,6 +172,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: true,
 			userRole: 'admin',
+			hrRole: null,
 			corporation: {
 				corporationId: '1001',
 				name: 'Alpha Corp',
@@ -194,6 +198,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: true,
 			userRole: 'Director',
+			hrRole: null,
 			corporation: {
 				corporationId: '1001',
 				name: 'Alpha Corp',
@@ -204,6 +209,30 @@ describe('corporations access route', () => {
 			},
 		})
 		expect(charStub.getCharacterInfo).not.toHaveBeenCalled()
+	})
+
+	it('preserves director access while exposing an explicit HR admin role', async () => {
+		corpStub.getCorporationInfo.mockResolvedValue({ ceoId: '9999' } as any)
+		corpStub.getDirectors.mockResolvedValue([{ characterId: '1001' }] as any)
+		hrStub.getUserRoles.mockResolvedValue([{ role: 'hr_admin', grantedBy: 'user-2' }])
+
+		const app = createApp(makeUser(), dbStub)
+		const response = await app.request('/api/corporations/1001/access', {}, env)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			hasAccess: true,
+			userRole: 'Director',
+			hrRole: 'hr_admin',
+			corporation: {
+				corporationId: '1001',
+				name: 'Alpha Corp',
+				ticker: 'ALP',
+				isMemberCorporation: true,
+				isAltCorp: false,
+				isSpecialPurpose: false,
+			},
+		})
 	})
 
 	it('returns HR admin access for member corporations', async () => {
@@ -218,6 +247,7 @@ describe('corporations access route', () => {
 		])
 		getCachedUserPermissionsMock.mockResolvedValue([])
 		hrStub.checkPermission.mockResolvedValue(true)
+		hrStub.getUserRoles.mockResolvedValue([{ role: 'hr_admin', grantedBy: 'user-2' }])
 
 		const app = createApp(makeUser(), dbStub)
 		const response = await app.request('/api/corporations/1001/access', {}, env)
@@ -226,6 +256,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: true,
 			userRole: 'hr_admin',
+			hrRole: 'hr_admin',
 			corporation: {
 				corporationId: '1001',
 				name: 'Alpha Corp',
@@ -252,6 +283,7 @@ describe('corporations access route', () => {
 			async (_userId: string, _corporationId: string, requiredRole: string) =>
 				requiredRole === 'hr_viewer' || requiredRole === 'hr_reviewer'
 		)
+		hrStub.getUserRoles.mockResolvedValue([{ role: 'hr_reviewer', grantedBy: 'user-2' }])
 
 		const app = createApp(makeUser(), dbStub)
 		const response = await app.request('/api/corporations/1001/access', {}, env)
@@ -260,6 +292,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: true,
 			userRole: 'hr_reviewer',
+			hrRole: 'hr_reviewer',
 			corporation: {
 				corporationId: '1001',
 				name: 'Alpha Corp',
@@ -291,6 +324,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: true,
 			userRole: 'hr_viewer',
+			hrRole: null,
 			corporation: {
 				corporationId: '1001',
 				name: 'Alpha Corp',
@@ -321,6 +355,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: false,
 			userRole: null,
+			hrRole: null,
 			corporation: {
 				corporationId: '1001',
 				name: 'Alpha Corp',
@@ -343,6 +378,7 @@ describe('corporations access route', () => {
 		expect(await response.json()).toEqual({
 			hasAccess: false,
 			userRole: null,
+			hrRole: null,
 			corporation: null,
 		})
 		expect(corpStub.getCorporationInfo).not.toHaveBeenCalled()

--- a/apps/core/src/routes/corporations/index.ts
+++ b/apps/core/src/routes/corporations/index.ts
@@ -82,8 +82,11 @@ type CorporationAccessScope = {
 type CorporationAccessScopeResponse = {
 	hasAccess: boolean
 	userRole: 'CEO' | 'Director' | 'admin' | 'hr_admin' | 'hr_reviewer' | 'hr_viewer' | null
+	hrRole: 'hr_admin' | 'hr_reviewer' | 'hr_viewer' | null
 	corporation: CorporationAccessScope | null
 }
+
+type ExplicitCorporationHrRole = 'hr_admin' | 'hr_reviewer' | 'hr_viewer'
 
 async function hasMemberCorpHrPermission(
 	c: Context<App>,
@@ -132,6 +135,42 @@ async function resolveCorporationMembersAccess(
 }
 
 /**
+ * Resolve an explicitly granted HR role without treating leadership inference
+ * as an HR assignment. Leadership remains available through `userRole`.
+ */
+async function resolveExplicitCorporationHrRole(
+	c: Context<App>,
+	corporationId: string,
+	managedCorp: MemberCorpHrAccess | null
+): Promise<ExplicitCorporationHrRole | null> {
+	if (!managedCorp?.isMemberCorporation) {
+		return null
+	}
+
+	const user = c.get('user')!
+	const hr = getStub<Hr>(c.env.HR, 'default')
+
+	try {
+		return await withRpcResult(hr.getUserRoles(user.id, corporationId), (roles) => {
+			const explicitRoles = roles.filter((role) => role.grantedBy !== 'leadership-inference')
+			if (explicitRoles.some((role) => role.role === 'hr_admin')) return 'hr_admin'
+			if (explicitRoles.some((role) => role.role === 'hr_reviewer')) return 'hr_reviewer'
+			if (explicitRoles.some((role) => role.role === 'hr_viewer')) return 'hr_viewer'
+			return null
+		})
+	} catch (error) {
+		// A capability decoration failure must not remove already-resolved
+		// leadership access from the page.
+		logger.warn('[Corporations] Failed to resolve explicit HR role', {
+			corporationId,
+			userId: user.id,
+			error: error instanceof Error ? error.message : String(error),
+		})
+		return null
+	}
+}
+
+/**
  * GET /corporations/:corporationId/access
  * Corp-scoped access check used by single-corporation screens.
  * Returns the corporation metadata needed for page-level gating plus the access role.
@@ -165,6 +204,7 @@ app.get('/:corporationId/access', requireAuth(), async (c) => {
 			const response: CorporationAccessScopeResponse = {
 				hasAccess: false,
 				userRole: null,
+				hrRole: null,
 				corporation: null,
 			}
 			return c.json(response)
@@ -174,10 +214,14 @@ app.get('/:corporationId/access', requireAuth(), async (c) => {
 			const userRole = await resolveCorporationMembersAccess(c, corporationId, {
 				isMemberCorporation: managedCorp.isMemberCorporation,
 			})
+			const hrRole = await resolveExplicitCorporationHrRole(c, corporationId, {
+				isMemberCorporation: managedCorp.isMemberCorporation,
+			})
 
 			const response: CorporationAccessScopeResponse = {
 				hasAccess: true,
 				userRole,
+				hrRole,
 				corporation: managedCorp,
 			}
 			return c.json(response)
@@ -189,6 +233,7 @@ app.get('/:corporationId/access', requireAuth(), async (c) => {
 			const response: CorporationAccessScopeResponse = {
 				hasAccess: false,
 				userRole: null,
+				hrRole: null,
 				corporation: managedCorp,
 			}
 			return c.json(response)

--- a/apps/ui/src/client/features/applications/routes/hr-roles-management.tsx
+++ b/apps/ui/src/client/features/applications/routes/hr-roles-management.tsx
@@ -78,6 +78,7 @@ export default function HrRolesManagement() {
 		canAccess,
 		isLoading: accessLoading,
 		userRole,
+		hrRole,
 		corporation: accessCorp,
 	} = useCanAccessCorporation(corporationId!)
 	const { data: corporation, isLoading: corpLoading } = useMyCorporation(corporationId!)
@@ -112,9 +113,9 @@ export default function HrRolesManagement() {
 	// Check if current user can manage HR roles (CEO, site admin, or HR admin)
 	const canManageHrRoles = useMemo(() => {
 		return (
-			isMemberCorporation && (userRole === 'CEO' || userRole === 'admin' || userRole === 'hr_admin')
+			isMemberCorporation && (userRole === 'CEO' || userRole === 'admin' || hrRole === 'hr_admin')
 		)
-	}, [isMemberCorporation, userRole])
+	}, [isMemberCorporation, hrRole, userRole])
 	const canRevokeHrAdmin = useMemo(
 		() => isMemberCorporation && (userRole === 'CEO' || userRole === 'admin'),
 		[isMemberCorporation, userRole]
@@ -441,10 +442,15 @@ export default function HrRolesManagement() {
 							Manage HR roles for {corp?.name || 'this corporation'}
 							{corp?.ticker && ` [${corp.ticker}]`}
 						</p>
-						{userRole && (
+						{(userRole || hrRole) && (
 							<p className="text-sm text-muted-foreground mt-1">
 								Your role:{' '}
-								<span className="font-medium">{formatCorporationRoleLabel(userRole)}</span>
+								<span className="font-medium">
+									{[userRole, hrRole]
+										.filter((role, index, roles) => role !== null && roles.indexOf(role) === index)
+										.map((role) => formatCorporationRoleLabel(role))
+										.join(' / ')}
+								</span>
 							</p>
 						)}
 					</div>

--- a/apps/ui/src/client/features/corporations/api.ts
+++ b/apps/ui/src/client/features/corporations/api.ts
@@ -202,6 +202,7 @@ export interface CorporationCoverageResult {
 export interface CorporationScopedAccessResult {
 	hasAccess: boolean
 	userRole: 'CEO' | 'Director' | 'admin' | 'hr_admin' | 'hr_reviewer' | 'hr_viewer' | null
+	hrRole: 'hr_admin' | 'hr_reviewer' | 'hr_viewer' | null
 	corporation: Pick<
 		ManagedCorporation,
 		'corporationId' | 'name' | 'ticker' | 'isMemberCorporation' | 'isAltCorp' | 'isSpecialPurpose'

--- a/apps/ui/src/client/features/corporations/hooks.ts
+++ b/apps/ui/src/client/features/corporations/hooks.ts
@@ -331,6 +331,7 @@ export function useCanAccessCorporation(corporationId: string) {
 	const canAccess = access?.hasAccess ?? false
 	const corporation = access?.corporation ?? undefined
 	const userRole = access?.userRole ?? undefined
+	const hrRole = access?.hrRole ?? undefined
 
-	return { canAccess, userRole, corporation, isLoading, isFetching }
+	return { canAccess, userRole, hrRole, corporation, isLoading, isFetching }
 }

--- a/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
+++ b/apps/ui/src/client/features/corporations/routes/corporation-members.tsx
@@ -144,6 +144,7 @@ export default function CorporationMembers() {
 		canAccess: hasCorpAccess,
 		isLoading: accessLoading,
 		userRole,
+		hrRole,
 		corporation: accessCorp,
 	} = useCanAccessCorporation(corporationId!)
 	const canAccess = hasCorpAccess || isAuditor
@@ -180,9 +181,8 @@ export default function CorporationMembers() {
 
 	// Determine capability flags based on user role
 	const isLeadership = userRole === 'CEO' || userRole === 'Director' || userRole === 'admin'
-	const isHrAdmin = userRole === 'hr_admin'
-	const isHrOnly =
-		userRole === 'hr_admin' || userRole === 'hr_reviewer' || userRole === 'hr_viewer' || isAuditor
+	const isHrAdmin = hrRole === 'hr_admin'
+	const isHrOnly = Boolean(hrRole) || isAuditor
 	const isMemberCorporation =
 		corporation?.isMemberCorporation ?? accessCorp?.isMemberCorporation ?? false
 
@@ -195,10 +195,8 @@ export default function CorporationMembers() {
 
 	// Can manage HR roles: member corp only, with CEO/admin/hr_admin access
 	const canManageHrRoles = useMemo(() => {
-		return (
-			isMemberCorporation && (userRole === 'CEO' || userRole === 'admin' || userRole === 'hr_admin')
-		)
-	}, [isMemberCorporation, userRole])
+		return isMemberCorporation && (userRole === 'CEO' || userRole === 'admin' || isHrAdmin)
+	}, [isMemberCorporation, isHrAdmin, userRole])
 	const { data: hrRoles, isLoading: hrRolesLoading } = useHrRoles(corporationId!, {
 		enabled: canManageHrRoles,
 	})
@@ -206,7 +204,7 @@ export default function CorporationMembers() {
 		() =>
 			!isMemberCorporation
 				? ([] as const)
-				: userRole === 'CEO'
+				: userRole === 'CEO' || userRole === 'admin'
 					? (['hr_admin', 'hr_reviewer', 'hr_viewer'] as const)
 					: (['hr_reviewer', 'hr_viewer'] as const),
 		[isMemberCorporation, userRole]
@@ -462,10 +460,15 @@ export default function CorporationMembers() {
 							View and manage all members of {corpTicker ? `[${corpTicker}]` : 'this corporation'}
 							{corpAllianceName && ` • Alliance: ${corpAllianceName}`}
 						</p>
-						{userRole && (
+						{(userRole || hrRole) && (
 							<p className="text-sm text-muted-foreground mt-1">
 								Your role:{' '}
-								<span className="font-medium">{formatCorporationRoleLabel(userRole)}</span>
+								<span className="font-medium">
+									{[userRole, hrRole]
+										.filter((role, index, roles) => role !== null && roles.indexOf(role) === index)
+										.map((role) => formatCorporationRoleLabel(role))
+										.join(' / ')}
+								</span>
 							</p>
 						)}
 					</div>
@@ -509,7 +512,7 @@ export default function CorporationMembers() {
 						{canUseHrTools ? (
 							<CardDescription>
 								{isHrOnly && !isLeadership
-									? `You have ${formatCorporationRoleLabel(userRole ?? 'hr_viewer')} access for this corporation`
+									? `You have ${formatCorporationRoleLabel(hrRole ?? 'hr_viewer')} access for this corporation`
 									: userRole === 'CEO'
 										? 'You have CEO access to all HR features'
 										: 'You have site admin access to all HR features'}

--- a/apps/ui/src/client/features/corporations/routes/corporation-settings.tsx
+++ b/apps/ui/src/client/features/corporations/routes/corporation-settings.tsx
@@ -53,13 +53,14 @@ export default function CorporationSettings() {
 	const {
 		isLoading: accessLoading,
 		userRole,
+		hrRole,
 		corporation: accessCorp,
 	} = useCanAccessCorporation(corporationId ?? '')
 	const isMemberCorporation = accessCorp?.isMemberCorporation === true
 	const canManageSettings =
 		user?.is_admin === true ||
 		(isMemberCorporation &&
-			(userRole === 'CEO' || userRole === 'Director' || userRole === 'hr_admin'))
+			(userRole === 'CEO' || userRole === 'Director' || hrRole === 'hr_admin'))
 
 	// Fetch corporation details
 	const {


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Fixes HR admin access being silently dropped when a user who already has leadership access (e.g. a Director) is also explicitly granted the `hr_admin` HR role. Previously the corporation access endpoint returned a single `userRole` that prioritized leadership over HR grants, so callers comparing `userRole === 'hr_admin'` never matched for a Director/CEO/admin who also held an HR role.

## Changes
- `apps/core/src/routes/corporations/index.ts`: add `resolveExplicitCorporationHrRole`, which looks up the user's HR roles via the `Hr` durable object and returns the highest explicitly granted role (`hr_admin` > `hr_reviewer` > `hr_viewer`), ignoring roles inferred from leadership (`grantedBy === 'leadership-inference'`). Add a new `hrRole` field to the `/corporations/:corporationId/access` response, returned alongside the existing `userRole`, and default it to `null` on all early-return/no-access paths. Failures resolving HR roles are logged and treated as "no explicit HR role" rather than failing the whole access check.
- `apps/ui/src/client/features/corporations/api.ts` and `hooks.ts`: add `hrRole` to `CorporationScopedAccessResult` and expose it from `useCanAccessCorporation`.
- `apps/ui/src/client/features/corporations/routes/corporation-members.tsx`, `corporation-settings.tsx`, `applications/routes/hr-roles-management.tsx`: switch HR-admin/HR-only capability checks (`canManageHrRoles`, `isHrAdmin`, `isHrOnly`, settings access) to use the new `hrRole` instead of overloading `userRole`, and update the "Your role" display to show both the leadership role and the explicit HR role when both are present.

## Testing
- Updated/added unit tests in `apps/core/src/routes/__tests__/corporations.access.route.test.ts` covering the new `hrRole` field on all response branches, including a new case verifying a Director with an explicitly granted `hr_admin` role keeps `userRole: 'Director'` and gets `hrRole: 'hr_admin'`.
<!-- claude:end -->