### PR TITLE
add parameter to reqeust a bounded count of tokens

### DIFF
--- a/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
+++ b/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
@@ -127,7 +127,7 @@ describe('member access token export route', () => {
 		expect(await response.json()).toEqual({ corporationIds: ['100', '200'] })
 	})
 
-	it('selects directors first and caps each corporation at fifteen tokens', async () => {
+	it('randomly selects valid tokens and honors the requested per-corporation count', async () => {
 		db.query.managedCorporations.findMany.mockResolvedValue([
 			{ corporationId: '100', name: 'Member Corp' },
 			{ corporationId: '200', name: 'Special Corp' },
@@ -148,7 +148,7 @@ describe('member access token export route', () => {
 		)
 
 		const response = await createApp().request(
-			'/api/internal/member-refresh-tokens',
+			'/api/internal/member-refresh-tokens?count=3',
 			{
 				method: 'GET',
 				headers: { Authorization: 'Bearer expected-token' },
@@ -160,23 +160,19 @@ describe('member access token export route', () => {
 		expect(response.headers.get('Cache-Control')).toBe('no-store')
 		const body = (await response.json()) as any
 		expect(body.corporations).toHaveLength(2)
-		expect(body.corporations[0].tokens).toHaveLength(15)
-		expect(body.corporations[0].tokens.slice(0, 2).map((token: any) => token.role)).toEqual([
-			'director',
-			'director',
-		])
+		expect(body.corporations[0].tokens).toHaveLength(3)
 		expect(body.corporations[0].tokens.every((token: any) => token.accessToken)).toBe(true)
 		expect(body.corporations[0].tokens.every((token: any) => token.expiresAt)).toBe(true)
 		expect(body.corporations[0].tokens.every((token: any) => !token.refreshToken)).toBe(true)
-		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledTimes(1)
-		const firstLookup = tokenStore.getAccessTokensForIntegration.mock.calls[0][0] as string[]
-		expect(firstLookup.slice(0, 2)).toEqual(['1010', '1011'])
-		expect(new Set(firstLookup)).toEqual(
-			new Set(characters.map((character) => character.characterId))
-		)
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledTimes(2)
+		expect(
+			tokenStore.getAccessTokensForIntegration.mock.calls.every(
+				([characterIds]) => (characterIds as string[]).length === 3
+			)
+		).toBe(true)
 	})
 
-	it('randomizes ordinary member ordering while retaining director priority', async () => {
+	it('randomizes all candidates without director priority', async () => {
 		db.query.managedCorporations.findMany.mockResolvedValue([
 			{ corporationId: '100', name: 'Member Corp' },
 		])
@@ -223,7 +219,52 @@ describe('member access token export route', () => {
 		}
 	})
 
-	it('excludes unknown-token characters and unhealthy directors', async () => {
+	it('continues with another candidate when access-token generation fails', async () => {
+		db.query.managedCorporations.findMany.mockResolvedValue([
+			{ corporationId: '100', name: 'Member Corp' },
+		])
+		db.query.userCharacters.findMany.mockResolvedValue([
+			{ characterId: '1000', characterName: 'Member 1', userId: 'user-1', hasValidToken: true },
+			{ characterId: '1001', characterName: 'Member 2', userId: 'user-2', hasValidToken: true },
+			{ characterId: '1002', characterName: 'Member 3', userId: 'user-3', hasValidToken: true },
+		])
+		tokenStore.getAccessTokensForIntegration.mockResolvedValue([
+			{ characterId: '1002', accessToken: 'access-1002', expiresAt: '2026-09-01T00:00:00.000Z' },
+			{ characterId: '1000', accessToken: 'access-1000', expiresAt: '2026-09-01T00:00:00.000Z' },
+		])
+
+		const cryptoApi = (
+			globalThis as unknown as {
+				crypto: { getRandomValues: (array: ArrayBufferView) => ArrayBufferView }
+			}
+		).crypto
+		const randomValues = vi.spyOn(cryptoApi, 'getRandomValues').mockImplementation((array) => {
+			;(array as Uint32Array)[0] = 0
+			return array
+		})
+		try {
+			const response = await createApp().request(
+				'/api/internal/member-refresh-tokens?count=2',
+				{
+					method: 'GET',
+					headers: { Authorization: 'Bearer expected-token' },
+				},
+				env
+			)
+
+			const body = (await response.json()) as any
+			expect(body.corporations[0].tokens.map((token: any) => token.characterId)).toEqual([
+				'1002',
+				'1000',
+			])
+			expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(1, ['1001', '1002'])
+			expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(2, ['1000'])
+		} finally {
+			randomValues.mockRestore()
+		}
+	})
+
+	it('excludes characters without a database-valid token', async () => {
 		db.query.managedCorporations.findMany.mockResolvedValue([
 			{ corporationId: '100', name: 'Member Corp' },
 		])
@@ -280,8 +321,25 @@ describe('member access token export route', () => {
 		)
 
 		const body = (await response.json()) as any
-		expect(body.corporations[0].tokens).toMatchObject([{ characterId: '1000', role: 'member' }])
+		expect(body.corporations[0].tokens).toMatchObject([{ characterId: '1000', role: 'director' }])
 		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledWith(['1000'])
+	})
+
+	it('rejects a token count outside the supported range', async () => {
+		const response = await createApp().request(
+			'/api/internal/member-refresh-tokens?count=61',
+			{
+				method: 'GET',
+				headers: { Authorization: 'Bearer expected-token' },
+			},
+			env
+		)
+
+		expect(response.status).toBe(400)
+		expect(await response.json()).toEqual({
+			error: 'count must be an integer between 1 and 60',
+		})
+		expect(createDbMock).not.toHaveBeenCalled()
 	})
 
 	it('deduplicates token rows and does not expose internal errors', async () => {

--- a/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
+++ b/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
@@ -59,23 +59,14 @@ describe('member access token export route', () => {
 			if (binding === env.EVE_TOKEN_STORE) return tokenStore as any
 			if (binding === env.EVE_CORPORATION_DATA) {
 				return {
-					getDirectors: vi.fn().mockImplementation(() =>
-						failCorporationData
-							? Promise.reject(new Error('SELECT refresh_token FROM secret_table'))
-							: Promise.resolve(
-									name === '100'
-										? [
-												{ characterId: '1010', isHealthy: true },
-												{ characterId: '1011', isHealthy: true },
-											]
-										: []
-								)
-					),
 					getCorporationIdsByCharacterIds: vi
 						.fn()
-						.mockImplementation(async (characterIds: string[]) =>
-							Object.fromEntries(characterIds.map((characterId) => [characterId, name]))
-						),
+						.mockImplementation(async (characterIds: string[]) => {
+							if (failCorporationData) {
+								throw new Error('SELECT refresh_token FROM secret_table')
+							}
+							return Object.fromEntries(characterIds.map((characterId) => [characterId, name]))
+						}),
 				} as any
 			}
 			throw new Error('Unexpected binding')
@@ -134,11 +125,10 @@ describe('member access token export route', () => {
 		])
 		const characters = Array.from({ length: 17 }, (_, index) => ({
 			characterId: String(1000 + index),
-			characterName: `Character ${index}`,
-			userId: `user-${index}`,
-			hasValidToken: true,
 		}))
-		db.query.userCharacters.findMany.mockResolvedValue(characters)
+		db.query.userCharacters.findMany.mockImplementation(async ({ limit }: { limit: number }) =>
+			characters.slice(0, limit)
+		)
 		tokenStore.getAccessTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
 			characterIds.map((characterId) => ({
 				characterId,
@@ -163,6 +153,9 @@ describe('member access token export route', () => {
 		expect(body.corporations[0].tokens).toHaveLength(3)
 		expect(body.corporations[0].tokens.every((token: any) => token.accessToken)).toBe(true)
 		expect(body.corporations[0].tokens.every((token: any) => token.expiresAt)).toBe(true)
+		expect(body.corporations[0].tokens.every((token: any) => !('characterName' in token))).toBe(
+			true
+		)
 		expect(body.corporations[0].tokens.every((token: any) => !token.refreshToken)).toBe(true)
 		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledTimes(2)
 		expect(
@@ -170,16 +163,20 @@ describe('member access token export route', () => {
 				([characterIds]) => (characterIds as string[]).length === 3
 			)
 		).toBe(true)
+		expect(db.query.userCharacters.findMany).toHaveBeenCalledTimes(2)
+		expect(
+			db.query.userCharacters.findMany.mock.calls.every(([options]) => options.limit === 3)
+		).toBe(true)
 	})
 
-	it('randomizes all candidates without director priority', async () => {
+	it('delegates random candidate selection and projection to the database', async () => {
 		db.query.managedCorporations.findMany.mockResolvedValue([
 			{ corporationId: '100', name: 'Member Corp' },
 		])
 		db.query.userCharacters.findMany.mockResolvedValue([
-			{ characterId: '1000', characterName: 'Member 1', userId: 'user-1', hasValidToken: true },
-			{ characterId: '1001', characterName: 'Member 2', userId: 'user-2', hasValidToken: true },
-			{ characterId: '1002', characterName: 'Member 3', userId: 'user-3', hasValidToken: true },
+			{ characterId: '1000' },
+			{ characterId: '1001' },
+			{ characterId: '1002' },
 		])
 		tokenStore.getAccessTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
 			characterIds.map((characterId) => ({
@@ -189,79 +186,58 @@ describe('member access token export route', () => {
 			}))
 		)
 
-		type CryptoApi = {
-			getRandomValues(array: ArrayBufferView): ArrayBufferView
-		}
-		const cryptoApi = (globalThis as unknown as { crypto: CryptoApi }).crypto
-		const randomValues = vi.spyOn(cryptoApi, 'getRandomValues').mockImplementation((array) => {
-			;(array as Uint32Array)[0] = 0
-			return array
-		})
-		try {
-			const response = await createApp().request(
-				'/api/internal/member-refresh-tokens',
-				{
-					method: 'GET',
-					headers: { Authorization: 'Bearer expected-token' },
-				},
-				env
-			)
+		const response = await createApp().request(
+			'/api/internal/member-refresh-tokens?count=2',
+			{
+				method: 'GET',
+				headers: { Authorization: 'Bearer expected-token' },
+			},
+			env
+		)
 
-			const body = (await response.json()) as any
-			expect(body.corporations[0].tokens.map((token: any) => token.characterId)).toEqual([
-				'1001',
-				'1002',
-				'1000',
-			])
-			expect(randomValues).toHaveBeenCalledTimes(2)
-		} finally {
-			randomValues.mockRestore()
-		}
+		const body = (await response.json()) as any
+		expect(body.corporations[0].tokens).toHaveLength(2)
+		expect(db.query.userCharacters.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				limit: 2,
+				columns: { characterId: true },
+			})
+		)
+		expect(db.query.userCharacters.findMany.mock.calls[0][0].orderBy).toBeDefined()
 	})
 
 	it('continues with another candidate when access-token generation fails', async () => {
 		db.query.managedCorporations.findMany.mockResolvedValue([
 			{ corporationId: '100', name: 'Member Corp' },
 		])
-		db.query.userCharacters.findMany.mockResolvedValue([
-			{ characterId: '1000', characterName: 'Member 1', userId: 'user-1', hasValidToken: true },
-			{ characterId: '1001', characterName: 'Member 2', userId: 'user-2', hasValidToken: true },
-			{ characterId: '1002', characterName: 'Member 3', userId: 'user-3', hasValidToken: true },
-		])
-		tokenStore.getAccessTokensForIntegration.mockResolvedValue([
-			{ characterId: '1002', accessToken: 'access-1002', expiresAt: '2026-09-01T00:00:00.000Z' },
-			{ characterId: '1000', accessToken: 'access-1000', expiresAt: '2026-09-01T00:00:00.000Z' },
-		])
-
-		const cryptoApi = (
-			globalThis as unknown as {
-				crypto: { getRandomValues: (array: ArrayBufferView) => ArrayBufferView }
-			}
-		).crypto
-		const randomValues = vi.spyOn(cryptoApi, 'getRandomValues').mockImplementation((array) => {
-			;(array as Uint32Array)[0] = 0
-			return array
-		})
-		try {
-			const response = await createApp().request(
-				'/api/internal/member-refresh-tokens?count=2',
-				{
-					method: 'GET',
-					headers: { Authorization: 'Bearer expected-token' },
-				},
-				env
-			)
-
-			const body = (await response.json()) as any
-			expect(body.corporations[0].tokens.map((token: any) => token.characterId)).toEqual([
-				'1002',
-				'1000',
+		db.query.userCharacters.findMany
+			.mockResolvedValueOnce([{ characterId: '1000' }, { characterId: '1001' }])
+			.mockResolvedValueOnce([{ characterId: '1002' }])
+		tokenStore.getAccessTokensForIntegration
+			.mockResolvedValueOnce([
+				{ characterId: '1001', accessToken: 'access-1001', expiresAt: '2026-09-01T00:00:00.000Z' },
 			])
-			expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(1, ['1001', '1002'])
-			expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(2, ['1000'])
-		} finally {
-			randomValues.mockRestore()
-		}
+			.mockResolvedValueOnce([
+				{ characterId: '1002', accessToken: 'access-1002', expiresAt: '2026-09-01T00:00:00.000Z' },
+			])
+
+		const response = await createApp().request(
+			'/api/internal/member-refresh-tokens?count=2',
+			{
+				method: 'GET',
+				headers: { Authorization: 'Bearer expected-token' },
+			},
+			env
+		)
+
+		const body = (await response.json()) as any
+		expect(body.corporations[0].tokens.map((token: any) => token.characterId)).toEqual([
+			'1001',
+			'1002',
+		])
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(1, ['1000', '1001'])
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(2, ['1002'])
+		expect(db.query.userCharacters.findMany).toHaveBeenCalledTimes(2)
 	})
 
 	it('excludes characters without a database-valid token', async () => {
@@ -271,21 +247,6 @@ describe('member access token export route', () => {
 		db.query.userCharacters.findMany.mockResolvedValue([
 			{
 				characterId: '1000',
-				characterName: 'Healthy Member',
-				userId: 'user-1',
-				hasValidToken: true,
-			},
-			{
-				characterId: '1001',
-				characterName: 'Unknown Member',
-				userId: 'user-2',
-				hasValidToken: null,
-			},
-			{
-				characterId: '1002',
-				characterName: 'Invalid Member',
-				userId: 'user-3',
-				hasValidToken: false,
 			},
 		])
 		tokenStore.getAccessTokensForIntegration.mockImplementation(async (characterIds: string[]) =>
@@ -300,7 +261,6 @@ describe('member access token export route', () => {
 			if (binding === env.EVE_TOKEN_STORE) return tokenStore as any
 			if (binding === env.EVE_CORPORATION_DATA) {
 				return {
-					getDirectors: vi.fn().mockResolvedValue([{ characterId: '1000', isHealthy: false }]),
 					getCorporationIdsByCharacterIds: vi
 						.fn()
 						.mockImplementation(async (characterIds: string[]) =>
@@ -321,7 +281,7 @@ describe('member access token export route', () => {
 		)
 
 		const body = (await response.json()) as any
-		expect(body.corporations[0].tokens).toMatchObject([{ characterId: '1000', role: 'director' }])
+		expect(body.corporations[0].tokens).toMatchObject([{ characterId: '1000' }])
 		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledWith(['1000'])
 	})
 
@@ -346,9 +306,7 @@ describe('member access token export route', () => {
 		db.query.managedCorporations.findMany.mockResolvedValue([
 			{ corporationId: '100', name: 'Member Corp' },
 		])
-		db.query.userCharacters.findMany.mockResolvedValue([
-			{ characterId: '1000', characterName: 'Character', userId: 'user-1', hasValidToken: true },
-		])
+		db.query.userCharacters.findMany.mockResolvedValue([{ characterId: '1000' }])
 		tokenStore.getAccessTokensForIntegration.mockResolvedValue([
 			{ characterId: '1000', accessToken: 'access-first', expiresAt: '2026-09-01T00:00:00.000Z' },
 			{ characterId: '1000', accessToken: 'access-second', expiresAt: '2026-09-01T00:00:00.000Z' },

--- a/apps/core/src/routes/member-refresh-tokens.ts
+++ b/apps/core/src/routes/member-refresh-tokens.ts
@@ -11,7 +11,8 @@ import type { EveCorporationData } from '@repo/eve-corporation-data'
 import type { DecryptedAccessToken, EveTokenStore } from '@repo/eve-token-store'
 import type { App } from '../context'
 
-const MAX_TOKENS_PER_CORPORATION = 15
+const DEFAULT_TOKENS_PER_CORPORATION = 15
+const MAX_TOKENS_PER_CORPORATION = 60
 const TOKEN_BATCH_SIZE = 100
 const CORPORATION_CONCURRENCY = 4
 
@@ -62,6 +63,26 @@ function parseRequestedCorporationIds(url: URL): { ids: string[] | null; error?:
 	return { ids }
 }
 
+function parseRequestedTokenCount(url: URL): { count: number; error?: string } {
+	const values = url.searchParams.getAll('count')
+	if (values.length === 0) return { count: DEFAULT_TOKENS_PER_CORPORATION }
+	if (values.length !== 1 || !/^\d+$/.test(values[0].trim())) {
+		return {
+			count: DEFAULT_TOKENS_PER_CORPORATION,
+			error: 'count must be an integer between 1 and 60',
+		}
+	}
+
+	const count = Number(values[0])
+	if (!Number.isSafeInteger(count) || count < 1 || count > MAX_TOKENS_PER_CORPORATION) {
+		return {
+			count: DEFAULT_TOKENS_PER_CORPORATION,
+			error: 'count must be an integer between 1 and 60',
+		}
+	}
+	return { count }
+}
+
 function getIntegrationAuthFailure(
 	expectedToken: string | undefined,
 	authorization: string | undefined
@@ -97,37 +118,30 @@ async function findEligibleCorporations(
 	})) as Corporation[]
 }
 
-function orderCandidates(
+function shuffleCandidates(
 	characters: Array<{ characterId: string; characterName: string; userId: string }>,
 	directorIds: Set<string>
 ): Candidate[] {
-	const directors: Candidate[] = []
-	const members: Candidate[] = []
+	const uniqueCharacters = [
+		...new Map(characters.map((character) => [character.characterId, character])).values(),
+	]
+	const candidates = uniqueCharacters.map((character) => ({
+		characterId: character.characterId,
+		characterName: character.characterName,
+		userId: character.userId,
+		role: directorIds.has(character.characterId) ? ('director' as const) : ('member' as const),
+	}))
 
-	for (const character of characters) {
-		const candidate = {
-			characterId: character.characterId,
-			characterName: character.characterName,
-			userId: character.userId,
-			role: directorIds.has(character.characterId) ? ('director' as const) : ('member' as const),
-		}
-		if (candidate.role === 'director') directors.push(candidate)
-		else members.push(candidate)
-	}
-
-	// Keep director priority deterministic, but rotate ordinary members so
-	// repeated daemon requests do not select the same fifteen characters forever.
-	directors.sort((a, b) => a.characterId.localeCompare(b.characterId))
-	for (let index = members.length - 1; index > 0; index -= 1) {
+	for (let index = candidates.length - 1; index > 0; index -= 1) {
 		const random = new Uint32Array(1)
 		crypto.getRandomValues(random)
 		const swapIndex = random[0] % (index + 1)
-		const current = members[index]
-		members[index] = members[swapIndex]
-		members[swapIndex] = current
+		const current = candidates[index]
+		candidates[index] = candidates[swapIndex]
+		candidates[swapIndex] = current
 	}
 
-	return [...directors, ...members]
+	return candidates
 }
 
 async function mapWithConcurrency<T, R>(
@@ -150,26 +164,54 @@ async function mapWithConcurrency<T, R>(
 	return results
 }
 
-async function getAccessTokensInBatches(
+async function resolveCorporationTokens(
 	tokenStore: EveTokenStore,
-	characterIds: readonly string[]
-): Promise<Map<string, DecryptedAccessToken>> {
-	const uniqueCharacterIds = [...new Set(characterIds)]
-	const batches = Array.from(
-		{ length: Math.ceil(uniqueCharacterIds.length / TOKEN_BATCH_SIZE) },
-		(_, index) => uniqueCharacterIds.slice(index * TOKEN_BATCH_SIZE, (index + 1) * TOKEN_BATCH_SIZE)
-	)
-	const tokenBatches = await mapWithConcurrency(batches, CORPORATION_CONCURRENCY, (batch) =>
-		tokenStore.getAccessTokensForIntegration(batch)
-	)
+	corporationData: EveCorporationData,
+	corporationId: string,
+	candidates: readonly Candidate[],
+	count: number
+): Promise<Array<Candidate & DecryptedAccessToken>> {
+	const selected: Array<Candidate & DecryptedAccessToken> = []
 
-	const tokensByCharacterId = new Map<string, DecryptedAccessToken>()
-	for (const token of tokenBatches.flat()) {
-		if (!tokensByCharacterId.has(token.characterId)) {
-			tokensByCharacterId.set(token.characterId, token)
+	// Process shuffled candidates in bounded batches. A token-store failure for
+	// one character is represented by an omitted result, so later candidates
+	// continue filling the requested count.
+	for (let offset = 0; offset < candidates.length && selected.length < count; ) {
+		const remaining = count - selected.length
+		const batch = candidates.slice(offset, offset + Math.min(TOKEN_BATCH_SIZE, remaining))
+		offset += batch.length
+		const membershipByCharacterId = await corporationData.getCorporationIdsByCharacterIds(
+			batch.map((candidate) => candidate.characterId)
+		)
+		const currentMemberCandidates = batch.filter(
+			(candidate) => membershipByCharacterId[candidate.characterId] === corporationId
+		)
+		if (currentMemberCandidates.length === 0) continue
+
+		const tokenRows = await tokenStore.getAccessTokensForIntegration(
+			currentMemberCandidates.map((candidate) => candidate.characterId)
+		)
+		const tokensByCharacterId = new Map<string, DecryptedAccessToken>()
+		for (const token of tokenRows) {
+			if (
+				typeof token.accessToken === 'string' &&
+				token.accessToken.length > 0 &&
+				typeof token.expiresAt === 'string' &&
+				!tokensByCharacterId.has(token.characterId)
+			) {
+				tokensByCharacterId.set(token.characterId, token)
+			}
+		}
+
+		for (const candidate of currentMemberCandidates) {
+			const token = tokensByCharacterId.get(candidate.characterId)
+			if (!token) continue
+			selected.push({ ...candidate, ...token })
+			if (selected.length === count) break
 		}
 	}
-	return tokensByCharacterId
+
+	return selected
 }
 
 const app = new Hono<App>()
@@ -199,6 +241,8 @@ app.get('/', async (c) => {
 
 	const parsed = parseRequestedCorporationIds(new URL(c.req.url))
 	if (parsed.error) return c.json({ error: parsed.error }, 400)
+	const requestedCount = parseRequestedTokenCount(new URL(c.req.url))
+	if (requestedCount.error) return c.json({ error: requestedCount.error }, 400)
 
 	const database = c.get('db') ?? createDb(c.env.DATABASE_URL)
 	const corporations = await findEligibleCorporations(database, parsed.ids)
@@ -236,38 +280,16 @@ app.get('/', async (c) => {
 					corporationData.getDirectors(corporation.corporationId),
 				])
 
-				const directorIds = new Set(
-					directors.filter((director) => director.isHealthy).map((director) => director.characterId)
-				)
-				const candidates = orderCandidates(
+				const directorIds = new Set(directors.map((director) => director.characterId))
+				const candidates = shuffleCandidates(
 					characters.filter((character) => character.hasValidToken === true),
 					directorIds
 				)
-				const directorCandidates = candidates.filter((candidate) => candidate.role === 'director')
-				const memberCandidates = candidates.filter((candidate) => candidate.role === 'member')
-				const candidatesForTokenLookup = [
-					...directorCandidates,
-					...memberCandidates.slice(0, MAX_TOKENS_PER_CORPORATION),
-				]
-				const currentMemberCandidates: Candidate[] = []
-
-				for (let offset = 0; offset < candidatesForTokenLookup.length; offset += TOKEN_BATCH_SIZE) {
-					const batch = candidatesForTokenLookup.slice(offset, offset + TOKEN_BATCH_SIZE)
-					const membershipByCharacterId = await corporationData.getCorporationIdsByCharacterIds(
-						batch.map((candidate) => candidate.characterId)
-					)
-					currentMemberCandidates.push(
-						...batch.filter(
-							(candidate) =>
-								membershipByCharacterId[candidate.characterId] === corporation.corporationId
-						)
-					)
-				}
 
 				return {
 					result: {
 						corporation,
-						candidates: currentMemberCandidates,
+						candidates,
 					},
 					error: null,
 				}
@@ -286,32 +308,57 @@ app.get('/', async (c) => {
 			}
 		}
 	)
-	const tokenLookupCandidates = corporationCandidates.flatMap((entry) =>
-		entry.result ? entry.result.candidates.map((candidate) => candidate.characterId) : []
+	const resolvedCorporations = await mapWithConcurrency(
+		corporationCandidates,
+		CORPORATION_CONCURRENCY,
+		async (entry) => {
+			if (!entry.result) return entry
+			const corporationData = getStub<EveCorporationData>(
+				c.env.EVE_CORPORATION_DATA,
+				entry.result.corporation.corporationId
+			)
+			try {
+				const tokens = await resolveCorporationTokens(
+					tokenStore,
+					corporationData,
+					entry.result.corporation.corporationId,
+					entry.result.candidates,
+					requestedCount.count
+				)
+				return {
+					result: {
+						corporation: entry.result.corporation,
+						candidates: tokens,
+					},
+					error: null,
+				}
+			} catch (error) {
+				logger.error('[MemberAccessTokenExport] Failed to resolve corporation access tokens', {
+					corporationId: entry.result.corporation.corporationId,
+					error: error instanceof Error ? error.message : String(error),
+				})
+				return {
+					result: null,
+					error: {
+						corporationId: entry.result.corporation.corporationId,
+						error: 'Unable to retrieve access tokens for this corporation',
+					},
+				}
+			}
+		}
 	)
-	const tokensByCharacterId = await getAccessTokensInBatches(tokenStore, tokenLookupCandidates)
-	const results = corporationCandidates.flatMap((entry) => {
+	const results = resolvedCorporations.flatMap((entry) => {
 		if (!entry.result) return []
 		const { corporation, candidates } = entry.result
 		return [
 			{
 				corporationId: corporation.corporationId,
 				corporationName: corporation.name,
-				tokens: candidates
-					.filter((candidate) => tokensByCharacterId.has(candidate.characterId))
-					.slice(0, MAX_TOKENS_PER_CORPORATION)
-					.map((candidate) => {
-						const token = tokensByCharacterId.get(candidate.characterId)!
-						return {
-							...candidate,
-							accessToken: token.accessToken,
-							expiresAt: token.expiresAt,
-						}
-					}),
+				tokens: candidates,
 			},
 		]
 	})
-	const errors = corporationCandidates.flatMap((entry) => (entry.error ? [entry.error] : []))
+	const errors = resolvedCorporations.flatMap((entry) => (entry.error ? [entry.error] : []))
 
 	return c.json(
 		{

--- a/apps/core/src/routes/member-refresh-tokens.ts
+++ b/apps/core/src/routes/member-refresh-tokens.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 
-import { and, eq, or } from '@repo/db-utils'
+import { and, eq, notInArray, or, sql } from '@repo/db-utils'
 import { getStub } from '@repo/do-utils'
 import { logger } from '@repo/hono-helpers'
 
@@ -18,19 +18,11 @@ const CORPORATION_CONCURRENCY = 4
 
 type Candidate = {
 	characterId: string
-	characterName: string
-	userId: string
-	role: 'director' | 'member'
 }
 
 type Corporation = {
 	corporationId: string
 	name: string
-}
-
-type CorporationCandidates = {
-	corporation: Corporation
-	candidates: Candidate[]
 }
 
 type Database = ReturnType<typeof createDb>
@@ -118,30 +110,30 @@ async function findEligibleCorporations(
 	})) as Corporation[]
 }
 
-function shuffleCandidates(
-	characters: Array<{ characterId: string; characterName: string; userId: string }>,
-	directorIds: Set<string>
-): Candidate[] {
-	const uniqueCharacters = [
-		...new Map(characters.map((character) => [character.characterId, character])).values(),
+async function findRandomCandidates(
+	database: Database,
+	corporationId: string,
+	excludedCharacterIds: readonly string[],
+	limit: number
+): Promise<Candidate[]> {
+	const conditions = [
+		eq(userCharacters.corporationId, corporationId),
+		eq(userCharacters.isDeleted, false),
+		eq(userCharacters.status, 'active'),
+		eq(userCharacters.hasValidToken, true),
 	]
-	const candidates = uniqueCharacters.map((character) => ({
-		characterId: character.characterId,
-		characterName: character.characterName,
-		userId: character.userId,
-		role: directorIds.has(character.characterId) ? ('director' as const) : ('member' as const),
-	}))
-
-	for (let index = candidates.length - 1; index > 0; index -= 1) {
-		const random = new Uint32Array(1)
-		crypto.getRandomValues(random)
-		const swapIndex = random[0] % (index + 1)
-		const current = candidates[index]
-		candidates[index] = candidates[swapIndex]
-		candidates[swapIndex] = current
+	if (excludedCharacterIds.length > 0) {
+		conditions.push(notInArray(userCharacters.characterId, [...excludedCharacterIds]))
 	}
 
-	return candidates
+	return (await database.query.userCharacters.findMany({
+		where: and(...conditions),
+		columns: {
+			characterId: true,
+		},
+		orderBy: sql`random()`,
+		limit,
+	})) as Candidate[]
 }
 
 async function mapWithConcurrency<T, R>(
@@ -165,25 +157,36 @@ async function mapWithConcurrency<T, R>(
 }
 
 async function resolveCorporationTokens(
+	database: Database,
 	tokenStore: EveTokenStore,
 	corporationData: EveCorporationData,
 	corporationId: string,
-	candidates: readonly Candidate[],
 	count: number
 ): Promise<Array<Candidate & DecryptedAccessToken>> {
 	const selected: Array<Candidate & DecryptedAccessToken> = []
+	const attemptedCharacterIds = new Set<string>()
 
-	// Process shuffled candidates in bounded batches. A token-store failure for
-	// one character is represented by an omitted result, so later candidates
-	// continue filling the requested count.
-	for (let offset = 0; offset < candidates.length && selected.length < count; ) {
+	// Let PostgreSQL choose a bounded random batch. Candidates that are no longer
+	// members or cannot produce an access token are excluded from replacements.
+	while (selected.length < count) {
 		const remaining = count - selected.length
-		const batch = candidates.slice(offset, offset + Math.min(TOKEN_BATCH_SIZE, remaining))
-		offset += batch.length
-		const membershipByCharacterId = await corporationData.getCorporationIdsByCharacterIds(
-			batch.map((candidate) => candidate.characterId)
+		const batch = await findRandomCandidates(
+			database,
+			corporationId,
+			[...attemptedCharacterIds],
+			Math.min(TOKEN_BATCH_SIZE, remaining)
 		)
-		const currentMemberCandidates = batch.filter(
+		if (batch.length === 0) break
+		const freshBatch = batch.filter(
+			(candidate) => !attemptedCharacterIds.has(candidate.characterId)
+		)
+		if (freshBatch.length === 0) break
+		for (const candidate of freshBatch) attemptedCharacterIds.add(candidate.characterId)
+
+		const membershipByCharacterId = await corporationData.getCorporationIdsByCharacterIds(
+			freshBatch.map((candidate) => candidate.characterId)
+		)
+		const currentMemberCandidates = freshBatch.filter(
 			(candidate) => membershipByCharacterId[candidate.characterId] === corporationId
 		)
 		if (currentMemberCandidates.length === 0) continue
@@ -248,13 +251,16 @@ app.get('/', async (c) => {
 	const corporations = await findEligibleCorporations(database, parsed.ids)
 
 	const tokenStore = getStub<EveTokenStore>(c.env.EVE_TOKEN_STORE, 'default')
-	const corporationCandidates = await mapWithConcurrency(
+	const resolvedCorporations = await mapWithConcurrency(
 		corporations as Corporation[],
 		CORPORATION_CONCURRENCY,
 		async (
 			corporation
 		): Promise<
-			| { result: CorporationCandidates; error: null }
+			| {
+					result: { corporation: Corporation; candidates: Array<Candidate & DecryptedAccessToken> }
+					error: null
+			  }
 			| { result: null; error: { corporationId: string; error: string } }
 		> => {
 			try {
@@ -262,39 +268,22 @@ app.get('/', async (c) => {
 					c.env.EVE_CORPORATION_DATA,
 					corporation.corporationId
 				)
-				const [characters, directors] = await Promise.all([
-					database.query.userCharacters.findMany({
-						where: and(
-							eq(userCharacters.corporationId, corporation.corporationId),
-							eq(userCharacters.isDeleted, false),
-							eq(userCharacters.status, 'active'),
-							eq(userCharacters.hasValidToken, true)
-						),
-						columns: {
-							characterId: true,
-							characterName: true,
-							userId: true,
-							hasValidToken: true,
-						},
-					}),
-					corporationData.getDirectors(corporation.corporationId),
-				])
-
-				const directorIds = new Set(directors.map((director) => director.characterId))
-				const candidates = shuffleCandidates(
-					characters.filter((character) => character.hasValidToken === true),
-					directorIds
+				const tokens = await resolveCorporationTokens(
+					database,
+					tokenStore,
+					corporationData,
+					corporation.corporationId,
+					requestedCount.count
 				)
-
 				return {
 					result: {
 						corporation,
-						candidates,
+						candidates: tokens,
 					},
 					error: null,
 				}
 			} catch (error) {
-				logger.error('[MemberAccessTokenExport] Failed to load corporation candidates', {
+				logger.error('[MemberAccessTokenExport] Failed to resolve corporation access tokens', {
 					corporationId: corporation.corporationId,
 					error: error instanceof Error ? error.message : String(error),
 				})
@@ -302,45 +291,6 @@ app.get('/', async (c) => {
 					result: null,
 					error: {
 						corporationId: corporation.corporationId,
-						error: 'Unable to retrieve access tokens for this corporation',
-					},
-				}
-			}
-		}
-	)
-	const resolvedCorporations = await mapWithConcurrency(
-		corporationCandidates,
-		CORPORATION_CONCURRENCY,
-		async (entry) => {
-			if (!entry.result) return entry
-			const corporationData = getStub<EveCorporationData>(
-				c.env.EVE_CORPORATION_DATA,
-				entry.result.corporation.corporationId
-			)
-			try {
-				const tokens = await resolveCorporationTokens(
-					tokenStore,
-					corporationData,
-					entry.result.corporation.corporationId,
-					entry.result.candidates,
-					requestedCount.count
-				)
-				return {
-					result: {
-						corporation: entry.result.corporation,
-						candidates: tokens,
-					},
-					error: null,
-				}
-			} catch (error) {
-				logger.error('[MemberAccessTokenExport] Failed to resolve corporation access tokens', {
-					corporationId: entry.result.corporation.corporationId,
-					error: error instanceof Error ? error.message : String(error),
-				})
-				return {
-					result: null,
-					error: {
-						corporationId: entry.result.corporation.corporationId,
 						error: 'Unable to retrieve access tokens for this corporation',
 					},
 				}


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a `count` query parameter to the member refresh-tokens export endpoint so callers can request a bounded number of tokens per corporation (1-60, default 15), and refactors candidate selection to pick random valid-token members directly from the database instead of pre-loading and sorting all candidates in memory.

## Changes
- Add `parseRequestedTokenCount` to validate the new `count` query param (integer, 1-60), returning a 400 error otherwise; raise `MAX_TOKENS_PER_CORPORATION` to 60 and introduce `DEFAULT_TOKENS_PER_CORPORATION` (15).
- Replace `orderCandidates` (director-priority sort + in-memory Fisher-Yates shuffle via `crypto.getRandomValues`) with `findRandomCandidates`, which uses `ORDER BY random()` in the DB query and excludes already-attempted character IDs via `notInArray`.
- Add `resolveCorporationTokens`, which loops fetching random candidate batches, filters out members whose corporation membership or access token lookup fails, and keeps trying additional candidates until the requested count is met or no candidates remain.
- Drop the `getDirectors` call and director/member role distinction entirely; `Candidate` now only carries `characterId`, and returned tokens no longer include `characterName`, `userId`, or `role`.
- Simplify the route handler to use `resolveCorporationTokens` per corporation instead of the previous two-pass candidate-then-token-batch flow, removing `getAccessTokensInBatches` and `CorporationCandidates`.

## Testing
- Updated `apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts` to cover: honoring the requested `count`, rejecting out-of-range counts (>60) with a 400, falling back to additional DB-selected candidates when access-token generation fails, and delegating random selection/column projection to the database mock instead of asserting on `crypto.getRandomValues` behavior.
<!-- claude:end -->