### PR TITLE
force refresh integration tokens

### DIFF
--- a/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
+++ b/apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts
@@ -160,6 +160,11 @@ describe('member access token export route', () => {
 		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledTimes(2)
 		expect(
 			tokenStore.getAccessTokensForIntegration.mock.calls.every(
+				([, options]) => options?.forceRefresh === true
+			)
+		).toBe(true)
+		expect(
+			tokenStore.getAccessTokensForIntegration.mock.calls.every(
 				([characterIds]) => (characterIds as string[]).length === 3
 			)
 		).toBe(true)
@@ -235,8 +240,12 @@ describe('member access token export route', () => {
 			'1001',
 			'1002',
 		])
-		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(1, ['1000', '1001'])
-		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(2, ['1002'])
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(1, ['1000', '1001'], {
+			forceRefresh: true,
+		})
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenNthCalledWith(2, ['1002'], {
+			forceRefresh: true,
+		})
 		expect(db.query.userCharacters.findMany).toHaveBeenCalledTimes(2)
 	})
 
@@ -282,7 +291,9 @@ describe('member access token export route', () => {
 
 		const body = (await response.json()) as any
 		expect(body.corporations[0].tokens).toMatchObject([{ characterId: '1000' }])
-		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledWith(['1000'])
+		expect(tokenStore.getAccessTokensForIntegration).toHaveBeenCalledWith(['1000'], {
+			forceRefresh: true,
+		})
 	})
 
 	it('rejects a token count outside the supported range', async () => {

--- a/apps/core/src/routes/member-refresh-tokens.ts
+++ b/apps/core/src/routes/member-refresh-tokens.ts
@@ -192,7 +192,8 @@ async function resolveCorporationTokens(
 		if (currentMemberCandidates.length === 0) continue
 
 		const tokenRows = await tokenStore.getAccessTokensForIntegration(
-			currentMemberCandidates.map((candidate) => candidate.characterId)
+			currentMemberCandidates.map((candidate) => candidate.characterId),
+			{ forceRefresh: true }
 		)
 		const tokensByCharacterId = new Map<string, DecryptedAccessToken>()
 		for (const token of tokenRows) {

--- a/apps/eve-token-store/src/durable-object.ts
+++ b/apps/eve-token-store/src/durable-object.ts
@@ -35,6 +35,7 @@ import type {
 	EveTokenResponse,
 	EveTokenStore,
 	EveVerifyResponse,
+	IntegrationAccessTokenOptions,
 	PublicDataVerifyResult,
 	TokenInfo,
 	TokenRefreshResult,
@@ -937,7 +938,10 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	 * internal integration. This reuses the warm cache and demand-driven refresh
 	 * path so plaintext refresh tokens never leave the token-store domain.
 	 */
-	async getAccessTokensForIntegration(characterIds: string[]): Promise<DecryptedAccessToken[]> {
+	async getAccessTokensForIntegration(
+		characterIds: string[],
+		options: IntegrationAccessTokenOptions = {}
+	): Promise<DecryptedAccessToken[]> {
 		const uniqueCharacterIds = [...new Set(characterIds.map((characterId) => String(characterId)))]
 		if (uniqueCharacterIds.length === 0) return []
 		if (uniqueCharacterIds.length > 100) {
@@ -962,7 +966,7 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 			eligibleCharacterIds,
 			ACCESS_TOKEN_INTEGRATION_CONCURRENCY,
 			async (characterId) => {
-				const result = await this.getAccessTokenResult(characterId)
+				const result = await this.getAccessTokenResult(characterId, options)
 				if (result.status !== 'ok') return null
 				return {
 					characterId,
@@ -1327,14 +1331,19 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 	 * Internal access-token lookup that preserves retryable refresh failures so
 	 * authenticated callers can distinguish transient outages from hard auth loss.
 	 */
-	private async getAccessTokenResult(characterId: string): Promise<AccessTokenLookupResult> {
+	private async getAccessTokenResult(
+		characterId: string,
+		options: IntegrationAccessTokenOptions = {}
+	): Promise<AccessTokenLookupResult> {
 		try {
-			const warmAccessToken = await this.getWarmAccessToken(characterId)
-			if (warmAccessToken) {
-				return {
-					status: 'ok',
-					accessToken: warmAccessToken.accessToken,
-					expiresAt: warmAccessToken.expiresAt,
+			if (!options.forceRefresh) {
+				const warmAccessToken = await this.getWarmAccessToken(characterId)
+				if (warmAccessToken) {
+					return {
+						status: 'ok',
+						accessToken: warmAccessToken.accessToken,
+						expiresAt: warmAccessToken.expiresAt,
+					}
 				}
 			}
 
@@ -1373,10 +1382,9 @@ export class EveTokenStoreDO extends DurableObject<Env> implements EveTokenStore
 
 			// Check if token is expired
 			const now = new Date()
-			const requiresRefresh = !isWarmAccessTokenUsable(
-				tokenRecord.expiresAt.getTime(),
-				now.getTime()
-			)
+			const requiresRefresh =
+				options.forceRefresh ||
+				!isWarmAccessTokenUsable(tokenRecord.expiresAt.getTime(), now.getTime())
 
 			if (requiresRefresh) {
 				if (!tokenRecord.refreshToken) {

--- a/packages/eve-token-store/src/index.ts
+++ b/packages/eve-token-store/src/index.ts
@@ -254,6 +254,12 @@ export interface DecryptedAccessToken {
 	expiresAt: string
 }
 
+/** Options for trusted internal access-token resolution. */
+export interface IntegrationAccessTokenOptions {
+	/** Refresh through EVE SSO instead of reusing a warm access-token cache entry. */
+	forceRefresh?: boolean
+}
+
 /**
  * Token validation outcome for refresh and auth-sensitive workflows.
  *
@@ -421,7 +427,10 @@ export interface EveTokenStore {
 	 * Token-store owns warm-cache lookup, safety-margin refresh, and decryption;
 	 * callers must authenticate the downstream request before returning values.
 	 */
-	getAccessTokensForIntegration(characterIds: string[]): Promise<DecryptedAccessToken[]>
+	getAccessTokensForIntegration(
+		characterIds: string[],
+		options?: IntegrationAccessTokenOptions
+	): Promise<DecryptedAccessToken[]>
 
 	/**
 	 * Validate that a character token is present, refreshable/verifiable, and


### PR DESCRIPTION
<!-- claude:begin -->
## Summary
Adds a `forceRefresh` option to the token-store's integration access-token API so the member refresh-token export route always pulls a freshly refreshed access token from EVE SSO instead of reusing a warm cache entry.

## Changes
- Add `IntegrationAccessTokenOptions` (with `forceRefresh?: boolean`) to the `EveTokenStore` interface in `packages/eve-token-store/src/index.ts`.
- Thread an optional `options` parameter through `getAccessTokensForIntegration` and the internal `getAccessTokenResult` in `apps/eve-token-store/src/durable-object.ts`, so `forceRefresh` skips the warm-token cache and forces a refresh-token exchange.
- Update `resolveCorporationTokens` in `apps/core/src/routes/member-refresh-tokens.ts` to call `getAccessTokensForIntegration` with `{ forceRefresh: true }`.

## Testing
- Updated unit tests in `apps/core/src/routes/__tests__/member-refresh-tokens.route.test.ts` to assert that `getAccessTokensForIntegration` is always called with `{ forceRefresh: true }`.
<!-- claude:end -->